### PR TITLE
tests: fix some python and test syntax

### DIFF
--- a/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
+++ b/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
@@ -193,7 +193,7 @@ def test_rt_extcomm_list_expanded_delete():
     _unset_extcomm_list(r2, "rt", "1.1.1.1:1")
 
     # set the extended community with regex for deletion
-    _set_extcomm_list_regex(r2, "rt", "1\.1\.1\.[1-2]:1")
+    _set_extcomm_list_regex(r2, "rt", "1.1.1.[1-2]:1")
 
     # check for the deletion of the extended community
     test_func = functools.partial(

--- a/tests/topotests/wucmp_bgp_diamond/test_wucmp_use_underlay.py
+++ b/tests/topotests/wucmp_bgp_diamond/test_wucmp_use_underlay.py
@@ -37,9 +37,9 @@ def build_topo(tgen):
     """
     Build a diamond topology:
           r1 (AS 65001)
-         /  \
+         / \\
         r2  r3 (AS 65002/65003)
-         \  /
+         \\ /
           r4 (AS 65004)
 
     All nodes have eBGP sessions with their directly connected peers.

--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -21,8 +21,6 @@ import json
 from functools import partial
 from lib.topolog import logger
 
-pytestmark = pytest.mark.random_order(disabled=True)
-
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))


### PR DESCRIPTION
Fix a couple of python escape syntax warnings, and an unknown pytest mark - was seeing these reported in recent CI runs.
