### PR TITLE
yang: Fix pyang errors in frr-ospf6-route-map.yang

### DIFF
--- a/yang/frr-ospf6-route-map.yang
+++ b/yang/frr-ospf6-route-map.yang
@@ -22,6 +22,9 @@ module frr-ospf6-route-map {
   revision 2020-01-02 {
     description
       "Initial revision";
+
+    reference
+      "FRRouting";
   }
 
   identity forwarding-address {
@@ -37,10 +40,15 @@ module frr-ospf6-route-map {
   }
 
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:rmap-set-action/frr-route-map:set-action" {
+    description
+      "Augments the 'set-action' to add IPv6 address support for forwarding actions";
+
     case ipv6-address {
       when "derived-from-or-self(../frr-route-map:action, 'forwarding-address')";
       leaf ipv6-address {
         type inet:ipv6-address;
+        description
+          "IPv6 address used for forwarding actions";
       }
     }
   }


### PR DESCRIPTION
Fix pyang errors in frr-ospf6-route-map.yang

frr-ospf6-route-map.yang:22: error: RFC 8407: 4.8: statement "revision" must have a "reference" substatement
frr-ospf6-route-map.yang:39: error: RFC 8407: 4.14: statement "augment" must have a "description" substatement
frr-ospf6-route-map.yang:42: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement