### PR TITLE
lib: display End.DX2 route with appropriate oif attribute

### DIFF
--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -179,6 +179,7 @@ const char *seg6local_context2str(char *str, size_t size,
 				  uint32_t action)
 {
 	char flavor[SRV6_FLAVORS_STRLEN], *p_flavor;
+	struct interface *ifp;
 
 	flavor[0] = '\0';
 	p_flavor = seg6local_flavors2str(flavor, sizeof(flavor), &ctx->flv);
@@ -212,6 +213,9 @@ const char *seg6local_context2str(char *str, size_t size,
 		snprintfrr(str, size, "nh6 %pI6%s", &ctx->nh6, p_flavor);
 		return str;
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DX2:
+		ifp = if_lookup_by_index(ctx->ifindex, VRF_DEFAULT);
+		snprintfrr(str, size, "oif %s", ifp ? ifp->name : "<unknown>");
+		return str;
 	case ZEBRA_SEG6_LOCAL_ACTION_END_BM:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_S:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_AS:


### PR DESCRIPTION
Without that change, no extra attribute is associated to that SRv6 instruction.

> ip route add 2001:db1::/48 encap seg6local action End.DX2 oif dum1 dev loop1
>
> PE1# show ipv6 route
> Codes: K - kernel route, C - connected, L - local, S - static,
>        R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
>        T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
>        F - PBR, f - OpenFabric, t - Table-Direct,
>        > - selected route, * - FIB route, q - queued, r - rejected, b - backup
>        t - trapped, o - offload failure
>
> IPv6 unicast VRF default:
> K>* 2001:db1::/48 [0/1024] is directly connected, loop1, seg6local End.DX2 oif dum1, weight 1, 00:00:04