### PR TITLE
staticd: warn when no valid nexthops found for static route install

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -553,8 +553,10 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 	 * If we have been given an install but nothing is valid
 	 * go ahead and delete the route for double plus fun
 	 */
-	if (!nh_num && install)
+	if (!nh_num && install) {
 		install = false;
+		zlog_warn("%s: No valid nexthops for route %pFX, suppressing install", __func__, p);
+	}
 
 	zclient_route_send(install ?
 			   ZEBRA_ROUTE_ADD : ZEBRA_ROUTE_DELETE,


### PR DESCRIPTION
When a static route is configured with an invalid nexthop, the install request is silently converted to a delete without any output. Add a zlog_warn() that includes the affected route prefix so the error can be identified faster.