### PR TITLE
pimd: When address change ensure DR changes too.

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -274,8 +274,11 @@ static void pim_addr_change(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	pim_if_dr_election(ifp); /* router's own DR Priority (addr) changes --
-				    Done TODO T30 */
+	pim_if_dr_election(ifp);
+
+	if (!pim_ifp->pim_enable)
+		return;
+
 	pim_if_update_join_desired(pim_ifp); /* depends on DR */
 	pim_if_update_could_assert(ifp);     /* depends on DR */
 	pim_if_update_my_assert_metric(ifp); /* depends on could_assert */
@@ -471,13 +474,8 @@ static void detect_address_change(struct interface *ifp, int force_prim_as_any,
 	}
 
 
-	if (changed) {
-		if (!pim_ifp->pim_enable) {
-			return;
-		}
-
+	if (changed)
 		pim_addr_change(ifp);
-	}
 
 	/* XXX: if we have unnumbered interfaces we need to run detect address
 	 * address change on all of them when the lo address changes */


### PR DESCRIPTION
When pim is coming up without any ip addresses on interfaces yet, and pim_sock_reset is called, the pim primary address is being set to the loopbacks ip address, additionally it is resetting the DR to that address.  When an address is finally set on the interface, pim is recognizing the address but it is not recognizing the fact that the DR should change as well when pim has not been enabled yet.

Modify the code to always reset the DR when the interfaces address has been changed even if pim has not been enabled yet.