### PR TITLE
ospf6d: clear local ifp per ECMP path rebuild

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1532,6 +1532,7 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 
 			for (ALL_LIST_ELEMENTS_RO(old_route->paths, anode,
 						  o_path)) {
+				ifp = NULL;
 				ls_entry = ospf6_route_lookup(
 							&o_path->ls_prefix,
 							oa->spf_table);


### PR DESCRIPTION
`ospf6_intra_prefix_route_ecmp_path()` can reuse a stale `ifp` value while rebuilding the effective nexthop set for an existing intra-prefix route.

**What changes**
- reset `ifp` to `NULL` at the start of each `old_route->paths` iteration

**Why**
The current loop only assigns `ifp` for self-originated Intra-Prefix-LSAs. Without an explicit reset, a previous successful interface lookup can leak into a later unrelated path and cause FRR to install a wrong on-link nexthop.

**Impact**
- fixes incorrect direct-connect nexthop reuse

Fixes #21036