### PR TITLE
bgpd: fix suppress-fib-pending blocking EVPN GR

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4732,9 +4732,12 @@ void bgp_do_deferred_path_selection(struct bgp *bgp, afi_t afi, safi_t safi)
 	 */
 	if (!bgp->gr_info[afi][safi].gr_deferred) {
 		/* t_select_deferral will be NULL when either gr_route_fib_install_pending_cnt is 0
-		 * or deferral timer for fib install expires
+		 * or deferral timer for fib install expires.
+		 * Also proceed if pending count is already zero (e.g. EVPN
+		 * MACIP routes skip FIB tracking), no FIB acks to wait for.
 		 */
-		if (!BGP_SUPPRESS_FIB_ENABLED(bgp) || !bgp->gr_info[afi][safi].t_select_deferral)
+		if (!BGP_SUPPRESS_FIB_ENABLED(bgp) || !bgp->gr_info[afi][safi].t_select_deferral ||
+		    !bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt)
 			bgp_process_gr_deferral_complete(bgp, afi, safi);
 	} else {
 		/*

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2012,12 +2012,17 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 	 * let's set the fact that we expect this route to be installed
 	 */
 	if (install) {
-		if (BGP_SUPPRESS_FIB_ENABLED(bgp)) {
+		if (BGP_SUPPRESS_FIB_ENABLED(bgp) && !is_evpn) {
 			/*
 			 * If the dest has already been installed at some point
 			 * in time, we know that it is safe to immediately send
 			 * the route to peers since they have a path toward us
 			 * As such let's just let normal mechanisms fly
+			 *
+			 * Skip for EVPN: MACIP routes are installed via
+			 * ZEBRA_REMOTE_MACIP_ADD which does not send a FIB
+			 * install ack back to BGP, so the pending count
+			 * would never decrement to zero.
 			 */
 			if (!CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED)) {
 				bgp_dest_increment_gr_fib_install_pending_count(dest);


### PR DESCRIPTION
When bgp graceful-restart and bgp suppress-fib-pending are both configured, EVPN type-2/3 routes in the global L2VPN EVPN table get BGP_NODE_FIB_INSTALL_PENDING set, incrementing
gr_route_fib_install_pending_cnt. However, these routes are installed in zebra via ZEBRA_REMOTE_MACIP_ADD into MAC/neigh tables, not via ZEBRA_ROUTE_ADD into the RIB. The RIB install path sends ZAPI_ROUTE_INSTALLED back to BGP to decrement the count; the EVPN MACIP install path has no such FIB ack mechanism.

This causes gr_route_fib_install_pending_cnt for L2VPN EVPN to never reach zero, preventing ROUTE_UPDATE_COMPLETE from being sent until the select-defer-time timer expires. Since VRF deferred bestpath waits for default VRF L2VPN EVPN ROUTE_UPDATE_COMPLETE, all type-5 and VRF host route installation is
blocked till select-defer-time expires.

Fix:
- Skip setting FIB_INSTALL_PENDING for EVPN routes in bgp_zebra_route_install() since zebra cannot send FIB ack for MACIP entries.
- In bgp_do_deferred_path_selection(), proceed with GR deferral completion when gr_route_fib_install_pending_cnt is zero, as there are no FIB acks to wait for.