### PR TITLE
yang: Revision statements are not given in reverse chronological order

### DIFF
--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -57,17 +57,20 @@ module frr-nexthop {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2026-01-23 {
+    description
+      "Add support for 16-bit weights.";
+
+    reference
+      "FRRouting";
+  }
+
   revision 2019-08-15 {
     description
       "Initial revision.";
 
     reference
       "FRRouting";
-  }
-
-  revision 2026-01-23 {
-    description
-      "Add support for 16-bit weights.";
   }
 
   typedef optional-ip-address {


### PR DESCRIPTION
Revision statements are not given in reverse chronological order

frr-nexthop.yang:68: warning: the revision statements are not given in reverse chronological order
frr-nexthop.yang:68: error: RFC 8407: 4.8: statement "revision" must have a "reference" sub statement