### PR TITLE
zebra: fix memlink in json rmac command

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2815,9 +2815,6 @@ void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 	struct zebra_mac *zrmac = NULL;
 	json_object *json = NULL;
 
-	if (use_json)
-		json = json_object_new_object();
-
 	if (!is_evpn_enabled()) {
 		if (use_json)
 			vty_json_empty(vty, json);
@@ -2843,6 +2840,9 @@ void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 				l3vni);
 		return;
 	}
+
+	if (use_json)
+		json = json_object_new_object();
 
 	zl3vni_print_rmac(zrmac, vty, json);
 


### PR DESCRIPTION
Fix memlink in json rmac command when the rmac
does not exist.