### PR TITLE
Allow bgp to de-duplicate based upon what is going to be installed into zebra

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -21,6 +21,7 @@
 #include "lib/bfd.h"
 #include "lib/route_opaque.h"
 #include "filter.h"
+#include "jhash.h"
 #include "mpls.h"
 #include "vxlan.h"
 #include "pbr.h"
@@ -1280,6 +1281,119 @@ static bool bgp_zebra_use_nhop_weighted(struct bgp *bgp, struct attr *attr,
 	return true;
 }
 
+PREDECL_HASH(bgp_nh_dedup);
+
+struct bgp_nh_dedup_entry {
+	struct bgp_nh_dedup_item itm;
+	struct zapi_nexthop *nh;
+};
+
+static uint32_t bgp_nh_dedup_hash_key(const struct bgp_nh_dedup_entry *item)
+{
+	const struct zapi_nexthop *nh = item->nh;
+	uint32_t key;
+
+	key = jhash_2words(nh->type, nh->vrf_id, 0x55aa5a5a);
+
+	switch (nh->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		key = jhash_1word(nh->gate.ipv4.s_addr, key);
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		key = jhash2((const uint32_t *)&nh->gate.ipv6,
+			     sizeof(nh->gate.ipv6) / sizeof(uint32_t), key);
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+	case NEXTHOP_TYPE_BLACKHOLE:
+		break;
+	}
+
+	key = jhash_1word(nh->ifindex, key);
+
+	if (nh->label_num)
+		key = jhash(nh->labels, nh->label_num * sizeof(mpls_label_t),
+			    key);
+
+	if (nh->seg_num)
+		key = jhash(nh->seg6_segs,
+			    nh->seg_num * sizeof(struct in6_addr), key);
+
+	key = jhash_1word(nh->srte_color, key);
+
+	return key;
+}
+
+/*
+ * Compare forwarding-relevant fields of two zapi nexthops.
+ * Weight is intentionally excluded -- it is a scheduling
+ * parameter, not forwarding identity.
+ */
+static int bgp_nh_dedup_hash_cmp(const struct bgp_nh_dedup_entry *a,
+				 const struct bgp_nh_dedup_entry *b)
+{
+	const struct zapi_nexthop *n1 = a->nh;
+	const struct zapi_nexthop *n2 = b->nh;
+	int ret;
+
+	if (n1->type != n2->type)
+		return numcmp(n1->type, n2->type);
+	if (n1->vrf_id != n2->vrf_id)
+		return numcmp(n1->vrf_id, n2->vrf_id);
+
+	switch (n1->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV6:
+		ret = nexthop_g_addr_cmp(n1->type, &n1->gate, &n2->gate);
+		if (ret)
+			return ret;
+		break;
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		ret = nexthop_g_addr_cmp(n1->type, &n1->gate, &n2->gate);
+		if (ret)
+			return ret;
+		if (n1->ifindex != n2->ifindex)
+			return numcmp(n1->ifindex, n2->ifindex);
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+		if (n1->ifindex != n2->ifindex)
+			return numcmp(n1->ifindex, n2->ifindex);
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		if (n1->bh_type != n2->bh_type)
+			return numcmp(n1->bh_type, n2->bh_type);
+		break;
+	}
+
+	if (n1->label_num != n2->label_num)
+		return numcmp(n1->label_num, n2->label_num);
+	if (n1->label_num > 0) {
+		ret = memcmp(n1->labels, n2->labels,
+			     n1->label_num * sizeof(mpls_label_t));
+		if (ret)
+			return ret;
+	}
+
+	if (n1->seg_num != n2->seg_num)
+		return numcmp(n1->seg_num, n2->seg_num);
+	if (n1->seg_num > 0) {
+		ret = memcmp(n1->seg6_segs, n2->seg6_segs,
+			     n1->seg_num * sizeof(struct in6_addr));
+		if (ret)
+			return ret;
+	}
+
+	if (n1->srte_color != n2->srte_color)
+		return numcmp(n1->srte_color, n2->srte_color);
+
+	return 0;
+}
+
+DECLARE_HASH(bgp_nh_dedup, struct bgp_nh_dedup_entry, itm,
+	     bgp_nh_dedup_hash_cmp, bgp_nh_dedup_hash_key);
+
 static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const struct prefix *p,
 					     struct bgp *bgp, struct zapi_route *api,
 					     unsigned int *valid_nh_count, afi_t afi, safi_t safi,
@@ -1304,12 +1418,17 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 	uint32_t exp = 0;
 
 	struct bgp_route_evpn *bre = NULL;
+	struct bgp_nh_dedup_head nh_hash;
+	struct bgp_nh_dedup_entry dedup_items[MULTIPATH_NUM];
+	unsigned int dedup_idx = 0;
 
 	/*
 	 * vrf leaking support (will have only one nexthop)
 	 */
 	if (info->extra && info->extra->vrfleak && info->extra->vrfleak->bgp_orig)
 		nh_othervrf = 1;
+
+	bgp_nh_dedup_init(&nh_hash);
 
 	/* EVPN MAC-IP routes are installed with a L3 NHG id */
 	if (nhg_id && bgp_evpn_path_es_use_nhg(bgp, info, nhg_id)) {
@@ -1519,8 +1638,26 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6);
 		}
 
+		if (!is_evpn) {
+			struct bgp_nh_dedup_entry lookup = { .nh = api_nh };
+
+			if (bgp_nh_dedup_find(&nh_hash, &lookup)) {
+				if (bgp_debug_zebra(&api->prefix))
+					zlog_debug("%s: p=%pFX, skipping duplicate nexthop",
+						   __func__, p);
+				continue;
+			}
+
+			dedup_items[dedup_idx].nh = api_nh;
+			bgp_nh_dedup_add(&nh_hash, &dedup_items[dedup_idx]);
+			dedup_idx++;
+		}
 		(*valid_nh_count)++;
 	}
+
+	while (bgp_nh_dedup_pop(&nh_hash))
+		;
+	bgp_nh_dedup_fini(&nh_hash);
 }
 
 static void bgp_debug_zebra_nh(struct zapi_route *api)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1718,12 +1718,13 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 		}
 
 		if (!is_evpn) {
+			char buf[1024];
 			struct bgp_nh_dedup_entry lookup = { .nh = api_nh };
 
 			if (bgp_nh_dedup_find(&nh_hash, &lookup)) {
 				if (bgp_debug_zebra(&api->prefix))
-					zlog_debug("%s: p=%pFX, skipping duplicate nexthop",
-						   __func__, p);
+					zlog_debug("%s: p=%pFX, skipping duplicate nexthop: %s",
+						   __func__, p, bgp_debug_zebra_nh_individual(api_nh, buf, sizeof(buf), *valid_nh_count));
 				continue;
 			}
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1391,6 +1391,85 @@ static int bgp_nh_dedup_hash_cmp(const struct bgp_nh_dedup_entry *a,
 	return 0;
 }
 
+static char *bgp_debug_zebra_nh_individual(struct zapi_nexthop *api_nh, char *buf, int length,
+					   int current_spot)
+{
+	int nh_family;
+	char nh_buf[INET6_ADDRSTRLEN];
+	char eth_buf[ETHER_ADDR_STRLEN + 7] = { '\0' };
+	char buf1[ETHER_ADDR_STRLEN];
+	/* strlen("label ") + 8 chars per label + '/' or '\0' for each label */
+	char label_buf[6 + 9 * BGP_MAX_LABELS];
+	char sid_buf[20];
+	char segs_buf[256];
+
+	switch (api_nh->type) {
+	case NEXTHOP_TYPE_IFINDEX:
+		nh_buf[0] = '\0';
+		break;
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		nh_family = AF_INET;
+		inet_ntop(nh_family, &api_nh->gate, nh_buf, sizeof(nh_buf));
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		nh_family = AF_INET6;
+		inet_ntop(nh_family, &api_nh->gate, nh_buf, sizeof(nh_buf));
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		strlcpy(nh_buf, "blackhole", sizeof(nh_buf));
+		break;
+	default:
+		/* Note: add new nexthop case */
+		assert(0);
+		break;
+	}
+
+	label_buf[0] = '\0';
+	eth_buf[0] = '\0';
+	segs_buf[0] = '\0';
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL) &&
+	    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
+		int label_len;
+		int j;
+
+		label_len = snprintf(label_buf, sizeof(label_buf), "label %u", api_nh->labels[0]);
+
+		for (j = 1; j < api_nh->label_num; j++) {
+			label_len += snprintf(label_buf + label_len, sizeof(label_buf) - label_len,
+					      "/%u", api_nh->labels[j]);
+		}
+	}
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6) &&
+	    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
+		inet_ntop(AF_INET6, &api_nh->seg6_segs[0], sid_buf, sizeof(sid_buf));
+		snprintf(segs_buf, sizeof(segs_buf), "segs %s", sid_buf);
+	}
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN) && !is_zero_mac(&api_nh->rmac))
+		snprintf(eth_buf, sizeof(eth_buf), " RMAC %s",
+			 prefix_mac2str(&api_nh->rmac, buf1, sizeof(buf1)));
+
+	snprintf(buf, length, "  nhop [%d]: %s if %u VRF %u wt %" PRIu64 " %s %s %s",
+		 current_spot + 1, nh_buf, api_nh->ifindex, api_nh->vrf_id, api_nh->weight,
+		 label_buf, segs_buf, eth_buf);
+
+	return buf;
+}
+
+static void bgp_debug_zebra_nh(struct zapi_route *api)
+{
+	char buf[1024];
+
+	int i, count;
+
+	count = api->nexthop_num;
+
+	for (i = 0; i < count; i++)
+		zlog_debug("%s",
+			   bgp_debug_zebra_nh_individual(&api->nexthops[i], buf, sizeof(buf), i));
+}
+
 DECLARE_HASH(bgp_nh_dedup, struct bgp_nh_dedup_entry, itm,
 	     bgp_nh_dedup_hash_cmp, bgp_nh_dedup_hash_key);
 
@@ -1658,83 +1737,6 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 	while (bgp_nh_dedup_pop(&nh_hash))
 		;
 	bgp_nh_dedup_fini(&nh_hash);
-}
-
-static void bgp_debug_zebra_nh(struct zapi_route *api)
-{
-	int i;
-	int nh_family;
-	char nh_buf[INET6_ADDRSTRLEN];
-	char eth_buf[ETHER_ADDR_STRLEN + 7] = { '\0' };
-	char buf1[ETHER_ADDR_STRLEN];
-	/* strlen("label ") + 8 chars per label + '/' or '\0' for each label */
-	char label_buf[6 + 9 * BGP_MAX_LABELS];
-	char sid_buf[20];
-	char segs_buf[256];
-	struct zapi_nexthop *api_nh;
-	int count;
-
-	count = api->nexthop_num;
-	for (i = 0; i < count; i++) {
-		api_nh = &api->nexthops[i];
-		switch (api_nh->type) {
-		case NEXTHOP_TYPE_IFINDEX:
-			nh_buf[0] = '\0';
-			break;
-		case NEXTHOP_TYPE_IPV4:
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
-			nh_family = AF_INET;
-			inet_ntop(nh_family, &api_nh->gate, nh_buf,
-				  sizeof(nh_buf));
-			break;
-		case NEXTHOP_TYPE_IPV6:
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			nh_family = AF_INET6;
-			inet_ntop(nh_family, &api_nh->gate, nh_buf,
-				  sizeof(nh_buf));
-			break;
-		case NEXTHOP_TYPE_BLACKHOLE:
-			strlcpy(nh_buf, "blackhole", sizeof(nh_buf));
-			break;
-		default:
-			/* Note: add new nexthop case */
-			assert(0);
-			break;
-		}
-
-		label_buf[0] = '\0';
-		eth_buf[0] = '\0';
-		segs_buf[0] = '\0';
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL) &&
-		    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
-			int label_len;
-			int j;
-
-			label_len = snprintf(label_buf, sizeof(label_buf), "label %u",
-					     api_nh->labels[0]);
-
-			for (j = 1; j < api_nh->label_num; j++) {
-				label_len += snprintf(label_buf + label_len,
-						      sizeof(label_buf) - label_len, "/%u",
-						      api_nh->labels[j]);
-			}
-		}
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6) &&
-		    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
-			inet_ntop(AF_INET6, &api_nh->seg6_segs[0], sid_buf,
-				  sizeof(sid_buf));
-			snprintf(segs_buf, sizeof(segs_buf), "segs %s", sid_buf);
-		}
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN) &&
-		    !is_zero_mac(&api_nh->rmac))
-			snprintf(eth_buf, sizeof(eth_buf), " RMAC %s",
-				 prefix_mac2str(&api_nh->rmac, buf1,
-						sizeof(buf1)));
-		zlog_debug("  nhop [%d]: %s if %u VRF %u wt %" PRIu64
-			   " %s %s %s",
-			   i + 1, nh_buf, api_nh->ifindex, api_nh->vrf_id,
-			   api_nh->weight, label_buf, segs_buf, eth_buf);
-	}
 }
 
 enum zclient_send_status bgp_zebra_announce_actual(struct bgp_dest *dest,

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1401,6 +1401,84 @@ static int bgp_nh_dedup_hash_cmp(const struct bgp_nh_dedup_entry *a,
 	return 0;
 }
 
+static char *bgp_debug_zebra_nh_individual(struct zapi_nexthop *api_nh, char *buf, int length,
+					   int current_spot)
+{
+	int nh_family;
+	char nh_buf[INET6_ADDRSTRLEN];
+	char eth_buf[ETHER_ADDR_STRLEN + 7] = { '\0' };
+	char buf1[ETHER_ADDR_STRLEN];
+	/* strlen("label ") + 8 chars per label + '/' or '\0' for each label */
+	char label_buf[6 + BGP_MAX_LABEL_DIGITS];
+	char sid_buf[20];
+	char segs_buf[256];
+
+	switch (api_nh->type) {
+	case NEXTHOP_TYPE_IFINDEX:
+		nh_buf[0] = '\0';
+		break;
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		nh_family = AF_INET;
+		inet_ntop(nh_family, &api_nh->gate, nh_buf, sizeof(nh_buf));
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		nh_family = AF_INET6;
+		inet_ntop(nh_family, &api_nh->gate, nh_buf, sizeof(nh_buf));
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		strlcpy(nh_buf, "blackhole", sizeof(nh_buf));
+		break;
+	default:
+		/* Note: add new nexthop case */
+		assert(0);
+		break;
+	}
+
+	label_buf[0] = '\0';
+	eth_buf[0] = '\0';
+	segs_buf[0] = '\0';
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL) &&
+	    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
+		int label_len;
+		int j;
+
+		label_len = snprintfrr(label_buf, sizeof(label_buf), "label %u", api_nh->labels[0]);
+
+		for (j = 1; j < api_nh->label_num; j++) {
+			label_len += snprintfrr(label_buf + label_len, sizeof(label_buf) - label_len,
+					      "/%u", api_nh->labels[j]);
+		}
+	}
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6) &&
+	    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
+		inet_ntop(AF_INET6, &api_nh->seg6_segs[0], sid_buf, sizeof(sid_buf));
+		snprintfrr(segs_buf, sizeof(segs_buf), "segs %s", sid_buf);
+	}
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN) && !is_zero_mac(&api_nh->rmac))
+		snprintfrr(eth_buf, sizeof(eth_buf), " RMAC %s",
+			 prefix_mac2str(&api_nh->rmac, buf1, sizeof(buf1)));
+	snprintfrr(buf, length, "  nhop [%d]: %s if %u VRF %u wt %" PRIu64 " %s %s %s",
+		   current_spot + 1, nh_buf, api_nh->ifindex, api_nh->vrf_id, api_nh->weight,
+		   label_buf, segs_buf, eth_buf);
+
+	return buf;
+}
+
+static void bgp_debug_zebra_nh(struct zapi_route *api)
+{
+	char buf[1024];
+
+	int i, count;
+
+	count = api->nexthop_num;
+
+	for (i = 0; i < count; i++)
+		zlog_debug("%s",
+			   bgp_debug_zebra_nh_individual(&api->nexthops[i], buf, sizeof(buf), i));
+}
+
 DECLARE_HASH(bgp_nh_dedup, struct bgp_nh_dedup_entry, itm,
 	     bgp_nh_dedup_hash_cmp, bgp_nh_dedup_hash_key);
 
@@ -1658,83 +1736,6 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 	while (bgp_nh_dedup_pop(&nh_hash))
 		;
 	bgp_nh_dedup_fini(&nh_hash);
-}
-
-static void bgp_debug_zebra_nh(struct zapi_route *api)
-{
-	int i;
-	int nh_family;
-	char nh_buf[INET6_ADDRSTRLEN];
-	char eth_buf[ETHER_ADDR_STRLEN + 7] = { '\0' };
-	char buf1[ETHER_ADDR_STRLEN];
-	/* strlen("label ") + 8 chars per label + '/' or '\0' for each label */
-	char label_buf[6 + BGP_MAX_LABEL_DIGITS];
-	char sid_buf[20];
-	char segs_buf[256];
-	struct zapi_nexthop *api_nh;
-	int count;
-
-	count = api->nexthop_num;
-	for (i = 0; i < count; i++) {
-		api_nh = &api->nexthops[i];
-		switch (api_nh->type) {
-		case NEXTHOP_TYPE_IFINDEX:
-			nh_buf[0] = '\0';
-			break;
-		case NEXTHOP_TYPE_IPV4:
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
-			nh_family = AF_INET;
-			inet_ntop(nh_family, &api_nh->gate, nh_buf,
-				  sizeof(nh_buf));
-			break;
-		case NEXTHOP_TYPE_IPV6:
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			nh_family = AF_INET6;
-			inet_ntop(nh_family, &api_nh->gate, nh_buf,
-				  sizeof(nh_buf));
-			break;
-		case NEXTHOP_TYPE_BLACKHOLE:
-			strlcpy(nh_buf, "blackhole", sizeof(nh_buf));
-			break;
-		default:
-			/* Note: add new nexthop case */
-			assert(0);
-			break;
-		}
-
-		label_buf[0] = '\0';
-		eth_buf[0] = '\0';
-		segs_buf[0] = '\0';
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL) &&
-		    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
-			int label_len;
-			int j;
-
-			label_len = snprintf(label_buf, sizeof(label_buf), "label %u",
-					     api_nh->labels[0]);
-
-			for (j = 1; j < api_nh->label_num; j++) {
-				label_len += snprintf(label_buf + label_len,
-						      sizeof(label_buf) - label_len, "/%u",
-						      api_nh->labels[j]);
-			}
-		}
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6) &&
-		    !CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN)) {
-			inet_ntop(AF_INET6, &api_nh->seg6_segs[0], sid_buf,
-				  sizeof(sid_buf));
-			snprintf(segs_buf, sizeof(segs_buf), "segs %s", sid_buf);
-		}
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_EVPN) &&
-		    !is_zero_mac(&api_nh->rmac))
-			snprintf(eth_buf, sizeof(eth_buf), " RMAC %s",
-				 prefix_mac2str(&api_nh->rmac, buf1,
-						sizeof(buf1)));
-		zlog_debug("  nhop [%d]: %s if %u VRF %u wt %" PRIu64
-			   " %s %s %s",
-			   i + 1, nh_buf, api_nh->ifindex, api_nh->vrf_id,
-			   api_nh->weight, label_buf, segs_buf, eth_buf);
-	}
 }
 
 enum zclient_send_status bgp_zebra_announce_actual(struct bgp_dest *dest,

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1717,12 +1717,13 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 		}
 
 		if (!is_evpn) {
+			char buf[1024];
 			struct bgp_nh_dedup_entry lookup = { .nh = api_nh };
 
 			if (bgp_nh_dedup_find(&nh_hash, &lookup)) {
 				if (bgp_debug_zebra(&api->prefix))
-					zlog_debug("%s: p=%pFX, skipping duplicate nexthop",
-						   __func__, p);
+					zlog_debug("%s: p=%pFX, skipping duplicate nexthop: %s",
+						   __func__, p, bgp_debug_zebra_nh_individual(api_nh, buf, sizeof(buf), *valid_nh_count));
 				continue;
 			}
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -21,6 +21,7 @@
 #include "lib/bfd.h"
 #include "lib/route_opaque.h"
 #include "filter.h"
+#include "jhash.h"
 #include "mpls.h"
 #include "vxlan.h"
 #include "pbr.h"
@@ -1290,6 +1291,119 @@ static bool bgp_zebra_use_nhop_weighted(struct bgp *bgp, struct bgp_path_info *b
 	return true;
 }
 
+PREDECL_HASH(bgp_nh_dedup);
+
+struct bgp_nh_dedup_entry {
+	struct bgp_nh_dedup_item itm;
+	struct zapi_nexthop *nh;
+};
+
+static uint32_t bgp_nh_dedup_hash_key(const struct bgp_nh_dedup_entry *item)
+{
+	const struct zapi_nexthop *nh = item->nh;
+	uint32_t key;
+
+	key = jhash_2words(nh->type, nh->vrf_id, 0x55aa5a5a);
+
+	switch (nh->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		key = jhash_1word(nh->gate.ipv4.s_addr, key);
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		key = jhash2((const uint32_t *)&nh->gate.ipv6,
+			     sizeof(nh->gate.ipv6) / sizeof(uint32_t), key);
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+	case NEXTHOP_TYPE_BLACKHOLE:
+		break;
+	}
+
+	key = jhash_1word(nh->ifindex, key);
+
+	if (nh->label_num)
+		key = jhash(nh->labels, nh->label_num * sizeof(mpls_label_t),
+			    key);
+
+	if (nh->seg_num)
+		key = jhash(nh->seg6_segs,
+			    nh->seg_num * sizeof(struct in6_addr), key);
+
+	key = jhash_1word(nh->srte_color, key);
+
+	return key;
+}
+
+/*
+ * Compare forwarding-relevant fields of two zapi nexthops.
+ * Weight is intentionally excluded -- it is a scheduling
+ * parameter, not forwarding identity.
+ */
+static int bgp_nh_dedup_hash_cmp(const struct bgp_nh_dedup_entry *a,
+				 const struct bgp_nh_dedup_entry *b)
+{
+	const struct zapi_nexthop *n1 = a->nh;
+	const struct zapi_nexthop *n2 = b->nh;
+	int ret;
+
+	if (n1->type != n2->type)
+		return numcmp(n1->type, n2->type);
+	if (n1->vrf_id != n2->vrf_id)
+		return numcmp(n1->vrf_id, n2->vrf_id);
+
+	switch (n1->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV6:
+		ret = nexthop_g_addr_cmp(n1->type, &n1->gate, &n2->gate);
+		if (ret)
+			return ret;
+		break;
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		ret = nexthop_g_addr_cmp(n1->type, &n1->gate, &n2->gate);
+		if (ret)
+			return ret;
+		if (n1->ifindex != n2->ifindex)
+			return numcmp(n1->ifindex, n2->ifindex);
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+		if (n1->ifindex != n2->ifindex)
+			return numcmp(n1->ifindex, n2->ifindex);
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		if (n1->bh_type != n2->bh_type)
+			return numcmp(n1->bh_type, n2->bh_type);
+		break;
+	}
+
+	if (n1->label_num != n2->label_num)
+		return numcmp(n1->label_num, n2->label_num);
+	if (n1->label_num > 0) {
+		ret = memcmp(n1->labels, n2->labels,
+			     n1->label_num * sizeof(mpls_label_t));
+		if (ret)
+			return ret;
+	}
+
+	if (n1->seg_num != n2->seg_num)
+		return numcmp(n1->seg_num, n2->seg_num);
+	if (n1->seg_num > 0) {
+		ret = memcmp(n1->seg6_segs, n2->seg6_segs,
+			     n1->seg_num * sizeof(struct in6_addr));
+		if (ret)
+			return ret;
+	}
+
+	if (n1->srte_color != n2->srte_color)
+		return numcmp(n1->srte_color, n2->srte_color);
+
+	return 0;
+}
+
+DECLARE_HASH(bgp_nh_dedup, struct bgp_nh_dedup_entry, itm,
+	     bgp_nh_dedup_hash_cmp, bgp_nh_dedup_hash_key);
+
 static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const struct prefix *p,
 					     struct bgp *bgp, struct zapi_route *api,
 					     unsigned int *valid_nh_count, afi_t afi, safi_t safi,
@@ -1314,12 +1428,17 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 	uint32_t exp = 0;
 
 	struct bgp_route_evpn *bre = NULL;
+	struct bgp_nh_dedup_head nh_hash;
+	struct bgp_nh_dedup_entry dedup_items[MULTIPATH_NUM];
+	unsigned int dedup_idx = 0;
 
 	/*
 	 * vrf leaking support (will have only one nexthop)
 	 */
 	if (info->extra && info->extra->vrfleak && info->extra->vrfleak->bgp_orig)
 		nh_othervrf = 1;
+
+	bgp_nh_dedup_init(&nh_hash);
 
 	/* EVPN MAC-IP routes are installed with a L3 NHG id */
 	if (nhg_id && bgp_evpn_path_es_use_nhg(bgp, info, nhg_id)) {
@@ -1519,8 +1638,26 @@ static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const s
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6);
 		}
 
+		if (!is_evpn) {
+			struct bgp_nh_dedup_entry lookup = { .nh = api_nh };
+
+			if (bgp_nh_dedup_find(&nh_hash, &lookup)) {
+				if (bgp_debug_zebra(&api->prefix))
+					zlog_debug("%s: p=%pFX, skipping duplicate nexthop",
+						   __func__, p);
+				continue;
+			}
+
+			dedup_items[dedup_idx].nh = api_nh;
+			bgp_nh_dedup_add(&nh_hash, &dedup_items[dedup_idx]);
+			dedup_idx++;
+		}
 		(*valid_nh_count)++;
 	}
+
+	while (bgp_nh_dedup_pop(&nh_hash))
+		;
+	bgp_nh_dedup_fini(&nh_hash);
 }
 
 static void bgp_debug_zebra_nh(struct zapi_route *api)

--- a/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
+++ b/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
@@ -313,6 +313,88 @@ def check_ipv4_prefix_recursive_with_multiple_nexthops(
     ), f"Failed to check that {prefix} is correctly recursive via {recursive_nexthop}"
 
 
+def check_no_duplicate_nexthops(prefix):
+    """Verify that no nexthop for the prefix is marked as duplicate by zebra."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _check():
+        output = json.loads(tgen.gears["r1"].vtysh_cmd(f"show ip route {prefix} json"))
+        if prefix not in output:
+            return f"{prefix} not found in route table"
+        for nh in output[prefix][0]["nexthops"]:
+            if nh.get("duplicate"):
+                return f"Nexthop {nh} is marked duplicate for {prefix}"
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=60, wait=0.5)
+    assert result is None, result
+
+
+def check_same_ip_different_labels_preserved(prefix):
+    """Verify that nexthops sharing an IP but with different labels are NOT deduplicated."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _check():
+        output = json.loads(tgen.gears["r1"].vtysh_cmd(f"show ip route {prefix} json"))
+        if prefix not in output:
+            return f"{prefix} not found in route table"
+        nhs = output[prefix][0]["nexthops"]
+        resolved_nhs = [
+            (nh["ip"], tuple(nh.get("labels", [])))
+            for nh in nhs
+            if not nh.get("recursive")
+        ]
+        for ip in ("172.31.0.3", "172.31.2.4"):
+            labels_for_ip = sorted(
+                [labels for nhip, labels in resolved_nhs if nhip == ip]
+            )
+            if len(labels_for_ip) != 2:
+                return (
+                    f"Expected 2 nexthops for {ip} (different labels), "
+                    f"got {len(labels_for_ip)}: {labels_for_ip}"
+                )
+            if (16006,) not in labels_for_ip or (16055,) not in labels_for_ip:
+                return (
+                    f"Expected labels [16006] and [16055] for {ip}, "
+                    f"got {labels_for_ip}"
+                )
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=60, wait=0.5)
+    assert result is None, result
+
+
+def check_nhg_size(prefix, expected_fib_count):
+    """Verify the NHG entry count matches the expected FIB nexthop count."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _check():
+        output = json.loads(tgen.gears["r1"].vtysh_cmd(f"show ip route {prefix} json"))
+        if prefix not in output:
+            return f"{prefix} not found in route table"
+
+        route = output[prefix][0]
+        nh_num = route.get("internalNextHopNum")
+        fib_num = route.get("internalNextHopFibInstalledNum")
+        active_num = route.get("internalNextHopActiveNum")
+
+        if fib_num != expected_fib_count:
+            return (
+                f"Expected internalNextHopFibInstalledNum={expected_fib_count}, "
+                f"got {fib_num} (total={nh_num}, active={active_num})"
+            )
+        return None
+
+    _, result = topotest.run_and_expect(_check, None, count=60, wait=0.5)
+    assert result is None, result
+
+
 def check_ipv4_prefix_with_multiple_nexthops_linux(prefix):
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -389,10 +471,15 @@ def test_bgp_ipv4_convergence():
 
     check_ipv4_prefix_with_multiple_nexthops_linux("192.0.2.9")
 
+    step("Verify no nexthop is marked as duplicate for 192.0.2.9/32")
+    check_no_duplicate_nexthops("192.0.2.9/32")
+
 
 def test_bgp_ipv4_recursive_routes():
     """
-    Check that R1 has received the recursive routes, and duplicate nexthops are in zebra, but are not installed
+    Check that R1 has received the recursive routes, that deduplication
+    removed the duplicate nexthops, and that same-IP-different-label
+    nexthops are preserved.
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -402,17 +489,14 @@ def test_bgp_ipv4_recursive_routes():
 
     check_ipv4_prefix_with_multiple_nexthops_linux("192.0.2.8")
 
-    # Calculate expected installed count: Count nexthops that are actually installed
-    output = json.loads(tgen.gears["r1"].vtysh_cmd("show ip route 192.0.2.8/32 json"))
-    expected_installed = 0
-    for nh in output["192.0.2.8/32"][0]["nexthops"]:
-        if nh.get("fib") == True:
-            expected_installed += 1
+    step("Verify no nexthop is marked as duplicate after dedup")
+    check_no_duplicate_nexthops("192.0.2.8/32")
 
-    installed_num = output["192.0.2.8/32"][0]["internalNextHopFibInstalledNum"]
-    assert (
-        installed_num == expected_installed
-    ), f"Expected internalNextHopFibInstalledNum={expected_installed}, got {installed_num}"
+    step("Verify same-IP-different-label nexthops are preserved (not deduplicated)")
+    check_same_ip_different_labels_preserved("192.0.2.8/32")
+
+    step("Verify NHG has exactly 4 FIB-installed nexthops (not 8)")
+    check_nhg_size("192.0.2.8/32", expected_fib_count=4)
 
 
 def test_bgp_ipv4_recursive_routes_when_no_mpath():
@@ -439,6 +523,43 @@ def test_bgp_ipv4_recursive_routes_when_no_mpath():
     check_ipv4_prefix_recursive_with_multiple_nexthops(
         "192.0.2.8/32", "192.0.2.9", multipath=False
     )
+
+
+def test_bgp_ipv4_recursive_routes_when_mpath_reenabled():
+    """
+    Re-enable multipath ibgp after the previous test disabled it.
+    Verify deduplication still works correctly across reconfiguration.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd(
+        """
+        configure terminal
+        router bgp
+        address family ipv4 unicast
+        maximum-paths ibgp 128
+        """,
+        isjson=False,
+    )
+    tgen.gears["r1"].vtysh_cmd("clear bgp ipv4 *")
+
+    step("Verify multipath routes re-converge with dedup after re-enable")
+    check_ipv4_prefix_with_multiple_nexthops("192.0.2.9/32")
+
+    check_ipv4_prefix_recursive_with_multiple_nexthops("192.0.2.8/32", "192.0.2.9")
+
+    step("Verify no duplicate nexthops after multipath re-enable")
+    check_no_duplicate_nexthops("192.0.2.8/32")
+
+    step("Verify same-IP-different-label nexthops preserved after re-enable")
+    check_same_ip_different_labels_preserved("192.0.2.8/32")
+
+    step("Verify NHG size correct after multipath re-enable")
+    check_nhg_size("192.0.2.8/32", expected_fib_count=4)
+
+    check_ipv4_prefix_with_multiple_nexthops_linux("192.0.2.8")
 
 
 def test_memory_leak():

--- a/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
+++ b/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
@@ -304,21 +304,6 @@ def check_ipv4_prefix_recursive_with_multiple_nexthops(
         for nh in r6_nh:
             expected[prefix][0]["nexthops"].append(get_nh_formatted(nh))
 
-        for nh in recursive_nh:
-            expected[prefix][0]["nexthops"].append(
-                get_nh_formatted(nh, fib=False, duplicate=True)
-            )
-
-        for nh in r5_nh:
-            expected[prefix][0]["nexthops"].append(
-                get_nh_formatted(nh, fib=False, duplicate=True)
-            )
-
-        for nh in r6_nh:
-            expected[prefix][0]["nexthops"].append(
-                get_nh_formatted(nh, fib=False, duplicate=True)
-            )
-
     test_func = functools.partial(
         ip_check_path_selection, tgen.gears["r1"], prefix, expected, check_fib=True
     )

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_enhe.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_enhe.py
@@ -91,13 +91,6 @@ def test_bgp_dynamic_capability_enhe():
                             "interfaceName": "r1-eth0",
                             "active": True,
                         },
-                        {
-                            "duplicate": True,
-                            "ip": "192.168.1.2",
-                            "afi": "ipv4",
-                            "interfaceName": "r1-eth0",
-                            "active": True,
-                        },
                     ],
                 }
             ]


### PR DESCRIPTION
See individual commits for more data.  But allow bgp to do a base level deduplication at the time of sending routes to zebra.