### PR TITLE
mgmtd: add periodic notify mode with mode/mode_data and FE test support

### DIFF
--- a/doc/user/mgmtd.rst
+++ b/doc/user/mgmtd.rst
@@ -166,6 +166,47 @@ API:
  - NOTIFY_SELECT (send) - specify the sub-set of notifications the front-end
    wishes to receive, rather than the default of receiving all.
 
+Native NOTIFY_SELECT Mode Semantics
+-----------------------------------
+
+Native ``NOTIFY_SELECT`` supports mode-based delivery control through
+``struct mgmt_msg_notify_select`` (``lib/mgmt_msg_native.h``):
+
+ - ``mode``: notification mode.
+ - ``mode_data``: mode-specific data.
+
+The following modes are defined:
+
+ - ``NOTIFY_MODE_ON_CHANGE``: on-change notifications. ``mode_data`` must be
+   ``0``.
+ - ``NOTIFY_MODE_PERIODIC``: periodic notifications. ``mode_data`` is the
+   sample interval in milliseconds and must be non-zero.
+
+Invalid ``mode``/``mode_data`` combinations are rejected with native ``ERROR``
+(for example, ``-EINVAL``).
+
+In periodic mode, mgmtd maintains a per-session timer. On each timer expiry,
+mgmtd requests refreshed operational data for that session's selectors and
+forwards notifications to the front-end client.
+
+On-change and periodic selectors are tracked separately per session:
+
+- on-change selectors continue to use the existing ``notify_xpaths`` behavior
+- periodic selectors are tracked independently and sampled by the periodic timer
+
+When a session issues multiple periodic requests, mgmtd keeps one base timer
+using the smallest requested interval for that session.
+
+Front-end C clients can use:
+
+.. code-block:: c
+
+   int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client,
+                                      uint64_t session_id, uint64_t req_id,
+                                      bool replace, uint8_t mode,
+                                      uint32_t mode_data,
+                                      const char **selectors);
+
 
 Please refer to the MGMT Frontend Client Developers Reference and Guide
 (coming soon) for more details.

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -299,6 +299,38 @@ int mgmt_fe_send_commit_req(struct mgmt_fe_client *client, uint64_t session_id, 
 	return ret;
 }
 
+int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client, uint64_t session_id,
+				   uint64_t req_id, bool replace, uint8_t mode,
+				   uint32_t mode_data, const char **selectors)
+{
+	struct mgmt_msg_notify_select *msg;
+	uint i;
+	int ret;
+
+	msg = mgmt_msg_native_alloc_msg(struct mgmt_msg_notify_select, 0,
+					MTYPE_MSG_NATIVE_NOTIFY_SELECT);
+	msg->refer_id = session_id;
+	msg->req_id = req_id;
+	msg->code = MGMT_MSG_CODE_NOTIFY_SELECT;
+	msg->replace = replace;
+	msg->get_only = 0;
+	msg->subscribing = 0;
+	msg->mode = mode;
+	msg->mode_data = mode_data;
+
+	darr_foreach_i (selectors, i)
+		mgmt_msg_native_add_str(msg, selectors[i]);
+
+	debug_fe_client("Sending NOTIFY_SELECT session-id %" PRIu64 " req-id %" PRIu64
+			" mode=%u mode-data=%u selectors=%u",
+			session_id, req_id, msg->mode, msg->mode_data,
+			darr_len(selectors));
+
+	ret = mgmt_msg_native_send_msg(&client->client.conn, msg, false);
+	ret = fe_client_push_sent_msg(client, (struct mgmt_msg_header *)msg, ret);
+	return ret;
+}
+
 /*
  * Send get-data request.
  */

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -238,6 +238,40 @@ extern int mgmt_fe_send_commit_req(struct mgmt_fe_client *client, uint64_t sessi
 				   bool unlock);
 
 /*
+ * Send NOTIFY-SELECT to MGMTD daemon.
+ *
+ * client
+ *    Client object.
+ *
+ * session_id
+ *    Client session ID.
+ *
+ * req_id
+ *    Client request ID.
+ *
+ * replace
+ *    TRUE to replace existing selectors, FALSE to append selectors.
+ *
+ * mode
+ *    Notification mode: either NOTIFY_MODE_ON_CHANGE or NOTIFY_MODE_PERIODIC.
+ *
+ * mode_data
+ *    Mode-specific data:
+ *      - ON_CHANGE: must be 0.
+ *      - PERIODIC: interval in msec, must be non-zero.
+ *
+ * selectors
+ *    darr array of xpath selectors (must be darr-allocated).
+ *
+ * Returns:
+ *    0 on success, otherwise msg_conn_send_msg() return values.
+ */
+extern int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client,
+					  uint64_t session_id, uint64_t req_id, bool replace,
+					  uint8_t mode, uint32_t mode_data,
+					  const char **selectors);
+
+/*
  * Send GET-DATA to MGMTD daemon.
  *
  * client

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -484,6 +484,10 @@ _Static_assert(sizeof(struct mgmt_msg_rpc_reply) ==
 		       offsetof(struct mgmt_msg_rpc_reply, data),
 	       "Size mismatch");
 
+/* notify-select mode values */
+#define NOTIFY_MODE_ON_CHANGE 0
+#define NOTIFY_MODE_PERIODIC  1
+
 /**
  * struct mgmt_msg_notify_select - Add notification selectors for FE client.
  *
@@ -501,13 +505,18 @@ _Static_assert(sizeof(struct mgmt_msg_rpc_reply) ==
  * @selectors: the xpath prefixes to selectors notifications through.
  * @replace: if true replace existing selectors with `selectors`.
  * @get_only: [backend-only]: if true do get op, don't change selectors.
+ * @mode: on-change or periodic mode.
+ * @mode_data: mode-specific data.
+ *            - NOTIFY_MODE_ON_CHANGE: must be 0.
+ *            - NOTIFY_MODE_PERIODIC: interval in msec, must be non-zero.
  */
 struct mgmt_msg_notify_select {
 	struct mgmt_msg_header;
 	uint8_t replace;
 	uint8_t get_only;
 	uint8_t subscribing;
-	uint8_t resv2[5];
+	uint8_t mode;
+	uint32_t mode_data;
 
 	alignas(8) char selectors[];
 };

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -38,8 +38,11 @@ struct mgmt_fe_session_ctx {
 	uint64_t txn_id;
 	uint64_t cfg_txn_id;
 	uint8_t notify_format;
+	uint32_t periodic_interval;
 	uint8_t ds_locked[MGMTD_DS_MAX_ID];
 	const char **notify_xpaths;
+	const char **periodic_xpaths;
+	struct event *periodic_notify_timer;
 	struct event *proc_cfg_txn_clnp;
 	struct event *proc_show_txn_clnp;
 
@@ -77,6 +80,7 @@ DECLARE_RBTREE_UNIQ(ns_string, struct ns_string, link, ns_string_compare);
 
 static struct msg_conn *fe_adapter_create(int conn_fd, union sockunion *from);
 static void fe_session_compute_commit_timers(struct mgmt_commit_stats *cmt_stats);
+static void fe_session_update_periodic_notify_timer(struct mgmt_fe_session_ctx *session);
 
 /* ---------------- */
 /* Global variables */
@@ -242,6 +246,61 @@ void mgmt_fe_ns_string_add_be_client(uint client_id, const char **selectors)
 	uint64_t session_id = MGMT_BE_CLIENT_TO_SESSION_ID(client_id);
 
 	ns_string_add_session(0, selectors, session_id, false, 0);
+}
+
+static uint64_t fe_session_notify_clients(struct mgmt_fe_session_ctx *session)
+{
+	const char **sp;
+	uint64_t clients = 0;
+
+	/* Resolve BE adapters that can serve the session's selector set. */
+	darr_foreach_p (session->periodic_xpaths, sp)
+		clients |= mgmt_be_interested_clients(*sp, MGMT_BE_XPATH_SUBSCR_TYPE_OPER,
+						      "periodic-notify-timer");
+
+	return clients;
+}
+
+static void fe_session_periodic_notify_timer(struct event *event)
+{
+	struct mgmt_fe_session_ctx *session = EVENT_ARG(event);
+	uint64_t clients;
+
+	session->periodic_notify_timer = NULL;
+
+	if (!darr_len(session->periodic_xpaths))
+		return;
+
+	clients = fe_session_notify_clients(session);
+	if (clients)
+		/*
+		 * Use get_only flow (session-id refer_id) to request current state
+		 * and forward it as NOTIFY data to this FE session.
+		 */
+		mgmt_txn_send_notify_selectors(0, session->session_id, clients, false,
+					       session->periodic_xpaths);
+
+	fe_session_update_periodic_notify_timer(session);
+}
+
+static void fe_session_update_periodic_notify_timer(struct mgmt_fe_session_ctx *session)
+{
+	if (!darr_len(session->periodic_xpaths)) {
+		event_cancel(&session->periodic_notify_timer);
+		return;
+	}
+
+	assert(session->periodic_interval);
+
+	if (event_is_scheduled(session->periodic_notify_timer) &&
+	    event_timer_remain_msec(session->periodic_notify_timer) >
+		    session->periodic_interval)
+		event_cancel(&session->periodic_notify_timer);
+
+	if (!event_is_scheduled(session->periodic_notify_timer))
+		event_add_timer_msec(mgmt_loop, fe_session_periodic_notify_timer, session,
+				     session->periodic_interval,
+				     &session->periodic_notify_timer);
 }
 
 uint64_t *mgmt_fe_ns_string_select(struct nb_node *nb_node, const char *notif)
@@ -502,7 +561,9 @@ static void fe_session_cleanup(struct mgmt_fe_session_ctx **sessionp)
 	rm_clients = ns_string_remove_session(session->session_id);
 	if (rm_clients && !mm->terminating)
 		mgmt_txn_send_notify_selectors(0, MGMTD_SESSION_ID_NONE, rm_clients, false, NULL);
+	event_cancel(&session->periodic_notify_timer);
 	darr_free_free(session->notify_xpaths);
+	darr_free_free(session->periodic_xpaths);
 	hash_release(mgmt_fe_sessions, session);
 	XFREE(MTYPE_MGMTD_FE_SESSION, session);
 	*sessionp = NULL;
@@ -523,6 +584,7 @@ static struct mgmt_fe_session_ctx *fe_session_create(struct mgmt_fe_client_adapt
 	session->client_id = client_id;
 	session->adapter = adapter;
 	session->notify_format = notify_format;
+	session->periodic_interval = 0;
 	session->txn_id = MGMTD_TXN_ID_NONE;
 	session->cfg_txn_id = MGMTD_TXN_ID_NONE;
 	LIST_INSERT_HEAD(&adapter->sessions, session, link);
@@ -1329,6 +1391,8 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	const char **new;
 	const char **sp;
 	uint64_t rm_clients = 0;
+	const char ***xpaths = NULL;
+	bool is_periodic;
 
 
 	if (msg_len >= sizeof(*msg)) {
@@ -1337,6 +1401,37 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 			fe_session_send_error(session, req_id, false, -EINVAL, "Invalid message");
 			return;
 		}
+	}
+
+	if (msg->mode != NOTIFY_MODE_ON_CHANGE && msg->mode != NOTIFY_MODE_PERIODIC) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "Invalid mode: %u", msg->mode);
+		darr_free_free(selectors);
+		return;
+	}
+	/* ON_CHANGE must not carry interval data. */
+	if (msg->mode == NOTIFY_MODE_ON_CHANGE && msg->mode_data) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "mode_data must be 0 for on-change mode");
+		darr_free_free(selectors);
+		return;
+	}
+	/* PERIODIC requires a non-zero interval in msec. */
+	if (msg->mode == NOTIFY_MODE_PERIODIC && selectors && msg->mode_data == 0) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "mode_data must be non-zero for periodic mode");
+		darr_free_free(selectors);
+		return;
+	}
+
+	is_periodic = msg->mode == NOTIFY_MODE_PERIODIC;
+	xpaths = is_periodic ? &session->periodic_xpaths : &session->notify_xpaths;
+
+	if (!msg->replace && !selectors) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "non-replace notify-select requires selectors");
+		darr_free_free(selectors);
+		return;
 	}
 
 	/* Validate all selectors, they need to resolve to actual northbound_nodes */
@@ -1351,31 +1446,43 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 		darr_free(nb_nodes);
 	}
 
+	/*
+	 * Commit mode/mode_data only after all selector validation succeeds.
+	 * Periodic mode keeps a session base tick at the minimum requested
+	 * interval; this allows multiple periodic requests to share one timer.
+	 */
+	if (is_periodic) {
+		/* If replacing or first-time setting selectors, set the periodic interval. */
+		if (msg->replace || !darr_len(session->periodic_xpaths))
+			session->periodic_interval = msg->mode_data;
+		else if (msg->mode_data < session->periodic_interval)
+			session->periodic_interval = msg->mode_data;
+	}
+
 	if (msg->replace) {
-		/* KISS: remove all existing selectors, add back new set */
-		rm_clients = ns_string_remove_session(session->session_id);
-		darr_free_free(session->notify_xpaths);
-		session->notify_xpaths = selectors;
-	} else if (selectors) {
-		/* TODO: would be nice to sort the stored selectors and eliminate dups */
-		new = darr_append_nz(session->notify_xpaths, darr_len(selectors));
-		memcpy(new, selectors, darr_len(selectors) * sizeof(*selectors));
+		/* Replace this mode's selector set with the provided selectors. */
+		if (!is_periodic)
+			rm_clients = ns_string_remove_session(session->session_id);
+		darr_free_free(*xpaths);
+		*xpaths = selectors;
 	} else {
-		_log_err("Invalid msg from session-id: %Lu: no selectors present in non-replace msg",
-			 session->session_id);
-		darr_free_free(selectors);
-		selectors = NULL;
-		goto done;
+		/* TODO: would be nice to sort the stored selectors and eliminate dups */
+		new = darr_append_nz(*xpaths, darr_len(selectors));
+		memcpy(new, selectors, darr_len(selectors) * sizeof(*selectors));
 	}
 
-	if (session->notify_xpaths && DEBUG_MODE_CHECK(&mgmt_debug_fe, DEBUG_MODE_ALL)) {
-		_dbg("Update NOTIFY selectors '%pSAd' (replace: %d) for session-id: %Lu",
-		     session->notify_xpaths, msg->replace, session->session_id);
+	if (*xpaths && DEBUG_MODE_CHECK(&mgmt_debug_fe, DEBUG_MODE_ALL)) {
+		_dbg("Update %s selectors '%pSAd' (replace: %d mode-data: %u) for session-id: %Lu",
+		     is_periodic ? "PERIODIC" : "ON-CHANGE", *xpaths, msg->replace,
+		     session->periodic_interval, session->session_id);
 	}
 
-	ns_string_add_session(req_id, selectors, session->session_id, msg->replace, rm_clients);
-done:
-	if (session->notify_xpaths != selectors)
+	if (!is_periodic)
+		ns_string_add_session(req_id, selectors, session->session_id, msg->replace,
+				      rm_clients);
+	else
+		fe_session_update_periodic_notify_timer(session);
+	if (*xpaths != selectors)
 		darr_free(selectors);
 }
 

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -604,6 +604,13 @@ void mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t session_id, uint64
 	msg->replace = selectors == NULL;
 	msg->get_only = session_id != MGMTD_SESSION_ID_NONE;
 	msg->subscribing = subscribing;
+	/*
+	 * MGMTd owns periodic scheduling for FE sessions. Backend selector-update
+	 * messages stay in on-change mode; periodic behavior is driven by MGMTd's
+	 * per-session timer and get_only polling flow.
+	 */
+	msg->mode = NOTIFY_MODE_ON_CHANGE;
+	msg->mode_data = 0;
 
 	if (selectors == NULL) {
 		/* Get selectors for all sessions */

--- a/tests/topotests/lib/fe_client.py
+++ b/tests/topotests/lib/fe_client.py
@@ -79,7 +79,14 @@ NOTIFY_OP_DELETE = 2
 NOTIFY_OP_PATCH = 3
 NOTIFY_OP_GET_SYNC = 4
 
-MSG_FMT_NOTIFY_SELECT = "=B7x"
+MSG_FMT_NOTIFY_SELECT = "=BBBBI"
+NOTIFY_SELECT_FIELD_REPLACE = 0
+NOTIFY_SELECT_FIELD_GET_ONLY = 1
+NOTIFY_SELECT_FIELD_SUBSCRIBING = 2
+NOTIFY_SELECT_FIELD_MODE = 3
+NOTIFY_SELECT_MODE_ON_CHANGE = 0
+NOTIFY_SELECT_MODE_PERIODIC = 1
+NOTIFY_SELECT_FIELD_MODE_DATA = 4
 
 MSG_FMT_SESSION_REQ = "=B7x"
 
@@ -369,21 +376,29 @@ class Session:
         logging.debug("Received GET: %s: %s", mfixed, mdata)
         return result
 
-    def add_notify_select(self, replace, notif_xpaths):
+    def add_notify_select(
+        self,
+        replace,
+        notif_xpaths,
+        mode=NOTIFY_SELECT_MODE_ON_CHANGE,
+        mode_data=0,
+    ):
         """Send a request to add notification subscriptions to the given XPaths.
 
         Args:
             replace (bool): Whether to replace existing notification subscriptions.
             notif_xpaths (list of str): List of XPaths to subscribe to notifications on.
+            mode (int): Notification mode, e.g. ON_CHANGE or PERIODIC.
+            mode_data (int): Mode-specific data. For periodic mode, interval in msec.
         """
         mdata, _ = self.get_native_msg_header(MSG_CODE_NOTIFY_SELECT)
-        mdata += struct.pack(MSG_FMT_NOTIFY_SELECT, replace)
+        mdata += struct.pack(MSG_FMT_NOTIFY_SELECT, int(replace), 0, 0, mode, mode_data)
 
         for xpath in notif_xpaths:
             mdata += xpath.encode("utf-8") + b"\x00"
 
         self.send_native_msg(mdata)
-        logging.debug("Sent NOTIFY_SELECT")
+        logging.debug("Sent NOTIFY_SELECT mode=%s mode_data=%s", mode, mode_data)
 
     def recv_notify(self, xpaths=None):
         """Receive a notification message, optionally setting up XPath filters first.
@@ -434,6 +449,23 @@ def __parse_args():
         help="Number of notifications to listen for 0 for infinite",
     )
     parser.add_argument(
+        "--notify-mode",
+        choices=["on-change", "periodic"],
+        default="on-change",
+        help="Notification mode for --listen subscriptions",
+    )
+    parser.add_argument(
+        "--notify-mode-data",
+        type=int,
+        default=0,
+        help="Mode-specific data (msec for periodic mode)",
+    )
+    parser.add_argument(
+        "--allow-invalid-mode-data",
+        action="store_true",
+        help="Allow sending invalid mode/mode_data combinations for negative tests",
+    )
+    parser.add_argument(
         "-b", "--both", action="store_true", help="return both config and data"
     )
     parser.add_argument(
@@ -448,6 +480,12 @@ def __parse_args():
     parser.add_argument("-s", "--server", default=MPATH, help="path to server socket")
     parser.add_argument("-v", "--verbose", action="store_true", help="Be verbose")
     args = parser.parse_args()
+
+    if not args.allow_invalid_mode_data:
+        if args.notify_mode == "on-change" and args.notify_mode_data != 0:
+            parser.error("--notify-mode-data must be 0 for --notify-mode on-change")
+        if args.notify_mode == "periodic" and args.notify_mode_data <= 0:
+            parser.error("--notify-mode-data must be > 0 for --notify-mode periodic")
 
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(level=level, format="%(asctime)s %(levelname)s: %(message)s")
@@ -493,8 +531,18 @@ def __main():
 
     if args.listen is not None:
         i = args.notify_count
+        notify_mode = (
+            NOTIFY_SELECT_MODE_PERIODIC
+            if args.notify_mode == "periodic"
+            else NOTIFY_SELECT_MODE_ON_CHANGE
+        )
         if args.listen:
-            sess.add_notify_select(True, args.listen)
+            sess.add_notify_select(
+                True,
+                args.listen,
+                mode=notify_mode,
+                mode_data=args.notify_mode_data,
+            )
         while i > 0 or args.notify_count == 0:
             result_type, op, xpath, notif = sess.recv_notify()
             if op == NOTIFY_OP_NOTIFICATION:


### PR DESCRIPTION
Adds periodic subscription support to native NOTIFY_SELECT by introducing mode and mode_data semantics (ON_CHANGE vs PERIODIC). 
mgmtd now validates mode/mode_data combinations and runs per-session periodic sampling timers for periodic subscriptions, while keeping backend notify-select updates on-change. 
Also extends tests/topotests/lib/fe_client.py for new notify-select format and expose CLI flags for periodic and negative-path testing.

Testing:

```
`sudo python3 tests/topotests/lib/fe_client.py \
  --server /var/run/frr/mgmtd_fe.sock \
  --listen "/frr-interface:lib/interface" \
  --notify-mode periodic \
  --notify-mode-data 10000 \
  --notify-count 3 \
  -v
2026-03-18 13:40:42,373 DEBUG: Connecting to server on /var/run/frr/mgmtd_fe.sock
2026-03-18 13:40:42,374 INFO: Connected to server on /var/run/frr/mgmtd_fe.sock
2026-03-18 13:40:42,374 DEBUG: Sent native SESSION-REQ
2026-03-18 13:40:42,374 DEBUG: Recv native SESSION-REPLY Message: sess-id 1003: fixed: (1,): b''
2026-03-18 13:40:42,374 DEBUG: Sent NOTIFY_SELECT mode=1 mode_data=10000
2026-03-18 13:40:42,374 DEBUG: Waiting for Notify Message
2026-03-18 13:40:42,385 DEBUG: Received Notify Message: (2, 4): b'/frr-interface:lib/interface\x00{"frr-interface:lib":{"interface":[{"name":"docker0","vrf":"default","state":{"if-index":3,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"ee:08:31:f9:ef:e4"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-bridge"}}},{"name":"eth0","vrf":"default","state":{"if-index":2,"mtu":1500,"mtu6":1500,"speed":0,"metric":0,"phy-address":"02:a6:85:00:09:34"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"lo","vrf":"default","state":{"if-index":1,"mtu":65536,"mtu6":65536,"speed":0,"metric":0,"phy-address":"00:00:00:00:00:00"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"veth43e8949","vrf":"default","state":{"if-index":6,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"16:08:6a:88:ec:8d"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-veth"}}}]}}\x00'
2026-03-18 13:40:42,385 WARNING: ignoring datastore notification op: 4 xpath: /frr-interface:lib/interface data: {"frr-interface:lib":{"interface":[{"name":"docker0","vrf":"default","state":{"if-index":3,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"ee:08:31:f9:ef:e4"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-bridge"}}},{"name":"eth0","vrf":"default","state":{"if-index":2,"mtu":1500,"mtu6":1500,"speed":0,"metric":0,"phy-address":"02:a6:85:00:09:34"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"lo","vrf":"default","state":{"if-index":1,"mtu":65536,"mtu6":65536,"speed":0,"metric":0,"phy-address":"00:00:00:00:00:00"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"veth43e8949","vrf":"default","state":{"if-index":6,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"16:08:6a:88:ec:8d"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-veth"}}}]}}
2026-03-18 13:40:42,385 DEBUG: Waiting for Notify Message
2026-03-18 13:40:52,385 DEBUG: Received Notify Message: (2, 4): b'/frr-interface:lib/interface\x00{"frr-interface:lib":{"interface":[{"name":"docker0","vrf":"default","state":{"if-index":3,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"ee:08:31:f9:ef:e4"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-bridge"}}},{"name":"eth0","vrf":"default","state":{"if-index":2,"mtu":1500,"mtu6":1500,"speed":0,"metric":0,"phy-address":"02:a6:85:00:09:34"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"lo","vrf":"default","state":{"if-index":1,"mtu":65536,"mtu6":65536,"speed":0,"metric":0,"phy-address":"00:00:00:00:00:00"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"veth43e8949","vrf":"default","state":{"if-index":6,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"16:08:6a:88:ec:8d"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-veth"}}}]}}\x00'
2026-03-18 13:40:52,386 WARNING: ignoring datastore notification op: 4 xpath: /frr-interface:lib/interface data: {"frr-interface:lib":{"interface":[{"name":"docker0","vrf":"default","state":{"if-index":3,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"ee:08:31:f9:ef:e4"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-bridge"}}},{"name":"eth0","vrf":"default","state":{"if-index":2,"mtu":1500,"mtu6":1500,"speed":0,"metric":0,"phy-address":"02:a6:85:00:09:34"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"lo","vrf":"default","state":{"if-index":1,"mtu":65536,"mtu6":65536,"speed":0,"metric":0,"phy-address":"00:00:00:00:00:00"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"veth43e8949","vrf":"default","state":{"if-index":6,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"16:08:6a:88:ec:8d"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-veth"}}}]}}
2026-03-18 13:40:52,386 DEBUG: Waiting for Notify Message
^C2026-03-18 13:40:53,928 INFO: Exiting



sudo python3 tests/topotests/lib/fe_client.py   --server /var/run/frr/mgmtd_fe.sock   --listen "/frr-interface:lib/interface"   --notify-mode on-change   --notify-mode-data 0   --notify-count 1   -v
2026-03-18 13:50:12,753 DEBUG: Connecting to server on /var/run/frr/mgmtd_fe.sock
2026-03-18 13:50:12,753 INFO: Connected to server on /var/run/frr/mgmtd_fe.sock
2026-03-18 13:50:12,754 DEBUG: Sent native SESSION-REQ
2026-03-18 13:50:12,754 DEBUG: Recv native SESSION-REPLY Message: sess-id 1007: fixed: (1,): b''
2026-03-18 13:50:12,754 DEBUG: Sent NOTIFY_SELECT mode=0 mode_data=0
2026-03-18 13:50:12,754 DEBUG: Waiting for Notify Message
2026-03-18 13:50:12,765 DEBUG: Received Notify Message: (2, 4): b'/frr-interface:lib/interface\x00{"frr-interface:lib":{"interface":[{"name":"docker0","vrf":"default","state":{"if-index":3,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"ee:08:31:f9:ef:e4"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-bridge"}}},{"name":"eth0","vrf":"default","state":{"if-index":2,"mtu":1500,"mtu6":1500,"speed":0,"metric":0,"phy-address":"02:a6:85:00:09:34"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"lo","vrf":"default","state":{"if-index":1,"mtu":65536,"mtu6":65536,"speed":0,"metric":0,"phy-address":"00:00:00:00:00:00"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"veth43e8949","vrf":"default","state":{"if-index":6,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"16:08:6a:88:ec:8d"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-veth"}}}]}}\x00'
2026-03-18 13:50:12,765 WARNING: ignoring datastore notification op: 4 xpath: /frr-interface:lib/interface data: {"frr-interface:lib":{"interface":[{"name":"docker0","vrf":"default","state":{"if-index":3,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"ee:08:31:f9:ef:e4"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-bridge"}}},{"name":"eth0","vrf":"default","state":{"if-index":2,"mtu":1500,"mtu6":1500,"speed":0,"metric":0,"phy-address":"02:a6:85:00:09:34"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"lo","vrf":"default","state":{"if-index":1,"mtu":65536,"mtu6":65536,"speed":0,"metric":0,"phy-address":"00:00:00:00:00:00"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-other"}}},{"name":"veth43e8949","vrf":"default","state":{"if-index":6,"mtu":1500,"mtu6":1500,"speed":10000,"metric":0,"phy-address":"16:08:6a:88:ec:8d"},"frr-zebra:zebra":{"state":{"up-count":0,"down-count":0,"zif-type":"zif-veth"}}}]}}

You tested:
one FE client session
one xpath: /frr-interface:lib/interface
modes:
periodic (1s, 10s)
on-change
invalid on-change + mode_data for rejection

`
```

Usage:

```
Periodic mode test (1s):
--notify-mode periodic --notify-mode-data 1000
Received repeated NOTIFY messages at ~1s cadence.

On-change mode test:
--notify-mode on-change --notify-mode-data 0
Received initial sync notify as expected.

Negative validation test:
--notify-mode on-change --notify-mode-data 1000 --allow-invalid-mode-data
mgmtd returned EINVAL with message: mode_data must be 0 for on-change mode.

```

<img width="581" height="556" alt="image" src="https://github.com/user-attachments/assets/2169796f-250e-4b98-9cdb-244bd76c2e21" />
