### PR TITLE
Move import table around

### DIFF
--- a/tests/topotests/zebra_rib/test_zebra_import.py
+++ b/tests/topotests/zebra_rib/test_zebra_import.py
@@ -17,7 +17,7 @@ import platform
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, get_topogen
+from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step, write_test_header
 
@@ -42,6 +42,106 @@ sys.path.append(os.path.join(CWD, "../"))
 pytestmark = [pytest.mark.sharpd]
 krel = platform.release()
 
+
+def _route_missing(route_output, prefix):
+    return prefix not in route_output or route_output[prefix] is None
+
+
+def _check_route_present_in_table_only(router, prefix, table_id):
+    source_output = json.loads(
+        router.vtysh_cmd(f"show ip route table {table_id} {prefix} json")
+    )
+    if _route_missing(source_output, prefix):
+        return (
+            f"Route {prefix} is missing from source table {table_id}: {source_output}"
+        )
+
+    imported_output = json.loads(router.vtysh_cmd(f"show ip route {prefix} json"))
+    if not _route_missing(imported_output, prefix):
+        return f"Route {prefix} was imported unexpectedly: {imported_output}"
+
+    return None
+
+
+def _check_imported_route_nexthop(router, prefix, nexthop_ip, ifname, distance):
+    output = json.loads(router.vtysh_cmd(f"show ip route {prefix} json"))
+    if _route_missing(output, prefix):
+        return f"Route {prefix} is missing from imported table: {output}"
+
+    routes = output[prefix]
+    if len(routes) != 1:
+        return f"Route {prefix} should have exactly one path: {output}"
+
+    route = routes[0]
+    if route.get("protocol") != "table" or route.get("instance") != 10:
+        return f"Route {prefix} is not the imported table route: {output}"
+    if not route.get("installed") or route.get("distance") != distance:
+        return f"Route {prefix} has unexpected install state or distance: {output}"
+
+    nexthops = route.get("nexthops", [])
+    if len(nexthops) != 1:
+        return f"Route {prefix} should have exactly one nexthop: {output}"
+
+    nexthop = nexthops[0]
+    if (
+        nexthop.get("ip") != nexthop_ip
+        or nexthop.get("interfaceName") != ifname
+        or not nexthop.get("active")
+        or not nexthop.get("fib")
+    ):
+        return f"Route {prefix} has unexpected nexthop state: {output}"
+
+    return None
+
+
+def _check_source_route_nexthop(router, prefix, table_id, protocol, nexthop_ip, ifname):
+    output = json.loads(
+        router.vtysh_cmd(f"show ip route table {table_id} {prefix} json")
+    )
+    if _route_missing(output, prefix):
+        return f"Route {prefix} is missing from source table {table_id}: {output}"
+
+    for route in output[prefix]:
+        if route.get("protocol") != protocol:
+            continue
+
+        nexthops = route.get("nexthops", [])
+        if len(nexthops) != 1:
+            return f"Route {prefix} should have exactly one nexthop: {output}"
+
+        nexthop = nexthops[0]
+        if (
+            route.get("installed")
+            and route.get("selected")
+            and route.get("destSelected")
+            and nexthop.get("ip") == nexthop_ip
+            and nexthop.get("interfaceName") == ifname
+            and nexthop.get("active")
+            and nexthop.get("fib")
+        ):
+            return None
+
+    return f"Route {prefix} is not selected via {protocol} {nexthop_ip}: {output}"
+
+
+def _cleanup_added_import_test_routes(router):
+    router.run(
+        "vtysh -c 'sharp remove routes 10.21.0.0 1 table 10' >/dev/null 2>&1 || true"
+    )
+    router.run(
+        "vtysh -c 'sharp remove routes 10.50.50.50 1 table 10' >/dev/null 2>&1 || true"
+    )
+    router.run(
+        "ip route del table 10 10.22.0.0/24 via 10.10.0.2 dev r1-eth1 >/dev/null 2>&1 || true"
+    )
+    router.run(
+        "ip route del table 10 10.22.0.0/24 via 10.0.0.2 dev r1-eth0 >/dev/null 2>&1 || true"
+    )
+    router.run(
+        "ip route del table 10 10.50.50.50/32 via 10.0.0.2 dev r1-eth0 >/dev/null 2>&1 || true"
+    )
+
+
 def build_topo(tgen):
     "Build function"
 
@@ -50,6 +150,7 @@ def build_topo(tgen):
     sw2 = tgen.add_switch("sw2")
     sw1.add_link(tgen.gears["r1"], "r1-eth0")
     sw2.add_link(tgen.gears["r1"], "r1-eth1")
+
 
 def setup_module(mod):
     "Sets up the pytest environment"
@@ -60,7 +161,14 @@ def setup_module(mod):
     router_list = tgen.routers()
     for rname, router in router_list.items():
         logger.info("Loading router %s" % rname)
-        router.load_frr_config(os.path.join(CWD, "{}/frr-import.conf".format(rname)))
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr-import.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_SHARP, None),
+                (TopoRouter.RD_STATIC, None),
+            ],
+        )
 
     # Initialize all routers.
     tgen.start_router()
@@ -89,24 +197,21 @@ def test_zebra_urib_import(request):
     step("Verify initial main routing table")
     initial_json_file = "{}/r1/import_init_table.json".format(CWD)
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip route json", expected
-    )
-    _, result = topotest.run_and_expect(test_func, None)
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, '"r1" JSON output mismatches'
 
     r1.vtysh_cmd(
         """
         conf term
          ip import-table 10 
-        """)
-    
+        """
+    )
+
     import_json_file = "{}/r1/import_table_2.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip route json", expected
-    )
-    _, result = topotest.run_and_expect(test_func, None)
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, '"r1" JSON output mismatches'
 
     step("Add a new static route and verify it gets added")
@@ -119,10 +224,8 @@ def test_zebra_urib_import(request):
 
     sync_json_file = "{}/r1/import_table_3.json".format(CWD)
     expected = json.loads(open(sync_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip route json", expected
-    )
-    _, result = topotest.run_and_expect(test_func, None)
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, '"r1" JSON output mismatches'
 
     step("Remove the static route and verify it gets removed")
@@ -134,9 +237,7 @@ def test_zebra_urib_import(request):
     )
 
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -149,9 +250,7 @@ def test_zebra_urib_import(request):
     )
 
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -160,15 +259,113 @@ def test_zebra_urib_import(request):
         """
         conf term
          ip import-table 10 distance 123
-        """)
-    
+        """
+    )
+
     import_json_file = "{}/r1/import_table_4.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    step("Add a sharp route that fails installation and verify it is not imported")
+    failed_prefix_start = "10.21.0.0"
+    failed_prefix = "10.21.0.0/32"
+    r1.vtysh_cmd(
+        f"sharp install routes {failed_prefix_start} nexthop 192.0.2.1 1 table 10"
+    )
+
+    test_func = partial(_check_route_present_in_table_only, r1, failed_prefix, 10)
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    r1.vtysh_cmd(f"sharp remove routes {failed_prefix_start} 1 table 10")
+
+    step("Replace an installed source-table route and verify imported nexthop updates")
+    replace_prefix = "10.22.0.0/24"
+    r1.run(f"ip route add table 10 {replace_prefix} via 10.10.0.2 dev r1-eth1")
+
+    test_func = partial(
+        _check_imported_route_nexthop, r1, replace_prefix, "10.10.0.2", "r1-eth1", 123
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    r1.run(f"ip route replace table 10 {replace_prefix} via 10.0.0.2 dev r1-eth0")
+
+    test_func = partial(
+        _check_imported_route_nexthop, r1, replace_prefix, "10.0.0.2", "r1-eth0", 123
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    r1.run(f"ip route del table 10 {replace_prefix} via 10.0.0.2 dev r1-eth0")
+
+
+def test_zebra_static_route_preferred_over_sharp_import(request):
+    "Verify a static route remains the imported winner when sharp adds the same prefix"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    _cleanup_added_import_test_routes(r1)
+
+    prefix = "10.50.50.50/32"
+    prefix_start = "10.50.50.50"
+
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip import-table 10 distance 123
+        """
+    )
+
+    step("Install a static route into table 10")
+    r1.vtysh_cmd(
+        f"""
+        conf term
+         ip route {prefix} 10.0.0.2 table 10
+        """
+    )
+
+    step(
+        "Verify the static route is installed in table 10 and imported into the main table"
+    )
+    test_func = partial(
+        _check_source_route_nexthop, r1, prefix, 10, "static", "10.0.0.2", "r1-eth0"
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    test_func = partial(
+        _check_imported_route_nexthop, r1, prefix, "10.0.0.2", "r1-eth0", 123
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    step("Install a sharp route for the same prefix into table 10")
+    r1.vtysh_cmd(f"sharp install routes {prefix_start} nexthop 10.0.0.3 1 table 10")
+
+    step("Verify the static route still wins in table 10")
+    test_func = partial(
+        _check_source_route_nexthop, r1, prefix, 10, "static", "10.0.0.2", "r1-eth0"
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    step("Verify the imported main-table route still uses the static nexthop")
+    test_func = partial(
+        _check_imported_route_nexthop, r1, prefix, "10.0.0.2", "r1-eth0", 123
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+    _cleanup_added_import_test_routes(r1)
+
 
 def test_zebra_mrib_import(request):
     "Verify router starts with the initial MRIB"
@@ -180,13 +377,12 @@ def test_zebra_mrib_import(request):
         pytest.skip(tgen.errors)
 
     r1 = tgen.gears["r1"]
+    _cleanup_added_import_test_routes(r1)
 
     step("Verify initial main MRIB routing table")
     initial_json_file = "{}/r1/import_init_mrib_table.json".format(CWD)
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -194,13 +390,12 @@ def test_zebra_mrib_import(request):
         """
         conf term
          ip import-table 10 mrib
-        """)
-    
+        """
+    )
+
     import_json_file = "{}/r1/import_mrib_table_2.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -214,9 +409,7 @@ def test_zebra_mrib_import(request):
 
     sync_json_file = "{}/r1/import_mrib_table_3.json".format(CWD)
     expected = json.loads(open(sync_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -229,9 +422,7 @@ def test_zebra_mrib_import(request):
     )
 
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -244,9 +435,7 @@ def test_zebra_mrib_import(request):
     )
 
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -255,13 +444,12 @@ def test_zebra_mrib_import(request):
         """
         conf term
          ip import-table 10 mrib distance 123
-        """)
-    
+        """
+    )
+
     import_json_file = "{}/r1/import_mrib_table_4.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -743,6 +743,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct rou
 	struct nexthop_group *ng;
 	route_map_result_t ret = RMAP_PERMITMATCH;
 	afi_t afi;
+	uint32_t import_flags;
 
 	afi = family2afi(rn->p.family);
 	if (rmap_name)
@@ -751,7 +752,6 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct rou
 							 rmap_name);
 
 	if (ret != RMAP_PERMITMATCH) {
-		UNSET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);
 		zebra_del_import_table_entry(zvrf, safi, rn, re);
 		return 0;
 	}
@@ -769,15 +769,15 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct rou
 			break;
 	}
 
-	if (same) {
-		UNSET_FLAG(same->flags, ZEBRA_FLAG_SELECTED);
+	if (same)
 		zebra_del_import_table_entry(zvrf, safi, rn, same);
-	}
 
-	UNSET_FLAG(re->flags, ZEBRA_FLAG_RR_USE_DISTANCE);
+	import_flags = re->flags;
+	UNSET_FLAG(import_flags, ZEBRA_FLAG_SELECTED);
+	UNSET_FLAG(import_flags, ZEBRA_FLAG_RR_USE_DISTANCE);
 
-	newre = zebra_rib_route_entry_new(0, ZEBRA_ROUTE_TABLE, re->table, re->flags, re->nhe_id,
-					  zvrf->table_id, re->metric, re->mtu,
+	newre = zebra_rib_route_entry_new(0, ZEBRA_ROUTE_TABLE, re->table, import_flags,
+					  re->nhe_id, zvrf->table_id, re->metric, re->mtu,
 					  zebra_import_table_distance[afi][safi][re->table],
 					  re->tag);
 
@@ -923,8 +923,7 @@ static void zebra_import_table_rm_update_vrf_afi(struct zebra_vrf *zvrf, afi_t a
 	if ((!rmap_name) || (strcmp(rmap_name, rmap) != 0))
 		return;
 
-	table = zebra_vrf_get_table_with_table_id(afi, safi,
-						  zvrf->vrf->vrf_id, table_id);
+	table = zebra_vrf_get_table_with_table_id(afi, safi, zvrf->vrf->vrf_id, table_id);
 	if (!table) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 			zlog_debug("%s: Table id=%d not found for VRF %s(%u)", __func__, table_id,

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -714,6 +714,26 @@ void zebra_interface_vrf_update_add(struct interface *ifp, vrf_id_t old_vrf_id)
 	}
 }
 
+static struct route_entry *zebra_import_table_selected_route(struct route_node *rn)
+{
+	rib_dest_t *dest;
+	struct route_entry *re;
+
+	dest = rib_dest_from_rnode(rn);
+	if (!dest)
+		return NULL;
+
+	re = dest->selected_fib;
+	if (!re)
+		return NULL;
+
+	if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED) ||
+	    !CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED))
+		return NULL;
+
+	return re;
+}
+
 int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct route_node *rn,
 				 struct route_entry *re, const char *rmap_name)
 {
@@ -840,18 +860,7 @@ int zebra_import_table(afi_t afi, safi_t safi, vrf_id_t vrf_id, uint32_t table_i
 	}
 
 	for (rn = route_top(table); rn; rn = route_next(rn)) {
-		/* For each entry in the non-default routing table,
-		 * add the entry in the main table
-		 */
-		if (!rn->info)
-			continue;
-
-		RNODE_FOREACH_RE (rn, re) {
-			if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED))
-				continue;
-			break;
-		}
-
+		re = zebra_import_table_selected_route(rn);
 		if (!re)
 			continue;
 
@@ -914,7 +923,8 @@ static void zebra_import_table_rm_update_vrf_afi(struct zebra_vrf *zvrf, afi_t a
 	if ((!rmap_name) || (strcmp(rmap_name, rmap) != 0))
 		return;
 
-	table = zebra_vrf_get_table_with_table_id(afi, safi, zvrf->vrf->vrf_id, table_id);
+	table = zebra_vrf_get_table_with_table_id(afi, safi,
+						  zvrf->vrf->vrf_id, table_id);
 	if (!table) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 			zlog_debug("%s: Table id=%d not found for VRF %s(%u)", __func__, table_id,
@@ -923,19 +933,7 @@ static void zebra_import_table_rm_update_vrf_afi(struct zebra_vrf *zvrf, afi_t a
 	}
 
 	for (rn = route_top(table); rn; rn = route_next(rn)) {
-		/*
-		 * For each entry in the non-default routing table,
-		 * add the entry in the main table
-		 */
-		if (!rn->info)
-			continue;
-
-		RNODE_FOREACH_RE (rn, re) {
-			if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED))
-				continue;
-			break;
-		}
-
+		re = zebra_import_table_selected_route(rn);
 		if (!re)
 			continue;
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1841,6 +1841,78 @@ done:
 	return rn;
 }
 
+static void rib_process_result_import_table_add(struct route_node *rn, struct route_entry *re)
+{
+	struct zebra_vrf *zvrf;
+	rib_dest_t *dest;
+	const char *rmap_name;
+	afi_t afi;
+	safi_t safi;
+
+	if (!rn || !re)
+		return;
+
+	dest = rib_dest_from_rnode(rn);
+	if (!dest || re != dest->selected_fib)
+		return;
+
+	if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED) ||
+	    !CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED))
+		return;
+
+	afi = family2afi(rn->p.family);
+	zvrf = zebra_vrf_lookup_by_id(re->vrf_id);
+	if (!zvrf)
+		return;
+
+	for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
+		if (!is_zebra_import_table_enabled(afi, safi, re->vrf_id, re->table))
+			continue;
+
+		rmap_name = zebra_get_import_table_route_map(afi, safi, re->table);
+		zebra_add_import_table_entry(zvrf, safi, rn, re, rmap_name);
+	}
+}
+
+static void rib_process_result_import_table_del(const struct zebra_dplane_ctx *ctx)
+{
+	const struct nexthop_group *nhg;
+	const struct prefix *p;
+	struct zebra_vrf *zvrf;
+	afi_t afi;
+	safi_t safi;
+	uint32_t table_id;
+	uint32_t metric;
+	uint32_t nhe_id;
+	uint32_t flags;
+	uint8_t distance;
+
+	if (!ctx)
+		return;
+
+	afi = dplane_ctx_get_afi(ctx);
+	table_id = dplane_ctx_get_table(ctx);
+	p = dplane_ctx_get_dest(ctx);
+	zvrf = zebra_vrf_lookup_by_id(dplane_ctx_get_vrf(ctx));
+	if (!p || !zvrf || afi == AFI_MAX)
+		return;
+
+	nhg = dplane_ctx_get_ng(ctx);
+	metric = dplane_ctx_get_metric(ctx);
+	distance = dplane_ctx_get_distance(ctx);
+	nhe_id = dplane_ctx_get_nhe_id(ctx);
+	flags = dplane_ctx_get_flags(ctx);
+
+	for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
+		if (!is_zebra_import_table_enabled(afi, safi, dplane_ctx_get_vrf(ctx), table_id))
+			continue;
+
+		rib_delete(afi, safi, zvrf->vrf->vrf_id, ZEBRA_ROUTE_TABLE, table_id, flags, p,
+			   NULL, nhg ? nhg->nexthop : NULL, nhe_id, zvrf->table_id, metric,
+			   distance, false);
+	}
+}
+
 
 /*
  * Route-update results processing after async dataplane update.
@@ -2011,6 +2083,8 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 				 */
 				re->nhe_installed_id = dplane_ctx_get_nhe_id(ctx);
 
+				rib_process_result_import_table_add(rn, re);
+
 				/* Redistribute if this is the selected re */
 				if (dest && re == dest->selected_fib)
 					redistribute_update(rn, re, old_re);
@@ -2077,6 +2151,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 				UNSET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
 				UNSET_FLAG(re->status, ROUTE_ENTRY_FAILED);
 			}
+			rib_process_result_import_table_del(ctx);
 			zsend_route_notify_owner_ctx(ctx, ZAPI_ROUTE_REMOVED);
 
 			if (zvrf)
@@ -3886,9 +3961,6 @@ rib_dest_t *zebra_rib_create_dest(struct route_node *rn)
 static void rib_link(struct route_node *rn, struct route_entry *re)
 {
 	rib_dest_t *dest;
-	afi_t afi;
-	safi_t safi;
-	const char *rmap_name;
 
 	assert(re && rn);
 
@@ -3901,18 +3973,6 @@ static void rib_link(struct route_node *rn, struct route_entry *re)
 	}
 
 	re_list_add_head(&dest->routes, re);
-
-	afi = (rn->p.family == AF_INET)
-		      ? AFI_IP
-		      : (rn->p.family == AF_INET6) ? AFI_IP6 : AFI_MAX;
-	for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
-		if (is_zebra_import_table_enabled(afi, safi, re->vrf_id, re->table)) {
-			struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(re->vrf_id);
-
-			rmap_name = zebra_get_import_table_route_map(afi, safi, re->table);
-			zebra_add_import_table_entry(zvrf, safi, rn, re, rmap_name);
-		}
-	}
 
 	rib_queue_add(rn);
 }
@@ -3966,9 +4026,6 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 
 void rib_delnode(struct route_node *rn, struct route_entry *re)
 {
-	afi_t afi;
-	safi_t safi;
-
 	if (IS_ZEBRA_DEBUG_RIB)
 		rnode_debug(rn, re->vrf_id, "rn %p, re %p, removing",
 			    (void *)rn, (void *)re);
@@ -3977,22 +4034,6 @@ void rib_delnode(struct route_node *rn, struct route_entry *re)
 		route_entry_dump(&rn->p, NULL, re);
 
 	SET_FLAG(re->status, ROUTE_ENTRY_REMOVED);
-
-	afi = (rn->p.family == AF_INET)
-		      ? AFI_IP
-		      : (rn->p.family == AF_INET6) ? AFI_IP6 : AFI_MAX;
-	for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
-		if (is_zebra_import_table_enabled(afi, safi, re->vrf_id, re->table)) {
-			struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(re->vrf_id);
-
-			zebra_del_import_table_entry(zvrf, safi, rn, re);
-			/* Just clean up if non main table */
-			if (IS_ZEBRA_DEBUG_RIB)
-				zlog_debug("%s %s(%u):%pRN: Freeing route rn %p, re %p (%s)",
-					   safi2str(safi), vrf_id_to_name(re->vrf_id), re->vrf_id,
-					   rn, rn, re, zebra_route_string(re->type));
-		}
-	}
 
 	rib_queue_add(rn);
 }


### PR DESCRIPTION
The import table processing is happening prior to the route actually being installed into the rib( or proof that it is installed ).  Move the import table processing until after this happens.  The main bug that can be shown is that current code if it receives an overlapping prefix that is not selected, that nexthop will be the one used in the main table.  Which is not good to do at all.