### PR TITLE
nhrpd: Correct addrlen check in os_recvmsg()

### DIFF
--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -85,7 +85,7 @@ int os_recvmsg(uint8_t *buf, size_t *len, int *ifindex, uint8_t *addr,
 	*len = r;
 	*ifindex = lladdr.sll_ifindex;
 
-	if (*addrlen <= (size_t)lladdr.sll_addr) {
+	if (lladdr.sll_halen <= *addrlen) {
 		if (memcmp(lladdr.sll_addr, "\x00\x00\x00\x00", 4) != 0) {
 			memcpy(addr, lladdr.sll_addr, lladdr.sll_halen);
 			*addrlen = lladdr.sll_halen;


### PR DESCRIPTION
Previously compared addrlen to the stack address of lladdr.sll_addr cast to size_t, virtually always true.

This should remain always true as sll_addr is an unsigned char array of size 8 and addr is an array of size 64 but this fixes the check and ensures enough space in addr for memcpy.