### PR TITLE
Nexthop in dplane

### DIFF
--- a/tests/topotests/zebra_kernel_nhg/test_zebra_kernel_nhg.py
+++ b/tests/topotests/zebra_kernel_nhg/test_zebra_kernel_nhg.py
@@ -47,6 +47,7 @@ def setup_module(mod):
     tgen.start_router()
 
     r1 = tgen.gears["r1"]
+    _install_kernel_nhgs(r1)
 
 
 def teardown_module():
@@ -76,6 +77,38 @@ def _install_kernel_nhgs(r1):
     r1.cmd("ip route add 10.60.0.0/24 via 192.168.1.20 dev r1-eth0")
 
 
+def _get_route_entry(r1, prefix):
+    route_json = r1.vtysh_cmd(f"show ip route {prefix} json", isjson=True)
+    routes = route_json.get(prefix, [])
+    if not routes:
+        return None
+    return routes[0]
+
+
+def _get_route_nhg_id(r1, prefix):
+    route = _get_route_entry(r1, prefix)
+    if not route:
+        return None
+    return route.get("nexthopGroupId")
+
+
+def _get_unused_nhg_ids(r1, count):
+    nhg_json = r1.vtysh_cmd("show nexthop-group rib json", isjson=True)
+    used_ids = set()
+
+    for vrf_data in nhg_json.values():
+        if not isinstance(vrf_data, dict):
+            continue
+        for nhg_id in vrf_data:
+            try:
+                used_ids.add(int(nhg_id))
+            except ValueError:
+                continue
+
+    candidate = (max(used_ids) + 1) if used_ids else 1
+    return list(range(candidate, candidate + count))
+
+
 def test_kernel_nhg_routes():
     "Verify kernel routes reflect expected NHG IDs in zebra"
     tgen = get_topogen()
@@ -83,8 +116,6 @@ def test_kernel_nhg_routes():
         pytest.skip(tgen.errors)
 
     r1 = tgen.gears["r1"]
-
-    _install_kernel_nhgs(r1)
 
     expected = {
         "10.10.0.0/24": 201,
@@ -137,6 +168,507 @@ def test_kernel_nhg_routes():
     step("Verify routes have expected received NHG IDs")
     success, _ = topotest.run_and_expect(_check_nhg_summary, True, count=20, wait=1)
     assert success, "Kernel routes missing expected received NHG IDs"
+
+
+def test_frr_owned_nhg_replace_is_reverted():
+    "Verify zebra restores FRR-owned NHGs after external replace"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    prefix = "10.80.0.0/24"
+    original_ip = "192.168.1.30"
+    replacement_ip = "192.168.1.31"
+
+    step("Create FRR-owned static route")
+    r1.vtysh_cmd(
+        f"""
+        configure terminal
+         ip route {prefix} {original_ip}
+        """
+    )
+
+    def _get_frr_owned_nhg():
+        nhg_id = _get_route_nhg_id(r1, prefix)
+        if nhg_id is None:
+            logger.info("Failed to get NHG ID for FRR-owned route %s", prefix)
+            return None
+
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {nhg_id} json", isjson=True)
+        nhg = nhg_json.get(str(nhg_id))
+        if not nhg:
+            logger.info("FRR-owned NHG %s not found", nhg_id)
+            return None
+
+        if nhg.get("type") != "zebra":
+            logger.info(
+                "Expected FRR-owned NHG %s to be type zebra, got %s",
+                nhg_id,
+                nhg.get("type"),
+            )
+            return None
+
+        return nhg_id
+
+    step("Wait for FRR-owned NHG to be installed")
+    success, nhg_id = topotest.run_and_expect_type(
+        _get_frr_owned_nhg, int, count=20, wait=1
+    )
+    assert success, f"FRR-owned NHG for route {prefix} was not installed"
+
+    step("Externally replace FRR-owned kernel nexthop")
+    r1.cmd(f"ip nexthop replace id {nhg_id} via {replacement_ip} dev r1-eth0")
+
+    def _check_frr_owned_replace_reverted():
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {nhg_id} json", isjson=True)
+        nhg = nhg_json.get(str(nhg_id))
+        if not nhg:
+            logger.info("FRR-owned NHG %s disappeared after replace", nhg_id)
+            return False
+
+        if nhg.get("type") != "zebra":
+            logger.info(
+                "FRR-owned NHG %s type mismatch after replace: %s",
+                nhg_id,
+                nhg.get("type"),
+            )
+            return False
+
+        nexthops = nhg.get("nexthops", [])
+        if len(nexthops) != 1 or nexthops[0].get("ip") != original_ip:
+            logger.info(
+                "FRR-owned NHG %s not restored to %s: %s", nhg_id, original_ip, nexthops
+            )
+            return False
+
+        kernel_nh = r1.cmd(f"ip nexthop show id {nhg_id}")
+        if original_ip not in kernel_nh or replacement_ip in kernel_nh:
+            logger.info("Kernel NHG %s not restored, output: %s", nhg_id, kernel_nh)
+            return False
+
+        return True
+
+    step("Verify zebra restored FRR-owned NHG to its original state")
+    success, _ = topotest.run_and_expect(
+        _check_frr_owned_replace_reverted, True, count=20, wait=1
+    )
+    assert success, "FRR-owned NHG replace was not reverted by zebra"
+
+    step("Remove FRR-owned static route")
+    r1.vtysh_cmd(
+        f"""
+        configure terminal
+         no ip route {prefix} {original_ip}
+        """
+    )
+
+
+def test_frr_owned_nhg_delete_is_recreated():
+    "Verify zebra recreates FRR-owned NHGs after external delete"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    prefix = "10.81.0.0/24"
+    gateway = "192.168.1.32"
+
+    step("Create FRR-owned static route for delete test")
+    r1.vtysh_cmd(
+        f"""
+        configure terminal
+         ip route {prefix} {gateway}
+        """
+    )
+
+    def _get_frr_owned_nhg():
+        nhg_id = _get_route_nhg_id(r1, prefix)
+        if nhg_id is None:
+            logger.info("Failed to get NHG ID for FRR-owned route %s", prefix)
+            return None
+
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {nhg_id} json", isjson=True)
+        nhg = nhg_json.get(str(nhg_id))
+        if not nhg or nhg.get("type") != "zebra":
+            logger.info("FRR-owned NHG %s missing or wrong type: %s", nhg_id, nhg)
+            return None
+
+        return nhg_id
+
+    step("Wait for FRR-owned NHG to be installed")
+    success, nhg_id = topotest.run_and_expect_type(
+        _get_frr_owned_nhg, int, count=20, wait=1
+    )
+    assert success, f"FRR-owned NHG for route {prefix} was not installed"
+
+    step("Externally delete FRR-owned kernel nexthop")
+    r1.cmd(f"ip nexthop del id {nhg_id}")
+
+    def _check_frr_owned_delete_recreated():
+        route = _get_route_entry(r1, prefix)
+        if not route or route.get("nexthopGroupId") != nhg_id:
+            logger.info(
+                "FRR-owned route %s missing or changed NHG after delete: %s",
+                prefix,
+                route,
+            )
+            return False
+
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {nhg_id} json", isjson=True)
+        nhg = nhg_json.get(str(nhg_id))
+        if not nhg or nhg.get("type") != "zebra":
+            logger.info(
+                "FRR-owned NHG %s missing or wrong type after delete: %s", nhg_id, nhg
+            )
+            return False
+
+        kernel_nh = r1.cmd(f"ip nexthop show id {nhg_id}")
+        if gateway not in kernel_nh:
+            logger.info(
+                "Kernel NHG %s was not recreated, output: %s", nhg_id, kernel_nh
+            )
+            return False
+
+        return True
+
+    step("Verify zebra recreated FRR-owned NHG")
+    success, _ = topotest.run_and_expect(
+        _check_frr_owned_delete_recreated, True, count=20, wait=1
+    )
+    assert success, "FRR-owned NHG delete was not recreated by zebra"
+
+    step("Remove FRR-owned static route")
+    r1.vtysh_cmd(
+        f"""
+        configure terminal
+         no ip route {prefix} {gateway}
+        """
+    )
+
+
+def test_kernel_nhg_replace_group_members():
+    "Verify zebra tracks runtime kernel NHG membership updates"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("Replace kernel nexthop-group 201 members")
+    r1.cmd("ip nexthop replace id 201 group 101/103")
+
+    def _check_replaced_group():
+        nhg_json = r1.vtysh_cmd("show nexthop-group rib 201 json", isjson=True)
+        nhg = nhg_json.get("201")
+        if not nhg:
+            logger.info("Kernel NHG 201 not found after replace")
+            return False
+
+        depends = nhg.get("depends", [])
+        if sorted(depends) != [101, 103]:
+            logger.info("Kernel NHG 201 depends mismatch after replace: %s", depends)
+            return False
+
+        route_json = r1.vtysh_cmd(
+            "show ip route nexthop-group summary json", isjson=True
+        )
+        route = route_json.get("10.10.0.0/24", [{}])[0]
+        if route.get("receivedNexthopGroupId") != 201:
+            logger.info(
+                "Route 10.10.0.0/24 expected received NHG 201, got %s",
+                route.get("receivedNexthopGroupId"),
+            )
+            return False
+
+        return True
+
+    step("Verify zebra updated NHG 201 membership")
+    success, _ = topotest.run_and_expect(_check_replaced_group, True, count=20, wait=1)
+    assert success, "Kernel NHG 201 membership change not reflected in zebra"
+
+
+def test_kernel_nhg_delete_notifications():
+    "Verify zebra tracks runtime kernel nexthop object deletions"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    singleton_id, group_id = _get_unused_nhg_ids(r1, 2)
+
+    step(
+        "Create temporary kernel nexthop {} and nexthop-group {}".format(
+            singleton_id, group_id
+        )
+    )
+    r1.cmd_raises(f"ip nexthop add id {singleton_id} via 192.168.1.13 dev r1-eth0")
+    r1.cmd_raises(f"ip nexthop add id {group_id} group 101/{singleton_id}")
+
+    def _check_temp_group_present():
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {group_id} json", isjson=True)
+        nhg = nhg_json.get(str(group_id))
+        if not nhg:
+            logger.info("Temporary kernel NHG %s not found", group_id)
+            return False
+
+        depends = nhg.get("depends", [])
+        if sorted(depends) != [101, singleton_id]:
+            logger.info("Kernel NHG %s depends mismatch: %s", group_id, depends)
+            return False
+
+        return True
+
+    step("Verify temporary kernel nexthop-group {} is present".format(group_id))
+    success, _ = topotest.run_and_expect(
+        _check_temp_group_present, True, count=20, wait=1
+    )
+    assert success, f"Temporary kernel NHG {group_id} was not learned by zebra"
+
+    step(
+        "Delete temporary kernel nexthop-group {} and singleton nexthop {}".format(
+            group_id, singleton_id
+        )
+    )
+    r1.cmd(f"ip nexthop del id {group_id}")
+    r1.cmd_raises(f"ip nexthop del id {singleton_id}")
+
+    def _check_temp_objects_removed():
+        nhg_json = r1.vtysh_cmd("show nexthop-group rib json", isjson=True)
+        default_vrf = nhg_json.get("default", {})
+        if str(group_id) in default_vrf:
+            logger.info("Temporary kernel NHG %s still present in zebra", group_id)
+            return False
+        if str(singleton_id) in default_vrf:
+            logger.info(
+                "Temporary singleton kernel NH %s still present in zebra",
+                singleton_id,
+            )
+            return False
+        return True
+
+    step(
+        "Verify zebra processed kernel delete notifications for {} and {}".format(
+            group_id, singleton_id
+        )
+    )
+    success, _ = topotest.run_and_expect(
+        _check_temp_objects_removed, True, count=20, wait=1
+    )
+    assert success, "Kernel nexthop delete notification not reflected in zebra"
+
+
+def test_kernel_deleted_nhg_with_references_is_not_kept_around():
+    "Verify kernel NHGs drop deleted members without entering keep-around"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    singleton_id, group_id = _get_unused_nhg_ids(r1, 2)
+
+    step(
+        "Create referenced kernel singleton {} and dependent kernel NHG {}".format(
+            singleton_id, group_id
+        )
+    )
+    r1.cmd_raises(f"ip nexthop add id {singleton_id} via 192.168.1.14 dev r1-eth0")
+    r1.cmd_raises(f"ip nexthop add id {group_id} group 101/{singleton_id}")
+
+    def _check_dependent_nhg_present():
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {group_id} json", isjson=True)
+        nhg = nhg_json.get(str(group_id))
+        if not nhg:
+            logger.info("Dependent kernel NHG %s not found", group_id)
+            return False
+
+        depends = nhg.get("depends", [])
+        if sorted(depends) != [101, singleton_id]:
+            logger.info(
+                "Dependent kernel NHG %s depends mismatch: %s", group_id, depends
+            )
+            return False
+
+        return True
+
+    step("Verify dependent kernel NHG {} is present".format(group_id))
+    success, _ = topotest.run_and_expect(
+        _check_dependent_nhg_present, True, count=20, wait=1
+    )
+    assert success, f"Dependent kernel NHG {group_id} was not learned by zebra"
+
+    step(
+        "Delete referenced kernel singleton {} while dependent NHG {} still exists".format(
+            singleton_id, group_id
+        )
+    )
+    r1.cmd(f"ip nexthop del id {singleton_id}")
+
+    def _check_deleted_member_removed_from_group():
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {group_id} json", isjson=True)
+        nhg = nhg_json.get(str(group_id))
+        if not nhg:
+            logger.info("Dependent kernel NHG %s disappeared unexpectedly", group_id)
+            return False
+
+        depends = nhg.get("depends", [])
+        if depends != [101]:
+            logger.info(
+                "Dependent kernel NHG %s was not updated after deleting %s: %s",
+                group_id,
+                singleton_id,
+                depends,
+            )
+            return False
+
+        all_nhgs = r1.vtysh_cmd("show nexthop-group rib json", isjson=True).get(
+            "default", {}
+        )
+        singleton = all_nhgs.get(str(singleton_id))
+        if singleton:
+            if singleton.get("keepAround", False) or "timeToDeletion" in singleton:
+                logger.info(
+                    "Deleted kernel NHG %s incorrectly entered keep-around: %s",
+                    singleton_id,
+                    singleton,
+                )
+                return False
+            if singleton.get("installed", False):
+                logger.info(
+                    "Deleted kernel NHG %s should no longer be installed: %s",
+                    singleton_id,
+                    singleton,
+                )
+                return False
+
+        return True
+
+    step(
+        "Verify kernel NHG {} drops deleted member {} without keep-around".format(
+            group_id, singleton_id
+        )
+    )
+    success, _ = topotest.run_and_expect(
+        _check_deleted_member_removed_from_group, True, count=20, wait=1
+    )
+    assert (
+        success
+    ), f"Kernel NHG {group_id} was not updated correctly after deleting {singleton_id}"
+
+    def _check_deleted_singleton_removed():
+        nhg_json = r1.vtysh_cmd("show nexthop-group rib json", isjson=True)
+        default_vrf = nhg_json.get("default", {})
+        if str(singleton_id) in default_vrf:
+            logger.info(
+                "Deleted kernel NHG %s still present after dependent update",
+                singleton_id,
+            )
+            return False
+        return True
+
+    step(
+        "Verify deleted kernel singleton {} is removed after NHG {} update".format(
+            singleton_id, group_id
+        )
+    )
+    success, _ = topotest.run_and_expect(
+        _check_deleted_singleton_removed, True, count=20, wait=1
+    )
+    assert success, f"Deleted kernel NHG {singleton_id} was not fully removed"
+
+    step("Delete dependent kernel NHG {}".format(group_id))
+    r1.cmd_raises(f"ip nexthop del id {group_id}")
+
+    def _check_deleted_dependency_chain_removed():
+        nhg_json = r1.vtysh_cmd("show nexthop-group rib json", isjson=True)
+        default_vrf = nhg_json.get("default", {})
+        if str(group_id) in default_vrf:
+            logger.info("Deleted dependent kernel NHG %s still present", group_id)
+            return False
+        return True
+
+    step("Verify dependent kernel NHG {} is fully removed".format(group_id))
+    success, _ = topotest.run_and_expect(
+        _check_deleted_dependency_chain_removed, True, count=20, wait=1
+    )
+    assert success, f"Deleted dependent kernel NHG {group_id} was not fully removed"
+
+
+def test_kernel_blackhole_nexthop():
+    "Verify zebra receives kernel blackhole nexthops through dplane"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    (nhg_id,) = _get_unused_nhg_ids(r1, 1)
+
+    step("Create kernel blackhole nexthop {} and route".format(nhg_id))
+    r1.cmd_raises(f"ip nexthop add id {nhg_id} blackhole")
+    r1.cmd_raises(f"ip route add 10.70.0.0/24 nhid {nhg_id}")
+
+    def _check_blackhole_nexthop():
+        route_json = r1.vtysh_cmd(
+            "show ip route nexthop-group summary json", isjson=True
+        )
+        route = route_json.get("10.70.0.0/24", [{}])[0]
+        if route.get("receivedNexthopGroupId") != nhg_id:
+            logger.info(
+                "Route 10.70.0.0/24 expected received NHG %s, got %s",
+                nhg_id,
+                route.get("receivedNexthopGroupId"),
+            )
+            return False
+
+        nhg_json = r1.vtysh_cmd(f"show nexthop-group rib {nhg_id} json", isjson=True)
+        nhg = nhg_json.get(str(nhg_id))
+        if not nhg:
+            logger.info("Kernel blackhole NHG %s not found", nhg_id)
+            return False
+
+        if nhg.get("type") != "kernel":
+            logger.info(
+                "Kernel blackhole NHG %s type mismatch: %s", nhg_id, nhg.get("type")
+            )
+            return False
+
+        nexthops = nhg.get("nexthops", [])
+        if len(nexthops) != 1:
+            logger.info(
+                "Kernel blackhole NHG %s expected 1 nexthop, got %s",
+                nhg_id,
+                len(nexthops),
+            )
+            return False
+
+        nexthop = nexthops[0]
+        if not nexthop.get("unreachable", False):
+            logger.info(
+                "Kernel blackhole NHG %s is missing unreachable flag: %s",
+                nhg_id,
+                nexthop,
+            )
+            return False
+
+        if "interfaceName" in nexthop:
+            logger.info(
+                "Kernel blackhole NHG %s unexpectedly has interface data: %s",
+                nhg_id,
+                nexthop,
+            )
+            return False
+
+        return True
+
+    step("Verify zebra learned kernel blackhole nexthop {}".format(nhg_id))
+    success, _ = topotest.run_and_expect(
+        _check_blackhole_nexthop, True, count=20, wait=1
+    )
+    assert success, "Kernel blackhole nexthop was not reflected correctly in zebra"
+
+    step("Remove kernel blackhole nexthop {} and route".format(nhg_id))
+    r1.cmd("ip route del 10.70.0.0/24")
+    r1.cmd(f"ip nexthop del id {nhg_id}")
 
 
 if __name__ == "__main__":

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1644,7 +1644,7 @@ void interface_list_second(struct zebra_ns *zns)
 	 * so we need to get the nexthop info
 	 * from the kernel before we can do that
 	 */
-	netlink_nexthop_read(zns);
+	nexthop_read(zns);
 
 	interface_addr_lookup_netlink(zns);
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1640,11 +1640,6 @@ void interface_list(struct zebra_ns *zns)
 void interface_list_second(struct zebra_ns *zns)
 {
 	zebra_if_update_all_links(zns);
-	/* We add routes for interface address,
-	 * so we need to get the nexthop info
-	 * from the kernel before we can do that
-	 */
-	nexthop_read(zns);
 
 	interface_addr_lookup_netlink(zns);
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1453,7 +1453,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	dplane_ctx_set_ifp_zif_type(ctx, zif_type);
 	dplane_ctx_set_ifindex(ctx, ifi->ifi_index);
 	dplane_ctx_set_ifname(ctx, name);
-	dplane_ctx_set_ifp_startup(ctx, startup);
+	dplane_ctx_set_startup(ctx, startup);
 	dplane_ctx_set_ifp_family(ctx, ifi->ifi_family);
 	dplane_ctx_set_intf_txqlen(ctx, txqlen);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2047,7 +2047,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		protodown_set = dplane_ctx_get_ifp_protodown_set(ctx);
 		protodown = dplane_ctx_get_ifp_protodown(ctx);
 		rc_bitfield = dplane_ctx_get_ifp_rc_bitfield(ctx);
-		startup = dplane_ctx_get_ifp_startup(ctx);
+		startup = dplane_ctx_get_startup(ctx);
 		desc = dplane_ctx_get_ifp_desc(ctx);
 		family = dplane_ctx_get_ifp_family(ctx);
 		change_flags = dplane_ctx_get_ifp_change_flags(ctx);

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -400,10 +400,6 @@ static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 		return netlink_rule_change(h, ns_id, startup);
 	case RTM_DELRULE:
 		return netlink_rule_change(h, ns_id, startup);
-	case RTM_NEWNEXTHOP:
-		return netlink_nexthop_change(h, ns_id, startup);
-	case RTM_DELNEXTHOP:
-		return netlink_nexthop_change(h, ns_id, startup);
 	case RTM_NEWQDISC:
 	case RTM_DELQDISC:
 		return netlink_qdisc_change(h, ns_id, startup);
@@ -425,6 +421,8 @@ static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 	case RTM_DELLINK:
 	case RTM_NEWADDR:
 	case RTM_DELADDR:
+	case RTM_NEWNEXTHOP:
+	case RTM_DELNEXTHOP:
 	case RTM_NEWNETCONF:
 	case RTM_DELNETCONF:
 	case RTM_NEWTUNNEL:
@@ -467,6 +465,10 @@ static int dplane_netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 	case RTM_NEWADDR:
 	case RTM_DELADDR:
 		return netlink_interface_addr_dplane(h, ns_id, startup);
+
+	case RTM_NEWNEXTHOP:
+	case RTM_DELNEXTHOP:
+		return netlink_nexthop_change(h, ns_id, startup);
 
 	case RTM_NEWNETCONF:
 	case RTM_DELNETCONF:
@@ -1623,13 +1625,13 @@ void kernel_init(struct zebra_ns *zns)
 	 */
 	groups = RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE | RTMGRP_IPV4_MROUTE |
 		 ((uint32_t)1 << (RTNLGRP_IPV4_RULE - 1)) |
-		 ((uint32_t)1 << (RTNLGRP_IPV6_RULE - 1)) |
-		 ((uint32_t)1 << (RTNLGRP_NEXTHOP - 1)) | ((uint32_t)1 << (RTNLGRP_TC - 1));
+		 ((uint32_t)1 << (RTNLGRP_IPV6_RULE - 1)) | ((uint32_t)1 << (RTNLGRP_TC - 1));
 
 	dplane_groups = (RTMGRP_LINK | RTMGRP_NEIGH | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR |
 			 ((uint32_t)1 << (RTNLGRP_IPV4_NETCONF - 1)) |
 			 ((uint32_t)1 << (RTNLGRP_IPV6_NETCONF - 1)) |
-			 ((uint32_t)1 << (RTNLGRP_MPLS_NETCONF - 1)));
+			 ((uint32_t)1 << (RTNLGRP_MPLS_NETCONF - 1)) |
+			 ((uint32_t)1 << (RTNLGRP_NEXTHOP - 1)));
 
 	/* Use setsockopt for > 31 group */
 	ext_groups = RTNLGRP_TUNNEL;

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -101,6 +101,7 @@ extern void neigh_read(struct zebra_ns *zns);
 extern void neigh_read_for_vlan(struct zebra_ns *zns, struct interface *ifp);
 extern void neigh_read_specific_ip(const struct ipaddr *ip,
 				   struct interface *vlan_if);
+extern void nexthop_read(struct zebra_ns *zns);
 extern void route_read(struct zebra_ns *zns);
 extern int kernel_upd_mac_nh(uint32_t nh_id, struct ipaddr *vtep_ip);
 extern int kernel_del_mac_nh(uint32_t nh_id);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3502,7 +3502,7 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
 }
 
 /**
- * netlink_nexthop_process_nh() - Parse the gateway/if info from a new nexthop
+ * netlink_nexthop_parse_nh() - Parse the gateway/if info from a new nexthop
  *
  * @tb:		Netlink RTA data
  * @family:	Address family in the nhmsg
@@ -3511,20 +3511,22 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
  *
  * Return:	New nexthop
  */
-static struct nexthop netlink_nexthop_process_nh(struct rtattr **tb,
-						 unsigned char family,
-						 struct interface **ifp,
-						 ns_id_t ns_id)
+static int netlink_nexthop_parse_nh(struct rtattr **tb, unsigned char family, struct nexthop *nh,
+				    mpls_label_t *labels, uint16_t *label_count)
 {
-	struct nexthop nh = {.weight = 1};
 	void *gate = NULL;
 	enum nexthop_types_t type = 0;
 	int if_index = 0;
 	size_t sz = 0;
-	struct interface *ifp_lookup;
+
+	memset(nh, 0, sizeof(*nh));
+	nh->weight = 1;
+	nh->vrf_id = VRF_DEFAULT;
+
+	if (!tb[NHA_OIF])
+		return -1;
 
 	if_index = *(int *)RTA_DATA(tb[NHA_OIF]);
-
 
 	if (tb[NHA_GATEWAY]) {
 		switch (family) {
@@ -3537,56 +3539,39 @@ static struct nexthop netlink_nexthop_process_nh(struct rtattr **tb,
 			sz = 16;
 			break;
 		default:
-			flog_warn(
-				EC_ZEBRA_BAD_NHG_MESSAGE,
-				"Nexthop gateway with bad address family (%d) received from kernel",
-				family);
-			return nh;
+			flog_warn(EC_ZEBRA_BAD_NHG_MESSAGE,
+				  "Nexthop gateway with bad address family (%d) received from kernel",
+				  family);
+			return -1;
 		}
 		gate = RTA_DATA(tb[NHA_GATEWAY]);
 	} else
 		type = NEXTHOP_TYPE_IFINDEX;
 
 	if (type)
-		nh.type = type;
+		nh->type = type;
 
 	if (gate)
-		memcpy(&(nh.gate), gate, sz);
+		memcpy(&(nh->gate), gate, sz);
 
 	if (if_index)
-		nh.ifindex = if_index;
+		nh->ifindex = if_index;
 
-	ifp_lookup =
-		if_lookup_by_index_per_ns(zebra_ns_lookup(ns_id), nh.ifindex);
+	if (label_count)
+		*label_count = 0;
 
-	if (ifp)
-		*ifp = ifp_lookup;
-	if (ifp_lookup)
-		nh.vrf_id = ifp_lookup->vrf->vrf_id;
-	else {
-		flog_warn(
-			EC_ZEBRA_UNKNOWN_INTERFACE,
-			"%s: Unknown nexthop interface %u received, defaulting to VRF_DEFAULT",
-			__func__, nh.ifindex);
-
-		nh.vrf_id = VRF_DEFAULT;
-	}
-
-	if (tb[NHA_ENCAP] && tb[NHA_ENCAP_TYPE]) {
+	if (labels && label_count && tb[NHA_ENCAP] && tb[NHA_ENCAP_TYPE]) {
 		uint16_t encap_type = *(uint16_t *)RTA_DATA(tb[NHA_ENCAP_TYPE]);
 		int num_labels = 0;
-
-		mpls_label_t labels[MPLS_MAX_LABELS] = {0};
 
 		if (encap_type == LWTUNNEL_ENCAP_MPLS)
 			num_labels = parse_encap_mpls(tb[NHA_ENCAP], labels);
 
-		if (num_labels)
-			nexthop_add_labels(&nh, ZEBRA_LSP_STATIC, num_labels,
-					   labels);
+		if (num_labels > 0)
+			*label_count = num_labels;
 	}
 
-	return nh;
+	return 0;
 }
 
 static int netlink_nexthop_process_group(struct rtattr **tb,
@@ -3667,13 +3652,17 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	int type;
 	afi_t afi = AFI_UNSPEC;
 	vrf_id_t vrf_id = VRF_DEFAULT;
-	struct interface *ifp = NULL;
 	struct nhmsg *nhm = NULL;
-	struct nexthop nh = {.weight = 1};
+	struct nexthop nh;
 	struct nh_grp grp[MULTIPATH_NUM] = {};
 	/* Count of nexthops in group array */
 	uint16_t grp_count = 0;
 	struct rtattr *tb[NHA_MAX + 1] = {};
+	struct zebra_dplane_ctx *ctx = NULL;
+	mpls_label_t labels[MPLS_MAX_LABELS] = {};
+	uint16_t label_count = 0;
+	struct nhg_resilience nhgr = {};
+	bool has_nh = false;
 
 	frrtrace(3, frr_zebra, netlink_nexthop_change, h, ns_id, startup);
 
@@ -3730,9 +3719,17 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			   nl_msg_type_to_str(h->nlmsg_type), id,
 			   nl_family_to_str(family), ns_id);
 
+	ctx = dplane_ctx_alloc();
+	dplane_ctx_set_ns_id(ctx, ns_id);
+	dplane_ctx_set_nhe_id(ctx, id);
+	dplane_ctx_set_nhe_afi(ctx, afi);
+	dplane_ctx_set_nhe_type(ctx, type);
+	dplane_ctx_set_nhe_vrf_id(ctx, vrf_id);
+	dplane_ctx_set_nhe_notif(ctx, true);
+	dplane_ctx_set_startup(ctx, startup);
 
 	if (h->nlmsg_type == RTM_NEWNEXTHOP) {
-		struct nhg_resilience nhgr = {};
+		dplane_ctx_set_op(ctx, DPLANE_OP_NH_INSTALL);
 
 		if (tb[NHA_GROUP]) {
 			/**
@@ -3741,6 +3738,8 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			 */
 			grp_count = netlink_nexthop_process_group(
 				tb, grp, array_size(grp), &nhgr);
+			dplane_ctx_set_nhe_nh_grp(ctx, grp, grp_count);
+			dplane_ctx_set_nhe_resilience(ctx, &nhgr);
 		} else {
 			if (tb[NHA_BLACKHOLE]) {
 				/**
@@ -3748,36 +3747,48 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 				 * traffic, it should not have an OIF, GATEWAY,
 				 * or ENCAP
 				 */
+				memset(&nh, 0, sizeof(nh));
+				nh.weight = 1;
 				nh.type = NEXTHOP_TYPE_BLACKHOLE;
 				nh.bh_type = BLACKHOLE_UNSPEC;
-			} else if (tb[NHA_OIF])
+				has_nh = true;
+			} else if (tb[NHA_OIF]) {
 				/**
 				 * This is a true new nexthop, so we need
 				 * to parse the gateway and device info
 				 */
-				nh = netlink_nexthop_process_nh(tb, family,
-								&ifp, ns_id);
-			else {
-
+				if (netlink_nexthop_parse_nh(tb, family, &nh, labels,
+							     &label_count) < 0) {
+					dplane_ctx_fini(&ctx);
+					return -1;
+				}
+				has_nh = true;
+			} else {
 				flog_warn(
 					EC_ZEBRA_BAD_NHG_MESSAGE,
 					"Invalid Nexthop message received from the kernel with ID (%u)",
 					id);
+				dplane_ctx_fini(&ctx);
 				return -1;
 			}
-			SET_FLAG(nh.flags, NEXTHOP_FLAG_ACTIVE);
-			if (nhm->nh_flags & RTNH_F_ONLINK)
-				SET_FLAG(nh.flags, NEXTHOP_FLAG_ONLINK);
-			vrf_id = nh.vrf_id;
+
+			if (has_nh) {
+				SET_FLAG(nh.flags, NEXTHOP_FLAG_ACTIVE);
+				if (nhm->nh_flags & RTNH_F_ONLINK)
+					SET_FLAG(nh.flags, NEXTHOP_FLAG_ONLINK);
+				dplane_ctx_set_nhe_nh(ctx, &nh);
+				dplane_ctx_set_nhe_labels(ctx, labels, label_count);
+			}
 		}
+	} else if (h->nlmsg_type == RTM_DELNEXTHOP) {
+		dplane_ctx_set_op(ctx, DPLANE_OP_NH_DELETE);
+	} else {
+		dplane_ctx_fini(&ctx);
+		return 0;
+	}
 
-		if (zebra_nhg_kernel_find(id, &nh, grp, grp_count, vrf_id, afi,
-					  type, startup, &nhgr))
-			return -1;
-
-	} else if (h->nlmsg_type == RTM_DELNEXTHOP)
-		zebra_nhg_kernel_del(id, vrf_id);
-
+	/* Enqueue ctx for main pthread to process */
+	dplane_provider_enqueue_to_zebra(ctx);
 	return 0;
 }
 

--- a/zebra/rtread_netlink.c
+++ b/zebra/rtread_netlink.c
@@ -17,6 +17,11 @@
 #include "zebra/rule_netlink.h"
 #include "zebra/tc_netlink.h"
 
+void nexthop_read(struct zebra_ns *zns)
+{
+	netlink_nexthop_read(zns);
+}
+
 void route_read(struct zebra_ns *zns)
 {
 	netlink_route_read(zns);

--- a/zebra/rtread_sysctl.c
+++ b/zebra/rtread_sysctl.c
@@ -22,6 +22,10 @@
 #include "zebra/zebra_tc.h"
 #include "zebra/zebra_errors.h"
 
+void nexthop_read(struct zebra_ns *zns)
+{
+}
+
 /* Kernel routing table read up by sysctl function. */
 void route_read(struct zebra_ns *zns)
 {

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -211,7 +211,6 @@ struct dplane_intf_info {
 	enum zebra_slave_iftype zslave_type;
 	uint8_t bypass;
 	enum zebra_link_type zltype;
-	bool startup;
 	uint8_t family;
 	struct zebra_vxlan_vni_array *vniarray;
 	bool no_bvinfo_avail;
@@ -440,6 +439,8 @@ struct zebra_dplane_ctx {
 
 	char zd_ifname[IFNAMSIZ];
 	ifindex_t zd_ifindex;
+
+	bool zd_startup;
 
 	/* Support info for different kinds of updates */
 	union {
@@ -1636,18 +1637,18 @@ ns_id_t dplane_ctx_get_ifp_link_nsid(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.intf.link_nsid;
 }
 
-void dplane_ctx_set_ifp_startup(struct zebra_dplane_ctx *ctx, bool startup)
+void dplane_ctx_set_startup(struct zebra_dplane_ctx *ctx, bool startup)
 {
 	DPLANE_CTX_VALID(ctx);
 
-	ctx->u.intf.startup = startup;
+	ctx->zd_startup = startup;
 }
 
-bool dplane_ctx_get_ifp_startup(const struct zebra_dplane_ctx *ctx)
+bool dplane_ctx_get_startup(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 
-	return ctx->u.intf.startup;
+	return ctx->zd_startup;
 }
 
 void dplane_ctx_set_ifp_protodown_set(struct zebra_dplane_ctx *ctx, bool set)

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -87,6 +87,12 @@ struct dplane_nexthop_info {
 	afi_t afi;
 	vrf_id_t vrf_id;
 	int type;
+	bool is_notif;
+	bool nh_valid;
+	struct nexthop nh;
+	uint16_t nh_label_count;
+	mpls_label_t nh_labels[MPLS_MAX_LABELS];
+	struct nhg_resilience resilience;
 
 	struct nexthop_group ng;
 	struct nh_grp nh_grp[MULTIPATH_NUM];
@@ -2378,7 +2384,99 @@ int dplane_ctx_get_ns_sock(const struct zebra_dplane_ctx *ctx)
 #endif
 }
 
-/* Accessors for nexthop information */
+/* Setters/accessors for nexthop information */
+void dplane_ctx_set_nhe_id(struct zebra_dplane_ctx *ctx, uint32_t id)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.nhe.id = id;
+}
+
+void dplane_ctx_set_nhe_afi(struct zebra_dplane_ctx *ctx, afi_t afi)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.nhe.afi = afi;
+}
+
+void dplane_ctx_set_nhe_vrf_id(struct zebra_dplane_ctx *ctx, vrf_id_t vrf_id)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.nhe.vrf_id = vrf_id;
+}
+
+void dplane_ctx_set_nhe_type(struct zebra_dplane_ctx *ctx, int type)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.nhe.type = type;
+}
+
+void dplane_ctx_set_nhe_nh_grp(struct zebra_dplane_ctx *ctx, const struct nh_grp *grp,
+			       uint16_t count)
+{
+	uint16_t copy_count = count;
+
+	DPLANE_CTX_VALID(ctx);
+
+	if (copy_count > MULTIPATH_NUM)
+		copy_count = MULTIPATH_NUM;
+
+	ctx->u.rinfo.nhe.nh_grp_count = copy_count;
+	if (copy_count && grp)
+		memcpy(ctx->u.rinfo.nhe.nh_grp, grp, copy_count * sizeof(*grp));
+	else if (!copy_count)
+		memset(ctx->u.rinfo.nhe.nh_grp, 0, sizeof(ctx->u.rinfo.nhe.nh_grp));
+}
+
+void dplane_ctx_set_nhe_resilience(struct zebra_dplane_ctx *ctx,
+				   const struct nhg_resilience *resilience)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	if (resilience)
+		ctx->u.rinfo.nhe.resilience = *resilience;
+	else
+		memset(&ctx->u.rinfo.nhe.resilience, 0, sizeof(ctx->u.rinfo.nhe.resilience));
+}
+
+void dplane_ctx_set_nhe_nh(struct zebra_dplane_ctx *ctx, const struct nexthop *nh)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	if (nh) {
+		ctx->u.rinfo.nhe.nh = *nh;
+		ctx->u.rinfo.nhe.nh.next = NULL;
+		ctx->u.rinfo.nhe.nh.prev = NULL;
+		ctx->u.rinfo.nhe.nh_valid = true;
+	} else {
+		memset(&ctx->u.rinfo.nhe.nh, 0, sizeof(ctx->u.rinfo.nhe.nh));
+		ctx->u.rinfo.nhe.nh_valid = false;
+	}
+}
+
+void dplane_ctx_set_nhe_labels(struct zebra_dplane_ctx *ctx, const mpls_label_t *labels,
+			       uint16_t count)
+{
+	uint16_t copy_count = count;
+
+	DPLANE_CTX_VALID(ctx);
+
+	if (!labels || copy_count == 0) {
+		ctx->u.rinfo.nhe.nh_label_count = 0;
+		return;
+	}
+
+	if (copy_count > MPLS_MAX_LABELS)
+		copy_count = MPLS_MAX_LABELS;
+
+	ctx->u.rinfo.nhe.nh_label_count = copy_count;
+	memcpy(ctx->u.rinfo.nhe.nh_labels, labels, copy_count * sizeof(*labels));
+}
+
+void dplane_ctx_set_nhe_notif(struct zebra_dplane_ctx *ctx, bool notif)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.nhe.is_notif = notif;
+}
+
 uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -2427,6 +2525,40 @@ uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 	return ctx->u.rinfo.nhe.nh_grp_count;
+}
+
+bool dplane_ctx_get_nhe_notif(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.is_notif;
+}
+
+const struct nhg_resilience *dplane_ctx_get_nhe_resilience(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &ctx->u.rinfo.nhe.resilience;
+}
+
+const struct nexthop *dplane_ctx_get_nhe_nh(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	if (!ctx->u.rinfo.nhe.nh_valid)
+		return NULL;
+
+	return &ctx->u.rinfo.nhe.nh;
+}
+
+uint16_t dplane_ctx_get_nhe_label_count(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.nh_label_count;
+}
+
+const mpls_label_t *dplane_ctx_get_nhe_labels(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.nh_labels;
 }
 
 /* Accessors for LSP information */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -427,8 +427,8 @@ void dplane_ctx_set_ifp_change_flags(struct zebra_dplane_ctx *ctx, uint64_t chan
 uint64_t dplane_ctx_get_ifp_change_flags(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_ifp_protodown(struct zebra_dplane_ctx *ctx, bool protodown);
 bool dplane_ctx_get_ifp_protodown(const struct zebra_dplane_ctx *ctx);
-void dplane_ctx_set_ifp_startup(struct zebra_dplane_ctx *ctx, bool startup);
-bool dplane_ctx_get_ifp_startup(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_startup(struct zebra_dplane_ctx *ctx, bool startup);
+bool dplane_ctx_get_startup(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_ifp_protodown_set(struct zebra_dplane_ctx *ctx, bool set);
 bool dplane_ctx_get_ifp_protodown_set(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_ifp_rc_bitfield(struct zebra_dplane_ctx *ctx,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -624,7 +624,20 @@ dplane_ctx_get_backup_ng(const struct zebra_dplane_ctx *ctx);
 const struct nexthop_group *
 dplane_ctx_get_old_backup_ng(const struct zebra_dplane_ctx *ctx);
 
-/* Accessors for nexthop information */
+/* Setters/accessors for nexthop information */
+void dplane_ctx_set_nhe_id(struct zebra_dplane_ctx *ctx, uint32_t id);
+void dplane_ctx_set_nhe_afi(struct zebra_dplane_ctx *ctx, afi_t afi);
+void dplane_ctx_set_nhe_vrf_id(struct zebra_dplane_ctx *ctx, vrf_id_t vrf_id);
+void dplane_ctx_set_nhe_type(struct zebra_dplane_ctx *ctx, int type);
+void dplane_ctx_set_nhe_nh_grp(struct zebra_dplane_ctx *ctx, const struct nh_grp *grp,
+			       uint16_t count);
+void dplane_ctx_set_nhe_resilience(struct zebra_dplane_ctx *ctx,
+				   const struct nhg_resilience *resilience);
+void dplane_ctx_set_nhe_nh(struct zebra_dplane_ctx *ctx, const struct nexthop *nh);
+void dplane_ctx_set_nhe_labels(struct zebra_dplane_ctx *ctx, const mpls_label_t *labels,
+			       uint16_t count);
+void dplane_ctx_set_nhe_notif(struct zebra_dplane_ctx *ctx, bool notif);
+
 uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_old_nhe_id(const struct zebra_dplane_ctx *ctx);
 afi_t dplane_ctx_get_nhe_afi(const struct zebra_dplane_ctx *ctx);
@@ -635,6 +648,11 @@ dplane_ctx_get_nhe_ng(const struct zebra_dplane_ctx *ctx);
 const struct nh_grp *
 dplane_ctx_get_nhe_nh_grp(const struct zebra_dplane_ctx *ctx);
 uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_get_nhe_notif(const struct zebra_dplane_ctx *ctx);
+const struct nhg_resilience *dplane_ctx_get_nhe_resilience(const struct zebra_dplane_ctx *ctx);
+const struct nexthop *dplane_ctx_get_nhe_nh(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_get_nhe_label_count(const struct zebra_dplane_ctx *ctx);
+const mpls_label_t *dplane_ctx_get_nhe_labels(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for LSP information */
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1239,12 +1239,17 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	struct nhg_connected_tree_head nhg_depends = {};
 	struct nhg_hash_entry *lookup = NULL;
 	struct nhg_hash_entry *nhe = NULL;
+	struct nhg_hash_entry *old = NULL;
+	struct nhg_connected *rb_node_dep = NULL;
 
 	uint32_t id = nhg_ctx_get_id(ctx);
 	uint16_t count = nhg_ctx_get_count(ctx);
 	vrf_id_t vrf_id = nhg_ctx_get_vrf_id(ctx);
 	int type = nhg_ctx_get_type(ctx);
 	afi_t afi = nhg_ctx_get_afi(ctx);
+	int ret = 0;
+	bool replace = false;
+	bool restore_old_id = false;
 
 	lookup = zebra_nhg_lookup_id(id);
 
@@ -1253,11 +1258,22 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 			   __func__, id, count, lookup);
 
 	if (lookup) {
-		/* This is already present in our table, hence an update
-		 * that we did not initiate.
+		if (lookup->type != ZEBRA_ROUTE_KERNEL) {
+			/* This is already present in our table, hence an
+			 * update that we did not initiate. If the NHG is
+			 * FRR-owned, restore our version in the kernel.
+			 */
+			zebra_nhg_handle_kernel_state_change(lookup, false);
+			return 0;
+		}
+
+		/* Kernel-owned NHGs should track kernel replaces in-memory
+		 * instead of re-installing the previous version back down.
 		 */
-		zebra_nhg_handle_kernel_state_change(lookup, false);
-		return 0;
+		old = lookup;
+		replace = true;
+		hash_release(zrouter.nhgs_id, old);
+		restore_old_id = true;
 	}
 
 	if (nhg_ctx_get_count(ctx)) {
@@ -1265,9 +1281,8 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 		if (zebra_nhg_process_grp(nhg, &nhg_depends,
 					  nhg_ctx_get_grp(ctx), count,
 					  nhg_ctx_get_resilience(ctx))) {
-			depends_decrement_free(&nhg_depends);
-			nexthop_group_delete(&nhg);
-			return -ENOENT;
+			ret = -ENOENT;
+			goto done;
 		}
 
 		if (!zebra_nhg_find(&nhe, id, nhg, &nhg_depends, vrf_id, afi,
@@ -1285,13 +1300,35 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 			EC_ZEBRA_TABLE_LOOKUP_FAILED,
 			"Zebra failed to find or create a nexthop hash entry for ID (%u)",
 			id);
-		return -1;
+		ret = -1;
+		goto done;
 	}
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-		zlog_debug("%s: nhe %p (%pNG) is new", __func__, nhe, nhe);
+		zlog_debug("%s: nhe %p (%pNG) is %s", __func__, nhe, nhe,
+			   replace ? "replacement" : "new");
 
 	frrtrace(1, frr_zebra, nhg_ctx_process_new_nhe, id);
+
+	if (old) {
+		restore_old_id = false;
+		zebra_nhg_release_all_deps(old);
+
+		ret = rib_handle_nhg_replace(old, nhe);
+		if (ret)
+			old = NULL;
+		else {
+			if (!zebra_nhg_depends_is_empty(old)) {
+				frr_each (nhg_connected_tree, &old->nhg_depends, rb_node_dep)
+					zebra_nhg_decrement_ref(rb_node_dep->nhe);
+			}
+
+			old->refcnt = 0;
+			event_cancel(&old->timer);
+			zebra_nhg_free(old);
+			old = NULL;
+		}
+	}
 
 	/*
 	 * If daemon nhg from the kernel, add a refcnt here to indicate the
@@ -1304,7 +1341,19 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 
-	return 0;
+	ret = 0;
+
+done:
+	if (ret && old && restore_old_id)
+		zebra_nhg_insert_id(old);
+
+	if (ret == -ENOENT)
+		depends_decrement_free(&nhg_depends);
+
+	if (nhg)
+		nexthop_group_delete(&nhg);
+
+	return ret;
 }
 
 static int nhg_ctx_process_del(struct nhg_ctx *ctx)
@@ -1322,7 +1371,26 @@ static int nhg_ctx_process_del(struct nhg_ctx *ctx)
 		return -1;
 	}
 
-	zebra_nhg_handle_kernel_state_change(nhe, true);
+	if (nhe->type != ZEBRA_ROUTE_KERNEL) {
+		zebra_nhg_handle_kernel_state_change(nhe, true);
+		return 0;
+	}
+
+	/* Kernel-owned NHGs should track the kernel delete in-memory instead
+	 * of re-installing the previous version back down.
+	 */
+	UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+	UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED);
+	UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND);
+
+	if (nhe->refcnt > 0) {
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: keeping deleted kernel NHG %pNG in memory while still referenced (refcnt %u)",
+				   __func__, nhe, nhe->refcnt);
+		return 0;
+	}
+
+	zebra_nhg_handle_uninstall(nhe);
 
 	return 0;
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1240,7 +1240,6 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	struct nhg_hash_entry *lookup = NULL;
 	struct nhg_hash_entry *nhe = NULL;
 	struct nhg_hash_entry *old = NULL;
-	struct nhg_connected *rb_node_dep = NULL;
 
 	uint32_t id = nhg_ctx_get_id(ctx);
 	uint16_t count = nhg_ctx_get_count(ctx);
@@ -1318,11 +1317,6 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 		if (ret)
 			old = NULL;
 		else {
-			if (!zebra_nhg_depends_is_empty(old)) {
-				frr_each (nhg_connected_tree, &old->nhg_depends, rb_node_dep)
-					zebra_nhg_decrement_ref(rb_node_dep->nhe);
-			}
-
 			old->refcnt = 0;
 			event_cancel(&old->timer);
 			zebra_nhg_free(old);
@@ -1864,7 +1858,7 @@ void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 
 	nhe->refcnt--;
 
-	if (!zebra_router_in_shutdown() && nhe->refcnt <= 0 &&
+	if (!zebra_router_in_shutdown() && ZEBRA_NHG_CREATED(nhe) && nhe->refcnt <= 0 &&
 	    (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
 	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) &&
 	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND)) {
@@ -1877,6 +1871,16 @@ void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 
 	if (!zebra_nhg_depends_is_empty(nhe))
 		nhg_connected_tree_decrement_ref(&nhe->nhg_depends);
+
+	if (nhe->type == ZEBRA_ROUTE_KERNEL && nhe->refcnt == 0 &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: uninstalling unreferenced deleted kernel NHG %pNG",
+				   __func__, nhe);
+		zebra_nhg_handle_uninstall(nhe);
+		return;
+	}
 
 	if (ZEBRA_NHG_CREATED(nhe) && nhe->refcnt <= 0)
 		zebra_nhg_uninstall_kernel(nhe);

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -312,6 +312,7 @@ void zebra_ns_startup_continue(struct zebra_dplane_ctx *ctx)
 		break;
 	case ZEBRA_DPLANE_ADDRESSES_READ:
 		neigh_read(zns);
+		nexthop_read(zns);
 		route_read(zns);
 
 		vlan_read(zns);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4933,6 +4933,83 @@ static void rib_process_sys_route(struct zebra_dplane_ctx *ctx)
 	}
 }
 
+static void zebra_nhg_process_kernel_notif(struct zebra_dplane_ctx *ctx)
+{
+	enum dplane_op_e op = dplane_ctx_get_op(ctx);
+	uint32_t id = dplane_ctx_get_nhe_id(ctx);
+	vrf_id_t vrf_id = dplane_ctx_get_nhe_vrf_id(ctx);
+	afi_t afi = dplane_ctx_get_nhe_afi(ctx);
+	int type = dplane_ctx_get_nhe_type(ctx);
+	bool startup = dplane_ctx_get_startup(ctx);
+	uint16_t grp_count = dplane_ctx_get_nhe_nh_grp_count(ctx);
+	const struct nhg_resilience *nhgr = dplane_ctx_get_nhe_resilience(ctx);
+
+	if (zebra_evpn_mh_is_fdb_nh(id)) {
+		/* If this is a L2 NH just ignore it */
+		if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH)
+			zlog_debug("Ignore kernel update (%u) for fdb-nh 0x%x", op, id);
+
+		frrtrace(2, frr_zebra, netlink_nexthop_change_err, op, id);
+		return;
+	}
+
+	if (op == DPLANE_OP_NH_DELETE) {
+		zebra_nhg_kernel_del(id, vrf_id);
+		return;
+	}
+
+	if (grp_count) {
+		const struct nh_grp *grp = dplane_ctx_get_nhe_nh_grp(ctx);
+
+		if (zebra_nhg_kernel_find(id, NULL, (struct nh_grp *)grp, grp_count, vrf_id, afi,
+					  type, startup, (struct nhg_resilience *)nhgr))
+			return;
+	} else {
+		const struct nexthop *ctx_nh = dplane_ctx_get_nhe_nh(ctx);
+		struct nexthop nh;
+		const mpls_label_t *labels;
+		uint16_t label_count;
+		struct interface *ifp = NULL;
+		struct zebra_ns *zns;
+
+		if (!ctx_nh) {
+			flog_warn(EC_ZEBRA_BAD_NHG_MESSAGE,
+				  "Invalid Nexthop message received from the kernel with ID (%u)",
+				  id);
+			return;
+		}
+
+		nh = *ctx_nh;
+
+		labels = dplane_ctx_get_nhe_labels(ctx);
+		label_count = dplane_ctx_get_nhe_label_count(ctx);
+		if (label_count)
+			nexthop_add_labels(&nh, ZEBRA_LSP_STATIC, label_count, labels);
+
+		if (nh.type != NEXTHOP_TYPE_BLACKHOLE) {
+			zns = zebra_ns_lookup(dplane_ctx_get_ns_id(ctx));
+			if (zns)
+				ifp = if_lookup_by_index_per_ns(zns, nh.ifindex);
+
+			if (ifp)
+				nh.vrf_id = ifp->vrf->vrf_id;
+			else {
+				flog_warn(EC_ZEBRA_UNKNOWN_INTERFACE,
+					  "%s: Unknown nexthop interface %u received, defaulting to VRF_DEFAULT",
+					  __func__, nh.ifindex);
+				nh.vrf_id = VRF_DEFAULT;
+			}
+		} else {
+			nh.vrf_id = VRF_DEFAULT;
+		}
+
+		vrf_id = nh.vrf_id;
+
+		zebra_nhg_kernel_find(id, &nh, NULL, 0, vrf_id, afi, type, startup,
+				      (struct nhg_resilience *)nhgr);
+	}
+}
+
 /*
  * Handle results from the dataplane system. Dequeue update context
  * structs, dispatch to appropriate internal handlers.
@@ -5025,7 +5102,10 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_NH_INSTALL:
 			case DPLANE_OP_NH_UPDATE:
 			case DPLANE_OP_NH_DELETE:
-				zebra_nhg_dplane_result(ctx);
+				if (dplane_ctx_get_nhe_notif(ctx))
+					zebra_nhg_process_kernel_notif(ctx);
+				else
+					zebra_nhg_dplane_result(ctx);
 				break;
 
 			case DPLANE_OP_LSP_INSTALL:


### PR DESCRIPTION
Nexthop read in in zebra from the linux kernel is not being done in the dplane.  Move it over.  Additionally while testing I ran across a bunch of bugs in how kernel nexthop groups were being taken care of.  Fix these as well.