### PR TITLE
bgpd: reject import vrf route-map when route-map does not exist

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11118,6 +11118,12 @@ DEFPY(af_import_vrf_route_map, af_import_vrf_route_map_cmd,
 		SET_FLAG(bgp_default->flags, BGP_FLAG_INSTANCE_HIDDEN);
 	}
 
+	/* Reject configuration if route-map does not exist (interactive mode only;
+	 * allow forward references during config file loading)
+	 */
+	if (!route_map_lookup_warn_noexist(vty, rmap_str) && vty->type != VTY_FILE)
+		return CMD_WARNING_CONFIG_FAILED;
+
 	vpn_leak_prechange(dir, afi, bgp_get_default(), bgp);
 
 	if (bgp->vpn_policy[afi].rmap_name[dir])
@@ -11125,13 +11131,10 @@ DEFPY(af_import_vrf_route_map, af_import_vrf_route_map_cmd,
 		      bgp->vpn_policy[afi].rmap_name[dir]);
 	bgp->vpn_policy[afi].rmap_name[dir] =
 		XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_str);
-	bgp->vpn_policy[afi].rmap[dir] =
-		route_map_lookup_warn_noexist(vty, rmap_str);
+	bgp->vpn_policy[afi].rmap[dir] = route_map_lookup_by_name(rmap_str);
 
 	SET_FLAG(bgp->af_flags[afi][SAFI_UNICAST],
 		 BGP_CONFIG_VRF_TO_VRF_IMPORT);
-	if (!bgp->vpn_policy[afi].rmap[dir])
-		return CMD_SUCCESS;
 
 	vpn_leak_postchange(dir, afi, bgp_get_default(), bgp);
 


### PR DESCRIPTION
When configuring "import vrf route-map <name>", the system would warn "The route-map '<name>' does not exist" but still add the invalid config to the running configuration.

> tor-11(config)# router bgp 63420 vrf purple
> tor-11(config-router)#  address-family ipv4 unicast 
> tor-11(config-router-af)# import vrf route-map NVIDIA 
> The route-map 'NVIDIA' does not exist. // System notifies that the route-map does not exist. 
> tor-11(config-router-af)#end
> tor-11# exit
> cumulus@tor-11:mgmt:~$  sudo vtysh -c "show run" | grep NVIDIA
>  import vrf route-map NVIDIA // Applied even though the route-map 'NVIDIA' does not exist

Fix: Validate route-map existence before applying config. Return CMD_WARNING_CONFIG_FAILED when the route-map does not exist so the command is rejected and no config is stored.

Output:

> r1(config)# router bgp 10
> r1(config-router)# address-family ipv4 unicast
> r1(config-router-af)# import vrf route-map TEST_NON_EXIST_RMAP 
> The route-map 'TEST_NON_EXIST_RMAP' does not exist. 
> r1(config-router-af)# exit
> r1(config-router)# address-family ipv6 unicast
> r1(config-router-af)# import vrf route-map TEST_NON_EXIST_RMAP2 
> The route-map 'TEST_NON_EXIST_RMAP2' does not exist. 
> r1(config-router-af)# end
> r1# exit
> root@r1:mgmt:~# sudo vtysh -c "show run" | grep TEST_NON_EXIST_RMAP
> root@r1:mgmt:~# sudo vtysh -c "show run" | grep TEST_NON_EXIST_RMAP2 
> root@r1:mgmt:~#