### PR TITLE
lib: fix crash in thread_process_io_inner_loop on stale epoll event

### DIFF
--- a/lib/event.c
+++ b/lib/event.c
@@ -2167,7 +2167,17 @@ static inline void thread_process_io_inner_loop(struct event_loop *m,
 
 	set_ev.ev.data.fd = fd;
 	hash_ev = epoll_event_hash_find(&(m->handler.epoll_event_hash), &set_ev);
-	assert(hash_ev);
+	if (!hash_ev) {
+		/*
+		 * This fd was already cancelled and removed from the
+		 * epoll_event_hash before fd_poll() was called, but
+		 * the kernel had already queued this revent for the fd.
+		 * Nothing left to process.
+		 */
+		zlog_debug("%s: stale epoll event on fd %d (events 0x%x)", m->name ? m->name : "",
+			   fd, revent->events);
+		return;
+	}
 
 	is_regular = CHECK_FLAG(hash_ev->flags, FRR_EV_FD_IS_REGULAR);
 


### PR DESCRIPTION
When do_event_cancel() processes a pending cancellation at the top of event_fetch_inner_loop(), it removes the fd from the epoll_event_hash and calls EPOLL_CTL_DEL. However, epoll_wait() can still deliver events that were already queued in the kernel's ready list before the EPOLL_CTL_DEL took effect.

When thread_process_io_inner_loop() processes such a stale event, the hash lookup returns NULL and the assert(hash_ev) fires, crashing the daemon.

Fix:
===
Replace the assert with a graceful return

Crash:
======
```
Thread 4 (Thread 0x7f9ea41e89c0 (LWP 8531)):
0  0x00007f9ea449112b in ?? () from /lib/x86_64-linux-gnu/libc.so.6
1  0x00007f9ea4497482 in pthread_mutex_lock () from /lib/x86_64-linux-gnu/libc.so.6
2  0x00007f9ea471eaa5 in _frr_mtx_lock (mutex=0x5629ffcf86a8) at ../lib/frr_pthread.h:253
3  event_cancel_async (master=0x5629ffcf8580, thread=0x562a024559f8, eventobj=0x0) at ../lib/event.c:2040
4  0x00005629e3b4b15e in bgp_writes_off (connection=0x562a02455990) at ../bgpd/bgp_io.c:83
5  0x00005629e3b430ad in bgp_stop (connection=0x562a02455990) at ../bgpd/bgp_fsm.c:2065
6  0x00005629e3b48a9d in bgp_event_update (connection=connection@entry=0x562a02455990, event=TCP_connection_closed) at ../bgpd/bgp_fsm.c:3191
7  0x00005629e3c14828 in bgp_process_conn_error (event=<optimized out>) at ../bgpd/bgpd.c:9707
8  0x00007f9ea471f59a in event_call (event=event@entry=0x7fff59c62f90) at ../lib/event.c:2730
9  0x00007f9ea46bfed0 in frr_run (loop=0x5629ffb4fcd0) at ../lib/libfrr.c:1258
10 0x00005629e3af650e in main (argc=<optimized out>, argv=0x7fff59c63248) at ../bgpd/bgp_main.c:549
<SNIP>
Thread 1 (Thread 0x7f9ea2be06c0 (LWP 8534)):
0  0x00007f9ea4495eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
1  0x00007f9ea4446fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
2  0x00007f9ea470bf86 in core_handler (signo=6, siginfo=0x7f9ea2bdeb30, context=<optimized out>) at ../lib/sigevent.c:268
3  <signal handler called>
4  0x00007f9ea4495eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
5  0x00007f9ea4446fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
6  0x00007f9ea4431472 in abort () from /lib/x86_64-linux-gnu/libc.so.6
7  0x00007f9ea473def9 in _zlog_assert_failed (xref=xref@entry=0x7f9ea4803080 <_xref.24>, extra=extra@entry=0x0) at ../lib/zlog.c:779
8  0x00007f9ea471b979 in thread_process_io_inner_loop (m=m@entry=0x5629ffcf8580, revent=0x5629ffd00740) at ../lib/event.c:2170
9  0x00007f9ea471f3c3 in thread_process_io (num=1, m=0x5629ffcf8580) at ../lib/event.c:2247
10 event_fetch_inner_loop (event=0x0, continued=<synthetic pointer>, broken=<synthetic pointer>, fetch=0x7f9ea2bdfb80, m=0x5629ffcf8580) at ../lib/event.c:2544
11 event_fetch (m=0x5629ffcf8580, fetch=fetch@entry=0x7f9ea2bdfb80) at ../lib/event.c:2559
12 0x00007f9ea46ae9e9 in fpt_run (arg=0x5629ffcf8490) at ../lib/frr_pthread.c:368
13 0x00007f9ea44941f5 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
14 0x00007f9ea45148dc in ?? () from /lib/x86_64-linux-gnu/libc.so.6
```