### PR TITLE
build: update pkg-config file

### DIFF
--- a/tools/frr.pc.in
+++ b/tools/frr.pc.in
@@ -5,6 +5,7 @@
 moduledir="@e_moduledir@"
 prefix="@prefix@"
 includedir=${prefix}/include/frr
+libdir="${prefix}/lib"
 #
 # these are needed to make the build work
 #
@@ -14,6 +15,7 @@ Name: @PACKAGE@
 Description: FRRouting packaged-source-tree build support
 URL: @PACKAGE_BUGREPORT@
 Version: @FRR_PACKAGE_VERSION@
+Libs: -L${libdir} -lfrr
 Cflags: -I${includedir} -I${includedir}/lib		 \
 	-fms-extensions -DMULTIPATH_NUM=${multipath_num} \
 	-Wno-missing-field-initializers -Wno-unused-parameter


### PR DESCRIPTION
The .pc added in PR #19351 only exports the include flags, but the downstream users ship the .so as well (see [fedora:rpms/frr#76](https://src.fedoraproject.org/rpms/frr/pull-request/76#) as linked by the original PR).

Other build systems could benefit from the library self-exporting the link flags, so include pathing _and_ linking can be done in-system.