### PR TITLE
tests: Fix wrong expectations in `bgp_srv6_unicast` topotest

### DIFF
--- a/tests/topotests/bgp_srv6_unicast/test_bgp_srv6_unicast.py
+++ b/tests/topotests/bgp_srv6_unicast/test_bgp_srv6_unicast.py
@@ -267,12 +267,20 @@ def test_bgp_srv6_sid_unexport():
         no sid export auto
         """
     )
-    prefixes = ["10.0.0.1/32", "10.0.0.3/32"]
+    logger.info("Check 10.0.0.1/32 is installed without SRv6 SID on R2")
+    res = check_route(
+        tgen.gears["r2"], "show ip route 10.0.0.1/32 json", "10.0.0.1/32", ""
+    )
+    assert res is True, res
 
-    logger.info("Check 10.0.0.1/32 and 10.0.0.3/32 are installed on R2")
-    for prefix in prefixes:
-        res = check_route(tgen.gears["r2"], "show ip route %s json" % prefix, prefix, "")
-        assert res is True, res
+    logger.info("Check 10.0.0.3/32 keeps SRv6 SID from R3 on R2")
+    res = check_route(
+        tgen.gears["r2"],
+        "show ip route 10.0.0.3/32 json",
+        "10.0.0.3/32",
+        r3_unicast_sid,
+    )
+    assert res is True, res
 
     prefixes = ["10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32"]
     logger.info("Check 10.0.0.1-3/32 are not installed on R3")


### PR DESCRIPTION
After removing sid export on R1, the test checks both 10.0.0.1/32 and 10.0.0.3/32 on R2 with `expect_sid=""`, expecting neither to carry a SRv6 SID. This is wrong: 10.0.0.3/32 is originated by R3 which still has sid export configured, so it should still be
seen on R2 with `r3_unicast_sid`.

This wrong expectation was not caught because `check_route()` did not verify the absence of a SID when `expect_sid=""`.

Fix the check for 10.0.0.3/32 to expect `r3_unicast_sid` on R2, while keeping 10.0.0.1/32 checked for absence of SID.