### PR TITLE
zebra: route EVPN FDB/neighbor reads through dplane

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1114,6 +1114,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NONE:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_VLAN_INSTALL:
+	case DPLANE_OP_FDB_READ:
 		break;
 
 	}

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1115,6 +1115,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_VLAN_INSTALL:
 	case DPLANE_OP_FDB_READ:
+	case DPLANE_OP_NEIGH_READ:
 		break;
 
 	}

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1473,6 +1473,7 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_VLAN_INSTALL:
 	case DPLANE_OP_FDB_READ:
+	case DPLANE_OP_NEIGH_READ:
 		return FRR_NETLINK_ERROR;
 
 	case DPLANE_OP_GRE_SET:

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1472,6 +1472,7 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_IPSET_ENTRY_DELETE:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_VLAN_INSTALL:
+	case DPLANE_OP_FDB_READ:
 		return FRR_NETLINK_ERROR;
 
 	case DPLANE_OP_GRE_SET:

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1696,6 +1696,7 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 		case DPLANE_OP_VLAN_INSTALL:
 		case DPLANE_OP_FDB_READ:
+		case DPLANE_OP_NEIGH_READ:
 			flog_err(EC_ZEBRA_DPLANE_OP_UNHANDLED, "Unhandled dplane data for %s",
 				 dplane_op2str(dplane_ctx_get_op(ctx)));
 			res = ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1695,6 +1695,7 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		case DPLANE_OP_STARTUP_STAGE:
 		case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 		case DPLANE_OP_VLAN_INSTALL:
+		case DPLANE_OP_FDB_READ:
 			flog_err(EC_ZEBRA_DPLANE_OP_UNHANDLED, "Unhandled dplane data for %s",
 				 dplane_op2str(dplane_ctx_get_op(ctx)));
 			res = ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -89,14 +89,7 @@ extern void interface_list_tunneldump(struct zebra_ns *zns);
 extern void interface_list_second(struct zebra_ns *zns);
 extern void kernel_init(struct zebra_ns *zns);
 extern void kernel_terminate(struct zebra_ns *zns, bool complete);
-extern void macfdb_read(struct zebra_ns *zns);
-extern void macfdb_read_for_bridge(struct zebra_ns *zns, struct interface *ifp,
-				   struct interface *br_if, vlanid_t vid);
-extern void macfdb_read_mcast_entry_for_vni(struct zebra_ns *zns,
-					    struct interface *ifp, vni_t vni);
-extern void macfdb_read_specific_mac(struct zebra_ns *zns,
-				     struct interface *br_if,
-				     const struct ethaddr *mac, vlanid_t vid);
+extern void kernel_read_macfdb(struct zebra_dplane_ctx *ctx);
 extern void neigh_read(struct zebra_ns *zns);
 extern void neigh_read_for_vlan(struct zebra_ns *zns, struct interface *ifp);
 extern void neigh_read_specific_ip(const struct ipaddr *ip,

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -90,10 +90,7 @@ extern void interface_list_second(struct zebra_ns *zns);
 extern void kernel_init(struct zebra_ns *zns);
 extern void kernel_terminate(struct zebra_ns *zns, bool complete);
 extern void kernel_read_macfdb(struct zebra_dplane_ctx *ctx);
-extern void neigh_read(struct zebra_ns *zns);
-extern void neigh_read_for_vlan(struct zebra_ns *zns, struct interface *ifp);
-extern void neigh_read_specific_ip(const struct ipaddr *ip,
-				   struct interface *vlan_if);
+extern void kernel_read_neigh(struct zebra_dplane_ctx *ctx);
 extern void route_read(struct zebra_ns *zns);
 extern int kernel_upd_mac_nh(uint32_t nh_id, struct ipaddr *vtep_ip);
 extern int kernel_del_mac_nh(uint32_t nh_id);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4217,25 +4217,20 @@ static int netlink_request_macs(struct nlsock *netlink_cmd, int family,
 }
 
 /*
- * MAC forwarding database read using netlink interface. This is invoked
- * at startup.
+ * MAC forwarding database read using netlink interface.
+ * Called from the dplane pthread.
  */
-int netlink_macfdb_read(struct zebra_ns *zns)
+static int netlink_macfdb_read(struct nlsock *nl, const struct zebra_dplane_info *dp_info)
 {
 	int ret;
-	struct zebra_dplane_info dp_info;
-
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
 
 	/* Get bridge FDB table. */
-	ret = netlink_request_macs(&zns->netlink_cmd, AF_BRIDGE, RTM_GETNEIGH,
-				   0);
+	ret = netlink_request_macs(nl, AF_BRIDGE, RTM_GETNEIGH, 0);
 	if (ret < 0)
 		return ret;
 	/* We are reading entire table. */
 	filter_vlan = 0;
-	ret = netlink_parse_info(netlink_macfdb_table, &zns->netlink_cmd,
-				 &dp_info, 0, true);
+	ret = netlink_parse_info(netlink_macfdb_table, nl, dp_info, 0, true);
 
 	return ret;
 }
@@ -4243,48 +4238,44 @@ int netlink_macfdb_read(struct zebra_ns *zns)
 /*
  * MAC forwarding database read using netlink interface. This is for a
  * specific bridge and matching specific access VLAN (if VLAN-aware bridge).
+ * Called from the dplane pthread.
  */
-int netlink_macfdb_read_for_bridge(struct zebra_ns *zns, struct interface *ifp,
-				   struct interface *br_if, vlanid_t vid)
+static int netlink_macfdb_read_for_bridge(struct nlsock *nl,
+					  const struct zebra_dplane_info *dp_info,
+					  ifindex_t br_ifindex, bool vlan_aware, vlanid_t vid)
 {
-	struct zebra_if *br_zif;
-	struct zebra_dplane_info dp_info;
 	int ret = 0;
 
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
-
 	/* Save VLAN we're filtering on, if needed. */
-	br_zif = (struct zebra_if *)br_if->info;
-	if (IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif))
+	if (vlan_aware)
 		filter_vlan = vid;
 
 	/* Get bridge FDB table for specific bridge - we do the VLAN filtering.
 	 */
-	ret = netlink_request_macs(&zns->netlink_cmd, AF_BRIDGE, RTM_GETNEIGH,
-				   br_if->ifindex);
+	ret = netlink_request_macs(nl, AF_BRIDGE, RTM_GETNEIGH, br_ifindex);
 	if (ret < 0)
-		return ret;
-	ret = netlink_parse_info(netlink_macfdb_table, &zns->netlink_cmd,
-				 &dp_info, 0, false);
+		goto done;
 
+	ret = netlink_parse_info(netlink_macfdb_table, nl, dp_info, 0, false);
+
+done:
 	/* Reset VLAN filter. */
 	filter_vlan = 0;
 	return ret;
 }
 
-
-/* Request for MAC FDB for a specific MAC address in VLAN from the kernel */
-static int netlink_request_specific_mac(struct zebra_ns *zns, int family,
-					int type, struct interface *ifp,
-					const struct ethaddr *mac, vlanid_t vid,
-					vni_t vni, uint8_t flags)
+/* Request for MAC FDB for a specific MAC address in VLAN from the kernel.
+ * Called from the dplane pthread.
+ */
+static int netlink_request_specific_mac(struct nlsock *nl, int family, int type, ifindex_t ifindex,
+					const struct ethaddr *mac, vlanid_t vid, vni_t vni,
+					uint8_t flags, bool vlan_aware, bool is_vxlan)
 {
 	struct {
 		struct nlmsghdr n;
 		struct ndmsg ndm;
 		char buf[256];
 	} req;
-	struct zebra_if *zif;
 
 	memset(&req, 0, sizeof(req));
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
@@ -4299,83 +4290,97 @@ static int netlink_request_specific_mac(struct zebra_ns *zns, int family,
 		return -1;
 	}
 
-	zif = (struct zebra_if *)ifp->info;
 	/* Is this a read on a VXLAN interface? */
-	if (IS_ZEBRA_IF_VXLAN(ifp)) {
+	if (is_vxlan) {
 		if (!nl_attr_put32(&req.n, sizeof(req), NDA_VNI, vni)) {
 			zlog_err("%s: Failed to add NDA_VNI nl attribute", __func__);
 			return -1;
 		}
 		/* TBD: Why is ifindex not filled in the non-vxlan case? */
-		req.ndm.ndm_ifindex = ifp->ifindex;
+		req.ndm.ndm_ifindex = ifindex;
 	} else {
-		if (IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(zif) && vid > 0) {
+		if (vlan_aware && vid > 0) {
 			if (!nl_attr_put16(&req.n, sizeof(req), NDA_VLAN, vid)) {
 				zlog_err("%s: Failed to add NDA_VLAN nl attribute", __func__);
 				return -1;
 			}
 		}
-		if (!nl_attr_put32(&req.n, sizeof(req), NDA_MASTER, ifp->ifindex)) {
+		if (!nl_attr_put32(&req.n, sizeof(req), NDA_MASTER, ifindex)) {
 			zlog_err("%s: Failed to add NDA_MASTER nl attribute", __func__);
 			return -1;
 		}
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("Tx %s %s IF %s(%u) MAC %pEA vid %u vni %u",
-			   nl_msg_type_to_str(type),
-			   nl_family_to_str(req.ndm.ndm_family), ifp->name,
-			   ifp->ifindex, mac, vid, vni);
+		zlog_debug("Tx %s %s IF %u MAC %pEA vid %u vni %u",
+			   nl_msg_type_to_str(req.n.nlmsg_type),
+			   nl_family_to_str(req.ndm.ndm_family), ifindex, mac, vid, vni);
 
-	return netlink_request(&zns->netlink_cmd, &req);
+	return netlink_request(nl, &req);
 }
 
-int netlink_macfdb_read_specific_mac(struct zebra_ns *zns,
-				     struct interface *br_if,
-				     const struct ethaddr *mac, vlanid_t vid)
+static int netlink_macfdb_read_specific_mac(struct nlsock *nl,
+					    const struct zebra_dplane_info *dp_info,
+					    ifindex_t br_ifindex, const struct ethaddr *mac,
+					    vlanid_t vid, bool vlan_aware)
 {
 	int ret = 0;
-	struct zebra_dplane_info dp_info;
-
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
 
 	/* Get bridge FDB table for specific bridge - we do the VLAN filtering.
 	 */
-	ret = netlink_request_specific_mac(zns, AF_BRIDGE, RTM_GETNEIGH, br_if,
-					   mac, vid, 0, 0);
+	ret = netlink_request_specific_mac(nl, AF_BRIDGE, RTM_GETNEIGH, br_ifindex, mac, vid, 0, 0,
+					   vlan_aware, false);
 	if (ret < 0)
 		return ret;
 
-	ret = netlink_parse_info(netlink_macfdb_table, &zns->netlink_cmd,
-				 &dp_info, 1, 0);
-
-	return ret;
+	return netlink_parse_info(netlink_macfdb_table, nl, dp_info, 1, false);
 }
 
-int netlink_macfdb_read_mcast_for_vni(struct zebra_ns *zns,
-				      struct interface *ifp, vni_t vni)
+static int netlink_macfdb_read_mcast_for_vni(struct nlsock *nl,
+					     const struct zebra_dplane_info *dp_info,
+					     ifindex_t ifindex, vni_t vni, bool is_vxlan)
 {
-	struct zebra_if *zif;
 	struct ethaddr mac = {.octet = {0}};
-	struct zebra_dplane_info dp_info;
 	int ret = 0;
 
-	zif = ifp->info;
-	if (IS_ZEBRA_VXLAN_IF_VNI(zif))
-		return 0;
-
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
-
 	/* Get specific FDB entry for BUM handling, if any */
-	ret = netlink_request_specific_mac(zns, AF_BRIDGE, RTM_GETNEIGH, ifp,
-					   &mac, 0, vni, NTF_SELF);
+	ret = netlink_request_specific_mac(nl, AF_BRIDGE, RTM_GETNEIGH, ifindex, &mac, 0, vni,
+					   NTF_SELF, false, is_vxlan);
 	if (ret < 0)
 		return ret;
 
-	ret = netlink_parse_info(netlink_macfdb_table, &zns->netlink_cmd,
-				 &dp_info, 1, false);
+	return netlink_parse_info(netlink_macfdb_table, nl, dp_info, 1, false);
+}
 
-	return ret;
+void kernel_read_macfdb(struct zebra_dplane_ctx *ctx)
+{
+	const struct zebra_dplane_info *dp_info = dplane_ctx_get_ns(ctx);
+	struct nlsock *nl;
+
+	nl = kernel_netlink_nlsock_lookup(dplane_ctx_get_ns_sock(ctx));
+	if (!nl) {
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_FAILURE);
+		return;
+	}
+
+	ifindex_t ifindex = dplane_ctx_get_macfdb_read_ifindex(ctx);
+	ifindex_t br_ifindex = dplane_ctx_get_macfdb_read_br_ifindex(ctx);
+	vlanid_t vid = dplane_ctx_get_macfdb_read_vid(ctx);
+	vni_t vni = dplane_ctx_get_macfdb_read_vni(ctx);
+	const struct ethaddr *mac = dplane_ctx_get_macfdb_read_mac(ctx);
+	bool vlan_aware = dplane_ctx_get_macfdb_read_vlan_aware(ctx);
+	bool is_vxlan = dplane_ctx_get_macfdb_read_is_vxlan(ctx);
+
+	if (!is_zero_mac(mac))
+		netlink_macfdb_read_specific_mac(nl, dp_info, br_ifindex, mac, vid, vlan_aware);
+	else if (vni)
+		netlink_macfdb_read_mcast_for_vni(nl, dp_info, ifindex, vni, is_vxlan);
+	else if (ifindex)
+		netlink_macfdb_read_for_bridge(nl, dp_info, br_ifindex, vlan_aware, vid);
+	else
+		netlink_macfdb_read(nl, dp_info);
+
+	dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
 }
 
 /*

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4679,56 +4679,11 @@ static int netlink_request_neigh(struct nlsock *netlink_cmd, int family,
 }
 
 /*
- * IP Neighbor table read using netlink interface. This is invoked
- * at startup.
- */
-int netlink_neigh_read(struct zebra_ns *zns)
-{
-	int ret;
-	struct zebra_dplane_info dp_info;
-
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
-
-	/* Get IP neighbor table. */
-	ret = netlink_request_neigh(&zns->netlink_cmd, AF_UNSPEC, RTM_GETNEIGH,
-				    0);
-	if (ret < 0)
-		return ret;
-	ret = netlink_parse_info(netlink_neigh_table, &zns->netlink_cmd,
-				 &dp_info, 0, true);
-
-	return ret;
-}
-
-/*
- * IP Neighbor table read using netlink interface. This is for a specific
- * VLAN device.
- */
-int netlink_neigh_read_for_vlan(struct zebra_ns *zns, struct interface *vlan_if)
-{
-	int ret = 0;
-	struct zebra_dplane_info dp_info;
-
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
-
-	ret = netlink_request_neigh(&zns->netlink_cmd, AF_UNSPEC, RTM_GETNEIGH,
-				    vlan_if->ifindex);
-	if (ret < 0)
-		return ret;
-	ret = netlink_parse_info(netlink_neigh_table, &zns->netlink_cmd,
-				 &dp_info, 0, false);
-
-	return ret;
-}
-
-/*
  * Request for a specific IP in VLAN (SVI) device from IP Neighbor table,
  * read using netlink interface.
  */
-static int netlink_request_specific_neigh_in_vlan(struct zebra_ns *zns,
-						  int type,
-						  const struct ipaddr *ip,
-						  ifindex_t ifindex)
+static int netlink_request_specific_neigh_in_vlan(struct nlsock *nl, int type,
+						  const struct ipaddr *ip, ifindex_t ifindex)
 {
 	struct {
 		struct nlmsghdr n;
@@ -4764,35 +4719,41 @@ static int netlink_request_specific_neigh_in_vlan(struct zebra_ns *zns,
 			   nl_family_to_str(req.ndm.ndm_family), ifindex, ip,
 			   req.n.nlmsg_flags);
 
-	return netlink_request(&zns->netlink_cmd, &req);
+	return netlink_request(nl, &req);
 }
 
-int netlink_neigh_read_specific_ip(const struct ipaddr *ip,
-				   struct interface *vlan_if)
+void kernel_read_neigh(struct zebra_dplane_ctx *ctx)
 {
-	int ret = 0;
-	struct zebra_ns *zns;
-	struct zebra_vrf *zvrf = vlan_if->vrf->info;
-	struct zebra_dplane_info dp_info;
+	const struct zebra_dplane_info *dp_info = dplane_ctx_get_ns(ctx);
+	const struct ipaddr *ip;
+	struct nlsock *nl;
+	ifindex_t ifindex;
+	int ret;
 
-	zns = zvrf->zns;
+	nl = kernel_netlink_nlsock_lookup(dplane_ctx_get_ns_sock(ctx));
+	if (!nl) {
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_FAILURE);
+		return;
+	}
 
-	zebra_dplane_info_from_zns(&dp_info, zns, true /*is_cmd*/);
+	ifindex = dplane_ctx_get_neigh_read_ifindex(ctx);
+	ip = dplane_ctx_get_neigh_read_ip(ctx);
 
-	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("%s: neigh request IF %s(%u) IP %pIA vrf %s(%u)",
-			   __func__, vlan_if->name, vlan_if->ifindex, ip,
-			   vlan_if->vrf->name, vlan_if->vrf->vrf_id);
+	if (ip->ipa_type != IPADDR_NONE) {
+		ret = netlink_request_specific_neigh_in_vlan(nl, RTM_GETNEIGH, ip, ifindex);
+		if (ret >= 0)
+			netlink_parse_info(netlink_neigh_table, nl, dp_info, 1, false);
+	} else if (ifindex) {
+		ret = netlink_request_neigh(nl, AF_UNSPEC, RTM_GETNEIGH, ifindex);
+		if (ret >= 0)
+			netlink_parse_info(netlink_neigh_table, nl, dp_info, 0, false);
+	} else {
+		ret = netlink_request_neigh(nl, AF_UNSPEC, RTM_GETNEIGH, 0);
+		if (ret >= 0)
+			netlink_parse_info(netlink_neigh_table, nl, dp_info, 0, true);
+	}
 
-	ret = netlink_request_specific_neigh_in_vlan(zns, RTM_GETNEIGH, ip,
-					    vlan_if->ifindex);
-	if (ret < 0)
-		return ret;
-
-	ret = netlink_parse_info(netlink_neigh_table, &zns->netlink_cmd,
-				 &dp_info, 1, false);
-
-	return ret;
+	dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
 }
 
 int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id)

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -84,20 +84,9 @@ extern ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
 				       size_t buflen);
 
 extern int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id);
-extern int netlink_macfdb_read(struct zebra_ns *zns);
-extern int netlink_macfdb_read_for_bridge(struct zebra_ns *zns,
-					  struct interface *ifp,
-					  struct interface *br_if,
-					  vlanid_t vid);
-extern int netlink_macfdb_read_mcast_for_vni(struct zebra_ns *zns,
-					     struct interface *ifp, vni_t vni);
 extern int netlink_neigh_read(struct zebra_ns *zns);
 extern int netlink_neigh_read_for_vlan(struct zebra_ns *zns,
 				       struct interface *vlan_if);
-extern int netlink_macfdb_read_specific_mac(struct zebra_ns *zns,
-					    struct interface *br_if,
-					    const struct ethaddr *mac,
-					    uint16_t vid);
 extern int netlink_neigh_read_specific_ip(const struct ipaddr *ip,
 					  struct interface *vlan_if);
 

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -84,11 +84,6 @@ extern ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
 				       size_t buflen);
 
 extern int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id);
-extern int netlink_neigh_read(struct zebra_ns *zns);
-extern int netlink_neigh_read_for_vlan(struct zebra_ns *zns,
-				       struct interface *vlan_if);
-extern int netlink_neigh_read_specific_ip(const struct ipaddr *ip,
-					  struct interface *vlan_if);
 
 struct nl_batch;
 extern enum netlink_msg_status

--- a/zebra/rtread_netlink.c
+++ b/zebra/rtread_netlink.c
@@ -22,29 +22,6 @@ void route_read(struct zebra_ns *zns)
 	netlink_route_read(zns);
 }
 
-void macfdb_read(struct zebra_ns *zns)
-{
-	netlink_macfdb_read(zns);
-}
-
-void macfdb_read_for_bridge(struct zebra_ns *zns, struct interface *ifp,
-			    struct interface *br_if, vlanid_t vid)
-{
-	netlink_macfdb_read_for_bridge(zns, ifp, br_if, vid);
-}
-
-void macfdb_read_mcast_entry_for_vni(struct zebra_ns *zns,
-				     struct interface *ifp, vni_t vni)
-{
-	netlink_macfdb_read_mcast_for_vni(zns, ifp, vni);
-}
-
-void macfdb_read_specific_mac(struct zebra_ns *zns, struct interface *br_if,
-			      const struct ethaddr *mac, vlanid_t vid)
-{
-	netlink_macfdb_read_specific_mac(zns, br_if, mac, vid);
-}
-
 void neigh_read(struct zebra_ns *zns)
 {
 	netlink_neigh_read(zns);

--- a/zebra/rtread_netlink.c
+++ b/zebra/rtread_netlink.c
@@ -22,21 +22,6 @@ void route_read(struct zebra_ns *zns)
 	netlink_route_read(zns);
 }
 
-void neigh_read(struct zebra_ns *zns)
-{
-	netlink_neigh_read(zns);
-}
-
-void neigh_read_for_vlan(struct zebra_ns *zns, struct interface *vlan_if)
-{
-	netlink_neigh_read_for_vlan(zns, vlan_if);
-}
-
-void neigh_read_specific_ip(const struct ipaddr *ip, struct interface *vlan_if)
-{
-	netlink_neigh_read_specific_ip(ip, vlan_if);
-}
-
 void kernel_read_pbr_rules(struct zebra_ns *zns)
 {
 	netlink_rules_read(zns);

--- a/zebra/rtread_sysctl.c
+++ b/zebra/rtread_sysctl.c
@@ -67,23 +67,7 @@ void route_read(struct zebra_ns *zns)
 	return;
 }
 
-/* Only implemented for the netlink method. */
-void macfdb_read(struct zebra_ns *zns)
-{
-}
-
-void macfdb_read_for_bridge(struct zebra_ns *zns, struct interface *ifp,
-			    struct interface *br_if, vlanid_t vid)
-{
-}
-
-void macfdb_read_mcast_entry_for_vni(struct zebra_ns *zns,
-				     struct interface *ifp, vni_t vni)
-{
-}
-
-void macfdb_read_specific_mac(struct zebra_ns *zns, struct interface *br_if,
-			      const struct ethaddr *mac, vlanid_t vid)
+void kernel_read_macfdb(struct zebra_dplane_ctx *ctx)
 {
 }
 

--- a/zebra/rtread_sysctl.c
+++ b/zebra/rtread_sysctl.c
@@ -71,15 +71,7 @@ void kernel_read_macfdb(struct zebra_dplane_ctx *ctx)
 {
 }
 
-void neigh_read(struct zebra_ns *zns)
-{
-}
-
-void neigh_read_for_vlan(struct zebra_ns *zns, struct interface *vlan_if)
-{
-}
-
-void neigh_read_specific_ip(const struct ipaddr *ip, struct interface *vlan_if)
+void kernel_read_neigh(struct zebra_dplane_ctx *ctx)
 {
 }
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -409,6 +409,14 @@ struct dplane_macfdb_read_info {
 };
 
 /*
+ * EVPN neighbor read info for the dataplane
+ */
+struct dplane_neigh_read_info {
+	ifindex_t ifindex;
+	struct ipaddr ip;
+};
+
+/*
  * VLAN info for the dataplane
  */
 struct dplane_vlan_info {
@@ -481,6 +489,7 @@ struct zebra_dplane_ctx {
 		enum zebra_dplane_startup_notifications spot;
 		struct dplane_srv6_encap_ctx srv6_encap;
 		struct dplane_macfdb_read_info macfdb_read;
+		struct dplane_neigh_read_info neigh_read;
 	} u;
 
 	/* Namespace info, used especially for netlink kernel communication */
@@ -948,6 +957,7 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 			      ctx->u.vlan_info.vlan_array);
 		break;
 	case DPLANE_OP_FDB_READ:
+	case DPLANE_OP_NEIGH_READ:
 		break;
 	}
 }
@@ -1252,6 +1262,8 @@ const char *dplane_op2str(enum dplane_op_e op)
 
 	case DPLANE_OP_FDB_READ:
 		return "FDB_READ";
+	case DPLANE_OP_NEIGH_READ:
+		return "NEIGH_READ";
 	}
 
 	return "UNKNOWN";
@@ -3777,6 +3789,20 @@ bool dplane_ctx_get_macfdb_read_is_vxlan(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.macfdb_read.is_vxlan;
+}
+
+ifindex_t dplane_ctx_get_neigh_read_ifindex(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.neigh_read.ifindex;
+}
+
+const struct ipaddr *dplane_ctx_get_neigh_read_ip(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return &ctx->u.neigh_read.ip;
 }
 
 /*
@@ -6405,9 +6431,40 @@ static enum zebra_dplane_result dplane_fdb_read_enqueue(struct zebra_ns *zns, if
 	return result;
 }
 
+static enum zebra_dplane_result dplane_neigh_read_enqueue(struct zebra_ns *zns, ifindex_t ifindex,
+							  const struct ipaddr *ip)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	struct zebra_dplane_ctx *ctx;
+	int ret;
+
+	ctx = dplane_ctx_alloc();
+	ctx->zd_op = DPLANE_OP_NEIGH_READ;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	dplane_ctx_ns_init(ctx, zns, false);
+
+	ctx->u.neigh_read.ifindex = ifindex;
+	if (ip)
+		ctx->u.neigh_read.ip = *ip;
+
+	ret = dplane_update_enqueue(ctx);
+	if (ret == AOK)
+		result = ZEBRA_DPLANE_REQUEST_QUEUED;
+	else
+		dplane_ctx_free(&ctx);
+
+	return result;
+}
+
 enum zebra_dplane_result dplane_fdb_read(struct zebra_ns *zns)
 {
 	return dplane_fdb_read_enqueue(zns, 0, 0, 0, 0, NULL, false, false);
+}
+
+enum zebra_dplane_result dplane_neigh_read(struct zebra_ns *zns)
+{
+	return dplane_neigh_read_enqueue(zns, 0, NULL);
 }
 
 enum zebra_dplane_result dplane_fdb_read_for_bridge(struct zebra_ns *zns,
@@ -6439,6 +6496,19 @@ enum zebra_dplane_result dplane_fdb_read_specific_mac(struct zebra_ns *zns,
 
 	return dplane_fdb_read_enqueue(zns, 0, br_ifp->ifindex, vid, 0, mac,
 				       IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif), false);
+}
+
+enum zebra_dplane_result dplane_neigh_read_for_vlan(struct zebra_ns *zns,
+						    const struct interface *vlan_ifp)
+{
+	return dplane_neigh_read_enqueue(zns, vlan_ifp->ifindex, NULL);
+}
+
+enum zebra_dplane_result dplane_neigh_read_specific_ip(struct zebra_ns *zns,
+						       const struct ipaddr *ip,
+						       const struct interface *vlan_ifp)
+{
+	return dplane_neigh_read_enqueue(zns, vlan_ifp->ifindex, ip);
 }
 
 /*
@@ -7190,6 +7260,10 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 		zlog_debug("Dplane %s, ns %u, ifindex %u", dplane_op2str(dplane_ctx_get_op(ctx)),
 			   dplane_ctx_get_ns(ctx)->ns_id, dplane_ctx_get_macfdb_read_ifindex(ctx));
 		break;
+	case DPLANE_OP_NEIGH_READ:
+		zlog_debug("Dplane %s, ns %u, ifindex %u", dplane_op2str(dplane_ctx_get_op(ctx)),
+			   dplane_ctx_get_ns(ctx)->ns_id, dplane_ctx_get_neigh_read_ifindex(ctx));
+		break;
 	}
 }
 
@@ -7376,6 +7450,7 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 		break;
 
 	case DPLANE_OP_FDB_READ:
+	case DPLANE_OP_NEIGH_READ:
 		break;
 	}
 }
@@ -7406,6 +7481,13 @@ static void kernel_dplane_process_fdb_read(struct zebra_dplane_provider *prov,
 					   struct zebra_dplane_ctx *ctx)
 {
 	kernel_read_macfdb(ctx);
+	dplane_provider_enqueue_out_ctx(prov, ctx);
+}
+
+static void kernel_dplane_process_neigh_read(struct zebra_dplane_provider *prov,
+					     struct zebra_dplane_ctx *ctx)
+{
+	kernel_read_neigh(ctx);
 	dplane_provider_enqueue_out_ctx(prov, ctx);
 }
 
@@ -7469,6 +7551,8 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 			kernel_dplane_process_ipset_entry(prov, ctx);
 		else if (dplane_ctx_get_op(ctx) == DPLANE_OP_FDB_READ)
 			kernel_dplane_process_fdb_read(prov, ctx);
+		else if (dplane_ctx_get_op(ctx) == DPLANE_OP_NEIGH_READ)
+			kernel_dplane_process_neigh_read(prov, ctx);
 		else
 			dplane_ctx_list_add_tail(&work_list, ctx);
 	}

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -25,6 +25,7 @@
 #include "zebra/rt.h"
 #include "zebra/debug.h"
 #include "zebra/zebra_pbr.h"
+#include "zebra/zebra_l2.h"
 #include "zebra/zebra_neigh.h"
 #include "zebra/zebra_tc.h"
 #include "zebra/zebra_trace.h"
@@ -395,6 +396,19 @@ struct dplane_srv6_encap_ctx {
 };
 
 /*
+ * EVPN FDB read info for the dataplane
+ */
+struct dplane_macfdb_read_info {
+	ifindex_t ifindex;
+	ifindex_t br_ifindex;
+	vlanid_t vid;
+	vni_t vni;
+	struct ethaddr mac;
+	bool vlan_aware;
+	bool is_vxlan;
+};
+
+/*
  * VLAN info for the dataplane
  */
 struct dplane_vlan_info {
@@ -466,6 +480,7 @@ struct zebra_dplane_ctx {
 		struct dplane_netconf_info netconf;
 		enum zebra_dplane_startup_notifications spot;
 		struct dplane_srv6_encap_ctx srv6_encap;
+		struct dplane_macfdb_read_info macfdb_read;
 	} u;
 
 	/* Namespace info, used especially for netlink kernel communication */
@@ -932,6 +947,8 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 			XFREE(MTYPE_VLAN_CHANGE_ARR,
 			      ctx->u.vlan_info.vlan_array);
 		break;
+	case DPLANE_OP_FDB_READ:
+		break;
 	}
 }
 
@@ -1232,6 +1249,9 @@ const char *dplane_op2str(enum dplane_op_e op)
 
 	case DPLANE_OP_VLAN_INSTALL:
 		return "NEW_VLAN";
+
+	case DPLANE_OP_FDB_READ:
+		return "FDB_READ";
 	}
 
 	return "UNKNOWN";
@@ -3708,6 +3728,55 @@ dplane_ctx_get_vxlan_vlan_array(struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.vlan_info.vlan_array;
+}
+
+ifindex_t dplane_ctx_get_macfdb_read_ifindex(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.macfdb_read.ifindex;
+}
+
+ifindex_t dplane_ctx_get_macfdb_read_br_ifindex(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.macfdb_read.br_ifindex;
+}
+
+vlanid_t dplane_ctx_get_macfdb_read_vid(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.macfdb_read.vid;
+}
+
+vni_t dplane_ctx_get_macfdb_read_vni(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.macfdb_read.vni;
+}
+
+const struct ethaddr *dplane_ctx_get_macfdb_read_mac(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return &ctx->u.macfdb_read.mac;
+}
+
+bool dplane_ctx_get_macfdb_read_vlan_aware(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.macfdb_read.vlan_aware;
+}
+
+bool dplane_ctx_get_macfdb_read_is_vxlan(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.macfdb_read.is_vxlan;
 }
 
 /*
@@ -6303,6 +6372,75 @@ dplane_srv6_encap_srcaddr_set(const struct in6_addr *addr, ns_id_t ns_id)
 	return result;
 }
 
+static enum zebra_dplane_result dplane_fdb_read_enqueue(struct zebra_ns *zns, ifindex_t ifindex,
+							ifindex_t br_ifindex, vlanid_t vid,
+							vni_t vni, const struct ethaddr *mac,
+							bool vlan_aware, bool is_vxlan)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	struct zebra_dplane_ctx *ctx;
+	int ret;
+
+	ctx = dplane_ctx_alloc();
+	ctx->zd_op = DPLANE_OP_FDB_READ;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	dplane_ctx_ns_init(ctx, zns, false);
+
+	ctx->u.macfdb_read.ifindex = ifindex;
+	ctx->u.macfdb_read.br_ifindex = br_ifindex;
+	ctx->u.macfdb_read.vid = vid;
+	ctx->u.macfdb_read.vni = vni;
+	ctx->u.macfdb_read.vlan_aware = vlan_aware;
+	ctx->u.macfdb_read.is_vxlan = is_vxlan;
+	if (mac)
+		ctx->u.macfdb_read.mac = *mac;
+
+	ret = dplane_update_enqueue(ctx);
+	if (ret == AOK)
+		result = ZEBRA_DPLANE_REQUEST_QUEUED;
+	else
+		dplane_ctx_free(&ctx);
+
+	return result;
+}
+
+enum zebra_dplane_result dplane_fdb_read(struct zebra_ns *zns)
+{
+	return dplane_fdb_read_enqueue(zns, 0, 0, 0, 0, NULL, false, false);
+}
+
+enum zebra_dplane_result dplane_fdb_read_for_bridge(struct zebra_ns *zns,
+						    const struct interface *ifp,
+						    const struct interface *br_ifp, vlanid_t vid)
+{
+	struct zebra_if *br_zif = (struct zebra_if *)br_ifp->info;
+
+	return dplane_fdb_read_enqueue(zns, ifp->ifindex, br_ifp->ifindex, vid, 0, NULL,
+				       IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif), false);
+}
+
+enum zebra_dplane_result dplane_fdb_read_mcast_for_vni(struct zebra_ns *zns,
+						       const struct interface *ifp, vni_t vni)
+{
+	struct zebra_if *zif = (struct zebra_if *)ifp->info;
+
+	if (IS_ZEBRA_VXLAN_IF_VNI(zif))
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	return dplane_fdb_read_enqueue(zns, ifp->ifindex, 0, 0, vni, NULL, false, true);
+}
+
+enum zebra_dplane_result dplane_fdb_read_specific_mac(struct zebra_ns *zns,
+						      const struct interface *br_ifp,
+						      const struct ethaddr *mac, vlanid_t vid)
+{
+	struct zebra_if *br_zif = (struct zebra_if *)br_ifp->info;
+
+	return dplane_fdb_read_enqueue(zns, 0, br_ifp->ifindex, vid, 0, mac,
+				       IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif), false);
+}
+
 /*
  * Handler for 'show dplane'
  */
@@ -7047,6 +7185,11 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 			   dplane_op2str(dplane_ctx_get_op(ctx)),
 			   dplane_ctx_get_vlan_ifindex(ctx));
 		break;
+
+	case DPLANE_OP_FDB_READ:
+		zlog_debug("Dplane %s, ns %u, ifindex %u", dplane_op2str(dplane_ctx_get_op(ctx)),
+			   dplane_ctx_get_ns(ctx)->ns_id, dplane_ctx_get_macfdb_read_ifindex(ctx));
+		break;
 	}
 }
 
@@ -7231,6 +7374,9 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 			atomic_fetch_add_explicit(&zdplane_info.dg_other_errors,
 						  1, memory_order_relaxed);
 		break;
+
+	case DPLANE_OP_FDB_READ:
+		break;
 	}
 }
 
@@ -7253,6 +7399,13 @@ kernel_dplane_process_ipset_entry(struct zebra_dplane_provider *prov,
 				  struct zebra_dplane_ctx *ctx)
 {
 	zebra_pbr_process_ipset_entry(ctx);
+	dplane_provider_enqueue_out_ctx(prov, ctx);
+}
+
+static void kernel_dplane_process_fdb_read(struct zebra_dplane_provider *prov,
+					   struct zebra_dplane_ctx *ctx)
+{
+	kernel_read_macfdb(ctx);
 	dplane_provider_enqueue_out_ctx(prov, ctx);
 }
 
@@ -7314,6 +7467,8 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 			  || dplane_ctx_get_op(ctx)
 				     == DPLANE_OP_IPSET_ENTRY_DELETE))
 			kernel_dplane_process_ipset_entry(prov, ctx);
+		else if (dplane_ctx_get_op(ctx) == DPLANE_OP_FDB_READ)
+			kernel_dplane_process_fdb_read(prov, ctx);
 		else
 			dplane_ctx_list_add_tail(&work_list, ctx);
 	}

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -216,6 +216,9 @@ enum dplane_op_e {
 
 	/* Source address for SRv6 encapsulation */
 	DPLANE_OP_SRV6_ENCAP_SRCADDR_SET,
+
+	/* EVPN FDB read */
+	DPLANE_OP_FDB_READ,
 };
 
 /* Operational status of Bridge Ports */
@@ -869,6 +872,17 @@ dplane_ctx_gre_get_mtu(const struct zebra_dplane_ctx *ctx);
 const struct zebra_l2info_gre *
 dplane_ctx_gre_get_info(const struct zebra_dplane_ctx *ctx);
 
+/*
+ * Accessors for EVPN FDB read context.
+ */
+ifindex_t dplane_ctx_get_macfdb_read_ifindex(const struct zebra_dplane_ctx *ctx);
+ifindex_t dplane_ctx_get_macfdb_read_br_ifindex(const struct zebra_dplane_ctx *ctx);
+vlanid_t dplane_ctx_get_macfdb_read_vid(const struct zebra_dplane_ctx *ctx);
+vni_t dplane_ctx_get_macfdb_read_vni(const struct zebra_dplane_ctx *ctx);
+const struct ethaddr *dplane_ctx_get_macfdb_read_mac(const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_get_macfdb_read_vlan_aware(const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_get_macfdb_read_is_vxlan(const struct zebra_dplane_ctx *ctx);
+
 /* Interface netconf info */
 enum dplane_netconf_status_e
 dplane_ctx_get_netconf_mpls(const struct zebra_dplane_ctx *ctx);
@@ -1084,6 +1098,18 @@ dplane_gre_set(struct interface *ifp, struct interface *ifp_link,
 enum zebra_dplane_result
 dplane_srv6_encap_srcaddr_set(const struct in6_addr *addr, ns_id_t ns_id);
 
+/*
+ * Enqueue EVPN FDB read requests for the dataplane.
+ */
+enum zebra_dplane_result dplane_fdb_read(struct zebra_ns *zns);
+enum zebra_dplane_result dplane_fdb_read_for_bridge(struct zebra_ns *zns,
+						    const struct interface *ifp,
+						    const struct interface *br_ifp, vlanid_t vid);
+enum zebra_dplane_result dplane_fdb_read_mcast_for_vni(struct zebra_ns *zns,
+						       const struct interface *ifp, vni_t vni);
+enum zebra_dplane_result dplane_fdb_read_specific_mac(struct zebra_ns *zns,
+						      const struct interface *br_ifp,
+						      const struct ethaddr *mac, vlanid_t vid);
 
 /* Forward ref of zebra_pbr_rule */
 struct zebra_pbr_rule;

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -217,8 +217,9 @@ enum dplane_op_e {
 	/* Source address for SRv6 encapsulation */
 	DPLANE_OP_SRV6_ENCAP_SRCADDR_SET,
 
-	/* EVPN FDB read */
+	/* EVPN FDB/neighbor reads */
 	DPLANE_OP_FDB_READ,
+	DPLANE_OP_NEIGH_READ,
 };
 
 /* Operational status of Bridge Ports */
@@ -883,6 +884,12 @@ const struct ethaddr *dplane_ctx_get_macfdb_read_mac(const struct zebra_dplane_c
 bool dplane_ctx_get_macfdb_read_vlan_aware(const struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_get_macfdb_read_is_vxlan(const struct zebra_dplane_ctx *ctx);
 
+/*
+ * Accessors for EVPN neighbor read context.
+ */
+ifindex_t dplane_ctx_get_neigh_read_ifindex(const struct zebra_dplane_ctx *ctx);
+const struct ipaddr *dplane_ctx_get_neigh_read_ip(const struct zebra_dplane_ctx *ctx);
+
 /* Interface netconf info */
 enum dplane_netconf_status_e
 dplane_ctx_get_netconf_mpls(const struct zebra_dplane_ctx *ctx);
@@ -1102,6 +1109,7 @@ dplane_srv6_encap_srcaddr_set(const struct in6_addr *addr, ns_id_t ns_id);
  * Enqueue EVPN FDB read requests for the dataplane.
  */
 enum zebra_dplane_result dplane_fdb_read(struct zebra_ns *zns);
+enum zebra_dplane_result dplane_neigh_read(struct zebra_ns *zns);
 enum zebra_dplane_result dplane_fdb_read_for_bridge(struct zebra_ns *zns,
 						    const struct interface *ifp,
 						    const struct interface *br_ifp, vlanid_t vid);
@@ -1110,6 +1118,15 @@ enum zebra_dplane_result dplane_fdb_read_mcast_for_vni(struct zebra_ns *zns,
 enum zebra_dplane_result dplane_fdb_read_specific_mac(struct zebra_ns *zns,
 						      const struct interface *br_ifp,
 						      const struct ethaddr *mac, vlanid_t vid);
+
+/*
+ * Enqueue EVPN neighbor read requests for the dataplane.
+ */
+enum zebra_dplane_result dplane_neigh_read_for_vlan(struct zebra_ns *zns,
+						    const struct interface *vlan_ifp);
+enum zebra_dplane_result dplane_neigh_read_specific_ip(struct zebra_ns *zns,
+						       const struct ipaddr *ip,
+						       const struct interface *vlan_ifp);
 
 /* Forward ref of zebra_pbr_rule */
 struct zebra_pbr_rule;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -38,6 +38,7 @@
 #include "zebra/zebra_evpn_neigh.h"
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_evpn_vxlan.h"
+#include "zebra/zebra_dplane.h"
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_trace.h"
 
@@ -946,12 +947,11 @@ void zebra_evpn_read_mac_neigh(struct zebra_evpn *zevpn, struct interface *ifp)
 			ifp->name, ifp->ifindex, zevpn->vni,
 			zif->brslave_info.bridge_ifindex);
 
-	macfdb_read_for_bridge(zns, ifp, zif->brslave_info.br_if,
-			       vni->access_vlan);
+	dplane_fdb_read_for_bridge(zns, ifp, zif->brslave_info.br_if, vni->access_vlan);
 	/* We need to specifically read and retrieve the entry for BUM handling
 	 * via multicast, if any.
 	 */
-	macfdb_read_mcast_entry_for_vni(zns, ifp, zevpn->vni);
+	dplane_fdb_read_mcast_for_vni(zns, ifp, zevpn->vni);
 	vlan_if = zvni_map_to_svi(vni->access_vlan, zif->brslave_info.br_if);
 	if (vlan_if) {
 		/* Add SVI MAC */
@@ -1613,8 +1613,8 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr, uint16_t
 				zlog_debug(
 					"%s: MAC %pEA (flags 0x%x) is remote and duplicate, read kernel for local entry",
 					__func__, macaddr, mac->flags);
-			macfdb_read_specific_mac(zns, zif->brslave_info.br_if,
-						 macaddr, vnip->access_vlan);
+			dplane_fdb_read_specific_mac(zns, zif->brslave_info.br_if, macaddr,
+						     vnip->access_vlan);
 		}
 
 		if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)) {

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -969,7 +969,7 @@ void zebra_evpn_read_mac_neigh(struct zebra_evpn *zevpn, struct interface *ifp)
 				zebra_evpn_add_macip_for_intf(vrr_if, zevpn);
 		}
 
-		neigh_read_for_vlan(zns, vlan_if);
+		dplane_neigh_read_for_vlan(zns, vlan_if);
 	}
 }
 

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -26,6 +26,7 @@
 #include "zebra/zebra_vrf.h"
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_vxlan_if.h"
+#include "zebra/zebra_dplane.h"
 #include "zebra/zebra_evpn.h"
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_evpn_neigh.h"
@@ -2221,7 +2222,7 @@ void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 				__func__, ipaddr, n->flags,
 				vlan_if ? vlan_if->name : "Unknown");
 		if (vlan_if)
-			neigh_read_specific_ip(ipaddr, vlan_if);
+			dplane_neigh_read_specific_ip(zvrf->zns, ipaddr, vlan_if);
 	}
 
 	/* When the MAC changes for an IP, it is possible the

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -312,7 +312,7 @@ void zebra_ns_startup_continue(struct zebra_dplane_ctx *ctx)
 		interface_list_second(zns);
 		break;
 	case ZEBRA_DPLANE_ADDRESSES_READ:
-		neigh_read(zns);
+		dplane_neigh_read(zns);
 		route_read(zns);
 
 		vlan_read(zns);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5190,6 +5190,7 @@ static void rib_process_dplane_results(struct event *event)
 				break;
 
 			case DPLANE_OP_FDB_READ:
+			case DPLANE_OP_NEIGH_READ:
 				break;
 			} /* Dispatch by op code */
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5188,6 +5188,9 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_NEIGH_DISCOVER:
 				zebra_neigh_dplane_update(ctx);
 				break;
+
+			case DPLANE_OP_FDB_READ:
+				break;
 			} /* Dispatch by op code */
 
 			dplane_ctx_fini(&ctx);

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -429,6 +429,7 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_VLAN_INSTALL:
 	case DPLANE_OP_FDB_READ:
+	case DPLANE_OP_NEIGH_READ:
 		break;
 	} /* Dispatch by op code */
 }

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -428,6 +428,7 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NONE:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_VLAN_INSTALL:
+	case DPLANE_OP_FDB_READ:
 		break;
 	} /* Dispatch by op code */
 }

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5963,7 +5963,7 @@ static int neigh_read_ns(struct ns *ns,
 {
 	struct zebra_ns *zns = ns->info;
 
-	neigh_read(zns);
+	dplane_neigh_read(zns);
 	return NS_WALK_CONTINUE;
 }
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -40,6 +40,7 @@
 #include "zebra/zebra_evpn_neigh.h"
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_evpn_vxlan.h"
+#include "zebra/zebra_dplane.h"
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_trace.h"
 
@@ -5952,7 +5953,7 @@ static int macfdb_read_ns(struct ns *ns,
 {
 	struct zebra_ns *zns = ns->info;
 
-	macfdb_read(zns);
+	dplane_fdb_read(zns);
 	return NS_WALK_CONTINUE;
 }
 


### PR DESCRIPTION
When `advertise-all-vni` is enabled, zebra reads FDB and neighbor tables directly from the kernel via netlink, bypassing all dplane providers. A dplane provider has no way to supply its own FDB/neighbor state, making EVPN unusable with non-kernel dplane plugins (e.g. grout/DPDK).

This series adds two new dplane operations (`DPLANE_OP_FDB_READ` and `DPLANE_OP_NEIGH_READ`) and converts all FDB/neighbor read call sites to use the dplane enqueue path instead of calling netlink directly. The read results already flow through the dplane notification path, so only the read requests need to be rerouted.

The netlink-specific handling lives in `rt_netlink.c` (`macfdb_read_ctx()` / `neigh_read_ctx()`), with no-op stubs in `rtread_sysctl.c` for BSD, following the existing pattern for platform-specific read functions.

Fixes https://github.com/FRRouting/frr/issues/21190