### PR TITLE
lib: fix vty_is_closed() falsely reporting VTY_SHELL as closed

### DIFF
--- a/lib/vty.h
+++ b/lib/vty.h
@@ -419,8 +419,18 @@ extern void vty_stdio_close(void);
 /* Applications can check vty status */
 static inline bool vty_is_closed(const struct vty *vty)
 {
-	return (vty == NULL || vty->status == VTY_CLOSE || vty->fd < 0 ||
-		vty->wfd < 0);
+	if (vty == NULL || vty->status == VTY_CLOSE)
+		return true;
+	/*
+	 * VTY_SHELL (vtysh) uses fd = wfd = -1 and outputs
+	 * through vty->of (stdout) instead of socket FDs. If FDs are
+	 * valid, the VTY can produce output. Otherwise, fall back to
+	 * checking the FILE output path used by VTY_SHELL.
+	 */
+	if (vty->fd >= 0 && vty->wfd >= 0)
+		return false;
+
+	return (vty->of == NULL && vty->of_saved == NULL);
 }
 
 /*


### PR DESCRIPTION
vty_is_closed() checks fd < 0 || wfd < 0 to determine if a VTY can produce output. This is correct for VTY_TERM but wrong for VTY_SHELL which always has fd = wfd = -1 by design and uses vty->of for output.

As a result, any code path that calls vty_json() from within vtysh's local command handlers silently drops JSON output. This affects "show error <code> json" for LIB error codes, which vtysh handles locally rather than forwarding to daemons.

Fix by having vty_is_closed() use the appropriate closed check for VTY_SHELL

Testing:

Before fix:
```
root@r4:mgmt:/media/node# vtysh -c "show error 100663298 json"
root@r4:mgmt:/media/node#
```
After fix:
```
root@r4:mgmt:/media/node# vtysh -c "show error 100663298 json"
{
  "100663298":{
    "title":"VRF Failure on Start",
    "description":"Upon startup FRR failed to properly initialize and startup the VRF subsystem",
    "suggestion":"Ensure that there is sufficient memory to start processes and restart FRR"
  }
}
```