### PR TITLE
zebra: Modify rib_process_dplane_results to limmit work done

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -715,6 +715,11 @@ struct event_loop *dplane_get_thread_master(void)
 	return zdplane_info.dg_master;
 }
 
+uint32_t zebra_dplane_get_work_limit(void)
+{
+	return zdplane_info.dg_updates_per_cycle;
+}
+
 /*
  * Allocate a dataplane update context
  */
@@ -989,6 +994,24 @@ void dplane_ctx_list_append(struct dplane_ctx_list_head *to_list,
 
 	while ((ctx = dplane_ctx_list_pop(from_list)) != NULL)
 		dplane_ctx_list_add_tail(to_list, ctx);
+}
+
+/*
+ * Append a list of context blocks to another list
+ *
+ * limit is applied to the number transferred.
+ */
+uint32_t dplane_ctx_list_append_count_max(struct dplane_ctx_list_head *to_list,
+					  struct dplane_ctx_list_head *from_list, uint32_t limit)
+{
+	struct zebra_dplane_ctx *ctx;
+
+	while (limit && (ctx = dplane_ctx_list_pop(from_list)) != NULL) {
+		dplane_ctx_list_add_tail(to_list, ctx);
+		limit--;
+	}
+
+	return dplane_ctx_list_count(from_list);
 }
 
 struct zebra_dplane_ctx *dplane_ctx_get_head(struct dplane_ctx_list_head *q)

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -33,6 +33,8 @@ DECLARE_MTYPE(VLAN_CHANGE_ARR);
  */
 uint32_t zebra_dplane_get_version(void);
 
+uint32_t zebra_dplane_get_work_limit(void);
+
 /* Key netlink info from zebra ns */
 struct zebra_dplane_info {
 	ns_id_t ns_id;
@@ -327,6 +329,9 @@ void dplane_ctx_enqueue_tail(struct dplane_ctx_list_head *q,
  */
 void dplane_ctx_list_append(struct dplane_ctx_list_head *to_list,
 			    struct dplane_ctx_list_head *from_list);
+
+uint32_t dplane_ctx_list_append_count_max(struct dplane_ctx_list_head *to_list,
+					  struct dplane_ctx_list_head *from_list, uint32_t limit);
 
 /* Dequeue a context block from the head of caller's tailq */
 struct zebra_dplane_ctx *dplane_ctx_dequeue(struct dplane_ctx_list_head *q);


### PR DESCRIPTION
Under heavy load the rib_process_dplane_results can run for minutes at a time:

zebra daemon.warning : [R19DC-BSZSS][EC 100663313] CPU HOG: task rib_process_dplane_results (562d04b8be60) ran for 348292ms (cpu time 337021ms)

Add a bit of code to limit this work to a more reasonable number of items before allowing other processing to happen in FRR.