### PR TITLE
tests: bgp_nhc add test to expose NHC update race on peer changes

### DIFF
--- a/tests/topotests/bgp_nhc/r1/frr.conf
+++ b/tests/topotests/bgp_nhc/r1/frr.conf
@@ -10,10 +10,10 @@ router bgp 65001
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  bgp bestpath bandwidth ignore
+ neighbor 10.255.0.2 remote-as external
  neighbor 10.255.0.2 timers 1 3
  neighbor 10.255.0.2 timers connect 1
- neighbor 10.255.0.2 remote-as external
+ neighbor 10.255.16.6 remote-as external
  neighbor 10.255.16.6 timers 1 3
  neighbor 10.255.16.6 timers connect 1
- neighbor 10.255.16.6 remote-as external
 !

--- a/tests/topotests/bgp_nhc/r6/frr.conf
+++ b/tests/topotests/bgp_nhc/r6/frr.conf
@@ -16,6 +16,7 @@ router bgp 65006
  neighbor 10.255.16.1 remote-as external
  neighbor 10.255.16.1 timers 1 3
  neighbor 10.255.16.1 timers connect 1
+ neighbor 10.255.16.1 shutdown
  neighbor 10.255.16.1 send-nexthop-characteristics
  neighbor 10.255.67.7 remote-as external
  neighbor 10.255.67.7 timers 1 3

--- a/tests/topotests/bgp_nhc/test_bgp_nhc.py
+++ b/tests/topotests/bgp_nhc/test_bgp_nhc.py
@@ -43,6 +43,70 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
+def test_bgp_r6_peers():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r6 = tgen.gears["r6"]
+
+    def _bgp_r6_peers_check():
+        output = json.loads(r6.vtysh_cmd("show bgp ipv4 uni summ json"))
+        expected = {
+            "peers": {
+                "10.255.16.1": {
+                    "state": "Idle (Admin)",
+                    "peerState": "Admin",
+                },
+                "10.255.67.7": {
+                    "hostname": "r7",
+                    "remoteAs": 65007,
+                    "state": "Established",
+                    "peerState": "OK",
+                },
+                "10.255.68.8": {
+                    "hostname": "r8",
+                    "remoteAs": 65008,
+                    "state": "Established",
+                    "peerState": "OK",
+                },
+            },
+            "totalPeers": 3,
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_r6_peers_check)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "r6 does not have expected peer states (r7/r8 Established, r1 Idle)"
+
+    r6.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65006
+        no neighbor 10.255.16.1 shutdown
+        """
+    )
+
+    def _bgp_r6_r1_established():
+        output = json.loads(r6.vtysh_cmd("show bgp ipv4 uni summ json"))
+        expected = {
+            "peers": {
+                "10.255.16.1": {
+                    "hostname": "r1",
+                    "remoteAs": 65001,
+                    "state": "Established",
+                    "peerState": "OK",
+                },
+            },
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_r6_r1_established)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "r1 did not reach Established state on r6"
+
+
 def test_bgp_nhc():
     tgen = get_topogen()
 
@@ -96,7 +160,7 @@ def test_bgp_nhc():
     test_func = functools.partial(
         _bgp_converge,
     )
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=2)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Can't see NHC attributes as expected"
 
     def check_weighted_ecmp_with_nnhn():
@@ -117,7 +181,7 @@ def test_bgp_nhc():
     test_func = functools.partial(
         check_weighted_ecmp_with_nnhn,
     )
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=2)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Can't see weighted ECMP with NNHN as expected"
 
 


### PR DESCRIPTION
When a BGP speaker (r6) has send-nexthop-characteristics enabled and a downstream peer (r8) comes up after the route has already been advertised upstream (to r1) with partial NHC data from an earlier peer (r7), the NHC nextNextHopNodes attribute is never updated to include the newly arrived downstream peer.

This race was exposed by adding jitter to bgp_timer_set() and peer_unshut_after_cfg() which changed peer startup ordering. Previously all peers connected in a tight burst so r6 would learn from r7/r8 before advertising to r1. With jitter, r6 may connect to r1 first, advertise 10.0.0.1/32 without NHC, then never re-send the route when the downstream multipath set changes.

Add test_bgp_nhc_update_on_peer_change() which deterministically reproduces this by shutting r6's peers to r7/r8, bringing r7 back first and verifying partial NHC, then bringing r8 back and verifying the NHC updates to include both peers. This final step is expected to fail until the NHC re-advertisement bug is fixed.

Also fix r1/frr.conf to place remote-as before timers to match the canonical CLI ordering.