### PR TITLE
Esi reserved ranges

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -969,7 +969,7 @@ static enum zclient_send_status bgp_zebra_send_remote_macip(
 	/* If the ESI is valid that becomes the nexthop; tape out the
 	 * VTEP-IP for that case
 	 */
-	if (bgp_evpn_is_esi_valid(esi)) {
+	if (!esi_is_reserved(esi)) {
 		esi_valid = true;
 		stream_put_ipaddr(s, &zero_remote_vtep_ip);
 	} else {
@@ -1964,7 +1964,7 @@ static void update_evpn_route_entry_sync_info(struct bgp *bgp,
 		return;
 
 	esi = bgp_evpn_attr_get_esi(attr);
-	if (bgp_evpn_is_esi_valid(esi)) {
+	if (!esi_is_reserved(esi)) {
 		if (setup_sync) {
 			uint32_t max_sync_seq = 0;
 			bool active_on_peer = false;
@@ -2305,7 +2305,7 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	if (CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_PROXY_ADVERT))
 		SET_FLAG(attr.es_flags, ATTR_ES_PROXY_ADVERT);
 
-	if (esi && bgp_evpn_is_esi_valid(esi)) {
+	if (esi && !esi_is_reserved(esi)) {
 		memcpy(&attr.esi, esi, sizeof(esi_t));
 		/* ES should not be marked local if ESI is in bypass */
 		if (bgp_evpn_is_esi_local_and_non_bypass(esi))
@@ -5243,19 +5243,19 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 	 * An update containing a non-zero gateway IP and a non-zero ESI
 	 * at the same time is should be treated as withdraw
 	 */
-	if (bgp_evpn_is_esi_valid(&evpn->eth_s_id) &&
+	if (!esi_is_reserved(&evpn->eth_s_id) &&
 	    !ipaddr_is_zero(&evpn->gw_ip)) {
 		flog_err(EC_BGP_EVPN_ROUTE_INVALID,
 			 "%s - Rx EVPN Type-5 ESI and gateway-IP both non-zero.",
 			 peer->host);
 		is_valid_update = false;
-	} else if (bgp_evpn_is_esi_valid(&evpn->eth_s_id))
+	} else if (!esi_is_reserved(&evpn->eth_s_id))
 		evpn->type = OVERLAY_INDEX_ESI;
 	else if (!ipaddr_is_zero(&evpn->gw_ip))
 		evpn->type = OVERLAY_INDEX_GATEWAY_IP;
 	if (attr) {
 		if (is_zero_mac(&attr->rmac) &&
-		    !bgp_evpn_is_esi_valid(&evpn->eth_s_id) &&
+		    esi_is_reserved(&evpn->eth_s_id) &&
 		    ipaddr_is_zero(&evpn->gw_ip) && label == 0) {
 			flog_err(EC_BGP_EVPN_ROUTE_INVALID,
 				 "%s - Rx EVPN Type-5 ESI, gateway-IP, RMAC and label all zero",

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1745,8 +1745,8 @@ void bgp_evpn_path_es_link(struct bgp_path_info *pi, vni_t vni, esi_t *esi)
 	es_info = (pi->extra && pi->extra->evpn && pi->extra->evpn->mh_info)
 			  ? pi->extra->evpn->mh_info->es_info
 			  : NULL;
-	/* if the esi is zero just unlink the path from the old es */
-	if (!esi || !memcmp(esi, zero_esi, sizeof(*esi))) {
+	/* reserved ESIs (zero or MAX-ESI) are not linked to an ES */
+	if (esi_is_reserved(esi)) {
 		if (es_info)
 			bgp_evpn_path_es_unlink(es_info);
 		return;
@@ -3356,7 +3356,7 @@ bool bgp_evpn_path_es_use_nhg(struct bgp *bgp_vrf, struct bgp_path_info *pi,
 
 	/* non-es path, use legacy-exploded multipath */
 	esi = bgp_evpn_attr_get_esi(parent_pi->attr);
-	if (!memcmp(esi, zero_esi, sizeof(*esi)))
+	if (esi_is_reserved(esi))
 		return false;
 
 	/* we don't support NHG for d-vni yet */

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -345,10 +345,6 @@ static inline int bgp_evpn_is_es_local(struct bgp_evpn_es *es)
 }
 
 extern esi_t *zero_esi;
-static inline bool bgp_evpn_is_esi_valid(esi_t *esi)
-{
-	return !!memcmp(esi, zero_esi, sizeof(esi_t));
-}
 
 static inline esi_t *bgp_evpn_attr_get_esi(struct attr *attr)
 {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1042,7 +1042,7 @@ int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 
 		new_esi = bgp_evpn_attr_get_esi(newattr);
 		exist_esi = bgp_evpn_attr_get_esi(existattr);
-		if (bgp_evpn_is_esi_valid(new_esi) &&
+		if (!esi_is_reserved(new_esi) &&
 				!memcmp(new_esi, exist_esi, sizeof(esi_t))) {
 			same_esi = true;
 		} else {
@@ -11492,7 +11492,7 @@ void route_vty_out(struct vty *vty, const struct prefix *p, struct bgp_path_info
 		vty_out(vty, "%s", bgp_origin_str[attr->origin]);
 
 	if (json_paths) {
-		if (bgp_evpn_is_esi_valid(&attr->esi)) {
+		if (!esi_is_reserved(&attr->esi)) {
 			json_object_string_add(json_path, "esi",
 					esi_to_str(&attr->esi,
 					esi_buf, sizeof(esi_buf)));
@@ -11542,7 +11542,7 @@ void route_vty_out(struct vty *vty, const struct prefix *p, struct bgp_path_info
 		vty_out(vty, "\n");
 
 		if (safi == SAFI_EVPN) {
-			if (bgp_evpn_is_esi_valid(&attr->esi)) {
+			if (!esi_is_reserved(&attr->esi)) {
 				/* XXX - add these params to the json out */
 				vty_out(vty, "%*s", 20, " ");
 				vty_out(vty, "ESI:%s",
@@ -12709,7 +12709,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	}
 
 	if (safi == SAFI_EVPN &&
-			bgp_evpn_is_esi_valid(&attr->esi)) {
+			!esi_is_reserved(&attr->esi)) {
 		route_vty_out_detail_es_info(vty, path, attr, json_path);
 	}
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1470,6 +1470,17 @@ char *esi_to_str(const esi_t *esi, char *buf, int size)
 	return ptr;
 }
 
+bool esi_is_reserved(const esi_t *esi)
+{
+	static const esi_t zero_esi = {0};
+	static const esi_t max_esi = {.val = MAX_ESI};
+
+	assert(esi);
+
+	return (!memcmp(esi, &zero_esi, sizeof(esi_t)) ||
+		!memcmp(esi, &max_esi, sizeof(esi_t)));
+}
+
 char *evpn_es_df_alg2str(uint8_t df_alg, char *buf, int buf_len)
 {
 	switch (df_alg) {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -488,6 +488,7 @@ extern unsigned prefix_hash_key(const void *pp);
 
 extern int str_to_esi(const char *str, esi_t *esi);
 extern char *esi_to_str(const esi_t *esi, char *buf, int size);
+extern bool esi_is_reserved(const esi_t *esi);
 extern char *evpn_es_df_alg2str(uint8_t df_alg, char *buf, int buf_len);
 extern void prefix_evpn_hexdump(const struct prefix_evpn *p);
 extern bool ipv4_unicast_valid(const struct in_addr *addr);

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -860,7 +860,9 @@ def test_evpn_vtep_change():
     # 4. Verify new VTEP appears and old VTEP is removed
     test_fn = partial(check_remote_es_vtep_present, dut, esi, secondary_vtep)
     _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
-    assertmsg = f"torm11: secondary VTEP {secondary_vtep} not found in ES {esi} after switch"
+    assertmsg = (
+        f"torm11: secondary VTEP {secondary_vtep} not found in ES {esi} after switch"
+    )
     assert result is None, assertmsg
 
     test_fn = partial(check_remote_es_vtep_absent, dut, esi, primary_vtep)
@@ -1025,6 +1027,218 @@ def test_evpn_es_config_without_bridge():
                 evpn mh es-sys-mac 44:38:39:ff:ff:01
             """
         )
+
+
+def test_evpn_max_esi_type2_behavior():
+    """
+    Configure MAX-ESI on rack-2 hostbond1 interfaces and verify that
+    rack-1 handles MAX-ESI as reserved:
+    1) no ES entry is created/learned for MAX-ESI
+    2) Type-2 route is still received in BGP
+    3) zebra installs the remote MAC from Type-2 route alone
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    max_esi = "ff:ff:ff:ff:ff:ff:ff:ff:ff:ff"
+    receiver = tgen.gears["torm11"]
+    senders = [tgen.gears["torm21"], tgen.gears["torm22"]]
+
+    # hostd21 is dual-homed via hostbond1 on rack-2 TORs.
+    vni = 1000
+    _, hostd21_mac = compute_host_ip_mac("hostd21")
+
+    def check_es_absent(dut, esi):
+        out = dut.vtysh_cmd("show bgp l2vp evpn es %s json" % esi)
+        es = json.loads(out)
+        if es:
+            return "esi %s still present on %s: %s" % (esi, dut.name, es)
+        return None
+
+    def check_type2_in_bgp(dut, mac):
+        out = dut.vtysh_cmd("show bgp l2vpn evpn route type 2")
+        out = out.lower()
+        if mac.lower() not in out:
+            return "type-2 for MAC %s missing on %s" % (mac, dut.name)
+        return None
+
+    def check_remote_mac_installed_any_esi(dut, vni_id, mac):
+        out = dut.vtysh_cmd("show evpn mac vni %d mac %s json" % (vni_id, mac))
+        mac_js = json.loads(out)
+        info = mac_js.get(mac)
+        if not info:
+            return "MAC %s not installed in zebra on %s" % (mac, dut.name)
+        if info.get("type", "") != "remote":
+            return "MAC %s is not remote on %s: %s" % (mac, dut.name, info)
+        return None
+
+    # Move hostbond1 from type-3 ESI to explicit type-0 MAX-ESI.
+    for tor in senders:
+        tor.vtysh_cmd(
+            "\n".join(
+                [
+                    "conf",
+                    "interface hostbond1",
+                    f"evpn mh es-id {max_esi}",
+                    "no evpn mh es-sys-mac",
+                ]
+            )
+        )
+
+    # Trigger MAC/IP activity so Type-2 updates are refreshed quickly.
+    ping_anycast_gw(tgen)
+
+    # MAX-ESI is reserved; receiver should not learn/create an ES for it.
+    test_fn = partial(check_es_absent, receiver, max_esi)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = (
+        f'"{receiver.name}" still has remote ES "{max_esi}" after MAX-ESI config'
+    )
+    assert result is None, assertmsg
+
+    # Verify the remote host MAC route is present in BGP.
+    test_fn = partial(check_type2_in_bgp, receiver, hostd21_mac)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = (
+        f'"{receiver.name}" missing Type-2 MAC {hostd21_mac} ' "after MAX-ESI config"
+    )
+    assert result is None, assertmsg
+
+    # Verify the remote host MAC is installed in zebra (without ES dependency).
+    test_fn = partial(check_remote_mac_installed_any_esi, receiver, vni, hostd21_mac)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = (
+        f'"{receiver.name}" did not install hostd21 MAC {hostd21_mac} '
+        "in zebra after MAX-ESI config"
+    )
+    assert result is None, assertmsg
+
+    # Block EAD (type-1) and ES (type-4) on receiver, keep type-2.
+    receiver.vtysh_cmd(
+        """
+        conf
+          route-map RM-BLOCK-ES-EAD deny 10
+            match evpn route-type ead
+          route-map RM-BLOCK-ES-EAD deny 20
+            match evpn route-type es
+          route-map RM-BLOCK-ES-EAD permit 100
+          router bgp 65002
+            address-family l2vpn evpn
+              neighbor 192.168.1.1 route-map RM-BLOCK-ES-EAD in
+              neighbor 192.168.5.1 route-map RM-BLOCK-ES-EAD in
+        """
+    )
+    receiver.vtysh_cmd("clear bgp l2vpn evpn 192.168.1.1 soft in")
+    receiver.vtysh_cmd("clear bgp l2vpn evpn 192.168.5.1 soft in")
+
+    # Re-trigger host traffic to refresh type-2 updates.
+    ping_anycast_gw(tgen)
+
+    # ES (type-4) should now be absent.
+    test_fn = partial(check_es_absent, receiver, max_esi)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = f'"{receiver.name}" still has ES route for {max_esi} after filter'
+    assert result is None, assertmsg
+
+    # Type-2 should still be present in BGP.
+    test_fn = partial(check_type2_in_bgp, receiver, hostd21_mac)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = (
+        f'"{receiver.name}" missing Type-2 MAC {hostd21_mac} '
+        f"after EAD/ES filter was applied"
+    )
+    assert result is None, assertmsg
+
+    # Zebra should still install remote MAC from MAC/IP route alone.
+    test_fn = partial(check_remote_mac_installed_any_esi, receiver, vni, hostd21_mac)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = (
+        f'"{receiver.name}" failed to keep MAC {hostd21_mac} installed in zebra '
+        "with only Type-2 available"
+    )
+    assert result is None, assertmsg
+
+
+def test_evpn_zero_esi_type2_behavior():
+    """
+    Configure zero ESI on rack-2 hostbond2 interfaces and verify:
+    1) Type-2 route is received in BGP on receiver.
+    2) Remote MAC is installed in zebra without ES association and with
+       remote-VTEP forwarding semantics.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    zero_esi = "00:00:00:00:00:00:00:00:00:00"
+    receiver = tgen.gears["torm11"]
+    senders = [tgen.gears["torm21"], tgen.gears["torm22"]]
+
+    # hostd22 is dual-homed via hostbond2 on rack-2 TORs.
+    vni = 1000
+    _, hostd22_mac = compute_host_ip_mac("hostd22")
+
+    def check_type2_in_bgp(dut, mac):
+        out = dut.vtysh_cmd("show bgp l2vpn evpn route type 2")
+        if mac.lower() not in out.lower():
+            return "type-2 for MAC %s missing on %s" % (mac, dut.name)
+        return None
+
+    def check_zero_esi_mac_installed(dut, vni_id, mac):
+        out = dut.vtysh_cmd("show evpn mac vni %d mac %s json" % (vni_id, mac))
+        mac_js = json.loads(out)
+        info = mac_js.get(mac)
+        if not info:
+            return "MAC %s not installed in zebra on %s" % (mac, dut.name)
+        if info.get("type", "") != "remote":
+            return "MAC %s is not remote on %s: %s" % (mac, dut.name, info)
+
+        # For zero-ESI we expect no ES association in zebra output.
+        esi = info.get("esi", "")
+        if esi and esi != zero_esi:
+            return "unexpected non-zero ESI %s for MAC %s on %s" % (esi, mac, dut.name)
+
+        # Remote MAC should use remote VTEP forwarding semantics.
+        if not info.get("remoteVtep", ""):
+            return "remoteVtep missing for zero-ESI MAC %s on %s: %s" % (
+                mac,
+                dut.name,
+                info,
+            )
+        return None
+
+    # Move hostbond2 from type-3 ESI to explicit zero ESI.
+    for tor in senders:
+        tor.vtysh_cmd(
+            "\n".join(
+                [
+                    "conf",
+                    "interface hostbond2",
+                    f"evpn mh es-id {zero_esi}",
+                    "no evpn mh es-sys-mac",
+                ]
+            )
+        )
+
+    # Trigger MAC/IP activity so Type-2 updates are refreshed quickly.
+    ping_anycast_gw(tgen)
+
+    # 1) Type-2 should be present in BGP (received).
+    test_fn = partial(check_type2_in_bgp, receiver, hostd22_mac)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = f'"{receiver.name}" missing Type-2 MAC {hostd22_mac} for zero-ESI case'
+    assert result is None, assertmsg
+
+    # 2) Type-2 should be correctly installed in zebra.
+    test_fn = partial(check_zero_esi_mac_installed, receiver, vni, hostd22_mac)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = (
+        f'"{receiver.name}" failed zero-ESI install handling for MAC {hostd22_mac}'
+    )
+    assert result is None, assertmsg
 
 
 if __name__ == "__main__":

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1998,7 +1998,7 @@ static struct zebra_evpn_es *zebra_evpn_es_new(const esi_t *esi)
 {
 	struct zebra_evpn_es *es;
 
-	if (!memcmp(esi, zero_esi, sizeof(esi_t)))
+	if (esi_is_reserved(esi))
 		return NULL;
 
 	es = XCALLOC(MTYPE_ZES, sizeof(struct zebra_evpn_es));
@@ -2785,8 +2785,8 @@ bool zebra_evpn_es_mac_ref(struct zebra_mac *mac, const esi_t *esi)
 
 	es = zebra_evpn_es_find(esi);
 	if (!es) {
-		/* If non-zero esi implicitly create a new ES */
-		if (memcmp(esi, zero_esi, sizeof(esi_t))) {
+		/* Reserved ESIs (zero and MAX-ESI) are never ES-referenced. */
+		if (!esi_is_reserved(esi)) {
 			es = zebra_evpn_es_new(esi);
 			if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 				zlog_debug("auto es %s add on mac ref",


### PR DESCRIPTION
rfc7432 states this:

When a customer site is connected to one or more PEs via a set of
       Ethernet links, then this set of Ethernet links constitutes an
       "Ethernet segment".  For a multihomed site, each Ethernet segment
       (ES) is identified by a unique non-zero identifier called an Ethernet
       Segment Identifier (ESI).  An ESI is encoded as a 10-octet integer in
       line format with the most significant octet sent first.  The
       following two ESI values are reserved:
    
       - ESI 0 denotes a single-homed site.
    
       - ESI {0xFF} (repeated 10 times) is known as MAX-ESI and is reserved.

Additionally:

9.2.2.  Route Resolution

   If the Ethernet Segment Identifier field in a received MAC/IP
   Advertisement route is set to the reserved ESI value of 0 or MAX-ESI,
   then if the receiving PE decides to install forwarding state for the
   associated MAC address, it MUST be based on the MAC/IP Advertisement
   route alone.



FRR was correctly handling ESI 0, but not the MAX-ESI.  Fix the code to do so.