### PR TITLE
bgpd: Fix integer truncation of count when parsing Route Tag TLV

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -3483,7 +3483,7 @@ static int parse_igp_flags(struct stream *s, uint16_t length, struct bgp_ls_attr
  */
 static int parse_route_tag(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
 {
-	uint8_t count;
+	uint16_t count;
 	int i;
 
 	if (length % 4 != 0) {

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -583,7 +583,7 @@ struct bgp_ls_attr {
 	uint8_t igp_flags;
 
 	/* Route Tags (TLV 1153) */
-	uint8_t route_tag_count;
+	uint16_t route_tag_count;
 	uint32_t *route_tags;
 
 	/* Extended Tags (TLV 1154) */


### PR DESCRIPTION
`count` is declared as `uint8_t` but receives `length / 4` where `length` is a `uint16_t`.  For `length >= 1024`, the division result exceeds 255, which cannot be stored in `count` since `uint8_t` holds at most 255, and the value silently truncates.  The result is then stored in `attr->route_tag_count`, also `uint8_t`, which would re-truncate it.

Fix by widening `count` in `parse_route_tag()` and `route_tag_count` in `struct bgp_ls_attr` to `uint16_t`.