### PR TITLE
ospfd: fix sequence number check, avoid truncation ambiguity

### DIFF
--- a/ospfd/ospf_auth.c
+++ b/ospfd/ospf_auth.c
@@ -173,9 +173,9 @@ static int ospf_auth_check_hmac_sha_digest(struct ospf_interface *oi,
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 
 	if (nbr &&
-	    ntohl(nbr->crypt_seqnum) > ntohl(ospfh->u.crypt.crypt_seqnum)) {
+	    ntohl(nbr->crypt_seqnum) >= ntohl(ospfh->u.crypt.crypt_seqnum)) {
 		flog_warn(EC_OSPF_AUTH,
-			  "interface %s: ospf_check_hmac_sha bad sequence %u (expect %d), Router-ID: %pI4",
+			  "interface %s: ospf_check_hmac_sha bad sequence %u (expect > %u), Router-ID: %pI4",
 			  IF_NAME(oi), ntohl(ospfh->u.crypt.crypt_seqnum),
 			  ntohl(nbr->crypt_seqnum), &ospfh->router_id);
 		return 0;
@@ -238,9 +238,9 @@ static int ospf_auth_check_md5_digest(struct ospf_interface *oi,
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 
 	if (nbr &&
-	    ntohl(nbr->crypt_seqnum) > ntohl(ospfh->u.crypt.crypt_seqnum)) {
+	    ntohl(nbr->crypt_seqnum) >= ntohl(ospfh->u.crypt.crypt_seqnum)) {
 		flog_warn(EC_OSPF_AUTH,
-			  "interface %s: %s bad sequence %d (expect %d), Router-ID: %pI4",
+			  "interface %s: %s bad sequence %u (expect > %u), Router-ID: %pI4",
 			  IF_NAME(oi), __func__, ntohl(ospfh->u.crypt.crypt_seqnum),
 			  ntohl(nbr->crypt_seqnum), &ospfh->router_id);
 		return 0;

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1533,7 +1533,8 @@ static struct list *ospf_ls_upd_list_lsa(struct ospf_neighbor *nbr,
 					 struct stream *s,
 					 struct ospf_interface *oi, size_t size)
 {
-	uint16_t count, sum;
+	uint32_t count;
+	uint16_t sum;
 	uint32_t length;
 	struct lsa_header *lsah;
 	struct ospf_lsa *lsa;


### PR DESCRIPTION

    ospfd: reject equal cryptographic sequence numbers
    Require strictly increasing OSPF crypt sequence numbers for MD5 and HMAC-SHA
    authentication checks to prevent replay of the last accepted packet.
    

    ospfd: use 32-bit LS Update LSA count
    Match ospf_ls_upd_list_lsa() count type to the 32-bit on-wire field
    to avoid truncation ambiguity and keep parsing semantics consistent
    with packet validation.