### PR TITLE
zebra: Per route source count cache

### DIFF
--- a/tests/topotests/pbr_topo1/test_pbr_topo1.py
+++ b/tests/topotests/pbr_topo1/test_pbr_topo1.py
@@ -168,6 +168,124 @@ def test_pbr_data():
         )
 
 
+def _get_pbr_count_in_table(router, table_id):
+    "Return (rib, fib) for PBR in table_id, or (None, None) if no PBR entry."
+    cmd = "show ip route summary table {} json".format(table_id)
+    output = router.vtysh_cmd(cmd)
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        return None, None
+    for entry in data.get("prefixRoutes", []):
+        if entry.get("type") == "pbr":
+            return entry.get("rib", 0), entry.get("fib", 0)
+    return 0, 0
+
+
+def test_pbr_route_count():
+    "Verify PBR route count in show ip route summary"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Verifying PBR route count in route summary")
+
+    router = tgen.gears["r1"]
+
+    # 1) Add PBR entries to the table: create a new pbr-map with one rule
+    PBR_MAP = "ROUTE_COUNT_TEST"
+    vcmd = (
+        "configure terminal\n"
+        "pbr-map {} seq 1\n"
+        "match dst-ip 10.99.99.0/24\n"
+        "set nexthop-group A\n"
+        "end\n"
+        "end"
+    ).format(PBR_MAP)
+    router.vtysh_multicmd(vcmd)
+
+    # 2) Wait for route to be installed and find its table (poll with retries)
+    table_id = None
+    rib = 0
+    table_range = range(10000, 10021)
+    for attempt in range(15):
+        topotest.sleep(1, "Waiting for PBR route (attempt %d)" % (attempt + 1))
+        # Try to get table id from show pbr map json
+        try:
+            pbr_map_output = router.vtysh_cmd("show pbr map json")
+            pbr_maps = json.loads(pbr_map_output)
+            if not isinstance(pbr_maps, list):
+                pbr_maps = [pbr_maps]
+            for m in pbr_maps:
+                if m.get("name") != PBR_MAP:
+                    continue
+                for pol in m.get("policies", []):
+                    nhg = pol.get("nexthopGroup")
+                    if nhg and "tableId" in nhg and nhg["tableId"] > 0:
+                        table_id = nhg["tableId"]
+                        break
+                if table_id is not None:
+                    break
+        except (json.JSONDecodeError, TypeError):
+            pass
+        # If we have table_id from JSON, check if it has PBR routes
+        if table_id is not None:
+            rib, fib = _get_pbr_count_in_table(router, table_id)
+            if rib is not None and rib >= 1:
+                break
+        # Otherwise scan table range for any table with PBR routes (our new one)
+        table_id = None
+        for tid in table_range:
+            r, f = _get_pbr_count_in_table(router, tid)
+            if r is not None and r >= 1:
+                table_id = tid
+                rib, fib = r, f
+                break
+        if table_id is not None and rib >= 1:
+            break
+
+    assert table_id is not None, (
+        "Could not find table id for PBR map {} after 15s".format(PBR_MAP)
+    )
+    assert rib >= 1, (
+        "Expected at least 1 PBR route in table {} after adding pbr-map, got rib={}".format(
+            table_id, rib
+        )
+    )
+
+    # 3) Verify route summary shows PBR entries in that table
+    rib, fib = _get_pbr_count_in_table(router, table_id)
+    assert rib is not None, "No route summary for table {}".format(table_id)
+    assert rib >= 1, (
+        "Expected at least 1 PBR route in table {} after adding pbr-map, got rib={}".format(
+            table_id, rib
+        )
+    )
+    assert rib >= 0 and fib >= 0, "PBR counts negative: rib={} fib={}".format(
+        rib, fib
+    )
+    logger.info("Table %d: PBR rib=%s fib=%s (after adding %s)", table_id, rib, fib, PBR_MAP)
+
+    # 4) Remove PBR map and verify count drops
+    router.vtysh_multicmd(
+        "configure terminal\nno pbr-map {}\nend".format(PBR_MAP)
+    )
+    rib_after = -1
+    for _ in range(10):
+        topotest.sleep(1, "Waiting for PBR route to be removed")
+        rib_after, fib_after = _get_pbr_count_in_table(router, table_id)
+        if rib_after is not None and rib_after == 0:
+            break
+    assert rib_after is not None, "No route summary for table {} after remove".format(table_id)
+    assert rib_after == 0, (
+        "Expected 0 PBR routes in table {} after removing pbr-map, got rib={}".format(
+            table_id, rib_after
+        )
+    )
+    logger.info("Table %d: PBR rib=%s after removing %s", table_id, rib_after, PBR_MAP)
+
+
 ########################################################################
 # 			Field test - START
 ########################################################################

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -22,6 +22,7 @@
 #include "mpls.h"
 #include "srcdest_table.h"
 #include "zebra/zebra_nhg.h"
+#include "lib/route_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -319,6 +320,9 @@ struct rib_table_info {
 	afi_t afi;
 	safi_t safi;
 	uint32_t table_id;
+
+	/* Per-route-type count (e.g. for PBR), updated on add/delete */
+	uint32_t route_count[ZEBRA_ROUTE_MAX];
 };
 
 enum rib_tables_iter_state {
@@ -367,6 +371,9 @@ zebra_rib_route_entry_new(vrf_id_t vrf_id, int type, uint8_t instance,
 			  uint32_t flags, uint32_t nhe_id, uint32_t table_id,
 			  uint32_t metric, uint32_t mtu, uint8_t distance,
 			  route_tag_t tag);
+
+void rib_update_route_count(vrf_id_t vrf_id, int type, afi_t afi, safi_t safi,
+			    uint32_t tableid, bool add);
 
 #define ZEBRA_RIB_LOOKUP_ERROR -1
 #define ZEBRA_RIB_FOUND_EXACT 0

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2688,6 +2688,8 @@ static void process_subq_early_route_add(struct zebra_early_route *ere)
 
 	SET_FLAG(re->status, ROUTE_ENTRY_CHANGED);
 	rib_addnode(rn, re);
+	rib_update_route_count(re->vrf_id, re->type, ere->afi, ere->safi,
+			       re->table, true);
 
 	dest = rib_dest_from_rnode(rn);
 	/* Free implicit route.*/
@@ -2717,6 +2719,8 @@ static void process_subq_early_route_add(struct zebra_early_route *ere)
 		}
 
 		rib_delnode(rn, same);
+		rib_update_route_count(same->vrf_id, same->type, ere->afi,
+				       ere->safi, same->table, false);
 	}
 
 	/* See if we can remove some RE entries that are queued for
@@ -2958,6 +2962,8 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 			dplane_sys_route_del(rn, same);
 
 		rib_delnode(rn, same);
+		rib_update_route_count(re->vrf_id, re->type, ere->afi,
+				       ere->safi, re->table, false);
 	}
 
 	route_unlock_node(rn);
@@ -5280,4 +5286,32 @@ struct route_table *rib_tables_iter_next(rib_tables_iter_t *iter)
 		iter->state = RIB_TABLES_ITER_S_DONE;
 
 	return table;
+}
+
+/*
+ * Rib route count stored in the vrf table *info struct to be updated
+ * on route adds and deletes, currently updating for PBR
+ */
+void rib_update_route_count(vrf_id_t vrf_id, int type, afi_t afi, safi_t safi,
+			    uint32_t tableid, bool add)
+{
+	if (type == ZEBRA_ROUTE_PBR) {
+		if (IS_ZEBRA_DEBUG_RIB)
+			zlog_debug("Table id %d afi %d safi %d vrf_id %d",
+				   tableid, afi, safi, vrf_id);
+		/*
+		 * Route info count is kept against the vrf table which needs to
+		 * be updated with a total PBR count from all tables
+		 */
+		struct route_table *vrf_table =
+			zebra_vrf_table(afi, safi, vrf_id);
+		struct rib_table_info *info = route_table_get_info(vrf_table);
+
+		if (info) {
+			if (add)
+				info->route_count[ZEBRA_ROUTE_PBR]++;
+			else if (info->route_count[ZEBRA_ROUTE_PBR] != 0)
+				info->route_count[ZEBRA_ROUTE_PBR]--;
+		}
+	}
 }


### PR DESCRIPTION
    zebra: PBR count tracking
    
    Add count to the zebra route info for PBR.
    
    What this PR does:
    - Maintains a PBR route count in the VRF table's route info, updated on
      route add and delete (rib_update_route_count).
    - Exposes the count in YANG operational data (e.g. ipv4-route-count.pbr)
      and keeps it consistent with the RIB.
    - Adds a topotest that creates a PBR map, verifies the route summary
      shows the PBR count, then removes the map and verifies the count
      returns to zero.
    
    Test:
    
    r3# show yang operational-data /frr-zebra:lib zebra
    {
      "frr-zebra:lib": {
        "vrf": [
          {
            "id": "default",
            "ipv4-route-count": {
              "total": 23,
              "connected": 4,
              "bgp": 9,
              "kernel": 0,
              "static": 0,
              "pbr": 1,
              "table": 0,
              "ospf": 8
            },
    
    r3# show pbr map
      pbr-map otel-pbr valid: yes
        Seq: 1 rule: 300
            Installed: yes Reason: Valid
            DST IP Match: 20.10.0.4/32
            Nexthop-Group: otel-nhg
              Installed: yes Tableid: 10000
    r3# show running-config no-header
    r3# show ip route table 10000
    Codes: K - kernel route, C - connected, S - static, R - RIP,
           O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
           T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
           Z - FRR,
           > - selected route, * - FIB route, q - queued, r - rejected, b - backup
           t - trapped, o - offload failure
    
    VRF default table 10000:
    F>  0.0.0.0/0 [200/0] via 20.0.0.1 inactive, weight 1, 00:01:30
      *                   via 20.1.1.9, swp1, weight 1, 00:01:30
    
    r3# show ip route summary table 10000
    Route Source         Routes               FIB  (vrf default)
    pbr                  1                    1
    ------
    Totals               1                    1
    
    Signed-off-by: Ashwini Reddy <ashred@nvidia.com>

