### PR TITLE
tests: Don't try to use identical rmacs in rare situation

### DIFF
--- a/tests/topotests/bgp_evpn_three_tier_clos_topo1/test_bgp_evpn_v4_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_three_tier_clos_topo1/test_bgp_evpn_v4_v6_vtep.py
@@ -1883,7 +1883,11 @@ def test_l3vni_rmac_change(tgen_and_ip_version):
     # Step 2: Change the MAC address (trigger RMAC change)
     logger.info("Step 2: Changing router MAC on tor-21")
 
-    new_mac = initial_rmac[:-2] + "99"  # Change last byte to 99
+    new_mac = initial_rmac[:-2] + "99"
+
+    if new_mac == initial_rmac:
+        new_mac = initial_rmac[:-2] + "98"
+
     logger.info(f"Changing vlan4001 MAC from {original_mac} to {new_mac}")
 
     tor21.run(f"ip link set dev vlan4001 down")


### PR DESCRIPTION
We have this:

2026-02-13 22:24:54,781  INFO: topo: Step 2: Changing router MAC on tor-21
2026-02-13 22:24:54,781  INFO: topo: Changing vlan4001 MAC from 2e:d8:4f:14:f7:99 to 2e:d8:4f:14:f7:99

Notice how the rmac is changed from itself to itself.  This is because the code just blindly changes the last byte to a 99.  If the last byte is already 99 then the test will just fail.  Modify the code to detect this rare situation and to then use 98 instead.  I was unable to find anything in the code that would not make this work.