### PR TITLE
ldpd: improve tlv validation in several places

### DIFF
--- a/ldpd/address.c
+++ b/ldpd/address.c
@@ -211,7 +211,7 @@ recv_address(struct nbr *nbr, char *buf, uint16_t len)
 	memcpy(&alt, buf, sizeof(alt));
 	alt_len = ntohs(alt.length);
 	alt_family = ntohs(alt.family);
-	if (alt_len > len - TLV_HDR_SIZE) {
+	if ((alt_len < 2) || (alt_len > len - TLV_HDR_SIZE)) {
 		session_shutdown(nbr, S_BAD_TLV_LEN, msg.id, msg.type);
 		return (-1);
 	}

--- a/ldpd/labelmapping.c
+++ b/ldpd/labelmapping.c
@@ -769,7 +769,7 @@ tlv_decode_fec_elm(struct nbr *nbr, struct ldp_msg *msg, char *buf,
 			}
 
 			memcpy(&stlv, buf + off, sizeof(stlv));
-			if (stlv.length > pw_len) {
+			if ((stlv.length < SUBTLV_HDR_SIZE) || (stlv.length > pw_len)) {
 				session_shutdown(nbr, S_BAD_TLV_LEN, msg->id, msg->type);
 				return (-1);
 			}

--- a/ldpd/notification.c
+++ b/ldpd/notification.c
@@ -163,6 +163,7 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 		struct tlv 	tlv;
 		uint16_t	tlv_type;
 		uint16_t	tlv_len;
+		uint32_t intbuf;
 
 		if (len < sizeof(tlv)) {
 			session_shutdown(nbr, S_BAD_TLV_LEN, msg.id, msg.type);
@@ -193,7 +194,8 @@ recv_notification(struct nbr *nbr, char *buf, uint16_t len)
 				return (-1);
 			}
 
-			nm.pw_status = ntohl(*(uint32_t *)buf);
+			memcpy(&intbuf, buf, 4);
+			nm.pw_status = ntohl(intbuf);
 			SET_FLAG(nm.flags, F_NOTIF_PW_STATUS);
 			break;
 		case TLV_TYPE_FEC:


### PR DESCRIPTION
Improve validation in address-list tlv, PWID subtlv, and notification tlv processing. Check for valid tlv/subtlv lengths, avoid a possibly unaligned htonl() call.
