### PR TITLE
bgpd: speed up peer teardown with per-peer route indexes

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -188,7 +188,16 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 	adj->uptime = monotime(NULL);
 	adj->addpath_rx_id = addpath_id;
 	adj->labels = bgp_labels_intern(labels);
+	adj->dest = dest;
 	BGP_ADJ_IN_ADD(dest, adj);
+
+	/* Link into per-peer adj-in list for fast teardown */
+	adj->peer_adj_next = peer->adj_in_head;
+	adj->peer_adj_prev = NULL;
+	if (peer->adj_in_head)
+		peer->adj_in_head->peer_adj_prev = adj;
+	peer->adj_in_head = adj;
+
 	peer->stat_pfx_adj_rib_in++;
 	bgp_dest_lock_node(dest);
 }
@@ -197,8 +206,17 @@ void bgp_adj_in_remove(struct bgp_dest **dest, struct bgp_adj_in *bai)
 {
 	bgp_attr_unintern(&bai->attr);
 	bgp_labels_unintern(&bai->labels);
-	if (bai->peer)
+	if (bai->peer) {
 		bai->peer->stat_pfx_adj_rib_in--;
+
+		/* Unlink from per-peer adj-in list */
+		if (bai->peer_adj_prev)
+			bai->peer_adj_prev->peer_adj_next = bai->peer_adj_next;
+		else
+			bai->peer->adj_in_head = bai->peer_adj_next;
+		if (bai->peer_adj_next)
+			bai->peer_adj_next->peer_adj_prev = bai->peer_adj_prev;
+	}
 	BGP_ADJ_IN_DEL(*dest, bai);
 	*dest = bgp_dest_unlock_node(*dest);
 	peer_unlock(bai->peer); /* adj_in peer reference */

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -89,6 +89,13 @@ struct bgp_adj_in {
 	struct bgp_adj_in *next;
 	struct bgp_adj_in *prev;
 
+	/* For per-peer adj-in list (fast peer teardown) */
+	struct bgp_adj_in *peer_adj_next;
+	struct bgp_adj_in *peer_adj_prev;
+
+	/* Back pointer to the prefix node */
+	struct bgp_dest *dest;
+
 	/* Received peer.  */
 	struct peer *peer;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -18,6 +18,7 @@
 #include "filter.h"
 #include "log.h"
 #include "routemap.h"
+#include "hash.h"
 #include "buffer.h"
 #include "sockunion.h"
 #include "plist.h"
@@ -86,6 +87,31 @@
 
 #include "bgpd/bgp_route_clippy.c"
 
+PREDECL_HASH(bgp_clear_dests);
+
+struct bgp_clear_dest_ref {
+	struct bgp_dest *dest;
+	struct bgp_clear_dests_item item;
+};
+
+static int bgp_clear_dest_ref_cmp(const struct bgp_clear_dest_ref *a,
+				  const struct bgp_clear_dest_ref *b)
+{
+	if (a->dest < b->dest)
+		return -1;
+	if (a->dest > b->dest)
+		return 1;
+	return 0;
+}
+
+static uint32_t bgp_clear_dest_ref_hash(const struct bgp_clear_dest_ref *ref)
+{
+	return (uint32_t)((uintptr_t)ref->dest >> 4);
+}
+
+DECLARE_HASH(bgp_clear_dests, struct bgp_clear_dest_ref, item, bgp_clear_dest_ref_cmp,
+	     bgp_clear_dest_ref_hash);
+
 static bool bgp_attr_nexthop_same(const struct attr *attr1, const struct attr *attr2, afi_t afi)
 {
 	afi_t nh_afi1 = BGP_ATTR_NH_AFI(afi, attr1);
@@ -103,6 +129,7 @@ static bool bgp_attr_nexthop_same(const struct attr *attr1, const struct attr *a
 
 DEFINE_MTYPE_STATIC(BGPD, BGP_EOIU_MARKER_INFO, "BGP EOIU Marker info");
 DEFINE_MTYPE_STATIC(BGPD, BGP_METAQ, "BGP MetaQ");
+DEFINE_MTYPE_STATIC(BGPD, BGP_CLEAR_DEST_REF, "BGP clear dest ref");
 /* Memory for batched clearing of peers from the RIB */
 DEFINE_MTYPE(BGPD, CLEARING_BATCH, "Clearing batch");
 
@@ -628,8 +655,10 @@ void bgp_path_info_add_with_caller(const char *name, struct bgp_dest *dest,
 	bgp_dest_lock_node(dest);
 	peer_lock(pi->peer); /* bgp_path_info peer reference */
 	bgp_dest_set_defer_flag(dest, false);
-	if (pi->peer)
+	if (pi->peer) {
 		pi->peer->stat_pfx_loc_rib++;
+		LIST_INSERT_HEAD(&pi->peer->paths, pi, peer_thread);
+	}
 	hook_call(bgp_snmp_update_stats, dest, pi, true);
 }
 
@@ -655,8 +684,10 @@ struct bgp_dest *bgp_path_info_reap(struct bgp_dest *dest,
 	if (table)
 		bgp_pi_hash_del(&table->pi_hash, pi);
 
-	if (pi->peer)
+	if (pi->peer) {
 		pi->peer->stat_pfx_loc_rib--;
+		LIST_REMOVE(pi, peer_thread);
+	}
 	hook_call(bgp_snmp_update_stats, dest, pi, false);
 
 	bgp_path_info_unlock(pi);
@@ -676,8 +707,10 @@ static struct bgp_dest *bgp_path_info_reap_unsorted(struct bgp_dest *dest,
 	if (table)
 		bgp_pi_hash_del(&table->pi_hash, pi);
 
-	if (pi->peer)
+	if (pi->peer) {
 		pi->peer->stat_pfx_loc_rib--;
+		LIST_REMOVE(pi, peer_thread);
+	}
 	hook_call(bgp_snmp_update_stats, dest, pi, false);
 	bgp_path_info_unlock(pi);
 
@@ -7097,6 +7130,9 @@ static wq_item_status bgp_clear_route_node(struct work_queue *wq, void *data)
 		if (pi->peer != peer)
 			continue;
 
+		if (CHECK_FLAG(pi->flags, BGP_PATH_REMOVED))
+			continue;
+
 		/* graceful restart STALE flag set.
 		 * Note: we intentionally do NOT check for BGP_PATH_STALE here.
 		 * A route may already be stale (e.g., from a prior enhanced
@@ -7208,102 +7244,101 @@ bool bgp_clear_node_queue_drain(struct peer *peer)
 	return need_peer_unlock;
 }
 
-static void bgp_clear_route_table(struct peer *peer, afi_t afi, safi_t safi,
-				  struct bgp_table *table)
+static void bgp_clear_route_table(struct peer *peer, afi_t afi, safi_t safi)
 {
+	struct bgp_adj_in *ain, *ain_next;
+	struct bgp_path_info *pi, *pi_temp;
+	struct bgp_clear_dest_ref *ref;
 	struct bgp_dest *dest;
 	int force = (!peer->bgp->process_queue || bm->terminating) ? 1 : 0;
+	struct bgp_table *table;
+	struct bgp_clear_dests_head queued_dests;
 
-	if (!table)
-		table = peer->bgp->rib[afi][safi];
+	bgp_clear_dests_init(&queued_dests);
 
-	/* If still no table => afi/safi isn't configured at all or smth. */
-	if (!table)
-		return;
+	/*
+	 * Walk the per-peer adj-in list instead of scanning the entire routing
+	 * table.  This turns O(table_size) into O(peer_adj_in_count).
+	 */
+	for (ain = peer->adj_in_head; ain; ain = ain_next) {
+		ain_next = ain->peer_adj_next;
 
-	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		struct bgp_path_info *pi, *next;
-		struct bgp_adj_in *ain;
-		struct bgp_adj_in *ain_next;
+		if (!ain->dest)
+			continue;
 
-		/* XXX:TODO: This is suboptimal, every non-empty route_node is
-		 * queued for every clearing peer, regardless of whether it is
-		 * relevant to the peer at hand.
-		 *
-		 * Overview: There are 3 different indices which need to be
-		 * scrubbed, potentially, when a peer is removed:
-		 *
-		 * 1 peer's routes visible via the RIB (ie accepted routes)
-		 * 2 peer's routes visible by the (optional) peer's adj-in index
-		 * 3 other routes visible by the peer's adj-out index
-		 *
-		 * 3 there is no hurry in scrubbing, once the struct peer is
-		 * removed from bgp->peer, we could just GC such deleted peer's
-		 * adj-outs at our leisure.
-		 *
-		 * 1 and 2 must be 'scrubbed' in some way, at least made
-		 * invisible via RIB index before peer session is allowed to be
-		 * brought back up. So one needs to know when such a 'search' is
-		 * complete.
-		 *
-		 * Ideally:
-		 *
-		 * - there'd be a single global queue or a single RIB walker
-		 * - rather than tracking which route_nodes still need to be
-		 *   examined on a peer basis, we'd track which peers still
-		 *   aren't cleared
-		 *
-		 * Given that our per-peer prefix-counts now should be reliable,
-		 * this may actually be achievable. It doesn't seem to be a huge
-		 * problem at this time,
-		 *
-		 * It is possible that we have multiple paths for a prefix from
-		 * a peer
-		 * if that peer is using AddPath.
+		/*
+		 * Keep EVPN clear behavior scoped to RD-backed global entries.
+		 * Per-VNI EVPN entries are drained by EVPN-specific cleanup.
 		 */
-		ain = dest->adj_in;
-		while (ain) {
-			ain_next = ain->next;
+		if (safi == SAFI_EVPN && !ain->dest->pdest)
+			continue;
 
-			if (ain->peer == peer)
-				bgp_adj_in_remove(&dest, ain);
+		table = bgp_dest_table(ain->dest);
+		if (!table || table->afi != afi || table->safi != safi)
+			continue;
 
-			ain = ain_next;
+		dest = ain->dest;
+		bgp_adj_in_remove(&dest, ain);
+	}
 
-			assert(dest);
-		}
+	/*
+	 * Walk the per-peer path list instead of scanning the entire routing
+	 * table.  This turns O(table_size) into O(peer_path_count).
+	 */
+	LIST_FOREACH_SAFE (pi, &peer->paths, peer_thread, pi_temp) {
+		if (!pi->net)
+			continue;
 
-		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = next) {
-			next = pi->next;
-			if (pi->peer != peer)
+		/*
+		 * Keep EVPN clear behavior scoped to RD-backed global entries.
+		 * Per-VNI EVPN entries are drained by EVPN-specific cleanup.
+		 */
+		if (safi == SAFI_EVPN && !pi->net->pdest)
+			continue;
+
+		table = bgp_dest_table(pi->net);
+		if (!table || table->afi != afi || table->safi != safi)
+			continue;
+
+		if (force) {
+			dest = bgp_path_info_reap(pi->net, pi);
+			/* In per-peer path walk, this path may already have been reaped. */
+			if (!dest)
 				continue;
+		} else {
+			struct bgp_clear_node_queue *cnq;
 
-			if (force) {
-				dest = bgp_path_info_reap(dest, pi);
-				assert(dest);
-			} else {
-				struct bgp_clear_node_queue *cnq;
+			dest = pi->net;
 
+			/*
+			 * With AddPath we may have multiple paths per dest.
+			 * Avoid queueing the same dest multiple times;
+			 * the worker handles all paths on the dest.
+			 */
+			ref = XCALLOC(MTYPE_BGP_CLEAR_DEST_REF, sizeof(*ref));
+			ref->dest = dest;
+			if (!bgp_clear_dests_add(&queued_dests, ref)) {
 				/* both unlocked in bgp_clear_node_queue_del */
 				bgp_table_lock(bgp_dest_table(dest));
 				bgp_dest_lock_node(dest);
-				cnq = XCALLOC(
-					MTYPE_BGP_CLEAR_NODE_QUEUE,
-					sizeof(struct bgp_clear_node_queue));
+				cnq = XCALLOC(MTYPE_BGP_CLEAR_NODE_QUEUE,
+					      sizeof(struct bgp_clear_node_queue));
 				cnq->dest = dest;
 				work_queue_add(peer->clear_node_queue, cnq);
-				break;
+			} else {
+				XFREE(MTYPE_BGP_CLEAR_DEST_REF, ref);
 			}
 		}
 	}
-	return;
+
+	while ((ref = bgp_clear_dests_pop(&queued_dests)) != NULL)
+		XFREE(MTYPE_BGP_CLEAR_DEST_REF, ref);
+
+	bgp_clear_dests_fini(&queued_dests);
 }
 
 void bgp_clear_route(struct peer *peer, afi_t afi, safi_t safi)
 {
-	struct bgp_dest *dest;
-	struct bgp_table *table;
-
 	if (peer->clear_node_queue == NULL)
 		bgp_clear_node_queue_init(peer);
 
@@ -7327,17 +7362,7 @@ void bgp_clear_route(struct peer *peer, afi_t afi, safi_t safi)
 	if (!peer->clear_node_queue->event)
 		peer_lock(peer);
 
-	if (safi != SAFI_MPLS_VPN && safi != SAFI_ENCAP && safi != SAFI_EVPN)
-		bgp_clear_route_table(peer, afi, safi, NULL);
-	else
-		for (dest = bgp_table_top(peer->bgp->rib[afi][safi]); dest;
-		     dest = bgp_route_next(dest)) {
-			table = bgp_dest_get_bgp_table_info(dest);
-			if (!table)
-				continue;
-
-			bgp_clear_route_table(peer, afi, safi, table);
-		}
+	bgp_clear_route_table(peer, afi, safi);
 
 	/* unlock if no nodes got added to the clear-node-queue. */
 	if (!peer->clear_node_queue->event)
@@ -7817,28 +7842,24 @@ void bgp_clear_route_all(struct peer *peer)
 void bgp_clear_adj_in(struct peer *peer, afi_t afi, safi_t safi)
 {
 	struct bgp_table *table;
+	struct bgp_adj_in *ain, *ain_next;
 	struct bgp_dest *dest;
-	struct bgp_adj_in *ain;
-	struct bgp_adj_in *ain_next;
 
-	table = peer->bgp->rib[afi][safi];
-
-	/* It is possible that we have multiple paths for a prefix from a peer
-	 * if that peer is using AddPath.
+	/*
+	 * Walk the per-peer adj-in list instead of the entire routing table.
 	 */
-	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		ain = dest->adj_in;
+	for (ain = peer->adj_in_head; ain; ain = ain_next) {
+		ain_next = ain->peer_adj_next;
 
-		while (ain) {
-			ain_next = ain->next;
+		if (!ain->dest)
+			continue;
 
-			if (ain->peer == peer)
-				bgp_adj_in_remove(&dest, ain);
+		table = bgp_dest_table(ain->dest);
+		if (!table || table->afi != afi || table->safi != safi)
+			continue;
 
-			ain = ain_next;
-
-			assert(dest);
-		}
+		dest = ain->dest;
+		bgp_adj_in_remove(&dest, ain);
 	}
 }
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -292,6 +292,9 @@ struct bgp_path_info {
 	/* For nexthop linked list */
 	LIST_ENTRY(bgp_path_info) nh_thread;
 
+	/* For per-peer path list (fast peer teardown) */
+	LIST_ENTRY(bgp_path_info) peer_thread;
+
 	/* Back pointer to the prefix node */
 	struct bgp_dest *net;
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1775,6 +1775,8 @@ struct peer *peer_new(struct bgp *bgp, union sockunion *su, enum connection_dire
 	peer->last_reset = PEER_DOWN_NONE;
 	peer->down_last_reset = PEER_DOWN_NONE;
 
+	LIST_INIT(&peer->paths);
+
 	/* Set default flags. */
 	FOREACH_AFI_SAFI (afi, safi) {
 		SET_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SEND_COMMUNITY);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2000,6 +2000,12 @@ struct peer {
 	/* workqueues */
 	struct work_queue *clear_node_queue;
 
+	/* Per-peer path list for fast teardown (avoids full table walk) */
+	LIST_HEAD(peer_path_list, bgp_path_info) paths;
+
+	/* Per-peer adj-in list for fast teardown */
+	struct bgp_adj_in *adj_in_head;
+
 #define PEER_TOTAL_RX(peer)                                                    \
 	atomic_load_explicit(&peer->open_in, memory_order_relaxed)             \
 		+ atomic_load_explicit(&peer->update_in, memory_order_relaxed) \


### PR DESCRIPTION
Track adj-in and path_info entries per peer so clear operations avoid full RIB/tree scans during neighbor teardown. Deduplicate queued bgp_dest work items so AddPath peers do not enqueue the same destination repeatedly.

Signed-off-by: Nick Bouliane <nbouliane@coreweave.com>