### PR TITLE
tests: Do not fail zebra_nhg_check if skipped is not 0 on initial

### DIFF
--- a/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
+++ b/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
@@ -302,8 +302,12 @@ def test_bgp_routes_on_r2():
             nhg_info = nhg_data.get(str(nhg_id), {})
             member_count = len(nhg_info.get("nexthops", []))
             logger.info(f"Nexthop group {nhg_id} has {member_count} members")
-            if (member_count != 128):
-                logger.info(net["r2"].cmd(f'vtysh -c "show nexthop-group rib {nhg_id}" -c "show bgp ipv4 uni" -c "show ip route 33.99.0.0 nexthop-group"'))
+            if member_count != 128:
+                logger.info(
+                    net["r2"].cmd(
+                        f'vtysh -c "show nexthop-group rib {nhg_id}" -c "show bgp ipv4 uni" -c "show ip route 33.99.0.0 nexthop-group"'
+                    )
+                )
             return member_count
         except (json.JSONDecodeError, KeyError) as e:
             logger.info(f"Error checking nexthop group members: {e}")
@@ -380,6 +384,7 @@ def test_bgp_shutdown_some_links():
     assert success, "BGP routes are not using the same nexthop group"
 
     step("Collect route update skips before link shutdown")
+
     def get_route_updates_skipped():
         output = net["r2"].cmd('vtysh -c "show zebra dplane detailed"')
         match = re.search(r"Route updates skipped:\s+(\d+)", output)
@@ -390,7 +395,7 @@ def test_bgp_shutdown_some_links():
 
     skipped_updates_before = get_route_updates_skipped()
     assert (
-        skipped_updates_before == 0
+        skipped_updates_before != -1
     ), "Could not retrieve route updates skipped before shutdown"
     logger.info(f"Route updates skipped before shutdown: {skipped_updates_before}")
 
@@ -469,6 +474,7 @@ def test_bgp_shutdown_some_links():
     assert success, "Nexthop group ID changed after interface shutdowns"
 
     step("Verify route update skips increased after shutdowns")
+
     def check_route_updates_skipped_increase():
         skipped_now = get_route_updates_skipped()
         if skipped_now < 0:


### PR DESCRIPTION
The test is looking for the number of routes skipped before it does a test that should cause routes to be skipped for installation. Unfortunately it is treating anything non-zero as a failure. Allow for non-zero values to be used as long as it is not -1 which indicates a failure.