### PR TITLE
tests: fix a regex in all_protos topotest

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -852,9 +852,8 @@ def test_ospfv2_interfaces():
             actual = re.sub(r"ifindex [0-9]+", "ifindex X", actual)
 
             # Drop time in next due
-            actual = re.sub(r"Hello due in [0-9\.]+s", "Hello due in XX.XXXs", actual)
             actual = re.sub(
-                r"Hello due in [0-9\.]+ usecs", "Hello due in XX.XXXs", actual
+                r"Hello due in [-0-9\.]+s", "Hello due in XX.XXXs", actual
             )
             # Fix 'MTU mismatch detection: enabled' vs 'MTU mismatch detection:enabled' - accept both
             actual = re.sub(


### PR DESCRIPTION
Allow a regex to tolerate a negative value; remove a duplicated statement (looks like a line was duplicated during a reformatting pass).
