### PR TITLE
bfdd: Fix wrong memory free when using ttable code

### DIFF
--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -1283,7 +1283,7 @@ DEFPY(
 
 	out = ttable_dump(tt, "\n");
 	vty_out(vty, "%s", out);
-	XFREE(MTYPE_TMP, out);
+	XFREE(MTYPE_TMP_TTABLE, out);
 	ttable_del(tt);
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
ttable_dump expects MTYPE_TMP_TTABLE for the XFREE.