### PR TITLE
isisd: fix edge condition in max_lsp_count computation

### DIFF
--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -2173,7 +2173,7 @@ static uint16_t get_max_lsp_count(uint16_t size)
 
 	/* The last TLV, if any */
 	remaining_size = size % MAX_LSP_ENTRIES_TLV_SIZE;
-	if (remaining_size - 2 >= LSP_ENTRIES_LEN)
+	if ((remaining_size > 2) && (remaining_size - 2 >= LSP_ENTRIES_LEN))
 		lsp_count += (remaining_size - 2) / LSP_ENTRIES_LEN;
 
 	return lsp_count;


### PR DESCRIPTION
Fix an edge condition in the arithmetic in the max_lsp_count api.
