### PR TITLE
lib: align messages to 8-bytes boundary in stream buffers

### DIFF
--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -36,6 +36,15 @@ static bool trace;
 #define MGMT_MSG_ERR(ms, fmt, ...)                                             \
 	zlog_err("%s: %s: " fmt, (ms)->idtag, __func__, ##__VA_ARGS__)
 
+/*
+ * Round up message length to 8-byte boundary. When multiple messages are
+ * packed into a stream buffer, this ensures each message starts at an
+ * 8-byte aligned offset. Native message structs contain uint64_t fields
+ * that require proper alignment; on strict-alignment architectures (e.g.,
+ * ARM with NEON), unaligned access to these fields causes SIGBUS.
+ */
+#define MGMT_MSG_ALIGN(len) (((len) + 7) & ~(size_t)7)
+
 DEFINE_MTYPE(LIB, MSG_CONN, "msg connection state");
 
 /**
@@ -96,17 +105,20 @@ enum mgmt_msg_rsched mgmt_msg_read(struct mgmt_msg_state *ms, int fd,
 	assert(stream_get_getp(ms->ins) == 0);
 	left = stream_get_endp(ms->ins);
 	while (left > (ssize_t)sizeof(struct mgmt_msg_hdr)) {
+		size_t aligned_len;
+
 		mhdr = (struct mgmt_msg_hdr *)(STREAM_DATA(ms->ins) + total);
 		if (!MGMT_MSG_IS_MARKER(mhdr->marker)) {
 			MGMT_MSG_DBG(dbgtag, "recv corrupt buffer on fd %d, disconnect", fd);
 			return MSR_DISCONNECT;
 		}
-		if ((ssize_t)mhdr->len > left)
+		aligned_len = MGMT_MSG_ALIGN(mhdr->len);
+		if ((ssize_t)aligned_len > left)
 			break;
 
 		MGMT_MSG_TRACE(dbgtag, "read full message on fd %d len %u", fd, mhdr->len);
-		total += mhdr->len;
-		left -= mhdr->len;
+		total += aligned_len;
+		left -= aligned_len;
 		mcount++;
 	}
 
@@ -121,7 +133,7 @@ enum mgmt_msg_rsched mgmt_msg_read(struct mgmt_msg_state *ms, int fd,
 			 * therefor the stream is too small to fit the message..
 			 * Resize the stream to fit.
 			 */
-			news = stream_new(mhdr->len);
+			news = stream_new(MGMT_MSG_ALIGN(mhdr->len));
 			stream_put(news, mhdr, left);
 			stream_set_endp(news, left);
 			stream_free(ms->ins);
@@ -140,7 +152,7 @@ enum mgmt_msg_rsched mgmt_msg_read(struct mgmt_msg_state *ms, int fd,
 		ms->ins = stream_new(ms->max_msg_sz);
 	else
 		/* handle case where message is greater than max */
-		ms->ins = stream_new(MAX(ms->max_msg_sz, mhdr->len));
+		ms->ins = stream_new(MAX(ms->max_msg_sz, MGMT_MSG_ALIGN(mhdr->len)));
 	if (left) {
 		stream_put(ms->ins, mhdr, left);
 		stream_set_endp(ms->ins, left);
@@ -187,7 +199,7 @@ bool mgmt_msg_procbufs(struct mgmt_msg_state *ms,
 		MGMT_MSG_TRACE(dbgtag, "Processing stream of len %zu", left);
 
 		for (; left > sizeof(struct mgmt_msg_hdr);
-		     left -= mhdr->len, data += mhdr->len) {
+		     left -= MGMT_MSG_ALIGN(mhdr->len), data += MGMT_MSG_ALIGN(mhdr->len)) {
 			mhdr = (struct mgmt_msg_hdr *)data;
 
 			assert(MGMT_MSG_IS_MARKER(mhdr->marker));
@@ -317,6 +329,7 @@ int mgmt_msg_send_msg(struct mgmt_msg_state *ms, uint8_t version, void *msg,
 	uint8_t *dstbuf;
 	size_t endp, n;
 	size_t mlen = len + sizeof(*mhdr);
+	size_t aligned_mlen = MGMT_MSG_ALIGN(mlen);
 
 	if (mlen > ms->max_msg_sz)
 		MGMT_MSG_TRACE(dbgtag, "Sending large msg size %zu > max size %zu", mlen,
@@ -324,19 +337,19 @@ int mgmt_msg_send_msg(struct mgmt_msg_state *ms, uint8_t version, void *msg,
 
 	if (!ms->outs) {
 		MGMT_MSG_TRACE(dbgtag, "creating new stream for msg len %zu", mlen);
-		ms->outs = stream_new(MAX(ms->max_msg_sz, mlen));
+		ms->outs = stream_new(MAX(ms->max_msg_sz, aligned_mlen));
 	} else if (mlen > ms->max_msg_sz && ms->outs->endp == 0) {
 		/* msg is larger than stream max size get a fit-to-size stream */
 		MGMT_MSG_TRACE(dbgtag, "replacing old stream with fit-to-size for msg len %zu",
 			       mlen);
 		stream_free(ms->outs);
-		ms->outs = stream_new(mlen);
-	} else if (STREAM_WRITEABLE(ms->outs) < mlen) {
+		ms->outs = stream_new(aligned_mlen);
+	} else if (STREAM_WRITEABLE(ms->outs) < aligned_mlen) {
 		MGMT_MSG_TRACE(dbgtag,
 			       "enq existing stream len %zu and creating new stream for msg len %zu",
 			       STREAM_WRITEABLE(ms->outs), mlen);
 		stream_fifo_push(&ms->outq, ms->outs);
-		ms->outs = stream_new(MAX(ms->max_msg_sz, mlen));
+		ms->outs = stream_new(MAX(ms->max_msg_sz, aligned_mlen));
 	} else {
 		MGMT_MSG_TRACE(dbgtag, "using existing stream with avail %zu for msg len %zu",
 			       STREAM_WRITEABLE(ms->outs), mlen);
@@ -366,7 +379,9 @@ int mgmt_msg_send_msg(struct mgmt_msg_state *ms, uint8_t version, void *msg,
 		memcpy(dstbuf, msg, len);
 		n = len;
 	}
-	stream_set_endp(s, endp + n);
+	if (n < aligned_mlen - sizeof(*mhdr))
+		memset(dstbuf + n, 0, aligned_mlen - sizeof(*mhdr) - n);
+	stream_set_endp(s, endp + aligned_mlen - sizeof(*mhdr));
 	ms->ntxm++;
 
 	return 0;


### PR DESCRIPTION
On ARM32 systems, mgmtd crashes at startup on an alignment fault:

```
  frrinit.sh[158]: Starting watchfrr with command: '  /usr/sbin/watchfrr  -d   mgmtd zebra staticd'
  watchfrr[168]: [T83RR-8SM5G] watchfrr 10.5.2 starting: vty@0
  watchfrr[168]: [ZCJ3S-SPH5S] mgmtd state -> down : initial connection attempt failed
  watchfrr[168]: [ZCJ3S-SPH5S] zebra state -> down : initial connection attempt failed
  watchfrr[168]: [ZCJ3S-SPH5S] staticd state -> down : initial connection attempt failed
  watchfrr[168]: [YFT0P-5Q5YX] Forked background command [pid 169]: /usr/sbin/watchfrr.sh restart all
  frrinit.sh[180]: 2026/02/27 09:14:13 ZEBRA: [KGY44-D47GD][EC 4043309111] Disabling MPLS support (no kernel support)
  watchfrr[168]: [QDG3Y-BY5TN] zebra state -> up : connect succeeded
  kernel: Alignment trap: not handling instruction edc30b02 at [<004c3c1c>]
  kernel: 8<--- cut here ---
  kernel: Unhandled fault: alignment exception (0x801) at 0x008879f6
  kernel: [008879f6] *pgd=9baf6831
  watchfrr[168]: [YFT0P-5Q5YX] Forked background command [pid 189]: /usr/sbin/watchfrr.sh restart mgmtd
  frrinit.sh[189]: Cannot stop mgmtd: pid 179 not running
  watchfrr.sh[196]: Cannot stop mgmtd: pid 179 not running
  frrinit.sh[202]: [202|zebra] sending configuration
  frrinit.sh[202]: [202|zebra] done
  frrinit.sh[216]: [216|watchfrr] sending configuration
  frrinit.sh[218]: [218|staticd] sending configuration
  watchfrr[168]: [VTVCM-Y2NW3] Configuration Read in Took: 00:00:00
  frrinit.sh[199]: Waiting for children to finish applying config...
  frrinit.sh[216]: [216|watchfrr] done
```

When checking crashlogs in /var/tmp/frr, mgmt gives the following:

```
  MGMTD: Received signal 7 at 1772183653 (si_addr 0x8879f6); aborting...
  MGMTD: /lib/libfrr.so.0(zlog_backtrace_sigsafe+0x5c) [0xb6e89c90]
  MGMTD: /lib/libfrr.so.0(zlog_signal+0xe0) [0xb6e89e80]
  MGMTD: /lib/libfrr.so.0(+0xd4374) [0xb6ed3374]
  MGMTD: /lib/libc.so.6(__default_rt_sa_restorer+0) [0xb6ab4d90]
  MGMTD: /usr/sbin/mgmtd(mgmt_fe_adapter_send_notify+0x6b8) [0x4c3c20]
  MGMTD: /lib/libfrr.so.0(mgmt_msg_procbufs+0x124) [0xb6e976b8]
  MGMTD: /lib/libfrr.so.0(+0x98798) [0xb6e97798]
  MGMTD: /lib/libfrr.so.0(event_call+0xa8) [0xb6ee739c]
  MGMTD: /lib/libfrr.so.0(frr_run+0xd4) [0xb6e80fc8]
  MGMTD: /usr/sbin/mgmtd(main+0x188) [0x4bd7ec]
  MGMTD: /lib/libc.so.6(+0x236b0) [0xb6a9f6b0]
  MGMTD: /lib/libc.so.6(__libc_start_main+0x98) [0xb6a9f790]
  MGMTD: in thread msg_conn_proc_msgs scheduled from lib/mgmt_msg.c:543 msg_conn_sched_proc_msgs()
```

The issue is that messages are queued for sending/receive back-to-back with no padding. This means that when mgmt creates a pointer back to the data waiting in queue and tries to access fields inside the dereferenced message, those accesses are not performed with the alignment constraints required by some architectures. For example, ARM ABI AAPCS32 ([1]) states that structures alignment should be the same as the "most aligned" member; so a struct mgmt_msg_header, which contains some uint64_t fields (which are 8-bytes alignes), should be 8-bytes aligned as well.

On x86, this goes unnoticed because the CPU handles unaligned access transparently. On ARM 32-bit with NEON/VFP, the compiler generates 64-bit store instructions that trap on unaligned addresses. The kernel cannot emulate these instructions and kills the process with SIGBUS.

Fix this alignment issue by introducing MGMT_MSG_ALIGN() to systematically round up messages length to 8-bytes boundaries, which sounds reasonable for standard architectures and ABIs. The actual message length in mhdr->len is left unchanged so that receivers see the real payload size. The alignment is applied in three places:

 - mgmt_msg_send_msg(): reserve and zero-pad space up to the next 8-byte boundary after each message in the stream buffer.
 - mgmt_msg_read(): advance through received data using the aligned length so that message boundaries are found correctly.
 - mgmt_msg_procbufs(): advance through queued messages using the aligned length so that handlers receive properly aligned pointers.

Fixes #20087.

[1] https://github.com/ARM-software/abi-aa/blob/main/aapcs32/aapcs32.rst#data-types-and-alignment


Co-developed-by: Alexis Lothoré <alexis.lothore@bootlin.com>

---
The issue has been observed on FRR 10.5.2, and the corresponding fix has been validated on top of this version, but following developer's documentation, the fix is provided on top of master.
- clang-format has been run
- ./buidtest.sh has been executed successfully (in an Ubuntu 24.04 container)