### PR TITLE
zebra: Move `allow-external-route-update` to mgmt frontend side

### DIFF
--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -127,6 +127,18 @@ static void zebra_allow_external_route_update_cli_write(struct vty *vty,
 	vty_out(vty, "allow-external-route-update\n");
 }
 
+DEFPY_YANG (allow_external_route_update,
+	    allow_external_route_update_cmd,
+	    "[no] allow-external-route-update",
+	    NO_STR
+	    "Allow FRR routes to be overwritten by external processes\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/allow-external-route-update",
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 DEFPY_YANG (multicast_new,
 	multicast_new_cmd,
 	"[no] multicast <enable$on|disable$off>",
@@ -3135,6 +3147,7 @@ void zebra_cli_init(void)
 	install_element(CONFIG_NODE, &ipv6_protocol_nht_rmap_cmd);
 	install_element(VRF_NODE, &ipv6_protocol_nht_rmap_cmd);
 	install_element(CONFIG_NODE, &zebra_route_map_timer_cmd);
+	install_element(CONFIG_NODE, &allow_external_route_update_cmd);
 
 	install_element(CONFIG_NODE, &ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2714,29 +2714,6 @@ static void vty_show_ip_route_summary_prefix(struct vty *vty,
 	}
 }
 
-DEFPY_YANG (allow_external_route_update,
-	    allow_external_route_update_cmd,
-	    "allow-external-route-update",
-	    "Allow FRR routes to be overwritten by external processes\n")
-{
-	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/allow-external-route-update", NB_OP_CREATE,
-			      NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
-}
-
-DEFPY_YANG (no_allow_external_route_update,
-	    no_allow_external_route_update_cmd,
-	    "no allow-external-route-update",
-	    NO_STR
-	    "Allow FRR routes to be overwritten by external processes\n")
-{
-	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/allow-external-route-update", NB_OP_DESTROY,
-			      NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
-}
-
 /* show vrf */
 DEFUN (show_vrf,
        show_vrf_cmd,
@@ -4486,9 +4463,6 @@ void zebra_vty_init(void)
 
 	install_node(&ip_node);
 	install_node(&protocol_node);
-
-	install_element(CONFIG_NODE, &allow_external_route_update_cmd);
-	install_element(CONFIG_NODE, &no_allow_external_route_update_cmd);
 
 	install_element(CONFIG_NODE, &zebra_nexthop_group_keep_cmd);
 	install_element(CONFIG_NODE, &ip_zebra_import_table_distance_cmd);


### PR DESCRIPTION
The `allow-external-route-update` command was being compiled into the zebra side of the nb code.  Thus when configuration was being applied that uses mgmtd as a frontend and zebra as the frontend one would get there first and lock the database, preventing the other side from working.  Move this command to the correct spot.