### PR TITLE
pimd/pim6d: fix the wrong check of multicast interface in nb

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2239,6 +2239,78 @@ int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args)
 	return NB_OK;
 }
 
+static int pim_interface_num_get(const struct lyd_node *if_dnode)
+{
+	struct interface *ifp;
+	struct pim_instance *pim;
+	const struct lyd_node *iter, *lib_dnode;
+	int cnt = 0;
+	int i;
+
+	/*
+	 * If the interface already exists in running datastore, check the
+	 * per-VRF iface_vif_index array directly for used VIF slots.
+	 * This correctly accounts for pimreg reserving VIF index 0, is
+	 * scoped to the correct VRF.
+	 */
+	ifp = nb_running_get_entry(if_dnode, NULL, false);
+	if (ifp) {
+		pim = ifp->vrf->info;
+		if (pim) {
+			for (i = 0; i < MAXVIFS; i++) {
+				if (pim->iface_vif_index[i] != 0)
+					cnt++;
+			}
+			return cnt;
+		}
+	}
+
+	/*
+	 * If the interface is not yet in running datastore, then walk the
+	 * candidate config tree and count interfaces with PIM or GMP enabled
+	 * for the current address family.
+	 */
+	lib_dnode = lyd_parent(if_dnode);
+
+	LY_LIST_FOR (lyd_child(lib_dnode), iter) {
+		const struct lyd_node *gmp_enable;
+		const struct lyd_node *pim_enable;
+		struct interface *iter_ifp;
+
+		if (iter->schema->nodetype != LYS_LIST)
+			continue;
+
+		gmp_enable =
+			yang_dnode_getf(iter,
+					"frr-gmp:gmp/address-family[address-family='%s']/enable",
+					FRR_PIM_AF_XPATH_VAL);
+		pim_enable =
+			yang_dnode_getf(iter,
+					"frr-pim:pim/address-family[address-family='%s']/pim-enable",
+					FRR_PIM_AF_XPATH_VAL);
+
+		if (!((gmp_enable && yang_dnode_get_bool(gmp_enable, NULL)) ||
+		      (pim_enable && yang_dnode_get_bool(pim_enable, NULL))))
+			continue;
+
+		/*
+		 * Skip siblings in a different VRF. If either side has no
+		 * running entry, count conservatively (may over-count
+		 * in multi-VRF scenarios, but never under-count).
+		 */
+		if (ifp) {
+			iter_ifp = nb_running_get_entry(iter, NULL, false);
+			if (iter_ifp && iter_ifp->vrf != ifp->vrf)
+				continue;
+		}
+
+		cnt++;
+	}
+
+	/* +1 to account for pimreg which always reserves VIF index 0 */
+	return cnt + 1;
+}
+
 /*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/pim-enable
  */
@@ -2246,17 +2318,22 @@ int lib_interface_pim_address_family_pim_enable_modify(struct nb_cb_modify_args 
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
-	int mcast_if_count;
 	const struct lyd_node *if_dnode;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
-		mcast_if_count =
-			yang_get_list_elements_count(if_dnode);
-
 		/* Limiting mcast interfaces to number of VIFs */
-		if (mcast_if_count == MAXVIFS) {
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+
+		/*
+		 * If this interface already has a pim_interface,
+		 * it will share the same VIF slot.
+		 */
+		ifp = nb_running_get_entry(if_dnode, NULL, false);
+		if (ifp && ifp->info)
+			break;
+
+		if (pim_interface_num_get(if_dnode) >= MAXVIFS) {
 			snprintf(args->errmsg, args->errmsg_len,
 				 "Max multicast interfaces(%d) reached.",
 				 MAXVIFS);
@@ -4688,17 +4765,23 @@ int lib_interface_gmp_address_family_enable_modify(
 {
 	struct interface *ifp;
 	bool gm_enable;
-	int mcast_if_count;
 	const char *ifp_name;
 	const struct lyd_node *if_dnode;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
-		mcast_if_count =
-			yang_get_list_elements_count(if_dnode);
 		/* Limiting mcast interfaces to number of VIFs */
-		if (mcast_if_count == MAXVIFS) {
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+
+		/*
+		 * If this interface already has a pim_interface,
+		 * it will share the same VIF slot.
+		 */
+		ifp = nb_running_get_entry(if_dnode, NULL, false);
+		if (ifp && ifp->info)
+			break;
+
+		if (pim_interface_num_get(if_dnode) >= MAXVIFS) {
 			ifp_name = yang_dnode_get_string(if_dnode, "name");
 			snprintf(
 				args->errmsg, args->errmsg_len,


### PR DESCRIPTION
For example, on this case of interfaces created by frr, no real one on system at that time:

```
int x1
   ip igmp
int x2
   ip igmp
int x3
……….
```

The `yang_get_list_elements_count()` in pim is wrong:
The configuration node is added at the end of the link list. Therefore,
this function will traverse from the configuration node, so it
usually/wrongly returns 1.

Please refer to commit log for details.