### PR TITLE
zebra: add 'show evpn es-peer' command for EVPN-MH peer VTEP list

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2980,6 +2980,20 @@ DEFPY(show_evpn_es,
 	return CMD_SUCCESS;
 }
 
+DEFPY(show_evpn_es_peer, show_evpn_es_peer_cmd,
+      "show evpn es-peer [json$json]",
+      SHOW_STR
+      "EVPN\n"
+      "Ethernet Segment peer\n"
+      JSON_STR)
+{
+	bool uj = !!json;
+
+	zebra_evpn_mh_vtep_show(vty, uj);
+
+	return CMD_SUCCESS;
+}
+
 DEFPY(show_evpn_es_evi,
       show_evpn_es_evi_cmd,
       "show evpn es-evi [vni (1-16777215)$vni] [detail$detail] [json$json]",
@@ -4464,6 +4478,7 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_evpn_vni_vni_cmd);
 	install_element(VIEW_NODE, &show_evpn_l2_nh_cmd);
 	install_element(VIEW_NODE, &show_evpn_es_cmd);
+	install_element(VIEW_NODE, &show_evpn_es_peer_cmd);
 	install_element(VIEW_NODE, &show_evpn_es_evi_cmd);
 	install_element(VIEW_NODE, &show_evpn_access_vlan_cmd);
 	install_element(VIEW_NODE, &show_evpn_rmac_vni_mac_cmd);


### PR DESCRIPTION
In an EVPN multihoming topology with ESI bonds, there was no way to view the aggregated list of peer VTEPs participating in local Ethernet Segments, along with the ES count and SPH (Split-Horizon Preference) offset. This made debugging EVPN-MH peering and split-horizon filtering difficult.

Fix:
Add the 'show evpn es-peer [json]' command in zebra to display peer VTEPs on local Ethernet Segments:
- Introduce struct zebra_evpn_mh_vtep and a global mh_vtep_list with sph_id_bitmap to aggregate peer VTEPs across local ESs.
- Add zebra_evpn_es_vtep_local_set/local_clear helpers to link each es_vtep to its parent mh_vtep when the ES becomes local; tracked via ZEBRA_EVPNES_VTEP_LOCAL flag.
- Register "show evpn es-peer [json]" in zebra_vty.

Output:
torm-11# show evpn es-peer
VTEP                                    #ES        SPH offset
27.0.0.4                                3          1
27.0.0.5                                3          2
torm-11#
torm-11# show evpn es-peer json
[
  {
    "vtepIp":"27.0.0.4",
    "esCount":3,
    "sphOffset":1
  },
  {
    "vtepIp":"27.0.0.5",
    "esCount":3,
    "sphOffset":2
  }
]