### PR TITLE
Bfd QoL improvements

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -274,6 +274,7 @@ struct bfd_key {
 } __attribute__((packed));
 
 struct bfd_session_stats {
+	uint64_t rx_bad_ctrl_pkt;
 	uint64_t rx_ctrl_pkt;
 	uint64_t tx_ctrl_pkt;
 	uint64_t rx_echo_pkt;

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -918,6 +918,7 @@ void bfd_recv_cb(struct event *t)
 			 vrfid, (uint32_t)mlen, BFD_PKT_LEN);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "too small (%zd bytes)", mlen);
+
 		return;
 	}
 
@@ -995,6 +996,7 @@ void bfd_recv_cb(struct event *t)
 			 vrfid, vrfid, bfd->vrf->vrf_id); /* actual pkt vrf, expected session vrf */
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "wrong vrfid.");
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -1005,6 +1007,7 @@ void bfd_recv_cb(struct event *t)
 			 vrfid, bfd->ses_state);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "'remote discriminator' is zero, not overridden");
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -1020,6 +1023,7 @@ void bfd_recv_cb(struct event *t)
 			cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 				 "exceeded max hop count (expected %d, got %d)",
 				 bfd->mh_ttl, ttl);
+			bfd->stats.rx_bad_ctrl_pkt++;
 			return;
 		}
 	} else {

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -912,12 +912,23 @@ void bfd_recv_cb(struct event *t)
 			vrfid = ifp->vrf->vrf_id;
 	}
 
+	/* Find the session that this packet belongs. */
+	cp = (struct bfd_pkt *)(msgbuf);
+	bfd = ptm_bfd_sess_find(cp, &peer, &local, ifp, vrfid, is_mhop);
+	if (bfd == NULL) {
+		frrtrace(6, frr_bfd, packet_session_not_found, is_mhop, &peer, &local, ifindex,
+			 vrfid, ntohl(cp->discrs.my_discr));
+		cp_debug(is_mhop, &peer, &local, ifindex, vrfid, "no session found");
+		return;
+	}
+
 	/* Implement RFC 5880 6.8.6 */
 	if (mlen < BFD_PKT_LEN) {
 		frrtrace(8, frr_bfd, packet_validation_error, 1, is_mhop, &peer, &local, ifindex,
 			 vrfid, (uint32_t)mlen, BFD_PKT_LEN);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "too small (%zd bytes)", mlen);
+		bfd->stats.rx_bad_ctrl_pkt++;
 
 		return;
 	}
@@ -928,6 +939,7 @@ void bfd_recv_cb(struct event *t)
 			 vrfid, ttl, BFD_TTL_VAL);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "invalid TTL: %d expected %d", ttl, BFD_TTL_VAL);
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -938,12 +950,12 @@ void bfd_recv_cb(struct event *t)
 	 * - Short packets;
 	 * - Invalid discriminator;
 	 */
-	cp = (struct bfd_pkt *)(msgbuf);
 	if (BFD_GETVER(cp->diag) != BFD_VERSION) {
 		frrtrace(8, frr_bfd, packet_validation_error, 3, is_mhop, &peer, &local, ifindex,
 			 vrfid, BFD_GETVER(cp->diag), BFD_VERSION);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "bad version %d", BFD_GETVER(cp->diag));
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -952,6 +964,7 @@ void bfd_recv_cb(struct event *t)
 			 vrfid, 0, 1); /* actual=0, expected>=1 */
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "detect multiplier set to zero");
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -959,6 +972,7 @@ void bfd_recv_cb(struct event *t)
 		frrtrace(8, frr_bfd, packet_validation_error, 5, is_mhop, &peer, &local, ifindex,
 			 vrfid, cp->len, (uint32_t)mlen);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid, "too small");
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -967,6 +981,7 @@ void bfd_recv_cb(struct event *t)
 			 vrfid, 1, 0); /* actual=1 (M bit set), expected=0 */
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "detect non-zero Multipoint (M) flag");
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
@@ -976,18 +991,10 @@ void bfd_recv_cb(struct event *t)
 			 1); /* actual discriminator from packet, expected!=0 */
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "'my discriminator' is zero");
+		bfd->stats.rx_bad_ctrl_pkt++;
 		return;
 	}
 
-	/* Find the session that this packet belongs. */
-	bfd = ptm_bfd_sess_find(cp, &peer, &local, ifp, vrfid, is_mhop);
-	if (bfd == NULL) {
-		frrtrace(6, frr_bfd, packet_session_not_found, is_mhop, &peer, &local, ifindex,
-			 vrfid, ntohl(cp->discrs.my_discr));
-		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
-			 "no session found");
-		return;
-	}
 	/*
 	 * We may have a situation where received packet is on wrong vrf
 	 */

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -991,7 +991,7 @@ void bfd_recv_cb(struct event *t)
 	/*
 	 * We may have a situation where received packet is on wrong vrf
 	 */
-	if (bfd && bfd->vrf && bfd->vrf->vrf_id != vrfid) {
+	if (bfd->vrf && bfd->vrf->vrf_id != vrfid) {
 		frrtrace(8, frr_bfd, packet_validation_error, 8, is_mhop, &peer, &local, ifindex,
 			 vrfid, vrfid, bfd->vrf->vrf_id); /* actual pkt vrf, expected session vrf */
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -106,7 +106,7 @@ void bfd_cli_show_header_end(struct vty *vty, const struct lyd_node *dnode
 
 DEFPY_YANG_NOSH(
 	bfd_peer_enter, bfd_peer_enter_cmd,
-	"peer <A.B.C.D|X:X::X:X> [{multihop$multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME$ifname|vrf NAME}]",
+	"peer <A.B.C.D|X:X::X:X>$peer [{multihop$multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME$ifname|vrf NAME}]",
 	PEER_STR
 	PEER_IPV4_STR
 	PEER_IPV6_STR
@@ -173,7 +173,7 @@ DEFPY_YANG_NOSH(
 
 DEFPY_YANG(
 	bfd_no_peer, bfd_no_peer_cmd,
-	"no peer <A.B.C.D|X:X::X:X> [{multihop$multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME$ifname|vrf NAME}]",
+	"no peer <A.B.C.D|X:X::X:X>$peer [{multihop$multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME$ifname|vrf NAME}]",
 	NO_STR
 	PEER_STR
 	PEER_IPV4_STR
@@ -231,7 +231,7 @@ DEFPY_YANG(
 
 DEFPY_YANG_NOSH(
 	sbfd_echo_peer_enter, sbfd_echo_peer_enter_cmd,
-	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-echo bfd-name BFDNAME$bfdname \
+	"peer <A.B.C.D|X:X::X:X>$peer bfd-mode sbfd-echo bfd-name BFDNAME$bfdname \
 	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
 	srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
 	PEER_STR
@@ -305,7 +305,7 @@ DEFPY_YANG_NOSH(
 
 DEFPY_YANG(
 	sbfd_echo_no_peer, sbfd_echo_no_peer_cmd,
-	"no peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-echo bfd-name BFDNAME$bfdname \
+	"no peer <A.B.C.D|X:X::X:X>$peer bfd-mode sbfd-echo bfd-name BFDNAME$bfdname \
 	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
 	srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
 	NO_STR
@@ -348,7 +348,7 @@ DEFPY_YANG(
 
 DEFPY_YANG_NOSH(
 	sbfd_init_peer_enter, sbfd_init_peer_enter_cmd,
-	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	"peer <A.B.C.D|X:X::X:X>$peer bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
 	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
 	remote-discr (1-4294967295)$discr srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
 	PEER_STR
@@ -440,7 +440,7 @@ DEFPY_YANG_NOSH(
 
 DEFPY_YANG(
 	sbfd_init_no_peer, sbfd_init_no_peer_cmd,
-	"no peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	"no peer <A.B.C.D|X:X::X:X>$peer bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
 	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
 	remote-discr (0-4294967295)$discr srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
 	NO_STR
@@ -484,7 +484,7 @@ DEFPY_YANG(
 
 DEFPY_YANG_NOSH(
 	sbfd_init_peer_raw_enter, sbfd_init_peer_raw_enter_cmd,
-	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	"peer <A.B.C.D|X:X::X:X>$peer bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
 	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
 	remote-discr (1-4294967295)$discr",
 	PEER_STR
@@ -559,7 +559,7 @@ DEFPY_YANG_NOSH(
 
 DEFPY_YANG(
 	sbfd_init_no_peer_raw, sbfd_init_no_peer_raw_cmd,
-	"no peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	"no peer <A.B.C.D|X:X::X:X>$peer bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
 	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
 	remote-discr (0-4294967295)$discr",
 	NO_STR
@@ -1311,9 +1311,49 @@ static void bfd_profile_var(vector comps, struct cmd_token *token)
 	}
 }
 
+struct bfd_peer_var_walk_ctx {
+	vector comps;
+	struct cmd_token *token;
+};
+
+static void bfd_peer_var_walker(struct hash_bucket *hb, void *arg)
+{
+	struct bfd_peer_var_walk_ctx *ctx = arg;
+	struct bfd_session *bs = hb->data;
+	char addr_buf[INET6_ADDRSTRLEN];
+	enum cmd_token_type match_type;
+
+	if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
+		return;
+
+	if (bs->key.family == AF_INET)
+		match_type = IPV4_TKN;
+	else if (bs->key.family == AF_INET6)
+		match_type = IPV6_TKN;
+	else
+		return;
+
+	if (ctx->token->type != match_type)
+		return;
+
+	if (inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf)))
+		vector_set(ctx->comps, XSTRDUP(MTYPE_COMPLETION, addr_buf));
+}
+
+static void bfd_peer_var(vector comps, struct cmd_token *token)
+{
+	struct bfd_peer_var_walk_ctx ctx = {
+		.comps = comps,
+		.token = token,
+	};
+
+	bfd_key_iterate(bfd_peer_var_walker, &ctx);
+}
+
 static const struct cmd_variable_handler bfd_vars[] = {
-	{.tokenname = "BFDPROF", .completions = bfd_profile_var},
-	{.completions = NULL}
+	{ .varname = "peer", .completions = bfd_peer_var },
+	{ .tokenname = "BFDPROF", .completions = bfd_profile_var },
+	{ .completions = NULL }
 };
 
 void

--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -292,6 +292,12 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-input-count-bad",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_bad_get_elem,
+			}
+		},
+		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-output-count",
 			.cbs = {
 				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
@@ -478,6 +484,12 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/control-packet-input-count",
 			.cbs = {
 				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/control-packet-input-count-bad",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_bad_get_elem,
 			}
 		},
 		{
@@ -725,6 +737,12 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/control-packet-input-count-bad",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_bad_get_elem,
+			}
+		},
+		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/control-packet-output-count",
 			.cbs = {
 				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
@@ -945,6 +963,12 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/control-packet-input-count",
 			.cbs = {
 				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/control-packet-input-count-bad",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_bad_get_elem,
 			}
 		},
 		{

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -100,8 +100,9 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem(
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem(
 	struct nb_cb_get_elem_args *args);
-struct yang_data *
-bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem(
+struct yang_data *bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_bad_get_elem(
+	struct nb_cb_get_elem_args *args);
+struct yang_data *bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
 bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem(

--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -266,6 +266,18 @@ bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem(
 
 /*
  * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-input-count-bad
+ */
+struct yang_data *bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_bad_get_elem(
+	struct nb_cb_get_elem_args *args)
+{
+	const struct bfd_session *bs = args->list_entry;
+
+	return yang_data_new_uint64(args->xpath, bs->stats.rx_bad_ctrl_pkt);
+}
+
+/*
+ * XPath:
  * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-output-count
  */
 struct yang_data *

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -570,6 +570,7 @@ static void _display_peer_counter(struct vty *vty, struct bfd_session *bs)
 	vty_out(vty, "\t\tZebra notifications: %" PRIu64 "\n",
 		bs->stats.znotification);
 	vty_out(vty, "\t\tTx fail packet: %" PRIu64 "\n", bs->stats.tx_fail_pkt);
+	vty_out(vty, "\t\tRX fail packet: %" PRIu64 "\n", bs->stats.rx_bad_ctrl_pkt);
 	vty_out(vty, "\n");
 }
 
@@ -586,6 +587,7 @@ static struct json_object *__display_peer_counters_json(struct bfd_session *bs)
 
 	json_object_int_add(jo, "id", bs->discrs.my_discr);
 	json_object_int_add(jo, "control-packet-input", bs->stats.rx_ctrl_pkt);
+	json_object_int_add(jo, "controlPacketBadInput", bs->stats.rx_bad_ctrl_pkt);
 	json_object_int_add(jo, "control-packet-output", bs->stats.tx_ctrl_pkt);
 	json_object_int_add(jo, "echo-packet-input", bs->stats.rx_echo_pkt);
 	json_object_int_add(jo, "echo-packet-output", bs->stats.tx_echo_pkt);
@@ -778,6 +780,7 @@ static void _clear_peer_counter(struct bfd_session *bs)
 	/* Clear only pkt stats, intention is not to loose system
 	   events counters */
 	bs->stats.rx_ctrl_pkt = 0;
+	bs->stats.rx_bad_ctrl_pkt = 0;
 	bs->stats.tx_ctrl_pkt = 0;
 	bs->stats.rx_echo_pkt = 0;
 	bs->stats.tx_echo_pkt = 0;

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -800,7 +800,12 @@ static void _display_peer_brief(struct vty *vty, struct bfd_session *bs)
 		vty_out(vty, " %-20s\n", bs->profile_name ? bs->profile_name : "-");
 	} else {
 		vty_out(vty, "%-10u", bs->discrs.my_discr);
-		vty_out(vty, " %-40s", satostr(&bs->local_address));
+		if (memcmp(&bs->key.local, &zero_addr, sizeof(bs->key.local)))
+			vty_out(vty, " %-40s",
+				inet_ntop(bs->key.family, &bs->key.local, addr_buf,
+					  sizeof(addr_buf)));
+		else
+			vty_out(vty, " %-40s", satostr(&bs->local_address));
 		inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
 		vty_out(vty, " %-40s", addr_buf);
 

--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -136,6 +136,71 @@ static void ts_end(void)
 
 #define TYPE ATOMSORT_NONUNIQ
 #include "test_typelist.h"
+PREDECL_RBTREE_UNIQ(rtree);
+struct item {
+	uint32_t ival;
+	struct rtree_item link;
+};
+
+static int rcomp(const struct item *a, const struct item *b)
+{
+	if (a->ival < b->ival)
+		return -1;
+	else if (a->ival > b->ival)
+		return 1;
+	else
+		return 0;
+}
+
+DECLARE_RBTREE_UNIQ(rtree, struct item, link, rcomp);
+
+
+static void count_rb_one(const struct typed_rb_entry *re, int *count_p)
+{
+	if (re) {
+		(*count_p) += 1;
+
+		count_rb_one(re->rbt_left, count_p);
+		count_rb_one(re->rbt_right, count_p);
+	}
+}
+
+static void show_rb_counts(const struct rtree_head *rt)
+{
+	int left = 0, right = 0;
+	const struct typed_rb_entry *re;
+
+	re = rt->rr.rbt_root;
+
+	if (re) {
+		count_rb_one(re->rbt_left, &left);
+		count_rb_one(re->rbt_right, &right);
+	}
+
+	printf("RBTree counts: left %d, right %d\n", left, right);
+}
+
+#define RBMAX_COUNT 10000
+static struct item rbarr[RBMAX_COUNT];
+
+static void test_rb_pop(void)
+{
+	int i;
+	struct rtree_head head;
+	struct item *ptr;
+
+	rtree_init(&head);
+
+	memset(rbarr, 0, sizeof(rbarr));
+
+	printf("\nAdding %d integers, in order\n", RBMAX_COUNT);
+	for (i = 0; i < RBMAX_COUNT; i++) {
+		rbarr[i].ival = i;
+		rtree_add(&head, (&rbarr[i]));
+	}
+
+	show_rb_counts(&head);
+}
 
 int main(int argc, char **argv)
 {
@@ -156,6 +221,7 @@ int main(int argc, char **argv)
 	test_ATOMSORT_UNIQ();
 	test_ATOMSORT_NONUNIQ();
 
+	test_rb_pop();
 	log_memstats(NULL, true);
 	return 0;
 }

--- a/tests/topotests/bfd_topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd_topo1/test_bfd_topo1.py
@@ -92,6 +92,51 @@ def test_bfd_connection():
         assert result is None, assertmsg
 
 
+def test_bfd_yang_operational_data():
+    "Verify BFD session stats are retrievable via YANG operational data."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("querying BFD operational data via YANG on r1")
+
+    r1 = tgen.gears["r1"]
+    output = json.loads(
+        r1.vtysh_cmd(
+            "show yang operational-data /frr-bfdd:bfdd/bfd/sessions bfdd",
+        )
+    )
+
+    logger.info(output)
+    sessions = output["frr-bfdd:bfdd"]["bfd"]["sessions"]["single-hop"]
+    assert len(sessions) > 0, "Expected at least one single-hop BFD session"
+
+    session = sessions[0]
+    stats = session["stats"]
+
+    expected_keys = [
+        "control-packet-input-count",
+        "control-packet-input-count-bad",
+        "control-packet-output-count",
+        "echo-packet-input-count",
+        "echo-packet-output-count",
+        "session-down-count",
+        "session-up-count",
+    ]
+    for key in expected_keys:
+        assert key in stats, "Missing expected stats key '{}'".format(key)
+
+    assert (
+        int(stats["control-packet-input-count"]) > 0
+    ), "Expected control-packet-input-count > 0 for an established session"
+    assert (
+        int(stats["control-packet-output-count"]) > 0
+    ), "Expected control-packet-output-count > 0 for an established session"
+    assert (
+        int(stats["control-packet-input-count-bad"]) >= 0
+    ), "control-packet-input-count-bad should be a non-negative integer"
+
+
 def test_bgp_convergence():
     "Assert that BGP is converging."
     tgen = get_topogen()

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -401,6 +401,11 @@ module frr-bfdd {
       description "Number of control packets received";
     }
 
+    leaf control-packet-input-count-bad {
+      type uint64;
+      description "Number of control packets received that were not correct";
+    }
+
     leaf control-packet-output-count {
       type uint64;
       description "Number of control packets sent";


### PR DESCRIPTION
a) Add a bad packet received counter that we can keep track of
b) Fix `show bfd peers brief` to show local address when you have not connected to a peer yet
c) Add in command line completion to the peer keyword in bfdd.
