### PR TITLE
zebra: add json support for svd vxlan type

### DIFF
--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE1/show_intf_vxlan0.json
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE1/show_intf_vxlan0.json
@@ -1,0 +1,21 @@
+{
+  "vxlan0": {
+    "interfaceType": "Vxlan",
+    "vtepIp": "10.10.10.10",
+    "masterInterface": "bridge",
+    "vxlanId": {
+      "101": {
+        "accessVlanId": 1,
+        "mcastGroup": "0.0.0.0"
+      },
+      "100": {
+        "accessVlanId": 100,
+        "mcastGroup": "0.0.0.0"
+      },
+      "4000": {
+        "accessVlanId": 400,
+        "mcastGroup": "0.0.0.0"
+      }
+    }
+  }
+}

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -322,6 +322,64 @@ def test_pe2_converge_evpn():
     assert result is None, assertmsg
 
 
+def show_interface_vxlan0_json(pe, expected):
+    output_json = pe.vtysh_cmd("show interface vxlan0 json", isjson=True)
+    return topotest.json_cmp(output_json, expected)
+
+
+def test_svd_vxlan_interface_json():
+    "Verify SVD vxlan0 JSON output on PE1 contains vxlanId with per-VNI entries"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+    json_file = "{}/{}/show_intf_vxlan0.json".format(CWD, pe1.name)
+    expected = json.loads(open(json_file).read())
+
+    test_func = partial(show_interface_vxlan0_json, pe1, expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    output_json = pe1.vtysh_cmd("show interface vxlan0 json", isjson=True)
+    logger.info(
+        "PE1 show interface vxlan0 json:\n%s", json.dumps(output_json, indent=2)
+    )
+
+    assertmsg = '"{}" show interface vxlan0 json output mismatch'.format(pe1.name)
+    assert result is None, assertmsg
+
+
+def test_svd_vxlan_interface_vty():
+    "Verify SVD vxlan0 VTY output on PE1 shows VTEP IP and per-VNI info"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+    output = pe1.vtysh_cmd("show interface vxlan0")
+    logger.info("PE1 show interface vxlan0:\n%s", output)
+
+    expected_strings = [
+        "VTEP IP: 10.10.10.10",
+        "VxLAN Id 101",
+        "Access VLAN Id 1",
+        "VxLAN Id 100",
+        "Access VLAN Id 100",
+        "VxLAN Id 4000",
+        "Access VLAN Id 400",
+        "Master interface: bridge",
+    ]
+
+    for s in expected_strings:
+        assert (
+            s in output
+        ), '"{}" show interface vxlan0 missing "{}"\nFull output:\n{}'.format(
+            pe1.name, s, output
+        )
+
+
 def test_learning_pe1():
     "test MAC learning on PE1"
 

--- a/tests/topotests/bgp_evpn_vxlan_topo1/PE1/show_intf_vxlan101.json
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/PE1/show_intf_vxlan101.json
@@ -1,0 +1,12 @@
+{
+  "vxlan101": {
+    "interfaceType": "Vxlan",
+    "vtepIp": "10.10.10.10",
+    "masterInterface": "br101",
+    "vxlanId": {
+      "101": {
+        "mcastGroup": "0.0.0.0"
+      }
+    }
+  }
+}

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -633,6 +633,59 @@ def test_evpn_l3vni_vlan_bridge():
         assert "Type: L3" in output, assertmsg
 
 
+def show_interface_vxlan101_json(pe, expected):
+    output_json = pe.vtysh_cmd("show interface vxlan101 json", isjson=True)
+    return topotest.json_cmp(output_json, expected)
+
+
+def test_tvd_vxlan_interface_json():
+    "Verify TVD vxlan101 JSON output on PE1 contains vxlanId with single VNI entry"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+    json_file = "{}/{}/show_intf_vxlan101.json".format(CWD, pe1.name)
+    expected = json.loads(open(json_file).read())
+
+    test_func = partial(show_interface_vxlan101_json, pe1, expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    output_json = pe1.vtysh_cmd("show interface vxlan101 json", isjson=True)
+    logger.info(
+        "PE1 show interface vxlan101 json:\n%s", json.dumps(output_json, indent=2)
+    )
+
+    assertmsg = '"{}" show interface vxlan101 json output mismatch'.format(pe1.name)
+    assert result is None, assertmsg
+
+
+def test_tvd_vxlan_interface_vty():
+    "Verify TVD vxlan101 VTY output on PE1 shows VTEP IP and VNI info"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+    output = pe1.vtysh_cmd("show interface vxlan101")
+    logger.info("PE1 show interface vxlan101:\n%s", output)
+
+    expected_strings = [
+        "VTEP IP: 10.10.10.10",
+        "VxLAN Id 101",
+        "Master interface: br101",
+    ]
+
+    for s in expected_strings:
+        assert (
+            s in output
+        ), '"{}" show interface vxlan101 missing "{}"\nFull output:\n{}'.format(
+            pe1.name, s, output
+        )
+
+
 def test_imet():
     """
     Verify PMSI tunnel attribute info

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2710,30 +2710,42 @@ static inline bool if_is_protodown_applicable(struct interface *ifp)
 	return true;
 }
 
-static void zebra_vxlan_if_vni_dump_vty(struct vty *vty,
+struct zebra_vxlan_vni_dump_ctx {
+	struct vty *vty;
+	json_object *json_if;
+};
+
+static void zebra_vxlan_if_vni_dump_vty(struct vty *vty, json_object *json_if,
 					struct zebra_vxlan_vni *vni)
 {
-	char str[INET6_ADDRSTRLEN];
+	json_object *json_vni;
+	char vni_str[VNI_STR_LEN];
 
-	vty_out(vty, "\n  VxLAN Id %u", vni->vni);
-	if (vni->access_vlan)
-		vty_out(vty, " Access VLAN Id %u\n", vni->access_vlan);
+	if (vty) {
+		vty_out(vty, "\n  VxLAN Id %u", vni->vni);
+		if (vni->access_vlan)
+			vty_out(vty, " Access VLAN Id %u", vni->access_vlan);
 
-	if (vni->mcast_grp.s_addr != INADDR_ANY)
-		vty_out(vty, "  Mcast Group %s",
-			inet_ntop(AF_INET, &vni->mcast_grp, str, sizeof(str)));
+		if (vni->mcast_grp.s_addr != INADDR_ANY)
+			vty_out(vty, "\n  Mcast Group %pI4", &vni->mcast_grp);
+	} else if (json_if) {
+		json_vni = json_object_new_object();
+		snprintf(vni_str, sizeof(vni_str), "%u", vni->vni);
+		if (vni->access_vlan)
+			json_object_int_add(json_vni, "accessVlanId", vni->access_vlan);
+		json_object_string_addf(json_vni, "mcastGroup", "%pI4", &vni->mcast_grp);
+		json_object_object_add(json_if, vni_str, json_vni);
+	}
 }
 
 static void zebra_vxlan_if_vni_hash_dump_vty(struct hash_bucket *bucket,
 					     void *ctxt)
 {
-	struct vty *vty;
+	struct zebra_vxlan_vni_dump_ctx *ctx = ctxt;
 	struct zebra_vxlan_vni *vni;
 
 	vni = (struct zebra_vxlan_vni *)bucket->data;
-	vty = (struct vty *)ctxt;
-
-	zebra_vxlan_if_vni_dump_vty(vty, vni);
+	zebra_vxlan_if_vni_dump_vty(ctx->vty, ctx->json_if, vni);
 }
 
 static void zebra_vxlan_if_dump_vty(struct vty *vty, struct zebra_if *zebra_if)
@@ -2758,10 +2770,11 @@ static void zebra_vxlan_if_dump_vty(struct vty *vty, struct zebra_if *zebra_if)
 	}
 
 	if (IS_ZEBRA_VXLAN_IF_VNI(zebra_if)) {
-		zebra_vxlan_if_vni_dump_vty(vty, &vni_info->vni);
+		zebra_vxlan_if_vni_dump_vty(vty, NULL, &vni_info->vni);
 	} else {
-		hash_iterate(vni_info->vni_table,
-			     zebra_vxlan_if_vni_hash_dump_vty, vty);
+		struct zebra_vxlan_vni_dump_ctx ctx = { .vty = vty };
+
+		hash_iterate(vni_info->vni_table, zebra_vxlan_if_vni_hash_dump_vty, &ctx);
 	}
 
 	vty_out(vty, "\n");
@@ -3082,41 +3095,6 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 #endif /* HAVE_NET_RT_IFLIST */
 }
 
-/*
- * Create hierarchical JSON structure for VNI information
- * This creates a nested object keyed by VNI ID to support both:
- * - TVD (Traditional VxLAN Device): single VLAN-to-VNI mapping
- * - SVD (Single VxLAN Device): multiple VLAN-to-VNI mappings
- * The VNI ID is used as the key, allowing multiple VNI entries
- * to coexist under the "vxlanId" parent object.
- */
-static void zebra_vxlan_if_vni_dump_vty_json(json_object *json_if,
-					     struct zebra_vxlan_vni *vni)
-{
-	json_object *json_vni;
-	char vni_str[VNI_STR_LEN];
-
-	json_vni = json_object_new_object();
-	snprintf(vni_str, sizeof(vni_str), "%u", vni->vni);
-	if (vni->access_vlan)
-		json_object_int_add(json_vni, "accessVlanId", vni->access_vlan);
-	if (vni->mcast_grp.s_addr != INADDR_ANY)
-		json_object_string_addf(json_vni, "mcastGroup", "%pI4", &vni->mcast_grp);
-	json_object_object_add(json_if, vni_str, json_vni);
-}
-
-static void zebra_vxlan_if_vni_hash_dump_vty_json(struct hash_bucket *bucket,
-						  void *ctxt)
-{
-	json_object *json_if;
-	struct zebra_vxlan_vni *vni;
-
-	vni = (struct zebra_vxlan_vni *)bucket->data;
-	json_if = (json_object *)ctxt;
-
-	zebra_vxlan_if_vni_dump_vty_json(json_if, vni);
-}
-
 static void zebra_vxlan_if_dump_vty_json(json_object *json_if,
 					 struct zebra_if *zebra_if)
 {
@@ -3141,10 +3119,13 @@ static void zebra_vxlan_if_dump_vty_json(json_object *json_if,
 	}
 
 	json_vnis = json_object_new_object();
-	if (IS_ZEBRA_VXLAN_IF_VNI(zebra_if))
-		zebra_vxlan_if_vni_dump_vty_json(json_vnis, &vni_info->vni);
-	else
-		hash_iterate(vni_info->vni_table, zebra_vxlan_if_vni_hash_dump_vty_json, json_vnis);
+	if (IS_ZEBRA_VXLAN_IF_VNI(zebra_if)) {
+		zebra_vxlan_if_vni_dump_vty(NULL, json_vnis, &vni_info->vni);
+	} else {
+		struct zebra_vxlan_vni_dump_ctx ctx = { .json_if = json_vnis };
+
+		hash_iterate(vni_info->vni_table, zebra_vxlan_if_vni_hash_dump_vty, &ctx);
+	}
 
 	json_object_object_add(json_if, "vxlanId", json_vnis);
 }
@@ -3292,7 +3273,6 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 		json_object_int_add(json_if, "vlanId", vlan_info->vid);
 	} else if (IS_ZEBRA_IF_VXLAN(ifp)) {
 		zebra_vxlan_if_dump_vty_json(json_if, zebra_if);
-
 	} else if (IS_ZEBRA_IF_GRE(ifp) || IS_ZEBRA_IF_GRETAP(ifp) || IS_ZEBRA_IF_IP6GRE(ifp) ||
 		   IS_ZEBRA_IF_IP6GRETAP(ifp)) {
 		struct zebra_l2info_gre *gre_info;


### PR DESCRIPTION
Reorganize common vlxan dump api to handle
both screen rending and json data object.

Testing Done:

    "interfaceType":"Vxlan",
    "vtepIp":"27.0.0.16",
    "vxlanId":{
      "1006":{
        "accessVlan":1006,
        "mcastGroup":"239.1.1.106"
      }
    },
    "linkInterface":"ipmr-lo",
    "masterInterface":"bridge",

SVD interface output:

    "interfaceType":"Vxlan",
    "vtepIp":"27.0.0.16",
    "vxlanId":{
      "1005":{
        "accessVlan":1005,
        "mcastGroup":"0.0.0.0"
      },
      "1001":{
        "accessVlan":1001,
        "mcastGroup":"0.0.0.0"
      },
      "4001":{
        "accessVlan":4001,
        "mcastGroup":"0.0.0.0"
      },
      "1003":{
        "accessVlan":1003,
        "mcastGroup":"0.0.0.0"
      },
      "1007":{
        "accessVlan":1007,
        "mcastGroup":"0.0.0.0"
      }
    },
    "masterInterface":"bridge",