### PR TITLE
Ospf6d: fix router LSA when BDR becomes DR without BDR

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -951,6 +951,7 @@ void backup_seen(struct event *event)
 void neighbor_change(struct event *event)
 {
 	struct ospf6_interface *oi;
+	int ret;
 
 	oi = (struct ospf6_interface *)EVENT_ARG(event);
 	assert(oi && oi->interface);
@@ -959,9 +960,15 @@ void neighbor_change(struct event *event)
 		zlog_debug("Interface Event %s: [NeighborChange]",
 			   oi->interface->name);
 
-	if (oi->state == OSPF6_INTERFACE_DROTHER ||
-	    oi->state == OSPF6_INTERFACE_BDR || oi->state == OSPF6_INTERFACE_DR)
-		ospf6_interface_state_change(dr_election(oi), oi);
+	if (oi->state == OSPF6_INTERFACE_DROTHER || oi->state == OSPF6_INTERFACE_BDR ||
+	    oi->state == OSPF6_INTERFACE_DR) {
+		ret = ospf6_interface_state_change(dr_election(oi), oi);
+
+		/* In this case router LSA is not originated elsewhere */
+		if (oi->area && oi->type == OSPF_IFTYPE_BROADCAST && ret == -1 &&
+		    oi->bdrouter == htonl(0))
+			OSPF6_ROUTER_LSA_SCHEDULE(oi->area);
+	}
 }
 
 void interface_down(struct event *event)

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -951,6 +951,7 @@ void backup_seen(struct event *event)
 void neighbor_change(struct event *event)
 {
 	struct ospf6_interface *oi;
+	int ret;
 
 	oi = (struct ospf6_interface *)EVENT_ARG(event);
 	assert(oi && oi->interface);
@@ -959,9 +960,31 @@ void neighbor_change(struct event *event)
 		zlog_debug("Interface Event %s: [NeighborChange]",
 			   oi->interface->name);
 
-	if (oi->state == OSPF6_INTERFACE_DROTHER ||
-	    oi->state == OSPF6_INTERFACE_BDR || oi->state == OSPF6_INTERFACE_DR)
-		ospf6_interface_state_change(dr_election(oi), oi);
+	if (!oi->area)
+		return;
+
+	if (oi->state == OSPF6_INTERFACE_DROTHER || oi->state == OSPF6_INTERFACE_BDR ||
+	    oi->state == OSPF6_INTERFACE_DR) {
+		ret = ospf6_interface_state_change(dr_election(oi), oi);
+
+		/* When new DR/BDR is elected, one of them was usually in Twoway state
+		 * (if it was neither DR nor BDR before that). It then changes state to
+		 * Full and for all DROther routers OSPF6_ROUTER_LSA_SCHEDULE is called
+		 * in ospf6_neighbor_state_change when they see this change.
+		 *
+		 * But when there is no new BDR, current BDR becomes DR without any
+		 * such state change (it is already in Full state) and router LSA is
+		 * not originated anywhere for DROther.
+		 *
+		 * Check: ret == -1 means that there was no state change for current
+		 * router (it didn't become DR/BDR and didn't become not DR/BDR), in
+		 * such case if BDR is 0, previous BDR became DR, there was no state
+		 * change and we need to originate LSA here.
+		 */
+		if (oi->type == OSPF_IFTYPE_BROADCAST && ret == -1 &&
+		    oi->bdrouter == htonl(0))
+			OSPF6_ROUTER_LSA_SCHEDULE(oi->area);
+	}
 }
 
 void interface_down(struct event *event)

--- a/tests/topotests/ospf6_no_new_bdr/r1/frr.conf
+++ b/tests/topotests/ospf6_no_new_bdr/r1/frr.conf
@@ -1,0 +1,37 @@
+!
+interface r1-stubnet
+ ipv6 address fc00:1:1:1::1/64
+!
+interface r1-sw5
+ ipv6 address fc00:a:a:a::1/64
+!
+interface lo
+!
+ipv6 route fc00:1111:1111:1111::/64 fc00:1:1:1::1234
+!
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
+!
+interface r1-stubnet
+ ipv6 ospf6 area 0.0.0.0
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+interface r1-sw5
+ ipv6 ospf6 area 0.0.0.0
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 priority 100
+!
+router ospf6
+ ospf6 router-id 10.0.0.1
+ log-adjacency-changes detail
+ redistribute static
+!

--- a/tests/topotests/ospf6_no_new_bdr/r1/ip_6_address.nhg.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r1/ip_6_address.nhg.ref
@@ -1,0 +1,7 @@
+fc00:1111:1111:1111::/64 nhid XXXX via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_no_new_bdr/r1/ip_6_address.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r1/ip_6_address.ref
@@ -1,0 +1,7 @@
+fc00:1111:1111:1111::/64 via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_no_new_bdr/r1/show_ipv6_route.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r1/show_ipv6_route.ref
@@ -1,0 +1,4 @@
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r1-sw5, weight 1, XX:XX:XX

--- a/tests/topotests/ospf6_no_new_bdr/r2/frr.conf
+++ b/tests/topotests/ospf6_no_new_bdr/r2/frr.conf
@@ -1,0 +1,37 @@
+!
+interface r2-stubnet
+ ipv6 address fc00:2:2:2::2/64
+!
+interface r2-sw5
+ ipv6 address fc00:a:a:a::2/64
+!
+interface lo
+!
+ipv6 route fc00:2222:2222:2222::/64 fc00:2:2:2::1234
+!
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
+!
+interface r2-stubnet
+ ipv6 ospf6 area 0.0.0.0
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+interface r2-sw5
+ ipv6 ospf6 area 0.0.0.0
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 priority 90
+!
+router ospf6
+ ospf6 router-id 10.0.0.2
+ log-adjacency-changes detail
+ redistribute static
+!

--- a/tests/topotests/ospf6_no_new_bdr/r2/ip_6_address.nhg.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r2/ip_6_address.nhg.ref
@@ -1,0 +1,7 @@
+fc00:1111:1111:1111::/64 nhid XXXX via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 nhid XXXX via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 nhid XXXX via fc00:2:2:2::1234 dev r2-stubnet proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 dev r2-stubnet proto XXXX metric 256 pref medium
+fc00:3333:3333:3333::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r2-sw5 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_no_new_bdr/r2/ip_6_address.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r2/ip_6_address.ref
@@ -1,0 +1,7 @@
+fc00:1111:1111:1111::/64 via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r1-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fc00:2:2:2::1234 dev r2-stubnet proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 dev r2-stubnet proto XXXX metric 256 pref medium
+fc00:3333:3333:3333::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 via fe80::__(r3-sw5)__ dev r2-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r2-sw5 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_no_new_bdr/r2/show_ipv6_route.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r2/show_ipv6_route.ref
@@ -1,0 +1,5 @@
+O>* fc00:1:1:1::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+

--- a/tests/topotests/ospf6_no_new_bdr/r2/show_ipv6_route_after_r1_dead.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r2/show_ipv6_route_after_r1_dead.ref
@@ -1,0 +1,3 @@
+O>* fc00:3:3:3::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+O>* fc00:3333:3333:3333::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r2-sw5, weight 1, XX:XX:XX
+

--- a/tests/topotests/ospf6_no_new_bdr/r3/frr.conf
+++ b/tests/topotests/ospf6_no_new_bdr/r3/frr.conf
@@ -1,0 +1,37 @@
+!
+interface r3-stubnet
+ ipv6 address fc00:3:3:3::3/64
+!
+interface r3-sw5
+ ipv6 address fc00:a:a:a::3/64
+!
+interface lo
+!
+ipv6 route fc00:3333:3333:3333::/64 fc00:3:3:3::1234
+!
+! debug ospf6 message all
+! debug ospf6 lsa unknown
+! debug ospf6 zebra
+! debug ospf6 interface
+! debug ospf6 neighbor
+! debug ospf6 route table
+! debug ospf6 flooding
+!
+interface r3-stubnet
+ ipv6 ospf6 area 0.0.0.0
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+interface r3-sw5
+ ipv6 ospf6 area 0.0.0.0
+ ipv6 ospf6 network broadcast
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+ ipv6 ospf6 priority 0
+!
+router ospf6
+ ospf6 router-id 10.0.0.3
+ log-adjacency-changes detail
+ redistribute static
+!

--- a/tests/topotests/ospf6_no_new_bdr/r3/ip_6_address.nhg.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r3/ip_6_address.nhg.ref
@@ -1,0 +1,7 @@
+fc00:1111:1111:1111::/64 nhid XXXX via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 nhid XXXX via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 nhid XXXX via fc00:3:3:3::1234 dev r3-stubnet proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 dev r3-stubnet proto XXXX metric 256 pref medium
+fc00:a:a:a::/64 dev r3-sw5 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_no_new_bdr/r3/ip_6_address.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r3/ip_6_address.ref
@@ -1,0 +1,7 @@
+fc00:1111:1111:1111::/64 via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 via fe80::__(r1-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2222:2222:2222::/64 via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 via fe80::__(r2-sw5)__ dev r3-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 via fc00:3:3:3::1234 dev r3-stubnet proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 dev r3-stubnet proto XXXX metric 256 pref medium
+fc00:a:a:a::/64 dev r3-sw5 proto XXXX metric 256 pref medium

--- a/tests/topotests/ospf6_no_new_bdr/r3/show_ipv6_route.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r3/show_ipv6_route.ref
@@ -1,0 +1,5 @@
+O>* fc00:1:1:1::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:1111:1111:1111::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+

--- a/tests/topotests/ospf6_no_new_bdr/r3/show_ipv6_route_after_r1_dead.ref
+++ b/tests/topotests/ospf6_no_new_bdr/r3/show_ipv6_route_after_r1_dead.ref
@@ -1,0 +1,3 @@
+O>* fc00:2:2:2::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+O>* fc00:2222:2222:2222::/64 [110/20] via fe80::XXXX:XXXX:XXXX:XXXX, r3-sw5, weight 1, XX:XX:XX
+

--- a/tests/topotests/ospf6_no_new_bdr/test_ospf6_no_new_bdr.py
+++ b/tests/topotests/ospf6_no_new_bdr/test_ospf6_no_new_bdr.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026 by
+# Kyrylo Yatsenko <hedrok@gmail.com>
+#
+
+r"""
+test_ospf6_no_new_bdr.py:
+
+When on broadcast network only two routers are eligible to become Designated
+Routers, one of them becomes DR (R1), other one becomes BDR (R2).
+
+If after that R1 goes down, R2 becomes DR and network has no BDR.
+
+In this case there was wrong behaviour that router LSA from DROther (R3) router
+didn't have the network and no routes from R3 were installed on R2.
+
+	                                                  -----\
+	  SW1 - Stub Net 1            SW2 - Stub Net 2          \
+	  fc00:1:1:1::/64             fc00:2:2:2::/64            \
+	\___________________/      \___________________/          |
+	          |                          |                    |
+	          |                          |                    |
+	          | ::1                      | ::2                |
+	+---------+---------+      +---------+---------+          |
+	|        R1         |      |        R2         |          |
+	|     FRRouting     |      |     FRRouting     |          |
+	| Rtr-ID: 10.0.0.1  |      | Rtr-ID: 10.0.0.2  |          |
+	| Prio: 100         |      | Prio: 90          |          |
+	+---------+---------+      +---------+---------+          |
+	          | ::1                      | ::2                 \
+	           \______        ___________/                      OSPFv3
+	                  \      /                               Area 0.0.0.0
+	                   \    /                                  /
+	             ~~~~~~~~~~~~~~~~~~                           |
+	           ~~       SW5        ~~                         |
+	         ~~       Switch         ~~                       |
+	           ~~  fc00:A:A:A::/64 ~~                         |
+	             ~~~~~~~~~~~~~~~~~~                           |
+	                     |                 /----              |
+	                     | ::3            | SW3 - Stub Net 3  |
+	           +---------+---------+    /-+ fc00:3:3:3::/64   |
+	           |        R3         |   /  |                  /
+	           |     FRRouting     +--/    \----            /
+	           | Rtr-ID: 10.0.0.3  | ::3        ___________/
+	           | Prio: 0           |
+	           +-------------------+
+"""
+
+import os
+import re
+import sys
+import pytest
+
+from functools import partial
+
+
+# Save the Current Working Directory to find configuration files later.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+
+pytestmark = [pytest.mark.ospf6d]
+
+
+def build_topo(tgen):
+    # Create 3 routers
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    #
+    # Wire up the switches and routers
+    # Note that we specify the link names so we match the config files
+    #
+
+    # Create a empty network for router 1
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"], nodeif="r1-stubnet")
+
+    # Create a empty network for router 2
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"], nodeif="r2-stubnet")
+
+    # Create a empty network for router 3
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r3"], nodeif="r3-stubnet")
+
+    # Interconnect routers 1, 2, and 3
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["r1"], nodeif="r1-sw5")
+    switch.add_link(tgen.gears["r2"], nodeif="r2-sw5")
+    switch.add_link(tgen.gears["r3"], nodeif="r3-sw5")
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    logger.info("** %s: Setup Topology" % mod.__name__)
+    logger.info("******************************************")
+
+    # For debugging after starting net, but before starting FRR,
+    # uncomment the next line
+    # tgen.mininet_cli()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    # For debugging after starting FRR daemons, uncomment the next line
+    # tgen.mininet_cli()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def _expect_neighbor_full(rname, router, neighbor, interface_state=None):
+    "Wait until OSPFv3 convergence."
+    logger.info(f"waiting OSPFv3 router '{rname}'")
+    expect_dict = {
+        "neighbors": [
+            {
+                "neighborId": neighbor,
+                "state": "Full",
+            }
+        ]
+    }
+    if interface_state:
+        expect_dict["neighbors"][0]["interfaceState"] = interface_state
+    test_func = partial(
+        topotest.router_json_cmp,
+        router,
+        "show ipv6 ospf6 neighbor json",
+        expect_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+    assertmsg = f'"{rname}" convergence failure'
+    assert result is None, assertmsg
+
+
+def test_wait_protocol_convergence():
+    "Wait for OSPFv3 to converge"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for protocols to converge")
+
+    def expect_neighbor_full(router, neighbor):
+        _expect_neighbor_full(router, tgen.gears[router], neighbor)
+
+    expect_neighbor_full("r1", "10.0.0.2")
+    expect_neighbor_full("r1", "10.0.0.3")
+
+    expect_neighbor_full("r2", "10.0.0.1")
+    expect_neighbor_full("r2", "10.0.0.3")
+
+    expect_neighbor_full("r3", "10.0.0.1")
+    expect_neighbor_full("r3", "10.0.0.2")
+
+
+def compare_show_ipv6(rname, expected):
+    """
+    Calls 'show ipv6 route' for router `rname` and compare the obtained
+    result with the expected output.
+    """
+    tgen = get_topogen()
+
+    # Use the vtysh output, with some masking to make comparison easy
+    current = topotest.ip6_route_zebra(tgen.gears[rname])
+
+    # Use just the 'O'spf lines of the output
+    linearr = []
+    for line in current.splitlines():
+        if re.match("^O", line):
+            linearr.append(line)
+
+    current = "\n".join(linearr)
+
+    return topotest.difflines(
+        topotest.normalize_text(current),
+        topotest.normalize_text(expected),
+        title1="Current output",
+        title2="Expected output",
+    )
+
+
+def test_ospfv3_routingTable():
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+
+    # Verify OSPFv3 Routing Table
+    for router, _ in tgen.routers().items():
+        logger.info('Waiting for router "%s" convergence', router)
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, "{}/show_ipv6_route.ref".format(router))
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 did not converge on {}:\n{}".format(router, diff)
+
+
+def test_linux_ipv6_kernel_routingTable():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # Verify Linux Kernel Routing Table
+    logger.info("Verifying Linux IPv6 Kernel Routing Table")
+
+    failures = 0
+
+    # Get a list of all current link-local addresses first as they change for
+    # each run and we need to translate them
+    linklocals = []
+    for i in range(1, 4):
+        linklocals += tgen.net["r{}".format(i)].get_ipv6_linklocal()
+
+    # Now compare the routing tables (after substituting link-local addresses)
+
+    for i in range(1, 4):
+        # Actual output from router
+        actual = tgen.gears["r{}".format(i)].run("ip -6 route").rstrip()
+        if "nhid" in actual:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
+        else:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.ref".format(i))
+
+        if os.path.isfile(refTableFile):
+            expected = open(refTableFile).read().rstrip()
+            # Fix newlines (make them all the same)
+            expected = ("\n".join(expected.splitlines())).splitlines(1)
+
+            # Mask out Link-Local mac addresses
+            for ll in linklocals:
+                actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
+            # Mask out protocol name or number
+            actual = re.sub(r"[ ]+proto [0-9a-z]+ +", "  proto XXXX ", actual)
+            actual = re.sub(r"[ ]+nhid [0-9]+ +", " nhid XXXX ", actual)
+            # Remove ff00::/8 routes (seen on some kernels - not from FRR)
+            actual = re.sub(r"ff00::/8.*", "", actual)
+
+            # Strip empty lines
+            actual = actual.lstrip()
+            actual = actual.rstrip()
+            actual = re.sub(r"  +", " ", actual)
+
+            filtered_lines = []
+            for line in sorted(actual.splitlines()):
+                if line.startswith("fe80::/64 ") or line.startswith(
+                    "unreachable fe80::/64 "
+                ):
+                    continue
+                filtered_lines.append(line)
+            actual = "\n".join(filtered_lines).splitlines(1)
+
+            # Print Actual table
+            # logger.info("Router r%s table" % i)
+            # for line in actual:
+            #     logger.info(line.rstrip())
+
+            # Generate Diff
+            diff = topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual OSPFv3 IPv6 routing table",
+                title2="expected OSPFv3 IPv6 routing table",
+            )
+
+            # Empty string if it matches, otherwise diff contains unified diff
+            if diff:
+                sys.stderr.write(
+                    "r%s failed Linux IPv6 Kernel Routing Table Check:\n%s\n"
+                    % (i, diff)
+                )
+                failures += 1
+            else:
+                logger.info("r%s ok" % i)
+
+            assert failures == 0, (
+                "Linux Kernel IPv6 Routing Table verification failed for router r%s:\n%s"
+                % (i, diff)
+            )
+        else:
+            logger.error("r{} failed - no nhid ref file: {}".format(i, refTableFile))
+
+            assert False, (
+                "Linux Kernel IPv6 Routing Table verification failed for router r%s\n"
+                % (i)
+            )
+
+
+def test_wait_r2_become_dr():
+    "Wait for R2 to become DR"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("shutting for R1 down...")
+    net = tgen.net
+    net["r1"].stopRouter()
+
+    logger.info("waiting for R2 to become DR")
+
+    _expect_neighbor_full("r2", tgen.gears["r2"], "10.0.0.3", "DR")
+    _expect_neighbor_full("r3", tgen.gears["r3"], "10.0.0.2", "DROther")
+
+
+    for router in ("r2", "r3"):
+        logger.info(f'Waiting for router "{router}" convergence')
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, f"{router}/show_ipv6_route_after_r1_dead.ref")
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 did not converge on {}:\n{}".format(router, diff)
+
+    net["r1"].startRouter()
+
+
+def test_shutdown_check_stderr():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        logger.info(
+            "SKIPPED final check on StdErr output: Disabled (TOPOTESTS_CHECK_STDERR undefined)\n"
+        )
+        pytest.skip("Skipping test for Stderr output")
+
+    net = tgen.net
+
+    logger.info("\n\n** Verifying unexpected STDERR output from daemons")
+    logger.info("******************************************")
+
+    for i in range(1, 4):
+        net["r%s" % i].stopRouter()
+        log = net["r%s" % i].getStdErr("ospf6d")
+        if log:
+            logger.info("\nRouter r%s OSPF6d StdErr Log:\n%s" % (i, log))
+        log = net["r%s" % i].getStdErr("zebra")
+        if log:
+            logger.info("\nRouter r%s Zebra StdErr Log:\n%s" % (i, log))
+
+
+def test_shutdown_check_memleak():
+    "Run the memory leak test and report results."
+
+    if os.environ.get("TOPOTESTS_CHECK_MEMLEAK") is None:
+        logger.info(
+            "SKIPPED final check on Memory leaks: Disabled (TOPOTESTS_CHECK_MEMLEAK undefined)"
+        )
+        pytest.skip("Skipping test for memory leaks")
+
+    tgen = get_topogen()
+
+    net = tgen.net
+
+    for i in range(1, 4):
+        net["r%s" % i].stopRouter()
+        net["r%s" % i].report_memory_leaks(
+            os.environ.get("TOPOTESTS_CHECK_MEMLEAK"), os.path.basename(__file__)
+        )
+
+
+if __name__ == "__main__":
+
+    # To suppress tracebacks, either use the following pytest call or
+    # add "--tb=no" to cli
+    # retval = pytest.main(["-s", "--tb=no"])
+
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/tests/topotests/ospf6_no_new_bdr/test_ospf6_no_new_bdr.py
+++ b/tests/topotests/ospf6_no_new_bdr/test_ospf6_no_new_bdr.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026 by
+# Kyrylo Yatsenko <hedrok@gmail.com>
+#
+
+r"""
+test_ospf6_no_new_bdr.py:
+
+When on broadcast network only two routers are eligible to become Designated
+Routers, one of them becomes DR (R1), other one becomes BDR (R2).
+
+If after that R1 goes down, R2 becomes DR and network has no BDR.
+
+In this case there was wrong behaviour that router LSA from DROther (R3) router
+didn't have the network and no routes from R3 were installed on R2.
+
+	                                                  -----\
+	  SW1 - Stub Net 1            SW2 - Stub Net 2          \
+	  fc00:1:1:1::/64             fc00:2:2:2::/64            \
+	\___________________/      \___________________/          |
+	          |                          |                    |
+	          |                          |                    |
+	          | ::1                      | ::2                |
+	+---------+---------+      +---------+---------+          |
+	|        R1         |      |        R2         |          |
+	|     FRRouting     |      |     FRRouting     |          |
+	| Rtr-ID: 10.0.0.1  |      | Rtr-ID: 10.0.0.2  |          |
+	| Prio: 100         |      | Prio: 90          |          |
+	+---------+---------+      +---------+---------+          |
+	          | ::1                      | ::2                 \
+	           \______        ___________/                      OSPFv3
+	                  \      /                               Area 0.0.0.0
+	                   \    /                                  /
+	             ~~~~~~~~~~~~~~~~~~                           |
+	           ~~       SW5        ~~                         |
+	         ~~       Switch         ~~                       |
+	           ~~  fc00:A:A:A::/64 ~~                         |
+	             ~~~~~~~~~~~~~~~~~~                           |
+	                     |                 /----              |
+	                     | ::3            | SW3 - Stub Net 3  |
+	           +---------+---------+    /-+ fc00:3:3:3::/64   |
+	           |        R3         |   /  |                  /
+	           |     FRRouting     +--/    \----            /
+	           | Rtr-ID: 10.0.0.3  | ::3        ___________/
+	           | Prio: 0           |
+	           +-------------------+
+"""
+
+import os
+import re
+import sys
+import pytest
+
+from functools import partial
+
+# Save the Current Working Directory to find configuration files later.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.ospf6d]
+
+
+def build_topo(tgen):
+    # Create 3 routers
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    #
+    # Wire up the switches and routers
+    # Note that we specify the link names so we match the config files
+    #
+
+    # Create a empty network for router 1
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"], nodeif="r1-stubnet")
+
+    # Create a empty network for router 2
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"], nodeif="r2-stubnet")
+
+    # Create a empty network for router 3
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r3"], nodeif="r3-stubnet")
+
+    # Interconnect routers 1, 2, and 3
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["r1"], nodeif="r1-sw5")
+    switch.add_link(tgen.gears["r2"], nodeif="r2-sw5")
+    switch.add_link(tgen.gears["r3"], nodeif="r3-sw5")
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    logger.info("** %s: Setup Topology" % mod.__name__)
+    logger.info("******************************************")
+
+    # For debugging after starting net, but before starting FRR,
+    # uncomment the next line
+    # tgen.mininet_cli()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    # For debugging after starting FRR daemons, uncomment the next line
+    # tgen.mininet_cli()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _expect_neighbor_full(
+    rname, router, neighbor, neighbor_interface_state=None, local_interface_state=None
+):
+    "Wait until OSPFv3 convergence."
+    logger.info(f"waiting OSPFv3 router '{rname}'")
+    expect_dict = {
+        "neighbors": [
+            {
+                "neighborId": neighbor,
+                "state": "Full",
+            }
+        ]
+    }
+    if neighbor_interface_state:
+        expect_dict["neighbors"][0]["interfaceState"] = neighbor_interface_state
+    if local_interface_state:
+        expect_dict["neighbors"][0]["ifState"] = local_interface_state
+    test_func = partial(
+        topotest.router_json_cmp,
+        router,
+        "show ipv6 ospf6 neighbor json",
+        expect_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+    assertmsg = f'"{rname}" convergence failure'
+    assert result is None, assertmsg
+
+
+def test_wait_protocol_convergence():
+    "Wait for OSPFv3 to converge"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for protocols to converge")
+
+    def expect_neighbor_full(router, neighbor):
+        _expect_neighbor_full(router, tgen.gears[router], neighbor)
+
+    expect_neighbor_full("r1", "10.0.0.2")
+    expect_neighbor_full("r1", "10.0.0.3")
+
+    expect_neighbor_full("r2", "10.0.0.1")
+    expect_neighbor_full("r2", "10.0.0.3")
+
+    expect_neighbor_full("r3", "10.0.0.1")
+    expect_neighbor_full("r3", "10.0.0.2")
+
+
+def compare_show_ipv6(rname, expected):
+    """
+    Calls 'show ipv6 route' for router `rname` and compare the obtained
+    result with the expected output.
+    """
+    tgen = get_topogen()
+
+    # Use the vtysh output, with some masking to make comparison easy
+    current = topotest.ip6_route_zebra(tgen.gears[rname])
+
+    # Use just the 'O'spf lines of the output
+    linearr = []
+    for line in current.splitlines():
+        if re.match("^O", line):
+            linearr.append(line)
+
+    current = "\n".join(linearr)
+
+    return topotest.difflines(
+        topotest.normalize_text(current),
+        topotest.normalize_text(expected),
+        title1="Current output",
+        title2="Expected output",
+    )
+
+
+def test_ospfv3_routingTable():
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # For debugging, uncomment the next line
+    # tgen.mininet_cli()
+
+    # Verify OSPFv3 Routing Table
+    for router, _ in tgen.routers().items():
+        logger.info('Waiting for router "%s" convergence', router)
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, "{}/show_ipv6_route.ref".format(router))
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 did not converge on {}:\n{}".format(router, diff)
+
+
+def test_linux_ipv6_kernel_routingTable():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # Verify Linux Kernel Routing Table
+    logger.info("Verifying Linux IPv6 Kernel Routing Table")
+
+    failures = 0
+
+    # Get a list of all current link-local addresses first as they change for
+    # each run and we need to translate them
+    linklocals = []
+    for i in range(1, 4):
+        linklocals += tgen.net["r{}".format(i)].get_ipv6_linklocal()
+
+    # Now compare the routing tables (after substituting link-local addresses)
+
+    for i in range(1, 4):
+        # Actual output from router
+        actual = tgen.gears["r{}".format(i)].run("ip -6 route").rstrip()
+        # Normalize NHA_GROUP-of-one routes back to singleton rendering so
+        # the reference tables (captured with singleton output) keep matching.
+        actual = topotest.normalize_iproute_nhg_output(actual)
+        if "nhid" in actual:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
+        else:
+            refTableFile = os.path.join(CWD, "r{}/ip_6_address.ref".format(i))
+
+        if os.path.isfile(refTableFile):
+            expected = open(refTableFile).read().rstrip()
+            # Fix newlines (make them all the same)
+            expected = ("\n".join(expected.splitlines())).splitlines(1)
+
+            # Mask out Link-Local mac addresses
+            for ll in linklocals:
+                actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
+            # Mask out protocol name or number
+            actual = re.sub(r"[ ]+proto [0-9a-z]+ +", "  proto XXXX ", actual)
+            actual = re.sub(r"[ ]+nhid [0-9]+ +", " nhid XXXX ", actual)
+            # Remove ff00::/8 routes (seen on some kernels - not from FRR)
+            actual = re.sub(r"ff00::/8.*", "", actual)
+
+            # Strip empty lines
+            actual = actual.lstrip()
+            actual = actual.rstrip()
+            actual = re.sub(r"  +", " ", actual)
+
+            filtered_lines = []
+            for line in sorted(actual.splitlines()):
+                if line.startswith("fe80::/64 ") or line.startswith(
+                    "unreachable fe80::/64 "
+                ):
+                    continue
+                filtered_lines.append(line)
+            actual = "\n".join(filtered_lines).splitlines(1)
+
+            # Print Actual table
+            # logger.info("Router r%s table" % i)
+            # for line in actual:
+            #     logger.info(line.rstrip())
+
+            # Generate Diff
+            diff = topotest.get_textdiff(
+                actual,
+                expected,
+                title1="actual OSPFv3 IPv6 routing table",
+                title2="expected OSPFv3 IPv6 routing table",
+            )
+
+            # Empty string if it matches, otherwise diff contains unified diff
+            if diff:
+                sys.stderr.write(
+                    "r%s failed Linux IPv6 Kernel Routing Table Check:\n%s\n"
+                    % (i, diff)
+                )
+                failures += 1
+            else:
+                logger.info("r%s ok" % i)
+
+            assert failures == 0, (
+                "Linux Kernel IPv6 Routing Table verification failed for router r%s:\n%s"
+                % (i, diff)
+            )
+        else:
+            logger.error("r{} failed - no nhid ref file: {}".format(i, refTableFile))
+
+            assert False, (
+                "Linux Kernel IPv6 Routing Table verification failed for router r%s\n"
+                % (i)
+            )
+
+
+def test_wait_r2_become_dr():
+    "Wait for R2 to become DR"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("shutting for R1 down...")
+    net = tgen.net
+    net["r1"].stopRouter()
+
+    logger.info("waiting for R2 to become DR")
+
+    _expect_neighbor_full(
+        "r2",
+        tgen.gears["r2"],
+        "10.0.0.3",
+        neighbor_interface_state="DR",
+        local_interface_state="DROther",
+    )
+    _expect_neighbor_full(
+        "r3",
+        tgen.gears["r3"],
+        "10.0.0.2",
+        neighbor_interface_state="DROther",
+        local_interface_state="DR",
+    )
+
+    for router in ("r2", "r3"):
+        logger.info(f'Waiting for router "{router}" convergence')
+
+        # Load expected results from the command
+        reffile = os.path.join(CWD, f"{router}/show_ipv6_route_after_r1_dead.ref")
+        expected = open(reffile).read()
+
+        # Run test function until we get an result. Wait at most 60 seconds.
+        test_func = partial(compare_show_ipv6, router, expected)
+        result, diff = topotest.run_and_expect(test_func, "", count=120, wait=0.5)
+        assert result, "OSPFv3 did not converge on {}:\n{}".format(router, diff)
+
+    net["r1"].startRouter()
+
+
+def test_shutdown_check_stderr():
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        logger.info(
+            "SKIPPED final check on StdErr output: Disabled (TOPOTESTS_CHECK_STDERR undefined)\n"
+        )
+        pytest.skip("Skipping test for Stderr output")
+
+    net = tgen.net
+
+    logger.info("\n\n** Verifying unexpected STDERR output from daemons")
+    logger.info("******************************************")
+
+    for i in range(1, 4):
+        net["r%s" % i].stopRouter()
+        log = net["r%s" % i].getStdErr("ospf6d")
+        if log:
+            logger.info("\nRouter r%s OSPF6d StdErr Log:\n%s" % (i, log))
+        log = net["r%s" % i].getStdErr("zebra")
+        if log:
+            logger.info("\nRouter r%s Zebra StdErr Log:\n%s" % (i, log))
+
+
+def test_shutdown_check_memleak():
+    "Run the memory leak test and report results."
+
+    if os.environ.get("TOPOTESTS_CHECK_MEMLEAK") is None:
+        logger.info(
+            "SKIPPED final check on Memory leaks: Disabled (TOPOTESTS_CHECK_MEMLEAK undefined)"
+        )
+        pytest.skip("Skipping test for memory leaks")
+
+    tgen = get_topogen()
+
+    net = tgen.net
+
+    for i in range(1, 4):
+        net["r%s" % i].stopRouter()
+        net["r%s" % i].report_memory_leaks(
+            os.environ.get("TOPOTESTS_CHECK_MEMLEAK"), os.path.basename(__file__)
+        )
+
+
+if __name__ == "__main__":
+
+    # To suppress tracebacks, either use the following pytest call or
+    # add "--tb=no" to cli
+    # retval = pytest.main(["-s", "--tb=no"])
+
+    retval = pytest.main(["-s"])
+    sys.exit(retval)


### PR DESCRIPTION
When on broadcast network only two routers are eligible to become Designated Routers, one of them becomes DR (R1), other one becomes BDR (R2).

If after that R1 goes down, R2 becomes DR and network has no BDR.

In this case on all other routers when R1 went down `ospf6_router_lsa_originate` originates router LSA without this network description as it has no fully adjacent Designated Router yet (it is not elected).

But when R2 is elected as DR, no new router LSA is originated in `neighbor_change`: it calls `ospf6_interface_state_change`, but state of interface is unchanged, so it just returns -1. And for all other routers network doesn't exist.

Fix this by originating router LSA in `neighbor_change` for this specific case.

Also added topotest for the issue.