### PR TITLE
bgpd: speed up peer teardown with per-peer route indexes

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -188,7 +188,16 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 	adj->uptime = monotime(NULL);
 	adj->addpath_rx_id = addpath_id;
 	adj->labels = bgp_labels_intern(labels);
+	adj->dest = dest;
 	BGP_ADJ_IN_ADD(dest, adj);
+
+	/* Link into per-peer adj-in list for fast teardown */
+	adj->peer_adj_next = peer->adj_in_head;
+	adj->peer_adj_prev = NULL;
+	if (peer->adj_in_head)
+		peer->adj_in_head->peer_adj_prev = adj;
+	peer->adj_in_head = adj;
+
 	peer->stat_pfx_adj_rib_in++;
 	bgp_dest_lock_node(dest);
 }
@@ -197,8 +206,17 @@ void bgp_adj_in_remove(struct bgp_dest **dest, struct bgp_adj_in *bai)
 {
 	bgp_attr_unintern(&bai->attr);
 	bgp_labels_unintern(&bai->labels);
-	if (bai->peer)
+	if (bai->peer) {
 		bai->peer->stat_pfx_adj_rib_in--;
+
+		/* Unlink from per-peer adj-in list */
+		if (bai->peer_adj_prev)
+			bai->peer_adj_prev->peer_adj_next = bai->peer_adj_next;
+		else
+			bai->peer->adj_in_head = bai->peer_adj_next;
+		if (bai->peer_adj_next)
+			bai->peer_adj_next->peer_adj_prev = bai->peer_adj_prev;
+	}
 	BGP_ADJ_IN_DEL(*dest, bai);
 	*dest = bgp_dest_unlock_node(*dest);
 	peer_unlock(bai->peer); /* adj_in peer reference */

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -89,6 +89,13 @@ struct bgp_adj_in {
 	struct bgp_adj_in *next;
 	struct bgp_adj_in *prev;
 
+	/* For per-peer adj-in list (fast peer teardown) */
+	struct bgp_adj_in *peer_adj_next;
+	struct bgp_adj_in *peer_adj_prev;
+
+	/* Back pointer to the prefix node */
+	struct bgp_dest *dest;
+
 	/* Received peer.  */
 	struct peer *peer;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -632,8 +632,10 @@ void bgp_path_info_add_with_caller(const char *name, struct bgp_dest *dest,
 	bgp_dest_lock_node(dest);
 	peer_lock(pi->peer); /* bgp_path_info peer reference */
 	bgp_dest_set_defer_flag(dest, false);
-	if (pi->peer)
+	if (pi->peer) {
 		pi->peer->stat_pfx_loc_rib++;
+		LIST_INSERT_HEAD(&pi->peer->paths, pi, peer_thread);
+	}
 	hook_call(bgp_snmp_update_stats, dest, pi, true);
 }
 
@@ -659,8 +661,10 @@ struct bgp_dest *bgp_path_info_reap(struct bgp_dest *dest,
 	if (table)
 		bgp_pi_hash_del(&table->pi_hash, pi);
 
-	if (pi->peer)
+	if (pi->peer) {
 		pi->peer->stat_pfx_loc_rib--;
+		LIST_REMOVE(pi, peer_thread);
+	}
 	hook_call(bgp_snmp_update_stats, dest, pi, false);
 
 	bgp_path_info_unlock(pi);
@@ -680,8 +684,10 @@ static struct bgp_dest *bgp_path_info_reap_unsorted(struct bgp_dest *dest,
 	if (table)
 		bgp_pi_hash_del(&table->pi_hash, pi);
 
-	if (pi->peer)
+	if (pi->peer) {
 		pi->peer->stat_pfx_loc_rib--;
+		LIST_REMOVE(pi, peer_thread);
+	}
 	hook_call(bgp_snmp_update_stats, dest, pi, false);
 	bgp_path_info_unlock(pi);
 
@@ -7050,6 +7056,9 @@ static wq_item_status bgp_clear_route_node(struct work_queue *wq, void *data)
 		if (pi->peer != peer)
 			continue;
 
+		if (CHECK_FLAG(pi->flags, BGP_PATH_REMOVED))
+			continue;
+
 		/* graceful restart STALE flag set.
 		 * Note: we intentionally do NOT check for BGP_PATH_STALE here.
 		 * A route may already be stale (e.g., from a prior enhanced
@@ -7134,7 +7143,10 @@ static void bgp_clear_node_queue_init(struct peer *peer)
 static void bgp_clear_route_table(struct peer *peer, afi_t afi, safi_t safi,
 				  struct bgp_table *table)
 {
+	struct bgp_adj_in *ain, *ain_next;
+	struct bgp_path_info *pi, *pi_temp;
 	struct bgp_dest *dest;
+	struct bgp_dest *last_queued = NULL;
 	int force = peer->bgp->process_queue ? 0 : 1;
 
 	if (!table)
@@ -7144,82 +7156,54 @@ static void bgp_clear_route_table(struct peer *peer, afi_t afi, safi_t safi,
 	if (!table)
 		return;
 
-	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		struct bgp_path_info *pi, *next;
-		struct bgp_adj_in *ain;
-		struct bgp_adj_in *ain_next;
+	/*
+	 * Walk the per-peer adj-in list instead of scanning the entire routing
+	 * table.  This turns O(table_size) into O(peer_adj_in_count).
+	 */
+	for (ain = peer->adj_in_head; ain; ain = ain_next) {
+		ain_next = ain->peer_adj_next;
 
-		/* XXX:TODO: This is suboptimal, every non-empty route_node is
-		 * queued for every clearing peer, regardless of whether it is
-		 * relevant to the peer at hand.
-		 *
-		 * Overview: There are 3 different indices which need to be
-		 * scrubbed, potentially, when a peer is removed:
-		 *
-		 * 1 peer's routes visible via the RIB (ie accepted routes)
-		 * 2 peer's routes visible by the (optional) peer's adj-in index
-		 * 3 other routes visible by the peer's adj-out index
-		 *
-		 * 3 there is no hurry in scrubbing, once the struct peer is
-		 * removed from bgp->peer, we could just GC such deleted peer's
-		 * adj-outs at our leisure.
-		 *
-		 * 1 and 2 must be 'scrubbed' in some way, at least made
-		 * invisible via RIB index before peer session is allowed to be
-		 * brought back up. So one needs to know when such a 'search' is
-		 * complete.
-		 *
-		 * Ideally:
-		 *
-		 * - there'd be a single global queue or a single RIB walker
-		 * - rather than tracking which route_nodes still need to be
-		 *   examined on a peer basis, we'd track which peers still
-		 *   aren't cleared
-		 *
-		 * Given that our per-peer prefix-counts now should be reliable,
-		 * this may actually be achievable. It doesn't seem to be a huge
-		 * problem at this time,
-		 *
-		 * It is possible that we have multiple paths for a prefix from
-		 * a peer
-		 * if that peer is using AddPath.
-		 */
-		ain = dest->adj_in;
-		while (ain) {
-			ain_next = ain->next;
+		if (bgp_dest_table(ain->dest) != table)
+			continue;
 
-			if (ain->peer == peer)
-				bgp_adj_in_remove(&dest, ain);
+		dest = ain->dest;
+		bgp_adj_in_remove(&dest, ain);
+	}
 
-			ain = ain_next;
+	/*
+	 * Walk the per-peer path list instead of scanning the entire routing
+	 * table.  This turns O(table_size) into O(peer_path_count).
+	 */
+	LIST_FOREACH_SAFE (pi, &peer->paths, peer_thread, pi_temp) {
+		if (!pi->net || bgp_dest_table(pi->net) != table)
+			continue;
 
+		if (force) {
+			dest = bgp_path_info_reap(pi->net, pi);
 			assert(dest);
-		}
+		} else {
+			struct bgp_clear_node_queue *cnq;
 
-		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = next) {
-			next = pi->next;
-			if (pi->peer != peer)
+			dest = pi->net;
+
+			/*
+			 * With AddPath we may have multiple paths per dest.
+			 * Avoid queueing the same dest multiple times;
+			 * the worker handles all paths on the dest.
+			 */
+			if (dest == last_queued)
 				continue;
+			last_queued = dest;
 
-			if (force) {
-				dest = bgp_path_info_reap(dest, pi);
-				assert(dest);
-			} else {
-				struct bgp_clear_node_queue *cnq;
-
-				/* both unlocked in bgp_clear_node_queue_del */
-				bgp_table_lock(bgp_dest_table(dest));
-				bgp_dest_lock_node(dest);
-				cnq = XCALLOC(
-					MTYPE_BGP_CLEAR_NODE_QUEUE,
-					sizeof(struct bgp_clear_node_queue));
-				cnq->dest = dest;
-				work_queue_add(peer->clear_node_queue, cnq);
-				break;
-			}
+			/* both unlocked in bgp_clear_node_queue_del */
+			bgp_table_lock(bgp_dest_table(dest));
+			bgp_dest_lock_node(dest);
+			cnq = XCALLOC(MTYPE_BGP_CLEAR_NODE_QUEUE,
+				      sizeof(struct bgp_clear_node_queue));
+			cnq->dest = dest;
+			work_queue_add(peer->clear_node_queue, cnq);
 		}
 	}
-	return;
 }
 
 void bgp_clear_route(struct peer *peer, afi_t afi, safi_t safi)
@@ -7739,27 +7723,21 @@ void bgp_clear_adj_in(struct peer *peer, afi_t afi, safi_t safi)
 {
 	struct bgp_table *table;
 	struct bgp_dest *dest;
-	struct bgp_adj_in *ain;
-	struct bgp_adj_in *ain_next;
+	struct bgp_adj_in *ain, *ain_next;
 
 	table = peer->bgp->rib[afi][safi];
 
-	/* It is possible that we have multiple paths for a prefix from a peer
-	 * if that peer is using AddPath.
+	/*
+	 * Walk the per-peer adj-in list instead of the entire routing table.
 	 */
-	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		ain = dest->adj_in;
+	for (ain = peer->adj_in_head; ain; ain = ain_next) {
+		ain_next = ain->peer_adj_next;
 
-		while (ain) {
-			ain_next = ain->next;
+		if (bgp_dest_table(ain->dest) != table)
+			continue;
 
-			if (ain->peer == peer)
-				bgp_adj_in_remove(&dest, ain);
-
-			ain = ain_next;
-
-			assert(dest);
-		}
+		dest = ain->dest;
+		bgp_adj_in_remove(&dest, ain);
 	}
 }
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -292,6 +292,9 @@ struct bgp_path_info {
 	/* For nexthop linked list */
 	LIST_ENTRY(bgp_path_info) nh_thread;
 
+	/* For per-peer path list (fast peer teardown) */
+	LIST_ENTRY(bgp_path_info) peer_thread;
+
 	/* Back pointer to the prefix node */
 	struct bgp_dest *net;
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1712,6 +1712,8 @@ struct peer *peer_new(struct bgp *bgp, union sockunion *su, enum connection_dire
 	peer->last_reset = PEER_DOWN_NONE;
 	peer->down_last_reset = PEER_DOWN_NONE;
 
+	LIST_INIT(&peer->paths);
+
 	/* Set default flags. */
 	FOREACH_AFI_SAFI (afi, safi) {
 		SET_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SEND_COMMUNITY);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1961,6 +1961,12 @@ struct peer {
 	/* workqueues */
 	struct work_queue *clear_node_queue;
 
+	/* Per-peer path list for fast teardown (avoids full table walk) */
+	LIST_HEAD(peer_path_list, bgp_path_info) paths;
+
+	/* Per-peer adj-in list for fast teardown */
+	struct bgp_adj_in *adj_in_head;
+
 #define PEER_TOTAL_RX(peer)                                                    \
 	atomic_load_explicit(&peer->open_in, memory_order_relaxed)             \
 		+ atomic_load_explicit(&peer->update_in, memory_order_relaxed) \


### PR DESCRIPTION
Track adj-in and path_info entries per peer so clear operations avoid full RIB/tree scans during neighbor teardown. Deduplicate queued bgp_dest work items so AddPath peers do not enqueue the same destination repeatedly.

Signed-off-by: Nick Bouliane <nbouliane@coreweave.com>