### PR TITLE
lib: use const in vty-is-shell apis

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1394,7 +1394,7 @@ DEFUN_YANG (config_exit,
 
 static int root_on_exit(struct vty *vty)
 {
-	if (vty_shell(vty))
+	if (vty_is_shell(vty))
 		exit(0);
 	else
 		vty->status = VTY_CLOSE;
@@ -2010,7 +2010,7 @@ DEFUN (no_config_password,
 	bool warned = false;
 
 	if (host.password) {
-		if (!vty_shell_serv(vty)) {
+		if (!vty_is_shell_serv(vty)) {
 			vty_out(vty, NO_PASSWD_CMD_WARNING);
 			warned = true;
 		}
@@ -2019,7 +2019,7 @@ DEFUN (no_config_password,
 	host.password = NULL;
 
 	if (host.password_encrypt) {
-		if (!warned && !vty_shell_serv(vty))
+		if (!warned && !vty_is_shell_serv(vty))
 			vty_out(vty, NO_PASSWD_CMD_WARNING);
 		XFREE(MTYPE_HOST, host.password_encrypt);
 	}
@@ -2092,7 +2092,7 @@ DEFUN (no_config_enable_password,
 	bool warned = false;
 
 	if (host.enable) {
-		if (!vty_shell_serv(vty)) {
+		if (!vty_is_shell_serv(vty)) {
 			vty_out(vty, NO_PASSWD_CMD_WARNING);
 			warned = true;
 		}
@@ -2101,7 +2101,7 @@ DEFUN (no_config_enable_password,
 	host.enable = NULL;
 
 	if (host.enable_encrypt) {
-		if (!warned && !vty_shell_serv(vty))
+		if (!warned && !vty_is_shell_serv(vty))
 			vty_out(vty, NO_PASSWD_CMD_WARNING);
 		XFREE(MTYPE_HOST, host.enable_encrypt);
 	}

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -801,7 +801,7 @@ struct route_map *route_map_lookup_warn_noexist(struct vty *vty, const char *nam
 	struct route_map *route_map = route_map_lookup_by_name(name);
 
 	if (!route_map)
-		if (vty_shell_serv(vty))
+		if (vty_is_shell_serv(vty))
 			vty_out(vty, "The route-map '%s' does not exist.\n", name);
 
 	return route_map;

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3458,12 +3458,12 @@ char *vty_get_cwd(void)
 	return vty_cwd;
 }
 
-int vty_shell(struct vty *vty)
+int vty_is_shell(const struct vty *vty)
 {
 	return vty->type == VTY_SHELL ? 1 : 0;
 }
 
-int vty_shell_serv(struct vty *vty)
+int vty_is_shell_serv(const struct vty *vty)
 {
 	return vty->type == VTY_SHELL_SERV ? 1 : 0;
 }

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -406,8 +406,8 @@ extern int vty_config_enter(struct vty *vty, bool private_config,
 			    bool exclusive, bool file_lock);
 extern void vty_config_exit(struct vty *vty);
 extern int vty_config_node_exit(struct vty *vty);
-extern int vty_shell(struct vty *vty);
-extern int vty_shell_serv(struct vty *vty);
+extern int vty_is_shell(const struct vty *vty);
+extern int vty_is_shell_serv(const struct vty *vty);
 extern void vty_hello(struct vty *vty);
 
 /* ^Z / SIGTSTP handling */


### PR DESCRIPTION
Use const and clarify name of a couple of vty object accessors (we noticed this when looking at another PR, so just trying to offer it before... we forget about it)