### PR TITLE
tests: Allow for different bestpaths to be generated.

### DIFF
--- a/tests/topotests/bgp_default_route_route_map_set/test_bgp_default-originate_route-map_set.py
+++ b/tests/topotests/bgp_default_route_route_map_set/test_bgp_default-originate_route-map_set.py
@@ -66,14 +66,11 @@ def test_bgp_default_originate_route_map():
     r2 = tgen.gears["r2"]
     r3 = tgen.gears["r3"]
 
-    def _bgp_converge(router, pfxCount):
+    def _bgp_converge(router):
         output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
         expected = {
             "192.168.255.1": {
                 "bgpState": "Established",
-                "addressFamilyInfo": {
-                    "ipv4Unicast": {"acceptedPrefixCounter": pfxCount}
-                },
             }
         }
         return topotest.json_cmp(output, expected)
@@ -85,7 +82,7 @@ def test_bgp_default_originate_route_map():
         }
         return topotest.json_cmp(output, expected)
 
-    test_func = functools.partial(_bgp_converge, r2, 1)
+    test_func = functools.partial(_bgp_converge, r2)
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Failed to see bgp convergence in r2"
 
@@ -93,7 +90,7 @@ def test_bgp_default_originate_route_map():
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Failed to see applied metric for default route in r2"
 
-    test_func = functools.partial(_bgp_converge, r3, 2)
+    test_func = functools.partial(_bgp_converge, r3)
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Failed to see bgp convergence in r3"
 


### PR DESCRIPTION
r1 is connected to both r2 and r3.  r2 is generating a 192.168.255.0/24 prefix and r3 is generating it as well. If the prefix is received on r1 from r3 first it is choosen as best-path.  If it is received from r2 first it is choosen as best-path.  In the former case r2 is going to see the path for 192.168.255.0/24 from r3 - r1 as a second path for the prefix, while in the later case the bestpath returned is going to have the as path of r2 in it's path and it will be rejected.  Relax the test to not care about the prefixes as that there is very little that can be done about startup timings.