### PR TITLE
eigrpd: handle the gr neighbor list safely in update_receive

### DIFF
--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -434,7 +434,7 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 	eigrp_query_send_all(eigrp);
 	eigrp_update_send_all(eigrp, ei);
 
-	if (nbr_prefixes)
+	if (nbr_prefixes && (nbr_prefixes != nbr->nbr_gr_prefixes))
 		list_delete(&nbr_prefixes);
 }
 


### PR DESCRIPTION
Be careful handling the gr neighbor list; don't free the list if it's present in the neighbor struct. Reported by a team at Ga Tech.

