### PR TITLE
bgpd: support brief json for bgp l2vpn evpn rd and rd type command

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3031,9 +3031,8 @@ static void evpn_show_route_rd_prefix(struct vty *vty, struct bgp *bgp, struct p
  * Display BGP EVPN routing table -- for specific RD (vty handler)
  * If 'type' is non-zero, only routes matching that type are shown.
  */
-static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
-			       struct prefix_rd *prd, int type,
-			       json_object *json)
+static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp, struct prefix_rd *prd, int type,
+			       json_object *json, bool brief)
 {
 	struct bgp_dest *rd_dest;
 	struct bgp_table *table;
@@ -3042,13 +3041,16 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 	int rd_header = 1;
 	afi_t afi;
 	safi_t safi;
-	uint32_t prefix_cnt, path_cnt;
+	uint32_t prefix_cnt, path_cnt, rd_prefix_cnt;
 	json_object *json_rd = NULL;
+	json_object *json_rd_prefixes = NULL;
 	int add_rd_to_json = 0;
+	int prefix_path_count, multi_path_count;
+	bool best_path_selected;
 
 	afi = AFI_L2VPN;
 	safi = SAFI_EVPN;
-	prefix_cnt = path_cnt = 0;
+	prefix_cnt = path_cnt = rd_prefix_cnt = 0;
 
 	rd_dest = bgp_node_lookup(bgp->rib[afi][safi], (struct prefix *)prd);
 	if (!rd_dest)
@@ -3062,8 +3064,18 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 
 	if (json) {
 		json_rd = json_object_new_object();
-		json_object_string_addf(json_rd, "rd",
-					BGP_RD_AS_FORMAT(bgp->asnotation), prd);
+		if (brief) {
+			/*
+			 * Brief output: keep RD object as a struct of named
+			 * fields. Per-prefix entries live in their own
+			 * "prefixes" sub-object so the collection is not
+			 * mixed with scalar metadata like "numPrefixes".
+			 */
+			json_rd_prefixes = json_object_new_object();
+		} else {
+			json_object_string_addf(json_rd, "rd", BGP_RD_AS_FORMAT(bgp->asnotation),
+						prd);
+		}
 	}
 
 	bgp_dest_unlock_node(rd_dest);
@@ -3074,6 +3086,7 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			(const struct prefix_evpn *)bgp_dest_get_prefix(dest);
 		json_object *json_prefix = NULL;
 		json_object *json_paths = NULL;
+		json_object *json_flags = NULL; /* contains flags under a prefix */
 		int add_prefix_to_json = 0;
 
 		if (type && evp->prefix.route_type != type)
@@ -3099,63 +3112,111 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 				rd_header = 0;
 			}
 
-			/* Prefix and num paths displayed once per prefix. */
-			route_vty_out_detail_header(vty, bgp, dest,
-						    bgp_dest_get_prefix(dest),
-						    prd, afi, safi, json_prefix,
-						    false, false);
+			if (!brief)
+				/* Prefix and num paths displayed once per prefix. */
+				route_vty_out_detail_header(vty, bgp, dest,
+							    bgp_dest_get_prefix(dest), prd, afi,
+							    safi, json_prefix, false, false);
 
 			prefix_cnt++;
+			rd_prefix_cnt++;
 		}
 
-		if (json)
+		prefix_path_count = 0;
+		best_path_selected = false;
+		multi_path_count = 0;
+		if (json && !brief)
 			json_paths = json_object_new_array();
 
 		/* Display each path for this prefix. */
 		for (; pi; pi = pi->next) {
 			json_object *json_path = NULL;
 
-			if (json)
-				json_path = json_object_new_array();
+			if (!brief) {
+				if (json)
+					json_path = json_object_new_array();
 
-			route_vty_out_detail(vty, bgp, dest, bgp_dest_get_prefix(dest), pi, afi,
-					     safi, RPKI_NOT_BEING_USED, json_path, NULL, 0);
+				route_vty_out_detail(vty, bgp, dest, bgp_dest_get_prefix(dest), pi,
+						     afi, safi, RPKI_NOT_BEING_USED, json_path,
+						     NULL, 0);
 
-			if (json)
-				json_object_array_add(json_paths, json_path);
+				if (json)
+					json_object_array_add(json_paths, json_path);
+			}
 
 			path_cnt++;
 			add_prefix_to_json = 1;
 			add_rd_to_json = 1;
+
+			prefix_path_count++;
+			if (CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH))
+				multi_path_count++;
+			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+				best_path_selected = true;
 		}
 
 		if (json) {
+			json_object_int_add(json_prefix, "pathCount", prefix_path_count);
+			/* add +1 to the multipath count because it does
+			 * not include the best path itself
+			 */
+			if (best_path_selected)
+				json_object_int_add(json_prefix, "multiPathCount",
+						    multi_path_count + 1);
+			else
+				json_object_int_add(json_prefix, "multiPathCount",
+						    multi_path_count);
+
 			if (add_prefix_to_json) {
-				json_object_object_add(json_prefix, "paths",
-						       json_paths);
-				json_object_object_addf(json_rd, json_prefix,
-							"%pFX", evp);
+				if (!brief)
+					json_object_object_add(json_prefix, "paths", json_paths);
+
+				json_flags = json_object_new_object();
+				json_object_boolean_add(json_flags, "bestPathExists",
+							best_path_selected);
+				json_object_object_add(json_prefix, "flags", json_flags);
+
+				if (brief)
+					json_object_object_addf(json_rd_prefixes, json_prefix,
+								"%pFX", evp);
+				else
+					json_object_object_addf(json_rd, json_prefix, "%pFX", evp);
 			} else {
-				json_object_free(json_paths);
+				if (!brief) {
+					json_object_free(json_paths);
+					json_paths = NULL;
+				}
 				json_object_free(json_prefix);
-				json_paths = NULL;
+				json_object_free(json_flags);
 				json_prefix = NULL;
+				json_flags = NULL;
 			}
 		}
 	}
 
 	if (json) {
-		if (add_rd_to_json)
+		if (add_rd_to_json) {
+			if (brief) {
+				json_object_int_add(json_rd, "numPrefixes", rd_prefix_cnt);
+				json_object_object_add(json_rd, "prefixes", json_rd_prefixes);
+				json_rd_prefixes = NULL;
+			}
 			json_object_object_addf(
 				json, json_rd,
 				BGP_RD_AS_FORMAT(bgp->asnotation), prd);
-		else {
+		} else {
 			json_object_free(json_rd);
 			json_rd = NULL;
+			if (json_rd_prefixes) {
+				json_object_free(json_rd_prefixes);
+				json_rd_prefixes = NULL;
+			}
 		}
 
-		json_object_int_add(json, "numPrefix", prefix_cnt);
-		json_object_int_add(json, "numPaths", path_cnt);
+		if (!brief) {
+			json_object_int_add(json, "numPrefix", prefix_cnt);
+			json_object_int_add(json, "numPaths", path_cnt);
+		}
 	} else {
 		if (prefix_cnt == 0)
 			vty_out(vty, "No prefixes exist with this RD%s\n",
@@ -5190,9 +5251,9 @@ DEFPY(show_bgp_l2vpn_evpn_route,
 /*
  * Display global EVPN routing table for specific RD.
  */
-DEFUN(show_bgp_l2vpn_evpn_route_rd,
+DEFPY(show_bgp_l2vpn_evpn_route_rd,
       show_bgp_l2vpn_evpn_route_rd_cmd,
-      "show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN|all> [type "EVPN_TYPE_ALL_LIST"] [json]",
+      "show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN|all> [type "EVPN_TYPE_ALL_LIST"] [json$uj [brief$brief]]",
       SHOW_STR
       BGP_STR
       L2VPN_HELP_STR
@@ -5203,13 +5264,13 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd,
       "All VPN Route Distinguishers\n"
       EVPN_TYPE_HELP_STR
       EVPN_TYPE_ALL_LIST_HELP_STR
-      JSON_STR)
+      JSON_STR
+      "Brief information on EVPN routes (JSON output)\n")
 {
 	struct bgp *bgp;
 	int ret = 0;
 	struct prefix_rd prd;
 	int type = 0;
-	bool uj = false;
 	json_object *json = NULL;
 	int idx_ext_community = 0;
 	int rd_all = 0;
@@ -5217,9 +5278,6 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd,
 	bgp = bgp_get_evpn();
 	if (!bgp)
 		return CMD_WARNING;
-
-	/* check if we need json output */
-	uj = use_json(argc, argv);
 
 	if (!argv_find(argv, argc, "all", &rd_all)) {
 		/* get the RD */
@@ -5244,7 +5302,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd,
 		if (uj)
 			vty_out(vty, "{\n");
 
-		evpn_show_all_routes(vty, bgp, type, json, 1, false, false);
+		evpn_show_all_routes(vty, bgp, type, json, 1, false, uj && brief);
 
 		if (uj) {
 			vty_out(vty, "}\n");
@@ -5252,7 +5310,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd,
 			return CMD_SUCCESS;
 		}
 	} else {
-		evpn_show_route_rd(vty, bgp, &prd, type, json);
+		evpn_show_route_rd(vty, bgp, &prd, type, json, uj && brief);
 	}
 
 	if (uj)

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5826,6 +5826,25 @@ Displaying Routes by Route Distinguisher
    ``all`` is used instead of a specific RD). Only ``json`` is supported here;
    there is no ``brief`` modifier on this variant.
 
+BGP EVPN Route RD Brief Command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. clicmd:: show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN|all> [json [brief]]
+
+   Display EVPN routes for the given Route Distinguisher. Without ``json``,
+   output is the usual detailed text. With ``json``, output is full detail in
+   JSON.
+
+   The ``brief`` keyword is only valid together with ``json``. Use
+   ``json brief`` for a reduced JSON structure: ``numPrefixes`` per RD and, per
+   prefix, ``pathCount``, ``multiPathCount``, and ``flags`` (including
+   ``bestPathExists``).
+
+.. clicmd:: show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN|all> type <ead|1|macip|2|multicast|3|es|4|prefix|5> [json [brief]]
+
+   Same as above, restricted to the given EVPN route type. Use ``json brief``
+   for the same reduced JSON format.
+
 Displaying Update Group Information
 -----------------------------------
 

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -344,6 +344,53 @@ def test_ip_pe2_learn():
     # tgen.mininet_cli()
 
 
+def test_evpn_route_rd_brief_json():
+    """
+    Test show bgp l2vpn evpn route rd <rd> json brief output format
+    (brief is only valid with json).
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe2 = tgen.gears["PE2"]
+    rd, _oip, _soo = get_bgp_l2vni_fields(pe2, 101)
+
+    step(f"Verify 'show bgp l2vpn evpn route rd {rd} json brief' structure")
+    out = pe2.vtysh_cmd(f"show bgp l2vpn evpn route rd {rd} json brief", isjson=True)
+    assert rd in out, f"json brief missing RD key '{rd}'"
+    rd_obj = out[rd]
+    assert "numPrefixes" in rd_obj
+    assert isinstance(rd_obj["numPrefixes"], int)
+    assert "prefixes" in rd_obj and isinstance(
+        rd_obj["prefixes"], dict
+    ), f"RD '{rd}' missing 'prefixes' sub-object"
+    assert rd_obj["numPrefixes"] == len(rd_obj["prefixes"]), (
+        f"RD '{rd}' numPrefixes ({rd_obj['numPrefixes']}) does not match "
+        f"len(prefixes) ({len(rd_obj['prefixes'])})"
+    )
+    for key, val in rd_obj["prefixes"].items():
+        assert isinstance(val, dict), f"prefix '{key}' should be object"
+        assert "pathCount" in val, f"prefix '{key}' missing pathCount"
+        assert "multiPathCount" in val, f"prefix '{key}' missing multiPathCount"
+        assert "flags" in val and isinstance(val["flags"], dict)
+        assert "bestPathExists" in val["flags"]
+
+    step(f"Verify 'show bgp l2vpn evpn route rd {rd} type 3 json brief'")
+    out_type3 = pe2.vtysh_cmd(
+        f"show bgp l2vpn evpn route rd {rd} type 3 json brief",
+        isjson=True,
+    )
+    assert rd in out_type3
+    rd_obj3 = out_type3[rd]
+    assert "numPrefixes" in rd_obj3
+    assert "prefixes" in rd_obj3 and isinstance(rd_obj3["prefixes"], dict)
+    assert rd_obj3["numPrefixes"] == len(rd_obj3["prefixes"])
+    for key, val in rd_obj3["prefixes"].items():
+        assert "pathCount" in val and "multiPathCount" in val and "flags" in val
+        assert "bestPathExists" in val["flags"]
+
+
 def is_installed(json_paths, soo):
     """
     check if any path has been selected as best.


### PR DESCRIPTION
brief-json support is added for show bgp l2vpn-evpn rd and route-type.

The new cli will look like below:
OUTPUT LOGS:
PE1# show bgp l2vpn evpn route rd 10.30.30.30:101 type 3 json brief
{
  "10.30.30.30:101":{
    "numPrefixes":1,
    "prefixes":{
      "[3]:[0]:[32]:[10.30.30.30]":{
        "pathCount":1,
        "multiPathCount":1,
        "flags":{
          "bestPathExists":true
        }
      }
    }
  }
}
PE1# 

PE1# 
PE1# show bgp l2vpn evpn route rd 10.30.30.30:101 json brief 
{
  "10.30.30.30:101":{
    "numPrefixes":5,
    "prefixes":{
      "[2]:[0]:[48]:[22:56:eb:84:c1:90]":{
        "pathCount":1,
        "multiPathCount":1,
        "flags":{
          "bestPathExists":true
        }
      },
      "[2]:[0]:[48]:[7a:6d:0c:13:16:a6]":{
        "pathCount":1,
        "multiPathCount":1,
        "flags":{
          "bestPathExists":true
        }
      },
      "[2]:[0]:[48]:[aa:bb:cc:00:22:ff]:[32]:[10.10.1.3]":{
        "pathCount":1,
        "multiPathCount":1,
        "flags":{
          "bestPathExists":true
        }
      },
      "[2]:[0]:[48]:[aa:bb:cc:00:22:ff]:[128]:[fe80::a8bb:ccff:fe00:22ff]":{
        "pathCount":1,
        "multiPathCount":1,
        "flags":{
          "bestPathExists":true
        }
      },
      "[3]:[0]:[32]:[10.30.30.30]":{
        "pathCount":1,
        "multiPathCount":1,
        "flags":{
          "bestPathExists":true
        }
      }
    }
  }
}
PE1# 