### PR TITLE
tests: Show that multiple interface up events do not create multiple …

### DIFF
--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -225,6 +225,7 @@ def test_zebra_kernel_route_blackhole_add():
     result, _ = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result, "Blackhole Route should have not been removed\n{}".format(_)
 
+
 def test_zebra_kernel_route_interface_linkdown():
     "Test that a kernel routes should be affected by interface change"
 
@@ -239,8 +240,8 @@ def test_zebra_kernel_route_interface_linkdown():
     expected = json.loads(open(kernel).read())
 
     test_func = partial(
-            topotest.router_json_cmp, router, "show ip route 5.5.6.7/32 json", expected
-            )
+        topotest.router_json_cmp, router, "show ip route 5.5.6.7/32 json", expected
+    )
     result, _ = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result, "Kernel Route should be selected:\n{}".format(_)
 
@@ -265,10 +266,77 @@ def test_zebra_kernel_route_interface_linkdown():
     expected = json.loads(open(kernel).read())
 
     test_func = partial(
-            topotest.router_json_cmp, router, "show ip route 5.5.6.7/32 json", expected
-            )
+        topotest.router_json_cmp, router, "show ip route 5.5.6.7/32 json", expected
+    )
     result, _ = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result, "Kernel Route should be selected:\n{}".format(_)
+
+
+def test_zebra_mtu_single_local_route_per_address():
+    "Set MTU to 6000 on r2-eth2 and ensure only one local route per address on the interface"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+    ifname = "r2-eth2"
+
+    # Set MTU to 6000 on r2-eth2 (via kernel; FRR has no mtu command)
+    logger.info("Setting MTU 6000 on %s", ifname)
+    r2.run("ip link set dev {} mtu 6000".format(ifname))
+
+    def _check_one_local_per_address():
+        # Get interface addresses (IPv4) on r2-eth2
+        if_output = r2.vtysh_cmd("show interface {} json".format(ifname), isjson=True)
+        if not if_output or ifname not in if_output:
+            return "Interface {} not found in show interface output".format(ifname)
+        ip_addresses = if_output[ifname].get("ipAddresses", [])
+        # Collect IPv4 /32 prefixes (host routes) for each address
+        local_prefixes = []
+        for addr_obj in ip_addresses:
+            addr = addr_obj.get("address", "")
+            if not addr or "/" not in addr:
+                continue
+            prefix, plen = addr.split("/")
+            plen = int(plen)
+            if ":" in prefix:
+                continue  # skip IPv6
+            # Local route for this address is the host /32
+            local_prefixes.append(prefix + "/32")
+
+        if not local_prefixes:
+            return "No IPv4 addresses found on {}".format(ifname)
+
+        # Get route table
+        route_output = r2.vtysh_cmd("show ip route json", isjson=True)
+        if not route_output:
+            return "No output from show ip route json"
+
+        for prefix in local_prefixes:
+            if prefix not in route_output:
+                return "Prefix {} not in route table".format(prefix)
+            entries = route_output[prefix]
+            local_count = 0
+            for entry in entries:
+                if entry.get("protocol") != "local":
+                    continue
+                nexthops = entry.get("nexthops", [])
+                for nh in nexthops:
+                    if nh.get("interfaceName") == ifname:
+                        local_count += 1  # one local route entry for this prefix
+                        break
+            if local_count != 1:
+                return "Expected exactly one local route for {} on {}, found {}".format(
+                    prefix, ifname, local_count
+                )
+        return None
+
+    _, result = topotest.run_and_expect(
+        _check_one_local_per_address, None, count=20, wait=1
+    )
+    assert result is None, "Local route check failed: {}".format(result)
+
 
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]


### PR DESCRIPTION
…local routes

Show that the previous commit works properly and that when FRR receives a change for a interface that causes multiple event up scenarios, to treat the local routes as duplicate.