### PR TITLE
bgpd: Fix integer truncation of SRLG count when parsing SRLG TLV

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -3269,7 +3269,7 @@ static int parse_igp_metric(struct stream *s, uint16_t length, struct bgp_ls_att
  */
 static int parse_srlg(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
 {
-	uint8_t count;
+	uint16_t count;
 	int i;
 
 	if (length % 4 != 0) {

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -548,7 +548,7 @@ struct bgp_ls_attr {
 	uint32_t igp_metric;
 
 	/* Shared Risk Link Group (TLV 1096) */
-	uint8_t srlg_count;
+	uint16_t srlg_count;
 	uint32_t *srlg_values;
 
 	/* Link Name (TLV 1098) */


### PR DESCRIPTION
`count` is declared as `uint8_t` but receives `length / 4` where `length` is a `uint16_t`.  For `length >= 1024`, the division result exceeds 255, which cannot be stored in `count` since `uint8_t` holds at most 255, and the value silently truncates.  The result is then stored in `attr->srlg_count`, also `uint8_t`, which would re-truncate it.

Fix the issue by widening `count` in `parse_srlg()` and `srlg_count` in `struct bgp_ls_attr` to `uint16_t`.