### PR TITLE
zebra: Add `no locators` command to delete all SRv6 locators

### DIFF
--- a/tests/topotests/srv6_locator/expected_locators9.json
+++ b/tests/topotests/srv6_locator/expected_locators9.json
@@ -1,0 +1,15 @@
+{
+    "locators":[
+      {
+        "name": "loc1",
+        "prefix": "fcbb:bbbb:1::/48",
+        "statusUp": true
+      },
+      {
+        "name": "loc2",
+        "prefix": "fcbb:bbbb:2::/48",
+        "statusUp": true
+      }
+    ]
+  }
+    

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -46,15 +46,15 @@ def _check_sharpd_chunk(router, expected_chunk_file):
     return topotest.json_cmp(output, expected)
 
 
-def _check_srv6_locator(router, expected_locator_file):
+def _check_srv6_locator(router, expected_locator_file, exact):
     logger.info("checking zebra locator status")
     output = json.loads(router.vtysh_cmd("show segment-routing srv6 locator json"))
     expected = open_json_file("{}/{}".format(CWD, expected_locator_file))
-    return topotest.json_cmp(output, expected)
+    return topotest.json_cmp(output, expected, exact)
 
 
-def check_srv6_locator(router, expected_file):
-    func = functools.partial(_check_srv6_locator, router, expected_file)
+def check_srv6_locator(router, expected_file, exact=False):
+    func = functools.partial(_check_srv6_locator, router, expected_file, exact)
     _, result = topotest.run_and_expect(func, None, count=15, wait=1)
     assert result is None, "Failed"
 

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -251,6 +251,47 @@ def test_srv6_no_prefix_explicit():
     check_sharpd_chunk(router, "expected_chunks6.json")
 
 
+def test_srv6_no_locators():
+    """
+    Verify that 'no locators' under 'srv6' removes all configured locators
+    at once, leaving the SRv6 instance intact but with an empty locator list.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+
+    logger.info("Re-add loc1 and loc2")
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            locator loc1
+             prefix fcbb:bbbb:1::/48
+             format usid-f3216
+            locator loc2
+             prefix fcbb:bbbb:2::/48
+             format usid-f3216
+        """
+    )
+    check_srv6_locator(router, "expected_locators9.json")
+    check_sharpd_chunk(router, "expected_chunks1.json")
+
+    logger.info("Issue 'no locators' and verify all locators are removed")
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           no locators
+        """
+    )
+    check_srv6_locator(router, "expected_locators6.json", exact=True)
+    check_sharpd_chunk(router, "expected_chunks6.json")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -798,6 +798,16 @@ DEFUN_NOSH (srv6_locators,
 	return CMD_SUCCESS;
 }
 
+DEFUN (no_srv6_locators,
+       no_srv6_locators_cmd,
+       "no locators",
+       NO_STR
+       "Segment Routing SRv6 locators\n")
+{
+	zebra_srv6_locators_delete_all();
+	return CMD_SUCCESS;
+}
+
 DEFUN_NOSH (srv6_locator,
             srv6_locator_cmd,
             "locator WORD",
@@ -1803,6 +1813,7 @@ void zebra_srv6_vty_init(void)
 	install_element(SEGMENT_ROUTING_NODE, &srv6_cmd);
 	install_element(SEGMENT_ROUTING_NODE, &no_srv6_cmd);
 	install_element(SRV6_NODE, &srv6_locators_cmd);
+	install_element(SRV6_NODE, &no_srv6_locators_cmd);
 	install_element(SRV6_NODE, &srv6_encap_cmd);
 	install_element(SRV6_NODE, &no_srv6_encap_cmd);
 	install_element(SRV6_NODE, &srv6_sid_formats_cmd);

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -745,11 +745,8 @@ static void unset_srv6_encap_source_address(void)
 	dplane_srv6_encap_srcaddr_set(&in6addr_any, NS_DEFAULT);
 }
 
-DEFUN (no_srv6,
-       no_srv6_cmd,
-       "no srv6",
-       NO_STR
-       "Segment Routing SRv6\n")
+/* Delete all SRv6 locators and release their SID blocks. */
+static void zebra_srv6_locators_delete_all(void)
 {
 	struct zebra_srv6 *srv6 = zebra_srv6_get_default();
 	struct srv6_locator *locator;
@@ -778,7 +775,15 @@ DEFUN (no_srv6,
 
 		zebra_srv6_locator_delete(locator);
 	}
+}
 
+DEFUN (no_srv6,
+       no_srv6_cmd,
+       "no srv6",
+       NO_STR
+       "Segment Routing SRv6\n")
+{
+	zebra_srv6_locators_delete_all();
 	unset_srv6_encap_source_address();
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
Add `no locators` command to delete all SRv6 locators at once.

Example:

```
router# show segment-routing srv6 locator
Locator:
Name                 ID      Prefix                   Status
-------------------- ------- ------------------------ -------
loc1                       1 fcbb:bbbb:1::/48         Up
loc2                       2 fcbb:bbbb:2::/48         Up
```

```
router# configure
router(config)# segment-routing
router(config-sr)# srv6
router(config-srv6)# no locators
```

```
router# show segment-routing srv6 locator
Locator:
Name                 ID      Prefix                   Status
-------------------- ------- ------------------------ -------
```