### PR TITLE
tests: Stop several tests from running on old branch

### DIFF
--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -32,7 +32,7 @@ log_file_date_format = %Y-%m-%d %H:%M:%S
 junit_logging = all
 junit_log_passing_tests = true
 
-norecursedirs = .git example_munet example_test example_topojson_test lib munet docker high_ecmp
+norecursedirs = .git example_munet example_test example_topojson_test lib munet docker high_ecmp bgp_multiple_link_bandwidth_communities zebra_kernel_nhg
 
 # Directory to store test results and run logs in, default shown
 # rundir = /tmp/topotests


### PR DESCRIPTION
These two tests:

bgp_multiple_link_bandwidth_communities -> relies on new json key value pairs that were not backported to 10.5
zebra_kernel_nhg -> relies on a completely new show command which is not available on 10.5

Just make these two tests not run on 10.5.  The fixes that are associated with these two tests are being tested on master.  Let's just let the tests move on on older branches.