### PR TITLE
Bgp peer sendq timing

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -495,7 +495,7 @@ done : {
 	if (update_last_write) {
 		atomic_store_explicit(&peer->last_write, now,
 				      memory_order_relaxed);
-		peer->last_sendq_ok = now;
+		connection->last_sendq_ok = now;
 	}
 }
 

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -495,7 +495,7 @@ done : {
 	if (update_last_write) {
 		atomic_store_explicit(&peer->last_write, now,
 				      memory_order_relaxed);
-		connection->last_sendq_ok = now;
+		atomic_store_explicit(&connection->last_sendq_ok, now, memory_order_relaxed);
 	}
 }
 

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -513,6 +513,9 @@ static void bgp_accept(struct event *event)
 
 		if (dynamic_peer) {
 			incoming = dynamic_peer->connection;
+
+			incoming->last_sendq_ok = monotime(NULL);
+
 			/* Dynamic neighbor has been created, let it proceed */
 			incoming->fd = bgp_sock;
 
@@ -672,6 +675,7 @@ static void bgp_accept(struct event *event)
 	incoming->fd = bgp_sock;
 	incoming->su_local = sockunion_getsockname(incoming->fd);
 	incoming->su_remote = sockunion_dup(&su);
+	incoming->last_sendq_ok = monotime(NULL);
 
 	if (bgp_set_socket_ttl(incoming) < 0)
 		if (bgp_debug_neighbor_events(doppelganger))
@@ -812,6 +816,8 @@ enum connect_result bgp_connect(struct peer_connection *connection)
 
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_WRITES_ON));
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_READS_ON));
+
+	connection->last_sendq_ok = monotime(NULL);
 
 	if (peer->bgp->router_id.s_addr == INADDR_ANY) {
 		peer_set_last_reset(peer, PEER_DOWN_ROUTER_ID_ZERO);

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -514,7 +514,8 @@ static void bgp_accept(struct event *event)
 		if (dynamic_peer) {
 			incoming = dynamic_peer->connection;
 
-			incoming->last_sendq_ok = monotime(NULL);
+			atomic_store_explicit(&incoming->last_sendq_ok, monotime(NULL),
+					      memory_order_relaxed);
 
 			/* Dynamic neighbor has been created, let it proceed */
 			incoming->fd = bgp_sock;
@@ -675,7 +676,7 @@ static void bgp_accept(struct event *event)
 	incoming->fd = bgp_sock;
 	incoming->su_local = sockunion_getsockname(incoming->fd);
 	incoming->su_remote = sockunion_dup(&su);
-	incoming->last_sendq_ok = monotime(NULL);
+	atomic_store_explicit(&incoming->last_sendq_ok, monotime(NULL), memory_order_relaxed);
 
 	if (bgp_set_socket_ttl(incoming) < 0)
 		if (bgp_debug_neighbor_events(doppelganger))
@@ -817,7 +818,7 @@ enum connect_result bgp_connect(struct peer_connection *connection)
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_WRITES_ON));
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_READS_ON));
 
-	connection->last_sendq_ok = monotime(NULL);
+	atomic_store_explicit(&connection->last_sendq_ok, monotime(NULL), memory_order_relaxed);
 
 	if (peer->bgp->router_id.s_addr == INADDR_ANY) {
 		peer_set_last_reset(peer, PEER_DOWN_ROUTER_ID_ZERO);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -119,12 +119,14 @@ static void bgp_packet_add(struct peer_connection *connection,
 		 * after it'll get confused
 		 */
 		if (!stream_fifo_count_safe(connection->obuf))
-			connection->last_sendq_ok = monotime(NULL);
+			atomic_store_explicit(&connection->last_sendq_ok, monotime(NULL),
+					      memory_order_relaxed);
 
 		stream_fifo_push(connection->obuf, s);
 	}
 
-	delta = monotime(NULL) - connection->last_sendq_ok;
+	delta = monotime(NULL) -
+		atomic_load_explicit(&connection->last_sendq_ok, memory_order_relaxed);
 
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_TIMER))
 		holdtime = atomic_load_explicit(&peer->holdtime, memory_order_relaxed);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1493,10 +1493,17 @@ struct peer_connection {
 
 	struct stream *curr;
 
-	/* only updated under io_mtx.
+	/*
+	 * Timestamp of the last outgoing messge to the peer.
+	 * This timestamp is written on multiple threads and read
+	 * on the master pthread.  As such it must be atomic.
+	 */
+	atomic_time_t last_sendq_ok;
+	/*
+	 * only updated under io_mtx.
 	 * last_sendq_warn is only for ratelimiting log warning messages.
 	 */
-	time_t last_sendq_ok, last_sendq_warn;
+	time_t last_sendq_warn;
 };
 
 /* Declare the FIFO list implementation */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1492,6 +1492,11 @@ struct peer_connection {
 	struct peer_connection_fifo_item fifo_item;
 
 	struct stream *curr;
+
+	/* only updated under io_mtx.
+	 * last_sendq_warn is only for ratelimiting log warning messages.
+	 */
+	time_t last_sendq_ok, last_sendq_warn;
 };
 
 /* Declare the FIFO list implementation */
@@ -2006,11 +2011,6 @@ struct peer {
 	_Atomic time_t last_write;
 	/* timestamp when the last msg was written */
 	_Atomic time_t last_update;
-
-	/* only updated under io_mtx.
-	 * last_sendq_warn is only for ratelimiting log warning messages.
-	 */
-	time_t last_sendq_ok, last_sendq_warn;
 
 	/* Notify data. */
 	struct bgp_notify notify;

--- a/lib/frratomic.h
+++ b/lib/frratomic.h
@@ -9,6 +9,7 @@
 /* C++ compatibility */
 #ifdef __cplusplus
 #include <stdint.h>
+#include <ctime>
 #include <atomic>
 using std::atomic_int;
 using std::memory_order;
@@ -23,9 +24,12 @@ typedef std::atomic<bool>		atomic_bool;
 typedef std::atomic<size_t>		atomic_size_t;
 typedef std::atomic<uint_fast32_t>	atomic_uint_fast32_t;
 typedef std::atomic<uintptr_t>		atomic_uintptr_t;
+typedef std::atomic<std::time_t>	atomic_time_t;
 
 #else
 #include <stdatomic.h>
+#include <time.h>
+typedef _Atomic(time_t) atomic_time_t;
 #endif
 
 #endif /* _FRRATOMIC_H */


### PR DESCRIPTION
See 2nd commit for the bulk of the problem.  Effectively there is a small timing window where bgp can decide that no sendQ progress has been made on a completely new connection.