### PR TITLE
lib: use poll() instead of select() in zclient_read_sync_response

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3351,7 +3351,7 @@ static int zclient_read_sync_response(struct zclient *zclient,
 	uint8_t version;
 	vrf_id_t vrf_id;
 	uint16_t cmd;
-	fd_set readfds;
+	struct pollfd pfd;
 	int ret;
 
 	ret = 0;
@@ -3360,11 +3360,17 @@ static int zclient_read_sync_response(struct zclient *zclient,
 		s = zclient->ibuf;
 		stream_reset(s);
 
-		/* wait until response arrives */
-		FD_ZERO(&readfds);
-		FD_SET(zclient->sock, &readfds);
-		select(zclient->sock + 1, &readfds, NULL, NULL, NULL);
-		if (!FD_ISSET(zclient->sock, &readfds))
+		/* wait until response arrives (poll avoids FD_SETSIZE limit) */
+		pfd.fd = zclient->sock;
+		pfd.events = POLLIN;
+		if (poll(&pfd, 1, -1) < 0) {
+			if (errno == EINTR)
+				continue;
+			flog_err(EC_LIB_ZAPI_SOCKET, "%s: poll failed: %s",
+				 __func__, safe_strerror(errno));
+			return -1;
+		}
+		if (!(pfd.revents & POLLIN))
 			continue;
 		/* read response */
 		ret = zclient_read_header(s, zclient->sock, &size, &marker,


### PR DESCRIPTION
select() and fd_set are limited to FD_SETSIZE (1024). With many BGP peers, the zebra socket can get fd >= 1024 and FD_SET() triggers __fdelt_warn. poll() has no such limit.

Backtrace example:
```
Mar 09 22:16:42 core frrinit.sh[898790]: *** bit out of range 0 - FD_SETSIZE on fd_set ***: terminated
Mar 09 22:16:42 core bgpd[898790]: Received signal 6 at 1773109002 (si_addr 0x79000db6e6, PC 0x784cc629eb2c); aborting...
Mar 09 22:16:42 core BGP[898790]: Received signal 6 at 1773109002 (si_addr 0x79000db6e6, PC 0x784cc629eb2c); aborting...
Mar 09 22:16:42 core bgpd[898790]: zlog_signal+0xf9                   784cc66cb339     7ffcee9cf4f0 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core zebra[898717]: client 47 says hello and bids fair to announce only bgp routes vrf=0
Mar 09 22:16:42 core BGP[898790]: zlog_signal+0xf9                   784cc66cb339     7ffcee9cf4f0 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core bgpd[898790]: core_handler+0xb5                  784cc670ea05     7ffcee9cf630 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core zebra[898717]: [V98V0-MTWPF] client 47 says hello and bids fair to announce only bgp routes vrf=0
Mar 09 22:16:42 core bgpd[898790]: __sigaction+0x50                   784cc6245330     7ffcee9cf780 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: core_handler+0xb5                  784cc670ea05     7ffcee9cf630 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core bgpd[898790]:     ---- signal ----
Mar 09 22:16:42 core BGP[898790]: __sigaction+0x50                   784cc6245330     7ffcee9cf780 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: pthread_kill+0x11c                 784cc629eb2c     7ffcee9d0470 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]:     ---- signal ----
Mar 09 22:16:42 core bgpd[898790]: gsignal+0x1e                       784cc624527e     7ffcee9d04c0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: pthread_kill+0x11c                 784cc629eb2c     7ffcee9d0470 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: abort+0xdf                         784cc62288ff     7ffcee9d04e0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: gsignal+0x1e                       784cc624527e     7ffcee9d04c0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: perror+0xd23                       784cc62297b6     7ffcee9d05a0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: abort+0xdf                         784cc62288ff     7ffcee9d04e0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: __fortify_fail+0x19                784cc6336c49     7ffcee9d06c0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: perror+0xd23                       784cc62297b6     7ffcee9d05a0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: __fdelt_warn+0x25                  784cc6336745     7ffcee9d06d0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: __fortify_fail+0x19                784cc6336c49     7ffcee9d06c0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: zclient_read_sync_response+0x8b     784cc67390bb     7ffcee9d06e0 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core BGP[898790]: __fdelt_warn+0x25                  784cc6336745     7ffcee9d06d0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: lm_label_manager_connect+0xeb      784cc673e23b     7ffcee9d07c0 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core BGP[898790]: zclient_read_sync_response+0x8b     784cc67390bb     7ffcee9d06e0 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core bgpd[898790]: bgp_start_label_manager+0x57       59b8e8bfb987     7ffcee9d0810 /usr/lib/frr/bgpd (mapped at 0x59b8e8a10000)
Mar 09 22:16:42 core BGP[898790]: lm_label_manager_connect+0xeb      784cc673e23b     7ffcee9d07c0 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core bgpd[898790]: event_call+0xae                    784cc6721c8e     7ffcee9d0820 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core BGP[898790]: bgp_start_label_manager+0x57       59b8e8bfb987     7ffcee9d0810 /usr/lib/frr/bgpd (mapped at 0x59b8e8a10000)
Mar 09 22:16:42 core bgpd[898790]: frr_run+0xc8                       784cc66c2018     7ffcee9d0950 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core BGP[898790]: event_call+0xae                    784cc6721c8e     7ffcee9d0820 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core bgpd[898790]: main+0x3e3                         59b8e8afd213     7ffcee9d0a70 /usr/lib/frr/bgpd (mapped at 0x59b8e8a10000)
Mar 09 22:16:42 core BGP[898790]: frr_run+0xc8                       784cc66c2018     7ffcee9d0950 /usr/lib/frr/libfrr.so.0 (mapped at 0x784cc6600000)
Mar 09 22:16:42 core bgpd[898790]: __libc_init_first+0x8a             784cc622a1ca     7ffcee9d0b00 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: main+0x3e3                         59b8e8afd213     7ffcee9d0a70 /usr/lib/frr/bgpd (mapped at 0x59b8e8a10000)
Mar 09 22:16:42 core bgpd[898790]: __libc_start_main+0x8b             784cc622a28b     7ffcee9d0ba0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core BGP[898790]: __libc_init_first+0x8a             784cc622a1ca     7ffcee9d0b00 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: _start+0x25                        59b8e8b00345     7ffcee9d0c00 /usr/lib/frr/bgpd (mapped at 0x59b8e8a10000)
Mar 09 22:16:42 core BGP[898790]: __libc_start_main+0x8b             784cc622a28b     7ffcee9d0ba0 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x784cc6200000)
Mar 09 22:16:42 core bgpd[898790]: in thread bgp_start_label_manager scheduled from bgpd/bgp_zebra.c:4190 bgp_zebra_init()
Mar 09 22:16:42 core BGP[898790]: _start+0x25                        59b8e8b00345     7ffcee9d0c00 /usr/lib/frr/bgpd (mapped at 0x59b8e8a10000)
Mar 09 22:16:42 core BGP[898790]: in thread bgp_start_label_manager scheduled from bgpd/bgp_zebra.c:4190 bgp_zebra_init()
```

Signed-off-by: Nick Bouliane <nbouliane@coreweave.com>