### PR TITLE
zebra: add debug in route install around nhg not ready

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3928,11 +3928,18 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		 * matters for INSTALL/UPDATE.
 		 */
 		if (zebra_nhg_kernel_nexthops_enabled() &&
-		    (((op == DPLANE_OP_ROUTE_INSTALL) ||
-		      (op == DPLANE_OP_ROUTE_UPDATE)) &&
+		    (((op == DPLANE_OP_ROUTE_INSTALL) || (op == DPLANE_OP_ROUTE_UPDATE)) &&
 		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
-		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)))
+		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED))) {
+			frrtrace(4, frr_zebra, dplane_ctx_route_kernel_nhg_not_ready, op, nhe->id,
+				 nhe->flags, re->vrf_id);
+			if (IS_ZEBRA_DEBUG_DPLANE_DETAIL || IS_ZEBRA_DEBUG_RIB_DETAILED)
+				zlog_debug("%s route %pRN op %s nhg id %u flags 0x%x nh %pNHs not installed nor queued",
+					   __func__, rn, dplane_op2str(op), nhe->id, nhe->flags,
+					   nhe->nhg.nexthop);
+
 			return ENOENT;
+		}
 	}
 #endif /* HAVE_NETLINK */
 

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -458,6 +458,28 @@ TRACEPOINT_EVENT(
 
 TRACEPOINT_LOGLEVEL(frr_zebra, zebra_nhg_dplane_result, TRACE_INFO)
 
+/*
+ * Route dataplane context init aborted: kernel nexthop group not yet installed
+ * or queued. Scalar fields only for lightweight tracing.
+ */
+TRACEPOINT_EVENT(
+	frr_zebra,
+	dplane_ctx_route_kernel_nhg_not_ready,
+	TP_ARGS(
+		enum dplane_op_e, op,
+		uint32_t, nhe_id,
+		uint32_t, nhe_flags,
+		vrf_id_t, vrf_id),
+	TP_FIELDS(
+		ctf_integer(uint32_t, op, op)
+		ctf_integer(uint32_t, nhe_id, nhe_id)
+		ctf_integer(uint32_t, nhe_flags, nhe_flags)
+		ctf_integer(vrf_id_t, vrf_id, vrf_id)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_zebra, dplane_ctx_route_kernel_nhg_not_ready, TRACE_INFO)
+
 TRACEPOINT_EVENT(
 	frr_zebra,
 	zebra_nhg_free_nhe_refcount,


### PR DESCRIPTION



debug log:
```
2026/03/20 01:41:09.401823 ZEBRA: [ZSM84-3K06X] dplane_ctx_route_init
route 81.0.0.5/32 op ROUTE_UPDATE nhg id 225 flags 0x5 nh 27.0.0.1 if 4
vrfid 0 not installed nor queued
```

Tracepoint:
```
2026-03-20T01:35:06.111 frr_zebra:dplane_ctx_route_kernel_nhg_not_ready
{'op': 2, 'nhe_id': 141, 'nhe_flags': 515, 'vrf_id': 41}
2026-03-20T01:35:10.366 frr_zebra:dplane_ctx_route_kernel_nhg_not_ready
{'op': 2, 'nhe_id': 73529432, 'nhe_flags': 3, 'vrf_id': 31}
2026-03-20T01:35:10.366 frr_zebra:dplane_ctx_route_kernel_nhg_not_ready
{'op': 2, 'nhe_id': 73529444, 'nhe_flags': 3, 'vrf_id': 41}
```
