### PR TITLE
bgpd: Fix incorrect BGP_PATH_MULTIPATH flag when route becomes invalid

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -459,7 +459,12 @@ void bgp_path_info_mpath_update(struct bgp *bgp, struct bgp_dest *dest,
 
 	if (old_best) {
 		old_mpath_count = bgp_path_info_mpath_count(dest);
-		if (old_mpath_count == 1)
+		/* Only mark old best as multipath when we have a new best path.
+		 * When new_best is NULL (e.g. only path became invalid/holddown),
+		 * the old path is not "another ECMP path" and should not show
+		 * as multipath.
+		 */
+		if (new_best && old_mpath_count == 1)
 			SET_FLAG(old_best->flags, BGP_PATH_MULTIPATH);
 		old_cum_bw = bgp_path_info_mpath_cumbw(dest);
 		bgp_path_info_mpath_count_set(dest, 0);

--- a/tests/topotests/bgp_mpath_invalid_prefix/r1/frr.conf
+++ b/tests/topotests/bgp_mpath_invalid_prefix/r1/frr.conf
@@ -1,0 +1,15 @@
+!
+int r1-eth0
+ ip address 192.168.12.1/24
+!
+router bgp 65001
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ neighbor 192.168.12.2 remote-as 65002
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ !
+ address-family ipv4 unicast
+  network 200.1.12.0/24
+ exit-address-family
+!

--- a/tests/topotests/bgp_mpath_invalid_prefix/r2/frr.conf
+++ b/tests/topotests/bgp_mpath_invalid_prefix/r2/frr.conf
@@ -1,0 +1,11 @@
+!
+int r2-eth0
+ ip address 192.168.12.2/24
+!
+router bgp 65002
+ bgp router-id 2.2.2.2
+ no bgp ebgp-requires-policy
+ neighbor 192.168.12.1 remote-as 65001
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ !

--- a/tests/topotests/bgp_mpath_invalid_prefix/test_bgp_mpath_invalid_prefix.py
+++ b/tests/topotests/bgp_mpath_invalid_prefix/test_bgp_mpath_invalid_prefix.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_mpath_invalid_prefix.py
+# Part of NetDEF Topology Tests
+#
+# Test that when a BGP route becomes invalid (e.g. network statement
+# no longer has a matching local interface), the path is NOT incorrectly
+# marked with the multipath flag. See issue #21103.
+#
+# Scenario:
+# - r1 has "network 200.1.12.0/24" but no interface in that subnet (invalid).
+# - Add dummy interface with 200.1.12.1/24 on r1 -> route becomes valid.
+# - Remove that address -> route becomes invalid again.
+# - Assert the path for 200.1.12.0/24 does not show multipath: true when invalid.
+#
+
+import json
+import os
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import create_interface_in_kernel, step
+
+pytestmark = [pytest.mark.bgpd]
+
+DUMMY_IF = "dum0"
+NETWORK_PREFIX = "200.1.12.0/24"
+NETWORK_IP = "200.1.12.1/24"
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    r1 = tgen.gears.get("r1")
+    if r1:
+        r1.run("ip link show {} >/dev/null 2>&1 && ip link del {}".format(DUMMY_IF, DUMMY_IF))
+    tgen.stop_topology()
+
+
+def _get_bgp_prefix_json(router, prefix):
+    """Return parsed JSON for 'show bgp ipv4 unicast <prefix> json' or None."""
+    try:
+        out = router.vtysh_cmd("show bgp ipv4 unicast {} json".format(prefix), isjson=True)
+        return out
+    except (ValueError, TypeError):
+        return None
+
+
+def test_bgp_mpath_flag_not_set_when_route_invalid():
+    """
+    When the only path to a prefix becomes invalid (e.g. network statement
+    no longer has a matching connected subnet), that path must not be
+    marked as multipath. Regression test for #21103.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("Ensure 200.1.12.0/24 is in BGP but invalid (no matching interface)")
+    # Initially r1 has network 200.1.12.0/24 but no interface in that subnet
+    output = _get_bgp_prefix_json(r1, NETWORK_PREFIX)
+    assert output is not None, "BGP should have entry for {}".format(NETWORK_PREFIX)
+    paths = output.get("paths", [])
+    assert len(paths) >= 1, "Expected at least one path (local)"
+
+    step("Add dummy interface with 200.1.12.1/24 so the route becomes valid")
+    create_interface_in_kernel(tgen, "r1", DUMMY_IF, NETWORK_IP)
+
+    def _route_valid():
+        out = _get_bgp_prefix_json(r1, NETWORK_PREFIX)
+        if not out:
+            return None
+        for p in out.get("paths", []):
+            if p.get("valid") and p.get("bestpath", {}).get("overall"):
+                return True
+        return None
+
+    _, res = topotest.run_and_expect(_route_valid, True, count=30, wait=0.5)
+    assert res is not None, "Route 200.1.12.0/24 should become valid after adding interface"
+
+    step("Remove 200.1.12.1/24 from dummy so the route becomes invalid again")
+    r1.run("ip addr del {} dev {}".format(NETWORK_IP, DUMMY_IF))
+
+    def _route_has_no_best():
+        out = _get_bgp_prefix_json(r1, NETWORK_PREFIX)
+        if not out:
+            return None
+        has_best = any(
+            p.get("bestpath", {}).get("overall") for p in out.get("paths", [])
+        )
+        return True if not has_best else None
+
+    success, _ = topotest.run_and_expect(_route_has_no_best, True, count=30, wait=0.5)
+    assert success, (
+        "Route 200.1.12.0/24 should become invalid (no best path) after removing interface"
+    )
+
+    step("Verify no path has multipath set when route is invalid")
+    out_after_invalid = _get_bgp_prefix_json(r1, NETWORK_PREFIX)
+    assert out_after_invalid is not None, "BGP entry for {} should still exist".format(NETWORK_PREFIX)
+    paths = out_after_invalid.get("paths", [])
+    for i, p in enumerate(paths):
+        multipath = p.get("multipath")
+        assert multipath is not True, (
+            "Path {} should not have multipath=True when route is invalid (no best path). "
+            "Got multipath={}. Full path: {}".format(i, multipath, p)
+        )
+    logger.info("PASS: Invalid path(s) do not show multipath=True")


### PR DESCRIPTION
## Summary

This PR fixes a bug where BGP routes incorrectly show as "multipath" in the BGP table when they become invalid. When a route transitions from valid to invalid (e.g. the only path goes to holddown or becomes inaccessible), `new_best` is NULL but the code was still setting `BGP_PATH_MULTIPATH` on the old best path.

## Root Cause

In `bgp_path_info_mpath_update()` (`bgpd/bgp_mpath.c`), the multipath flag was set on the old best path whenever `old_mpath_count == 1`, without checking whether a new best path exists. When `new_best` is NULL (route became invalid), the old path is not one of multiple ECMP paths and should not be displayed as multipath.

## Changes

- Add a `new_best` check before setting `BGP_PATH_MULTIPATH` on the old best path.
- Only set the flag when there is a new best path and the old path was the single previous best (i.e. it is now an alternate ECMP path).
- Add a short comment explaining the condition.

## Testing

- Invalid routes (e.g. after removing the local IP that made the network statement valid) no longer show the spurious "multipath" or "=" attribute in `show bgp ipv4 unicast`.
- Normal multipath behaviour is unchanged when multiple valid ECMP paths exist.

Closes #21103