### PR TITLE
zebra: Allow connected routes NHG sent to dplane

### DIFF
--- a/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
+++ b/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
@@ -224,6 +224,130 @@ def test_fpm_connected_and_local_routes():
     assert success, f"Failed to find {result} local routes"
 
 
+def _get_nhg_for_prefix(router, prefix):
+    """
+    Helper: return (nhg_id, nhg_data) for a given route prefix string,
+    or (None, None) if not found.
+    """
+    route_info = router.vtysh_cmd("show ip route {} json".format(prefix))
+    try:
+        route_json = json.loads(route_info)
+    except json.JSONDecodeError:
+        return None, None
+
+    for pfx, routes in route_json.items():
+        if pfx == prefix:
+            nhg_id = routes[0].get("nexthopGroupId")
+            if nhg_id is None:
+                return None, None
+            nhg_info = router.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
+            try:
+                nhg_json = json.loads(nhg_info)
+                return nhg_id, nhg_json.get(str(nhg_id))
+            except json.JSONDecodeError:
+                return None, None
+    return None, None
+
+
+def _check_nhg_fpm_and_not_kernel(router, prefix, route_type):
+    """
+    Helper: assert that the NHG for prefix has been sent to FPM
+    while skipping kernel programming.
+    """
+
+    def check_nhg_sent_to_fpm():
+        nhg_id, nhg_data = _get_nhg_for_prefix(router, prefix)
+        if nhg_id is None or nhg_data is None:
+            return False
+        return nhg_data.get("fpm", False) is True
+
+    success, result = topotest.run_and_expect(
+        check_nhg_sent_to_fpm, True, count=60, wait=1
+    )
+    assert success, (
+        "{} route NHG ({}) was not sent to FPM "
+        "(NEXTHOP_GROUP_FPM flag not set). NHG data: {}".format(
+            route_type, prefix, result
+        )
+    )
+
+    def check_nhg_not_in_kernel():
+        nhg_id, _ = _get_nhg_for_prefix(router, prefix)
+        if nhg_id is None:
+            return False
+        output = router.run("ip nexthop show")
+        return "id {} ".format(nhg_id) not in output
+
+    success, _ = topotest.run_and_expect(
+        check_nhg_not_in_kernel, True, count=30, wait=1
+    )
+    assert (
+        success
+    ), "{} route NHG ({}) was unexpectedly installed in the Linux kernel.".format(
+        route_type, prefix
+    )
+
+
+def test_fpm_system_route_nhg_sent_to_fpm_not_kernel():
+    """
+    Test that NHGs for system routes (connected, local, kernel) are forwarded
+    to FPM but NOT installed in the kernel.
+      - FPM provider receives and sends the NHG  (NEXTHOP_GROUP_FPM flag set)
+      - Kernel provider skips netlink programming (NHG absent from kernel)
+
+    Three sub-cases are verified:
+      1. Connected route  (ZEBRA_ROUTE_CONNECT) - 172.16.1.0/24
+      2. Local route      (ZEBRA_ROUTE_LOCAL)   - 172.16.1.1/32
+      3. Kernel route     (ZEBRA_ROUTE_KERNEL)  - 172.16.2.0/24
+    """
+
+    tgen = get_topogen()
+    router = tgen.gears["r1"]
+
+    # Sub-case 1 & 2: connected + local routes
+    router.vtysh_cmd(
+        """
+        configure terminal
+        interface r1-eth0
+        ip address 172.16.1.1/24
+        """
+    )
+
+    _check_nhg_fpm_and_not_kernel(router, "172.16.1.0/24", "connected")
+    _check_nhg_fpm_and_not_kernel(router, "172.16.1.1/32", "local")
+
+    # Cleanup sub-case 1 & 2
+    router.vtysh_cmd(
+        """
+        configure terminal
+        interface r1-eth0
+        no ip address 172.16.1.1/24
+        """
+    )
+
+    # Sub-case 3: kernel route
+    router.run("ip route add 172.16.2.0/24 dev r1-eth0")
+
+    def kernel_route_visible():
+        route_info = router.vtysh_cmd("show ip route 172.16.2.0/24 json")
+        try:
+            rj = json.loads(route_info)
+            for pfx, routes in rj.items():
+                if pfx == "172.16.2.0/24":
+                    return routes[0].get("protocol") == "kernel"
+        except (json.JSONDecodeError, KeyError, IndexError):
+            pass
+        return False
+
+    success, _ = topotest.run_and_expect(kernel_route_visible, True, count=30, wait=1)
+    assert success, "Kernel route 172.16.2.0/24 did not appear in zebra RIB"
+
+    _check_nhg_fpm_and_not_kernel(router, "172.16.2.0/24", "kernel")
+
+    # Cleanup sub-case 3
+    router.run("ip route del 172.16.2.0/24 dev r1-eth0")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -4835,17 +4835,14 @@ dplane_nexthop_update_internal(struct nhg_hash_entry *nhe, enum dplane_op_e op)
 
 	ret = dplane_ctx_nexthop_init(ctx, op, nhe);
 	if (ret == AOK) {
-		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
-			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED);
-			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL);
-			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
-
-			dplane_ctx_free(&ctx);
-			atomic_fetch_add_explicit(&zdplane_info.dg_nexthops_in,
-						  1, memory_order_relaxed);
-
-			return ZEBRA_DPLANE_REQUEST_SUCCESS;
-		}
+		/*
+		 * If the NHG has the 'initial delay' flag set (kernel/connected/
+		 * local routes), we still enqueue it to dplane so FPM providers
+		 * can program it (e.g. for SONiC RIF creation), but we ask the
+		 * kernel provider to skip actual kernel programming.
+		 */
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL))
+			dplane_ctx_set_skip_kernel(ctx);
 
 		ret = dplane_update_enqueue(ctx);
 	}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3451,21 +3451,23 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 				   nhe->flags);
 	}
 
-	if ((type != ZEBRA_ROUTE_CONNECT && type != ZEBRA_ROUTE_LOCAL &&
-	     type != ZEBRA_ROUTE_KERNEL) &&
-	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
-		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL);
-		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
-	}
-
 	/* Make sure all depends are installed/queued */
 	frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
 		zebra_nhg_install_kernel(rb_node_dep->nhe, type);
 	}
 
-	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID) &&
+	/*
+	 * Clear QUEUED flag for non-system routes to allow re-installation
+	 * when the NHG is shared between multiple protocols.
+	 */
+	if (!RSYSTEM_ROUTE(type))
+		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED);
+
+	if ((CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID) ||
+	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) &&
 	    (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
-	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL)) &&
+	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL) ||
+	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) &&
 	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
 		/* Change its type to us since we are installing it */
 		if (!ZEBRA_NHG_CREATED(nhe)) {
@@ -3473,6 +3475,19 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 			frrtrace(2, frr_zebra, zebra_nhg_install_kernel, nhe, 1);
 		} else
 			frrtrace(2, frr_zebra, zebra_nhg_install_kernel, nhe, 2);
+
+		/*
+		 * If this NHG was created for a system route (kernel/connect/local)
+		 * and is now being used by a non-system route, clear the
+		 * INITIAL_DELAY_INSTALL flag so it will be actually installed
+		 * to the kernel (not just skip kernel for FPM).
+		 */
+		if (!RSYSTEM_ROUTE(type)) {
+			if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
+				UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL);
+				UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+			}
+		}
 
 		enum zebra_dplane_result ret = dplane_nexthop_add(nhe);
 


### PR DESCRIPTION
When "fpm use-next-hop-groups" is enabled, connected routes' NHGs are not being sent to dplane. 
This causes routes that resolve their nexthop through a connected route to fail insertion in the FPM.

Fix this by restricting the NEXTHOP_GROUP_INITIAL_DELAY_INSTALL flag to KERNEL and LOCAL routes only, 
allowing connected routes' NHG to be properly downloaded to the dplane.