### PR TITLE
pcep: fix heap buffer overflow

### DIFF
--- a/pathd/path_pcep_lib.c
+++ b/pathd/path_pcep_lib.c
@@ -1068,7 +1068,7 @@ void pcep_lib_parse_lsp_symbolic_name(
 	uint16_t size = tlv->symbolic_path_name_length;
 	assert(path->name == NULL);
 	size = size > MAX_PATH_NAME_SIZE ? MAX_PATH_NAME_SIZE : size;
-	path->name = XCALLOC(MTYPE_PCEP, size);
+	path->name = XCALLOC(MTYPE_PCEP, size + 1);
 	strlcpy((char *)path->name, tlv->symbolic_path_name, size + 1);
 }
 


### PR DESCRIPTION
ASAN reported a heap buffer overflow when printing path->name in path_pcep_config_update_path():

```
  snprintf(segment_list_name_buff, sizeof(segment_list_name_buff),
           "%s-%u", path->name, path->plsp_id);
```

The symbolic name is allocated in pcep_lib_parse_lsp_symbolic_name() using the following:
```

  path->name = XCALLOC(MTYPE_PCEP, size);
  strlcpy((char *)path->name, tlv->symbolic_path_name, size + 1);
```

However, "size" does not account for '\0' at the end. Since strlcpy() is called with "size + 1", this results in a 1-byte heap overflow. Fix it by allocating "size + 1" bytes to properly accomodate the null terminator.

Fixes: 56634922390f ("pathd: Handle PCInitiated messages, thread controller. (2/4)")