### PR TITLE
bgpd: Fix nht to properly notice a change

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1518,7 +1518,8 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 		if (old_path_valid != bnc_is_valid_nexthop)
 			hook_call(bgp_nht_path_update, bgp_path, path, bnc_is_valid_nexthop);
 
-		if (CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_METRIC_CHANGED) ||
+		if (old_path_valid != bnc_is_valid_nexthop ||
+		    CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_METRIC_CHANGED) ||
 		    CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED))
 			bgp_process(bgp_path, dest, path, afi, safi);
 	}


### PR DESCRIPTION
commit: 8dcd0a6b9cdbfac47eea2cf2100badf7744dbf98 broke path handling in some rare cases.  This can be especially seen in bgp evpn processing when a path transitions from !valid to valid.  The bgp_evpn_rt5_addpath code is failing occassionally because of this change.  Modify the code to intentionally also call bgp_process when the old_path_valid is not the same as the new path being valid.