### PR TITLE
bgpd: Fix routes to be removed from rib when suppress fib pending is configed

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -488,6 +488,12 @@ void bm_wait_for_fib_set(bool set)
 				continue;
 
 			peer_notify_config_change(peer->connection);
+			/* Since this is a local config change, not a graceful restart.
+			 * Clear NSF_WAIT so clearing properly removes paths instead of
+			 * marking them STALE. Routes need a fresh Zebra round-trip to
+			 * set FIB_INSTALLED correctly.
+			 */
+			UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
 		}
 	}
 }
@@ -570,6 +576,12 @@ void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set)
 			continue;
 
 		peer_notify_config_change(peer->connection);
+		/* Since this is a local config change, not a graceful restart.
+		 * Clear NSF_WAIT so clearing properly removes paths instead of
+		 * marking them STALE. Routes need a fresh Zebra round-trip to
+		 * set FIB_INSTALLED correctly.
+		 */
+		UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
 	}
 }
 


### PR DESCRIPTION
If GR N bit is set and fib suppress pending is configured then routes
will not be advertised to GR peer. This is because the routes are marked
as stale during the peer reset due to GR config. When peers reconnect
bgp does not attempt a route install as the routes were never removed from
rib.
Fix by unsetting the PEER_STATUS_NSF_WAIT flag explicitely in the fib
suppress config path.