### PR TITLE
isisd: Fix remaining buffer size calculation in lsp_bits2string

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -689,8 +689,6 @@ void lspid_print(uint8_t *lsp_id, char *dest, size_t dest_len, char dynhost,
 /* Convert the lsp attribute bits to attribute string */
 static const char *lsp_bits2string(uint8_t lsp_bits, char *buf, size_t buf_size)
 {
-	char *pos = buf;
-
 	if (!lsp_bits)
 		return " none";
 
@@ -698,13 +696,10 @@ static const char *lsp_bits2string(uint8_t lsp_bits, char *buf, size_t buf_size)
 		return " error";
 
 	/* we only focus on the default metric */
-	pos += snprintf(pos, buf_size, "%d/",
-			ISIS_MASK_LSP_ATT_BITS(lsp_bits) ? 1 : 0);
-
-	pos += snprintf(pos, buf_size, "%d/",
-			ISIS_MASK_LSP_PARTITION_BIT(lsp_bits) ? 1 : 0);
-
-	snprintf(pos, buf_size, "%d", ISIS_MASK_LSP_OL_BIT(lsp_bits) ? 1 : 0);
+	snprintf(buf, buf_size, "%d/%d/%d",
+		 ISIS_MASK_LSP_ATT_BITS(lsp_bits) ? 1 : 0,
+		 ISIS_MASK_LSP_PARTITION_BIT(lsp_bits) ? 1 : 0,
+		 ISIS_MASK_LSP_OL_BIT(lsp_bits) ? 1 : 0);
 
 	return buf;
 }


### PR DESCRIPTION
### Summary
The lsp_bits2string function was incorrectly passing the total
buf_size to subsequent snprintf calls instead of the remaining
buffer space. This caused the compiler's _FORTIFY_SOURCE security
checks to trigger a SIGABRT, as the requested write size exceeded
the actual remaining bounds of the buffer.

I started seeing this crash after building FRR with clang 18 on
Ubuntu 24.04.

Corrected the size argument by properly subtracting the already
consumed space (pos - buf) from the total buf_size.

### Related Issue

### Components
isisd
