### PR TITLE
zebra: fix spurious tag mismatch in rib_route_match_ctx()

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1553,8 +1553,7 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    (re->distance != dplane_ctx_get_old_distance(ctx) ||
-			     re->tag != dplane_ctx_get_old_tag(ctx))) {
+			    re->distance != dplane_ctx_get_old_distance(ctx)) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_old_metric(ctx)) {
@@ -1580,8 +1579,7 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    (re->distance != dplane_ctx_get_distance(ctx) ||
-			     re->tag != dplane_ctx_get_tag(ctx))) {
+			    re->distance != dplane_ctx_get_distance(ctx)) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_metric(ctx)) {


### PR DESCRIPTION
rib_route_match_ctx() matches a returning dplane result back to the correct route_entry.  For ZEBRA_ROUTE_STATIC it narrowed the match using both distance and tag.  However, tag is an attribute of the route_entry, not part of its identity — a tag change modifies the route_entry in place without creating a new one.

Including tag in the match creates a race: if a tag update arrives and modifies re->tag before a pending dplane result is processed, the stored re->tag no longer matches the tag captured in the dplane context, and the correct route_entry is not found.

Since distance alone is sufficient to identify a ZEBRA_ROUTE_STATIC route_entry (before metric is introduced as a key), remove the tag comparison.