### PR TITLE
lib: fix and rework frr pthread non controlled startup

### DIFF
--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -253,15 +253,6 @@ void frr_pthread_stop_all(void)
 	}
 }
 
-static void *frr_pthread_attr_non_controlled_start(void *arg)
-{
-	struct frr_pthread *fpt = arg;
-
-	fpt->running = true;
-
-	return NULL;
-}
-
 /* Create a FRR pthread context from a non FRR pthread initialized from an
  * external library in order to allow logging */
 int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
@@ -270,22 +261,6 @@ int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
 	struct rcu_thread *rcu_thread = rcu_thread_new(NULL);
 
 	rcu_thread_start(rcu_thread);
-
-	struct frr_pthread_attr attr = {
-		.start = frr_pthread_attr_non_controlled_start,
-		.stop = frr_pthread_attr_default.stop,
-	};
-	struct frr_pthread *fpt;
-
-	fpt = frr_pthread_new(&attr, name, os_name);
-	if (!fpt)
-		return -1;
-
-	fpt->thread = thread;
-	fpt->rcu_thread = rcu_thread;
-	fpt->started = true;
-
-	frr_pthread_inner(fpt);
 
 	return 0;
 }

--- a/lib/frrcu.c
+++ b/lib/frrcu.c
@@ -154,16 +154,18 @@ struct rcu_thread *rcu_thread_new(void *arg)
 {
 	struct rcu_thread *rt, *cur = arg;
 
-	/* new thread always starts with rcu_read_lock held at depth 1, and
-	 * holding the same epoch as the parent (this makes it possible to
-	 * use RCU for things passed into the thread through its arg)
-	 */
 	rt = XCALLOC(MTYPE_RCU_THREAD, sizeof(*rt));
-	rt->depth = 1;
 
 	seqlock_init(&rt->rcu);
-	if (cur)
+	if (cur) {
+		/* new thread with a parent always starts with rcu_read_lock held
+		 * at depth 1, and holding the same epoch as the parent (this
+		 * makes it possible to use RCU for things passed into the
+		 * thread through its arg)
+		 */
 		seqlock_acquire(&rt->rcu, &cur->rcu);
+		rt->depth = 1;
+	}
 
 	rcu_threads_add_tail(&rcu_threads, rt);
 


### PR DESCRIPTION
Hi, this PR fixes a crash at cleanup in bgpd when using RPKI and refactors RCU initialization for external threads.

We were previously using frr_pthread_non_controlled_startup() to enable logging in rtrlib threads. This caused crashes during shutdown because we may restarted rtrlib threads, and FRR would keep stale thread IDs in its managed list, leading to duplicates if the OS recycled an ID, and eventually attempt to double-join them. Additionally, these threads were incorrectly starting at RCU depth 1 without actually holding the seqlock, leaving data unprotected.