### PR TITLE
zebra: lib: use old compatible value for lyd_new_term

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1745,8 +1745,7 @@ static enum nb_error lib_interface_vrf_get(const struct nb_node *nb_node, const 
 	const struct lysc_node *snode = nb_node->snode;
 	const struct interface *ifp = list_entry;
 
-	if (lyd_new_term(parent, snode->module, snode->name, ifp->vrf->name, LYD_NEW_PATH_UPDATE,
-			 NULL))
+	if (lyd_new_term(parent, snode->module, snode->name, ifp->vrf->name, false, NULL))
 		return NB_ERR_RESOURCE;
 	return NB_OK;
 }

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -254,7 +254,7 @@ static enum nb_error _router_id_get(const struct nb_node *nb_node, const struct 
 		goto done;
 
 	inet_ntop(afi == AFI_IP ? AF_INET : AF_INET6, &p.u.prefix, buf, sizeof(buf));
-	err = lyd_new_term(parent, snode->module, snode->name, buf, LYD_NEW_VAL_CANON, NULL);
+	err = lyd_new_term(parent, snode->module, snode->name, buf, false, NULL);
 	if (err != LY_SUCCESS)
 		return NB_ERR;
 done:


### PR DESCRIPTION
For now use backward compatible `false` value for the penultimate arg to `lyd_new_term()` to match earlier versions of libyang API. This matches all the other current uses of `lyd_new_term()` in the code.