### PR TITLE
tests: Convert lots of places to use run_and_expect

### DIFF
--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -311,9 +311,13 @@ def test_router_check_ip():
             }
         ]
     }
-    result = topotest.router_json_cmp(
-        tgen.gears["r1"], "show ipv6 route vrf vrf-101 fd01::2/128 json", expected
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show ipv6 route vrf vrf-101 fd01::2/128 json",
+        expected,
     )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "ipv6 route check failed"
 
 
@@ -385,13 +389,17 @@ def _test_router_check_evpn_contexts(router, ipv4_only=False, ipv6_only=False):
                 },
             }
         }
-    result = topotest.router_json_cmp(
-        router, "show evpn next-hops vni all json", expected
+    test_func = partial(
+        topotest.router_json_cmp, router, "show evpn next-hops vni all json", expected
     )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "evpn next-hops check failed"
 
     expected = {"101": {"numRmacs": 1}}
-    result = topotest.router_json_cmp(router, "show evpn rmac vni all json", expected)
+    test_func = partial(
+        topotest.router_json_cmp, router, "show evpn rmac vni all json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "evpn rmac number check failed"
 
 
@@ -993,7 +1001,8 @@ def _validate_evpn_rmacs(router, expected):
                     # Compare VTEP IPs - a forgiving comparison
                     if detail["vtepIp"].find(jvni[rmac]["vtepIp"]) < 0:
                         return "VTEP {} failed, not found in VNI {}".format(
-                            detail["vtepIp"], vni)
+                            detail["vtepIp"], vni
+                        )
             if vtep_ip in vtep_ips:
                 # VTEP IP is occuring for more than one RMAC in the same VNI
                 return "Duplicate VTEP IP {} found in VNI {}".format(vtep_ip, vni)

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
@@ -306,9 +306,13 @@ def test_router_check_ip():
             }
         ]
     }
-    result = topotest.router_json_cmp(
-        tgen.gears["r1"], "show ipv6 route vrf r1-vrf-101 fd00::2/128 json", expected
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show ipv6 route vrf r1-vrf-101 fd00::2/128 json",
+        expected,
     )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "ipv6 route check failed"
 
 
@@ -325,13 +329,17 @@ def _test_router_check_evpn_contexts(router):
         }
     }
 
-    result = topotest.router_json_cmp(
-        router, "show evpn next-hops vni all json", expected
+    test_func = partial(
+        topotest.router_json_cmp, router, "show evpn next-hops vni all json", expected
     )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "evpn next-hops check failed"
 
     expected = {"101": {"numRmacs": 1}}
-    result = topotest.router_json_cmp(router, "show evpn rmac vni all json", expected)
+    test_func = partial(
+        topotest.router_json_cmp, router, "show evpn rmac vni all json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "evpn rmac number check failed"
 
 

--- a/tests/topotests/bgp_l3vpn_label_export/test_bgp_l3vpn_label_export.py
+++ b/tests/topotests/bgp_l3vpn_label_export/test_bgp_l3vpn_label_export.py
@@ -186,6 +186,26 @@ def check_mpls_ldp_binding():
     return topotest.json_cmp(output, expected)
 
 
+def check_label_table_state(ldp_regex=None, bgp_present=None, required_lines=None):
+    tgen = get_topogen()
+    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
+
+    if ldp_regex and not re.search(ldp_regex, output):
+        return "LDP label chunk state mismatch"
+
+    if bgp_present is True and "Proto bgp: " not in output:
+        return "Failed to see BGP label chunk"
+    if bgp_present is False and "Proto bgp: " in output:
+        return "Unexpected BGP label chunk"
+
+    if required_lines:
+        for line in required_lines:
+            if line not in output:
+                return "Missing expected label chunk: {}".format(line)
+
+    return None
+
+
 def test_convergence():
     "Test protocol convergence"
 
@@ -211,13 +231,13 @@ def test_convergence():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed to see BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: [2222/2222]" in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        required_lines=["Proto bgp: [2222/2222]"],
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_export_16():
@@ -252,13 +272,13 @@ def test_vpn_label_export_16():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Unexpected BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp" not in output, "Unexpected BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        bgp_present=False,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_export_2222():
@@ -293,13 +313,13 @@ def test_vpn_label_export_2222():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Unexpected BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: [2222/2222]" in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        required_lines=["Proto bgp: [2222/2222]"],
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_export_auto():
@@ -334,13 +354,13 @@ def test_vpn_label_export_auto():
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
     assert result is None, "Failed to see BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        bgp_present=True,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_export_no_auto():
@@ -382,13 +402,13 @@ def test_vpn_label_export_no_auto():
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
     assert result is None, "Unexpected BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " not in output, "Unexpected BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        bgp_present=False,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_export_auto_back():
@@ -427,13 +447,13 @@ def test_vpn_label_export_auto_back():
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
     assert result is None, "Failed to see BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        bgp_present=True,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_export_manual_from_auto():
@@ -479,13 +499,13 @@ def test_vpn_label_export_manual_from_auto():
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
     assert result is None, "Failed to see BGP label on R2"
 
-    output = tgen.net["r2"].cmd("vtysh -c 'show debugging label-table' | grep Proto")
-    assert re.match(
-        r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]", output
-    ), "Failed to see LDP label chunk"
-
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(
+        check_label_table_state,
+        ldp_regex=r"Proto ldp: \[16/(1[7-9]|[2-9]\d+|\d{3,})\]",
+        bgp_present=True,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 def test_vpn_label_configure_dynamic_range():
@@ -511,8 +531,9 @@ def test_vpn_label_configure_dynamic_range():
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
     assert result is None, "Unexpected BGP label on R2"
 
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(check_label_table_state, bgp_present=True)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify debug label-table state"
 
 
 if __name__ == "__main__":
@@ -533,8 +554,14 @@ def test_vpn_label_restart_ldp():
     step("Kill LDP on R2")
     kill_router_daemons(tgen, "r2", ["ldpd"])
 
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto ldp: " not in output, "Unexpected LDP label chunk"
+    _, result = topotest.run_and_expect(
+        lambda: "Proto ldp: "
+        not in tgen.gears["r2"].vtysh_cmd("show debugging label-table"),
+        True,
+        count=60,
+        wait=0.5,
+    )
+    assert result is True, "Unexpected LDP label chunk"
 
     step("Bring up LDP on R2")
 
@@ -544,9 +571,12 @@ def test_vpn_label_restart_ldp():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed to see LDP label on R2"
 
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto ldp: [628/691]" in output, "Failed to see LDP label chunk [628/691]"
-    assert "Proto ldp: [692/755]" in output, "Failed to see LDP label chunk [692/755]"
+    test_func = functools.partial(
+        check_label_table_state,
+        required_lines=["Proto ldp: [628/691]", "Proto ldp: [692/755]"],
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to verify LDP label chunk ranges"
 
 
 def test_vpn_label_unconfigure_dynamic_range():
@@ -565,8 +595,9 @@ def test_vpn_label_unconfigure_dynamic_range():
         "no label vpn export auto"
     )
 
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " not in output, "Unexpected BGP label chunk"
+    test_func = functools.partial(check_label_table_state, bgp_present=False)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Unexpected BGP label chunk"
 
     tgen.gears["r2"].vtysh_cmd(
         "conf\n"
@@ -583,5 +614,6 @@ def test_vpn_label_unconfigure_dynamic_range():
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
     assert result is None, "Unexpected BGP label on R2"
 
-    output = tgen.gears["r2"].vtysh_cmd("show debugging label-table")
-    assert "Proto bgp: " in output, "Failed to see BGP label chunk"
+    test_func = functools.partial(check_label_table_state, bgp_present=True)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to see BGP label chunk"

--- a/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
@@ -15,6 +15,7 @@ test_bgp_snmp_mplsl3vpn.py: Test mplsL3Vpn MIB [RFC4382].
 import os
 import sys
 from time import sleep
+from functools import partial
 import pytest
 
 # Save the Current Working Directory to find configuration files.
@@ -239,17 +240,13 @@ def test_pe1_converge_evpn():
     assert result, assertmsg
 
     r1_snmp = SnmpTester(r1, "10.1.1.1", "public", "2c")
-    count = 0
-    passed = False
-    while count < 125:
-        if r1_snmp.test_oid_walk("bgpPeerLocalAddr.10.4.4.4", ["10.1.1.1"]):
-            passed = True
-            break
-        count += 1
-        sleep(1)
-    # tgen.mininet_cli()
+
+    def _peer_local_addr_ready():
+        return r1_snmp.test_oid_walk("bgpPeerLocalAddr.10.4.4.4", ["10.1.1.1"])
+
+    _, result = topotest.run_and_expect(_peer_local_addr_ready, True, count=125, wait=1)
     assertmsg = "BGP Peer 10.4.4.4 did not connect"
-    assert passed, assertmsg
+    assert result is True, assertmsg
 
 
 interfaces_up_test = {
@@ -295,20 +292,24 @@ def test_r1_mplsvpn_scalars_interface():
     r1.vtysh_cmd("conf t\ninterface r1-eth3\nshutdown")
     r1.vtysh_cmd("conf t\ninterface r1-eth4\nshutdown")
 
-    for item in interfaces_up_test.keys():
-        assertmsg = "{} should be {}: value {}".format(
-            item, interfaces_down_test[item], r1_snmp.get_next(item)
-        )
-        assert r1_snmp.test_oid(item, interfaces_down_test[item]), assertmsg
+    def _check_scalars(expected):
+        for item in interfaces_up_test.keys():
+            if not r1_snmp.test_oid(item, expected[item]):
+                return False
+        return True
+
+    _, result = topotest.run_and_expect(
+        partial(_check_scalars, interfaces_down_test), True, count=30, wait=1
+    )
+    assert result is True, "MPLS L3VPN scalar values did not converge after shutdown"
 
     r1.vtysh_cmd("conf t\ninterface r1-eth3\nno shutdown")
     r1.vtysh_cmd("conf t\ninterface r1-eth4\nno shutdown")
 
-    for item in interfaces_up_test.keys():
-        assertmsg = "{} should be {}: value {}".format(
-            item, interfaces_up_test[item], r1_snmp.get_next(item)
-        )
-        assert r1_snmp.test_oid(item, interfaces_up_test[item]), assertmsg
+    _, result = topotest.run_and_expect(
+        partial(_check_scalars, interfaces_up_test), True, count=30, wait=1
+    )
+    assert result is True, "MPLS L3VPN scalar values did not converge after no shutdown"
 
 
 def router_interface_get_ifindex(router, interface):
@@ -381,11 +382,16 @@ def test_r1_mplsvpn_IfTable():
     # an inactive vrf should not affect these values
     r1.cmd("ip link set r1-eth5 down")
 
-    for item in iftable_up_test.keys():
-        assertmsg = "{} should be {} oids {} full dict {}:".format(
-            item, iftable_up_test[item], oids, r1_snmp.walk(item)
-        )
-        assert r1_snmp.test_oid_walk(item, iftable_up_test[item], oids), assertmsg
+    def _check_iftable(expected):
+        for item in expected.keys():
+            if not r1_snmp.test_oid_walk(item, expected[item], oids):
+                return False
+        return True
+
+    _, result = topotest.run_and_expect(
+        partial(_check_iftable, iftable_up_test), True, count=30, wait=1
+    )
+    assert result is True, "mplsL3VpnIf table did not converge after link down"
 
     r1.cmd("ip link set r1-eth5 up")
 
@@ -452,20 +458,26 @@ def test_r1_mplsvpn_VrfTable():
     )
     ts_val_last_1 = get_timetick_val(ts_last)
     r1.vtysh_cmd("conf t\ninterface r1-eth3\nshutdown")
-    active_int = r1_snmp.get(
-        "mplsL3VpnVrfActiveInterfaces.{}".format(snmp_str_to_oid("VRF-a"))
-    )
-    assertmsg = "mplsL3VpnVrfActiveInterfaces incorrect should be 1 value {}".format(
-        active_int
-    )
-    assert active_int == "1", assertmsg
 
-    ts_last = r1_snmp.get(
-        "mplsL3VpnVrfConfLastChanged.{}".format(snmp_str_to_oid("VRF-a"))
+    def _check_vrf_active_and_last_changed(last_changed_before):
+        active_int = r1_snmp.get(
+            "mplsL3VpnVrfActiveInterfaces.{}".format(snmp_str_to_oid("VRF-a"))
+        )
+        ts_last = r1_snmp.get(
+            "mplsL3VpnVrfConfLastChanged.{}".format(snmp_str_to_oid("VRF-a"))
+        )
+        ts_val_last = get_timetick_val(ts_last)
+        return active_int == "1" and ts_val_last > last_changed_before
+
+    _, result = topotest.run_and_expect(
+        partial(_check_vrf_active_and_last_changed, ts_val_last_1),
+        True,
+        count=30,
+        wait=1,
     )
-    ts_val_last_2 = get_timetick_val(ts_last)
-    assertmsg = "mplsL3VpnVrfConfLastChanged does not update on interface change"
-    assert ts_val_last_2 > ts_val_last_1, assertmsg
+    assert (
+        result is True
+    ), "VRF active interface/timestamp did not converge after shutdown"
     r1.vtysh_cmd("conf t\ninterface r1-eth3\nno shutdown")
 
     # take Last changed time, fiddle with associated interfaces, ensure
@@ -477,22 +489,25 @@ def test_r1_mplsvpn_VrfTable():
     r1.cmd("ip link set r1-eth6 master VRF-a")
     r1.cmd("ip link set r1-eth6 up")
 
-    associated_int = r1_snmp.get(
-        "mplsL3VpnVrfAssociatedInterfaces.{}".format(snmp_str_to_oid("VRF-a"))
-    )
-    assertmsg = (
-        "mplsL3VpnVrfAssociatedInterfaces incorrect should be 3 value {}".format(
-            associated_int
+    def _check_vrf_associated_and_last_changed(last_changed_before):
+        associated_int = r1_snmp.get(
+            "mplsL3VpnVrfAssociatedInterfaces.{}".format(snmp_str_to_oid("VRF-a"))
         )
-    )
+        ts_last = r1_snmp.get(
+            "mplsL3VpnVrfConfLastChanged.{}".format(snmp_str_to_oid("VRF-a"))
+        )
+        ts_val_last = get_timetick_val(ts_last)
+        return associated_int == "3" and ts_val_last > last_changed_before
 
-    assert associated_int == "3", assertmsg
-    ts_last = r1_snmp.get(
-        "mplsL3VpnVrfConfLastChanged.{}".format(snmp_str_to_oid("VRF-a"))
+    _, result = topotest.run_and_expect(
+        partial(_check_vrf_associated_and_last_changed, ts_val_last_1),
+        True,
+        count=30,
+        wait=1,
     )
-    ts_val_last_2 = get_timetick_val(ts_last)
-    assertmsg = "mplsL3VpnVrfConfLastChanged does not update on interface change"
-    assert ts_val_last_2 > ts_val_last_1, assertmsg
+    assert (
+        result is True
+    ), "VRF associated interface/timestamp did not converge after interface move"
     r1.cmd("ip link del r1-eth6 master VRF-a")
     r1.cmd("ip link set r1-eth6 down")
 
@@ -536,18 +551,12 @@ def test_r1_mplsvpn_perf_table():
     oid_a = snmp_str_to_oid("VRF-a")
     oid_b = snmp_str_to_oid("VRF-b")
 
-    # poll for 10 seconds for routes to appear
-    count = 0
-    passed = False
-    while count < 60:
-        if r1_snmp.test_oid_walk(
+    def _perf_routes_ready():
+        return r1_snmp.test_oid_walk(
             "mplsL3VpnVrfPerfCurrNumRoutes.{}".format(oid_a), ["7"]
-        ):
-            passed = True
-            break
-        count += 1
-        sleep(1)
-    # tgen.mininet_cli()
+        )
+
+    _, passed = topotest.run_and_expect(_perf_routes_ready, True, count=60, wait=1)
     assertmsg = "mplsL3VpnVrfPerfCurrNumRoutes shouold be 7 got {}".format(
         r1_snmp.get("mplsL3VpnVrfPerfCurrNumRoutes.{}".format(oid_a))
     )

--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -225,11 +225,13 @@ def test_local_vs_non_local():
 
     r2 = tgen.gears["r2"]
 
-    output = json.loads(r2.vtysh_cmd("show bgp ipv4 uni 60.0.0.0/24 json"))
-    paths = output["paths"]
-    for i in range(len(paths)):
-        if "fibPending" in paths[i]:
-            assert False, "Route 60.0.0.0/24 should not have fibPending"
+    def check_no_fib_pending():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 uni 60.0.0.0/24 json"))
+        paths = output.get("paths", [])
+        return all("fibPending" not in path for path in paths)
+
+    _, result = topotest.run_and_expect(check_no_fib_pending, True, count=20, wait=1)
+    assert result is True, "Route 60.0.0.0/24 should not have fibPending"
 
 
 def test_ip_protocol_any_fib_filter():

--- a/tests/topotests/ldp_establish_hello_topo1/test_establish_hello_topo1.py
+++ b/tests/topotests/ldp_establish_hello_topo1/test_establish_hello_topo1.py
@@ -36,13 +36,25 @@ import os
 import re
 import sys
 import pytest
-from time import sleep
 
+from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
 fatal_error = ""
 
 pytestmark = [pytest.mark.ldpd]
+
+
+def _hello_packet_counts(output):
+    pattern = r"\n\s+(\d+)"
+    return [int(count) for count in re.findall(pattern, output)]
+
+
+def _has_hello_packets(tgen):
+    output = tgen.gears["r3"].run("iptables -t filter -L -v -n")
+    matches = _hello_packet_counts(output)
+    return len(matches) == 3 and all(count > 0 for count in matches)
+
 
 def build_topo(tgen):
     # Setup Routers
@@ -54,6 +66,7 @@ def build_topo(tgen):
     switch.add_link(tgen.gears["r1"])
     switch.add_link(tgen.gears["r2"])
     switch.add_link(tgen.gears["r3"])
+
 
 def setup_module(module):
 
@@ -80,7 +93,7 @@ def teardown_module(module):
 
 
 def test_default_behaviour():
-    
+
     global fatal_error
 
     # Skip if previous fatal error condition is raised
@@ -90,40 +103,50 @@ def test_default_behaviour():
     tgen = get_topogen()
 
     # Setup counters
-    tgen.gears["r3"].run("""
+    tgen.gears["r3"].run(
+        """
             iptables -t filter -A INPUT -s 10.0.1.1 -p udp --dport 646 -j ACCEPT
             iptables -t filter -A INPUT -s 10.0.1.2 -p udp --dport 646 -j ACCEPT
             iptables -t filter -A OUTPUT -s 10.0.1.3 -p udp --dport 646 -j ACCEPT
-            """)
+            """
+    )
 
     # Setup the LDP service
     for router in ["r3", "r2", "r1"]:
-        tgen.gears[router].vtysh_multicmd([
-                            "configure terminal",
-                            "mpls ldp",
-                            "address-family ipv4",
-                            f"interface {router}-eth0",
-                            "end"])
+        tgen.gears[router].vtysh_multicmd(
+            [
+                "configure terminal",
+                "mpls ldp",
+                "address-family ipv4",
+                f"interface {router}-eth0",
+                "end",
+            ]
+        )
 
-    sleep(7)
+    _, ready = topotest.run_and_expect(
+        lambda: _has_hello_packets(tgen), True, count=15, wait=1
+    )
+    assert ready is True, "No LDP hello messages detected in iptables counters"
 
     # Get values from counters
     output = tgen.gears["r3"].run("iptables -t filter -L -v -n")
 
     # Disable the LDP service
     for router in ["r3", "r2", "r1"]:
-        tgen.gears[router].vtysh_multicmd([
-                            "configure terminal",
-                            "mpls ldp",
-                            "address-family ipv4",
-                            f"no interface {router}-eth0",
-                            "end"])
+        tgen.gears[router].vtysh_multicmd(
+            [
+                "configure terminal",
+                "mpls ldp",
+                "address-family ipv4",
+                f"no interface {router}-eth0",
+                "end",
+            ]
+        )
 
     # Remove counter
     tgen.gears["r3"].run("iptables -t filter -F")
 
-    pattern = r"\n\s+(\d+)"
-    matches = re.findall(pattern, output)
+    matches = _hello_packet_counts(output)
 
     # Each router should send at least 2 packets of LDP hello,
     # one at the start and one after the "interval"(default 5 sec)
@@ -132,11 +155,11 @@ def test_default_behaviour():
     # Router 10.0.1.3(3.3.3.3) sent 2 packets plus 2 packets to the 1.1.1.1 and 4 packets to the 2.2.2.2 - in total 8
     # Check that any hello packets are being sent out at all
     assert len(matches) == 3, "Expected 3 packet count entries"
-    assert all(int(count) > 0 for count in matches), "No LDP hello messages detected"
+    assert all(count > 0 for count in matches), "No LDP hello messages detected"
 
 
 def test_disable_establish_hello():
-    
+
     global fatal_error
 
     # Skip if previous fatal error condition is raised
@@ -146,47 +169,58 @@ def test_disable_establish_hello():
     tgen = get_topogen()
 
     # Setup counters
-    tgen.gears["r3"].run("""
+    tgen.gears["r3"].run(
+        """
             iptables -t filter -A INPUT -s 10.0.1.1 -p udp --dport 646 -j ACCEPT
             iptables -t filter -A INPUT -s 10.0.1.2 -p udp --dport 646 -j ACCEPT
             iptables -t filter -A OUTPUT -s 10.0.1.3 -p udp --dport 646 -j ACCEPT
-            """)
+            """
+    )
 
     # Setup the LDP service with disable-establish-hello option
     for router in ["r3", "r2", "r1"]:
-        tgen.gears[router].vtysh_multicmd([
-                            "configure terminal",
-                            "mpls ldp",
-                            "address-family ipv4",
-                            f"interface {router}-eth0",
-                            "disable-establish-hello",
-                            "end"])
+        tgen.gears[router].vtysh_multicmd(
+            [
+                "configure terminal",
+                "mpls ldp",
+                "address-family ipv4",
+                f"interface {router}-eth0",
+                "disable-establish-hello",
+                "end",
+            ]
+        )
 
-    sleep(7)
+    _, ready = topotest.run_and_expect(
+        lambda: _has_hello_packets(tgen), True, count=15, wait=1
+    )
+    assert ready is True, "No LDP hello messages detected in iptables counters"
 
     # Get values from counters
     output = tgen.gears["r3"].run("iptables -t filter -L -v -n")
 
     # Disable the LDP service
     for router in ["r3", "r2", "r1"]:
-        tgen.gears[router].vtysh_multicmd([
-                            "configure terminal",
-                            "mpls ldp",
-                            "address-family ipv4",
-                            f"no interface {router}-eth0",
-                            "end"])
+        tgen.gears[router].vtysh_multicmd(
+            [
+                "configure terminal",
+                "mpls ldp",
+                "address-family ipv4",
+                f"no interface {router}-eth0",
+                "end",
+            ]
+        )
 
     # Remove counter
     tgen.gears["r3"].run("iptables -t filter -F")
 
-    pattern = r"\n\s+(\d+)"
-    matches = re.findall(pattern, output)
+    matches = _hello_packet_counts(output)
 
     # With disabled sending LDP hello message on attempt to establish TCP connection
     # Each router should only send 2 packets, at start and after 5 seconds(default interval)
     # Check that any hello packets are being sent out at all
     assert len(matches) == 3, "Expected 3 packet count entries"
-    assert all(int(count) > 0 for count in matches), "No LDP hello messages detected"
+    assert all(count > 0 for count in matches), "No LDP hello messages detected"
+
 
 if __name__ == "__main__":
 

--- a/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
@@ -49,7 +49,6 @@ import os
 import sys
 import pytest
 import json
-from time import sleep
 from functools import partial
 
 # Save the Current Working Directory to find configuration files.
@@ -222,7 +221,6 @@ def test_ldp_bindings_all_routes():
     # remove ACL that blocks advertising everything but host routes */
     cmd = 'vtysh -c "configure terminal" -c "mpls ldp" -c "address-family ipv4" -c "no label local allocate host-routes"'
     tgen.net["r1"].cmd(cmd)
-    sleep(2)
 
     for rname in ["r1", "r2", "r3", "r4"]:
         router_compare_json_output(

--- a/tests/topotests/ldp_topo1/test_ldp_topo1.py
+++ b/tests/topotests/ldp_topo1/test_ldp_topo1.py
@@ -163,11 +163,16 @@ def test_router_running():
 
     print("\n\n** Check if FRR is running on each Router node")
     print("******************************************\n")
-    sleep(5)
 
     # Starting Routers
     for i in range(1, 5):
-        fatal_error = net["r%s" % i].checkRouterRunning()
+
+        def _router_is_running(router_idx):
+            return net["r%s" % router_idx].checkRouterRunning()
+
+        test_func = partial(_router_is_running, i)
+        _, result = topotest.run_and_expect(test_func, "", count=20, wait=1)
+        fatal_error = result
         assert fatal_error == "", fatal_error
 
 
@@ -265,61 +270,45 @@ def test_mpls_ldp_neighbor_establish():
     # Wait for MPLS LDP neighbors to establish.
     print("\n\n** Verify MPLS LDP neighbors to establish")
     print("******************************************\n")
-    timeout = 90
-    while timeout > 0:
-        print("Timeout in %s: " % timeout),
-        sys.stdout.flush()
-        # Look for any node not yet converged
+
+    def _all_ldp_neighbors_operational():
         for i in range(1, 5):
-            established = (
+            output = (
                 net["r%s" % i]
                 .cmd('vtysh -c "show mpls ldp neighbor" 2> /dev/null')
                 .rstrip()
             )
 
-            # On current version, we need to make sure they all turn to OPERATIONAL on all lines
-            #
-            lines = ("\n".join(established.splitlines()) + "\n").splitlines(1)
-            # Check all lines to be either table header (starting with ^AF or show OPERATIONAL)
+            lines = ("\n".join(output.splitlines()) + "\n").splitlines(1)
             header = r"^AF.*"
             operational = r"^ip.*OPERATIONAL.*"
             found_operational = 0
-            for j in range(1, len(lines)):
-                if (not re.search(header, lines[j])) and (
-                    not re.search(operational, lines[j])
-                ):
-                    established = ""  # Empty string shows NOT established
-                if re.search(operational, lines[j]):
+
+            for line in lines[1:]:
+                if (not re.search(header, line)) and (not re.search(operational, line)):
+                    logger.info(
+                        "r%s has non-operational LDP neighbor line: %s", i, line
+                    )
+                    return False
+                if re.search(operational, line):
                     found_operational += 1
 
-            logger.info("Found operational %d" % found_operational)
+            logger.info("r%s operational neighbors: %d", i, found_operational)
             if found_operational < 1:
-                # Need at least one operational neighbor
-                established = ""  # Empty string shows NOT established
-            else:
-                if found_operational != neighbors_operational[i]:
-                    established = ""
-            if not established:
-                print("Waiting for r%s" % i)
-                sys.stdout.flush()
-                break
-        if not established:
-            sleep(5)
-            timeout -= 5
-        else:
-            print("Done")
-            break
-    else:
-        # Bail out with error if a router fails to converge
+                return False
+            if found_operational != neighbors_operational[i]:
+                return False
+
+        return True
+
+    _, established = topotest.run_and_expect(
+        _all_ldp_neighbors_operational, True, count=18, wait=5
+    )
+    if not established:
         fatal_error = "MPLS LDP neighbors did not establish"
-        assert False, "MPLS LDP neighbors did not establish"
+    assert established, "MPLS LDP neighbors did not establish"
 
     print("MPLS LDP neighbors established.")
-
-    if timeout < 60:
-        # Only wait if we actually went through a convergence
-        print("\nwaiting 15s for LDP sessions to establish")
-        sleep(15)
 
     # Make sure that all daemons are running
     for i in range(1, 5):
@@ -671,8 +660,6 @@ def test_zebra_ipv4_routingtable_with_ldp():
     router["r1"].vtysh_cmd(
         "config \n mpls ldp \n addr ipv4 \n no neighbor 2.2.2.2 targeted \n end"
     )
-
-    sleep(5)
 
     # Make sure with label in route with their original state
     test_func = partial(show_route_with_label)

--- a/tests/topotests/msdp_topo1/test_msdp_topo1.py
+++ b/tests/topotests/msdp_topo1/test_msdp_topo1.py
@@ -560,14 +560,16 @@ def test_msdp_log_events():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    r1_log = tgen.gears["r1"].net.getLog("log", "pimd")
+    def check_msdp_log_messages():
+        r1_log = tgen.gears["r1"].net.getLog("log", "pimd")
+        peer_ok = re.search(
+            "MSDP peer 192.168.1.2 state changed to established", r1_log
+        )
+        sa_ok = re.search(r"MSDP SA \(192.168.10.100\,229.1.2.3\) created", r1_log)
+        return peer_ok is not None and sa_ok is not None
 
-    # Look up for informational messages that should have been enabled.
-    match = re.search("MSDP peer 192.168.1.2 state changed to established", r1_log)
-    assert match is not None
-
-    match = re.search(r"MSDP SA \(192.168.10.100\,229.1.2.3\) created", r1_log)
-    assert match is not None
+    _, result = topotest.run_and_expect(check_msdp_log_messages, True, count=30, wait=1)
+    assert result is True, "Expected MSDP log messages not found"
 
 
 def test_msdp_shutdown():

--- a/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
+++ b/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
@@ -42,6 +42,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
+from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
 from lib.common_config import (
@@ -982,32 +983,49 @@ def test_BSM_fragmentation_p1(request):
     fhr_node.run("ip link set f1-i1-eth2 mtu 100")
     inter_node.run("ip link set i1-f1-eth0 mtu 100")
 
-    # Use scapy to send pre-defined packet from senser to receiver
-    result = scapy_send_bsr_raw_packet(tgen, topo, "b1", "f1", "packet2")
+    # Use scapy to send pre-defined packet from sender to receiver.
+    # Poll in case link MTU updates are not fully applied yet.
+    _, result = topotest.run_and_expect(
+        lambda: scapy_send_bsr_raw_packet(tgen, topo, "b1", "f1", "packet2"),
+        True,
+        count=10,
+        wait=1,
+    )
     assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
-    result = app_helper.run_join("r1", GROUP_ADDRESS, "l1")
+    _, result = topotest.run_and_expect(
+        lambda: app_helper.run_join("r1", GROUP_ADDRESS, "l1"),
+        True,
+        count=10,
+        wait=1,
+    )
     assert result is True, "Testcase {}:Failed \n Error: {}".format(tc_name, result)
 
     # Verify bsr state in FHR
     step("Verify if b1 chosen as BSR")
-    result = verify_pim_bsr(tgen, topo, "f1", bsr_ip)
+    _, result = topotest.run_and_expect(
+        lambda: verify_pim_bsr(tgen, topo, "f1", bsr_ip),
+        True,
+        count=20,
+        wait=1,
+    )
     assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
     # Verify if bsrp list is same across f1, i1 and l1
     step("Verify if bsrp list is same across f1, i1 and l1 after fragmentation")
-    bsrp_f1 = fhr_node.vtysh_cmd("show ip pim bsrp-info json", isjson=True)
-    logger.info("show_ip_pim_bsrp_info_json f1: \n %s", bsrp_f1)
-    bsrp_i1 = inter_node.vtysh_cmd("show ip pim bsrp-info json", isjson=True)
-    logger.info("show_ip_pim_bsrp_info_json i1: \n %s", bsrp_i1)
-    bsrp_l1 = lhr_node.vtysh_cmd("show ip pim bsrp-info json", isjson=True)
-    logger.info("show_ip_pim_bsrp_info_json l1: \n %s", bsrp_l1)
 
-    if bsrp_f1 == bsrp_l1:
-        result = True
-    else:
-        result = "bsrp info in f1 is not same in l1"
+    def _check_bsrp_match_after_fragmentation():
+        bsrp_f1 = fhr_node.vtysh_cmd("show ip pim bsrp-info json", isjson=True)
+        logger.info("show_ip_pim_bsrp_info_json f1: \n %s", bsrp_f1)
+        bsrp_i1 = inter_node.vtysh_cmd("show ip pim bsrp-info json", isjson=True)
+        logger.info("show_ip_pim_bsrp_info_json i1: \n %s", bsrp_i1)
+        bsrp_l1 = lhr_node.vtysh_cmd("show ip pim bsrp-info json", isjson=True)
+        logger.info("show_ip_pim_bsrp_info_json l1: \n %s", bsrp_l1)
+        return bsrp_f1 == bsrp_l1
 
+    _, result = topotest.run_and_expect(
+        _check_bsrp_match_after_fragmentation, True, count=20, wait=1
+    )
     assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
     step("clear  BSM database before moving to next case")

--- a/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
+++ b/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
@@ -58,11 +58,11 @@ def test_multicast_ssm():
     "Test SSM group"
     pim_test = [
         {"address": "229.0.0.100", "type": "ASM"},
-        {"address": "230.0.0.100", "type": "SSM"}
+        {"address": "230.0.0.100", "type": "SSM"},
     ]
     pim6_test = [
         {"address": "FF32::100", "type": "ASM"},
-        {"address": "FF35::100", "type": "SSM"}
+        {"address": "FF35::100", "type": "SSM"},
     ]
 
     tgen = get_topogen()
@@ -72,12 +72,30 @@ def test_multicast_ssm():
     router = tgen.gears["r1"]
 
     for test in pim_test:
-        output = router.vtysh_cmd(f"show ip pim group-type {test['address']} json", isjson=True)
-        assert test["type"] == output["groupType"], "Wrong group type"
+
+        def check_group_type_v4():
+            output = router.vtysh_cmd(
+                f"show ip pim group-type {test['address']} json", isjson=True
+            )
+            return output.get("groupType")
+
+        _, result = topotest.run_and_expect(
+            check_group_type_v4, test["type"], count=20, wait=1
+        )
+        assert result == test["type"], "Wrong group type"
 
     for test in pim6_test:
-        output = router.vtysh_cmd(f"show ipv6 pim group-type {test['address']} json", isjson=True)
-        assert test["type"] == output["groupType"], "Wrong group type"
+
+        def check_group_type_v6():
+            output = router.vtysh_cmd(
+                f"show ipv6 pim group-type {test['address']} json", isjson=True
+            )
+            return output.get("groupType")
+
+        _, result = topotest.run_and_expect(
+            check_group_type_v6, test["type"], count=20, wait=1
+        )
+        assert result == test["type"], "Wrong group type"
 
 
 def test_memory_leak():

--- a/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
+++ b/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
@@ -52,7 +52,6 @@ import os
 import sys
 import pytest
 import json
-from time import sleep
 from functools import partial
 
 # Save the Current Working Directory to find configuration files.
@@ -246,23 +245,18 @@ def check_routers(initial_convergence=False, exiting=None, restarting=None):
 
 
 def ensure_gr_is_in_zebra(rname):
-    retry = True
-    retry_times = 10
     tgen = get_topogen()
 
-    while retry and retry_times > 0:
+    def check_gr_capability():
         out = tgen.net[rname].cmd(
             'vtysh -c "show zebra client" | grep "Client: ospf6$" -A 40 | grep "Capabilities "'
         )
+        return "Graceful Restart" in out
 
-        if "Graceful Restart" not in out:
-            sleep(2)
-            retry_times -= 1
-        else:
-            retry = False
+    _, result = topotest.run_and_expect(check_gr_capability, True, count=10, wait=2)
 
     assertmsg = "%s does not appear to have Graceful Restart setup" % rname
-    assert not retry and retry_times > 0, assertmsg
+    assert result is True, assertmsg
 
 
 #

--- a/tests/topotests/ospf_multi_instance/test_ospf_multi_instance.py
+++ b/tests/topotests/ospf_multi_instance/test_ospf_multi_instance.py
@@ -112,10 +112,16 @@ def test_multi_instance_default_origination():
     r1.vtysh_cmd("conf t\nip route 0.0.0.0/0 Null0")
 
     step("Verify the R1 configuration and install of 'ip route 0.0.0.0/0 Null0'")
-    prefix_suppression_cfg = (
-        tgen.net["r1"]
-        .cmd('vtysh -c "show running" | grep "^ip route 0.0.0.0/0 Null0"')
-        .rstrip()
+
+    def check_default_route_config():
+        return (
+            tgen.net["r1"]
+            .cmd('vtysh -c "show running" | grep "^ip route 0.0.0.0/0 Null0"')
+            .rstrip()
+        )
+
+    _, prefix_suppression_cfg = topotest.run_and_expect(
+        check_default_route_config, "ip route 0.0.0.0/0 Null0", count=30, wait=1
     )
     assertmsg = "'ip route 0.0.0.0/0 Null0' applied, but not present in configuration"
     assert prefix_suppression_cfg == "ip route 0.0.0.0/0 Null0", assertmsg

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
@@ -9,7 +9,6 @@
 
 import os
 import sys
-from time import sleep
 from functools import partial
 import pytest
 
@@ -352,12 +351,21 @@ def p2mp_broadcast_neighbor_filter_common(delay_reflood):
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nip ospf neighbor-filter nbr-filter")
 
     step("Verify the R1 configuration of 'ip ospf neighbor-filter nbr-filter'")
-    neighbor_filter_cfg = (
-        tgen.net["r1"]
-        .cmd(
-            'vtysh -c "show running ospfd" | grep "^ ip ospf neighbor-filter nbr-filter"'
+
+    def check_neighbor_filter_config():
+        return (
+            tgen.net["r1"]
+            .cmd(
+                'vtysh -c "show running ospfd" | grep "^ ip ospf neighbor-filter nbr-filter"'
+            )
+            .rstrip()
         )
-        .rstrip()
+
+    _, neighbor_filter_cfg = topotest.run_and_expect(
+        check_neighbor_filter_config,
+        " ip ospf neighbor-filter nbr-filter",
+        count=30,
+        wait=1,
     )
     assertmsg = (
         "'ip ospf neighbor-filter nbr-filter' applied, but not present in configuration"
@@ -402,9 +410,14 @@ def p2mp_broadcast_neighbor_filter_common(delay_reflood):
 
     step("Remove neighbor filter configuration and verify")
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nno ip ospf neighbor-filter")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf neighbor-filter'", warn=False
-    )
+
+    def check_neighbor_filter_removed():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | grep -q 'ip ospf neighbor-filter'", warn=False
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(check_neighbor_filter_removed, 1, count=30, wait=1)
     assertmsg = "'ip ospf neighbor' not applied, but present in R1 configuration"
     assert rc, assertmsg
 
@@ -490,16 +503,22 @@ def test_p2mp_broadcast_neighbor_filter_delay_reflood():
         "Add redistribution and spaced static routes to r1 to test delay flood retransmission"
     )
     r1.vtysh_cmd("conf t\nrouter ospf\nredistribute static")
-    r1.vtysh_cmd("conf t\nip route 20.1.1.1/32 null0")
-    sleep(1)
-    r1.vtysh_cmd("conf t\nip route 20.1.1.2/32 null0")
-    sleep(1)
-    r1.vtysh_cmd("conf t\nip route 20.1.1.3/32 null0")
-    sleep(1)
-    r1.vtysh_cmd("conf t\nip route 20.1.1.4/32 null0")
-    sleep(1)
-    r1.vtysh_cmd("conf t\nip route 20.1.1.5/32 null0")
-    sleep(1)
+
+    def check_static_route_installed(prefix):
+        output = r1.vtysh_cmd(f"show ip route {prefix} json", isjson=True)
+        return prefix in output
+
+    for prefix in [
+        "20.1.1.1/32",
+        "20.1.1.2/32",
+        "20.1.1.3/32",
+        "20.1.1.4/32",
+        "20.1.1.5/32",
+    ]:
+        r1.vtysh_cmd(f"conf t\nip route {prefix} null0")
+        test_func = partial(check_static_route_installed, prefix)
+        _, route_ready = topotest.run_and_expect(test_func, True, count=20, wait=0.5)
+        assert route_ready is True, f"Static route {prefix} not installed on r1"
 
     step(
         "Verify the routes are installed on r1 with delay-reflood in P2MP partial mesh"

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
@@ -124,16 +124,16 @@ def verify_p2mp_interface(tgen, router, nbr_cnt, nbr_adj_cnt, non_broadcast):
     topo_router = tgen.gears[router]
 
     step("Test running configuration for P2MP configuration")
-    rc = 0
     rc, _, _ = tgen.net[router].cmd_status(
-        "show running ospfd | grep 'ip ospf network point-to-multipoint'", warn=False
+        "vtysh -c 'show running ospfd' | grep -q 'ip ospf network point-to-multipoint'",
+        warn=False,
     )
     assertmsg = (
         "'ip ospf network point-to-multipoint' applied, but not present in "
         + router
-        + "configuration"
+        + " configuration"
     )
-    assert rc, assertmsg
+    assert rc == 0, assertmsg
 
     step("Test OSPF interface for P2MP settings")
     input_dict = {
@@ -235,9 +235,16 @@ def test_p2mp_non_broadcast_connectivity():
     verify_p2mp_interface(tgen, "r1", 3, 3, True)
 
     step("Verify router r1 interface r1-eth0 p2mp non-broadcast configuration")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf network point-to-multipoint non-broadcast'",
-        warn=False,
+
+    def check_p2mp_non_broadcast_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "vtysh -c 'show running ospfd' | grep -q 'ip ospf network point-to-multipoint non-broadcast'",
+            warn=False,
+        )
+        return rc == 0
+
+    _, rc = topotest.run_and_expect(
+        check_p2mp_non_broadcast_config, True, count=30, wait=1
     )
     assertmsg = "'ip ospf network point-to-multipoint non-broadcast' applied, but not present in R1 configuration"
     assert rc, assertmsg
@@ -260,12 +267,11 @@ def test_p2mp_non_broadcast_connectivity():
 
     step("Remove r1 interface r1-eth0 p2mp non-broadcast configuration")
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nip ospf network point-to-multipoint")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf network point-to-multipoint non-broadcast'",
-        warn=False,
+    matched, _ = topotest.run_and_expect(
+        check_p2mp_non_broadcast_config, False, count=30, wait=1
     )
     assertmsg = "'ip ospf network point-to-multipoint non-broadcast' not applied, but present in r1 configuration"
-    assert rc, assertmsg
+    assert matched, assertmsg
 
     step("Verify router r1 interface OSPF point-to-multipoint broadcast interface")
     verify_p2mp_interface(tgen, "r1", 3, 3, False)
@@ -274,9 +280,8 @@ def test_p2mp_non_broadcast_connectivity():
     r1.vtysh_cmd(
         "conf t\ninterface r1-eth0\nip ospf network point-to-multipoint non-broadcast"
     )
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep 'ip ospf network point-to-multipoint non-broadcast'",
-        warn=False,
+    _, rc = topotest.run_and_expect(
+        check_p2mp_non_broadcast_config, True, count=30, wait=1
     )
     assertmsg = "'ip ospf netrwork point-to-multipoint non-broadcast' applied, but not present in R1 configuration"
     assert rc, assertmsg

--- a/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
+++ b/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
@@ -286,10 +286,19 @@ def test_broadcast_stub_suppression():
     r1.vtysh_cmd("conf t\ninterface r1-eth4\nip ospf prefix-suppression")
 
     step("Verify the R1 configuration of 'ip ospf prefix-suppression'")
-    prefix_suppression_cfg = (
-        tgen.net["r1"]
-        .cmd('vtysh -c "show running ospfd" | grep "^ ip ospf prefix-suppression"')
-        .rstrip()
+
+    def check_prefix_suppression_config():
+        return (
+            tgen.net["r1"]
+            .cmd('vtysh -c "show running ospfd" | grep "^ ip ospf prefix-suppression"')
+            .rstrip()
+        )
+
+    _, prefix_suppression_cfg = topotest.run_and_expect(
+        check_prefix_suppression_config,
+        " ip ospf prefix-suppression",
+        count=30,
+        wait=1,
     )
     assertmsg = "'ip ospf prefix-suppression' applied, but not present in configuration"
     assert prefix_suppression_cfg == " ip ospf prefix-suppression", assertmsg
@@ -348,8 +357,15 @@ def test_broadcast_stub_suppression():
     r1.vtysh_cmd("conf t\ninterface r1-eth4\nno ip ospf prefix-suppression")
 
     step("Verify no R1 configuration of 'ip ospf prefix-suppression")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf prefix-suppression'", warn=False
+
+    def check_no_prefix_suppression_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | grep -q 'ip ospf prefix-suppression'", warn=False
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(
+        check_no_prefix_suppression_config, 1, count=30, wait=1
     )
     assertmsg = (
         "'ip ospf prefix-suppression' not applied, but present in R1 configuration"
@@ -412,12 +428,21 @@ def test_broadcast_transit_suppression():
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nip ospf prefix-suppression 10.1.1.1")
 
     step("Verify the R1 configuration of 'ip ospf prefix-suppression 10.1.1.1'")
-    prefix_suppression_cfg = (
-        tgen.net["r1"]
-        .cmd(
-            'vtysh -c "show running ospfd" | grep "^ ip ospf prefix-suppression 10.1.1.1"'
+
+    def check_prefix_suppression_addr_config():
+        return (
+            tgen.net["r1"]
+            .cmd(
+                'vtysh -c "show running ospfd" | grep "^ ip ospf prefix-suppression 10.1.1.1"'
+            )
+            .rstrip()
         )
-        .rstrip()
+
+    _, prefix_suppression_cfg = topotest.run_and_expect(
+        check_prefix_suppression_addr_config,
+        " ip ospf prefix-suppression 10.1.1.1",
+        count=30,
+        wait=1,
     )
     assertmsg = "'ip ospf prefix-suppression 10.1.1.1' applied, but not present in configuration"
     assert prefix_suppression_cfg == " ip ospf prefix-suppression 10.1.1.1", assertmsg
@@ -488,8 +513,16 @@ def test_broadcast_transit_suppression():
     r2.vtysh_cmd("conf t\ninterface r2-eth0\nno ip ospf prefix-suppression 10.1.1.2")
 
     step("Verify no R1 configuration of 'ip ospf prefix-suppression")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf prefix-suppression 10.1.1.1'", warn=False
+
+    def check_no_prefix_suppression_addr_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | grep -q 'ip ospf prefix-suppression 10.1.1.1'",
+            warn=False,
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(
+        check_no_prefix_suppression_addr_config, 1, count=30, wait=1
     )
     assertmsg = "'ip ospf prefix-suppression 10.1.1.1' not applied, but present in R1 configuration"
     assert rc, assertmsg
@@ -608,8 +641,15 @@ def test_nbma_transit_suppression():
     r2.vtysh_cmd("conf t\ninterface r2-eth1\nno ip ospf prefix-suppression")
 
     step("Verify no R1 configuration of 'ip ospf prefix-suppression")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf prefix-suppression'", warn=False
+
+    def check_no_nbma_prefix_suppression_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | grep -q 'ip ospf prefix-suppression'", warn=False
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(
+        check_no_nbma_prefix_suppression_config, 1, count=30, wait=1
     )
     assertmsg = (
         "'ip ospf prefix-suppression' not applied, but present in R1 configuration"
@@ -682,12 +722,21 @@ def test_p2p_suppression():
     r2.vtysh_cmd("conf t\ninterface r2-eth2\nip ospf prefix-suppression 10.1.3.2")
 
     step("Verify the R1 configuration of 'ip ospf prefix-suppression 10.1.3.1'")
-    prefix_suppression_cfg = (
-        tgen.net["r1"]
-        .cmd(
-            'vtysh -c "show running ospfd" | grep "^ ip ospf prefix-suppression 10.1.3.1"'
+
+    def check_prefix_suppression_p2p_config():
+        return (
+            tgen.net["r1"]
+            .cmd(
+                'vtysh -c "show running ospfd" | grep "^ ip ospf prefix-suppression 10.1.3.1"'
+            )
+            .rstrip()
         )
-        .rstrip()
+
+    _, prefix_suppression_cfg = topotest.run_and_expect(
+        check_prefix_suppression_p2p_config,
+        " ip ospf prefix-suppression 10.1.3.1",
+        count=30,
+        wait=1,
     )
     assertmsg = "'ip ospf prefix-suppression 10.1.3.1' applied, but not present in configuration"
     assert prefix_suppression_cfg == " ip ospf prefix-suppression 10.1.3.1", assertmsg
@@ -738,8 +787,16 @@ def test_p2p_suppression():
     r2.vtysh_cmd("conf t\ninterface r2-eth2\nno ip ospf prefix-suppression 10.1.3.2")
 
     step("Verify no R1 configuration of 'ip ospf prefix-suppression")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf prefix-suppression 10.1.3.1'", warn=False
+
+    def check_no_prefix_suppression_p2p_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | grep -q 'ip ospf prefix-suppression 10.1.3.1'",
+            warn=False,
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(
+        check_no_prefix_suppression_p2p_config, 1, count=30, wait=1
     )
     assertmsg = "'ip ospf prefix-suppressio 10.1.3.1' not applied, but present in R1 configuration"
     assert rc, assertmsg
@@ -854,8 +911,15 @@ def test_p2mp_suppression():
     r2.vtysh_cmd("conf t\ninterface r2-eth3\nno ip ospf prefix-suppression")
 
     step("Verify no R1 configuration of 'ip ospf prefix-suppression")
-    rc, _, _ = tgen.net["r1"].cmd_status(
-        "show running ospfd | grep -q 'ip ospf prefix-suppression'", warn=False
+
+    def check_no_bcast_prefix_suppression_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | grep -q 'ip ospf prefix-suppression'", warn=False
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(
+        check_no_bcast_prefix_suppression_config, 1, count=30, wait=1
     )
     assertmsg = (
         "'ip ospf prefix-suppression' not applied, but present in R1 configuration"

--- a/tests/topotests/ospf_topo1/test_ospf_topo1.py
+++ b/tests/topotests/ospf_topo1/test_ospf_topo1.py
@@ -17,7 +17,6 @@ import os
 import re
 import sys
 from functools import partial
-from time import sleep
 import pytest
 
 # Save the Current Working Directory to find configuration files.
@@ -203,6 +202,16 @@ def compare_show_ipv6_ospf6(rname, expected):
         title1="Current output",
         title2="Expected output",
     )
+
+
+def compare_ipv4_kernel_routes(router, expected):
+    "Compare IPv4 kernel routes against expected routes."
+    return topotest.json_cmp(topotest.ip4_route(router), expected)
+
+
+def compare_ipv6_kernel_routes(router, expected):
+    "Compare IPv6 kernel routes against expected routes."
+    return topotest.json_cmp(topotest.ip6_route(router), expected)
 
 
 def test_ospf_convergence():
@@ -444,7 +453,6 @@ def test_ospf_link_down_kernel_route():
             'Checking OSPF IPv4 kernel routes in "%s" after link down', router.name
         )
 
-        routes = topotest.ip4_route(router)
         expected = {
             "10.0.1.0/24": {},
             "10.0.2.0/24": {},
@@ -478,18 +486,9 @@ def test_ospf_link_down_kernel_route():
         assertmsg = 'OSPF IPv4 route mismatch in router "{}" after link down'.format(
             router.name
         )
-        count = 0
-        not_found = True
-        while not_found and count < 10:
-            not_found = topotest.json_cmp(routes, expected)
-            if not_found:
-                sleep(1)
-                routes = topotest.ip4_route(router)
-                count += 1
-            else:
-                not_found = False
-                break
-        assert not_found is False, assertmsg
+        test_func = partial(compare_ipv4_kernel_routes, router, expected)
+        _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+        assert result is None, assertmsg
 
 
 def test_ospf6_link_down():
@@ -527,7 +526,6 @@ def test_ospf6_link_down_kernel_route():
             'Checking OSPF IPv6 kernel routes in "%s" after link down', router.name
         )
 
-        routes = topotest.ip6_route(router)
         expected = {
             "2001:db8:1::/64": {},
             "2001:db8:2::/64": {},
@@ -561,19 +559,9 @@ def test_ospf6_link_down_kernel_route():
         assertmsg = 'OSPF IPv6 route mismatch in router "{}" after link down'.format(
             router.name
         )
-        count = 0
-        not_found = True
-        while not_found and count < 10:
-            not_found = topotest.json_cmp(routes, expected)
-            if not_found:
-                sleep(1)
-                routes = topotest.ip6_route(router)
-                count += 1
-            else:
-                not_found = False
-                break
-
-        assert not_found is False, assertmsg
+        test_func = partial(compare_ipv6_kernel_routes, router, expected)
+        _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+        assert result is None, assertmsg
 
 
 def test_memory_leak():

--- a/tests/topotests/ospfv3_route_map_forwarding/test_ospfv3_route_map_forwarding.py
+++ b/tests/topotests/ospfv3_route_map_forwarding/test_ospfv3_route_map_forwarding.py
@@ -88,10 +88,10 @@ def test_ospfv3_neighbor_established():
         pytest.skip(tgen.errors)
 
     logger.info("Waiting for OSPFv3 neighbor to establish")
-    
+
     r1 = tgen.gears["r1"]
     r2 = tgen.gears["r2"]
-    
+
     # Check R1 has R2 as neighbor
     def check_r1_neighbor():
         output = r1.vtysh_cmd("show ipv6 ospf6 neighbor json")
@@ -99,7 +99,10 @@ def test_ospfv3_neighbor_established():
             data = json.loads(output)
             if "neighbors" in data:
                 for neighbor in data["neighbors"]:
-                    if neighbor.get("neighborId") == "10.0.0.2" and neighbor.get("state") == "Full":
+                    if (
+                        neighbor.get("neighborId") == "10.0.0.2"
+                        and neighbor.get("state") == "Full"
+                    ):
                         return True
             return False
         except:
@@ -108,7 +111,7 @@ def test_ospfv3_neighbor_established():
     test_func = check_r1_neighbor
     _, result = topotest.run_and_expect(test_func, True, count=60, wait=1)
     assert result, "R1 neighbor with R2 did not reach Full state"
-    
+
     logger.info("OSPFv3 neighbor R1<->R2 established")
 
 
@@ -119,9 +122,9 @@ def test_initial_convergence():
         pytest.skip(tgen.errors)
 
     logger.info("Waiting for OSPFv3 to converge and routes to be exchanged")
-    
+
     r2 = tgen.gears["r2"]
-    
+
     # Wait for R2 to see the external LSA from R1
     def check_r2_has_external_lsa():
         output = r2.vtysh_cmd("show ipv6 ospf6 database as-external json")
@@ -141,7 +144,7 @@ def test_initial_convergence():
     test_func = check_r2_has_external_lsa
     _, result = topotest.run_and_expect(test_func, True, count=60, wait=1)
     assert result, "R2 did not receive external LSA from R1"
-    
+
     logger.info("External LSA for 2001:db8:100::/64 successfully received on R2")
 
 
@@ -154,18 +157,16 @@ def test_initial_forwarding_address():
     r2 = tgen.gears["r2"]
 
     logger.info("Checking initial forwarding address from route-map")
-    
-    # Get the external LSA and check forwarding address
-    # Use LSA ID (0.0.0.1) and advertising router (10.0.0.1)
-    # Note: This format doesn't support 'detail' keyword, so omit it (shows detail by default)
-    output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
-    
-    logger.info("LSA detail output:\n%s" % output)
-    
-    # The route-map sets forwarding address to 2001:db8:ffff::1
-    assert "2001:db8:ffff::1" in output, \
-        "Initial forwarding address not set correctly by route-map"
-    
+
+    def check_initial_forwarding_address():
+        output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
+        return "2001:db8:ffff::1" in output
+
+    _, result = topotest.run_and_expect(
+        check_initial_forwarding_address, True, count=30, wait=1
+    )
+    assert result, "Initial forwarding address not set correctly by route-map"
+
     logger.info("Initial forwarding address correctly set to 2001:db8:ffff::1")
 
 
@@ -192,7 +193,7 @@ def test_modify_routemap_no_forwarding():
                 break
 
     logger.info("Modifying route-map to remove forwarding-address")
-    
+
     # Modify route-map on R1 - remove forwarding-address, only set metric
     r1.vtysh_cmd(
         """
@@ -204,7 +205,7 @@ def test_modify_routemap_no_forwarding():
     )
 
     # Wait for LSA to be updated (sequence number should increment)
-    
+
     def check_lsa_updated():
         output = r2.vtysh_cmd("show ipv6 ospf6 database as-external json")
         data = json.loads(output)
@@ -217,24 +218,23 @@ def test_modify_routemap_no_forwarding():
                         return current_seq > initial_seq
                     return False
         return False
-    
+
     test_func = check_lsa_updated
     _, result = topotest.run_and_expect(test_func, True, count=20, wait=1)
     assert result, "LSA was not updated after route-map change"
 
-    # Check forwarding address on R2
-    output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
-    
-    logger.info("LSA after route-map modification:\n%s" % output)
-    
-    # EXPECTED BEHAVIOR: When forwarding-address is removed from route-map,
-    # it should be cleared (not preserved). This is correct operator behavior.
-    
-    # Verify the forwarding address was cleared as expected
-    assert "2001:db8:ffff::1" not in output, \
-        "Forwarding address should be cleared when removed from route-map"
-    
-    logger.info("PASS: Forwarding address correctly cleared when removed from route-map")
+    def check_forwarding_cleared():
+        output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
+        return "2001:db8:ffff::1" not in output
+
+    _, result = topotest.run_and_expect(
+        check_forwarding_cleared, True, count=30, wait=1
+    )
+    assert result, "Forwarding address should be cleared when removed from route-map"
+
+    logger.info(
+        "PASS: Forwarding address correctly cleared when removed from route-map"
+    )
 
 
 def test_explicitly_clear_forwarding():
@@ -250,7 +250,7 @@ def test_explicitly_clear_forwarding():
     r2 = tgen.gears["r2"]
 
     logger.info("Explicitly setting forwarding-address to :: in route-map")
-    
+
     # Set forwarding address explicitly to :: (unspecified)
     r1.vtysh_cmd(
         """
@@ -267,21 +267,22 @@ def test_explicitly_clear_forwarding():
         if "2001:db8:ffff::1" in output:
             return False  # Still has old forwarding address
         return True
-    
+
     test_func = check_lsa_updated
     _, result = topotest.run_and_expect(test_func, True, count=20, wait=0.5)
     assert result, "LSA was not updated after route-map change"
 
-    # Check forwarding address on R2
-    output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
-    
-    logger.info("LSA after explicitly setting :: :\n%s" % output)
-    
-    # When explicitly set to ::, it should clear and allow auto-calculation
-    # So we should NOT see 2001:db8:ffff::1 anymore
-    assert "2001:db8:ffff::1" not in output, \
-        "Forwarding address should have been cleared when explicitly set to ::"
-    
+    def check_forwarding_cleared_to_unspecified():
+        output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
+        return "2001:db8:ffff::1" not in output
+
+    _, result = topotest.run_and_expect(
+        check_forwarding_cleared_to_unspecified, True, count=30, wait=1
+    )
+    assert (
+        result
+    ), "Forwarding address should have been cleared when explicitly set to ::"
+
     logger.info("PASS: Explicit :: correctly cleared forwarding address")
 
 
@@ -308,7 +309,7 @@ def test_change_forwarding_address():
                 break
 
     logger.info("Changing forwarding-address to a new value (2001:db8:eeee::1)")
-    
+
     # Change forwarding address to a new value
     r1.vtysh_cmd(
         """
@@ -332,25 +333,23 @@ def test_change_forwarding_address():
                         return current_seq > initial_seq
                     return False
         return False
-    
+
     test_func = check_lsa_updated
     _, result = topotest.run_and_expect(test_func, True, count=20, wait=1)
     assert result, "LSA was not updated after route-map change"
 
-    # Check forwarding address on R2
-    output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
-    
-    logger.info("LSA after changing forwarding-address:\n%s" % output)
-    
-    # Verify the new forwarding address is present
-    assert "2001:db8:eeee::1" in output, \
-        "New forwarding address 2001:db8:eeee::1 should be present in LSA"
-    
-    # Verify the old forwarding address is gone
-    assert "2001:db8:ffff::1" not in output, \
-        "Old forwarding address 2001:db8:ffff::1 should not be present"
-    
-    logger.info("PASS: Forwarding address successfully changed to new value 2001:db8:eeee::1")
+    def check_forwarding_changed():
+        output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
+        return "2001:db8:eeee::1" in output and "2001:db8:ffff::1" not in output
+
+    _, result = topotest.run_and_expect(
+        check_forwarding_changed, True, count=30, wait=1
+    )
+    assert result, "Forwarding address did not converge to the new value"
+
+    logger.info(
+        "PASS: Forwarding address successfully changed to new value 2001:db8:eeee::1"
+    )
 
 
 def test_change_forwarding_to_unspecified():
@@ -375,7 +374,7 @@ def test_change_forwarding_to_unspecified():
                 break
 
     logger.info("Changing forwarding-address from 2001:db8:eeee::1 to ::")
-    
+
     # Change forwarding address to :: (unspecified)
     r1.vtysh_cmd(
         """
@@ -399,27 +398,25 @@ def test_change_forwarding_to_unspecified():
                         return current_seq > initial_seq
                     return False
         return False
-    
+
     test_func = check_lsa_updated
     _, result = topotest.run_and_expect(test_func, True, count=20, wait=1)
     assert result, "LSA was not updated after route-map change"
 
-    # Check forwarding address on R2
-    output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
-    
-    logger.info("LSA after changing forwarding-address to :::\n%s" % output)
-    
-    # Verify the forwarding address was cleared
-    assert "2001:db8:eeee::1" not in output, \
-        "Forwarding address should be cleared when set to ::"
-    
-    assert "2001:db8:ffff::1" not in output, \
-        "Old forwarding address should not reappear"
-    
-    # Verify metric was updated to confirm LSA change
-    assert "Metric:   400" in output or "Metric: 400" in output, \
-        "Metric should be updated to 400"
-    
+    def check_forwarding_and_metric_updated():
+        output = r2.vtysh_cmd("show ipv6 ospf6 database as-external 0.0.0.1 10.0.0.1")
+        metric_ok = "Metric:   400" in output or "Metric: 400" in output
+        return (
+            "2001:db8:eeee::1" not in output
+            and "2001:db8:ffff::1" not in output
+            and metric_ok
+        )
+
+    _, result = topotest.run_and_expect(
+        check_forwarding_and_metric_updated, True, count=30, wait=1
+    )
+    assert result, "Forwarding address/metric did not converge to expected values"
+
     logger.info("PASS: Forwarding address correctly cleared when changed to ::")
 
 

--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -231,11 +231,12 @@ def test_pim_ssm_ping():
 
     r2.vtysh_cmd("conf\nip ssmpingd 10.0.20.2")
 
-    # Run ssmping from r1 to r2
-    output = r1.run("ssmping -I r1-eth0 10.0.20.2 -c 5")
+    def _check_ssmping():
+        output = r1.run("ssmping -I r1-eth0 10.0.20.2 -c 5")
+        return "5 packets received" in output
 
-    # Check if we got successful responses
-    assert "5 packets received" in output, "SSM ping failed"
+    _, result = topotest.run_and_expect(_check_ssmping, True, count=20, wait=1)
+    assert result is True, "SSM ping failed"
 
 
 def test_memory_leak():
@@ -258,36 +259,43 @@ def test_pim_static_mroute():
 
     r1 = tgen.gears["r1"]
 
-    ip_mroute_json = r1.vtysh_cmd("show ip mroute json", isjson=True)
-    assert "239.1.1.1" not in ip_mroute_json.keys()
+    expected = {"239.1.1.1": None}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "failed to converge initial mroute state"
 
     # Add ip mroute with iif=r1-eth0 oil=r1-eth1
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nip mroute r1-eth1 239.1.1.1 10.0.0.1")
 
     # Expect to find oil=[r1-eth1] in ip mroute command
-    ip_mroute_json = r1.vtysh_cmd("show ip mroute json", isjson=True)
-    assert list(ip_mroute_json["239.1.1.1"]["10.0.0.1"]["oil"].keys()) == ["r1-eth1"]
+    expected = {"239.1.1.1": {"10.0.0.1": {"oil": {"r1-eth1": "*", "r1-eth2": None}}}}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "failed to converge mroute state after adding r1-eth1"
 
     # Add ip mroute with iif=r1-eth0 oil=r1-eth2
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nip mroute r1-eth2 239.1.1.1 10.0.0.1")
 
     # Expect to find oil=[r1-eth1,r1-eth2] in ip mroute command
-    ip_mroute_json = r1.vtysh_cmd("show ip mroute json", isjson=True)
-    assert list(ip_mroute_json["239.1.1.1"]["10.0.0.1"]["oil"].keys()) == [
-        "r1-eth1",
-        "r1-eth2",
-    ]
+    expected = {"239.1.1.1": {"10.0.0.1": {"oil": {"r1-eth1": "*", "r1-eth2": "*"}}}}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "failed to converge mroute state after adding r1-eth2"
 
     # Remove ip mroute with oil=r1-eth1
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nno ip mroute r1-eth1 239.1.1.1 10.0.0.1")
-    ip_mroute_json = r1.vtysh_cmd("show ip mroute json", isjson=True)
     # This assert right here would break back in the day because only one oif was handled by the datamodel
-    assert list(ip_mroute_json["239.1.1.1"]["10.0.0.1"]["oil"].keys()) == ["r1-eth2"]
+    expected = {"239.1.1.1": {"10.0.0.1": {"oil": {"r1-eth1": None, "r1-eth2": "*"}}}}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "failed to converge mroute state after removing r1-eth1"
 
     r1.vtysh_cmd("conf t\ninterface r1-eth0\nno ip mroute r1-eth2 239.1.1.1 10.0.0.1")
     # Expect a clean state
-    ip_mroute_json = r1.vtysh_cmd("show ip mroute json", isjson=True)
-    assert "239.1.1.1" not in ip_mroute_json.keys()
+    expected = {"239.1.1.1": None}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "failed to converge final mroute state"
 
 
 if __name__ == "__main__":

--- a/tests/topotests/pim_override_behavior/test_pim_override_behavior.py
+++ b/tests/topotests/pim_override_behavior/test_pim_override_behavior.py
@@ -41,7 +41,7 @@ from lib.topolog import logger
 def build_topo(tgen):
     """
     Topology:
-    
+
                   +--------+
                   |   rp   |
                   | .6     |
@@ -68,7 +68,7 @@ def build_topo(tgen):
       |   |   r4   |  (Source/Receiver)
       +-->| .4     |
           +--------+
-    
+
     Key aspects:
     - rp connected to r1 and r2
     - r1, r2, r3 share a LAN (PIM Assert will occur here)
@@ -78,7 +78,7 @@ def build_topo(tgen):
     - RIP on rp, r1, r2, r3 with redistribute connected
     - RIP metrics configured to prefer rp->r2 direct link
     """
-    
+
     # Add routers
     tgen.add_router("rp")
     tgen.add_router("r1")
@@ -86,33 +86,33 @@ def build_topo(tgen):
     tgen.add_router("r3")
     tgen.add_router("r4")
     tgen.add_router("r5")
-    
+
     # Link 1: rp to r1
     switch = tgen.add_switch("s1")
     switch.add_link(tgen.gears["rp"])
     switch.add_link(tgen.gears["r1"])
-    
+
     # Link 2: Shared LAN - r1, r2, r3
     switch = tgen.add_switch("s2")
     switch.add_link(tgen.gears["r1"])
     switch.add_link(tgen.gears["r2"])
     switch.add_link(tgen.gears["r3"])
-    
+
     # Link 3: r2 to r4 (first connection)
     switch = tgen.add_switch("s3")
     switch.add_link(tgen.gears["r2"])
     switch.add_link(tgen.gears["r4"])
-    
+
     # Link 4: r2 to r4 (second connection)
     switch = tgen.add_switch("s4")
     switch.add_link(tgen.gears["r2"])
     switch.add_link(tgen.gears["r4"])
-    
+
     # Link 5: r3 to r5
     switch = tgen.add_switch("s5")
     switch.add_link(tgen.gears["r3"])
     switch.add_link(tgen.gears["r5"])
-    
+
     # Link 6: rp to r2 (direct connection)
     switch = tgen.add_switch("s6")
     switch.add_link(tgen.gears["rp"])
@@ -157,12 +157,12 @@ def teardown_module(_mod):
 def test_pim_neighbors():
     "Verify PIM neighbors are formed"
     tgen = get_topogen()
-    
+
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     logger.info("Checking PIM neighbor adjacencies")
-    
+
     # Check rp has neighbors with r1 and r2
     rp = tgen.gears["rp"]
     expected = {
@@ -175,7 +175,7 @@ def test_pim_neighbors():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assertmsg = "rp: PIM neighbors did not converge"
     assert result is None, assertmsg
-    
+
     # Check r1 has neighbors with rp, r2, and r3
     r1 = tgen.gears["r1"]
     expected = {
@@ -188,7 +188,7 @@ def test_pim_neighbors():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assertmsg = "r1: PIM neighbors did not converge"
     assert result is None, assertmsg
-    
+
     # Check r2 has neighbors on shared LAN and with rp
     r2 = tgen.gears["r2"]
     expected = {
@@ -201,7 +201,7 @@ def test_pim_neighbors():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assertmsg = "r2: PIM neighbors did not converge"
     assert result is None, assertmsg
-    
+
     # Check r3 has neighbors on shared LAN
     r3 = tgen.gears["r3"]
     expected = {
@@ -213,76 +213,76 @@ def test_pim_neighbors():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assertmsg = "r3: PIM neighbors did not converge"
     assert result is None, assertmsg
-    
+
     logger.info("All PIM neighbors converged successfully")
 
 
 def test_ensure_override_is_signaled():
     "Verify PIM override interval is properly configured and signaled"
     tgen = get_topogen()
-    
+
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     logger.info("Checking PIM override interval configuration")
-    
+
     # Check that override interval is set to 30000ms on all PIM interfaces
     routers_to_check = ["rp", "r1", "r2", "r3"]
-    
+
     for router_name in routers_to_check:
         router = tgen.gears[router_name]
         logger.info(f"Checking override interval on {router_name}")
-        
-        # Get PIM interface details
-        output = router.vtysh_cmd("show ip pim interface detail", isjson=False)
-        
-        # Check that at least one physical interface has override interval configured (30000 ms)
-        # Skip checking loopback and pimreg interfaces
-        # Look for the specific pattern "Override Interval           : 30000 msec"
-        found_30000 = False
-        for line in output.split('\n'):
-            if "Override Interval" in line and ": 30000 msec" in line:
-                found_30000 = True
-                logger.info(f"{router_name}: Found configured override interval: {line.strip()}")
-                break
-        
-        if not found_30000:
-            logger.error(f"{router_name} PIM interface detail output:\n{output}")
-            assert False, f"{router_name}: Override interval not set to 30000ms on any interface"
-        
+
+        def check_override_interval():
+            output = router.vtysh_cmd("show ip pim interface detail", isjson=False)
+            for line in output.split("\n"):
+                if "Override Interval" in line and ": 30000 msec" in line:
+                    logger.info(
+                        f"{router_name}: Found configured override interval: {line.strip()}"
+                    )
+                    return True
+            return False
+
+        _, result = topotest.run_and_expect(
+            check_override_interval, True, count=30, wait=1
+        )
+        assert (
+            result
+        ), f"{router_name}: Override interval not set to 30000ms on any interface"
+
         logger.info(f"{router_name}: Override interval is properly configured")
-    
+
     logger.info("All routers have override interval properly signaled")
 
 
 def do_not_run_pim_override_behavior():
     "Test PIM Assert/Override mechanism on shared LAN"
     logger.info("Testing PIM Override behavior on shared LAN")
-    
+
     tgen = get_topogen()
-    
+
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     r1 = tgen.gears["r1"]
     r2 = tgen.gears["r2"]
     r3 = tgen.gears["r3"]
     r4 = tgen.gears["r4"]
     r5 = tgen.gears["r5"]
-    
+
     # Start multicast receiver on r4
     mcast_tester = os.path.join(CWD, "../lib/mcast-tester.py")
     cmd_r4 = [mcast_tester, "229.1.1.1", "r4-eth1"]
     p_r4 = r4.popen(cmd_r4)
-    
+
     # Start multicast receiver on r5
     cmd_r5 = [mcast_tester, "229.1.1.1", "r5-eth0"]
     p_r5 = r5.popen(cmd_r5)
-    
+
     # Wait for *,G join to propagate from r2 and r3 to r1
     logger.info("Waiting for *,G join to propagate to r1")
     import time
-    
+
     # Check that r1 receives *,G join on the shared LAN interface (r1-eth1)
     expected = {
         "r1-eth1": {
@@ -294,22 +294,29 @@ def do_not_run_pim_override_behavior():
             }
         }
     }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip pim join json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip pim join json", expected)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assertmsg = "r1: *,G join for 229.1.1.1 not received on r1-eth1"
     assert result is None, assertmsg
-    
+
     logger.info("r1 has *,G state for 229.1.1.1 on shared LAN")
 
-    logger.info("start a stream on r4 and make sure that r1 is correct")    
+    logger.info("start a stream on r4 and make sure that r1 is correct")
     # Start multicast source on r4 (first interface)
     mcast_tx = os.path.join(CWD, "../pim_basic/mcast-tx.py")
-    cmd_tx = [mcast_tx, "--ttl", "10", "--count", "1000", "--interval", "1", 
-              "229.1.1.1", "r4-eth0"]
+    cmd_tx = [
+        mcast_tx,
+        "--ttl",
+        "10",
+        "--count",
+        "1000",
+        "--interval",
+        "1",
+        "229.1.1.1",
+        "r4-eth0",
+    ]
     p_tx = r4.popen(cmd_tx)
- 
+
     # Wait for traffic to flow and both S,G JOIN and S,G,rpt state to be established on r1
     logger.info("Waiting for S,G JOIN and S,G,rpt state on r1")
     expected = {
@@ -329,42 +336,42 @@ def do_not_run_pim_override_behavior():
                     "source": "10.0.3.4",
                     "group": "229.1.1.1",
                     "channelJoinName": "SGRpt(P)",
-                }
+                },
             }
         }
     }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip pim join json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip pim join json", expected)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
-    assertmsg = "r1: S,G JOIN and S,G,rpt state for 229.1.1.1 not established on r1-eth1"
+    assertmsg = (
+        "r1: S,G JOIN and S,G,rpt state for 229.1.1.1 not established on r1-eth1"
+    )
     assert result is None, assertmsg
-    
+
     logger.info("r1 has *,G, S,G JOIN, and S,G,rpt state for 229.1.1.1 on shared LAN")
-    
+
     # Check that traffic flows through the network
     # r2 and r3 are on a shared LAN with r1
     # Both should receive joins from downstream
     logger.info("Checking for PIM state on shared LAN")
-    
+
     # Check r1's upstream state
     r1_upstream = r1.vtysh_cmd("show ip pim upstream json", isjson=True)
     logger.info("r1 upstream state: {}".format(r1_upstream))
-    
+
     # Check r2's view
     r2_upstream = r2.vtysh_cmd("show ip pim upstream json", isjson=True)
     logger.info("r2 upstream state: {}".format(r2_upstream))
-    
+
     # Check r3's view
     r3_upstream = r3.vtysh_cmd("show ip pim upstream json", isjson=True)
     logger.info("r3 upstream state: {}".format(r3_upstream))
-    
+
     # Verify that traffic is being forwarded
     # r2 should have upstream state (source is behind r2)
     assert len(r2_upstream) > 0, "No upstream state found on r2"
-    
+
     logger.info("PIM Assert behavior test completed successfully")
-    
+
     if p_tx:
         p_tx.terminate()
         p_tx.wait()

--- a/tests/topotests/rip_default_route_handling/test_rip_default_route_handling.py
+++ b/tests/topotests/rip_default_route_handling/test_rip_default_route_handling.py
@@ -79,17 +79,26 @@ def test_rip_default_route_received_on_r2():
     assert result is None, "r2 did not receive default route via RIP: {}".format(result)
 
     # Verify RIP sees the default route as from r1 (R(n)), not kernel
-    output = r2.vtysh_cmd("show ip rip", isjson=False)
-    default_lines = [line for line in output.splitlines() if "0.0.0.0/0" in line]
-    assert (
-        default_lines
-    ), "Default route 0.0.0.0/0 not found in 'show ip rip'. Output:\n{}".format(output)
-    for line in default_lines:
-        assert (
-            "R(n)" in line
-        ), "RIP should show default route as from r1: R(n) 0.0.0.0/0. Line: {}".format(
-            line
-        )
+    def _check_rip_default_is_from_r1():
+        output = r2.vtysh_cmd("show ip rip", isjson=False)
+        default_lines = [line for line in output.splitlines() if "0.0.0.0/0" in line]
+        if not default_lines:
+            return "Default route 0.0.0.0/0 not found in 'show ip rip'. Output:\n{}".format(
+                output
+            )
+        for line in default_lines:
+            if "R(n)" not in line:
+                return "RIP should show default route as from r1: R(n) 0.0.0.0/0. Line: {}".format(
+                    line
+                )
+        return None
+
+    _, result = topotest.run_and_expect(
+        _check_rip_default_is_from_r1, None, count=60, wait=1
+    )
+    assert result is None, "RIP default route did not converge to R(n) view: {}".format(
+        result
+    )
 
 
 def test_kernel_default_route_selected_on_r2():

--- a/tests/topotests/rip_del_instance/test_rip_del_instance.py
+++ b/tests/topotests/rip_del_instance/test_rip_del_instance.py
@@ -73,10 +73,14 @@ def test_rip_del_instance(tgen):
 
     router = tgen.gears["r1"]
 
-    output = router.vtysh_cmd("show running-config")
-
     step("Checking if RIP is configured")
-    assert "router rip" in output, "RIP was not configured on r1"
+
+    def check_rip_configured():
+        output = router.vtysh_cmd("show running-config")
+        return "router rip" in output
+
+    _, result = topotest.run_and_expect(check_rip_configured, True, count=20, wait=1)
+    assert result, "RIP was not configured on r1"
 
     step("Deleting RIP instance via CLI")
     router.vtysh_cmd(

--- a/tests/topotests/rip_topo1/test_rip_topo1.py
+++ b/tests/topotests/rip_topo1/test_rip_topo1.py
@@ -18,7 +18,6 @@ import os
 import re
 import sys
 import pytest
-from time import sleep
 import functools
 
 
@@ -136,8 +135,27 @@ def test_converge_protocols():
     print("\n\n** Waiting for protocols convergence")
     print("******************************************\n")
 
-    # Not really implemented yet - just sleep 11 secs for now
-    sleep(21)
+    reffile = "%s/r1/rip_status.ref" % thisDir
+    if os.path.isfile(reffile):
+        expected = open(reffile).read().rstrip()
+        expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
+
+        def _verify_r1_rip_status():
+            actual = get_topogen().gears["r1"].vtysh_cmd("show ip rip status").rstrip()
+            actual = re.sub(r"in [0-9]+ seconds", "in XX seconds", actual)
+            actual = re.sub(r" [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", " XX:XX:XX", actual)
+            actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+            return topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual IP RIP status",
+                title2="expected IP RIP status",
+            )
+
+        success, diff = topotest.run_and_expect(
+            _verify_r1_rip_status, "", count=30, wait=1
+        )
+        assert success, "RIP did not converge in time:\n{}".format(diff)
 
     # Make sure that all daemons are still running
     for i in range(1, 4):
@@ -158,7 +176,6 @@ def test_rip_status():
     # Verify RIP Status
     print("\n\n** Verifing RIP status")
     print("******************************************\n")
-    failures = 0
     for i in range(1, 4):
         refTableFile = "%s/r%s/rip_status.ref" % (thisDir, i)
         if os.path.isfile(refTableFile):
@@ -167,35 +184,33 @@ def test_rip_status():
             # Fix newlines (make them all the same)
             expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
 
-            # Actual output from router
-            actual = (
-                get_topogen().gears["r%s" % i]
-                .vtysh_cmd("show ip rip status")
-                .rstrip()
-            )
-            # Drop time in next due
-            actual = re.sub(r"in [0-9]+ seconds", "in XX seconds", actual)
-            # Drop time in last update
-            actual = re.sub(r" [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", " XX:XX:XX", actual)
-            # Fix newlines (make them all the same)
-            actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+            def _verify_rip_status(router_idx, expected_data):
+                actual = (
+                    get_topogen()
+                    .gears["r%s" % router_idx]
+                    .vtysh_cmd("show ip rip status")
+                    .rstrip()
+                )
+                # Drop time in next due
+                actual = re.sub(r"in [0-9]+ seconds", "in XX seconds", actual)
+                # Drop time in last update
+                actual = re.sub(
+                    r" [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", " XX:XX:XX", actual
+                )
+                # Fix newlines (make them all the same)
+                actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
 
-            # Generate Diff
-            diff = topotest.get_textdiff(
-                actual,
-                expected,
-                title1="actual IP RIP status",
-                title2="expected IP RIP status",
-            )
+                return topotest.get_textdiff(
+                    actual,
+                    expected_data,
+                    title1="actual IP RIP status",
+                    title2="expected IP RIP status",
+                )
 
-            # Empty string if it matches, otherwise diff contains unified diff
-            if diff:
-                sys.stderr.write("r%s failed IP RIP status check:\n%s\n" % (i, diff))
-                failures += 1
-            else:
-                print("r%s ok" % i)
-
-            assert failures == 0, "IP RIP status failed for router r%s:\n%s" % (i, diff)
+            test_func = functools.partial(_verify_rip_status, i, expected)
+            success, diff = topotest.run_and_expect(test_func, "", count=30, wait=1)
+            assert success, "IP RIP status failed for router r{}:\n{}".format(i, diff)
+            print("r%s ok" % i)
 
     # Make sure that all daemons are still running
     for i in range(1, 4):
@@ -216,7 +231,6 @@ def test_rip_routes():
     # Verify RIP Status
     print("\n\n** Verifing RIP routes")
     print("******************************************\n")
-    failures = 0
     for i in range(1, 4):
         refTableFile = "%s/r%s/show_ip_rip.ref" % (thisDir, i)
         if os.path.isfile(refTableFile):
@@ -225,29 +239,29 @@ def test_rip_routes():
             # Fix newlines (make them all the same)
             expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
 
-            # Actual output from router
-            actual = get_topogen().gears["r%s" % i].vtysh_cmd("show ip rip").rstrip()
-            # Drop Time
-            actual = re.sub(r"[0-9][0-9]:[0-5][0-9]", "XX:XX", actual)
-            # Fix newlines (make them all the same)
-            actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+            def _verify_show_ip_rip(router_idx, expected_data):
+                actual = (
+                    get_topogen()
+                    .gears["r%s" % router_idx]
+                    .vtysh_cmd("show ip rip")
+                    .rstrip()
+                )
+                # Drop Time
+                actual = re.sub(r"[0-9][0-9]:[0-5][0-9]", "XX:XX", actual)
+                # Fix newlines (make them all the same)
+                actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
 
-            # Generate Diff
-            diff = topotest.get_textdiff(
-                actual,
-                expected,
-                title1="actual SHOW IP RIP",
-                title2="expected SHOW IP RIP",
-            )
+                return topotest.get_textdiff(
+                    actual,
+                    expected_data,
+                    title1="actual SHOW IP RIP",
+                    title2="expected SHOW IP RIP",
+                )
 
-            # Empty string if it matches, otherwise diff contains unified diff
-            if diff:
-                sys.stderr.write("r%s failed SHOW IP RIP check:\n%s\n" % (i, diff))
-                failures += 1
-            else:
-                print("r%s ok" % i)
-
-            assert failures == 0, "SHOW IP RIP failed for router r%s:\n%s" % (i, diff)
+            test_func = functools.partial(_verify_show_ip_rip, i, expected)
+            success, diff = topotest.run_and_expect(test_func, "", count=30, wait=1)
+            assert success, "SHOW IP RIP failed for router r{}:\n{}".format(i, diff)
+            print("r%s ok" % i)
 
     # Make sure that all daemons are still running
     for i in range(1, 4):
@@ -263,7 +277,9 @@ def test_zebra_ipv4_routingTable():
         # Actual output from router
         output = get_topogen().gears["r%s" % i].vtysh_cmd("show ip route")
         # Filter only RIP routes (lines starting with R)
-        actual = "\n".join(line for line in output.splitlines() if line.startswith("R")).rstrip()
+        actual = "\n".join(
+            line for line in output.splitlines() if line.startswith("R")
+        ).rstrip()
         # Drop timers on end of line
         actual = re.sub(r", [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", "", actual)
         # Fix newlines (make them all the same)

--- a/tests/topotests/ripng_topo1/test_ripng_topo1.py
+++ b/tests/topotests/ripng_topo1/test_ripng_topo1.py
@@ -18,7 +18,6 @@ import os
 import re
 import sys
 import pytest
-from time import sleep
 import functools
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -126,13 +125,35 @@ def test_converge_protocols():
     if fatal_error != "":
         pytest.skip(fatal_error)
 
-    thisDir = os.path.dirname(os.path.realpath(__file__))
-
     print("\n\n** Waiting for protocols convergence")
     print("******************************************\n")
 
-    # Not really implemented yet - just sleep 11 secs for now
-    sleep(11)
+    thisDir = os.path.dirname(os.path.realpath(__file__))
+    reffile = "%s/r1/ripng_status.ref" % thisDir
+
+    if os.path.isfile(reffile):
+        expected = open(reffile).read().rstrip()
+        expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
+
+        def _verify_r1_ripng_status():
+            actual = (
+                get_topogen().gears["r1"].vtysh_cmd("show ipv6 ripng status").rstrip()
+            )
+            actual = re.sub(r" fe80::[0-9a-f:]+", " fe80::XXXX:XXXX:XXXX:XXXX", actual)
+            actual = re.sub(r"in [0-9]+ seconds", "in XX seconds", actual)
+            actual = re.sub(r" [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", " XX:XX:XX", actual)
+            actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+            return topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual IPv6 RIPng status",
+                title2="expected IPv6 RIPng status",
+            )
+
+        success, diff = topotest.run_and_expect(
+            _verify_r1_ripng_status, "", count=30, wait=1
+        )
+        assert success, "RIPng did not converge in time:\n{}".format(diff)
 
     # Make sure that all daemons are running
     for i in range(1, 4):
@@ -153,7 +174,6 @@ def test_ripng_status():
     # Verify RIP Status
     print("\n\n** Verifying RIPng status")
     print("******************************************\n")
-    failures = 0
     for i in range(1, 4):
         refTableFile = "%s/r%s/ripng_status.ref" % (thisDir, i)
         if os.path.isfile(refTableFile):
@@ -162,42 +182,39 @@ def test_ripng_status():
             # Fix newlines (make them all the same)
             expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
 
-            # Actual output from router
-            actual = (
-                get_topogen().gears["r%s" % i]
-                .vtysh_cmd("show ipv6 ripng status")
-                .rstrip()
-            )
-            # Mask out Link-Local mac address portion. They are random...
-            actual = re.sub(r" fe80::[0-9a-f:]+", " fe80::XXXX:XXXX:XXXX:XXXX", actual)
-            # Drop time in next due
-            actual = re.sub(r"in [0-9]+ seconds", "in XX seconds", actual)
-            # Drop time in last update
-            actual = re.sub(r" [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", " XX:XX:XX", actual)
-            # Fix newlines (make them all the same)
-            actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
-
-            # Generate Diff
-            diff = topotest.get_textdiff(
-                actual,
-                expected,
-                title1="actual IPv6 RIPng status",
-                title2="expected IPv6 RIPng status",
-            )
-
-            # Empty string if it matches, otherwise diff contains unified diff
-            if diff:
-                sys.stderr.write(
-                    "r%s failed IPv6 RIPng status check:\n%s\n" % (i, diff)
+            def _verify_ripng_status(router_idx, expected_data):
+                actual = (
+                    get_topogen()
+                    .gears["r%s" % router_idx]
+                    .vtysh_cmd("show ipv6 ripng status")
+                    .rstrip()
                 )
-                failures += 1
-            else:
-                print("r%s ok" % i)
+                # Mask out Link-Local mac address portion. They are random...
+                actual = re.sub(
+                    r" fe80::[0-9a-f:]+", " fe80::XXXX:XXXX:XXXX:XXXX", actual
+                )
+                # Drop time in next due
+                actual = re.sub(r"in [0-9]+ seconds", "in XX seconds", actual)
+                # Drop time in last update
+                actual = re.sub(
+                    r" [0-2][0-9]:[0-5][0-9]:[0-5][0-9]", " XX:XX:XX", actual
+                )
+                # Fix newlines (make them all the same)
+                actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
 
-            assert failures == 0, "IPv6 RIPng status failed for router r%s:\n%s" % (
-                i,
-                diff,
+                return topotest.get_textdiff(
+                    actual,
+                    expected_data,
+                    title1="actual IPv6 RIPng status",
+                    title2="expected IPv6 RIPng status",
+                )
+
+            test_func = functools.partial(_verify_ripng_status, i, expected)
+            success, diff = topotest.run_and_expect(test_func, "", count=30, wait=1)
+            assert success, "IPv6 RIPng status failed for router r{}:\n{}".format(
+                i, diff
             )
+            print("r%s ok" % i)
 
     # Make sure that all daemons are running
     for i in range(1, 4):
@@ -218,7 +235,6 @@ def test_ripng_routes():
     # Verify RIPng Status
     print("\n\n** Verifying RIPng routes")
     print("******************************************\n")
-    failures = 0
     for i in range(1, 4):
         refTableFile = "%s/r%s/show_ipv6_ripng.ref" % (thisDir, i)
         if os.path.isfile(refTableFile):
@@ -227,41 +243,36 @@ def test_ripng_routes():
             # Fix newlines (make them all the same)
             expected = ("\n".join(expected.splitlines()) + "\n").splitlines(1)
 
-            # Actual output from router
-            actual = (
-                get_topogen().gears["r%s" % i].vtysh_cmd("show ipv6 ripng").rstrip()
-            )
-            # Drop Time
-            actual = re.sub(r" [0-9][0-9]:[0-5][0-9]", " XX:XX", actual)
-            # Mask out Link-Local mac address portion. They are random...
-            actual = re.sub(
-                r" fe80::[0-9a-f: ]+", " fe80::XXXX:XXXX:XXXX:XXXX   ", actual
-            )
-            # Remove trailing spaces on all lines
-            actual = "\n".join([line.rstrip() for line in actual.splitlines()])
+            def _verify_show_ipv6_ripng(router_idx, expected_data):
+                actual = (
+                    get_topogen()
+                    .gears["r%s" % router_idx]
+                    .vtysh_cmd("show ipv6 ripng")
+                    .rstrip()
+                )
+                # Drop Time
+                actual = re.sub(r" [0-9][0-9]:[0-5][0-9]", " XX:XX", actual)
+                # Mask out Link-Local mac address portion. They are random...
+                actual = re.sub(
+                    r" fe80::[0-9a-f: ]+", " fe80::XXXX:XXXX:XXXX:XXXX   ", actual
+                )
+                # Remove trailing spaces on all lines
+                actual = "\n".join([line.rstrip() for line in actual.splitlines()])
 
-            # Fix newlines (make them all the same)
-            actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
+                # Fix newlines (make them all the same)
+                actual = ("\n".join(actual.splitlines()) + "\n").splitlines(1)
 
-            # Generate Diff
-            diff = topotest.get_textdiff(
-                actual,
-                expected,
-                title1="actual SHOW IPv6 RIPng",
-                title2="expected SHOW IPv6 RIPng",
-            )
+                return topotest.get_textdiff(
+                    actual,
+                    expected_data,
+                    title1="actual SHOW IPv6 RIPng",
+                    title2="expected SHOW IPv6 RIPng",
+                )
 
-            # Empty string if it matches, otherwise diff contains unified diff
-            if diff:
-                sys.stderr.write("r%s failed SHOW IPv6 RIPng check:\n%s\n" % (i, diff))
-                failures += 1
-            else:
-                print("r%s ok" % i)
-
-            assert failures == 0, "SHOW IPv6 RIPng failed for router r%s:\n%s" % (
-                i,
-                diff,
-            )
+            test_func = functools.partial(_verify_show_ipv6_ripng, i, expected)
+            success, diff = topotest.run_and_expect(test_func, "", count=30, wait=1)
+            assert success, "SHOW IPv6 RIPng failed for router r{}:\n{}".format(i, diff)
+            print("r%s ok" % i)
 
     # Make sure that all daemons are running
     for i in range(1, 4):
@@ -277,7 +288,9 @@ def test_zebra_ipv6_routingTable():
         # Actual output from router
         output = get_topogen().gears["r%s" % i].vtysh_cmd("show ipv6 route")
         # Filter only RIPng routes (lines starting with R)
-        actual = "\n".join(line for line in output.splitlines() if line.startswith("R")).rstrip()
+        actual = "\n".join(
+            line for line in output.splitlines() if line.startswith("R")
+        ).rstrip()
         # Mask out Link-Local mac address portion. They are random...
         actual = re.sub(r" fe80::[0-9a-f:]+", " fe80::XXXX:XXXX:XXXX:XXXX", actual)
         # Drop timers on end of line

--- a/tests/topotests/sbfd_topo1/test_sbfd_topo1.py
+++ b/tests/topotests/sbfd_topo1/test_sbfd_topo1.py
@@ -36,7 +36,7 @@ from functools import partial
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(CWD, '../'))
+sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
@@ -59,25 +59,26 @@ test_sbfd_topo1.py: test simple sbfd with IPv6 encap. RT1 is sbfd Initiator, RT2
 """
 pytestmark = [pytest.mark.bfdd]
 
-def show_bfd_check(router, status, type='echo', encap=None):
+
+def show_bfd_check(router, status, type="echo", encap=None):
     output = router.cmd("vtysh -c 'show bfd peers'")
     if encap:
         # check encap data if any
-        pattern1 = re.compile(r'encap-data {}'.format(encap))
+        pattern1 = re.compile(r"encap-data {}".format(encap))
         ret = pattern1.findall(output)
         if len(ret) <= 0:
             logger.info("encap-data not match")
             return False
 
     # check  status
-    pattern2 = re.compile(r'Status: {}'.format(status))
+    pattern2 = re.compile(r"Status: {}".format(status))
     ret = pattern2.findall(output)
     if len(ret) <= 0:
         logger.info("Status not match")
         return False
 
     # check type
-    pattern3 = re.compile(r'Peer Type: {}'.format(type))
+    pattern3 = re.compile(r"Peer Type: {}".format(type))
     ret = pattern3.findall(output)
     if len(ret) <= 0:
         logger.info("Peer Type not match")
@@ -85,6 +86,7 @@ def show_bfd_check(router, status, type='echo', encap=None):
 
     logger.info("all check passed")
     return True
+
 
 def build_topo(tgen):
     "Test topology builder"
@@ -96,13 +98,14 @@ def build_topo(tgen):
     #
     # Create 2 routers
     for routern in range(1, 3):
-        tgen.add_router('r{}'.format(routern))
+        tgen.add_router("r{}".format(routern))
 
     # Create a switch with just one router connected to it to simulate a
     # empty network.
-    switch = tgen.add_switch('s1')
-    switch.add_link(tgen.gears['r1'])
-    switch.add_link(tgen.gears['r2'])
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
 
 def setup_module(mod):
     "Sets up the pytest environment"
@@ -117,7 +120,8 @@ def setup_module(mod):
     for rname, router in router_list.items():
         router.load_frr_config(
             os.path.join(CWD, "{}/frr.conf".format(rname)),
-            [(TopoRouter.RD_ZEBRA, None), (TopoRouter.RD_BFD, None)])
+            [(TopoRouter.RD_ZEBRA, None), (TopoRouter.RD_BFD, None)],
+        )
 
     # After loading the configurations, this function loads configured daemons.
     tgen.start_router()
@@ -126,9 +130,10 @@ def setup_module(mod):
     # daemon exists.
     for router in router_list.values():
         # Check for Version
-        if router.has_version('<', '5.1'):
-            tgen.set_error('Unsupported FRR version')
+        if router.has_version("<", "5.1"):
+            tgen.set_error("Unsupported FRR version")
             break
+
 
 def teardown_module(mod):
     "Teardown the pytest environment"
@@ -150,18 +155,21 @@ def test_sbfd_config_check():
         pytest.skip(tgen.errors)
 
     # config sbfd
-    r1 = tgen.net['r1']
+    r1 = tgen.net["r1"]
     check_ping("r1", "2001::20", True, 10, 1)
-    r1.cmd("vtysh -c 'config t' -c 'bfd' -c 'peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234'")
-
-    r2 = tgen.net['r2']
-    r2.cmd("vtysh -c 'config t' -c 'bfd' -c 'sbfd reflector source-address 2001::20 discriminator 1234'")
-
-    check_func = partial(
-        show_bfd_check, r1, 'up', type='sbfd initiator'
+    r1.cmd(
+        "vtysh -c 'config t' -c 'bfd' -c 'peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234'"
     )
+
+    r2 = tgen.net["r2"]
+    r2.cmd(
+        "vtysh -c 'config t' -c 'bfd' -c 'sbfd reflector source-address 2001::20 discriminator 1234'"
+    )
+
+    check_func = partial(show_bfd_check, r1, "up", type="sbfd initiator")
     success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
     assert success is True, "sbfd not up in 15 seconds"
+
 
 # step 2: shutdown if and no shutdown if then check sbfd status
 def test_sbfd_updown_interface():
@@ -175,25 +183,22 @@ def test_sbfd_updown_interface():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    r1 = tgen.net['r1']
-    r2 = tgen.net['r2']
+    r1 = tgen.net["r1"]
+    r2 = tgen.net["r2"]
 
     # shutdown interface
     r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'shutdown'")
 
-    check_func = partial(
-        show_bfd_check, r1, 'down', type='sbfd initiator'
-    )
+    check_func = partial(show_bfd_check, r1, "down", type="sbfd initiator")
     success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
     assert success is True, "sbfd not down in 15 seconds after shut"
 
     # up interface
     r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'no shutdown'")
-    check_func = partial(
-        show_bfd_check, r1, 'up', type='sbfd initiator'
-    )
+    check_func = partial(show_bfd_check, r1, "up", type="sbfd initiator")
     success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
     assert success is True, "sbfd not up in 15 seconds after no shut"
+
 
 # step 3: change transmit-interval and check sbfd status according to the interval time
 def test_sbfd_change_transmit_interval():
@@ -207,43 +212,46 @@ def test_sbfd_change_transmit_interval():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    r1 = tgen.net['r1']
-    r2 = tgen.net['r2']
+    r1 = tgen.net["r1"]
+    r2 = tgen.net["r2"]
 
-    r1.cmd("vtysh -c 'config t' -c 'bfd' -c 'peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234' -c 'transmit-interval 3000'")
-    #wait sometime for polling finish
+    r1.cmd(
+        "vtysh -c 'config t' -c 'bfd' -c 'peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234' -c 'transmit-interval 3000'"
+    )
+    # wait sometime for polling finish
     time.sleep(1)
 
     # shutdown interface
     r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'shutdown'")
 
-    #wait enough time for timeout
-    check_func = partial(
-        show_bfd_check, r1, 'down', type='sbfd initiator'
-    )
+    # wait enough time for timeout
+    check_func = partial(show_bfd_check, r1, "down", type="sbfd initiator")
     success, _ = topotest.run_and_expect(check_func, True, count=5, wait=3)
     assert success is True, "sbfd not down as expected"
 
     r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'no shutdown'")
-    check_func = partial(
-        show_bfd_check, r1, 'up', type='sbfd initiator'
-    )
+    check_func = partial(show_bfd_check, r1, "up", type="sbfd initiator")
     success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
     assert success is True, "sbfd not up in 15 seconds after no shut"
 
-    r1.cmd("vtysh -c 'config t' -c 'bfd' -c 'no peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234'")
-    success = show_bfd_check(r1, 'up', type='sbfd initiator')
-    assert success is False, "sbfd not deleted as unexpected"
+    r1.cmd(
+        "vtysh -c 'config t' -c 'bfd' -c 'no peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234'"
+    )
+    check_func = partial(show_bfd_check, r1, "up", type="sbfd initiator")
+    success, _ = topotest.run_and_expect(check_func, False, count=15, wait=1)
+    assert success is True, "sbfd not deleted as unexpected"
+
 
 # Memory leak test template
 def test_memory_leak():
     "Run the memory leak test and report results."
     tgen = get_topogen()
     if not tgen.is_memleak_enabled():
-        pytest.skip('Memory leak test/report is disabled')
+        pytest.skip("Memory leak test/report is disabled")
 
     tgen.report_memory_leaks()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/tests/topotests/simple_snmp_test/test_simple_snmp.py
+++ b/tests/topotests/simple_snmp_test/test_simple_snmp.py
@@ -22,9 +22,9 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
+from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.snmptest import SnmpTester
-from time import sleep
 from lib.topolog import logger
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
@@ -70,23 +70,22 @@ def setup_module(mod):
                 (TopoRouter.RD_OSPF6, "-M snmp"),
             ],
         )
-        router.load_config(TopoRouter.RD_SNMP,
-                           os.path.join(CWD, "{}/snmpd.conf".format(rname)),
-                           "-Le -Ivacm_conf,usmConf,iquery -V -DAgentX,trap")
-
+        router.load_config(
+            TopoRouter.RD_SNMP,
+            os.path.join(CWD, "{}/snmpd.conf".format(rname)),
+            "-Le -Ivacm_conf,usmConf,iquery -V -DAgentX,trap",
+        )
 
     # After loading the configurations, this function loads configured daemons.
     tgen.start_router()
-    # Why this sleep?  If you are using zebra w/ snmp we have a chicken
-    # and egg problem with the snmpd.  snmpd is being started up with
-    # ip addresses, and as such snmpd may not be ready to listen yet
-    # (see startup stuff in topotest.py ) with the 2 second delay
-    # on starting snmpd after zebra.  As such if we want to test
-    # anything in zebra we need to sleep a bit to allow the connection
-    # to happen.  I have no good way to test to see if zebra is up
-    # and running with snmp at this point in time.  So this will have
-    # to do.
-    sleep(17)
+
+    # Wait until SNMP is answering before tests start.
+    def _snmp_ready():
+        r1_snmp = SnmpTester(r1, "1.1.1.1", "public", "2c")
+        return r1_snmp.test_oid("bgpVersion", "10")
+
+    _, ready = topotest.run_and_expect(_snmp_ready, True, count=40, wait=1)
+    assert ready is True, "SNMP daemon did not become ready in time"
 
 
 def teardown_module():

--- a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+++ b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
@@ -203,11 +203,14 @@ def test_srv6_static_sids_wrong_sid_block():
         """
     )
 
-    output = json.loads(router.vtysh_cmd("show ipv6 route static json"))
-    if "fcbb:bbbb:1:fe50::/64" in output:
-        assert (
-            False
-        ), "Failed. Expected no entry for fcbb:bbbb:1:fe50::/64 since loc and node block dont match"
+    def wrong_sid_not_installed():
+        output = json.loads(router.vtysh_cmd("show ipv6 route static json"))
+        return "fcbb:bbbb:1:fe50::/64" not in output
+
+    _, result = topotest.run_and_expect(wrong_sid_not_installed, True, count=30, wait=1)
+    assert (
+        result is True
+    ), "Failed. Expected no entry for fcbb:bbbb:1:fe50::/64 since loc and node block dont match"
 
 
 def test_srv6_static_sids_sid_delete_all():

--- a/tests/topotests/zebra_fec_nexthop_resolution/test_zebra_fec_nexthop_resolution.py
+++ b/tests/topotests/zebra_fec_nexthop_resolution/test_zebra_fec_nexthop_resolution.py
@@ -138,7 +138,16 @@ def test_zebra_fec_nexthop_resolution_finalise_ospf_config():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    topotest.sleep(2)
+    def _all_routers_running():
+        for rname in ("r1", "r2", "r3", "r4", "r5", "r6", "r7"):
+            if tgen.net[rname].checkRouterRunning() != "":
+                return False
+        return True
+
+    _, ready = topotest.run_and_expect(_all_routers_running, True, count=10, wait=1)
+    assert (
+        ready is True
+    ), "Routers were not ready before applying OSPF post-start config"
 
     tgen.net["r1"].cmd("vtysh -f {}/r1/ospfd.conf.after".format(CWD))
     tgen.net["r2"].cmd("vtysh -f {}/r2/ospfd.conf.after".format(CWD))

--- a/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
+++ b/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
@@ -20,7 +20,6 @@ import re
 import sys
 import pytest
 import json
-from time import sleep
 
 from lib.common_config import (
     kill_router_daemons,
@@ -103,7 +102,6 @@ def teardown_module(_mod):
 
 
 def test_bgp_route_install_r1():
-    failures = 0
     tgen = get_topogen()
     net = tgen.net
     expected_route_count = 2000
@@ -130,17 +128,7 @@ def test_bgp_route_install_r1():
     ipv4_cmd = f"vtysh -c 'sharp install routes 39.99.0.0 nexthop {ipv4_nexthop} {expected_route_count}'"
     net["r1"].cmd(ipv4_cmd)
 
-    # Initialize actual counts
-    ipv4_actual_count = 0
-    max_attempts = 12  # 60 seconds max (12 * 5)
-    attempt = 0
-
-    # Wait until IPv4 routes are installed
-    while (ipv4_actual_count != expected_route_count) and attempt < max_attempts:
-        sleep(5)
-        attempt += 1
-
-        # Get current IPv4 route count
+    def check_ipv4_route_count():
         ipv4_count_str = (
             net["r2"]
             .cmd('vtysh -c "show bgp ipv4 unicast" | grep "39.99" | wc -l')
@@ -150,19 +138,15 @@ def test_bgp_route_install_r1():
         try:
             ipv4_actual_count = int(ipv4_count_str)
         except ValueError:
-            ipv4_actual_count = 0
+            return 0
+        return ipv4_actual_count
 
-        print(f"Attempt {attempt}")
-        print(f"IPv4 Routes found: {ipv4_actual_count} / {expected_route_count}")
-
-    # Verify we have the expected number of routes
-    if ipv4_actual_count != expected_route_count:
-        sys.stderr.write(
-            f"Failed to install expected IPv4 routes: got {ipv4_actual_count}, expected {expected_route_count}\n"
-        )
-        failures += 1
-    else:
-        print("IPv4 routes successfully installed")
+    success, result = topotest.run_and_expect(
+        check_ipv4_route_count, expected_route_count, count=60, wait=1
+    )
+    assert (
+        success
+    ), f"Failed to install expected IPv4 routes: got {result}, expected {expected_route_count}"
 
 
 def test_bgp_established():
@@ -175,6 +159,7 @@ def test_bgp_established():
         pytest.skip(tgen.errors)
 
     step("Test that BGP session between r1 and r2 is established")
+
     # Create a function to check BGP peer status on r1
     def check_bgp_peer():
         output = net["r2"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
@@ -222,6 +207,7 @@ def test_bgp_routes_on_r2():
         pytest.skip(tgen.errors)
 
     step("Test that routes installed on r1 are properly received by r2")
+
     # Create a function to check the route count on r2
     def check_r2_routes():
         route_count = (
@@ -245,6 +231,7 @@ def test_bgp_routes_on_r2():
     assert success, f"Expected {expected_route_count} routes on r2 but found {result}"
 
     step("Test that all routes are installed in the FIB")
+
     # Create a function to check the FIB route count
     def check_fib_routes():
         output = net["r2"].cmd('vtysh -c "show ip route summary"')
@@ -272,6 +259,7 @@ def test_bgp_routes_on_r2():
     assert success, f"Expected {expected_route_count} routes in FIB but found {result}"
 
     step("Verify that the nexthop group for 39.99.0.0 routes has 128 members")
+
     # Create a function to check the nexthop group member count
     def check_nhg_members():
         output = net["r2"].cmd('vtysh -c "show ip route 39.99.0.0 json"')
@@ -405,6 +393,7 @@ def test_bgp_shutdown_some_links():
         net["r2"].cmd(f"ip link set r2-eth{i} down")
 
     step("Test that 20 BGP peers are failed")
+
     # Create a function to check BGP peer status on r2
     def check_failed_peers():
         output = net["r2"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
@@ -444,6 +433,7 @@ def test_bgp_shutdown_some_links():
     assert success, f"Expected 20 failed BGP peers but found {result}"
 
     step("Verify that the nexthop group ID hasn't changed")
+
     # Verify that the nexthop group ID hasn't changed
     def verify_nhg_unchanged():
         output = net["r2"].cmd('vtysh -c "show ip route bgp json"')
@@ -501,6 +491,7 @@ def test_bgp_shutdown_some_links():
         net["r2"].cmd(f"ip link set r2-eth{i} up")
 
     step("Test that all BGP peers are established")
+
     # Create a function to check that all BGP peers are established
     def check_all_peers_established():
         output = net["r2"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
@@ -533,6 +524,7 @@ def test_bgp_shutdown_some_links():
     assert success, f"Expected 0 failed BGP peers but found {result}"
 
     step("Verify that the original nexthop group is still being used")
+
     # Final verification that the original nexthop group is still being used
     def verify_final_nhg():
         output = net["r2"].cmd('vtysh -c "show ip route bgp json"')

--- a/tests/topotests/zebra_received_nhe_kept/test_zebra_received_nhe_kept.py
+++ b/tests/topotests/zebra_received_nhe_kept/test_zebra_received_nhe_kept.py
@@ -152,10 +152,15 @@ def test_zebra_received_nhe_kept_remove_routes():
             break
 
     step("Verify NHG {} has refcount of 2".format(nhg_id))
+
     # Get the NHG information
-    nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
-    nhg_json = json.loads(nhg_info)
-    assert nhg_json[str(nhg_id)]["refCount"] == 4, "NHG refcount is not 4"
+    def check_nhg_refcount_4():
+        nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
+        nhg_json = json.loads(nhg_info)
+        return nhg_json.get(str(nhg_id), {}).get("refCount")
+
+    _, result = topotest.run_and_expect(check_nhg_refcount_4, 4, count=30, wait=1)
+    assert result == 4, "NHG refcount is not 4"
 
 
 def test_zebra_received_nhe_kept_add_routes():
@@ -219,10 +224,15 @@ def test_zebra_received_nhe_kept_add_routes():
         ), f"Route {prefix} has different NHG ID"
 
     step("Verify NHG {} has refcount of 10".format(nhg_id))
+
     # Get the NHG information
-    nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
-    nhg_json = json.loads(nhg_info)
-    assert nhg_json[str(nhg_id)]["refCount"] == 20, "NHG refcount is not 20"
+    def check_nhg_refcount_20():
+        nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
+        nhg_json = json.loads(nhg_info)
+        return nhg_json.get(str(nhg_id), {}).get("refCount")
+
+    _, result = topotest.run_and_expect(check_nhg_refcount_20, 20, count=30, wait=1)
+    assert result == 20, "NHG refcount is not 20"
 
 
 def test_zebra_received_nhe_kept_remove_all_routes():
@@ -272,14 +282,17 @@ def test_zebra_received_nhe_kept_remove_all_routes():
     assert result, "Routes were not properly removed"
 
     step("Get NHG information")
+
     # Get all NHG information
-    nhg_info = r1.vtysh_cmd("show nexthop-group rib json")
-    nhg_json = json.loads(nhg_info)
+    def check_nhg_removed():
+        nhg_info = r1.vtysh_cmd("show nexthop-group rib json")
+        nhg_json = json.loads(nhg_info)
+        return str(nhg_id) not in nhg_json
+
+    _, result = topotest.run_and_expect(check_nhg_removed, True, count=30, wait=1)
 
     # Verify the specific NHG we looked up is no longer present
-    assert (
-        str(nhg_id) not in nhg_json
-    ), f"NHG {nhg_id} still exists after removing all routes"
+    assert result, f"NHG {nhg_id} still exists after removing all routes"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are a large number of places where the topotests are changing state via some sort of command and then immediately checking to see if that state is reflected, without giving time for that command to be processed.  Modify these places that have been identified and switch the resulting show commands( of what ever ilk ) to use run_and_expect.