### PR TITLE
zebra: add numMacs and numArpNd to L3 VNI detail output

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -787,6 +787,12 @@ static void zl3vni_print(struct zebra_l3vni *zl3vni, void **ctx)
 			zl3vni_sysmac2str(zl3vni, buf, sizeof(buf)));
 		vty_out(vty, "  Router MAC: %s\n",
 			zl3vni_rmac2str(zl3vni, buf, sizeof(buf)));
+		vty_out(vty,
+			"  Number of MACs (local and remote) known for this VNI: %lu\n",
+			hashcount(zl3vni->rmac_table));
+		vty_out(vty,
+			"  Number of ARPs (IPv4 and IPv6, local and remote) known for this VNI: %lu\n",
+			hashcount(zl3vni->nh_table));
 		vty_out(vty, "  L2 VNIs: ");
 		for (ALL_LIST_ELEMENTS(zl3vni->l2vnis, node, nnode, zevpn))
 			vty_out(vty, "%u ", zevpn->vni);
@@ -821,6 +827,10 @@ static void zl3vni_print(struct zebra_l3vni *zl3vni, void **ctx)
 			json_object_array_add(json_evpn_list,
 					      json_object_new_int(zevpn->vni));
 		}
+		json_object_int_add(json, "numMacs",
+				    hashcount(zl3vni->rmac_table));
+		json_object_int_add(json, "numArpNd",
+				    hashcount(zl3vni->nh_table));
 		json_object_object_add(json, "l2Vnis", json_evpn_list);
 	}
 }


### PR DESCRIPTION
The "show evpn vni <VNI>" and "show evpn vni detail" commands display per-VNI detail via zl3vni_print(), but do not include the number of MACs (rmac_table) or ARP/ND entries (nh_table). The summary view (zl3vni_print_hash) already exposes these counters in both CLI and JSON output.

Add numMacs and numArpNd to both the CLI and JSON paths of zl3vni_print() for consistency.