### PR TITLE
Some Yang work

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -93,11 +93,11 @@ DEFPY (no_router_pim6,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFPY (pim6_joinprune_time,
-       pim6_joinprune_time_cmd,
-       "join-prune-interval (1-65535)$jpi",
-       "Join Prune Send Interval\n"
-       "Seconds\n")
+DEFPY_YANG (pim6_joinprune_time,
+	    pim6_joinprune_time_cmd,
+	    "join-prune-interval (1-65535)$jpi",
+	    "Join Prune Send Interval\n"
+	    "Seconds\n")
 {
 	return pim_process_join_prune_cmd(vty, jpi_str);
 }
@@ -141,15 +141,16 @@ DEFPY_ATTR(ipv6_joinprune_time,
 	return ret;
 }
 
-DEFPY (no_pim6_joinprune_time,
-       no_pim6_joinprune_time_cmd,
-       "no join-prune-interval [(1-65535)]",
-       NO_STR
-       "Join Prune Send Interval\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim6_joinprune_time,
+	    no_pim6_joinprune_time_cmd,
+	    "no join-prune-interval [(1-65535)]",
+	    NO_STR
+	    "Join Prune Send Interval\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_join_prune_cmd(vty);
 }
+
 DEFPY_ATTR(no_ipv6_pim_joinprune_time,
            no_ipv6_pim_joinprune_time_cmd,
            "no ipv6 pim join-prune-interval [(1-65535)]",
@@ -451,11 +452,11 @@ DEFPY_ATTR(no_ipv6_pim_spt_switchover_infinity_plist,
 	return ret;
 }
 
-DEFPY (pim6_packets,
-       pim6_packets_cmd,
-       "packets (1-255)",
-       "packets to process at one time per fd\n"
-       "Number of packets\n")
+DEFPY_YANG (pim6_packets,
+	    pim6_packets_cmd,
+	    "packets (1-255)",
+	    "packets to process at one time per fd\n"
+	    "Number of packets\n")
 {
 	return pim_process_pim_packet_cmd(vty, packets_str);
 }
@@ -500,12 +501,12 @@ DEFPY_ATTR(ipv6_pim_packets,
 	return ret;
 }
 
-DEFPY (no_pim6_packets,
-       no_pim6_packets_cmd,
-       "no packets [(1-255)]",
-       NO_STR
-       "packets to process at one time per fd\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim6_packets,
+	    no_pim6_packets_cmd,
+	    "no packets [(1-255)]",
+	    NO_STR
+	    "packets to process at one time per fd\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_pim_packet_cmd(vty);
 }
@@ -551,11 +552,11 @@ DEFPY_ATTR(no_ipv6_pim_packets,
 	return ret;
 }
 
-DEFPY (pim6_keep_alive,
-       pim6_keep_alive_cmd,
-       "keep-alive-timer (1-65535)$kat",
-       "Keep alive Timer\n"
-       "Seconds\n")
+DEFPY_YANG (pim6_keep_alive,
+	    pim6_keep_alive_cmd,
+	    "keep-alive-timer (1-65535)$kat",
+	    "Keep alive Timer\n"
+	    "Seconds\n")
 {
 	return pim_process_keepalivetimer_cmd(vty, kat_str);
 }
@@ -600,12 +601,12 @@ DEFPY_ATTR(ipv6_pim_keep_alive,
 	return ret;
 }
 
-DEFPY (no_pim6_keep_alive,
-       no_pim6_keep_alive_cmd,
-       "no keep-alive-timer [(1-65535)]",
-       NO_STR
-       "Keep alive Timer\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim6_keep_alive,
+	    no_pim6_keep_alive_cmd,
+	    "no keep-alive-timer [(1-65535)]",
+	    NO_STR
+	    "Keep alive Timer\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_keepalivetimer_cmd(vty);
 }
@@ -651,12 +652,12 @@ DEFPY_ATTR(no_ipv6_pim_keep_alive,
 	return ret;
 }
 
-DEFPY (pim6_rp_keep_alive,
-       pim6_rp_keep_alive_cmd,
-       "rp keep-alive-timer (1-65535)$kat",
-       "Rendezvous Point\n"
-       "Keep alive Timer\n"
-       "Seconds\n")
+DEFPY_YANG (pim6_rp_keep_alive,
+	    pim6_rp_keep_alive_cmd,
+	    "rp keep-alive-timer (1-65535)$kat",
+	    "Rendezvous Point\n"
+	    "Keep alive Timer\n"
+	    "Seconds\n")
 {
 	return pim_process_rp_kat_cmd(vty, kat_str);
 }
@@ -702,13 +703,13 @@ DEFPY_ATTR(ipv6_pim_rp_keep_alive,
 	return ret;
 }
 
-DEFPY (no_pim6_rp_keep_alive,
-       no_pim6_rp_keep_alive_cmd,
-       "no rp keep-alive-timer [(1-65535)]",
-       NO_STR
-       "Rendezvous Point\n"
-       "Keep alive Timer\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim6_rp_keep_alive,
+	    no_pim6_rp_keep_alive_cmd,
+	    "no rp keep-alive-timer [(1-65535)]",
+	    NO_STR
+	    "Rendezvous Point\n"
+	    "Keep alive Timer\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_rp_kat_cmd(vty);
 }
@@ -755,11 +756,11 @@ DEFPY_ATTR(no_ipv6_pim_rp_keep_alive,
 	return ret;
 }
 
-DEFPY (pim6_register_suppress,
-       pim6_register_suppress_cmd,
-       "register-suppress-time (1-65535)$rst",
-       "Register Suppress Timer\n"
-       "Seconds\n")
+DEFPY_YANG (pim6_register_suppress,
+	    pim6_register_suppress_cmd,
+	    "register-suppress-time (1-65535)$rst",
+	    "Register Suppress Timer\n"
+	    "Seconds\n")
 {
 	return pim_process_register_suppress_cmd(vty, rst_str);
 }
@@ -804,12 +805,12 @@ DEFPY_ATTR(ipv6_pim_register_suppress,
 	return ret;
 }
 
-DEFPY (no_pim6_register_suppress,
-       no_pim6_register_suppress_cmd,
-       "no register-suppress-time [(1-65535)]",
-       NO_STR
-       "Register Suppress Timer\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim6_register_suppress,
+	    no_pim6_register_suppress_cmd,
+	    "no register-suppress-time [(1-65535)]",
+	    NO_STR
+	    "Register Suppress Timer\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_register_suppress_cmd(vty);
 }

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4207,33 +4207,63 @@ DEFPY_ATTR(no_ip_pim_packets,
 	return ret;
 }
 
-DEFPY (ip_igmp_group_watermark,
-       ip_igmp_group_watermark_cmd,
-       "ip igmp watermark-warn (1-65535)$limit",
-       IP_STR
-       IGMP_STR
-       "Configure group limit for watermark warning\n"
-       "Group count to generate watermark warning\n")
+DEFPY_YANG (ip_igmp_group_watermark,
+	    ip_igmp_group_watermark_cmd,
+	    "ip igmp watermark-warn (1-65535)$limit",
+	    IP_STR
+	    IGMP_STR
+	    "Configure group limit for watermark warning\n"
+	    "Group count to generate watermark warning\n")
 {
-	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
-	pim->gm_watermark_limit = limit;
+	char xpath[XPATH_MAXLEN];
+	char watermark_xpath[XPATH_MAXLEN + 32];
+	const char *vrf_name;
 
-	return CMD_SUCCESS;
+	vrf_name = pim_cli_get_vrf_name(vty);
+	if (!vrf_name) {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrf_name,
+		 FRR_PIM_AF_XPATH_VAL);
+	snprintf(watermark_xpath, sizeof(watermark_xpath), "%s/gm-watermark-limit", xpath);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	nb_cli_enqueue_change(vty, watermark_xpath, NB_OP_MODIFY, limit_str);
+
+	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFPY (no_ip_igmp_group_watermark,
-       no_ip_igmp_group_watermark_cmd,
-       "no ip igmp watermark-warn [(1-65535)$limit]",
-       NO_STR
-       IP_STR
-       IGMP_STR
-       "Unconfigure group limit for watermark warning\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_ip_igmp_group_watermark,
+	    no_ip_igmp_group_watermark_cmd,
+	    "no ip igmp watermark-warn [(1-65535)$limit]",
+	    NO_STR
+	    IP_STR
+	    IGMP_STR
+	    "Unconfigure group limit for watermark warning\n"
+	    IGNORED_IN_NO_STR)
 {
-	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
-	pim->gm_watermark_limit = 0;
+	char xpath[XPATH_MAXLEN];
+	char watermark_xpath[XPATH_MAXLEN + 32];
+	const char *vrf_name;
 
-	return CMD_SUCCESS;
+	vrf_name = pim_cli_get_vrf_name(vty);
+	if (!vrf_name) {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrf_name,
+		 FRR_PIM_AF_XPATH_VAL);
+	snprintf(watermark_xpath, sizeof(watermark_xpath), "%s/gm-watermark-limit", xpath);
+
+	if (!yang_dnode_exists(vty->candidate_config->dnode, watermark_xpath))
+		return CMD_SUCCESS;
+
+	nb_cli_enqueue_change(vty, watermark_xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 DEFPY_YANG (pim_v6_secondary,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3703,11 +3703,11 @@ DEFPY_ATTR(ip_pim_register_accept_list,
 	return ret;
 }
 
-DEFPY (pim_joinprune_time,
-       pim_joinprune_time_cmd,
-       "join-prune-interval (1-65535)$jpi",
-       "Join Prune Send Interval\n"
-       "Seconds\n")
+DEFPY_YANG (pim_joinprune_time,
+	    pim_joinprune_time_cmd,
+	    "join-prune-interval (1-65535)$jpi",
+	    "Join Prune Send Interval\n"
+	    "Seconds\n")
 {
 	return pim_process_join_prune_cmd(vty, jpi_str);
 }
@@ -3752,15 +3752,16 @@ DEFPY_ATTR(ip_pim_joinprune_time,
 	return ret;
 }
 
-DEFPY (no_pim_joinprune_time,
-       no_pim_joinprune_time_cmd,
-       "no join-prune-interval [(1-65535)]",
-       NO_STR
-       "Join Prune Send Interval\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim_joinprune_time,
+	    no_pim_joinprune_time_cmd,
+	    "no join-prune-interval [(1-65535)]",
+	    NO_STR
+	    "Join Prune Send Interval\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_join_prune_cmd(vty);
 }
+
 DEFPY_ATTR(no_ip_pim_joinprune_time,
 			  no_ip_pim_joinprune_time_cmd,
 			  "no ip pim join-prune-interval [(1-65535)]",
@@ -3803,11 +3804,11 @@ DEFPY_ATTR(no_ip_pim_joinprune_time,
 	return ret;
 }
 
-DEFPY (pim_register_suppress,
-       pim_register_suppress_cmd,
-       "register-suppress-time (1-65535)$rst",
-       "Register Suppress Timer\n"
-       "Seconds\n")
+DEFPY_YANG (pim_register_suppress,
+	    pim_register_suppress_cmd,
+	    "register-suppress-time (1-65535)$rst",
+	    "Register Suppress Timer\n"
+	    "Seconds\n")
 {
 	return pim_process_register_suppress_cmd(vty, rst_str);
 }
@@ -3852,12 +3853,12 @@ DEFPY_ATTR(ip_pim_register_suppress,
 	return ret;
 }
 
-DEFPY (no_pim_register_suppress,
-       no_pim_register_suppress_cmd,
-       "no register-suppress-time [(1-65535)]",
-       NO_STR
-       "Register Suppress Timer\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim_register_suppress,
+	    no_pim_register_suppress_cmd,
+	    "no register-suppress-time [(1-65535)]",
+	    NO_STR
+	    "Register Suppress Timer\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_register_suppress_cmd(vty);
 }
@@ -3903,12 +3904,12 @@ DEFPY_ATTR(no_ip_pim_register_suppress,
 	return ret;
 }
 
-DEFPY (pim_rp_keep_alive,
-       pim_rp_keep_alive_cmd,
-       "rp keep-alive-timer (1-65535)$kat",
-       "Rendezvous Point\n"
-       "Keep alive Timer\n"
-       "Seconds\n")
+DEFPY_YANG (pim_rp_keep_alive,
+	    pim_rp_keep_alive_cmd,
+	    "rp keep-alive-timer (1-65535)$kat",
+	    "Rendezvous Point\n"
+	    "Keep alive Timer\n"
+	    "Seconds\n")
 {
 	return pim_process_rp_kat_cmd(vty, kat_str);
 }
@@ -3954,13 +3955,13 @@ DEFPY_ATTR(ip_pim_rp_keep_alive,
 	return ret;
 }
 
-DEFPY (no_pim_rp_keep_alive,
-       no_pim_rp_keep_alive_cmd,
-       "no rp keep-alive-timer [(1-65535)]",
-       NO_STR
-       "Rendezvous Point\n"
-       "Keep alive Timer\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim_rp_keep_alive,
+	    no_pim_rp_keep_alive_cmd,
+	    "no rp keep-alive-timer [(1-65535)]",
+	    NO_STR
+	    "Rendezvous Point\n"
+	    "Keep alive Timer\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_rp_kat_cmd(vty);
 }
@@ -4007,11 +4008,11 @@ DEFPY_ATTR(no_ip_pim_rp_keep_alive,
 	return ret;
 }
 
-DEFPY (pim_keep_alive,
-       pim_keep_alive_cmd,
-       "keep-alive-timer (1-65535)$kat",
-       "Keep alive Timer\n"
-       "Seconds\n")
+DEFPY_YANG (pim_keep_alive,
+	    pim_keep_alive_cmd,
+	    "keep-alive-timer (1-65535)$kat",
+	    "Keep alive Timer\n"
+	    "Seconds\n")
 {
 	return pim_process_keepalivetimer_cmd(vty, kat_str);
 }
@@ -4056,12 +4057,12 @@ DEFPY_ATTR(ip_pim_keep_alive,
 	return ret;
 }
 
-DEFPY (no_pim_keep_alive,
-       no_pim_keep_alive_cmd,
-       "no keep-alive-timer [(1-65535)]",
-       NO_STR
-       "Keep alive Timer\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim_keep_alive,
+	    no_pim_keep_alive_cmd,
+	    "no keep-alive-timer [(1-65535)]",
+	    NO_STR
+	    "Keep alive Timer\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_keepalivetimer_cmd(vty);
 }
@@ -4107,11 +4108,11 @@ DEFPY_ATTR(no_ip_pim_keep_alive,
 	return ret;
 }
 
-DEFPY (pim_packets,
-       pim_packets_cmd,
-       "packets (1-255)",
-       "packets to process at one time per fd\n"
-       "Number of packets\n")
+DEFPY_YANG (pim_packets,
+	    pim_packets_cmd,
+	    "packets (1-255)",
+	    "packets to process at one time per fd\n"
+	    "Number of packets\n")
 {
 	return pim_process_pim_packet_cmd(vty, packets_str);
 }
@@ -4156,12 +4157,12 @@ DEFPY_ATTR(ip_pim_packets,
 	return ret;
 }
 
-DEFPY (no_pim_packets,
-       no_pim_packets_cmd,
-       "no packets [(1-255)]",
-       NO_STR
-       "packets to process at one time per fd\n"
-       IGNORED_IN_NO_STR)
+DEFPY_YANG (no_pim_packets,
+	    no_pim_packets_cmd,
+	    "no packets [(1-255)]",
+	    NO_STR
+	    "packets to process at one time per fd\n"
+	    IGNORED_IN_NO_STR)
 {
 	return pim_process_no_pim_packet_cmd(vty);
 }

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -54,6 +54,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/gm-watermark-limit",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_pim_address_family_gm_watermark_limit_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_pim_address_family_gm_watermark_limit_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-pim:pim/address-family",
 			.cbs = {
 				.create = pim_address_family_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -23,6 +23,10 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ke
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_keep_alive_timer_modify(
 	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_gm_watermark_limit_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_gm_watermark_limit_destroy(
+	struct nb_cb_destroy_args *args);
 int pim_address_family_create(struct nb_cb_create_args *args);
 int pim_address_family_destroy(struct nb_cb_destroy_args *args);
 int pim_address_family_packets_modify(struct nb_cb_modify_args *args);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -761,6 +761,51 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 }
 
 /*
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/gm-watermark-limit
+ */
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_gm_watermark_limit_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		pim->gm_watermark_limit = yang_dnode_get_uint16(args->dnode, NULL);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int routing_control_plane_protocols_control_plane_protocol_pim_address_family_gm_watermark_limit_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		pim->gm_watermark_limit = 0;
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family
  */
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_create(

--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -217,6 +217,58 @@ def test_pim_igmp_report():
             p.wait()
 
 
+def test_pim_igmp_group_watermark():
+    "Configure and verify IGMP watermark warning using retry checks"
+    logger.info("Verify ip igmp watermark-warn configuration on r1")
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Ensure a clean baseline before testing.
+    r1.vtysh_cmd("conf t\nno ip igmp watermark-warn")
+
+    # Send an IGMP report to ensure the groups output has active state while
+    # checking the watermark value.
+    cmd = [os.path.join(CWD, "mcast-rx.py"), "229.1.1.9", "r2-eth0"]
+    p = r2.popen(cmd)
+    try:
+        expected = {"watermarkLimit": 0}
+        test_func = partial(
+            topotest.router_json_cmp, r1, "show ip igmp groups json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+        assertmsg = '"{}" default watermark JSON output mismatches'.format(r1.name)
+        assert result is None, assertmsg
+
+        r1.vtysh_cmd("conf t\nip igmp watermark-warn 11")
+        expected = {"watermarkLimit": 11}
+        test_func = partial(
+            topotest.router_json_cmp, r1, "show ip igmp groups json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+        assertmsg = '"{}" configured watermark JSON output mismatches'.format(r1.name)
+        assert result is None, assertmsg
+
+        r1.vtysh_cmd("conf t\nno ip igmp watermark-warn")
+        expected = {"watermarkLimit": 0}
+        test_func = partial(
+            topotest.router_json_cmp, r1, "show ip igmp groups json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+        assertmsg = '"{}" cleared watermark JSON output mismatches'.format(r1.name)
+        assert result is None, assertmsg
+    finally:
+        if p:
+            p.terminate()
+            p.wait()
+        r1.vtysh_cmd("conf t\nno ip igmp watermark-warn")
+
+
 def test_pim_ssm_ping():
     "Test SSM ping functionality between r1 and r2"
     logger.info("Testing SSM ping from r1 to r2")

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -416,6 +416,115 @@ def test_route_map_usage():
     assert ok, result
 
 
+def test_allow_external_route_update_kernel_delete_behavior():
+    "Validate kernel delete handling with allow-external-route-update toggled"
+    logger.info("Testing allow-external-route-update kernel delete behavior")
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of previous test failure")
+
+    r1 = tgen.gears["r1"]
+    prefix = "203.0.113.0/24"
+    nexthop = "192.168.210.2"
+
+    def check_route_in_zebra(expected_present):
+        output = r1.vtysh_cmd("show ip route {} json".format(prefix), isjson=True)
+        present = bool(output and output != {})
+        if present == expected_present:
+            return None
+        return "zebra route presence mismatch for {} (expected_present={})".format(
+            prefix, expected_present
+        )
+
+    def check_route_in_kernel(expected_present):
+        output = r1.run("ip route show {}".format(prefix)).strip()
+        present = bool(output)
+        if present == expected_present:
+            return None
+        return "kernel route presence mismatch for {} (expected_present={})".format(
+            prefix, expected_present
+        )
+
+    def check_allow_external_route_update_in_show_run(expected_present):
+        output = r1.vtysh_cmd("show running")
+        present = "allow-external-route-update" in output
+        if present == expected_present:
+            return None
+        return (
+            "show running allow-external-route-update mismatch "
+            "(expected_present={})".format(expected_present)
+        )
+
+    # Make sure the test starts from a clean state.
+    r1.vtysh_cmd("conf\nno ip route {} {}".format(prefix, nexthop))
+
+    #
+    # a) enable allow-external-route-update:
+    #    kernel delete should be accepted and FRR route should stay deleted.
+    #
+    step("Enable allow-external-route-update and install static route")
+    r1.vtysh_cmd("conf\nallow-external-route-update")
+    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
+
+    test_func = partial(check_allow_external_route_update_in_show_run, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(check_route_in_zebra, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(check_route_in_kernel, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    step("Delete route from kernel and verify FRR keeps it deleted")
+    r1.run("ip route del {} via {} dev r1-eth0 || true".format(prefix, nexthop))
+
+    test_func = partial(check_route_in_zebra, False)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(check_route_in_kernel, False)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    #
+    # b) disable allow-external-route-update:
+    #    external delete should not be accepted and zebra should restore route.
+    #
+    step("Disable allow-external-route-update")
+    r1.vtysh_cmd("conf\nno allow-external-route-update")
+    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
+
+    test_func = partial(check_allow_external_route_update_in_show_run, False)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(check_route_in_zebra, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(check_route_in_kernel, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    step("Delete route from kernel and verify FRR reprograms it")
+    r1.run("ip route del {} via {} dev r1-eth0 || true".format(prefix, nexthop))
+
+    test_func = partial(check_route_in_zebra, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(check_route_in_kernel, True)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    r1.vtysh_cmd("conf\nno allow-external-route-update")
+    r1.vtysh_cmd("conf\nno ip route {} {}".format(prefix, nexthop))
+    r1.run("ip route del {} via {} dev r1-eth0 || true".format(prefix, nexthop))
+
+
 def test_protodown():
     "Run protodown basic functionality test and report results."
     pdown = False

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -293,7 +293,12 @@ def test_zebra_kernel_override():
         pytest.skip("skipped because of previous test failure")
 
     r1 = tgen.gears["r1"]
-    r1.vtysh_cmd("conf\nip route 4.5.1.0/24 192.168.216.3")
+    r1.vtysh_cmd(
+        """
+        conf
+        ip route 4.5.1.0/24 192.168.216.3
+        """
+    )
     json_file = "{}/r1/v4_route_1_static_override.json".format(CWD)
     expected = json.loads(open(json_file).read())
 
@@ -306,7 +311,12 @@ def test_zebra_kernel_override():
     logger.info(
         "Test that the removal of the static route allows the kernel to take back over"
     )
-    r1.vtysh_cmd("conf\nno ip route 4.5.1.0/24 192.168.216.3")
+    r1.vtysh_cmd(
+        """
+        conf
+        no ip route 4.5.1.0/24 192.168.216.3
+        """
+    )
     json_file = "{}/r1/v4_route_1.json".format(CWD)
     expected = json.loads(open(json_file).read())
 
@@ -328,20 +338,76 @@ def test_route_map_usage():
 
     r1 = tgen.gears["r1"]
     # set the delay timer to 1 to improve test coverage (HA)
-    r1.vtysh_cmd("conf\nzebra route-map delay-timer 1")
-    r1.vtysh_cmd("conf\nroute-map static permit 10\nset src 192.168.215.1")
-    r1.vtysh_cmd("conf\naccess-list 5 seq 5 permit 10.0.0.44/32")
-    r1.vtysh_cmd("conf\naccess-list 10 seq 5 permit 10.0.1.0/24")
     r1.vtysh_cmd(
-        "conf\nroute-map sharp permit 10\nmatch ip address 10\nset src 192.168.214.1"
+        """
+        conf
+        zebra route-map delay-timer 1
+        """
     )
-    r1.vtysh_cmd("conf\nroute-map sharp permit 20\nset src 192.168.213.1")
-    r1.vtysh_cmd("conf\nip protocol static route-map static")
-    r1.vtysh_cmd("conf\nip protocol sharp route-map sharp")
+    r1.vtysh_cmd(
+        """
+        conf
+        route-map static permit 10
+          set src 192.168.215.1
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        access-list 5 seq 5 permit 10.0.0.44/32
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        access-list 10 seq 5 permit 10.0.1.0/24
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        route-map sharp permit 10
+          match ip address 10
+          set src 192.168.214.1
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        route-map sharp permit 20
+          set src 192.168.213.1
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        ip protocol static route-map static
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        ip protocol sharp route-map sharp
+        """
+    )
     sleep(4)
-    r1.vtysh_cmd("conf\nip route 10.100.100.100/32 192.168.216.3")
-    r1.vtysh_cmd("conf\nip route 10.100.100.101/32 10.0.0.44")
-    r1.vtysh_cmd("sharp install route 10.0.0.0 nexthop 192.168.216.3 500")
+    r1.vtysh_cmd(
+        """
+        conf
+        ip route 10.100.100.100/32 192.168.216.3
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        ip route 10.100.100.101/32 10.0.0.44
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        sharp install route 10.0.0.0 nexthop 192.168.216.3 500
+        """
+    )
 
     def check_initial_routes_installed(router):
         output = json.loads(router.vtysh_cmd("show ip route summ json"))
@@ -402,7 +468,13 @@ def test_route_map_usage():
         " and test that the routes installed are correct"
     )
 
-    r1.vtysh_cmd("conf\nroute-map sharp deny 5\nmatch ip address 5")
+    r1.vtysh_cmd(
+        """
+        conf
+        route-map sharp deny 5
+          match ip address 5
+        """
+    )
     # we are only checking the kernel here as that this will give us the implied
     # testing of both the route-map and staticd withdrawing the route
     # let's spot check that the routes were installed correctly
@@ -479,20 +551,39 @@ def test_allow_external_route_update_kernel_delete_behavior():
         )
 
     # Make sure the test starts from a clean state.
-    r1.vtysh_cmd("conf\nno ip route {} {}".format(prefix, nexthop))
+    r1.vtysh_cmd(
+        """
+        conf
+        no ip route {} {}
+        """.format(
+            prefix, nexthop
+        )
+    )
 
     #
     # a) enable allow-external-route-update:
     #    kernel delete should be accepted and FRR route should stay deleted.
     #
     step("Enable allow-external-route-update and install static route")
-    r1.vtysh_cmd("conf\nallow-external-route-update")
+    r1.vtysh_cmd(
+        """
+        conf
+        allow-external-route-update
+        """
+    )
 
     test_func = partial(check_allow_external_route_update_in_show_run, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
-    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
+    r1.vtysh_cmd(
+        """
+        conf
+        ip route {} {}
+        """.format(
+            prefix, nexthop
+        )
+    )
 
     test_func = partial(check_route_in_zebra, True, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
@@ -518,14 +609,33 @@ def test_allow_external_route_update_kernel_delete_behavior():
     #    external delete should not be accepted and zebra should restore route.
     #
     step("Disable allow-external-route-update")
-    r1.vtysh_cmd("conf\nno allow-external-route-update")
+    r1.vtysh_cmd(
+        """
+        conf
+        no allow-external-route-update
+        """
+    )
 
     test_func = partial(check_allow_external_route_update_in_show_run, False)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
-    r1.vtysh_cmd("conf\nno ip route {} {}".format(prefix, nexthop))
-    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
+    r1.vtysh_cmd(
+        """
+        conf
+        no ip route {} {}
+        """.format(
+            prefix, nexthop
+        )
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        ip route {} {}
+        """.format(
+            prefix, nexthop
+        )
+    )
 
     test_func = partial(check_route_in_zebra, True, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
@@ -546,8 +656,20 @@ def test_allow_external_route_update_kernel_delete_behavior():
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
-    r1.vtysh_cmd("conf\nno allow-external-route-update")
-    r1.vtysh_cmd("conf\nno ip route {} {}".format(prefix, nexthop))
+    r1.vtysh_cmd(
+        """
+        conf
+        no allow-external-route-update
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        conf
+        no ip route {} {}
+        """.format(
+            prefix, nexthop
+        )
+    )
     r1.run("ip route del {} via {} dev r1-eth0 || true".format(prefix, nexthop))
 
 

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -427,14 +427,37 @@ def test_allow_external_route_update_kernel_delete_behavior():
     prefix = "203.0.113.0/24"
     nexthop = "192.168.210.2"
 
-    def check_route_in_zebra(expected_present):
+    def check_route_in_zebra(expected_present, expected_installed):
         output = r1.vtysh_cmd("show ip route {} json".format(prefix), isjson=True)
-        present = bool(output and output != {})
-        if present == expected_present:
+        present = bool(output and output.get(prefix))
+        if present != expected_present:
+            return "zebra route presence mismatch for {} (expected_present={})".format(
+                prefix, expected_present
+            )
+
+        if not present:
             return None
-        return "zebra route presence mismatch for {} (expected_present={})".format(
-            prefix, expected_present
-        )
+
+        route = output[prefix][0]
+        installed = bool(route.get("installed", False))
+        fib_installed_num = int(route.get("internalNextHopFibInstalledNum", 0))
+        if installed != expected_installed:
+            return (
+                "zebra installed mismatch for {} "
+                "(expected_installed={}, installed={}, fib_installed_num={})"
+            ).format(prefix, expected_installed, installed, fib_installed_num)
+
+        if expected_installed and fib_installed_num <= 0:
+            return (
+                "zebra fib install count mismatch for {} " "(expected > 0, got {})"
+            ).format(prefix, fib_installed_num)
+
+        if not expected_installed and fib_installed_num != 0:
+            return (
+                "zebra fib install count mismatch for {} " "(expected 0, got {})"
+            ).format(prefix, fib_installed_num)
+
+        return None
 
     def check_route_in_kernel(expected_present):
         output = r1.run("ip route show {}".format(prefix)).strip()
@@ -464,13 +487,14 @@ def test_allow_external_route_update_kernel_delete_behavior():
     #
     step("Enable allow-external-route-update and install static route")
     r1.vtysh_cmd("conf\nallow-external-route-update")
-    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
 
     test_func = partial(check_allow_external_route_update_in_show_run, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
-    test_func = partial(check_route_in_zebra, True)
+    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
+
+    test_func = partial(check_route_in_zebra, True, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
@@ -479,9 +503,9 @@ def test_allow_external_route_update_kernel_delete_behavior():
     assert result is None, result
 
     step("Delete route from kernel and verify FRR keeps it deleted")
-    r1.run("ip route del {} via {} dev r1-eth0 || true".format(prefix, nexthop))
+    r1.run("ip route del {}".format(prefix))
 
-    test_func = partial(check_route_in_zebra, False)
+    test_func = partial(check_route_in_zebra, True, False)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
@@ -495,13 +519,15 @@ def test_allow_external_route_update_kernel_delete_behavior():
     #
     step("Disable allow-external-route-update")
     r1.vtysh_cmd("conf\nno allow-external-route-update")
-    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
 
     test_func = partial(check_allow_external_route_update_in_show_run, False)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
-    test_func = partial(check_route_in_zebra, True)
+    r1.vtysh_cmd("conf\nno ip route {} {}".format(prefix, nexthop))
+    r1.vtysh_cmd("conf\nip route {} {}".format(prefix, nexthop))
+
+    test_func = partial(check_route_in_zebra, True, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 
@@ -510,9 +536,9 @@ def test_allow_external_route_update_kernel_delete_behavior():
     assert result is None, result
 
     step("Delete route from kernel and verify FRR reprograms it")
-    r1.run("ip route del {} via {} dev r1-eth0 || true".format(prefix, nexthop))
+    r1.run("ip route del {}".format(prefix))
 
-    test_func = partial(check_route_in_zebra, True)
+    test_func = partial(check_route_in_zebra, True, True)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, result
 

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -270,6 +270,14 @@ module frr-pim {
         "RP keep alive Timer in seconds.";
     }
 
+    leaf gm-watermark-limit {
+      type uint16 {
+        range "1..max";
+      }
+      description
+        "Group count threshold for IGMP/MLD watermark warnings.";
+    }
+
     leaf send-v6-secondary {
       when "../frr-pim:address-family = 'frr-rt:ipv4'" {
         description

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -120,6 +120,13 @@ static void zebra_route_map_delay_cli_write(struct vty *vty,
 	vty_out(vty, "zebra route-map delay-timer %u\n", delay);
 }
 
+static void zebra_allow_external_route_update_cli_write(struct vty *vty,
+							const struct lyd_node *dnode,
+							bool show_defaults)
+{
+	vty_out(vty, "allow-external-route-update\n");
+}
+
 DEFPY_YANG (multicast_new,
 	multicast_new_cmd,
 	"[no] multicast <enable$on|disable$off>",
@@ -2790,6 +2797,10 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 		{
 			.xpath = "/frr-zebra:zebra/route-map-delay",
 			.cbs.cli_show = zebra_route_map_delay_cli_write,
+		},
+		{
+			.xpath = "/frr-zebra:zebra/allow-external-route-update",
+			.cbs.cli_show = zebra_allow_external_route_update_cli_write,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs",

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -232,8 +232,9 @@ int zebra_allow_external_route_update_create(struct nb_cb_create_args *args)
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+		break;
 	case NB_EV_APPLY:
-		/* TODO: implement me. */
+		zrouter.allow_delete = true;
 		break;
 	}
 
@@ -246,8 +247,9 @@ int zebra_allow_external_route_update_destroy(struct nb_cb_destroy_args *args)
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+		break;
 	case NB_EV_APPLY:
-		/* TODO: implement me. */
+		zrouter.allow_delete = false;
 		break;
 	}
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2714,25 +2714,27 @@ static void vty_show_ip_route_summary_prefix(struct vty *vty,
 	}
 }
 
-DEFUN (allow_external_route_update,
-       allow_external_route_update_cmd,
-       "allow-external-route-update",
-       "Allow FRR routes to be overwritten by external processes\n")
+DEFPY_YANG (allow_external_route_update,
+	    allow_external_route_update_cmd,
+	    "allow-external-route-update",
+	    "Allow FRR routes to be overwritten by external processes\n")
 {
-	zrouter.allow_delete = true;
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/allow-external-route-update", NB_OP_CREATE,
+			      NULL);
 
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
-DEFUN (no_allow_external_route_update,
-       no_allow_external_route_update_cmd,
-       "no allow-external-route-update",
-       NO_STR
-       "Allow FRR routes to be overwritten by external processes\n")
+DEFPY_YANG (no_allow_external_route_update,
+	    no_allow_external_route_update_cmd,
+	    "no allow-external-route-update",
+	    NO_STR
+	    "Allow FRR routes to be overwritten by external processes\n")
 {
-	zrouter.allow_delete = false;
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/allow-external-route-update", NB_OP_DESTROY,
+			      NULL);
 
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 /* show vrf */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4094,7 +4094,7 @@ DEFUN (show_zebra,
 		       zrouter.zav.supports_nhgs ? "Available" : "Unavailable");
 
 	ttable_add_row(table, "Allow Non FRR route deletion|%s",
-		       zrouter.allow_delete ? "Yes" : "No");
+		       zrouter.allow_delete ? "No" : "Yes");
 	ttable_add_row(table, "v4 All LinkDown Routes|%s",
 		       zrouter.all_linkdownv4 ? "On" : "Off");
 	ttable_add_row(table, "v4 Default LinkDown Routes|%s",


### PR DESCRIPTION
a) pim's `ip igmp watermark` was not using yang... make it so.
b) Some of pim's commands are using yang but using DEFPY instead of DEFPY_YANG, convert
c) Fix inversion of item in `show zebra`
d) zebra's `allow-external-route-update` command was not yangified, make it so.
e) Add tests for allow-external-route-update to show it works.