### PR TITLE
Mgmt frontend problems in zebra

### DIFF
--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -529,9 +529,20 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 								  commit_msg->unlock,
 								  err_msg->errstr);
 			break;
+		case MGMT_MSG_CODE_EDIT:
+			if (!session->client->cbs.edit_notify)
+				goto generic_error_handler;
+			edit_msg = (typeof(edit_msg))orig_msg;
+			xpath = mgmt_msg_native_xpath_decode(edit_msg,
+							     mgmt_msg_native_get_msg_len(edit_msg));
+			session->client->cbs.edit_notify(client, client->user_data,
+							 session->client_id, msg->refer_id,
+							 session->user_ctx, msg->req_id, xpath,
+							 err_msg->error ?: -EINVAL,
+							 err_msg->errstr);
+			break;
 		case MGMT_MSG_CODE_GET_DATA:
 		case MGMT_MSG_CODE_ERROR:
-		case MGMT_MSG_CODE_EDIT:
 		case MGMT_MSG_CODE_NOTIFY:
 		case MGMT_MSG_CODE_RPC:
 generic_error_handler:
@@ -610,11 +621,9 @@ generic_error_handler:
 			break;
 		}
 
-		session->client->cbs.edit_notify(client, client->user_data,
-						 session->client_id,
-						 msg->refer_id,
-						 session->user_ctx, msg->req_id,
-						 xpath);
+		session->client->cbs.edit_notify(client, client->user_data, session->client_id,
+						 msg->refer_id, session->user_ctx, msg->req_id,
+						 xpath, 0, NULL);
 		break;
 	case MGMT_MSG_CODE_RPC_REPLY:
 		if (!session->client->cbs.rpc_notify)

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -80,10 +80,9 @@ struct mgmt_fe_client_cbs {
 			       void *result, size_t len, int partial_error);
 
 	/* Called when edit result is returned */
-	int (*edit_notify)(struct mgmt_fe_client *client, uintptr_t user_data,
-			   uint64_t client_id, uint64_t session_id,
-			   uintptr_t session_ctx, uint64_t req_id,
-			   const char *xpath);
+	int (*edit_notify)(struct mgmt_fe_client *client, uintptr_t user_data, uint64_t client_id,
+			   uint64_t session_id, uintptr_t session_ctx, uint64_t req_id,
+			   const char *xpath, int error, const char *errstr);
 
 	/* Called when RPC result is returned */
 	int (*rpc_notify)(struct mgmt_fe_client *client, uintptr_t user_data,

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -2212,7 +2212,11 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction,
 			 * The dnode from 'delete' callbacks point to elements
 			 * from the running configuration. Use yang_dnode_get()
 			 * to get the corresponding dnode from the candidate
-			 * configuration that is being committed.
+			 * configuration that is being committed. If it doesn't
+			 * exist we fall through the below loop; however, there
+			 * will then exist a destroy change for the deleted
+			 * parent, and so we will repeat the process looking for
+			 * the parent's parent here, and so on.
 			 */
 			yang_dnode_get_path(dnode, xpath, sizeof(xpath));
 			dnode = yang_dnode_get(candidate_config->dnode, xpath);

--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -598,15 +598,22 @@ int vty_mgmt_send_edit_req(struct vty *vty, uint8_t datastore, LYD_FORMAT reques
 
 static int vty_mgmt_handle_edit_reply(struct mgmt_fe_client *client, uintptr_t user_data,
 				      uint64_t client_id, uint64_t session_id,
-				      uintptr_t session_ctx, uint64_t req_id, const char *xpath)
+				      uintptr_t session_ctx, uint64_t req_id, const char *xpath,
+				      int error, const char *errstr)
 {
 	struct vty *vty = (struct vty *)session_ctx;
 
-	debug_fe_client("EDIT request for client 0x%" PRIx64 " req-id %" PRIu64
-			" was successful, xpath: %s",
-			client_id, req_id, xpath);
+	if (!error)
+		debug_fe_client("EDIT request for client 0x%Lx req-id %Lu was successful, xpath: %s",
+				client_id, req_id, xpath);
+	else {
+		debug_fe_client("EDIT request for client 0x%Lx req-id %Lu failed xpath: %s: %d: %s",
+				client_id, req_id, xpath, error, errstr);
+		vty_out(vty, "%% %s\n", errstr);
+		vty_out(vty, "%% Failed to edit configuration.\n");
+	}
 
-	vty_mgmt_resume_response(vty, CMD_SUCCESS);
+	vty_mgmt_resume_response(vty, error ? CMD_WARNING_CONFIG_FAILED : CMD_SUCCESS);
 
 	return 0;
 }

--- a/tests/topotests/mgmt_config/test_conf_errant_end_exits.py
+++ b/tests/topotests/mgmt_config/test_conf_errant_end_exits.py
@@ -5,8 +5,13 @@
 #
 # Copyright (c) 2023, LabN Consulting, L.L.C.
 #
-"""
-Test mgmtd parsing of configs.
+"""Test mgmtd parsing of configs.
+
+This is a specific test suite to test the various behaviors of parsing
+config files either redirected or with -f, and in particular the behavior of
+errant exit and end in those files. The test files are crafted to have a specific
+number of exits and ends, and the test verifies that the expected config is
+applied after the file is processed.
 
 So:
 

--- a/tests/topotests/zebra_config/r1/frr.conf
+++ b/tests/topotests/zebra_config/r1/frr.conf
@@ -1,0 +1,14 @@
+!debug northbound notifications
+!debug northbound events
+!debug northbound callbacks
+!debug mgmt backend datastore frontend transaction
+!debug mgmt client backend
+!debug mgmt client frontend
+
+log timestamp precision 6
+log file frr.log debug
+
+interface r1-eth0
+  ip address 101.0.0.1/24
+  ipv6 address 2101::1/64
+exit

--- a/tests/topotests/zebra_config/r1/import-table-route-map-zebra.conf
+++ b/tests/topotests/zebra_config/r1/import-table-route-map-zebra.conf
@@ -1,0 +1,3 @@
+route-map IMPORT-FILTER permit 10
+ip import-table 11 route-map IMPORT-FILTER
+ipv6 import-table 11 mrib route-map IMPORT-FILTER

--- a/tests/topotests/zebra_config/r1/import-table-zebra.conf
+++ b/tests/topotests/zebra_config/r1/import-table-zebra.conf
@@ -1,0 +1,2 @@
+ip import-table 10
+ipv6 import-table 10 mrib

--- a/tests/topotests/zebra_config/test_zebra_config.py
+++ b/tests/topotests/zebra_config/test_zebra_config.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+#
+# April 7 2026, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2026, LabN Consulting, L.L.C.
+#
+#
+"""
+Test zebra config. Expand as we go.
+"""
+import ipaddress
+import logging
+import os
+import re
+from pathlib import Path
+
+import pytest
+from lib import topotest
+from lib.common_config import retry, step
+from lib.topogen import Topogen, TopoRouter
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    "Setup/Teardown the environment and provide tgen argument to tests"
+
+    topodef = {"s1": ("r1",)}
+
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+@pytest.fixture(scope="module")
+def r1(tgen):
+    return tgen.gears["r1"].net
+
+
+@pytest.fixture(scope="module")
+def confdir():
+    return Path(os.environ["PYTEST_TOPOTEST_SCRIPTDIR"]) / "r1"
+
+
+@pytest.fixture(autouse=True, scope="function")
+def cleanup_config(r1):
+    yield
+
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no allow-external-route-update'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no router-id 1.2.3.4'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no ip table range 2 3'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no ip import-table 10'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no ipv6 import-table 10 mrib'")
+    r1.cmd_nostatus(
+        "vtysh -c 'conf t' -c 'no ip import-table 11 route-map IMPORT-FILTER'"
+    )
+    r1.cmd_nostatus(
+        "vtysh -c 'conf t' -c 'no ipv6 import-table 11 mrib route-map IMPORT-FILTER'"
+    )
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no route-map IMPORT-FILTER'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no zebra work-queue'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no zebra zapi-packets'")
+    r1.cmd_nostatus("vtysh -c 'conf t' -c 'no zebra dplane limit'")
+    expect_show_running(
+        r1,
+        absent=[
+            "ip table range 2 3",
+            "ip import-table 10",
+            "ipv6 import-table 10 mrib",
+            "ip import-table 11 route-map IMPORT-FILTER",
+            "ipv6 import-table 11 mrib route-map IMPORT-FILTER",
+            "route-map IMPORT-FILTER permit 10",
+            "zebra work-queue",
+            "zebra zapi-packets",
+            "zebra dplane limit",
+        ],
+    )
+
+
+def check_show_running(r1, present=None, absent=None):
+    showrun = r1.cmd_nostatus("vtysh -c 'show running'")
+
+    for entry in present or []:
+        if entry not in showrun:
+            return f"Missing '{entry}' in show running:\n{showrun}"
+
+    for entry in absent or []:
+        if entry in showrun:
+            return f"Unexpected '{entry}' in show running:\n{showrun}"
+
+    return None
+
+
+def expect_show_running(r1, present=None, absent=None):
+    test_func = lambda: check_show_running(r1, present=present, absent=absent)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+
+def test_zebra_import_table_file(r1, confdir):
+    conf = "import-table-zebra.conf"
+    step(f"load {conf} file with vtysh -f ")
+    output = r1.cmd_nostatus(f"vtysh -f {confdir / conf}")
+    print(output)
+
+    expect_show_running(
+        r1,
+        present=["ip import-table 10", "ipv6 import-table 10 mrib"],
+        absent=["route-map IMPORT-FILTER"],
+    )
+
+
+def test_zebra_import_table_route_map_file(r1, confdir):
+    conf = "import-table-route-map-zebra.conf"
+    step(f"load {conf} file with vtysh -f ")
+    output = r1.cmd_nostatus(f"vtysh -f {confdir / conf}")
+    print(output)
+
+    expect_show_running(
+        r1,
+        present=[
+            "route-map IMPORT-FILTER permit 10",
+            "ip import-table 11 route-map IMPORT-FILTER",
+            "ipv6 import-table 11 mrib route-map IMPORT-FILTER",
+        ],
+    )
+
+
+def test_zebra_mgmt_frontend_smoke(r1):
+    step("Configure mgmt-fronted zebra smoke commands")
+    r1.cmd_nostatus(
+        "vtysh -c 'conf t' -c 'zebra work-queue 123' "
+        "-c 'zebra zapi-packets 456' -c 'zebra dplane limit 789'"
+    )
+
+    expect_show_running(
+        r1,
+        present=[
+            "zebra work-queue 123",
+            "zebra zapi-packets 456",
+            "zebra dplane limit 789",
+        ],
+    )
+
+    step("Remove mgmt-fronted zebra smoke commands")
+    r1.cmd_nostatus(
+        "vtysh -c 'conf t' -c 'no zebra work-queue' "
+        "-c 'no zebra zapi-packets' -c 'no zebra dplane limit'"
+    )
+
+    expect_show_running(
+        r1,
+        absent=[
+            "zebra work-queue",
+            "zebra zapi-packets",
+            "zebra dplane limit",
+        ],
+    )

--- a/tests/topotests/zebra_ipv6_import_table/test_zebra_ipv6_import_table.py
+++ b/tests/topotests/zebra_ipv6_import_table/test_zebra_ipv6_import_table.py
@@ -36,6 +36,7 @@ sys.path.append(os.path.join(CWD, "../"))
 pytestmark = [pytest.mark.staticd]
 krel = platform.release()
 
+
 def build_topo(tgen):
     "Build function"
 
@@ -44,6 +45,7 @@ def build_topo(tgen):
     sw2 = tgen.add_switch("sw2")
     sw1.add_link(tgen.gears["r1"], "r1-eth0")
     sw2.add_link(tgen.gears["r1"], "r1-eth1")
+
 
 def setup_module(mod):
     "Sets up the pytest environment"
@@ -69,6 +71,20 @@ def teardown_module():
     tgen.stop_topology()
 
 
+def check_show_running(r1, present=None, absent=None):
+    showrun = r1.vtysh_cmd("show running")
+
+    for entry in present or []:
+        if entry not in showrun:
+            return f"Missing '{entry}' in show running:\n{showrun}"
+
+    for entry in absent or []:
+        if entry in showrun:
+            return f"Unexpected '{entry}' in show running:\n{showrun}"
+
+    return None
+
+
 def test_zebra_urib_import(request):
     "Verify router starts with the initial URIB"
     tgen = get_topogen()
@@ -83,9 +99,7 @@ def test_zebra_urib_import(request):
     step("Verify initial main routing table")
     initial_json_file = "{}/r1/import_init_table.json".format(CWD)
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -93,15 +107,18 @@ def test_zebra_urib_import(request):
         """
         conf term
          ipv6 import-table 10
-        """)
+        """
+    )
 
     import_json_file = "{}/r1/import_table_2.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(check_show_running, r1, present=["ipv6 import-table 10"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
     step("Add a new static route and verify it gets added")
     r1.vtysh_cmd(
@@ -113,9 +130,7 @@ def test_zebra_urib_import(request):
 
     sync_json_file = "{}/r1/import_table_3.json".format(CWD)
     expected = json.loads(open(sync_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -128,9 +143,7 @@ def test_zebra_urib_import(request):
     )
 
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -143,26 +156,79 @@ def test_zebra_urib_import(request):
     )
 
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(check_show_running, r1, absent=["ipv6 import-table 10"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
     step("Re-import with distance and verify correct distance")
     r1.vtysh_cmd(
         """
         conf term
          ipv6 import-table 10 distance 123
-        """)
+        """
+    )
 
     import_json_file = "{}/r1/import_table_4.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 route json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(
+        check_show_running, r1, present=["ipv6 import-table 10 distance 123"]
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    step("Re-import with route-map and verify show running")
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ipv6 import-table 10 distance 123
+         route-map IMPORT6-FILTER permit 10
+         ipv6 import-table 10 distance 123 route-map IMPORT6-FILTER
+        """
+    )
+
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 route json", expected)
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(
+        check_show_running,
+        r1,
+        present=[
+            "route-map IMPORT6-FILTER permit 10",
+            "ipv6 import-table 10 distance 123 route-map IMPORT6-FILTER",
+        ],
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ipv6 import-table 10 route-map IMPORT6-FILTER
+         no route-map IMPORT6-FILTER
+        """
+    )
+
+    test_func = partial(
+        check_show_running,
+        r1,
+        absent=[
+            "ipv6 import-table 10 distance 123 route-map IMPORT6-FILTER",
+            "route-map IMPORT6-FILTER permit 10",
+        ],
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
 
 def test_zebra_mrib_import(request):
     "Verify router starts with the initial MRIB"
@@ -178,9 +244,7 @@ def test_zebra_mrib_import(request):
     step("Verify initial main MRIB routing table")
     initial_json_file = "{}/r1/import_init_mrib_table.json".format(CWD)
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -188,15 +252,18 @@ def test_zebra_mrib_import(request):
         """
         conf term
          ipv6 import-table 10 mrib
-        """)
+        """
+    )
 
     import_json_file = "{}/r1/import_mrib_table_2.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(check_show_running, r1, present=["ipv6 import-table 10 mrib"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
     step("Add a new static route and verify it gets added")
     r1.vtysh_cmd(
@@ -208,9 +275,7 @@ def test_zebra_mrib_import(request):
 
     sync_json_file = "{}/r1/import_mrib_table_3.json".format(CWD)
     expected = json.loads(open(sync_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -223,9 +288,7 @@ def test_zebra_mrib_import(request):
     )
 
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
@@ -238,26 +301,33 @@ def test_zebra_mrib_import(request):
     )
 
     expected = json.loads(open(initial_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(check_show_running, r1, absent=["ipv6 import-table 10 mrib"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
     step("Re-import with distance and verify correct distance")
     r1.vtysh_cmd(
         """
         conf term
          ipv6 import-table 10 mrib distance 123
-        """)
-    
+        """
+    )
+
     import_json_file = "{}/r1/import_mrib_table_4.json".format(CWD)
     expected = json.loads(open(import_json_file).read())
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ipv6 rpf json", expected
-    )
+    test_func = partial(topotest.router_json_cmp, r1, "show ipv6 rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(
+        check_show_running, r1, present=["ipv6 import-table 10 mrib distance 123"]
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
 
 def test_memory_leak():

--- a/tests/topotests/zebra_rib/test_zebra_import.py
+++ b/tests/topotests/zebra_rib/test_zebra_import.py
@@ -183,6 +183,20 @@ def teardown_module():
     tgen.stop_topology()
 
 
+def check_show_running(r1, present=None, absent=None):
+    showrun = r1.vtysh_cmd("show running")
+
+    for entry in present or []:
+        if entry not in showrun:
+            return f"Missing '{entry}' in show running:\n{showrun}"
+
+    for entry in absent or []:
+        if entry in showrun:
+            return f"Unexpected '{entry}' in show running:\n{showrun}"
+
+    return None
+
+
 def test_zebra_urib_import(request):
     "Verify router starts with the initial URIB"
     tgen = get_topogen()
@@ -213,6 +227,10 @@ def test_zebra_urib_import(request):
     test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(check_show_running, r1, present=["ip import-table 10"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
     step("Add a new static route and verify it gets added")
     r1.vtysh_cmd(
@@ -253,6 +271,10 @@ def test_zebra_urib_import(request):
     test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(check_show_running, r1, absent=["ip import-table 10"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
     step("Re-import with distance and verify correct distance")
     r1.vtysh_cmd(
@@ -300,6 +322,57 @@ def test_zebra_urib_import(request):
     assert result is None, result
 
     r1.run(f"ip route del table 10 {replace_prefix} via 10.0.0.2 dev r1-eth0")
+
+    test_func = partial(
+        check_show_running, r1, present=["ip import-table 10 distance 123"]
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    step("Re-import with route-map and verify show running")
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ip import-table 10 distance 123
+         route-map IMPORT-FILTER permit 10
+         ip import-table 10 distance 123 route-map IMPORT-FILTER
+        """
+    )
+
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(topotest.router_json_cmp, r1, "show ip route json", expected)
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(
+        check_show_running,
+        r1,
+        present=[
+            "route-map IMPORT-FILTER permit 10",
+            "ip import-table 10 distance 123 route-map IMPORT-FILTER",
+        ],
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ip import-table 10 route-map IMPORT-FILTER
+         no route-map IMPORT-FILTER
+        """
+    )
+
+    test_func = partial(
+        check_show_running,
+        r1,
+        absent=[
+            "ip import-table 10 distance 123 route-map IMPORT-FILTER",
+            "route-map IMPORT-FILTER permit 10",
+        ],
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
 
 
 def test_zebra_static_route_preferred_over_sharp_import(request):
@@ -399,6 +472,10 @@ def test_zebra_mrib_import(request):
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
+    test_func = partial(check_show_running, r1, present=["ip import-table 10 mrib"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
     step("Add a new static route and verify it gets added")
     r1.vtysh_cmd(
         """
@@ -439,6 +516,10 @@ def test_zebra_mrib_import(request):
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
 
+    test_func = partial(check_show_running, r1, absent=["ip import-table 10 mrib"])
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
     step("Re-import with distance and verify correct distance")
     r1.vtysh_cmd(
         """
@@ -452,6 +533,45 @@ def test_zebra_mrib_import(request):
     test_func = partial(topotest.router_json_cmp, r1, "show ip rpf json", expected)
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, '"r1" JSON output mismatches'
+
+    test_func = partial(
+        check_show_running, r1, present=["ip import-table 10 mrib distance 123"]
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, result
+
+
+def test_zebra_import_bad_values(request):
+    "Verify router starts with the initial MRIB"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    _cleanup_added_import_test_routes(r1)
+
+    invids = [0, 252, 254, 255]
+    step("Verify invalid table IDs are rejected")
+    for tid in invids:
+        json = f"""{{"import-kernel-table":[{{"afi-safi":"frr-routing:ipv4-unicast","table-id":{tid}}}]}}"""
+        rc, stdout, _ = r1.net.cmd_status(
+            f"vtysh -c 'conf term' -c 'mgmt edit create /frr-zebra:zebra lock commit {json}'",
+            warn=False,
+        )
+        assert rc, f"Pass with invalid table ID {tid}: {stdout}"
+
+    valids = [1, 253, 1000]
+    step("Verify valid table IDs are accepted")
+    for tid in valids:
+        json = f"""{{"import-kernel-table":[{{"afi-safi":"frr-routing:ipv4-unicast","table-id":{tid}}}]}}"""
+        rc, stdout, _ = r1.net.cmd_status(
+            f"vtysh -c 'conf term' -c 'mgmt edit create /frr-zebra:zebra lock commit {json}'",
+            warn=False,
+        )
+        assert rc == 0, f"Failure with valid table ID {tid}: {stdout}"
 
 
 def test_memory_leak():

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -3126,14 +3126,23 @@ module frr-zebra {
         "Number of ZAPI packets to process before relinquishing
          the main thread.";
     }
-    container import-kernel-table {
+    list import-kernel-table {
+      key "afi-safi table-id";
       description
-        "Parameters to use when importing IPv4 routes from a non-main kernel
+        "Parameters to use when importing routes from a non-main kernel
          routing table.";
-      leaf table-id {
-        type uint32 {
-          range "1..252";
+      leaf afi-safi {
+        type identityref {
+          base frr-rt:afi-safi-type;
         }
+        must ". = 'frr-routing:ipv4-unicast' or . = 'frr-routing:ipv4-multicast' or . = 'frr-routing:ipv6-unicast' or . = 'frr-routing:ipv6-multicast'" {
+          error-message "Only IPv4 and IPv6 unicast and multicast import-table entries are supported.";
+        }
+        description
+          "The AFI/SAFI to import into.";
+      }
+      leaf table-id {
+        type uint32;
         description
           "The kernel table id.";
       }

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -143,6 +143,14 @@ static void zebra_zapi_packets_cli_write(struct vty *vty, const struct lyd_node 
 	vty_out(vty, "zebra zapi-packets %u\n", packets);
 }
 
+static void zebra_workqueue_hold_timer_cli_write(struct vty *vty, const struct lyd_node *dnode,
+						 bool show_defaults)
+{
+	uint32_t timer = yang_dnode_get_uint32(dnode, NULL);
+
+	vty_out(vty, "zebra work-queue %u\n", timer);
+}
+
 DEFPY_YANG (allow_external_route_update,
 	    allow_external_route_update_cmd,
 	    "[no] allow-external-route-update",
@@ -187,6 +195,24 @@ DEFPY_YANG_HIDDEN (zebra_zapi_packets,
 				      packets_str);
 	else
 		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/zapi-packets", NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG_HIDDEN (zebra_workqueue_timer,
+		   zebra_workqueue_timer_cmd,
+		   "[no] zebra work-queue ![(0-10000)$timer]",
+		   NO_STR
+		   ZEBRA_STR
+		   "Work Queue\n"
+		   "Time in milliseconds\n")
+{
+	if (!no)
+		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/workqueue-hold-timer", NB_OP_MODIFY,
+				      timer_str);
+	else
+		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/workqueue-hold-timer", NB_OP_DESTROY,
+				      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -2875,6 +2901,10 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 			.cbs.cli_show = zebra_zapi_packets_cli_write,
 		},
 		{
+			.xpath = "/frr-zebra:zebra/workqueue-hold-timer",
+			.cbs.cli_show = zebra_workqueue_hold_timer_cli_write,
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs",
 			.cbs.cli_show = lib_interface_zebra_ipv4_addrs_cli_write,
 		},
@@ -3210,6 +3240,7 @@ void zebra_cli_init(void)
 	install_element(CONFIG_NODE, &allow_external_route_update_cmd);
 	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
 	install_element(CONFIG_NODE, &zebra_zapi_packets_cmd);
+	install_element(CONFIG_NODE, &zebra_workqueue_timer_cmd);
 
 	install_element(CONFIG_NODE, &ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -6,6 +6,7 @@
 
 #include "command.h"
 #include "defaults.h"
+#include "frrdistance.h"
 #include "northbound_cli.h"
 #include "vrf.h"
 
@@ -151,6 +152,48 @@ static void zebra_workqueue_hold_timer_cli_write(struct vty *vty, const struct l
 	vty_out(vty, "zebra work-queue %u\n", timer);
 }
 
+static void zebra_import_kernel_table_xpath(char *xpath, size_t xpath_len, afi_t afi, safi_t safi,
+					    const char *table_id)
+{
+	snprintfrr(xpath, xpath_len,
+		   "/frr-zebra:zebra/import-kernel-table[afi-safi='%s'][table-id='%s']",
+		   yang_afi_safi_value2identity(afi, safi), table_id);
+}
+
+static void zebra_import_kernel_table_cli_write(struct vty *vty, const struct lyd_node *dnode,
+						bool show_defaults)
+{
+	const char *afi_safi = yang_dnode_get_string(dnode, "afi-safi");
+	uint32_t table_id = yang_dnode_get_uint32(dnode, "table-id");
+	uint32_t distance = yang_dnode_get_uint32(dnode, "distance");
+	const char *rmap = NULL;
+	afi_t afi;
+	safi_t safi;
+
+	if (yang_dnode_exists(dnode, "route-map"))
+		rmap = yang_dnode_get_string(dnode, "route-map");
+
+	yang_afi_safi_identity2value(afi_safi, &afi, &safi);
+
+	if (afi == AFI_IP)
+		vty_out(vty, "ip import-table %u", table_id);
+	else if (afi == AFI_IP6)
+		vty_out(vty, "ipv6 import-table %u", table_id);
+	else
+		return;
+
+	if (safi == SAFI_MULTICAST)
+		vty_out(vty, " mrib");
+
+	if (distance != ZEBRA_TABLE_DISTANCE_DEFAULT)
+		vty_out(vty, " distance %u", distance);
+
+	if (rmap)
+		vty_out(vty, " route-map %s", rmap);
+
+	vty_out(vty, "\n");
+}
+
 DEFPY_YANG (allow_external_route_update,
 	    allow_external_route_update_cmd,
 	    "[no] allow-external-route-update",
@@ -213,6 +256,88 @@ DEFPY_YANG_HIDDEN (zebra_workqueue_timer,
 	else
 		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/workqueue-hold-timer", NB_OP_DESTROY,
 				      NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (ip_zebra_import_table_distance,
+	    ip_zebra_import_table_distance_cmd,
+	    "ip import-table (1-252)$table_id [mrib]$mrib [distance (1-255)$distance] [route-map RMAP_NAME$rmap]",
+	    IP_STR
+	    "import routes from non-main kernel table\n"
+	    "kernel routing table id\n"
+	    "Import into the MRIB instead of the URIB\n"
+	    "Distance for imported routes\n"
+	    "Default distance value\n"
+	    "route-map for filtering\n"
+	    "route-map name\n")
+{
+	char xpath[XPATH_MAXLEN];
+	char xpath_child[XPATH_MAXLEN];
+	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
+
+	zebra_import_kernel_table_xpath(xpath, sizeof(xpath), AFI_IP, safi, table_id_str);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	snprintfrr(xpath_child, sizeof(xpath_child), "%s/distance", xpath);
+	nb_cli_enqueue_change(vty, xpath_child, NB_OP_MODIFY, distance_str ? distance_str : "15");
+
+	snprintfrr(xpath_child, sizeof(xpath_child), "%s/route-map", xpath);
+	nb_cli_enqueue_change(vty, xpath_child, rmap ? NB_OP_MODIFY : NB_OP_DESTROY, rmap);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (no_ip_zebra_import_table,
+	    no_ip_zebra_import_table_cmd,
+	    "no ip import-table (1-252)$table_id [mrib]$mrib [distance (1-255)] [route-map NAME]",
+	    NO_STR
+	    IP_STR
+	    "import routes from non-main kernel table\n"
+	    "kernel routing table id\n"
+	    "Import into the MRIB instead of the URIB\n"
+	    "Distance for imported routes\n"
+	    "Default distance value\n"
+	    "route-map for filtering\n"
+	    "route-map name\n")
+{
+	char xpath[XPATH_MAXLEN];
+	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
+
+	zebra_import_kernel_table_xpath(xpath, sizeof(xpath), AFI_IP, safi, table_id_str);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (ipv6_zebra_import_table_distance,
+	    ipv6_zebra_import_table_distance_cmd,
+	    "[no] ipv6 import-table (1-252)$table_id [mrib]$mrib [distance (1-255)$distance] [route-map RMAP_NAME$rmap]",
+	    NO_STR
+	    IPV6_STR
+	    "import routes from non-main kernel table\n"
+	    "kernel routing table id\n"
+	    "Import into the MRIB instead of the URIB\n"
+	    "Distance for imported routes\n"
+	    "Default distance value\n"
+	    "route-map for filtering\n"
+	    "route-map name\n")
+{
+	char xpath[XPATH_MAXLEN];
+	char xpath_child[XPATH_MAXLEN];
+	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
+
+	zebra_import_kernel_table_xpath(xpath, sizeof(xpath), AFI_IP6, safi, table_id_str);
+	nb_cli_enqueue_change(vty, xpath, no ? NB_OP_DESTROY : NB_OP_CREATE, NULL);
+
+	if (no)
+		return nb_cli_apply_changes(vty, NULL);
+
+	snprintfrr(xpath_child, sizeof(xpath_child), "%s/distance", xpath);
+	nb_cli_enqueue_change(vty, xpath_child, NB_OP_MODIFY, distance_str ? distance_str : "15");
+
+	snprintfrr(xpath_child, sizeof(xpath_child), "%s/route-map", xpath);
+	nb_cli_enqueue_change(vty, xpath_child, rmap ? NB_OP_MODIFY : NB_OP_DESTROY, rmap);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -2905,6 +3030,10 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 			.cbs.cli_show = zebra_workqueue_hold_timer_cli_write,
 		},
 		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table",
+			.cbs.cli_show = zebra_import_kernel_table_cli_write,
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs",
 			.cbs.cli_show = lib_interface_zebra_ipv4_addrs_cli_write,
 		},
@@ -3241,6 +3370,9 @@ void zebra_cli_init(void)
 	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
 	install_element(CONFIG_NODE, &zebra_zapi_packets_cmd);
 	install_element(CONFIG_NODE, &zebra_workqueue_timer_cmd);
+	install_element(CONFIG_NODE, &ip_zebra_import_table_distance_cmd);
+	install_element(CONFIG_NODE, &ipv6_zebra_import_table_distance_cmd);
+	install_element(CONFIG_NODE, &no_ip_zebra_import_table_cmd);
 
 	install_element(CONFIG_NODE, &ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -127,6 +127,14 @@ static void zebra_allow_external_route_update_cli_write(struct vty *vty,
 	vty_out(vty, "allow-external-route-update\n");
 }
 
+static void zebra_dplane_queue_limit_cli_write(struct vty *vty, const struct lyd_node *dnode,
+					       bool show_defaults)
+{
+	uint32_t limit = yang_dnode_get_uint32(dnode, NULL);
+
+	vty_out(vty, "zebra dplane limit %u\n", limit);
+}
+
 DEFPY_YANG (allow_external_route_update,
 	    allow_external_route_update_cmd,
 	    "[no] allow-external-route-update",
@@ -135,6 +143,25 @@ DEFPY_YANG (allow_external_route_update,
 {
 	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/allow-external-route-update",
 			      no ? NB_OP_DESTROY : NB_OP_CREATE, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (zebra_dplane_queue_limit,
+	    zebra_dplane_queue_limit_cmd,
+	    "[no] zebra dplane limit ![(0-10000)$limit]",
+	    NO_STR
+	    ZEBRA_STR
+	    "Zebra dataplane\n"
+	    "Limit incoming queued updates\n"
+	    "Number of queued updates\n")
+{
+	if (!no)
+		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/dplane-queue-limit", NB_OP_MODIFY,
+				      limit_str);
+	else
+		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/dplane-queue-limit", NB_OP_DESTROY,
+				      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -2815,6 +2842,10 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 			.cbs.cli_show = zebra_allow_external_route_update_cli_write,
 		},
 		{
+			.xpath = "/frr-zebra:zebra/dplane-queue-limit",
+			.cbs.cli_show = zebra_dplane_queue_limit_cli_write,
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs",
 			.cbs.cli_show = lib_interface_zebra_ipv4_addrs_cli_write,
 		},
@@ -3148,6 +3179,7 @@ void zebra_cli_init(void)
 	install_element(VRF_NODE, &ipv6_protocol_nht_rmap_cmd);
 	install_element(CONFIG_NODE, &zebra_route_map_timer_cmd);
 	install_element(CONFIG_NODE, &allow_external_route_update_cmd);
+	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
 
 	install_element(CONFIG_NODE, &ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -135,6 +135,14 @@ static void zebra_dplane_queue_limit_cli_write(struct vty *vty, const struct lyd
 	vty_out(vty, "zebra dplane limit %u\n", limit);
 }
 
+static void zebra_zapi_packets_cli_write(struct vty *vty, const struct lyd_node *dnode,
+					 bool show_defaults)
+{
+	uint32_t packets = yang_dnode_get_uint32(dnode, NULL);
+
+	vty_out(vty, "zebra zapi-packets %u\n", packets);
+}
+
 DEFPY_YANG (allow_external_route_update,
 	    allow_external_route_update_cmd,
 	    "[no] allow-external-route-update",
@@ -162,6 +170,23 @@ DEFPY_YANG (zebra_dplane_queue_limit,
 	else
 		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/dplane-queue-limit", NB_OP_DESTROY,
 				      NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG_HIDDEN (zebra_zapi_packets,
+		   zebra_zapi_packets_cmd,
+		   "[no] zebra zapi-packets ![(1-10000)$packets]",
+		   NO_STR
+		   ZEBRA_STR
+		   "Zapi Protocol\n"
+		   "Number of packets to process before relinquishing thread\n")
+{
+	if (!no)
+		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/zapi-packets", NB_OP_MODIFY,
+				      packets_str);
+	else
+		nb_cli_enqueue_change(vty, "/frr-zebra:zebra/zapi-packets", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -2846,6 +2871,10 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 			.cbs.cli_show = zebra_dplane_queue_limit_cli_write,
 		},
 		{
+			.xpath = "/frr-zebra:zebra/zapi-packets",
+			.cbs.cli_show = zebra_zapi_packets_cli_write,
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs",
 			.cbs.cli_show = lib_interface_zebra_ipv4_addrs_cli_write,
 		},
@@ -3180,6 +3209,7 @@ void zebra_cli_init(void)
 	install_element(CONFIG_NODE, &zebra_route_map_timer_cmd);
 	install_element(CONFIG_NODE, &allow_external_route_update_cmd);
 	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
+	install_element(CONFIG_NODE, &zebra_zapi_packets_cmd);
 
 	install_element(CONFIG_NODE, &ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -74,10 +74,11 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-zebra:zebra/import-kernel-table/table-id",
+			.xpath = "/frr-zebra:zebra/import-kernel-table",
 			.cbs = {
-				.modify = zebra_import_kernel_table_table_id_modify,
-				.destroy = zebra_import_kernel_table_table_id_destroy,
+				.create = zebra_import_kernel_table_create,
+				.destroy = zebra_import_kernel_table_destroy,
+				.apply_finish = zebra_import_kernel_table_apply_finish,
 			}
 		},
 		{

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -39,8 +39,9 @@ int zebra_workqueue_hold_timer_modify(struct nb_cb_modify_args *args);
 struct yang_data *zebra_ipv6_forwarding_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *zebra_state_mpls_forwarding_get_elem(struct nb_cb_get_elem_args *args);
 int zebra_zapi_packets_modify(struct nb_cb_modify_args *args);
-int zebra_import_kernel_table_table_id_modify(struct nb_cb_modify_args *args);
-int zebra_import_kernel_table_table_id_destroy(struct nb_cb_destroy_args *args);
+int zebra_import_kernel_table_create(struct nb_cb_create_args *args);
+int zebra_import_kernel_table_destroy(struct nb_cb_destroy_args *args);
+void zebra_import_kernel_table_apply_finish(struct nb_cb_apply_finish_args *args);
 int zebra_import_kernel_table_distance_modify(struct nb_cb_modify_args *args);
 int zebra_import_kernel_table_route_map_modify(struct nb_cb_modify_args *args);
 int zebra_import_kernel_table_route_map_destroy(

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -261,14 +261,12 @@ int zebra_allow_external_route_update_destroy(struct nb_cb_destroy_args *args)
  */
 int zebra_dplane_queue_limit_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	uint32_t limit = yang_dnode_get_uint32(args->dnode, NULL);
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	dplane_set_in_queue_limit(limit, true);
 
 	return NB_OK;
 }

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -140,35 +140,64 @@ int zebra_zapi_packets_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-/*
- * XPath: /frr-zebra:zebra/import-kernel-table/table-id
- */
-int zebra_import_kernel_table_table_id_modify(struct nb_cb_modify_args *args)
+static int zebra_import_kernel_table_apply(const struct lyd_node *dnode, bool add)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
+	const char *afi_safi = yang_dnode_get_string(dnode, "afi-safi");
+	uint32_t table_id = yang_dnode_get_uint32(dnode, "table-id");
+	uint32_t distance = 0;
+	const char *rmap = NULL;
+	afi_t afi;
+	safi_t safi;
+
+	yang_afi_safi_identity2value(afi_safi, &afi, &safi);
+
+	if (add) {
+		distance = yang_dnode_get_uint32(dnode, "distance");
+		if (yang_dnode_exists(dnode, "route-map"))
+			rmap = yang_dnode_get_string(dnode, "route-map");
+	}
+
+	return zebra_import_table(afi, safi, VRF_DEFAULT, table_id, distance, rmap, add);
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table
+ */
+int zebra_import_kernel_table_create(struct nb_cb_create_args *args)
+{
+	uint32_t table_id;
+
+	/* apply_finish handles creation */
+	if (args->event != NB_EV_VALIDATE)
+		return NB_OK;
+
+	table_id = yang_dnode_get_uint32(args->dnode, "table-id");
+
+	if (!is_zebra_valid_kernel_table(table_id) || is_zebra_main_routing_table(table_id)) {
+		snprintfrr(args->errmsg, args->errmsg_len,
+			   "invalid routing table ID %u: must be a non-default table in the range 1-252",
+			   table_id);
+		return NB_ERR_VALIDATION;
 	}
 
 	return NB_OK;
 }
 
-int zebra_import_kernel_table_table_id_destroy(struct nb_cb_destroy_args *args)
+int zebra_import_kernel_table_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	if (zebra_import_kernel_table_apply(args->dnode, false) < 0)
+		return NB_ERR;
 
 	return NB_OK;
+}
+
+void zebra_import_kernel_table_apply_finish(struct nb_cb_apply_finish_args *args)
+{
+	if (zebra_import_kernel_table_apply(args->dnode, true) < 0)
+		zlog_err("Failed to import kernel table");
 }
 
 /*
@@ -176,15 +205,7 @@ int zebra_import_kernel_table_table_id_destroy(struct nb_cb_destroy_args *args)
  */
 int zebra_import_kernel_table_distance_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
+	/* handled in apply_finish callback of the parent node */
 	return NB_OK;
 }
 
@@ -193,29 +214,13 @@ int zebra_import_kernel_table_distance_modify(struct nb_cb_modify_args *args)
  */
 int zebra_import_kernel_table_route_map_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
+	/* handled in apply_finish callback of the parent node */
 	return NB_OK;
 }
 
 int zebra_import_kernel_table_route_map_destroy(struct nb_cb_destroy_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
+	/* handled in apply_finish callback of the parent node */
 	return NB_OK;
 }
 

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -115,14 +115,12 @@ int zebra_ipv6_forwarding_destroy(struct nb_cb_destroy_args *args)
  */
 int zebra_workqueue_hold_timer_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	uint32_t timer = yang_dnode_get_uint32(args->dnode, NULL);
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zrouter.ribq->spec.hold = timer;
 
 	return NB_OK;
 }

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -132,14 +132,12 @@ int zebra_workqueue_hold_timer_modify(struct nb_cb_modify_args *args)
  */
 int zebra_zapi_packets_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	uint32_t packets = yang_dnode_get_uint32(args->dnode, NULL);
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	atomic_store_explicit(&zrouter.packets_to_process, packets, memory_order_relaxed);
 
 	return NB_OK;
 }

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -175,8 +175,7 @@ int zebra_import_kernel_table_create(struct nb_cb_create_args *args)
 
 	if (!is_zebra_valid_kernel_table(table_id) || is_zebra_main_routing_table(table_id)) {
 		snprintfrr(args->errmsg, args->errmsg_len,
-			   "invalid routing table ID %u: must be a non-default table in the range 1-252",
-			   table_id);
+			   "invalid routing table ID %u: must be a valid non-main table", table_id);
 		return NB_ERR_VALIDATION;
 	}
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3771,108 +3771,7 @@ DEFPY_HIDDEN (no_evpn_accept_bgp_seq,
 /* Static ip route configuration write function. */
 static int zebra_ip_config(struct vty *vty)
 {
-	int write = 0;
-
-	write += zebra_import_table_config(vty, VRF_DEFAULT);
-
-	return write;
-}
-
-DEFPY (ip_zebra_import_table_distance,
-       ip_zebra_import_table_distance_cmd,
-       "ip import-table (1-252)$table_id [mrib]$mrib [distance (1-255)$distance] [route-map RMAP_NAME$rmap]",
-       IP_STR
-       "import routes from non-main kernel table\n"
-       "kernel routing table id\n"
-	   "Import into the MRIB instead of the URIB\n"
-       "Distance for imported routes\n"
-       "Default distance value\n"
-       "route-map for filtering\n"
-       "route-map name\n")
-{
-	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
-
-	if (distance_str == NULL)
-		distance = ZEBRA_TABLE_DISTANCE_DEFAULT;
-
-	if (!is_zebra_valid_kernel_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be in range 1-252\n",
-			table_id);
-		return CMD_WARNING;
-	}
-
-	if (is_zebra_main_routing_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be non-default table\n",
-			table_id);
-		return CMD_WARNING;
-	}
-
-	return zebra_import_table(AFI_IP, safi, VRF_DEFAULT, table_id, distance, rmap, true);
-}
-
-DEFPY (ipv6_zebra_import_table_distance,
-       ipv6_zebra_import_table_distance_cmd,
-       "ipv6 import-table (1-252)$table_id [mrib]$mrib [distance (1-255)$distance] [route-map RMAP_NAME$rmap]",
-       IPV6_STR
-       "import routes from non-main kernel table\n"
-       "kernel routing table id\n"
-	   "Import into the MRIB instead of the URIB\n"
-       "Distance for imported routes\n"
-       "Default distance value\n"
-       "route-map for filtering\n"
-       "route-map name\n")
-{
-	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
-
-	if (distance_str == NULL)
-		distance = ZEBRA_TABLE_DISTANCE_DEFAULT;
-
-	if (!is_zebra_valid_kernel_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be in range 1-252\n",
-			table_id);
-		return CMD_WARNING;
-	}
-
-	if (is_zebra_main_routing_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be non-default table\n",
-			table_id);
-		return CMD_WARNING;
-	}
-
-	return zebra_import_table(AFI_IP6, safi, VRF_DEFAULT, table_id, distance, rmap, true);
-}
-
-DEFPY (no_ip_zebra_import_table,
-       no_ip_zebra_import_table_cmd,
-       "no ip import-table (1-252)$table_id [mrib]$mrib [distance (1-255)] [route-map NAME]",
-       NO_STR
-       IP_STR
-       "import routes from non-main kernel table\n"
-       "kernel routing table id\n"
-	   "Import into the MRIB instead of the URIB\n"
-       "Distance for imported routes\n"
-       "Default distance value\n"
-       "route-map for filtering\n"
-       "route-map name\n")
-{
-	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
-
-	if (!is_zebra_valid_kernel_table(table_id)) {
-		vty_out(vty,
-			"Invalid routing table ID. Must be in range 1-252\n");
-		return CMD_WARNING;
-	}
-
-	if (is_zebra_main_routing_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be non-default table\n",
-			table_id);
-		return CMD_WARNING;
-	}
-
-	if (!is_zebra_import_table_enabled(AFI_IP, safi, VRF_DEFAULT, table_id))
-		return CMD_SUCCESS;
-
-	return (zebra_import_table(AFI_IP, safi, VRF_DEFAULT, table_id, 0, NULL, false));
+	return 0;
 }
 
 DEFPY (zebra_nexthop_group_keep,
@@ -4376,9 +4275,6 @@ void zebra_vty_init(void)
 	install_node(&protocol_node);
 
 	install_element(CONFIG_NODE, &zebra_nexthop_group_keep_cmd);
-	install_element(CONFIG_NODE, &ip_zebra_import_table_distance_cmd);
-	install_element(CONFIG_NODE, &ipv6_zebra_import_table_distance_cmd);
-	install_element(CONFIG_NODE, &no_ip_zebra_import_table_cmd);
 	install_element(CONFIG_NODE, &nexthop_group_use_enable_cmd);
 	install_element(CONFIG_NODE, &proto_nexthop_group_only_cmd);
 	install_element(CONFIG_NODE, &backup_nexthop_recursive_use_enable_cmd);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3842,32 +3842,6 @@ DEFPY (ipv6_zebra_import_table_distance,
 	return zebra_import_table(AFI_IP6, safi, VRF_DEFAULT, table_id, distance, rmap, true);
 }
 
-DEFUN_HIDDEN (zebra_workqueue_timer,
-	      zebra_workqueue_timer_cmd,
-	      "zebra work-queue (0-10000)",
-	      ZEBRA_STR
-	      "Work Queue\n"
-	      "Time in milliseconds\n")
-{
-	uint32_t timer = strtoul(argv[2]->arg, NULL, 10);
-	zrouter.ribq->spec.hold = timer;
-
-	return CMD_SUCCESS;
-}
-
-DEFUN_HIDDEN (no_zebra_workqueue_timer,
-	      no_zebra_workqueue_timer_cmd,
-	      "no zebra work-queue [(0-10000)]",
-	      NO_STR
-	      ZEBRA_STR
-	      "Work Queue\n"
-	      "Time in milliseconds\n")
-{
-	zrouter.ribq->spec.hold = ZEBRA_RIB_PROCESS_HOLD_TIME;
-
-	return CMD_SUCCESS;
-}
-
 DEFPY (no_ip_zebra_import_table,
        no_ip_zebra_import_table_cmd,
        "no ip import-table (1-252)$table_id [mrib]$mrib [distance (1-255)] [route-map NAME]",
@@ -4405,8 +4379,6 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &ip_zebra_import_table_distance_cmd);
 	install_element(CONFIG_NODE, &ipv6_zebra_import_table_distance_cmd);
 	install_element(CONFIG_NODE, &no_ip_zebra_import_table_cmd);
-	install_element(CONFIG_NODE, &zebra_workqueue_timer_cmd);
-	install_element(CONFIG_NODE, &no_zebra_workqueue_timer_cmd);
 	install_element(CONFIG_NODE, &nexthop_group_use_enable_cmd);
 	install_element(CONFIG_NODE, &proto_nexthop_group_only_cmd);
 	install_element(CONFIG_NODE, &backup_nexthop_recursive_use_enable_cmd);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4199,39 +4199,6 @@ DEFUN (show_dataplane_providers,
 	return dplane_show_provs_helper(vty, detailed);
 }
 
-/* Configure dataplane incoming queue limit */
-DEFUN (zebra_dplane_queue_limit,
-       zebra_dplane_queue_limit_cmd,
-       "zebra dplane limit (0-10000)",
-       ZEBRA_STR
-       "Zebra dataplane\n"
-       "Limit incoming queued updates\n"
-       "Number of queued updates\n")
-{
-	uint32_t limit = 0;
-
-	limit = strtoul(argv[3]->arg, NULL, 10);
-
-	dplane_set_in_queue_limit(limit, true);
-
-	return CMD_SUCCESS;
-}
-
-/* Reset dataplane queue limit to default value */
-DEFUN (no_zebra_dplane_queue_limit,
-       no_zebra_dplane_queue_limit_cmd,
-       "no zebra dplane limit [(0-10000)]",
-       NO_STR
-       ZEBRA_STR
-       "Zebra dataplane\n"
-       "Limit incoming queued updates\n"
-       "Number of queued updates\n")
-{
-	dplane_set_in_queue_limit(0, false);
-
-	return CMD_SUCCESS;
-}
-
 DEFUN (zebra_show_routing_tables_summary,
        zebra_show_routing_tables_summary_cmd,
        "show zebra router table summary",
@@ -4543,8 +4510,6 @@ void zebra_vty_init(void)
 
 	install_element(VIEW_NODE, &show_dataplane_cmd);
 	install_element(VIEW_NODE, &show_dataplane_providers_cmd);
-	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
-	install_element(CONFIG_NODE, &no_zebra_dplane_queue_limit_cmd);
 	install_element(VIEW_NODE, &show_zebra_metaq_counters_cmd);
 	install_element(VIEW_NODE, &zebra_test_metaq_plug_cmd);
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3842,36 +3842,6 @@ DEFPY (ipv6_zebra_import_table_distance,
 	return zebra_import_table(AFI_IP6, safi, VRF_DEFAULT, table_id, distance, rmap, true);
 }
 
-DEFUN_HIDDEN (zebra_packet_process,
-	      zebra_packet_process_cmd,
-	      "zebra zapi-packets (1-10000)",
-	      ZEBRA_STR
-	      "Zapi Protocol\n"
-	      "Number of packets to process before relinquishing thread\n")
-{
-	uint32_t packets = strtoul(argv[2]->arg, NULL, 10);
-
-	atomic_store_explicit(&zrouter.packets_to_process, packets,
-			      memory_order_relaxed);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN_HIDDEN (no_zebra_packet_process,
-	      no_zebra_packet_process_cmd,
-	      "no zebra zapi-packets [(1-10000)]",
-	      NO_STR
-	      ZEBRA_STR
-	      "Zapi Protocol\n"
-	      "Number of packets to process before relinquishing thread\n")
-{
-	atomic_store_explicit(&zrouter.packets_to_process,
-			      ZEBRA_ZAPI_PACKETS_TO_PROCESS,
-			      memory_order_relaxed);
-
-	return CMD_SUCCESS;
-}
-
 DEFUN_HIDDEN (zebra_workqueue_timer,
 	      zebra_workqueue_timer_cmd,
 	      "zebra work-queue (0-10000)",
@@ -4437,8 +4407,6 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &no_ip_zebra_import_table_cmd);
 	install_element(CONFIG_NODE, &zebra_workqueue_timer_cmd);
 	install_element(CONFIG_NODE, &no_zebra_workqueue_timer_cmd);
-	install_element(CONFIG_NODE, &zebra_packet_process_cmd);
-	install_element(CONFIG_NODE, &no_zebra_packet_process_cmd);
 	install_element(CONFIG_NODE, &nexthop_group_use_enable_cmd);
 	install_element(CONFIG_NODE, &proto_nexthop_group_only_cmd);
 	install_element(CONFIG_NODE, &backup_nexthop_recursive_use_enable_cmd);


### PR DESCRIPTION
See individual commits for more detail:

Move `ip import-table`, `zebra work-queue`, `zebra zapi-packets`, `zebra dplane limit` and `allow-external-route-update` to their appropriate place in the mgmt frontend.

Add tests to show things are working better.