### PR TITLE
doc: add missing build dependencies for Ubuntu 2x.04

### DIFF
--- a/doc/developer/building-frr-for-ubuntu2x04.rst
+++ b/doc/developer/building-frr-for-ubuntu2x04.rst
@@ -11,7 +11,7 @@ Installing Dependencies
    sudo apt-get install \
       git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex \
-      libc-ares-dev python3-dev python3-sphinx \
+      libc-ares-dev python3-dev python3-sphinx python3-pytest \
       install-info build-essential libsnmp-dev perl \
       libcap-dev libelf-dev libunwind-dev \
       protobuf-c-compiler libprotobuf-c-dev


### PR DESCRIPTION
## Description
Following the discussion in #20767, this PR improves the Ubuntu 2x.04 build documentation.

**Changes:**
- Added `python3-pytest` to the dependency list (required for topotests).
This ensures a clean build environment for new contributors on Ubuntu 24.04.

## Checklist
- [x] Verified build passes.
- [x] Documentation renders correctly.