### PR TITLE
bgpd: Support established and failed options for show bgp neighbor co…

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -15659,8 +15659,10 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 	struct peer_af *paf;
 	const char *afi_safi = NULL;
 	uint32_t peer_pcount = 0, peer_scount = 0;
-	bool show_brief = CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_BRIEF_INFO);
 	bool is_first_afi_safi = true;
+	bool show_brief = ((CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_STATE_ESTABLISHED_INFO) ||
+			    CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_STATE_FAILED_INFO) ||
+			    CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_BRIEF_INFO)));
 
 	bgp = p->bgp;
 
@@ -17543,6 +17545,29 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 	}
 }
 
+static bool match_peer_state(struct peer *bpeer, uint32_t sh_flags)
+{
+	bool show_estab = CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_STATE_ESTABLISHED_INFO);
+	bool show_not_estab = CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_STATE_FAILED_INFO);
+
+	/* show flags for bgp state is not enabled */
+	if (!(show_estab || show_not_estab))
+		return true;
+	/* show flag for bgp state established is enabled and
+	 * bgp state is established
+	 */
+	else if (show_estab && bpeer->connection && peer_established(bpeer->connection))
+		return true;
+	/* show flag for bgp state failed (not-established)
+	 * is enabled and bgp state is not established
+	 */
+	else if (show_not_estab && bpeer->connection && !peer_established(bpeer->connection))
+		return true;
+
+	/* peer state does not match with show flag */
+	return false;
+}
+
 static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp, enum show_type type,
 			     union sockunion *su, const char *conf_if, uint16_t sh_flags,
 			     bool use_json, json_object *json)
@@ -17550,11 +17575,14 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp, enum show_type ty
 	struct listnode *node, *nnode;
 	struct peer *peer;
 	int find = 0;
+	bool peer_wrong_state = false;
 	bool nbr_output = false;
 	afi_t afi = AFI_MAX;
 	safi_t safi = SAFI_MAX;
 	bool is_first = true;
-	bool show_brief = CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_BRIEF_INFO);
+	bool show_brief = ((CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_STATE_ESTABLISHED_INFO) ||
+			    CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_STATE_FAILED_INFO) ||
+			    CHECK_FLAG(sh_flags, VTY_BGP_PEER_SHOW_BRIEF_INFO)));
 
 	if (type == show_ipv4_peer || type == show_ipv4_all) {
 		afi = AFI_IP;
@@ -17564,6 +17592,9 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp, enum show_type ty
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 		if (!peer_is_config_node(peer))
+			continue;
+		else if ((type == show_all || type == show_ipv4_all || type == show_ipv6_all) &&
+			 !match_peer_state(peer, sh_flags))
 			continue;
 		else if (show_brief && is_first && !use_json) {
 			vty_out(vty, BGP_SHOW_NEIGHBORS_BRIEF_HEADER);
@@ -17576,47 +17607,53 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp, enum show_type ty
 			break;
 		case show_peer:
 			if (conf_if) {
-				if ((peer->conf_if
-				     && !strcmp(peer->conf_if, conf_if))
-				    || (peer->hostname
-					&& !strcmp(peer->hostname, conf_if))) {
+				if ((peer->conf_if && strmatch(peer->conf_if, conf_if)) ||
+				    (peer->hostname && strmatch(peer->hostname, conf_if))) {
+					if (!match_peer_state(peer, sh_flags)) {
+						peer_wrong_state = true;
+						break;
+					}
 					find = 1;
 					bgp_show_peer(vty, peer, sh_flags, use_json, json);
 				}
 			} else {
 				if (sockunion_same(&peer->connection->su, su)) {
+					if (!match_peer_state(peer, sh_flags)) {
+						peer_wrong_state = true;
+						break;
+					}
 					find = 1;
 					bgp_show_peer(vty, peer, sh_flags, use_json, json);
 				}
 			}
 			break;
 		case show_ipv4_peer:
-		case show_ipv6_peer:
+		case show_ipv6_peer: {
+			bool matched = false;
+
 			FOREACH_SAFI (safi) {
-				if (peer->afc[afi][safi]) {
-					if (conf_if) {
-						if ((peer->conf_if
-						     && !strcmp(peer->conf_if, conf_if))
-						    || (peer->hostname
-							&& !strcmp(peer->hostname, conf_if))) {
-							find = 1;
-							bgp_show_peer(vty, peer, sh_flags,
-								      use_json, json);
-							break;
-						}
-					} else {
-						if (sockunion_same(&peer->connection
-									    ->su,
-								   su)) {
-							find = 1;
-							bgp_show_peer(vty, peer, sh_flags,
-								      use_json, json);
-							break;
-						}
+				if (!peer->afc[afi][safi])
+					continue;
+				if (conf_if) {
+					matched = (peer->conf_if &&
+						   strmatch(peer->conf_if, conf_if)) ||
+						  (peer->hostname &&
+						   strmatch(peer->hostname, conf_if));
+				} else {
+					matched = sockunion_same(&peer->connection->su, su);
+				}
+				if (matched) {
+					if (!match_peer_state(peer, sh_flags)) {
+						peer_wrong_state = true;
+						break;
 					}
+					find = 1;
+					bgp_show_peer(vty, peer, sh_flags, use_json, json);
+					break;
 				}
 			}
 			break;
+		}
 		case show_ipv4_all:
 		case show_ipv6_all:
 			FOREACH_SAFI (safi) {
@@ -17632,10 +17669,18 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp, enum show_type ty
 
 	if ((type == show_peer || type == show_ipv4_peer ||
 	     type == show_ipv6_peer) && !find) {
-		if (use_json)
-			json_object_boolean_true_add(json, "bgpNoSuchNeighbor");
-		else
-			vty_out(vty, "%% No such neighbor in this view/vrf\n");
+		if (peer_wrong_state) {
+			if (use_json)
+				json_object_boolean_true_add(json,
+							     "bgpNeighborNotInRequestedState");
+			else
+				vty_out(vty, "%% Neighbor is not in the requested state\n");
+		} else {
+			if (use_json)
+				json_object_boolean_true_add(json, "bgpNoSuchNeighbor");
+			else
+				vty_out(vty, "%% No such neighbor in this view/vrf\n");
+		}
 	}
 
 	if (type != show_peer && type != show_ipv4_peer &&
@@ -17797,22 +17842,25 @@ static int bgp_show_neighbor_vty(struct vty *vty, const char *name, enum show_ty
 }
 
 /* "show [ip] bgp neighbors" commands.  */
-DEFUN(show_ip_bgp_neighbors, show_ip_bgp_neighbors_cmd,
-      "show [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6>] neighbors [<A.B.C.D|X:X::X:X|WORD>] [brief|graceful-restart] [json]",
+DEFPY(show_ip_bgp_neighbors, show_ip_bgp_neighbors_cmd,
+      "show [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6>] neighbors [<A.B.C.D|X:X::X:X|WORD>] [graceful-restart] [json$uj [brief$brief [established|failed]]]",
       SHOW_STR IP_STR BGP_STR BGP_INSTANCE_HELP_STR BGP_AF_STR BGP_AF_STR
       "Detailed information on TCP and BGP neighbor connections\n"
       "Neighbor to display information about\n"
       "Neighbor to display information about\n"
       "Neighbor on BGP configured interface\n"
-      "Brief information on BGP neighbors\n"
-      "Neighbor graceful restart information\n" JSON_STR)
+      "Neighbor graceful restart information\n"
+      JSON_STR
+      "Brief information on BGP neighbors (JSON output)\n"
+      "Display only neighbors in Established state\n"
+      "Display only neighbors not in Established state\n")
 {
 	char *vrf = NULL;
 	char *sh_arg = NULL;
 	enum show_type sh_type;
 	afi_t afi = AFI_MAX;
 
-	bool uj = use_json(argc, argv);
+	bool use_json = !!uj;
 	int idx = 0;
 	int gr_idx = 0;
 	bool show_gr = false;
@@ -17865,10 +17913,15 @@ DEFUN(show_ip_bgp_neighbors, show_ip_bgp_neighbors_cmd,
 
 	if (show_gr)
 		peer_show_flags |= VTY_BGP_PEER_SHOW_GR_INFO;
-	else if (argv_find(argv, argc, "brief", &idx))
+	else if (use_json && brief) {
 		SET_FLAG(peer_show_flags, VTY_BGP_PEER_SHOW_BRIEF_INFO);
+		if (argv_find(argv, argc, "established", &idx))
+			SET_FLAG(peer_show_flags, VTY_BGP_PEER_SHOW_STATE_ESTABLISHED_INFO);
+		else if (argv_find(argv, argc, "failed", &idx))
+			SET_FLAG(peer_show_flags, VTY_BGP_PEER_SHOW_STATE_FAILED_INFO);
+	}
 
-	return bgp_show_neighbor_vty(vty, vrf, sh_type, sh_arg, peer_show_flags, uj);
+	return bgp_show_neighbor_vty(vty, vrf, sh_type, sh_arg, peer_show_flags, use_json);
 }
 
 /* Show BGP's AS paths internal data.  There are both `show [ip] bgp

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -148,6 +148,10 @@ extern void bgp_clear_soft_in(struct bgp *bgp, afi_t afi, safi_t safi);
 #define VTY_BGP_PEER_SHOW_GR_INFO (1 << 0)
 /* Value of 2 means - show brief info for neighbors */
 #define VTY_BGP_PEER_SHOW_BRIEF_INFO (1 << 1)
+/* Value of 4 means - list brief info for established neighbors */
+#define VTY_BGP_PEER_SHOW_STATE_ESTABLISHED_INFO (1 << 2)
+/* Value of 8 means - list brief info for not-established neighbors */
+#define VTY_BGP_PEER_SHOW_STATE_FAILED_INFO (1 << 3)
 
 #define BGP_ALLOWAS_IN_DEFAULT 3
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1166,14 +1166,24 @@ BGP GR Show Commands
 BGP Show Neighbors Brief Command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. clicmd:: show [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6>] neighbors [<A.B.C.D|X:X::X:X|WORD>] [brief] [json]
+.. clicmd:: show [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6>] neighbors [<A.B.C.D|X:X::X:X|WORD>] [graceful-restart] [json [brief [established|failed]]]
 
-   Display BGP neighbor information. When the ``brief`` option is included, output
-   is shortened to one line per neighbor (text) or a reduced JSON structure
-   (hostname, remoteAs, localAs, lastResetDueTo, status, lastResetTimerMsecs,
-   messageStats with totalSent/totalRecv, and addressFamilyInfo with
-   acceptedPrefixCounter/sentPrefixCounter per AFI/SAFI). Optional ``json``
-   formats the output as JSON.
+   Display BGP neighbor information. Without ``json``, output is the usual
+   detailed text. With ``json``, output is full neighbor detail in JSON.
+
+   The ``brief`` keyword is only valid together with ``json``. Use ``json brief``
+   for a reduced JSON object per neighbor (hostname, remoteAs, localAs,
+   lastResetDueTo, status, lastResetTimerMsecs, messageStats with
+   totalSent/totalRecv, and addressFamilyInfo with acceptedPrefixCounter and
+   sentPrefixCounter per AFI/SAFI).
+
+   After ``json brief``, you may add ``established`` to include only neighbors in
+   Established state, or ``failed`` for neighbors not in Established (for
+   example Idle, Active, Connect).
+
+   ``graceful-restart`` shows graceful-restart-related neighbor information; it
+   may be combined with ``json`` as in the command grammar above. See also
+   :clicmd:`show bgp [<ipv4|ipv6>] [<view|vrf> VRF] neighbors [<A.B.C.D|X:X::X:X|WORD>] graceful-restart [json]`.
 
 Long-lived Graceful Restart
 ---------------------------

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -176,7 +176,7 @@ def test_bgp_convergence():
 
 
 def test_bgp_neighbors_brief():
-    "Test 'show bgp neighbors [<ip>] brief' and 'show bgp neighbors [<ip>] brief json'"
+    "Test 'show bgp neighbors [<ip>] json brief' (brief is only valid with json)"
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
@@ -185,20 +185,11 @@ def test_bgp_neighbors_brief():
     neighbor_ip = "192.168.0.2"
     neighbor_ip2 = "192.168.101.2"
 
-    def _check_brief_text(out, expect_neighbors):
-        assert "Neighbor" in out and "AS " in out, "brief text missing header"
-        assert (
-            "MsgRcvd" in out and "MsgSent" in out
-        ), "brief text missing MsgRcvd/MsgSent"
-        assert (
-            "ResetTime" in out and "State " in out
-        ), "brief text missing ResetTime/State"
-        assert (
-            "Afi/Safi" in out and "PfxRcd" in out and "PfxSnt" in out
-        ), "brief text missing Afi/Safi or PfxRcd/PfxSnt"
-        for n in expect_neighbors:
-            assert n in out, f"brief text missing neighbor {n}"
-        assert "Established" in out or "IPv4" in out, "brief text missing State or AFI"
+    # Text output remains the full neighbor display (no 'brief' keyword).
+    logger.info(f"Checking 'show bgp neighbors {neighbor_ip}' text output")
+    out = r1.vtysh_cmd(f"show bgp neighbors {neighbor_ip}")
+    assert neighbor_ip in out, "full text output missing neighbor address"
+    assert "BGP neighbor" in out, "full text output missing BGP neighbor header"
 
     def _check_brief_json_nbr(nbr):
         assert "hostname" in nbr, "brief json missing hostname"
@@ -220,31 +211,124 @@ def test_bgp_neighbors_brief():
                 "sentPrefixCounter" in afi_obj
             ), "brief json AF entry missing sentPrefixCounter"
 
-    # 1. Single neighbor text: show bgp neighbors <ip> brief
-    logger.info(f"Checking 'show bgp neighbors {neighbor_ip} brief' text output")
-    out = r1.vtysh_cmd(f"show bgp neighbors {neighbor_ip} brief")
-    _check_brief_text(out, [neighbor_ip])
-    assert "65000" in out, "brief text missing AS 65000"
-
-    # 2. All neighbors text: show bgp neighbors brief
-    logger.info(f"Checking 'show bgp neighbors brief' text output (all neighbors)")
-    out_all = r1.vtysh_cmd("show bgp neighbors brief")
-    _check_brief_text(out_all, [neighbor_ip, neighbor_ip2])
-
-    # 3. Single neighbor JSON: show bgp neighbors <ip> brief json
-    logger.info(f"Checking 'show bgp neighbors {neighbor_ip} brief json' structure")
-    out_json = r1.vtysh_cmd(f"show bgp neighbors {neighbor_ip} brief json", isjson=True)
+    # 1. Single neighbor JSON: show bgp neighbors <ip> json brief
+    logger.info(f"Checking 'show bgp neighbors {neighbor_ip} json brief' structure")
+    out_json = r1.vtysh_cmd(f"show bgp neighbors {neighbor_ip} json brief", isjson=True)
     assert neighbor_ip in out_json, "brief json missing neighbor key"
     _check_brief_json_nbr(out_json[neighbor_ip])
 
-    # 4. All neighbors JSON: show bgp neighbors brief json
-    logger.info(f"Checking 'show bgp neighbors brief json' structure (all neighbors)")
-    out_json_all = r1.vtysh_cmd("show bgp neighbors brief json", isjson=True)
+    # 2. All neighbors JSON: show bgp neighbors json brief
+    logger.info("Checking 'show bgp neighbors json brief' structure (all neighbors)")
+    out_json_all = r1.vtysh_cmd("show bgp neighbors json brief", isjson=True)
     assert (
         neighbor_ip in out_json_all and neighbor_ip2 in out_json_all
     ), "brief json (all) missing expected neighbor keys"
     _check_brief_json_nbr(out_json_all[neighbor_ip])
     _check_brief_json_nbr(out_json_all[neighbor_ip2])
+
+
+def test_bgp_neighbors_established_failed():
+    "Test 'show bgp neighbors json brief established' and 'json brief failed'"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    neighbor_est = "192.168.0.2"
+    neighbor_fail = "192.168.101.2"
+
+    def _check_brief_json_nbr(nbr):
+        assert "hostname" in nbr, "brief json missing hostname"
+        assert "remoteAs" in nbr, "brief json missing remoteAs"
+        assert "localAs" in nbr, "brief json missing localAs"
+        assert "messageStats" in nbr, "brief json missing messageStats"
+        assert "addressFamilyInfo" in nbr, "brief json missing addressFamilyInfo"
+
+    # --- All peers up: established = both, failed = none ---
+    logger.info("Checking 'show bgp neighbors json brief established' (all peers up)")
+    json_est = r1.vtysh_cmd("show bgp neighbors json brief established", isjson=True)
+    assert (
+        neighbor_est in json_est and neighbor_fail in json_est
+    ), "established json should contain both neighbors when all up"
+    _check_brief_json_nbr(json_est[neighbor_est])
+    _check_brief_json_nbr(json_est[neighbor_fail])
+
+    logger.info(
+        "Checking 'show bgp neighbors json brief failed' (all peers up -> empty)"
+    )
+    json_fail = r1.vtysh_cmd("show bgp neighbors json brief failed", isjson=True)
+    assert (
+        neighbor_est not in json_fail and neighbor_fail not in json_fail
+    ), "failed json should have no neighbors when all are established"
+
+    # --- Shut one peer so we have one established, one failed ---
+    logger.info(
+        f"Shutting down neighbor {neighbor_fail} on r1 to test established/failed"
+    )
+    tgen.net["r1"].cmd(
+        f'vtysh -c "conf t" -c "router bgp 65000" '
+        f'-c "neighbor {neighbor_fail} shutdown"'
+    )
+    tgen.net["r4"].cmd(
+        'vtysh -c "conf t" -c "router bgp 65100" '
+        '-c "neighbor 192.168.101.1 shutdown"'
+    )
+
+    # Wait for peer to leave Established
+    for _ in range(30):
+        out_sum = r1.vtysh_cmd("show ip bgp summary json", isjson=True)
+        peers = {}
+        for key in out_sum:
+            if isinstance(out_sum[key], dict) and "peers" in out_sum[key]:
+                peers.update(out_sum[key]["peers"])
+        if neighbor_fail in peers:
+            state = peers[neighbor_fail].get("state", "") or peers[neighbor_fail].get(
+                "stateStr", ""
+            )
+            if str(state).lower() != "established":
+                break
+        time.sleep(1)
+    else:
+        assert (
+            False
+        ), f"neighbor {neighbor_fail} did not leave Established state after shutdown"
+
+    # --- established: only 192.168.0.2; failed: only 192.168.101.2 ---
+    logger.info("Checking 'show bgp neighbors json brief established' (one peer down)")
+    json_est = r1.vtysh_cmd("show bgp neighbors json brief established", isjson=True)
+    assert neighbor_est in json_est, f"established json should contain {neighbor_est}"
+    assert (
+        neighbor_fail not in json_est
+    ), "established json should not contain shut peer"
+    _check_brief_json_nbr(json_est[neighbor_est])
+
+    logger.info("Checking 'show bgp neighbors json brief failed' (one peer down)")
+    json_fail = r1.vtysh_cmd("show bgp neighbors json brief failed", isjson=True)
+    assert neighbor_fail in json_fail, "failed json should contain shut peer"
+    assert (
+        neighbor_est not in json_fail
+    ), "failed json should not contain established peer"
+    _check_brief_json_nbr(json_fail[neighbor_fail])
+
+    # --- Restore neighbor ---
+    logger.info(f"Restoring neighbor {neighbor_fail} on r1")
+    tgen.net["r1"].cmd(
+        f'vtysh -c "conf t" -c "router bgp 65000" '
+        f'-c "no neighbor {neighbor_fail} shutdown"'
+    )
+    tgen.net["r4"].cmd(
+        'vtysh -c "conf t" -c "router bgp 65100" '
+        '-c "no neighbor 192.168.101.1 shutdown"'
+    )
+
+    # Wait for reconvergence
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        r1,
+        "show ip bgp summary json",
+        json.loads(open(os.path.join(CWD, "r1/bgp_summary.json")).read()),
+    )
+    topotest.run_and_expect(test_func, None, count=60, wait=2)
 
 
 def get_shut_msg_count(tgen):


### PR DESCRIPTION
r1# show bgp neighbors json brief established 
{
  "192.168.0.2":{
    "hostname":"r2",
    "remoteAs":65000,
    "localAs":65000,
    "lastResetDueTo":"No path to specified Neighbor",
    "bgpState":"Established",
    "bgpTimerUpMsec":23000,
    "bgpTimerUpString":"00:00:23",
    "bgpTimerUpEstablishedEpoch":1775637487,
    "lastResetTimerMsecs":33000,
    "messageStats":{
      "totalSent":14,
      "totalRecv":14
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":7,
        "sentPrefixCounter":8
      }
    }
  },
  "192.168.101.2":{
    "hostname":"r4",
    "remoteAs":65100,
    "localAs":65000,
    "lastResetDueTo":"No path to specified Neighbor",
    "bgpState":"Established",
    "bgpTimerUpMsec":32000,
    "bgpTimerUpString":"00:00:32",
    "bgpTimerUpEstablishedEpoch":1775637478,
    "lastResetTimerMsecs":33000,
    "messageStats":{
      "totalSent":26,
      "totalRecv":28
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":3,
        "sentPrefixCounter":9
      }
    }
  }
}
r1# show bgp neighbors 192.168.0.2 json brief 
{
  "192.168.0.2":{
    "hostname":"r2",
    "remoteAs":65000,
    "localAs":65000,
    "lastResetDueTo":"No path to specified Neighbor",
    "bgpState":"Established",
    "bgpTimerUpMsec":106000,
    "bgpTimerUpString":"00:01:46",
    "bgpTimerUpEstablishedEpoch":1775637487,
    "lastResetTimerMsecs":116000,
    "messageStats":{
      "totalSent":42,
      "totalRecv":42
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":7,
        "sentPrefixCounter":8
      }
    }
  }
}
r1# show bgp neighbors 192.168.0.2 json brief established 
{
  "192.168.0.2":{
    "hostname":"r2",
    "remoteAs":65000,
    "localAs":65000,
    "lastResetDueTo":"No path to specified Neighbor",
    "bgpState":"Established",
    "bgpTimerUpMsec":110000,
    "bgpTimerUpString":"00:01:50",
    "bgpTimerUpEstablishedEpoch":1775637487,
    "lastResetTimerMsecs":120000,
    "messageStats":{
      "totalSent":43,
      "totalRecv":43
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":7,
        "sentPrefixCounter":8
      }
    }
  }
}
r1# 
r1# con t
r1(config)# router bgp 65000
r1(config-router)# neighbor 192.168.101.2 shutdown
r1(config-router)# end
r1# show bgp neighbors json brief established 
{
  "192.168.0.2":{
    "hostname":"r2",
    "remoteAs":65000,
    "localAs":65000,
    "lastResetDueTo":"No path to specified Neighbor",
    "bgpState":"Established",
    "bgpTimerUpMsec":172000,
    "bgpTimerUpString":"00:02:52",
    "bgpTimerUpEstablishedEpoch":1775637487,
    "lastResetTimerMsecs":182000,
    "messageStats":{
      "totalSent":65,
      "totalRecv":64
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":7,
        "sentPrefixCounter":5
      }
    }
  }
}
r1# show bgp neighbors json brief failed 
{
  "192.168.101.2":{
    "hostname":"r4",
    "remoteAs":65100,
    "localAs":65000,
    "lastResetDueTo":"Admin. shutdown",
    "bgpState":"Idle",
    "lastResetTimerMsecs":67000,
    "messageStats":{
      "totalSent":68,
      "totalRecv":69
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":0,
        "sentPrefixCounter":0
      }
    }
  }
}
r1# show bgp neighbors json brief 
{
  "192.168.0.2":{
    "hostname":"r2",
    "remoteAs":65000,
    "localAs":65000,
    "lastResetDueTo":"No path to specified Neighbor",
    "bgpState":"Established",
    "bgpTimerUpMsec":223000,
    "bgpTimerUpString":"00:03:43",
    "bgpTimerUpEstablishedEpoch":1775637487,
    "lastResetTimerMsecs":233000,
    "messageStats":{
      "totalSent":82,
      "totalRecv":81
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":7,
        "sentPrefixCounter":5
      }
    }
  },
  "192.168.101.2":{
    "hostname":"r4",
    "remoteAs":65100,
    "localAs":65000,
    "lastResetDueTo":"Admin. shutdown",
    "bgpState":"Idle",
    "lastResetTimerMsecs":78000,
    "messageStats":{
      "totalSent":68,
      "totalRecv":69
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":0,
        "sentPrefixCounter":0
      }
    }
  }
}
r1# 