### PR TITLE
bgpd: Fix route-map cleanup ordering in SRv6 unicast SID export

### DIFF
--- a/bgpd/bgp_srv6.c
+++ b/bgpd/bgp_srv6.c
@@ -172,9 +172,9 @@ void bgp_srv6_unicast_delete(struct bgp *bgp, afi_t afi)
 		XFREE(MTYPE_BGP_SRV6_SID, bgp->srv6_unicast[afi].sid_explicit);
 
 	if (bgp->srv6_unicast[afi].rmap_name) {
-		XFREE(MTYPE_ROUTE_MAP_NAME, bgp->srv6_unicast[afi].rmap_name);
 		route_map_counter_decrement(
 			route_map_lookup_by_name(bgp->srv6_unicast[afi].rmap_name));
+		XFREE(MTYPE_ROUTE_MAP_NAME, bgp->srv6_unicast[afi].rmap_name);
 	}
 
 	srv6_locator_free(bgp->srv6_unicast[afi].sid_locator);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10157,9 +10157,9 @@ DEFPY(sid_export,
 			return CMD_SUCCESS;
 
 		if (bgp->srv6_unicast[afi].rmap_name) {
-			XFREE(MTYPE_ROUTE_MAP_NAME, bgp->srv6_unicast[afi].rmap_name);
 			route_map_counter_decrement(
 				route_map_lookup_by_name(bgp->srv6_unicast[afi].rmap_name));
+			XFREE(MTYPE_ROUTE_MAP_NAME, bgp->srv6_unicast[afi].rmap_name);
 			bgp->srv6_unicast[afi].rmap_name = NULL;
 		}
 		if (bgp->srv6_unicast[afi].sid_explicit) {


### PR DESCRIPTION
When removing SRv6 unicast SID export config, route-map cleanup frees `rmap_name` before looking up the route-map and decrementing its counter.

Reorder cleanup to first call `route_map_lookup_by_name()` and `route_map_counter_decrement()`, then free `rmap_name`.

Apply the same ordering fix in the SRv6 unicast delete path for consistency.