### PR TITLE
ripd,yang: new RIP enable configuration in interface node

### DIFF
--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -173,6 +173,15 @@ RIP Configuration
 
    Controls the toggle of the RIP peer discovery / disappearance messages.
 
+In order to enable RIP functionality in the interfaces the following interface
+configuration is available:
+
+.. clicmd:: ip rip
+
+   Enables the RIP reception and sending of packets with other RIP router
+   neighbors.
+
+
 .. _rip-version-control:
 
 RIP Version Control

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -690,6 +690,35 @@ void cli_show_ripd_instance_default_bfd_profile(struct vty *vty,
 }
 
 /*
+ * XPath: /frr-interface:lib/interface/frr-ripd:rip/enable
+ */
+DEFPY_YANG(ip_rip_interface_enable, ip_rip_interface_enable_cmd,
+	   "[no] ip rip",
+	   NO_STR
+	   IP_STR
+	   RIP_STR)
+{
+	if (yang_dnode_get(vty->candidate_config->dnode, VTY_CURR_XPATH) == NULL) {
+		vty_out(vty, "%% Failed to find interface\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	nb_cli_enqueue_change(vty, "./frr-ripd:rip/enable", NB_OP_MODIFY, no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+static void cli_show_lib_interface_rip_enable(struct vty *vty, const struct lyd_node *dnode,
+					      bool show_defaults)
+{
+	if (yang_dnode_get_bool(dnode, NULL)) {
+		vty_out(vty, " ip rip\n");
+	} else {
+		if (show_defaults)
+			vty_out(vty, " no ip rip\n");
+	}
+}
+
+/*
  * XPath: /frr-interface:lib/interface/frr-ripd:rip/split-horizon
  */
 DEFPY_YANG (ip_rip_split_horizon,
@@ -1322,6 +1351,7 @@ void rip_cli_init(void)
 	install_element(RIP_NODE, &no_rip_bfd_default_profile_cmd);
 	install_default(RIP_NODE);
 
+	install_element(INTERFACE_NODE, &ip_rip_interface_enable_cmd);
 	install_element(INTERFACE_NODE, &ip_rip_split_horizon_cmd);
 	install_element(INTERFACE_NODE, &ip_rip_v2_broadcast_cmd);
 	install_element(INTERFACE_NODE, &ip_rip_receive_version_cmd);
@@ -1444,6 +1474,10 @@ const struct frr_yang_module_info frr_ripd_cli_info = {
 		{
 			.xpath = "/frr-ripd:ripd/instance/default-bfd-profile",
 			.cbs.cli_show = cli_show_ripd_instance_default_bfd_profile,
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/enable",
+			.cbs.cli_show = cli_show_lib_interface_rip_enable,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/split-horizon",

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -35,12 +35,9 @@ DEFINE_HOOK(rip_ifaddr_add, (struct connected * ifc), (ifc));
 DEFINE_HOOK(rip_ifaddr_del, (struct connected * ifc), (ifc));
 
 /* static prototypes */
-static void rip_enable_apply(struct interface *);
 static void rip_passive_interface_apply(struct interface *);
 static int rip_if_down(struct interface *ifp);
 static int rip_enable_if_lookup(struct rip *rip, const char *ifname);
-static int rip_enable_network_prefix_lookup(struct connected *connected);
-static void rip_enable_apply_all(struct rip *rip);
 
 const struct message ri_version_msg[] = {{RI_RIP_VERSION_1, "1"},
 					 {RI_RIP_VERSION_2, "2"},
@@ -379,8 +376,7 @@ static int rip_ifp_destroy(struct interface *ifp)
 
 static void rip_interface_clean(struct rip_interface *ri)
 {
-	ri->enable_network = 0;
-	ri->enable_interface = 0;
+	ri->working = false;
 	ri->running = 0;
 
 	event_cancel(&ri->t_wakeup);
@@ -494,7 +490,7 @@ static void rip_apply_address_add(struct connected *ifc)
 	nh.type = NEXTHOP_TYPE_IFINDEX;
 
 	/* Check if this connected address is RIP enabled. */
-	if (rip_enable_network_connected_lookup(ifc) >= 0)
+	if (rip_interface_is_enabled(ifc))
 		rip_redistribute_add(rip, ZEBRA_ROUTE_CONNECT,
 				     RIP_ROUTE_INTERFACE, &address, &nh, 0, 0,
 				     0);
@@ -645,16 +641,28 @@ static int rip_enable_network_prefix_lookup(struct connected *connected)
 	return -1;
 }
 
-/* Check whether connected is enabled by either form of `network`. */
-int rip_enable_network_connected_lookup(struct connected *connected)
+/*
+ * Check whether the interface is RIP enabled by going through the
+ * options:
+ * - `network IF_NAME`
+ * - `network A.B.C.D/M`
+ * - `ip rip`
+ */
+bool rip_interface_is_enabled(struct connected *ifc)
 {
-	struct rip_interface *ri = connected->ifp->info;
-	struct rip *rip = ri->rip;
+	struct rip_interface *ri = ifc->ifp->info;
 
-	if (rip_enable_if_lookup(rip, connected->ifp->name) >= 0)
-		return 1;
+	/* RIP instance is not ready yet, so just tell its not enabled. */
+	if (ri->rip == NULL)
+		return false;
 
-	return rip_enable_network_prefix_lookup(connected);
+	if (rip_enable_if_lookup(ri->rip, ifc->ifp->name) >= 0)
+		return true;
+
+	if (rip_enable_network_prefix_lookup(ifc) >= 0)
+		return true;
+
+	return ri->enabled;
 }
 
 /* Add RIP enable network. */
@@ -806,7 +814,7 @@ static void rip_connect_set(struct interface *ifp, int set)
 			/* Check once more whether this connected address is
 			 * enabled by a network statement.
 			 */
-			if (rip_enable_network_connected_lookup(connected) >= 0)
+			if (rip_interface_is_enabled(connected))
 				rip_redistribute_add(rip, ZEBRA_ROUTE_CONNECT,
 						     RIP_ROUTE_INTERFACE,
 						     &address, &nh, 0, 0, 0);
@@ -825,7 +833,6 @@ static void rip_connect_set(struct interface *ifp, int set)
 /* Update interface status. */
 void rip_enable_apply(struct interface *ifp)
 {
-	int ret;
 	struct rip_interface *ri = NULL;
 
 	/* Check interface. */
@@ -834,30 +841,24 @@ void rip_enable_apply(struct interface *ifp)
 
 	ri = ifp->info;
 
-	/* Check network configuration. */
-	ret = rip_enable_network_lookup_if(ifp);
-
-	/* If the interface is matched. */
-	if (ret > 0)
-		ri->enable_network = 1;
+	/*
+	 * Check if the RIP is enabled in this interface by looking up
+	 * the activation methods:
+	 * - `network A.B.C.D/M` (using `rip_enable_network_lookup_if`)
+	 * - `network IFNAME` (using `rip_enable_if_lookup`)
+	 * - `ip rip` (using `ri->enabled`)
+	 *
+	 * Finally the interface is only deemed working if there is at
+	 * least one IPv4 configured.
+	 */
+	if (ri->rip != NULL && (rip_enable_network_lookup_if(ifp) > 0 ||
+				rip_enable_if_lookup(ri->rip, ifp->name) >= 0 || ri->enabled))
+		ri->working = rip_if_ipv4_address_check(ifp) ? true : false;
 	else
-		ri->enable_network = 0;
-
-	/* Check interface name configuration. */
-	ret = rip_enable_if_lookup(ri->rip, ifp->name);
-	if (ret >= 0)
-		ri->enable_interface = 1;
-	else
-		ri->enable_interface = 0;
-
-	/* any interface MUST have an IPv4 address */
-	if (!rip_if_ipv4_address_check(ifp)) {
-		ri->enable_network = 0;
-		ri->enable_interface = 0;
-	}
+		ri->working = false;
 
 	/* Update running status of the interface. */
-	if (ri->enable_network || ri->enable_interface) {
+	if (ri->working) {
 		if (IS_RIP_DEBUG_EVENT)
 			zlog_debug("turn on %s", ifp->name);
 
@@ -877,7 +878,7 @@ void rip_enable_apply(struct interface *ifp)
 }
 
 /* Apply network configuration to all interface. */
-static void rip_enable_apply_all(struct rip *rip)
+void rip_enable_apply_all(struct rip *rip)
 {
 	struct interface *ifp;
 
@@ -1060,6 +1061,7 @@ int rip_show_network_config(struct vty *vty, struct rip *rip)
 {
 	unsigned int i;
 	char *ifname;
+	struct interface *ifp;
 	struct route_node *node;
 
 	/* Network type RIP enable interface statement. */
@@ -1072,6 +1074,19 @@ int rip_show_network_config(struct vty *vty, struct rip *rip)
 	for (i = 0; i < vector_active(rip->enable_interface); i++)
 		if ((ifname = vector_slot(rip->enable_interface, i)) != NULL)
 			vty_out(vty, "    %s\n", ifname);
+
+	FOR_ALL_INTERFACES (rip->vrf, ifp) {
+		const struct rip_interface *ri = ifp->info;
+
+		if (ri == NULL || !ri->enabled)
+			continue;
+
+		/* Skip repeated entries by `network IF_NAME` */
+		if (rip_enable_if_lookup(rip, ifp->name) >= 0)
+			continue;
+
+		vty_out(vty, "    %s\n", ifp->name);
+	}
 
 	/* RIP neighbors listing. */
 	for (node = route_top(rip->neighbor); node; node = route_next(node))

--- a/ripd/rip_interface.h
+++ b/ripd/rip_interface.h
@@ -25,6 +25,8 @@ extern int rip_interface_address_delete(int cmd, struct zclient *zclient, zebra_
 					vrf_id_t vrf_id);
 extern int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS);
 extern void rip_interface_sync(struct interface *ifp);
-extern int rip_enable_network_connected_lookup(struct connected *connected);
+extern bool rip_interface_is_enabled(struct connected *ifc);
+extern void rip_enable_apply(struct interface *ifp);
+extern void rip_enable_apply_all(struct rip *rip);
 
 #endif /* _QUAGGA_RIP_INTERFACE_H */

--- a/ripd/rip_nb.c
+++ b/ripd/rip_nb.c
@@ -266,6 +266,12 @@ const struct frr_yang_module_info frr_ripd_info = {
 			},
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/enable",
+			.cbs = {
+				.modify = lib_interface_rip_enable_modify,
+			},
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/split-horizon",
 			.cbs = {
 				.modify = lib_interface_rip_split_horizon_modify,

--- a/ripd/rip_nb.h
+++ b/ripd/rip_nb.h
@@ -141,6 +141,7 @@ ripd_instance_state_routes_route_nexthops_nexthop_expire_time_get_elem(
 struct yang_data *ripd_instance_state_routes_route_metric_get_elem(
 	struct nb_cb_get_elem_args *args);
 int clear_rip_route_rpc(struct nb_cb_rpc_args *args);
+int lib_interface_rip_enable_modify(struct nb_cb_modify_args *args);
 int lib_interface_rip_split_horizon_modify(struct nb_cb_modify_args *args);
 int lib_interface_rip_v2_broadcast_modify(struct nb_cb_modify_args *args);
 int lib_interface_rip_version_receive_modify(struct nb_cb_modify_args *args);

--- a/ripd/rip_nb_config.c
+++ b/ripd/rip_nb_config.c
@@ -69,6 +69,12 @@ int ripd_instance_create(struct nb_cb_create_args *args)
 
 		rip = rip_create(vrf_name, vrf, socket);
 		nb_running_set_entry(args->dnode, rip);
+
+		/*
+		 * RIP instance created, go through all interfaces
+		 * and set them to working state.
+		 */
+		rip_enable_apply_all(rip);
 		break;
 	}
 
@@ -974,6 +980,28 @@ int ripd_instance_default_bfd_profile_destroy(struct nb_cb_destroy_args *args)
 	rip = nb_running_get_entry(args->dnode, NULL, true);
 	XFREE(MTYPE_RIP_BFD_PROFILE, rip->default_bfd_profile);
 	rip_bfd_instance_update(rip);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-ripd:rip/enable
+ */
+int lib_interface_rip_enable_modify(struct nb_cb_modify_args *args)
+{
+	struct rip_interface *rip_interface;
+	struct interface *interface;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	interface = nb_running_get_entry(args->dnode, NULL, true);
+	rip_interface = interface->info;
+	rip_interface->enabled = yang_dnode_get_bool(args->dnode, NULL);
+
+	/* Only attempt to configure if instance has started. */
+	if (rip_interface->rip)
+		rip_enable_apply(interface);
 
 	return NB_OK;
 }

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2506,15 +2506,15 @@ static void rip_update_process(struct rip *rip, int route_type)
 			continue;
 		}
 
-		/* If unicast is used, but no `network` statement enables
-		 * this interface, we SHOULD NOT send an update to this neighbor.
-		 * If RIP is configured on such an interface, the redistribution
-		 * of route(s) from another routing protocol into RIP, received
-		 * through that interface, does not work.
+		/*
+		 * If unicast is used, but RIP is not enabled on this
+		 * interface (via `network A.B.C.D/M`, `network IFNAME`
+		 * or `ip rip`), we SHOULD NOT send an update to this
+		 * neighbor.
 		 */
-		if (rip_enable_network_connected_lookup(connected) < 0) {
+		if (!rip_interface_is_enabled(connected)) {
 			if (RIP_DEBUG_SEND)
-				zlog_debug("Neighbor %pI4 is not in any `network` statement!",
+				zlog_debug("Neighbor %pI4 is not on a RIP-enabled interface!",
 					   &p->u.prefix4);
 			continue;
 		}
@@ -3207,7 +3207,7 @@ DEFUN (show_ip_rip_status,
 		if (!ri->running)
 			continue;
 
-		if (ri->enable_network || ri->enable_interface) {
+		if (ri->working) {
 			if (ri->ri_send == RI_RIP_UNSPEC)
 				send_version =
 					lookup_msg(ri_version_msg,
@@ -3237,8 +3237,7 @@ DEFUN (show_ip_rip_status,
 	FOR_ALL_INTERFACES (rip->vrf, ifp) {
 		ri = ifp->info;
 
-		if ((ri->enable_network || ri->enable_interface) &&
-		    ri->passive) {
+		if (ri->working && ri->passive) {
 			if (!found_passive) {
 				vty_out(vty, "  Passive Interface(s):\n");
 				found_passive = 1;

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -297,9 +297,19 @@ struct rip_interface {
 	/* Interface data from zebra. */
 	struct interface *ifp;
 
-	/* RIP is enabled on this interface. */
-	int enable_network;
-	int enable_interface;
+	/* RIP enabled state (`ip rip` interface configuration). */
+	bool enabled;
+
+	/*
+	 * RIP is enabled by at least one of the following configurations:
+	 * - `network A.B.C.D/M`
+	 * - `network IFNAME`
+	 * - `ip rip` (interface configuration)
+	 *
+	 * It also means the interface is operational and has at least
+	 * one IPv4 address configured on it.
+	 */
+	bool working;
 
 	/* RIP is running on this interface. */
 	int running;

--- a/tests/topotests/all_protocol_startup/r1/rip_status.ref
+++ b/tests/topotests/all_protocol_startup/r1/rip_status.ref
@@ -9,7 +9,7 @@ Routing Protocol is "rip"
     Interface        Send  Recv   Key-chain
     r1-eth1          2     2      
   Routing for Networks:
-    192.168.1.0/26
+    r1-eth1
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
   Distance: (default is 120)

--- a/tests/topotests/all_protocol_startup/r1/ripd.conf
+++ b/tests/topotests/all_protocol_startup/r1/ripd.conf
@@ -3,9 +3,12 @@
 ! debug rip events
 ! debug rip zebra
 !
+interface r1-eth1
+ ip rip
+exit
+!
 router rip
  version 2
- network 192.168.1.0/26
 !
 line vty
 !

--- a/tests/topotests/mgmt_notif/r1/frr.conf
+++ b/tests/topotests/mgmt_notif/r1/frr.conf
@@ -19,12 +19,12 @@ ip route 11.11.11.11/32 lo
 
 interface r1-eth0
  ip address 1.1.1.1/24
+ ip rip
  ip rip authentication string foo
  ip rip authentication mode text
 exit
 
 router rip
- network 1.1.1.0/24
  timers basic 5 15 10
  redistribute static
 exit

--- a/tests/topotests/mgmt_notif/r2/frr.conf
+++ b/tests/topotests/mgmt_notif/r2/frr.conf
@@ -19,12 +19,12 @@ ip route 22.22.22.22/32 lo
 
 interface r2-eth0
  ip address 1.1.1.2/24
+ ip rip
  ip rip authentication string foo
  ip rip authentication mode text
 exit
 
 router rip
- network 1.1.1.0/24
  timers basic 5 15 10
  redistribute static
 exit

--- a/tests/topotests/pim_prune/rp/frr.conf
+++ b/tests/topotests/pim_prune/rp/frr.conf
@@ -4,23 +4,26 @@
 !
 interface lo
  ip address 10.0.0.1/32
+ ip rip
 !
 interface rp-eth0
  ip address 10.0.10.1/24
  ip pim
+ ip rip
 !
 interface rp-eth1
  ip address 10.0.11.1/24
  ip pim
+ ip rip
 !
 ! Interface to host_rp (source on RP pod - like hd31 in SSIM)
 interface rp-eth2
  ip address 10.0.20.1/24
  ip pim
  ip igmp
+ ip rip
 !
 router rip
- network 10.0.0.0/8
  redistribute connected
 !
 router pim

--- a/tests/topotests/pim_prune/spine1/frr.conf
+++ b/tests/topotests/pim_prune/spine1/frr.conf
@@ -4,21 +4,24 @@
 !
 interface lo
  ip address 10.0.0.2/32
+ ip rip
 !
 interface spine1-eth0
  ip address 10.0.10.2/24
  ip pim
+ ip rip
 !
 interface spine1-eth1
  ip address 10.0.12.2/24
  ip pim
+ ip rip
 !
 interface spine1-eth2
  ip address 10.0.19.2/24
  ip pim
+ ip rip
 !
 router rip
- network 10.0.0.0/8
  redistribute connected
 !
 router pim

--- a/tests/topotests/pim_prune/spine2/frr.conf
+++ b/tests/topotests/pim_prune/spine2/frr.conf
@@ -4,24 +4,27 @@
 !
 interface lo
  ip address 10.0.0.7/32
+ ip rip
 !
 interface spine2-eth0
  ip address 10.0.11.7/24
  ip pim
+ ip rip
 !
 interface spine2-eth1
  ip address 10.0.16.7/24
  ip pim
+ ip rip
 !
 interface spine2-eth2
  ip address 10.0.17.7/24
  ip pim
+ ip rip
 !
 ! Access list to match source network
 access-list MATCH_SOURCE permit 10.0.14.0 0.0.0.255
 !
 router rip
- network 10.0.0.0/8
  redistribute connected
  ! Make torc21 path less preferred for SOURCE routes
  offset-list MATCH_SOURCE in 5 spine2-eth2

--- a/tests/topotests/pim_prune/torc11/frr.conf
+++ b/tests/topotests/pim_prune/torc11/frr.conf
@@ -4,23 +4,28 @@
 !
 interface lo
  ip address 10.0.0.3/32
+ ip rip
 !
 interface torc11-eth0
  ip address 10.0.12.3/24
  ip pim
+ ip rip
 !
 interface torc11-eth1
  ip address 10.0.14.3/24
  ip pim
+ ip rip
 !
 interface torc11-eth2
  ip address 10.0.18.3/24
  ip pim
  ip igmp
+ ip rip
 !
 interface torc11-eth3
  ip address 10.0.16.3/24
  ip pim
+ ip rip
 !
 ! Access list to match 10.0.14.0/24 and 10.0.18.0/24 networks
 access-list MATCH_HOST11_NET permit 10.0.14.0 0.0.0.255
@@ -28,7 +33,6 @@ access-list MATCH_HOST11_NET permit 10.0.14.0 0.0.0.255
 access-list ALL permit any
 !
 router rip
- network 10.0.0.0/8
  redistribute connected
  offset-list MATCH_HOST11_NET out 5 torc11-eth3
  ! Make spine1 path less preferred, so torc11 uses spine2 for RP

--- a/tests/topotests/pim_prune/torc21/frr.conf
+++ b/tests/topotests/pim_prune/torc21/frr.conf
@@ -4,19 +4,23 @@
 !
 interface lo
  ip address 10.0.0.4/32
+ ip rip
 !
 interface torc21-eth0
  ip address 10.0.15.4/24
  ip pim
  ip igmp
+ ip rip
 !
 interface torc21-eth1
  ip address 10.0.17.4/24
  ip pim
+ ip rip
 !
 interface torc21-eth2
  ip address 10.0.19.4/24
  ip pim
+ ip rip
 !
 ! Access list to match RP network (for (*,G) joins via spine2)
 access-list MATCH_RP permit 10.0.0.0 0.0.0.255
@@ -25,7 +29,6 @@ access-list MATCH_RP permit 10.0.0.0 0.0.0.255
 access-list MATCH_SOURCE permit 10.0.14.0 0.0.0.255
 !
 router rip
- network 10.0.0.0/8
  redistribute connected
  ! Make spine1 path less preferred for RP routes, so torc21 uses spine2 for (*,G) joins
  ! This preserves the bug flow: torc21's (*,G) join goes to spine2

--- a/tests/topotests/rip_allow_ecmp/r1/frr.conf
+++ b/tests/topotests/rip_allow_ecmp/r1/frr.conf
@@ -1,9 +1,9 @@
 !
 int r1-eth0
  ip address 192.168.1.1/24
+ ip rip
 !
 router rip
  allow-ecmp
- network 192.168.1.0/24
  timers basic 5 15 10
 exit

--- a/tests/topotests/rip_allow_ecmp/r2/frr.conf
+++ b/tests/topotests/rip_allow_ecmp/r2/frr.conf
@@ -1,13 +1,13 @@
 !
 int lo
  ip address 10.10.10.1/32
+ ip rip
 !
 int r2-eth0
  ip address 192.168.1.2/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
- network 10.10.10.1/32
  timers basic 5 15 10
 exit
 

--- a/tests/topotests/rip_allow_ecmp/r3/frr.conf
+++ b/tests/topotests/rip_allow_ecmp/r3/frr.conf
@@ -1,13 +1,13 @@
 !
 int lo
  ip address 10.10.10.1/32
+ ip rip
 !
 int r3-eth0
  ip address 192.168.1.3/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
- network 10.10.10.1/32
  timers basic 5 15 10
 exit
 

--- a/tests/topotests/rip_allow_ecmp/r4/frr.conf
+++ b/tests/topotests/rip_allow_ecmp/r4/frr.conf
@@ -1,13 +1,13 @@
 !
 int lo
  ip address 10.10.10.1/32
+ ip rip
 !
 int r4-eth0
  ip address 192.168.1.4/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
- network 10.10.10.1/32
  timers basic 5 15 10
 exit
 

--- a/tests/topotests/rip_allow_ecmp/r5/frr.conf
+++ b/tests/topotests/rip_allow_ecmp/r5/frr.conf
@@ -1,13 +1,13 @@
 !
 int lo
  ip address 10.10.10.1/32
+ ip rip
 !
 int r5-eth0
  ip address 192.168.1.5/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
- network 10.10.10.1/32
  timers basic 5 15 10
 exit
 

--- a/tests/topotests/rip_bfd_topo1/r1/ripd.conf
+++ b/tests/topotests/rip_bfd_topo1/r1/ripd.conf
@@ -1,17 +1,17 @@
 interface r1-eth0
+ ip rip
  ip rip bfd
  ip rip bfd profile slow
 exit
 !
 interface r1-eth1
+ ip rip
  ip rip bfd
  ip rip bfd profile slow
 exit
 !
 router rip
  allow-ecmp
- network 192.168.0.1/24
- network 192.168.1.1/24
  redistribute connected
  timers basic 10 40 30
  log-neighbor-changes

--- a/tests/topotests/rip_bfd_topo1/r2/ripd.conf
+++ b/tests/topotests/rip_bfd_topo1/r2/ripd.conf
@@ -1,10 +1,10 @@
 interface r2-eth0
+ ip rip
  ip rip bfd
 exit
 !
 router rip
  bfd default-profile slow
- network 192.168.0.2/24
  redistribute connected
  redistribute static
  timers basic 10 40 30

--- a/tests/topotests/rip_bfd_topo1/r3/ripd.conf
+++ b/tests/topotests/rip_bfd_topo1/r3/ripd.conf
@@ -1,10 +1,10 @@
 interface r3-eth0
+ ip rip
  ip rip bfd
  ip rip bfd profile slow
 exit
 !
 router rip
- network 192.168.1.2/24
  redistribute connected
  redistribute static
  timers basic 10 40 30

--- a/tests/topotests/rip_default_metric/r1/frr.conf
+++ b/tests/topotests/rip_default_metric/r1/frr.conf
@@ -4,11 +4,11 @@ ip route 192.168.0.0/24 Null0
 !
 interface r1-eth0
  ip address 10.1.1.1/24
+ ip rip
 exit
 !
 router rip
  timers basic 5 25 60
- network 10.1.1.0/24
  redistribute static
  version 2
 exit

--- a/tests/topotests/rip_default_metric/r2/frr.conf
+++ b/tests/topotests/rip_default_metric/r2/frr.conf
@@ -2,10 +2,10 @@ hostname r2
 !
 interface r2-eth0
  ip address 10.1.1.2/24
+ ip rip
 exit
 !
 router rip
  timers basic 5 25 60
- network 10.1.1.0/24
  version 2
 exit

--- a/tests/topotests/rip_default_route_handling/r1/frr.conf
+++ b/tests/topotests/rip_default_route_handling/r1/frr.conf
@@ -2,9 +2,9 @@ hostname r1
 !
 interface r1-eth0
  ip address 10.0.0.1/24
+ ip rip
 !
 router rip
- network 10.0.0.0/24
  default-information originate
 !
 end

--- a/tests/topotests/rip_default_route_handling/r2/frr.conf
+++ b/tests/topotests/rip_default_route_handling/r2/frr.conf
@@ -2,9 +2,9 @@ hostname r2
 !
 interface r2-eth0
  ip address 10.0.0.2/24
+ ip rip
 !
 router rip
- network 10.0.0.0/24
  redistribute kernel
 !
 end

--- a/tests/topotests/rip_disabled_networks/r1/frr.conf
+++ b/tests/topotests/rip_disabled_networks/r1/frr.conf
@@ -1,8 +1,8 @@
 !
 int r1-eth0
  ip address 192.168.1.1/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
  timers basic 1 10 15
 exit

--- a/tests/topotests/rip_disabled_networks/r2/frr.conf
+++ b/tests/topotests/rip_disabled_networks/r2/frr.conf
@@ -1,12 +1,12 @@
 !
 int r2-eth0
  ip address 192.168.1.2/24
+ ip rip
 !
 int r2-eth1
  ip address 192.168.3.2/24
 !
 router rip
- network 192.168.1.0/24
  neighbor 192.168.3.3
  redistribute connected
  timers basic 1 10 15

--- a/tests/topotests/rip_disabled_networks/r3/frr.conf
+++ b/tests/topotests/rip_disabled_networks/r3/frr.conf
@@ -1,9 +1,9 @@
 !
 int r3-eth0
  ip address 192.168.3.3/24
+ ip rip
 !
 router rip
- network 192.168.3.0/24
  timers basic 1 10 15
 exit
 

--- a/tests/topotests/rip_distance/r1/frr.conf
+++ b/tests/topotests/rip_distance/r1/frr.conf
@@ -3,23 +3,23 @@ domainname localdomain
 !
 interface r1-eth0
  ip address 10.1.12.1/24
+ ip rip
 exit
 !
 interface r1-eth1
  ip address 10.1.13.1/24
+ ip rip
 exit
 !
 interface r1-eth2
  ip address 10.1.14.1/24
+ ip rip
 exit
 !
 router rip
  distance 105
  distance 115 10.1.14.4/32 test-acl
  distance 110 10.1.13.3/32
- network 10.1.12.0/24
- network 10.1.13.0/24
- network 10.1.14.0/24
  version 2
 exit
 !

--- a/tests/topotests/rip_distance/r2/frr.conf
+++ b/tests/topotests/rip_distance/r2/frr.conf
@@ -5,10 +5,10 @@ ip route 192.168.105.0/24 Null0
 !
 interface r2-eth0
  ip address 10.1.12.2/24
+ ip rip
 exit
 !
 router rip
- network 10.1.12.0/24
  redistribute static
  version 2
 exit

--- a/tests/topotests/rip_distance/r3/frr.conf
+++ b/tests/topotests/rip_distance/r3/frr.conf
@@ -5,10 +5,10 @@ ip route 192.168.110.0/24 Null0
 !
 interface r3-eth0
  ip address 10.1.13.3/24
+ ip rip
 exit
 !
 router rip
- network 10.1.13.0/24
  redistribute static
  version 2
 exit

--- a/tests/topotests/rip_distance/r4/frr.conf
+++ b/tests/topotests/rip_distance/r4/frr.conf
@@ -5,10 +5,10 @@ ip route 192.168.115.0/24 Null0
 !
 interface r4-eth0
  ip address 10.1.14.4/24
+ ip rip
 exit
 !
 router rip
- network 10.1.14.0/24
  redistribute static
  version 2
 exit

--- a/tests/topotests/rip_no_neighbor/r1/frr.conf
+++ b/tests/topotests/rip_no_neighbor/r1/frr.conf
@@ -2,10 +2,10 @@ hostname r1
 
 int r1-eth0
  ip address 10.1.12.1/24
+ ip rip
 
 
 router rip
- network 10.1.12.0/24
  passive-interface r1-eth0
  timers basic 1 10 15
  version 2

--- a/tests/topotests/rip_no_neighbor/r2/frr.conf
+++ b/tests/topotests/rip_no_neighbor/r2/frr.conf
@@ -5,10 +5,10 @@ ip route 192.168.105.0/24 Null0
 !
 int r2-eth0
  ip address 10.1.12.2/24
+ ip rip
 exit
 !
 router rip
- network r2-eth0
  passive-interface r2-eth0
  redistribute static
  neighbor 10.1.12.1

--- a/tests/topotests/rip_passive_interface/r1/frr.conf
+++ b/tests/topotests/rip_passive_interface/r1/frr.conf
@@ -3,9 +3,9 @@ allow-reserved-ranges
 !
 int r1-eth0
  ip address 192.168.1.1/24
+ ip rip
 !
 router rip
  allow-ecmp
- network 192.168.1.0/24
  timers basic 1 10 15
 exit

--- a/tests/topotests/rip_passive_interface/r2/frr.conf
+++ b/tests/topotests/rip_passive_interface/r2/frr.conf
@@ -4,14 +4,13 @@ allow-reserved-ranges
 int lo
  ip address 10.10.10.1/32
  ip address 0.0.10.1/32
+ ip rip
 !
 int r2-eth0
  ip address 192.168.1.2/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
- network 10.10.10.1/32
- network 0.0.10.1/32
  timers basic 1 10 15
 exit
 

--- a/tests/topotests/rip_passive_interface/r3/frr.conf
+++ b/tests/topotests/rip_passive_interface/r3/frr.conf
@@ -4,14 +4,13 @@ allow-reserved-ranges
 int lo
  ip address 10.10.10.1/32
  ip address 0.0.10.1/32
+ ip rip
 !
 int r3-eth0
  ip address 192.168.1.3/24
+ ip rip
 !
 router rip
- network 192.168.1.0/24
- network 10.10.10.1/32
- network 0.0.10.1/32
  timers basic 1 10 15
 exit
 

--- a/tests/topotests/rip_split_horizon/r1/frr.conf
+++ b/tests/topotests/rip_split_horizon/r1/frr.conf
@@ -2,11 +2,11 @@ hostname r1
 !
 interface r1-eth0
  ip address 10.1.1.1/24
+ ip rip
 exit
 !
 router rip
  timers basic 1 10 15
- network 10.1.1.0/24
  version 2
 exit
 !

--- a/tests/topotests/rip_split_horizon/r2/frr.conf
+++ b/tests/topotests/rip_split_horizon/r2/frr.conf
@@ -2,15 +2,15 @@ hostname r2
 !
 interface r2-eth0
  ip address 10.1.1.2/24
+ ip rip
 exit
 !
 interface lo
  ip address 100.100.100.100/32
+ ip rip
 !
 router rip
  timers basic 1 10 15
- network 10.1.1.0/24
- network 100.100.100.100/32
  passive-interface r2-eth0
  neighbor 10.1.1.1
  version 2

--- a/tests/topotests/rip_split_horizon/r3/frr.conf
+++ b/tests/topotests/rip_split_horizon/r3/frr.conf
@@ -2,11 +2,11 @@ hostname r3
 !
 interface r3-eth0
  ip address 10.1.1.3/24
+ ip rip
 exit
 !
 router rip
  timers basic 1 10 15
- network 10.1.1.0/24
  passive-interface r3-eth0
  neighbor 10.1.1.1
  version 2

--- a/tests/topotests/rip_topo1/r1/rip_status.ref
+++ b/tests/topotests/rip_topo1/r1/rip_status.ref
@@ -11,7 +11,7 @@ Routing Protocol is "rip"
     r1-eth2          2     2      
     r1-eth3          2     2      
   Routing for Networks:
-    193.1.1.0/26
+    r1-eth1
     r1-eth2
     r1-eth3
   Passive Interface(s):

--- a/tests/topotests/rip_topo1/r1/ripd.conf
+++ b/tests/topotests/rip_topo1/r1/ripd.conf
@@ -1,11 +1,20 @@
 
 !
+interface r1-eth1
+ ip rip
+exit
+!
+interface r1-eth2
+ ip rip
+exit
+!
+interface r1-eth3
+ ip rip
+exit
+!
 router rip
  timers basic 5 180 5
  version 2
- network 193.1.1.0/26
- network r1-eth2
- network r1-eth3
  passive-interface r1-eth3
 !
 line vty

--- a/tests/topotests/rip_topo1/r2/rip_status.ref
+++ b/tests/topotests/rip_topo1/r2/rip_status.ref
@@ -10,8 +10,8 @@ Routing Protocol is "rip"
     r2-eth0          2     2      
     r2-eth1          2     2      
   Routing for Networks:
-    193.1.1.0/26
-    193.1.2.0/24
+    r2-eth0
+    r2-eth1
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
     193.1.1.1                 0         0       120    XX:XX:XX

--- a/tests/topotests/rip_topo1/r2/ripd.conf
+++ b/tests/topotests/rip_topo1/r2/ripd.conf
@@ -1,11 +1,16 @@
 
 !
+interface r2-eth0
+ ip rip
+exit
+!
+interface r2-eth1
+ ip rip
+exit
 !
 router rip
  version 2
  timers basic 5 180 5
- network 193.1.1.0/26
- network 193.1.2.0/24
 !
 line vty
 !

--- a/tests/topotests/rip_topo1/r3/rip_status.ref
+++ b/tests/topotests/rip_topo1/r3/rip_status.ref
@@ -9,7 +9,7 @@ Routing Protocol is "rip"
     Interface        Send  Recv   Key-chain
     r3-eth1          2     2      
   Routing for Networks:
-    193.1.2.0/24
+    r3-eth1
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
     193.1.2.1                 0         0       120    XX:XX:XX

--- a/tests/topotests/rip_topo1/r3/ripd.conf
+++ b/tests/topotests/rip_topo1/r3/ripd.conf
@@ -1,12 +1,14 @@
 
 !
+interface r3-eth1
+ ip rip
+exit
 !
 router rip
  version 2
  timers basic 5 180 5
  redistribute connected
  redistribute static
- network 193.1.2.0/24
 !
 line vty
 !

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -74,6 +74,13 @@ module frr-ripd {
     reference
       "FRRouting";
   }
+  revision 2026-03-29 {
+    description
+      "Add interface setting to enable RIP (along with instance
+       network and interface leaf-lists).";
+    reference
+      "FRRouting";
+  }
   revision 2019-09-09 {
     description
       "Changed interface references to use
@@ -551,6 +558,14 @@ module frr-ripd {
     container rip {
       description
         "RIP interface parameters.";
+
+      leaf enable {
+        type boolean;
+        default "false";
+        description
+          "Enable RIP on interface.";
+      }
+
       leaf split-horizon {
         type enumeration {
           enum "disabled" {


### PR DESCRIPTION
New RIP command in interface node to toggle its functionality similarly like OSPF, IS-IS or PIM.