### PR TITLE
lib/typesafe: guard skiplist level generation against ctz(0) UB

### DIFF
--- a/lib/typesafe.c
+++ b/lib/typesafe.c
@@ -234,9 +234,13 @@ struct sskip_item *typesafe_skiplist_add(struct sskip_head *head,
 	size_t level = SKIPLIST_MAXDEPTH, newlevel, auxlevel;
 	struct sskip_item *prev = &head->hitem, *next, *auxprev, *auxnext;
 	int cmpval;
+	unsigned long rnd;
 
 	/* level / newlevel are 1-counted here */
-	newlevel = __builtin_ctz(frr_weak_random()) + 1;
+	do {
+		rnd = (unsigned long)frr_weak_random();
+	} while (rnd == 0);
+	newlevel = __builtin_ctzl(rnd) + 1;
 	if (newlevel > SKIPLIST_MAXDEPTH)
 		newlevel = SKIPLIST_MAXDEPTH;
 


### PR DESCRIPTION
  This PR fixes a crash in ospf6d seen in large OSPFv3 topologies (issue #20897).

  **Root cause:**

  - `typesafe_skiplist_add()` computed the random level with:
      - `__builtin_ctz(frr_weak_random()) + 1`
  - `frr_weak_random()` can return `0`.
  - `__builtin_ctz(0)` is undefined behavior, which can produce invalid newlevel values and lead to bogus large allocation sizes for skiplist overflow objects (matching the reported near-2^64 allocation failures).

  **Fix:**

  - Ensure the random value is non-zero before calling ctz.
  - Use `__builtin_ctzl()` on an unsigned long local after the zero guard.

  **Code changed:**

  - `lib/typesafe.c (typesafe_skiplist_add)`

  **Behavior impact:**

  - No functional change to normal skiplist behavior.
  - Prevents UB and resulting crash path when random returns zero.

  Fixes #20897
