### PR TITLE
Always compare med fix

### DIFF
--- a/tests/topotests/bgp_always_compare_med/test_bgp_always_compare_med_topo1.py
+++ b/tests/topotests/bgp_always_compare_med/test_bgp_always_compare_med_topo1.py
@@ -212,7 +212,7 @@ def initial_configuration(tgen, tc_name):
                                     "prefix_lists": "pf_ls_r2_{}".format(addr_type)
                                 }
                             },
-                            "set": {"med": 300},
+                            "set": {"metric": 300},
                         }
                     ]
                 }
@@ -227,7 +227,7 @@ def initial_configuration(tgen, tc_name):
                                     "prefix_lists": "pf_ls_r3_{}".format(addr_type)
                                 }
                             },
-                            "set": {"med": 200},
+                            "set": {"metric": 200},
                         }
                     ]
                 }
@@ -502,7 +502,7 @@ def test_verify_bgp_always_compare_med_functionality_bw_eBGP_peers_by_changing_A
         input_static_r1 = {
             "r1": {"static_routes": [{"network": NETWORK1_1[addr_type]}]}
         }
-        nh = topo["routers"]["r2"]["links"]["r1"][addr_type].split("/")[0]
+        nh = topo["routers"]["r3"]["links"]["r1"][addr_type].split("/")[0]
 
         result = verify_bgp_rib(tgen, addr_type, "r1", input_static_r1)
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
@@ -563,7 +563,7 @@ def test_verify_bgp_always_compare_med_functionality_bw_eBGP_peers_by_changing_A
         input_static_r1 = {
             "r1": {"static_routes": [{"network": NETWORK1_1[addr_type]}]}
         }
-        nh = topo["routers"]["r2"]["links"]["r1"][addr_type].split("/")[0]
+        nh = topo["routers"]["r3"]["links"]["r1"][addr_type].split("/")[0]
 
         result = verify_bgp_rib(tgen, addr_type, "r1", input_static_r1)
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
@@ -689,7 +689,7 @@ def test_verify_bgp_always_compare_med_functionality_bw_eBGP_peers_by_changing_M
                                     "prefix_lists": "pf_ls_r2_{}".format(addr_type)
                                 }
                             },
-                            "set": {"med": 150},
+                            "set": {"metric": 150},
                         }
                     ]
                 }
@@ -734,7 +734,7 @@ def test_verify_bgp_always_compare_med_functionality_bw_eBGP_peers_by_changing_M
                                     "prefix_lists": "pf_ls_r3_{}".format(addr_type)
                                 }
                             },
-                            "set": {"med": 100},
+                            "set": {"metric": 100},
                         }
                     ]
                 }

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -635,7 +635,7 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
     routemaps = {
         "r0": {
             "route_maps": {
-                "rmap_ipv4": [{"action": "permit", "set": {"med": 123}, "seq_id": 10}]
+                "rmap_ipv4": [{"action": "permit", "set": {"metric": 123}, "seq_id": 10}]
             }
         }
     }
@@ -661,7 +661,7 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
                     {
                         "action": "permit",
                         "match": {"med": 123},
-                        "set": {"med": 150},
+                        "set": {"metric": 150},
                         "seq_id": 10,
                     }
                 ]
@@ -696,7 +696,7 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
                     {
                         "action": "permit",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 150},
+                        "set": {"metric": 150},
                         "call": "rmap_match_pf_2_ipv4",
                         "seq_id": 10,
                     }
@@ -705,7 +705,7 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
                     {
                         "action": "permit",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 200},
+                        "set": {"metric": 200},
                         "seq_id": 10,
                     }
                 ],
@@ -737,20 +737,20 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
                         "action": "permit",
                         "seq_id": "10",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 150},
+                        "set": {"metric": 150},
                         "continue": "30",
                         "seq_id": 10,
                     },
                     {
                         "action": "permit",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 100},
+                        "set": {"metric": 100},
                         "seq_id": 20,
                     },
                     {
                         "action": "permit",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 50},
+                        "set": {"metric": 50},
                         "seq_id": 30,
                     },
                 ]
@@ -782,13 +782,13 @@ def test_ospf_routemaps_functionality_tc21_p0(request):
                         "action": "permit",
                         "seq_id": "20",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 100},
+                        "set": {"metric": 100},
                     },
                     {
                         "action": "permit",
                         "seq_id": "30",
                         "match": {"ipv4": {"prefix_lists": "pf_list_1_ipv4"}},
-                        "set": {"med": 200},
+                        "set": {"metric": 200},
                     },
                 ]
             }


### PR DESCRIPTION
topotests have a `create_route_map` function which takes a dict of values, of which some tester has choosen to send `med` down which means nothing.  Switch it to `metric` as it should be.