### PR TITLE
bgpd: fix NHT for explicit link-local BGP peers (backport)

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -342,8 +342,16 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop, afi_
 		 * NH could be set to different v6 LL address (compared to
 		 * peer's LL) using route-map. In such a scenario, do not set
 		 * the ifindex.
+		 *
+		 * Only do this for dynamic LL peers (conf_if set) where
+		 * scope_id is populated early from ifp->ifindex.  For
+		 * explicit LL peers (conf_if NULL, e.g. "neighbor fe80::X
+		 * interface swpN") the scope_id arrives only after the TCP
+		 * handshake; using it here would create a BNC keyed with the
+		 * real ifindex while peer-tracking already created one with
+		 * ifindex 0, causing a stale NHT entry after session flaps.
 		 */
-		if (afi == AFI_IP6 &&
+		if (afi == AFI_IP6 && pi->peer->conf_if &&
 		    IN6_IS_ADDR_LINKLOCAL(
 			    &pi->peer->connection->su.sin6.sin6_addr) &&
 		    IPV6_ADDR_SAME(&pi->peer->connection->su.sin6.sin6_addr,


### PR DESCRIPTION
When a BGP peer is configured with an explicit IPv6 link-local address (neighbor fe80::1 interface swp1), the NHT peer-tracking code skipped deriving the ifindex from the kernel-provided scope_id because peer->conf_if is NULL for this configuration style.  This caused peer-tracking to create a BNC keyed with ifindex 0 while path-tracking created a separate BNC keyed with the real ifindex from scope_id, resulting in a stale invalid NHT entry after session flaps.

Add a conf_if guard to the path-tracking ifindex derivation so that explicit LL peers (conf_if NULL) always use ifindex 0 for the BNC key, consistent with peer-tracking.  This ensures both tracking paths converge on the same BNC and Zebra-based nexthop validation.