### PR TITLE
bgpd: fix off-by-one error in FlowSpec operator array bounds check

### DIFF
--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -274,8 +274,10 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 	}
 
 	do {
-		if (loop > BGP_PBR_MATCH_VAL_MAX)
+		if (loop >= BGP_PBR_MATCH_VAL_MAX) {
 			*error = -2;
+			return offset;
+		}
 
 		if (offset >= max_len) {
 			*error = -1;
@@ -397,7 +399,7 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 	}
 
 	do {
-		if (loop > BGP_PBR_MATCH_VAL_MAX) {
+		if (loop >= BGP_PBR_MATCH_VAL_MAX) {
 			*error = -2;
 			return offset;
 		}


### PR DESCRIPTION
Change loop > BGP_PBR_MATCH_VAL_MAX to loop >= BGP_PBR_MATCH_VAL_MAX in bgp_flowspec_op_decode() and bgp_flowspec_bitmask_decode() to prevent writing one element past the end of the mval[] array when more than 5 chained operators are present in a FlowSpec component.
