### PR TITLE
Zebra MetaQ and dplane provider fixes

### DIFF
--- a/tests/topotests/zebra_metaq/r1/frr.conf
+++ b/tests/topotests/zebra_metaq/r1/frr.conf
@@ -1,0 +1,6 @@
+!
+interface r1-eth0
+ ip address 10.1.1.100/24
+!
+line vty
+!

--- a/tests/topotests/zebra_metaq/test_zebra_metaq.py
+++ b/tests/topotests/zebra_metaq/test_zebra_metaq.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_zebra_metaq_plug.py
+#
+# Test that with the meta queue plugged, NHG updates are deduplicated in the
+# meta queue (one entry per nexthop-group id), and that after unplugging
+# both groups are processed and created.
+#
+
+import json
+import os
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.sharpd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import step
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+
+def build_topo(tgen):
+    "Build single router topology"
+    tgen.add_router("r1")
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    "Set up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "frr.conf"),
+            [(TopoRouter.RD_ZEBRA, None), (TopoRouter.RD_SHARP, None)],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module():
+    "Tear down the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _get_nhg_current(router):
+    """Return current NHG Objects count from 'show zebra metaq json', or None on error."""
+    try:
+        output = router.vtysh_cmd("show zebra metaq json")
+        j = json.loads(output)
+        # subqueues[0] is NHG Objects
+        return j["subqueues"][0]["Current"]
+    except (KeyError, json.JSONDecodeError) as e:
+        logger.info("Failed to parse metaq json: %s", e)
+        return None
+
+
+def test_zebra_metaq_plug_dedup():
+    "Plug metaq, create NHGs, verify dedup in queue, unplug and verify both groups"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # a) Plug the meta queue
+    step("Plug the meta queue")
+    r1.vtysh_cmd("zebra test metaq disable")
+
+    # b) Create nexthop-group A
+    step("Create nexthop-group A")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        nexthop-group A
+        """
+    )
+
+    # c) Add first nexthop to A
+    step("Add nexthop 10.1.1.1 to nexthop-group A")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        nexthop-group A
+        nexthop 10.1.1.1 r1-eth0
+        """
+    )
+
+    # d) Show metaq has one NHG entry
+    step("Verify metaq has 1 entry in NHG Objects")
+    nhg_current = _get_nhg_current(r1)
+    assert nhg_current == 1, "Expected NHG Objects current 1, got {}".format(
+        nhg_current
+    )
+
+    # e) Add second nexthop to A, metaq should still have 1 entry
+    step("Add second nexthop to A, verify metaq still 1")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        nexthop-group A
+        nexthop 10.1.1.2 r1-eth0
+        """
+    )
+    nhg_current = _get_nhg_current(r1)
+    assert (
+        nhg_current == 1
+    ), "Expected NHG Objects current 1 after 2nd nexthop, got {}".format(nhg_current)
+
+    # f) Add 3–4 more nexthops to A, each time metaq should still have 1 entry
+    for i in range(3, 7):
+        step("Add nexthop 10.1.1.{} to A, verify metaq still 1".format(i))
+        r1.vtysh_cmd(
+            """
+            configure terminal
+            nexthop-group A
+            nexthop 10.1.1.{i} r1-eth0
+            """
+        )
+        nhg_current = _get_nhg_current(r1)
+        assert nhg_current == 1, (
+            "Expected NHG Objects current 1 after nexthop 10.1.1.{}, got {}"
+        ).format(i, nhg_current)
+
+    # g) Create nexthop-group B, add one nexthop, metaq should have 2 NHG entries
+    step("Create nexthop-group B and add one nexthop")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        nexthop-group B
+        nexthop 10.1.2.1 r1-eth0
+        """
+    )
+    step("Verify metaq has 2 entries in NHG Objects")
+    nhg_current = _get_nhg_current(r1)
+    assert nhg_current == 2, "Expected NHG Objects current 2, got {}".format(
+        nhg_current
+    )
+
+    # h) Add another nexthop to A, metaq should still have 2 NHG entries
+    step("Add another nexthop to A, verify metaq still 2")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        nexthop-group A
+        nexthop 10.1.1.7 r1-eth0
+        """
+    )
+    nhg_current = _get_nhg_current(r1)
+    assert nhg_current == 2, (
+        "Expected NHG Objects current 2 after adding nexthop to A, got {}"
+    ).format(nhg_current)
+
+    # Unplug the meta queue
+    step("Unplug the meta queue")
+    r1.vtysh_cmd("no zebra test metaq disable")
+
+    # Wait for meta queue to drain and verify 2 sharp non-singleton NHGs (A and B)
+    step("Wait for 2 sharp non-singleton nexthop groups")
+
+    def _two_sharp_nonsingleton_nhgs():
+        output = r1.vtysh_cmd("show nexthop-group rib sharp json", isjson=True)
+        if not output or "default" not in output:
+            return False
+        vrf = output["default"]
+        if not isinstance(vrf, dict):
+            return False
+        # Non-singleton = sharp NHG with more than one nexthop, or has "depends"
+        # (group that references other NHGs). We expect 2: group A (multi-nh) and B.
+        count = 0
+        for g in vrf.values():
+            if g.get("type") != "sharp":
+                continue
+            if g.get("nexthopCount", 0) > 1:
+                count += 1
+            elif "depends" in g:
+                count += 1
+        return count == 2
+
+    _, result = topotest.run_and_expect(
+        _two_sharp_nonsingleton_nhgs, True, count=30, wait=1
+    )
+    assert (
+        result
+    ), "Expected 2 sharp non-singleton nexthop groups (A and B) after unplug"

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -619,6 +619,7 @@ extern int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto, uint8_t ins
 
 extern void zebra_vty_init(void);
 extern uint32_t zebra_rib_dplane_results_count(void);
+extern uint32_t zebra_rib_dplane_results_max(void);
 
 extern pid_t zebra_pid;
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -583,6 +583,9 @@ static struct zebra_dplane_globals {
 	/* Limit number of pending, unprocessed updates */
 	_Atomic uint32_t dg_max_queued_updates;
 
+	/* High-water mark for incoming queue length */
+	_Atomic uint32_t dg_incoming_q_max;
+
 	/* Control whether system route notifications should be produced. */
 	bool dg_sys_route_notifs;
 
@@ -4574,6 +4577,11 @@ static int dplane_update_enqueue(struct zebra_dplane_ctx *ctx)
 	DPLANE_LOCK();
 	{
 		dplane_ctx_list_add_tail(&zdplane_info.dg_update_list, ctx);
+		curr = dplane_ctx_queue_count(&zdplane_info.dg_update_list);
+		high = atomic_load_explicit(&zdplane_info.dg_incoming_q_max, memory_order_relaxed);
+		if (curr > high)
+			atomic_store_explicit(&zdplane_info.dg_incoming_q_max, curr,
+					      memory_order_relaxed);
 	}
 	DPLANE_UNLOCK();
 
@@ -6435,9 +6443,11 @@ int dplane_show_provs_helper(struct vty *vty, bool detailed)
 	DPLANE_LOCK();
 	prov = dplane_prov_list_first(&zdplane_info.dg_providers);
 	in = dplane_ctx_queue_count(&zdplane_info.dg_update_list);
+	in_max = atomic_load_explicit(&zdplane_info.dg_incoming_q_max, memory_order_relaxed);
 	DPLANE_UNLOCK();
 
-	vty_out(vty, "dataplane Incoming Queue from Zebra: %" PRIu64 "\n", in);
+	vty_out(vty, "dataplane Incoming Queue from Zebra: %" PRIu64 ", q_max: %" PRIu64 "\n", in,
+		(uint64_t)in_max);
 	vty_out(vty, "Zebra dataplane providers:\n");
 
 	/* Show counters, useful info from each registered provider */
@@ -6468,7 +6478,9 @@ int dplane_show_provs_helper(struct vty *vty, bool detailed)
 	}
 
 	out = zebra_rib_dplane_results_count();
-	vty_out(vty, "dataplane Outgoing Queue to Zebra: %" PRIu64 "\n", out);
+	out_max = zebra_rib_dplane_results_max();
+	vty_out(vty, "dataplane Outgoing Queue to Zebra: %" PRIu64 ", q_max: %" PRIu64 "\n", out,
+		(uint64_t)out_max);
 
 	return CMD_SUCCESS;
 }

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3230,13 +3230,29 @@ static int rib_meta_queue_nhg_process(struct meta_queue *mq, void *data,
 {
 	struct nhg_hash_entry *nhe = NULL;
 	uint8_t qindex = META_QUEUE_NHG;
-	struct wq_nhg_wrapper *w;
+	struct wq_nhg_wrapper *w, *ow;
+	struct listnode *node, *nnode;
 	uint64_t curr, high;
 
 	nhe = (struct nhg_hash_entry *)data;
 
 	if (!nhe)
 		return -1;
+
+	/* For NHG wrapper type, replace any existing queue entry with the
+	 * same nh id: keep the current NHE and remove the old one.
+	 */
+	for (ALL_LIST_ELEMENTS(mq->subq[qindex], node, nnode, ow)) {
+		if (ow->type == WQ_NHG_WRAPPER_TYPE_NHG && ow->u.nhe->id == nhe->id) {
+			list_delete_node(mq->subq[qindex], node);
+			mq->size--;
+			atomic_fetch_sub_explicit(&mq->total_metaq, 1, memory_order_relaxed);
+			atomic_fetch_sub_explicit(&mq->total_subq[qindex], 1, memory_order_relaxed);
+			zebra_nhg_free(ow->u.nhe);
+			XFREE(MTYPE_WQ_WRAPPER, ow);
+			break;
+		}
+	}
 
 	w = XCALLOC(MTYPE_WQ_WRAPPER, sizeof(struct wq_nhg_wrapper));
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -66,6 +66,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, WQ_WRAPPER, "WQ wrapper");
 static pthread_mutex_t dplane_mutex;
 static struct event *t_dplane;
 static struct dplane_ctx_list_head rib_dplane_q;
+static _Atomic uint32_t rib_dplane_q_max;
 
 DEFINE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 	    (rn, reason));
@@ -5120,8 +5121,14 @@ static int rib_dplane_results(struct dplane_ctx_list_head *ctxlist)
 {
 	/* Take lock controlling queue of results */
 	frr_with_mutex (&dplane_mutex) {
+		uint32_t q_count, q_high;
+
 		/* Enqueue context blocks */
 		dplane_ctx_list_append(&rib_dplane_q, ctxlist);
+		q_count = dplane_ctx_queue_count(&rib_dplane_q);
+		q_high = atomic_load_explicit(&rib_dplane_q_max, memory_order_relaxed);
+		if (q_count > q_high)
+			atomic_store_explicit(&rib_dplane_q_max, q_count, memory_order_relaxed);
 	}
 
 	/* Ensure event is signalled to zebra main pthread */
@@ -5140,6 +5147,11 @@ uint32_t zebra_rib_dplane_results_count(void)
 	}
 
 	return count;
+}
+
+uint32_t zebra_rib_dplane_results_max(void)
+{
+	return atomic_load_explicit(&rib_dplane_q_max, memory_order_relaxed);
 }
 
 /*

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -21,6 +21,7 @@
 #include "termtable.h"
 #include "affinitymap.h"
 #include "frrdistance.h"
+#include "workqueue.h"
 #include "lib/frrscript.h"
 
 #include "zebra/zebra_router.h"
@@ -4266,6 +4267,26 @@ DEFUN (zebra_show_routing_tables_summary,
 	return CMD_SUCCESS;
 }
 
+DEFPY_HIDDEN(zebra_test_metaq_plug,
+	     zebra_test_metaq_plug_cmd,
+	     "[no] zebra test metaq disable",
+	     NO_STR
+	     ZEBRA_STR
+	     "Test command\n"
+	     "Meta queue\n"
+	     "Plug the meta queue (prevent processing)\n")
+{
+	if (zrouter.ribq == NULL)
+		return CMD_WARNING;
+
+	if (no)
+		work_queue_unplug(zrouter.ribq);
+	else
+		work_queue_plug(zrouter.ribq);
+
+	return CMD_SUCCESS;
+}
+
 /* Display Zebra MetaQ counters */
 DEFUN (show_zebra_metaq_counters,
        show_zebra_metaq_counters_cmd,
@@ -4549,6 +4570,7 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
 	install_element(CONFIG_NODE, &no_zebra_dplane_queue_limit_cmd);
 	install_element(VIEW_NODE, &show_zebra_metaq_counters_cmd);
+	install_element(VIEW_NODE, &zebra_test_metaq_plug_cmd);
 
 #ifdef HAVE_NETLINK
 	install_element(CONFIG_NODE, &zebra_kernel_netlink_batch_tx_buf_cmd);


### PR DESCRIPTION
1) When issuing a `show zebra dplane provider` command dump the high water marks for the queue to send to the dplane and to the queue to send to the zebra master pthread.
2) Limit the NHG metaQ to only 1 item per nhg id.
3) Add a hidden `[no] zebra test metaq disable`
4) Add a topotest that shows that the NHG metaQ reduces to 1 item 