### PR TITLE
ospf6d: recalculate AS-external routes on non-external RIB updates

### DIFF
--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -100,6 +100,7 @@ extern void ospf6_asbr_lsentry_add(struct ospf6_route *asbr_entry,
 				   struct ospf6 *ospf6);
 extern void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry,
 				      struct ospf6 *ospf6);
+extern void ospf6_asbr_recalculate_external_routes(struct ospf6 *ospf6);
 
 extern int ospf6_asbr_is_asbr(struct ospf6 *o);
 extern void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,


### PR DESCRIPTION
In the test_ospf6_point_to_multipoint.py topotest, intermittant failures showed that r2 was receiving AS-External LSAs for fc00:3333::/64 and fc00:4444::/64 but was still failing to install corresponding E2 routes before timeout of the test. The LSAs and forwarding-address reachability were present, indicating stale external route evaluation rather than adjacency/LSDB loss.

Fix this by adding explicit AS-external route recomputation when global non-external routes are added or removed (ospf6_top_route_hook_add/remove). This forces re-evaluation of Type-5 routes when forwarding-address reachability changes and keeps OSPF6 external installation synchronized with current topology. Add ospf6_asbr_recalculate_external_routes() in ospf6_asbr.c.