### PR TITLE
pimd: In sparse-dense mode, treat a group as sparse if an RP is configured

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -431,9 +431,26 @@ keyword at the end.
 
    Enable PIM on this interface. PIM will use this interface to form PIM
    neighborships and start exchaning PIM protocol messages with those
-   neighbors. The optional argument determines what mode PIM will use this
-   interface for. ``sm`` enables sparse mode, ``dm`` enables dense mode,
-   while ``sm-dm`` enables sparse-dense mode.
+   neighbors.
+   The available modes of operation are:
+      ``sm``
+      Sparse mode. All groups are forwarded following PIM-SM protocol.
+      This is the default mode if not specified.
+
+       ``dm``
+       Dense mode. All groups are forwarded following PIM-DM protocol only.
+       If a dm prefix-list is configured, then groups not matching the prefix
+       list will not be forwarded.
+
+       ``sm-dm``
+       Sparse-dense mode. If a group has a RP discovered/configured, then
+       it is forwarded using PIM-SM (even if the RP is currently unreachable),
+       otherwise it is forwarded using PIM-DM. If a dm prefix-list is configured,
+       then groups not matching the list will still be forwarded using PIM-SM
+       even if no RP is available.
+
+   Regardless of the PIM mode, any group matching the SSM range (default 232.0.0.0/8)
+   will be forwarded following the PIM-SSM protocol.
 
    Please note that this command does not enable the reception of IGMP
    reports on the interface. Refer to the ``ip igmp`` command for IGMP
@@ -442,11 +459,15 @@ keyword at the end.
 .. clicmd:: ip pim ssm prefix-list PREFIX_LIST
 
    Configure the Source-Specific-Multicast group range. Defaults to 232.0.0.0/8.
+   Any group within this range will always be treated as SSM.
 
 .. clicmd:: ip pim dm prefix-list PREFIX_LIST
 
    Limit dense mode multicast to the range configured with prefix-list. By default
-   there is no limit.
+   there is no limit. This is primarily used for interfaces in sparse-dense mode to
+   limit which groups are forwarded in dense mode when no RP is available for the group.
+   If this list is configured and an interface is in dense mode only, it will not forward
+   groups that do not match the prefix list.
 
 .. clicmd:: ip pim allowed-neighbors prefix-list PREFIX_LIST
 

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -431,7 +431,14 @@ bool pim_is_grp_dm(struct pim_instance *pim, pim_addr group_addr)
 	return pim_is_dm_prefix_filter(pim, group_addr);
 }
 
-
+/* Determine if a group should be considered as a dense mode group for a specific interface.
+ * A group is dense mode if it matches the following criteria:
+ *   1. Is NOT in the reserved groups range (224.0.0.0/24)
+ *   2. Is NOT in the SSM group range (default 232.0.0.0/8, or configured)
+ *   3. If interface is in sparse-dense mode, group is NOT covered by an RP (even if unreachable)
+ *   4. If a dense group filter list is configured, group is within the configured prefix list, if
+ *      no filter list is configured, then group is dense mode.
+ */
 bool pim_iface_grp_dm(struct pim_interface *pim_ifp, pim_addr group_addr)
 {
 	struct pim_rpf *rpg;
@@ -453,13 +460,12 @@ bool pim_iface_grp_dm(struct pim_interface *pim_ifp, pim_addr group_addr)
 		return false;
 
 	if (pim_ifp->pim_mode == PIM_MODE_SPARSE_DENSE) {
-		/*
-		 * check if it is an SM group
-		 * if we have an rp,
-		 * and the rp is reachable (I.e, we have source_nexthop.interface)
+		/* If the interface is configured in sparse-dense mode, then the group is sparse if it has
+		 * an RP discovered/configured, even if the RP is unreachable. Otherwise the group is a
+		 * dense group.
 		 */
 		rpg = RP(pim, group_addr);
-		if (rpg && rpg->source_nexthop.interface)
+		if (rpg && !pim_rpf_addr_is_inaddr_any(rpg))
 			return false;
 	}
 


### PR DESCRIPTION
When an RP is configured, sparse mode should trigger regardless of whether the RP is reachable or not. This behavior is consistent with other implementations/vendors.