### PR TITLE
  bgpd: Fixed crash in bgp received-routes detail json and code cleanup

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -16443,21 +16443,7 @@ static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table 
 
 	if (type == bgp_show_adj_route_advertised && subgrp
 	    && CHECK_FLAG(subgrp->sflags, SUBGRP_STATUS_DEFAULT_ORIGINATE)) {
-		if (use_json) {
-			json_object_int_add(json, "bgpTableVersion",
-					    table->version);
-			json_object_string_addf(json, "bgpLocalRouterId",
-						"%pI4", &bgp->router_id);
-			json_object_int_add(json, "defaultLocPrf",
-						bgp->default_local_pref);
-			json_object_int_add(json, "localAS",
-					    peer->change_local_as
-						    ? peer->change_local_as
-						    : peer->local_as);
-			json_object_string_add(
-				json, "bgpOriginatingDefaultNetwork",
-				(afi == AFI_IP) ? "0.0.0.0/0" : "::/0");
-		} else {
+		if (!use_json) {
 			vty_out(vty,
 				"BGP table version is %" PRIu64
 				", local router ID is %pI4, vrf id ",
@@ -16546,15 +16532,12 @@ static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table 
 						json_net =
 							json_object_new_object();
 
-					struct bgp_path_info pathi;
+					struct bgp_path_info pathi = {};
 					struct bgp_dest buildit = *dest;
 					struct bgp_dest *pass_in;
 
 					if (route_filtered ||
 					    ret == RMAP_DENY) {
-						memset(&pathi, 0,
-						       sizeof(struct
-							      bgp_path_info));
 						pathi.attr = &attr;
 						pathi.peer = peer;
 						buildit.info = &pathi;
@@ -16901,14 +16884,8 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 			json_object_int_add(json, "totalPrefixCounter", output_count);
 			json_object_int_add(json, "filteredPrefixCounter", filtered_count);
 			json_object_int_add(json, "totalPathsCount", paths_count);
-		}
-
-		/*
-		 * This is an extremely expensive operation at scale
-		 * and non-pretty reduces memory footprint significantly.
-		 */
-		if ((type != bgp_show_adj_route_advertised) && (type != bgp_show_adj_route_received))
 			vty_json_no_pretty(vty, json);
+		}
 	} else if (output_count > 0) {
 		if (!match && filtered_count > 0)
 			vty_out(vty,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -16552,6 +16552,9 @@ static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table 
 
 					if (route_filtered ||
 					    ret == RMAP_DENY) {
+						memset(&pathi, 0,
+						       sizeof(struct
+							      bgp_path_info));
 						pathi.attr = &attr;
 						pathi.peer = peer;
 						buildit.info = &pathi;


### PR DESCRIPTION
  1. During execution of detail JSON output of "show bgp ... neighbors <ADDR> received-routes detail json", the pathi (bgp_path_info) variable in show_adj_route() was passed to bgp_show_path_info() without zeroing remaining fields when the route was filtered, which caused BGP to crash in route_vty_out_detail_header() due to uninitialized memory.
  2. Removed dead JSON header fields (bgpTableVersion, bgpLocalRouterId, defaultLocPrf, localAS, bgpOriginatingDefaultNetwork) being added to the json object in the advertised-routes default_originate path. This json object is freed without serialization for the advertised type, so these fields were never visible in output.
  3. Moved vty_json_no_pretty() call inside the else block in peer_adj_routes() for clarity. The previous conditional (type != advertised && type != received) was logically equivalent to the else branch.

  Ticket:#3819820