### PR TITLE
ripngd: fix data handling in several places (10.5 backport)

### DIFF
--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1137,11 +1137,18 @@ static void ripng_response_process(struct ripng_packet *packet, int size,
 				   struct sockaddr_in6 *from,
 				   struct interface *ifp, int hoplimit)
 {
-	struct ripng_interface *ri = ifp->info;
-	struct ripng *ripng = ri->ripng;
+	struct ripng_interface *ri;
+	struct ripng *ripng;
 	caddr_t lim;
 	struct rte *rte;
 	struct ripng_nexthop nexthop;
+
+	/* Check RIPng process is enabled on this interface. */
+	ri = ifp->info;
+	if (ri == NULL || !ri->running)
+		return;
+
+	ripng = ri->ripng;
 
 	/* RFC2080 2.4.2  Response Messages:
 	 The Response must be ignored if it is not from the RIPng port.  */
@@ -1322,19 +1329,24 @@ static void ripng_request_process(struct ripng_packet *packet, int size,
 		p.family = AF_INET6;
 
 		for (; ((caddr_t)rte) < lim; rte++) {
+			rinfo = NULL;
+
 			p.prefix = rte->addr;
 			p.prefixlen = rte->prefixlen;
 			apply_mask_ipv6(&p);
 
-			rp = agg_node_lookup(ripng->table, (struct prefix *)&p);
+			rte->metric = RIPNG_METRIC_INFINITY;
 
+			rp = agg_node_lookup(ripng->table, (struct prefix *)&p);
 			if (rp) {
-				rinfo = listgetdata(
-					listhead((struct list *)rp->info));
-				rte->metric = rinfo->metric;
+				if (rp->info)
+					rinfo = listgetdata(
+						listhead((struct list *)rp->info));
+				if (rinfo)
+					rte->metric = rinfo->metric;
+
 				agg_unlock_node(rp);
-			} else
-				rte->metric = RIPNG_METRIC_INFINITY;
+			}
 		}
 		packet->command = RIPNG_RESPONSE;
 
@@ -1372,6 +1384,12 @@ static void ripng_read(struct event *thread)
 	if (len < 0) {
 		zlog_warn("RIPng recvfrom failed (VRF %s): %s.",
 			  ripng->vrf_name, safe_strerror(errno));
+		return;
+	}
+
+	if (len < RIPNG_MIN_PACKET_SIZE || len > RIPNG_MAX_PACKET_SIZE) {
+		zlog_warn("RIPng invalid packet size %d from %pI6 (VRF %s)",
+			  len, &from.sin6_addr, ripng->vrf_name);
 		return;
 	}
 

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -16,6 +16,7 @@
 /* RIPng version and port number. */
 #define RIPNG_V1                         1
 #define RIPNG_PORT_DEFAULT             521
+#define RIPNG_MIN_PACKET_SIZE            4
 #define RIPNG_MAX_PACKET_SIZE         1500
 #define RIPNG_PRIORITY_DEFAULT           0
 


### PR DESCRIPTION
Don't accept responses unless interface is configured; be more careful with route_node before dereferencing the info pointer; validate min and max packet size before processing.