### PR TITLE
zebra: extend rib_compare_routes() metric check to KERNEL routes

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1646,6 +1646,9 @@ static bool rib_compare_routes(const struct route_entry *re1, const struct route
 	    re1->distance != re2->distance)
 		return false;
 
+	if (re1->type == ZEBRA_ROUTE_KERNEL && re1->metric != re2->metric)
+		return false;
+
 	/* We support multiple connected routes: this supports multiple
 	 * v6 link-locals, and we also support multiple addresses in the same
 	 * subnet on a single interface.


### PR DESCRIPTION
In Linux, metric is part of a kernel route's identity: two routes for the same prefix at different metrics are distinct entries and arrive as separate RTM_NEWROUTE messages.  The delete-lookup loop in process_subq_early_route_delete already handled this — skipping ZEBRA_ROUTE_KERNEL entries whose metric differs from the DELETE request. Add the equivalent check to rib_compare_routes() so that an incoming ADD for a kernel route at a different metric is not treated as an update to the existing entry, making the two functions consistent.