### PR TITLE
ospf6d: reinstall routes after zebra reconnect

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -904,7 +904,7 @@ DEFUN (no_ospf6_log_adjacency_changes_detail,
 	return CMD_SUCCESS;
 }
 
-static void ospf6_reinstall_routes(struct ospf6 *ospf6)
+void ospf6_reinstall_routes(struct ospf6 *ospf6)
 {
 	struct ospf6_route *route;
 

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -249,6 +249,7 @@ void ospf6_vrf_link(struct ospf6 *ospf6, struct vrf *vrf);
 void ospf6_vrf_unlink(struct ospf6 *ospf6, struct vrf *vrf);
 struct ospf6 *ospf6_lookup_by_vrf_id(vrf_id_t vrf_id);
 struct ospf6 *ospf6_lookup_by_vrf_name(const char *name);
+void ospf6_reinstall_routes(struct ospf6 *ospf6);
 const char *ospf6_vrf_id_to_name(vrf_id_t vrf_id);
 void ospf6_vrf_init(void);
 bool ospf6_is_valid_summary_addr(struct vty *vty, struct prefix *p);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -669,6 +669,12 @@ static void ospf6_zebra_connected(struct zclient *zclient)
 			continue;
 		(void)ospf6_zebra_gr_enable(ospf6, ospf6->gr_info.grace_period);
 	}
+
+	/* Zebra reconnect can happen after OSPFv3 already computed best-paths.
+	 * Re-send existing routes so kernel FIB and OSPF RIB stay consistent.
+	 */
+	for (ALL_LIST_ELEMENTS_RO(om6->ospf6, node, ospf6))
+		ospf6_reinstall_routes(ospf6);
 }
 
 static zclient_handler *const ospf6_handlers[] = {


### PR DESCRIPTION
**Problem:**
In larger topologies under startup/churn load, OSPFv3 can enter a bad state where neighbors are Full but routes are not consistently installed in zebra/kernel.
Result: partial forwarding failures until manual clear ipv6 ospf6 process.

**Root cause direction:**
After zebra reconnect, OSPF6 may already have computed best paths, but those routes are not reliably re-sent to zebra/FIB in this corner case.

**Change:**
- Export `ospf6_reinstall_routes(struct ospf6 *ospf6)`
- Call it from `ospf6_zebra_connected()` for all OSPF6 instances

`Validation:`

- Stuck state reproducible before fix in large runs
- With this patch, convergence is stable and no manual clear is needed
- End-to-end checks pass after convergence in 500 and 1200 container scenarios

Fixes #21010