### PR TITLE
bfdd: moving bfd socket allocation from static to dynamic

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -324,6 +324,7 @@ int bfd_session_enable(struct bfd_session *bs)
 {
 	struct interface *ifp = NULL;
 	struct vrf *vrf = NULL;
+	struct bfd_vrf_global *bvrf;
 	int psock;
 
 	/* We are using data plane, we don't need software. */
@@ -348,6 +349,7 @@ int bfd_session_enable(struct bfd_session *bs)
 	}
 
 	assert(vrf);
+	bvrf = vrf->info;
 
 	if (bs->key.ifname[0]) {
 		ifp = if_lookup_by_name(bs->key.ifname, vrf->vrf_id);
@@ -410,6 +412,16 @@ int bfd_session_enable(struct bfd_session *bs)
 	 */
 	bs->sock = psock;
 
+	/*
+	 * Track active sessions per VRF for dynamic socket management.
+	 * Open VRF listening sockets on the first session;
+	 */
+	if (bvrf) {
+		if (bvrf->bg_session_count == 0)
+			bfd_vrf_start_sockets(bvrf);
+		bvrf->bg_session_count++;
+	}
+
 	/* Only start timers if we are using active mode. */
 	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_PASSIVE) == 0) {
 		if (bs->bfd_mode == BFD_MODE_TYPE_SBFD_ECHO) {
@@ -446,8 +458,24 @@ void bfd_session_disable(struct bfd_session *bs)
 
 	frrtrace(2, frr_bfd, session_enable_event, false, bs);
 
-	/* Free up socket resources. */
+	/* Free up socket resources and update VRF session count. */
 	if (bs->sock != -1) {
+		if (bs->vrf && bs->vrf->info) {
+			struct bfd_vrf_global *bvrf = bs->vrf->info;
+
+			if (bvrf->bg_session_count > 0) {
+				bvrf->bg_session_count--;
+
+				/*
+				 * Last session in this VRF: close the shared
+				 * listening sockets if no reflectors need them.
+				 */
+				if (bvrf->bg_session_count == 0 &&
+				    bvrf->bg_reflector_count == 0)
+					bfd_vrf_stop_sockets(bvrf);
+			}
+		}
+
 		close(bs->sock);
 		bs->sock = -1;
 	}
@@ -2519,50 +2547,17 @@ static int bfd_vrf_delete(struct vrf *vrf)
 
 static int bfd_vrf_enable(struct vrf *vrf)
 {
-	struct bfd_vrf_global *bvrf = vrf->info;
-
 	if (bglobal.debug_zebra)
 		zlog_debug("VRF enable add %s id %u", vrf->name, vrf->vrf_id);
 
 	frrtrace(2, frr_bfd, vrf_lifecycle, 3, vrf->vrf_id);
 
-	/* Don't open sockets when using data plane */
-	if (bglobal.bg_use_dplane)
-		goto skip_sockets;
+	/*
+	 * Sockets are no longer opened here statically.
+	 * They will be created dynamically when the first BFD session
+	 * is enabled for this VRF (see bfd_session_enable()).
+	 */
 
-	if (!bfd_vrf_is_perm(vrf->name))
-		return 0;
-
-	if (bvrf->bg_shop == -1)
-		bvrf->bg_shop = bp_udp_shop(vrf);
-	if (bvrf->bg_mhop == -1)
-		bvrf->bg_mhop = bp_udp_mhop(vrf);
-	if (bvrf->bg_shop6 == -1)
-		bvrf->bg_shop6 = bp_udp6_shop(vrf);
-	if (bvrf->bg_mhop6 == -1)
-		bvrf->bg_mhop6 = bp_udp6_mhop(vrf);
-	if (bvrf->bg_initv6 == -1)
-		bvrf->bg_initv6 = bp_initv6_socket(vrf);
-
-	if (bvrf->bg_ev[0] == NULL && bvrf->bg_shop != -1)
-		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop,
-			       &bvrf->bg_ev[0]);
-	if (bvrf->bg_ev[1] == NULL && bvrf->bg_mhop != -1)
-		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop,
-			       &bvrf->bg_ev[1]);
-	if (bvrf->bg_ev[2] == NULL && bvrf->bg_shop6 != -1)
-		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop6,
-			       &bvrf->bg_ev[2]);
-	if (bvrf->bg_ev[3] == NULL && bvrf->bg_mhop6 != -1)
-		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop6,
-			       &bvrf->bg_ev[3]);
-	if (bvrf->bg_ev[6] == NULL && bvrf->bg_initv6 != -1)
-		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_initv6, &bvrf->bg_ev[6]);
-
-	/* Toggle echo if VRF was disabled. */
-	bfd_vrf_toggle_echo(bvrf);
-
-skip_sockets:
 	if (vrf->vrf_id != VRF_DEFAULT) {
 		bfdd_zclient_register(vrf->vrf_id);
 		bfdd_sessions_enable_vrf(vrf);
@@ -2589,23 +2584,10 @@ static int bfd_vrf_disable(struct vrf *vrf)
 
 	frrtrace(2, frr_bfd, vrf_lifecycle, 4, vrf->vrf_id);
 
-	/* Disable read/write poll triggering. */
-	event_cancel(&bvrf->bg_ev[0]);
-	event_cancel(&bvrf->bg_ev[1]);
-	event_cancel(&bvrf->bg_ev[2]);
-	event_cancel(&bvrf->bg_ev[3]);
-	event_cancel(&bvrf->bg_ev[4]);
-	event_cancel(&bvrf->bg_ev[5]);
-	event_cancel(&bvrf->bg_ev[6]);
-
-	/* Close all descriptors. */
-	socket_close(&bvrf->bg_echo);
-	socket_close(&bvrf->bg_shop);
-	socket_close(&bvrf->bg_mhop);
-	socket_close(&bvrf->bg_shop6);
-	socket_close(&bvrf->bg_mhop6);
-	socket_close(&bvrf->bg_echov6);
-	socket_close(&bvrf->bg_initv6);
+	/* Close all sockets and cancel events for this VRF. */
+	bfd_vrf_stop_sockets(bvrf);
+	bvrf->bg_session_count = 0;
+	bvrf->bg_reflector_count = 0;
 
 	return 0;
 }
@@ -2646,6 +2628,8 @@ unsigned long bfd_get_session_count(void)
 struct sbfd_reflector *sbfd_reflector_new(const uint32_t discr, struct in6_addr *sip)
 {
 	struct sbfd_reflector *sr;
+	struct vrf *vrf;
+	struct bfd_vrf_global *bvrf;
 
 	sr = sbfd_discr_lookup(discr);
 	if (sr)
@@ -2657,6 +2641,16 @@ struct sbfd_reflector *sbfd_reflector_new(const uint32_t discr, struct in6_addr 
 
 	sbfd_discr_insert(sr);
 
+	vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	if (vrf) {
+		bvrf = vrf->info;
+		if (bvrf) {
+			if (bvrf->bg_reflector_count == 0 &&
+			    bvrf->bg_session_count == 0)
+				bfd_vrf_start_sockets(bvrf);
+			bvrf->bg_reflector_count++;
+		}
+	}
 
 	return sr;
 }
@@ -2664,6 +2658,8 @@ struct sbfd_reflector *sbfd_reflector_new(const uint32_t discr, struct in6_addr 
 void sbfd_reflector_free(const uint32_t discr)
 {
 	struct sbfd_reflector *sr;
+	struct vrf *vrf;
+	struct bfd_vrf_global *bvrf;
 
 	sr = sbfd_discr_lookup(discr);
 	if (!sr)
@@ -2672,7 +2668,16 @@ void sbfd_reflector_free(const uint32_t discr)
 	sbfd_discr_delete(discr);
 	XFREE(MTYPE_SBFD_REFLECTOR, sr);
 
-	return;
+	vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	if (vrf) {
+		bvrf = vrf->info;
+		if (bvrf && bvrf->bg_reflector_count > 0) {
+			bvrf->bg_reflector_count--;
+			if (bvrf->bg_reflector_count == 0 &&
+			    bvrf->bg_session_count == 0)
+				bfd_vrf_stop_sockets(bvrf);
+		}
+	}
 }
 
 void sbfd_reflector_flush(void)
@@ -2725,4 +2730,95 @@ void bfd_rtt_init(struct bfd_session *bfd)
 	bfd->rtt_index = 0;
 	for (i = 0; i < BFD_RTT_SAMPLE; i++)
 		bfd->rtt[i] = 0;
+}
+
+/*
+ * Dynamic BFD socket management functions.
+ *
+ * Sockets are created on demand when the first BFD session is enabled
+ * for a VRF, and closed when the last session is disabled.
+ */
+
+/*
+ * bfd_vrf_start_sockets: open all listening sockets for a VRF.
+ *
+ * Sockets are created dynamically on demand when the first BFD session
+ * is enabled for this VRF. This function is idempotent - it only opens
+ * sockets that are not already open.
+ */
+int bfd_vrf_start_sockets(struct bfd_vrf_global *bvrf)
+{
+	/* Don't open sockets when using data plane. */
+	if (bglobal.bg_use_dplane)
+		return 0;
+
+	if (!bfd_vrf_is_perm(bvrf->vrf->name))
+		return 0;
+
+	if (bglobal.debug_zebra)
+		zlog_debug("VRF start sockets %s id %u", bvrf->vrf->name,
+			   bvrf->vrf->vrf_id);
+
+	if (bvrf->bg_shop == -1)
+		bvrf->bg_shop = bp_udp_shop(bvrf->vrf);
+	if (bvrf->bg_mhop == -1)
+		bvrf->bg_mhop = bp_udp_mhop(bvrf->vrf);
+	if (bvrf->bg_shop6 == -1)
+		bvrf->bg_shop6 = bp_udp6_shop(bvrf->vrf);
+	if (bvrf->bg_mhop6 == -1)
+		bvrf->bg_mhop6 = bp_udp6_mhop(bvrf->vrf);
+	if (bvrf->bg_initv6 == -1)
+		bvrf->bg_initv6 = bp_initv6_socket(bvrf->vrf);
+
+	if (bvrf->bg_ev[0] == NULL && bvrf->bg_shop != -1)
+		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop,
+			       &bvrf->bg_ev[0]);
+	if (bvrf->bg_ev[1] == NULL && bvrf->bg_mhop != -1)
+		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop,
+			       &bvrf->bg_ev[1]);
+	if (bvrf->bg_ev[2] == NULL && bvrf->bg_shop6 != -1)
+		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop6,
+			       &bvrf->bg_ev[2]);
+	if (bvrf->bg_ev[3] == NULL && bvrf->bg_mhop6 != -1)
+		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop6,
+			       &bvrf->bg_ev[3]);
+	if (bvrf->bg_ev[6] == NULL && bvrf->bg_initv6 != -1)
+		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_initv6,
+			       &bvrf->bg_ev[6]);
+
+	/* Open echo sockets if any session in this VRF uses echo mode. */
+	bfd_vrf_toggle_echo(bvrf);
+
+	return 0;
+}
+
+/*
+ * bfd_vrf_stop_sockets: close all listening sockets for a VRF.
+ *
+ * Called when the last BFD session in a VRF is disabled, or when
+ * the VRF itself is disabled/deleted.
+ */
+void bfd_vrf_stop_sockets(struct bfd_vrf_global *bvrf)
+{
+	if (bglobal.debug_zebra)
+		zlog_debug("VRF stop sockets %s id %d", bvrf->vrf->name,
+			   bvrf->vrf->vrf_id);
+
+	/* Disable read/write poll triggering. */
+	event_cancel(&bvrf->bg_ev[0]);
+	event_cancel(&bvrf->bg_ev[1]);
+	event_cancel(&bvrf->bg_ev[2]);
+	event_cancel(&bvrf->bg_ev[3]);
+	event_cancel(&bvrf->bg_ev[4]);
+	event_cancel(&bvrf->bg_ev[5]);
+	event_cancel(&bvrf->bg_ev[6]);
+
+	/* Close all descriptors. */
+	socket_close(&bvrf->bg_echo);
+	socket_close(&bvrf->bg_shop);
+	socket_close(&bvrf->bg_mhop);
+	socket_close(&bvrf->bg_shop6);
+	socket_close(&bvrf->bg_mhop6);
+	socket_close(&bvrf->bg_echov6);
+	socket_close(&bvrf->bg_initv6);
 }

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -481,6 +481,12 @@ struct bfd_vrf_global {
 	struct vrf *vrf;
 
 	struct event *bg_ev[7];
+
+	/** Number of active BFD sessions using this VRF's sockets. */
+	int bg_session_count;
+
+	/** Number of SBFD reflectors using this VRF's sockets. */
+	int bg_reflector_count;
 };
 
 /* Forward declaration of data plane context struct. */
@@ -701,6 +707,8 @@ void bfd_initialize(void);
 void bfd_shutdown(void);
 void bfd_vrf_init(const char *context);
 void bfd_vrf_terminate(void);
+int bfd_vrf_start_sockets(struct bfd_vrf_global *bvrf);
+void bfd_vrf_stop_sockets(struct bfd_vrf_global *bvrf);
 struct bfd_vrf_global *bfd_vrf_look_by_session(struct bfd_session *bfd);
 struct bfd_session *bfd_id_lookup(uint32_t id);
 struct bfd_session *bfd_key_lookup(struct bfd_key *key);

--- a/tests/topotests/bfd_dynamic_sockets/r1/bfdd.conf
+++ b/tests/topotests/bfd_dynamic_sockets/r1/bfdd.conf
@@ -1,0 +1,4 @@
+!
+! No BFD peers configured at startup.
+! Peers will be added dynamically during the test.
+!

--- a/tests/topotests/bfd_dynamic_sockets/r1/zebra.conf
+++ b/tests/topotests/bfd_dynamic_sockets/r1/zebra.conf
@@ -1,0 +1,4 @@
+interface r1-eth0
+ ip address 192.168.0.1/24
+ ipv6 address 2001:db8::1/64
+!

--- a/tests/topotests/bfd_dynamic_sockets/r2/bfdd.conf
+++ b/tests/topotests/bfd_dynamic_sockets/r2/bfdd.conf
@@ -1,0 +1,4 @@
+!
+! No BFD peers configured at startup.
+! Peers will be added dynamically during the test.
+!

--- a/tests/topotests/bfd_dynamic_sockets/r2/zebra.conf
+++ b/tests/topotests/bfd_dynamic_sockets/r2/zebra.conf
@@ -1,0 +1,4 @@
+interface r2-eth0
+ ip address 192.168.0.2/24
+ ipv6 address 2001:db8::2/64
+!

--- a/tests/topotests/bfd_dynamic_sockets/test_bfd_dynamic_sockets.py
+++ b/tests/topotests/bfd_dynamic_sockets/test_bfd_dynamic_sockets.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bfd_dynamic_sockets.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2025 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_bfd_dynamic_sockets.py: Verify that BFD listening sockets are created
+dynamically when the first BFD session is configured and closed when the
+last session is removed.
+
+Topology:
+
+    +----+    +----+
+    | r1 |----| r2 |
+    +----+    +----+
+
+Both routers start with bfdd running but no BFD peers configured.
+The test verifies:
+ 1. No BFD sockets are open at startup (no sessions configured).
+ 2. Adding a BFD peer causes single-hop and multi-hop sockets to be created.
+ 3. The BFD session comes up successfully.
+ 4. Enabling echo mode causes echo sockets to be created.
+ 5. Adding a second peer in the same VRF does not change the sockets.
+ 6. Removing the BFD peer causes all sockets to be closed.
+ 7. Re-adding a peer with echo mode re-opens all socket types.
+"""
+
+import os
+import re
+import sys
+import time
+from functools import partial
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bfdd]
+
+# BFD well-known UDP ports
+BFD_SINGLE_HOP_PORT = 3784
+BFD_MULTI_HOP_PORT = 4784
+BFD_ECHO_PORT = 3785
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    topodef = {
+        "s1": ("r1", "r2"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BFD, os.path.join(CWD, "{}/bfdd.conf".format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def bfd_socket_count(router, port):
+    """Count the number of UDP sockets bound to the given port.
+
+    Runs 'ss -ulpn' inside the router namespace and counts occurrences
+    of the specified port in the output.
+    """
+    output = router.cmd("ss -ulpn sport = :{}".format(port))
+    logger.info("ss output for port %d on %s:\n%s", port, router.name, output)
+    # Count lines containing the port (skip the header line)
+    count = 0
+    for line in output.strip().splitlines():
+        if ":{}".format(port) in line:
+            count += 1
+    return count
+
+
+def get_socket_fds(router, port):
+    """Return the sorted list of fd numbers for BFD UDP sockets on the given port.
+
+    Parses 'ss -ulpn' output looking for entries like:
+        users:(("bfdd",pid=12345,fd=15))
+    and extracts the fd values.
+    """
+    output = router.cmd("ss -ulpn sport = :{}".format(port))
+    fds = []
+    for line in output.strip().splitlines():
+        if ":{}".format(port) not in line:
+            continue
+        match = re.search(r"fd=(\d+)", line)
+        if match:
+            fds.append(int(match.group(1)))
+    return sorted(fds)
+
+
+def check_all_sockets_closed(router):
+    """Check function for run_and_expect: returns None when all BFD sockets
+    (single-hop, multi-hop, and echo) are closed."""
+    shop = bfd_socket_count(router, BFD_SINGLE_HOP_PORT)
+    mhop = bfd_socket_count(router, BFD_MULTI_HOP_PORT)
+    echo = bfd_socket_count(router, BFD_ECHO_PORT)
+    if shop == 0 and mhop == 0 and echo == 0:
+        return None
+    return "single-hop={}, multi-hop={}, echo={}".format(shop, mhop, echo)
+
+
+def check_base_sockets_open(router):
+    """Check function for run_and_expect: returns None when single-hop and
+    multi-hop sockets are open."""
+    shop = bfd_socket_count(router, BFD_SINGLE_HOP_PORT)
+    mhop = bfd_socket_count(router, BFD_MULTI_HOP_PORT)
+    if shop > 0 and mhop > 0:
+        return None
+    return "single-hop={}, multi-hop={}".format(shop, mhop)
+
+
+def check_all_sockets_open(router):
+    """Check function for run_and_expect: returns None when single-hop,
+    multi-hop, and echo sockets are all open."""
+    shop = bfd_socket_count(router, BFD_SINGLE_HOP_PORT)
+    mhop = bfd_socket_count(router, BFD_MULTI_HOP_PORT)
+    echo = bfd_socket_count(router, BFD_ECHO_PORT)
+    if shop > 0 and mhop > 0 and echo > 0:
+        return None
+    return "single-hop={}, multi-hop={}, echo={}".format(shop, mhop, echo)
+
+
+def test_no_sockets_at_startup():
+    """Step 1: Assert no BFD sockets exist when no peers are configured."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking that no BFD listening sockets exist at startup")
+
+    for router in tgen.routers().values():
+        shop = bfd_socket_count(router, BFD_SINGLE_HOP_PORT)
+        mhop = bfd_socket_count(router, BFD_MULTI_HOP_PORT)
+        echo = bfd_socket_count(router, BFD_ECHO_PORT)
+        assertmsg = (
+            '"{}" should have no BFD sockets but found single-hop={}, '
+            "multi-hop={}, echo={}".format(router.name, shop, mhop, echo)
+        )
+        assert shop == 0 and mhop == 0 and echo == 0, assertmsg
+
+
+def test_sockets_created_on_peer_add():
+    """Step 2: Add a BFD peer and verify single-hop and multi-hop sockets
+    are dynamically created."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Adding BFD peer on r1 and r2")
+
+    # Configure BFD peer on r1 (no echo mode yet)
+    tgen.gears["r1"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.2
+  no shutdown
+ !
+!
+"""
+    )
+
+    # Configure BFD peer on r2 (no echo mode yet)
+    tgen.gears["r2"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.1
+  no shutdown
+ !
+!
+"""
+    )
+
+    logger.info("Verifying single-hop and multi-hop sockets are open on r1")
+    test_func = partial(check_base_sockets_open, tgen.gears["r1"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r1" BFD base sockets not created after adding peer'
+    assert result is None, assertmsg
+
+    logger.info("Verifying single-hop and multi-hop sockets are open on r2")
+    test_func = partial(check_base_sockets_open, tgen.gears["r2"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r2" BFD base sockets not created after adding peer'
+    assert result is None, assertmsg
+
+    # Echo sockets should NOT be open yet (echo mode not enabled)
+    echo_r1 = bfd_socket_count(tgen.gears["r1"], BFD_ECHO_PORT)
+    assertmsg = (
+        '"r1" should have no echo sockets without echo-mode but found {}'.format(
+            echo_r1
+        )
+    )
+    assert echo_r1 == 0, assertmsg
+
+
+def test_bfd_session_comes_up():
+    """Step 3: Verify the BFD session comes up between r1 and r2."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Waiting for BFD session to come up")
+
+    expected = [{"peer": "192.168.0.2", "status": "up"}]
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show bfd peers json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"r1" BFD session did not come up'
+    assert result is None, assertmsg
+
+
+def test_echo_sockets_created():
+    """Step 4: Enable echo mode and verify echo sockets are created."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Enabling echo-mode on r1 and r2")
+
+    tgen.gears["r1"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.2
+  echo-mode
+ !
+!
+"""
+    )
+
+    tgen.gears["r2"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.1
+  echo-mode
+ !
+!
+"""
+    )
+
+    logger.info("Verifying echo sockets are now open on r1")
+    test_func = partial(check_all_sockets_open, tgen.gears["r1"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r1" echo sockets not created after enabling echo-mode'
+    assert result is None, assertmsg
+
+    logger.info("Verifying echo sockets are now open on r2")
+    test_func = partial(check_all_sockets_open, tgen.gears["r2"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r2" echo sockets not created after enabling echo-mode'
+    assert result is None, assertmsg
+
+
+def test_sockets_unchanged_on_second_session():
+    """Step 5: Add a second BFD peer in the same VRF and verify the
+    listening socket file descriptors are not changed (sockets are reused,
+    not recreated)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Record current socket fds before adding the second peer.
+    shop_fds_before = get_socket_fds(r1, BFD_SINGLE_HOP_PORT)
+    mhop_fds_before = get_socket_fds(r1, BFD_MULTI_HOP_PORT)
+    echo_fds_before = get_socket_fds(r1, BFD_ECHO_PORT)
+
+    logger.info(
+        "Socket fds before second peer: shop=%s mhop=%s echo=%s",
+        shop_fds_before,
+        mhop_fds_before,
+        echo_fds_before,
+    )
+
+    # Add a second single-hop peer on r1 (peer address does not need to
+    # respond -- the session will stay down, but the session_count will
+    # increase and sockets must remain unchanged).
+    logger.info("Adding second BFD peer (192.168.0.3) on r1")
+    r1.vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.3
+  no shutdown
+ !
+!
+"""
+    )
+
+    # Give the daemon a moment to process.
+    time.sleep(1)
+
+    # Record socket fds after adding the second peer.
+    shop_fds_after = get_socket_fds(r1, BFD_SINGLE_HOP_PORT)
+    mhop_fds_after = get_socket_fds(r1, BFD_MULTI_HOP_PORT)
+    echo_fds_after = get_socket_fds(r1, BFD_ECHO_PORT)
+
+    logger.info(
+        "Socket fds after second peer: shop=%s mhop=%s echo=%s",
+        shop_fds_after,
+        mhop_fds_after,
+        echo_fds_after,
+    )
+
+    assertmsg = (
+        "Single-hop socket fds changed after adding second peer: "
+        "before={} after={}".format(shop_fds_before, shop_fds_after)
+    )
+    assert shop_fds_before == shop_fds_after, assertmsg
+
+    assertmsg = (
+        "Multi-hop socket fds changed after adding second peer: "
+        "before={} after={}".format(mhop_fds_before, mhop_fds_after)
+    )
+    assert mhop_fds_before == mhop_fds_after, assertmsg
+
+    assertmsg = (
+        "Echo socket fds changed after adding second peer: "
+        "before={} after={}".format(echo_fds_before, echo_fds_after)
+    )
+    assert echo_fds_before == echo_fds_after, assertmsg
+
+    # Now remove the second peer -- first peer is still active so sockets
+    # must stay open.
+    logger.info("Removing second BFD peer (192.168.0.3) on r1")
+    r1.vtysh_cmd(
+        """
+configure terminal
+bfd
+ no peer 192.168.0.3
+!
+"""
+    )
+
+    time.sleep(1)
+
+    # Sockets must still be open because the original peer remains.
+    shop_fds_final = get_socket_fds(r1, BFD_SINGLE_HOP_PORT)
+    mhop_fds_final = get_socket_fds(r1, BFD_MULTI_HOP_PORT)
+    echo_fds_final = get_socket_fds(r1, BFD_ECHO_PORT)
+
+    logger.info(
+        "Socket fds after removing second peer: shop=%s mhop=%s echo=%s",
+        shop_fds_final,
+        mhop_fds_final,
+        echo_fds_final,
+    )
+
+    assertmsg = (
+        "Sockets should still be open after removing second peer "
+        "(first peer still active): shop={} mhop={} echo={}".format(
+            shop_fds_final, mhop_fds_final, echo_fds_final
+        )
+    )
+    assert (
+        shop_fds_final == shop_fds_before
+        and mhop_fds_final == mhop_fds_before
+        and echo_fds_final == echo_fds_before
+    ), assertmsg
+
+
+def test_all_sockets_closed_on_peer_remove():
+    """Step 6: Remove the BFD peer and verify all sockets (single-hop,
+    multi-hop, and echo) are closed."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Removing BFD peer on r1 and r2")
+
+    tgen.gears["r1"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ no peer 192.168.0.2
+!
+"""
+    )
+
+    tgen.gears["r2"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ no peer 192.168.0.1
+!
+"""
+    )
+
+    logger.info("Verifying all BFD sockets are closed on r1")
+    test_func = partial(check_all_sockets_closed, tgen.gears["r1"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r1" BFD sockets still open after removing all peers'
+    assert result is None, assertmsg
+
+    logger.info("Verifying all BFD sockets are closed on r2")
+    test_func = partial(check_all_sockets_closed, tgen.gears["r2"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r2" BFD sockets still open after removing all peers'
+    assert result is None, assertmsg
+
+
+def test_all_sockets_reopen_on_new_peer():
+    """Step 7: Re-add a BFD peer with echo mode and verify all socket types
+    (single-hop, multi-hop, echo) re-open correctly."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Re-adding BFD peer with echo-mode on r1 and r2")
+
+    tgen.gears["r1"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.2
+  echo-mode
+  no shutdown
+ !
+!
+"""
+    )
+
+    tgen.gears["r2"].vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.1
+  echo-mode
+  no shutdown
+ !
+!
+"""
+    )
+
+    logger.info("Verifying all socket types re-open on r1")
+    test_func = partial(check_all_sockets_open, tgen.gears["r1"])
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assertmsg = '"r1" BFD sockets not re-created after adding peer with echo'
+    assert result is None, assertmsg
+
+    logger.info("Verifying BFD session comes up again")
+    expected = [{"peer": "192.168.0.2", "status": "up"}]
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show bfd peers json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"r1" BFD session did not come up on re-add'
+    assert result is None, assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
BFD currently allocates seven sockets per VRF regardless of whether BFD is configured in that VRF, leading to unnecessary socket consumption. To address this, we are switching to dynamic socket allocation to improve socket resource usage.