### PR TITLE
tools: Add ldp commands to support bundle generation

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -86,7 +86,6 @@ show nexthop-group rib
 show route-map
 show mpls table
 show mpls fec
-show mpls ldp
 show mpls pseudowires
 show zebra dplane detailed
 show zebra dplane provider
@@ -117,6 +116,17 @@ rule show
 nexthop show
 -family mpls route
 CMD_LIST_IP_END
+
+# LDP Support Bundle Command List
+PROC_NAME:ldp
+CMD_LIST_START
+show mpls ldp binding detail
+show mpls ldp capabilities
+show mpls ldp discovery detail
+show mpls ldp igp-sync
+show mpls ldp interface
+show mpls ldp neighbor detail
+CMD_LIST_END
 
 # OSPF Support Bundle Command List
 PROC_NAME:ospf


### PR DESCRIPTION
When LDP goes belly up there is no gathering of data around what is going on there.  Let's start with some basic commands to gather data.