### PR TITLE
tests: fix grpc_basic xdist collection mismatch

### DIFF
--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -43,6 +43,14 @@ pytestmark = [
 script_path = os.path.realpath(os.path.join(CWD, "../lib/grpc-query.py"))
 
 try:
+    import grpc  # noqa: F401
+    import grpc_tools  # noqa: F401
+except ImportError:
+    pytest.skip(
+        "skipping; gRPC modules not installed", allow_module_level=True
+    )
+
+try:
     commander.cmd_raises([script_path, "--check"])
 except Exception:
     pytest.skip(


### PR DESCRIPTION
Add a deterministic import check for grpc and grpc_tools before the subprocess-based --check call. When gRPC is not installed, all xdist workers skip consistently, avoiding the collection mismatch that causes pytest-xdist to abort with "Different tests were collected".