### PR TITLE
staticd: add 'show static routes' command

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -240,6 +240,119 @@ STATIC also supports steering of IPv4 traffic over an SRv6 SID list, as shown in
   S>* 10.0.0.1/32 [1/0] is directly connected, sr0, seg6 fcbb:bbbb:1:2:3:fe00:: encap behavior H.Encaps, weight 1, 00:00:06
   S>* 10.0.0.2/32 [1/0] is directly connected, sr0, seg6 fcbb:bbbb:1:2:3:fe00:: encap behavior H.Encaps.Red, weight 1, 00:00:06
 
+Showing Static Route Status
+===========================
+
+.. clicmd:: show static routes [vrf NAME] [json]
+
+   Display information about all configured static routes, including the
+   internal state of each nexthop.  This is a diagnostic tool for understanding
+   **why a static route is or is not installed** in the RIB.
+
+   Unlike ``show ip route`` (which displays what zebra has in its RIB), this
+   command shows staticd's own view: what it has been configured with, what
+   it has sent to zebra, and the per-nexthop status that determines whether a
+   nexthop is actually inserted.
+
+   For every nexthop the output includes:
+
+   ``active / inactive``
+      Whether the nexthop would currently be included when the route is sent
+      to zebra.  A nexthop can be *inactive* while the overall route shows as
+      *installed* (zebra accepted the route because at least one **other**
+      nexthop was active).
+
+   ``nh-registered``
+      Whether staticd has registered this nexthop for tracking with zebra.
+
+   ``nh-valid``
+      Whether zebra's nexthop tracking has confirmed that a route to this
+      gateway exists.
+
+   ``ifindex``
+      For interface nexthops, the kernel interface index (0 means the
+      interface is not yet resolved).
+
+   ``inactive reason``
+      When a nexthop is inactive, a human-readable reason is shown, for
+      example:
+
+      - *nexthop vrf is not active/known*
+      - *nexthop is not reachable (no route to nexthop)*
+      - *interface does not exist in specified vrf*
+      - *interface is not active*
+      - *BFD session is down*
+      - *rejected by zebra (e.g. another route with lower distance exists)*
+
+   The optional ``json`` keyword produces machine-readable JSON output.
+
+   Example (plain text)::
+
+      node1# show static routes
+      VRF default:
+        IPv4 Unicast:
+          10.0.0.0/8
+            distance 1, tag 0
+              nexthop dev test1
+                active, ifindex: 9
+              nexthop via 172.16.0.2
+                inactive, nh-registered: yes, nh-valid: no
+                inactive reason: nexthop is not reachable (no route to nexthop)
+
+   Example (JSON)::
+
+      node1# show static routes json
+      {
+        "default": {
+          "routes": [
+            {
+              "prefix": "10.0.0.0\/8",
+              "vrf": "default",
+              "afi": "ipv4",
+              "safi": "unicast",
+              "paths": [
+                {
+                  "distance": 1,
+                  "tag": 0,
+                  "tableId": 0,
+                  "nexthops": [
+                    {
+                      "type": "interface",
+                      "active": true,
+                      "routeState": "installed",
+                      "nexthopVrf": "test1",
+                      "interface": "test1",
+                      "interfaceIndex": 9
+                    },
+                    {
+                      "type": "ipv4-gateway",
+                      "active": false,
+                      "routeState": "installed",
+                      "nexthopVrf": "default",
+                      "gateway": "172.16.0.2",
+                      "nhRegistered": true,
+                      "nhValid": false,
+                      "reasonInactive": "nexthop is not reachable (no route to nexthop)"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+   .. note::
+
+      The ``routeState`` field reflects the route-level state reported by
+      zebra (installed / not-installed).  Because zebra reports a single
+      state for the whole route, it is possible for an individual nexthop to
+      show ``routeState: installed`` while being ``active: false``.  This
+      means zebra accepted the route using other active nexthop(s), but
+      this particular nexthop was **not** included.  The ``active`` field
+      and ``reasonInactive`` / ``inactive reason`` provide the per-nexthop
+      truth.
+
 SRv6 Static SIDs Commands
 =========================
 

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -2125,6 +2125,495 @@ DEFUN_NOSH (show_debugging_static,
 	return CMD_SUCCESS;
 }
 
+static const char *static_nh_state_str(enum static_install_states state)
+{
+	switch (state) {
+	case STATIC_START:
+		return "pending";
+	case STATIC_SENT_TO_ZEBRA:
+		return "sent-to-zebra";
+	case STATIC_INSTALLED:
+		return "installed";
+	case STATIC_NOT_INSTALLED:
+		return "not-installed";
+	}
+	return "unknown";
+}
+
+static const char *static_nh_type_str(enum static_nh_type type)
+{
+	switch (type) {
+	case STATIC_IFNAME:
+		return "interface";
+	case STATIC_IPV4_GATEWAY:
+		return "ipv4-gateway";
+	case STATIC_IPV4_GATEWAY_IFNAME:
+		return "ipv4-gateway-ifname";
+	case STATIC_IPV6_GATEWAY:
+		return "ipv6-gateway";
+	case STATIC_IPV6_GATEWAY_IFNAME:
+		return "ipv6-gateway-ifname";
+	case STATIC_BLACKHOLE:
+		return "blackhole";
+	}
+	return "unknown";
+}
+
+static const char *static_bh_type_str(enum static_blackhole_type bh_type)
+{
+	switch (bh_type) {
+	case STATIC_BLACKHOLE_DROP:
+		return "drop";
+	case STATIC_BLACKHOLE_NULL:
+		return "null0";
+	case STATIC_BLACKHOLE_REJECT:
+		return "reject";
+	}
+	return "unknown";
+}
+
+/*
+ * Determine whether a specific nexthop is "active", i.e. whether it
+ * would actually be included when sending the route to zebra.
+ * This mirrors the skip-logic in static_zebra_route_add().
+ *
+ * Note: route_notify_owner sets nh->state on ALL nexthops in a path
+ * (via static_nht_mark_state), so an inactive/skipped nexthop can
+ * still show STATIC_INSTALLED if other nexthops in the same path
+ * were successfully installed.
+ */
+static bool static_nexthop_is_active(const struct static_nexthop *nh)
+{
+	if (nh->nh_vrf_id == VRF_UNKNOWN)
+		return false;
+
+	if (nh->path_down)
+		return false;
+
+	switch (nh->type) {
+	case STATIC_IFNAME:
+		if (nh->ifindex == IFINDEX_INTERNAL)
+			return false;
+		break;
+	case STATIC_IPV4_GATEWAY:
+	case STATIC_IPV6_GATEWAY:
+		if (!nh->nh_valid)
+			return false;
+		break;
+	case STATIC_IPV4_GATEWAY_IFNAME:
+	case STATIC_IPV6_GATEWAY_IFNAME:
+		if (nh->ifindex == IFINDEX_INTERNAL)
+			return false;
+		break;
+	case STATIC_BLACKHOLE:
+		break;
+	}
+
+	return true;
+}
+
+/*
+ * Determine the reason why a nexthop is not active / not installed.
+ * Returns a human-readable string describing why the nexthop
+ * cannot be used.
+ */
+static const char *static_nh_reason_inactive(const struct static_nexthop *nh)
+{
+	struct interface *ifp;
+
+	if (static_nexthop_is_active(nh))
+		return NULL;
+
+	/* Check for unknown VRF */
+	if (nh->nh_vrf_id == VRF_UNKNOWN)
+		return "nexthop vrf is not active/known";
+
+	/* BFD path down */
+	if (nh->path_down)
+		return "BFD session is down";
+
+	/* Check nexthop validity for gateway types */
+	switch (nh->type) {
+	case STATIC_IPV4_GATEWAY:
+	case STATIC_IPV6_GATEWAY:
+		if (!nh->nh_registered)
+			return "nexthop not yet registered with zebra";
+		if (!nh->nh_valid)
+			return "nexthop is not reachable (no route to nexthop)";
+		break;
+	case STATIC_IPV4_GATEWAY_IFNAME:
+	case STATIC_IPV6_GATEWAY_IFNAME:
+		if (nh->ifindex == IFINDEX_INTERNAL) {
+			ifp = if_lookup_by_name(nh->ifname, nh->nh_vrf_id);
+			if (!ifp)
+				return "interface does not exist in specified vrf";
+			return "interface is not active";
+		}
+		break;
+	case STATIC_IFNAME:
+		if (nh->ifindex == IFINDEX_INTERNAL) {
+			ifp = if_lookup_by_name(nh->ifname, nh->nh_vrf_id);
+			if (!ifp)
+				return "interface does not exist in specified vrf";
+			return "interface is not active";
+		}
+		break;
+	case STATIC_BLACKHOLE:
+		break;
+	}
+
+	/*
+	 * If the route-level state is NOT_INSTALLED, zebra rejected the
+	 * whole route (e.g. a lower-distance route from another protocol).
+	 */
+	if (nh->state == STATIC_NOT_INSTALLED)
+		return "rejected by zebra (e.g. another route with lower distance exists)";
+
+	if (nh->state == STATIC_START)
+		return "waiting for initial processing";
+
+	if (nh->state == STATIC_SENT_TO_ZEBRA)
+		return "awaiting response from zebra";
+
+	return "unknown";
+}
+
+static void static_show_nh(struct vty *vty, const struct static_nexthop *nh, const char *vrf_name,
+			   struct json_object *jo_nh)
+{
+	const char *reason;
+	bool active = static_nexthop_is_active(nh);
+
+	if (jo_nh) {
+		json_object_string_add(jo_nh, "type", static_nh_type_str(nh->type));
+		json_object_boolean_add(jo_nh, "active", active);
+		json_object_string_add(jo_nh, "routeState", static_nh_state_str(nh->state));
+		json_object_string_add(jo_nh, "nexthopVrf", nh->nh_vrfname);
+		json_object_int_add(jo_nh, "nexthopVrfId", nh->nh_vrf_id);
+	} else {
+		vty_out(vty, "        nexthop");
+	}
+
+	switch (nh->type) {
+	case STATIC_IPV4_GATEWAY:
+		if (jo_nh) {
+			json_object_string_addf(jo_nh, "gateway", "%pI4", &nh->addr.ipv4);
+			json_object_boolean_add(jo_nh, "nhRegistered", nh->nh_registered);
+			json_object_boolean_add(jo_nh, "nhValid", nh->nh_valid);
+		} else {
+			vty_out(vty, " via %pI4", &nh->addr.ipv4);
+		}
+		break;
+	case STATIC_IPV6_GATEWAY:
+		if (jo_nh) {
+			json_object_string_addf(jo_nh, "gateway", "%pI6", &nh->addr.ipv6);
+			json_object_boolean_add(jo_nh, "nhRegistered", nh->nh_registered);
+			json_object_boolean_add(jo_nh, "nhValid", nh->nh_valid);
+		} else {
+			vty_out(vty, " via %pI6", &nh->addr.ipv6);
+		}
+		break;
+	case STATIC_IPV4_GATEWAY_IFNAME:
+		if (jo_nh) {
+			json_object_string_addf(jo_nh, "gateway", "%pI4", &nh->addr.ipv4);
+			json_object_string_add(jo_nh, "interface", nh->ifname);
+			json_object_int_add(jo_nh, "interfaceIndex", nh->ifindex);
+			json_object_boolean_add(jo_nh, "nhRegistered", nh->nh_registered);
+			json_object_boolean_add(jo_nh, "nhValid", nh->nh_valid);
+			json_object_boolean_add(jo_nh, "onlink", nh->onlink);
+		} else {
+			vty_out(vty, " via %pI4 dev %s", &nh->addr.ipv4, nh->ifname);
+		}
+		break;
+	case STATIC_IPV6_GATEWAY_IFNAME:
+		if (jo_nh) {
+			json_object_string_addf(jo_nh, "gateway", "%pI6", &nh->addr.ipv6);
+			json_object_string_add(jo_nh, "interface", nh->ifname);
+			json_object_int_add(jo_nh, "interfaceIndex", nh->ifindex);
+			json_object_boolean_add(jo_nh, "nhRegistered", nh->nh_registered);
+			json_object_boolean_add(jo_nh, "nhValid", nh->nh_valid);
+			json_object_boolean_add(jo_nh, "onlink", nh->onlink);
+		} else {
+			vty_out(vty, " via %pI6 dev %s", &nh->addr.ipv6, nh->ifname);
+		}
+		break;
+	case STATIC_IFNAME:
+		if (jo_nh) {
+			json_object_string_add(jo_nh, "interface", nh->ifname);
+			json_object_int_add(jo_nh, "interfaceIndex", nh->ifindex);
+		} else {
+			vty_out(vty, " dev %s", nh->ifname);
+		}
+		break;
+	case STATIC_BLACKHOLE:
+		if (jo_nh)
+			json_object_string_add(jo_nh, "blackholeType",
+					       static_bh_type_str(nh->bh_type));
+		else
+			vty_out(vty, " %s", static_bh_type_str(nh->bh_type));
+		break;
+	}
+
+	if (jo_nh) {
+		if (nh->color)
+			json_object_int_add(jo_nh, "color", nh->color);
+		if (nh->weight)
+			json_object_int_add(jo_nh, "weight", nh->weight);
+		if (nh->snh_label.num_labels) {
+			struct json_object *jo_labels = json_object_new_array();
+
+			for (uint8_t i = 0; i < nh->snh_label.num_labels; i++)
+				json_object_array_add(jo_labels,
+						      json_object_new_int(nh->snh_label.label[i]));
+			json_object_object_add(jo_nh, "labels", jo_labels);
+		}
+
+		json_object_boolean_add(jo_nh, "bfdMonitored", nh->bsp != NULL);
+		if (nh->bsp)
+			json_object_boolean_add(jo_nh, "bfdPathDown", nh->path_down);
+	} else {
+		if (strcmp(nh->nh_vrfname, vrf_name))
+			vty_out(vty, " nexthop-vrf %s", nh->nh_vrfname);
+
+		if (nh->onlink)
+			vty_out(vty, " onlink");
+
+		if (nh->color)
+			vty_out(vty, " color %" PRIu32, nh->color);
+
+		if (nh->weight)
+			vty_out(vty, " weight %u", nh->weight);
+
+		if (nh->snh_label.num_labels) {
+			vty_out(vty, " label");
+			for (uint8_t i = 0; i < nh->snh_label.num_labels; i++)
+				vty_out(vty, "%s%u", i ? "/" : " ", nh->snh_label.label[i]);
+		}
+
+		if (nh->bsp)
+			vty_out(vty, " (bfd %s)", nh->path_down ? "down" : "up");
+
+		vty_out(vty, "\n");
+
+		/* Show active/inactive and detailed status */
+		vty_out(vty, "          %s", active ? "active" : "inactive");
+
+		switch (nh->type) {
+		case STATIC_IPV4_GATEWAY:
+		case STATIC_IPV6_GATEWAY:
+		case STATIC_IPV4_GATEWAY_IFNAME:
+		case STATIC_IPV6_GATEWAY_IFNAME:
+			vty_out(vty, ", nh-registered: %s, nh-valid: %s",
+				nh->nh_registered ? "yes" : "no", nh->nh_valid ? "yes" : "no");
+			break;
+		case STATIC_IFNAME:
+			vty_out(vty, ", ifindex: %u", nh->ifindex);
+			break;
+		case STATIC_BLACKHOLE:
+			break;
+		}
+
+		if (nh->nh_vrf_id == VRF_UNKNOWN)
+			vty_out(vty, ", nh-vrf: UNKNOWN");
+
+		vty_out(vty, "\n");
+	}
+
+	/* Show reason if nexthop is not active */
+	if (!active) {
+		reason = static_nh_reason_inactive(nh);
+		if (reason) {
+			if (jo_nh)
+				json_object_string_add(jo_nh, "reasonInactive", reason);
+			else
+				vty_out(vty, "          inactive reason: %s\n", reason);
+		}
+	}
+}
+
+static void static_show_route_table(struct vty *vty, struct route_table *stable,
+				    const char *vrf_name, const char *afi_str,
+				    const char *safi_str, struct json_object *jo_routes)
+{
+	struct route_node *rn;
+	struct static_route_info *si;
+	struct static_path *pn;
+	struct static_nexthop *nh;
+	const struct prefix *dst_p, *src_p;
+	bool header_shown = false;
+
+	for (rn = route_top(stable); rn; rn = srcdest_route_next(rn)) {
+		si = static_route_info_from_rnode(rn);
+		if (!si)
+			continue;
+
+		srcdest_rnode_prefixes(rn, &dst_p, &src_p);
+
+		if (jo_routes) {
+			struct json_object *jo_route = json_object_new_object();
+
+			json_object_string_addf(jo_route, "prefix", "%pFX", dst_p);
+			if (src_p && src_p->prefixlen)
+				json_object_string_addf(jo_route, "sourcePrefix", "%pFX", src_p);
+			json_object_string_add(jo_route, "vrf", vrf_name);
+			json_object_string_add(jo_route, "afi", afi_str);
+			json_object_string_add(jo_route, "safi", safi_str);
+
+			struct json_object *jo_paths = json_object_new_array();
+
+			frr_each (static_path_list, &si->path_list, pn) {
+				struct json_object *jo_path = json_object_new_object();
+
+				json_object_int_add(jo_path, "distance", pn->distance);
+				json_object_int_add(jo_path, "tag", pn->tag);
+				json_object_int_add(jo_path, "tableId", pn->table_id);
+
+				struct json_object *jo_nhs = json_object_new_array();
+
+				frr_each (static_nexthop_list, &pn->nexthop_list, nh) {
+					struct json_object *jo_nh = json_object_new_object();
+
+					static_show_nh(vty, nh, vrf_name, jo_nh);
+					json_object_array_add(jo_nhs, jo_nh);
+				}
+				json_object_object_add(jo_path, "nexthops", jo_nhs);
+				json_object_array_add(jo_paths, jo_path);
+			}
+			json_object_object_add(jo_route, "paths", jo_paths);
+			json_object_array_add(jo_routes, jo_route);
+		} else {
+			if (!header_shown) {
+				vty_out(vty, "  %s:\n", afi_str);
+				header_shown = true;
+			}
+
+			if (src_p && src_p->prefixlen)
+				vty_out(vty, "    %pFX (from %pFX)\n", dst_p, src_p);
+			else
+				vty_out(vty, "    %pFX\n", dst_p);
+
+			frr_each (static_path_list, &si->path_list, pn) {
+				vty_out(vty, "      distance %u, tag %" PRIu32, pn->distance,
+					pn->tag);
+				if (pn->table_id)
+					vty_out(vty, ", table %" PRIu32, pn->table_id);
+				vty_out(vty, "\n");
+
+				frr_each (static_nexthop_list, &pn->nexthop_list, nh)
+					static_show_nh(vty, nh, vrf_name, NULL);
+			}
+		}
+	}
+}
+
+static void static_show_routes_vrf(struct vty *vty, struct static_vrf *svrf, bool json,
+				   struct json_object *jo)
+{
+	struct route_table *stable;
+	const char *vrf_name;
+
+	vrf_name = svrf->vrf ? svrf->vrf->name : "unknown";
+
+	if (json) {
+		struct json_object *jo_vrf = json_object_new_object();
+		struct json_object *jo_routes = json_object_new_array();
+
+		stable = static_vrf_static_table(AFI_IP, SAFI_UNICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "ipv4", "unicast",
+						jo_routes);
+
+		stable = static_vrf_static_table(AFI_IP, SAFI_MULTICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "ipv4", "multicast",
+						jo_routes);
+
+		stable = static_vrf_static_table(AFI_IP6, SAFI_UNICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "ipv6", "unicast",
+						jo_routes);
+
+		stable = static_vrf_static_table(AFI_IP6, SAFI_MULTICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "ipv6", "multicast",
+						jo_routes);
+
+		json_object_object_add(jo_vrf, "routes", jo_routes);
+		json_object_object_add(jo, vrf_name, jo_vrf);
+	} else {
+		vty_out(vty, "VRF %s:\n", vrf_name);
+
+		stable = static_vrf_static_table(AFI_IP, SAFI_UNICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "IPv4 Unicast", NULL, NULL);
+
+		stable = static_vrf_static_table(AFI_IP, SAFI_MULTICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "IPv4 Multicast", NULL,
+						NULL);
+
+		stable = static_vrf_static_table(AFI_IP6, SAFI_UNICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "IPv6 Unicast", NULL, NULL);
+
+		stable = static_vrf_static_table(AFI_IP6, SAFI_MULTICAST, svrf);
+		if (stable)
+			static_show_route_table(vty, stable, vrf_name, "IPv6 Multicast", NULL,
+						NULL);
+
+		vty_out(vty, "\n");
+	}
+}
+
+DEFPY(show_static_routes, show_static_routes_cmd,
+      "show static routes [vrf NAME$vrf_name] [json]$isjson",
+      SHOW_STR
+      STATICD_STR
+      "Configured static routes\n"
+      VRF_CMD_HELP_STR
+      JSON_STR)
+{
+	struct static_vrf *svrf;
+	bool json = !!isjson;
+	struct json_object *jo = NULL;
+
+	if (json)
+		jo = json_object_new_object();
+
+	if (vrf_name) {
+		bool found = false;
+
+		RB_FOREACH (svrf, svrf_name_head, &svrfs) {
+			if (svrf->vrf && strmatch(svrf->vrf->name, vrf_name)) {
+				static_show_routes_vrf(vty, svrf, json, jo);
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			if (json) {
+				vty_out(vty, "%s\n",
+					json_object_to_json_string_ext(jo,
+								       JSON_C_TO_STRING_PRETTY));
+				json_object_free(jo);
+			} else {
+				vty_out(vty, "%% VRF %s not found\n", vrf_name);
+			}
+			return CMD_WARNING;
+		}
+	} else {
+		RB_FOREACH (svrf, svrf_name_head, &svrfs)
+			static_show_routes_vrf(vty, svrf, json, jo);
+	}
+
+	if (json) {
+		vty_out(vty, "%s\n", json_object_to_json_string_ext(jo, JSON_C_TO_STRING_PRETTY));
+		json_object_free(jo);
+	}
+
+	return CMD_SUCCESS;
+}
+
 #endif /* ifndef INCLUDE_MGMTD_CMDDEFS_ONLY */
 
 void static_vty_init(void)
@@ -2134,6 +2623,7 @@ void static_vty_init(void)
 	install_element(CONFIG_NODE, &debug_staticd_cmd);
 	install_element(ENABLE_NODE, &show_debugging_static_cmd);
 	install_element(ENABLE_NODE, &staticd_show_bfd_routes_cmd);
+	install_element(VIEW_NODE, &show_static_routes_cmd);
 #else /* else INCLUDE_MGMTD_CMDDEFS_ONLY */
 	install_element(CONFIG_NODE, &ip_mroute_dist_cmd);
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -471,8 +471,6 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 			api_nh->srte_color = nh->color;
 		}
 
-		nh->state = STATIC_SENT_TO_ZEBRA;
-
 		switch (nh->type) {
 		case STATIC_IFNAME:
 			if (nh->ifindex == IFINDEX_INTERNAL)
@@ -518,6 +516,8 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 			}
 			break;
 		}
+
+		nh->state = STATIC_SENT_TO_ZEBRA;
 
 		if (nh->snh_label.num_labels) {
 			int i;

--- a/tests/topotests/static_show_routes/r1/frr.conf
+++ b/tests/topotests/static_show_routes/r1/frr.conf
@@ -1,0 +1,31 @@
+!
+interface r1-eth0
+ ip address 10.1.0.1/24
+ ipv6 address 2001:db8:1::1/64
+exit
+!
+! Route via a reachable gateway (directly connected)
+ip route 192.168.1.0/24 10.1.0.2
+!
+! Route via an unreachable gateway (no route to it)
+ip route 192.168.2.0/24 10.99.99.1
+!
+! Route via interface
+ip route 192.168.3.0/24 r1-eth0
+!
+! Blackhole route
+ip route 192.168.4.0/24 blackhole
+!
+! Reject route
+ip route 192.168.5.0/24 reject
+!
+! Multi-nexthop route: one reachable, one unreachable
+ip route 192.168.6.0/24 10.1.0.2
+ip route 192.168.6.0/24 10.99.99.2
+!
+! IPv6 route via reachable gateway
+ipv6 route 2001:db8:10::/48 2001:db8:1::2
+!
+! IPv6 blackhole
+ipv6 route 2001:db8:20::/48 blackhole
+!

--- a/tests/topotests/static_show_routes/test_static_show_routes.py
+++ b/tests/topotests/static_show_routes/test_static_show_routes.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2025
+#
+"""
+Test the 'show static routes [json]' command in staticd.
+
+Verifies:
+  - Basic JSON structure for various nexthop types
+  - active / inactive status per nexthop
+  - reasonInactive strings for unreachable gateways
+  - Blackhole and reject routes
+  - Multi-nexthop routes with mixed active/inactive nexthops
+  - IPv6 routes
+  - Plain-text output contains expected keywords
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.staticd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_show_static_json(r1):
+    """Return parsed JSON from 'show static routes json'."""
+    raw = r1.vtysh_cmd("show static routes json")
+    return json.loads(raw)
+
+
+def _find_route(routes, prefix):
+    """Find a route entry by prefix string in the routes array."""
+    for r in routes:
+        if r.get("prefix") == prefix:
+            return r
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_show_static_routes_json_structure(tgen=None):
+    """The JSON output must have the expected top-level structure."""
+    if tgen is None:
+        tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        # Must have a "default" VRF key
+        if "default" not in output:
+            return "missing 'default' key in output"
+        vrf = output["default"]
+        if "routes" not in vrf:
+            return "missing 'routes' in default VRF"
+        routes = vrf["routes"]
+        if not isinstance(routes, list):
+            return "'routes' is not a list"
+        if len(routes) == 0:
+            return "no routes found yet"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"JSON structure check failed: {result}"
+
+
+def test_show_static_gateway_reachable():
+    """A static route via a directly-connected gateway should be active."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.1.0/24")
+        if route is None:
+            return "route 192.168.1.0/24 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("type") != "ipv4-gateway":
+            return f"unexpected type: {nh.get('type')}"
+        if nh.get("gateway") != "10.1.0.2":
+            return f"unexpected gateway: {nh.get('gateway')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        if nh.get("nhValid") is not True:
+            return f"expected nhValid=true, got {nh.get('nhValid')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Reachable gateway check failed: {result}"
+
+
+def test_show_static_gateway_unreachable():
+    """A static route via an unreachable gateway should be inactive with reason."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.2.0/24")
+        if route is None:
+            return "route 192.168.2.0/24 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("active") is not False:
+            return f"expected active=false, got {nh.get('active')}"
+        if nh.get("nhValid") is not False:
+            return f"expected nhValid=false, got {nh.get('nhValid')}"
+        reason = nh.get("reasonInactive", "")
+        if "not reachable" not in reason and "not yet registered" not in reason:
+            return f"unexpected reasonInactive: {reason}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Unreachable gateway check failed: {result}"
+
+
+def test_show_static_interface_route():
+    """A static route via an existing interface should be active."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.3.0/24")
+        if route is None:
+            return "route 192.168.3.0/24 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("type") != "interface":
+            return f"unexpected type: {nh.get('type')}"
+        if nh.get("interface") != "r1-eth0":
+            return f"unexpected interface: {nh.get('interface')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Interface route check failed: {result}"
+
+
+def test_show_static_blackhole():
+    """Blackhole routes should always be active."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.4.0/24")
+        if route is None:
+            return "route 192.168.4.0/24 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("type") != "blackhole":
+            return f"unexpected type: {nh.get('type')}"
+        if nh.get("blackholeType") != "drop":
+            return f"unexpected blackholeType: {nh.get('blackholeType')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Blackhole route check failed: {result}"
+
+
+def test_show_static_reject():
+    """Reject routes should always be active."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.5.0/24")
+        if route is None:
+            return "route 192.168.5.0/24 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("type") != "blackhole":
+            return f"unexpected type: {nh.get('type')}"
+        if nh.get("blackholeType") != "reject":
+            return f"unexpected blackholeType: {nh.get('blackholeType')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Reject route check failed: {result}"
+
+
+def test_show_static_multi_nexthop():
+    """Multi-nexthop route: reachable NH active, unreachable NH inactive."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.6.0/24")
+        if route is None:
+            return "route 192.168.6.0/24 not found"
+        # All nexthops should be in the same path (same distance)
+        nexthops = route["paths"][0]["nexthops"]
+        if len(nexthops) < 2:
+            return f"expected 2 nexthops, got {len(nexthops)}"
+
+        # Build a map by gateway
+        by_gw = {}
+        for nh in nexthops:
+            gw = nh.get("gateway", "")
+            by_gw[gw] = nh
+
+        # 10.1.0.2 should be active (directly connected)
+        nh_good = by_gw.get("10.1.0.2")
+        if nh_good is None:
+            return "nexthop 10.1.0.2 not found"
+        if nh_good.get("active") is not True:
+            return f"10.1.0.2: expected active=true, got {nh_good.get('active')}"
+
+        # 10.99.99.2 should be inactive
+        nh_bad = by_gw.get("10.99.99.2")
+        if nh_bad is None:
+            return "nexthop 10.99.99.2 not found"
+        if nh_bad.get("active") is not False:
+            return f"10.99.99.2: expected active=false, got {nh_bad.get('active')}"
+        if "reasonInactive" not in nh_bad:
+            return "10.99.99.2: missing reasonInactive"
+
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Multi-nexthop check failed: {result}"
+
+
+def test_show_static_multi_nexthop_installed_but_inactive():
+    """When a multi-nexthop route is installed (because at least one NH is
+    valid), zebra marks ALL nexthops with routeState='installed' -- even the
+    invalid one. The 'active' field must still correctly show false for the
+    invalid nexthop, and a reasonInactive must be present.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "192.168.6.0/24")
+        if route is None:
+            return "route 192.168.6.0/24 not found"
+
+        nexthops = route["paths"][0]["nexthops"]
+        by_gw = {nh.get("gateway", ""): nh for nh in nexthops}
+
+        nh_good = by_gw.get("10.1.0.2")
+        nh_bad = by_gw.get("10.99.99.2")
+        if nh_good is None or nh_bad is None:
+            return "one of the nexthops not found yet"
+
+        # Wait until the valid nexthop is actually installed by zebra
+        if nh_good.get("routeState") != "installed":
+            return f"10.1.0.2: routeState not yet installed ({nh_good.get('routeState')})"
+
+        # THE BUG CHECK: zebra sets routeState=installed for ALL nexthops
+        # in the path, including the invalid one.  That's the kernel behavior
+        # we can't change.  But 'active' must correctly reflect reality.
+
+        # The valid nexthop: installed AND active
+        if nh_good.get("active") is not True:
+            return f"10.1.0.2: expected active=true, got {nh_good.get('active')}"
+
+        # The invalid nexthop: routeState may say 'installed' (the bug),
+        # but active MUST be false
+        if nh_bad.get("active") is not False:
+            return (
+                f"10.99.99.2: BUG - routeState={nh_bad.get('routeState')} "
+                f"but active should be false, got {nh_bad.get('active')}"
+            )
+
+        # Must have a reason explaining why it's inactive
+        reason = nh_bad.get("reasonInactive", "")
+        if not reason:
+            return "10.99.99.2: active=false but no reasonInactive provided"
+        if "not reachable" not in reason and "not yet registered" not in reason:
+            return f"10.99.99.2: unexpected reasonInactive: {reason}"
+
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=60, wait=1)
+    assert result is None, f"Installed-but-inactive check failed: {result}"
+
+
+def test_show_static_ipv6_gateway():
+    """IPv6 static route via reachable gateway should be active."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "2001:db8:10::/48")
+        if route is None:
+            return "route 2001:db8:10::/48 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("type") != "ipv6-gateway":
+            return f"unexpected type: {nh.get('type')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"IPv6 gateway check failed: {result}"
+
+
+def test_show_static_ipv6_blackhole():
+    """IPv6 blackhole route should be active."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "2001:db8:20::/48")
+        if route is None:
+            return "route 2001:db8:20::/48 not found"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("type") != "blackhole":
+            return f"unexpected type: {nh.get('type')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"IPv6 blackhole check failed: {result}"
+
+
+def test_show_static_plain_text():
+    """Plain-text output must contain key diagnostic strings."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = r1.vtysh_cmd("show static routes")
+        # Must mention VRF
+        if "VRF default:" not in output:
+            return f"missing 'VRF default:' in output:\n{output}"
+        # Must have at least one active nexthop
+        if "active" not in output:
+            return f"missing 'active' in output:\n{output}"
+        # Must show IPv4 Unicast header
+        if "IPv4 Unicast:" not in output:
+            return f"missing 'IPv4 Unicast:' in output:\n{output}"
+        # Must show some prefix
+        if "192.168.1.0/24" not in output:
+            return f"missing '192.168.1.0/24' in output:\n{output}"
+        # Unreachable routes should show inactive reason
+        if "inactive reason:" not in output:
+            return f"missing 'inactive reason:' in output:\n{output}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Plain-text output check failed: {result}"
+
+
+def test_show_static_plain_text_inactive_nexthop():
+    """Plain-text: for the multi-NH route, the unreachable NH must show
+    'inactive' (not misleadingly 'installed') with a reason string."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        output = r1.vtysh_cmd("show static routes")
+        # Find the 192.168.6.0/24 section
+        if "192.168.6.0/24" not in output:
+            return "192.168.6.0/24 not in plain-text output"
+        # The unreachable gateway line should be followed by "inactive"
+        lines = output.splitlines()
+        found_bad_nh = False
+        for i, line in enumerate(lines):
+            if "10.99.99.2" in line:
+                found_bad_nh = True
+                # Next line(s) should say "inactive"
+                remaining = "\n".join(lines[i:i + 3])
+                if "inactive" not in remaining:
+                    return (
+                        f"10.99.99.2 NH does not show 'inactive':\n{remaining}"
+                    )
+                if "inactive reason:" not in remaining:
+                    return (
+                        f"10.99.99.2 NH missing 'inactive reason:':\n{remaining}"
+                    )
+                break
+        if not found_bad_nh:
+            return "10.99.99.2 nexthop not found in plain-text output"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Plain-text inactive NH check failed: {result}"
+
+
+def test_show_static_vrf_filter():
+    """'show static routes vrf default' should work and match unfiltered output."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    output_all = _get_show_static_json(r1)
+    output_filtered = json.loads(r1.vtysh_cmd("show static routes vrf default json"))
+
+    # Both should have the default VRF with the same routes
+    assert "default" in output_filtered, "missing 'default' in VRF-filtered output"
+    all_routes = output_all["default"]["routes"]
+    filtered_routes = output_filtered["default"]["routes"]
+    assert len(all_routes) == len(filtered_routes), (
+        f"route count mismatch: all={len(all_routes)} filtered={len(filtered_routes)}"
+    )
+
+
+def test_show_static_vrf_nonexistent():
+    """'show static routes vrf BOGUS' should produce a warning."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    output = r1.vtysh_cmd("show static routes vrf BOGUS")
+    assert "not found" in output or output.strip() == "", (
+        f"Expected error for nonexistent VRF, got: {output}"
+    )
+
+
+def test_show_static_dynamic_route_add():
+    """Adding a route dynamically should appear in show static routes."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Add a new static route
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        ip route 172.16.99.0/24 10.1.0.2
+        """
+    )
+
+    def _check():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        route = _find_route(routes, "172.16.99.0/24")
+        if route is None:
+            return "route 172.16.99.0/24 not found after adding"
+        nh = route["paths"][0]["nexthops"][0]
+        if nh.get("gateway") != "10.1.0.2":
+            return f"unexpected gateway: {nh.get('gateway')}"
+        if nh.get("active") is not True:
+            return f"expected active=true, got {nh.get('active')}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=30, wait=1)
+    assert result is None, f"Dynamic route add check failed: {result}"
+
+    # Clean up
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        no ip route 172.16.99.0/24 10.1.0.2
+        """
+    )
+
+
+def test_show_static_dynamic_route_remove():
+    """Removing a route should make it disappear from show static routes."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Add and then remove
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        ip route 172.16.88.0/24 10.1.0.2
+        """
+    )
+
+    def _check_present():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        if _find_route(routes, "172.16.88.0/24") is None:
+            return "route 172.16.88.0/24 not found"
+        return None
+
+    _, result = topotest.run_and_expect(_check_present, None, count=30, wait=1)
+    assert result is None, f"Route not present after add: {result}"
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        no ip route 172.16.88.0/24 10.1.0.2
+        """
+    )
+
+    def _check_absent():
+        output = _get_show_static_json(r1)
+        routes = output["default"]["routes"]
+        if _find_route(routes, "172.16.88.0/24") is not None:
+            return "route 172.16.88.0/24 still present after removal"
+        return None
+
+    _, result = topotest.run_and_expect(_check_absent, None, count=30, wait=1)
+    assert result is None, f"Route still present after remove: {result}"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Currently it's quite hard to debug missing routes because there is no way to inspect staticd's internal per-nexthop state. 'show ip route' only shows what zebra has accepted into the RIB, so no information on e.g. unreachable nexthop or down interface.

Add a new 'show static routes' command that exposes staticd's view of every configured routes: nexthop type, active inactive status, NHT registration and validity, ifindex, and a human-readable reason when a nexthop is not active.

Also change `static_zebra_route_add` to set `SENT_TO_ZEBRA` state only for nexthops that pass 'skip checks'.

I'm not so sure about the `static_nh_reason_inactive` thing. It's nice to look at, but could quickly become out-of-sync or plainly wrong when somethings changes or some more complex route-reject logic happens.
