### PR TITLE
bgpd: fix aggregate route not removed on de-configuration

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10346,6 +10346,14 @@ static int bgp_aggregate_unset(struct vty *vty, const char *prefix_str,
 
 	aggregate = bgp_dest_get_bgp_aggregate_info(dest);
 	bgp_aggregate_delete(bgp, &p, afi, safi, aggregate);
+
+	/*
+	 * Ensure count is 0 to force bgp_aggregate_install() to uninstall.
+	 * bgp_aggregate_delete() should have already decremented the count,
+	 * but we set it explicitly to be certain.
+	 */
+	aggregate->count = 0;
+
 	bgp_aggregate_install(bgp, afi, safi, &p, 0, NULL, NULL,
 			      NULL, NULL,  0, aggregate);
 


### PR DESCRIPTION
When an aggregate-address is removed via configuration, the aggregate route sometimes remains in the BGP RIB even though the configuration has been removed.

Explicitly set aggregate->count = 0 to ensure the uninstall path is taken in bgp_aggregate_install().