### PR TITLE
yang: Correct pyang errors in frr-pim-candidate.yang

### DIFF
--- a/yang/frr-pim-candidate.yang
+++ b/yang/frr-pim-candidate.yang
@@ -94,19 +94,27 @@ module frr-pim-candidate {
       }
 
       choice source-address-or-interface {
-        description "IP address to use for BSR operation";
         default if-loopback;
+        description "IP address to use for BSR operation";
         leaf address {
           type inet:ip-address;
+          description
+            "Use this specific IP address as the source address for BSR operation.";
         }
         leaf interface {
           type frr-interface:interface-ref;
+          description
+            "Use the IP address of the specified interface for BSR operation.";
         }
         leaf if-loopback {
           type empty;
+          description
+            "Use the loopback interface IP address for BSR operation.";
         }
         leaf if-any {
           type empty;
+          description
+            "Use any available interface IP address for BSR operation.";
         }
       }
     } // candidate-bsr
@@ -146,19 +154,27 @@ module frr-pim-candidate {
       }
 
       choice source-address-or-interface {
-        description "IP address to use for RP operation";
         default if-loopback;
+        description "IP address to use for RP operation";
         leaf address {
           type inet:ip-address;
+          description
+            "Use this specific IP address as the source address for RP operation.";
         }
         leaf interface {
           type frr-interface:interface-ref;
+          description
+            "Use the IP address of the specified interface for RP operation.";
         }
         leaf if-loopback {
           type empty;
+          description
+            "Use the loopback interface IP address for RP operation.";
         }
         leaf if-any {
           type empty;
+          description
+            "Use any available interface IP address for RP operation.";
         }
       }
     }


### PR DESCRIPTION
Correct pyang errors in frr-pim-candidate.yang

frr-pim-candidate.yang:98: error: keyword "default" not in canonical order (see RFC 7950, Section 14)
frr-pim-candidate.yang:99: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:102: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:105: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:108: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:150: error: keyword "default" not in canonical order (see RFC 7950, Section 14)
frr-pim-candidate.yang:151: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:154: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:157: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-candidate.yang:160: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement