### PR TITLE
yang: Fix pyang errors in frr-bgp-types.yang

### DIFF
--- a/yang/frr-bgp-types.yang
+++ b/yang/frr-bgp-types.yang
@@ -40,18 +40,27 @@ module frr-bgp-types {
   revision 2019-12-03 {
     description
       "Initial revision.";
+
+    reference
+      "FRRouting";
   }
 
   typedef plist-ref {
     type string;
+    description
+      "Reference to a plist.";
   }
 
   typedef access-list-ref {
     type string;
+    description
+      "Reference to an access list.";
   }
 
   typedef as-path-filter-ref {
     type string;
+    description
+      "Reference to an AS path filter, which specifies a filter for AS paths in BGP routing.";
   }
 
   typedef bgp-instance-type {
@@ -72,6 +81,8 @@ module frr-bgp-types {
           "BGP instance view.";
       }
     }
+    description
+      "BGP instance type, which specifies the type of BGP instance.";
   }
 
   typedef as-type {
@@ -92,6 +103,8 @@ module frr-bgp-types {
           "External BGP peer.";
       }
     }
+    description
+      "AS type, which specifies the type of AS or BGP peer.";
   }
 
   typedef add-path-type {
@@ -112,6 +125,8 @@ module frr-bgp-types {
           "Add path feature is disabled.";
       }
     }
+    description
+      "Add path type, which specifies how paths are advertised to a neighbor.";
   }
 
   typedef bfd-session-type {
@@ -132,6 +147,8 @@ module frr-bgp-types {
           "Not Configured.";
       }
     }
+    description
+      "BFD session type, which can be single-hop, multi-hop, or not-configured.";
   }
 
   typedef direction {
@@ -147,5 +164,7 @@ module frr-bgp-types {
           "OUT, egress, Tx.";
       }
     }
+    description
+      "Direction of traffic flow, either ingress or egress.";
   }
 }


### PR DESCRIPTION
Fix pyang errors in frr-bgp-types.yang

frr-bgp-types.yang:40: error: RFC 8407: 4.8: statement "revision" must have a "reference" substatement
frr-bgp-types.yang:45: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:49: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:53: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:57: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:77: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:97: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:117: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-types.yang:137: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
