### PR TITLE
staticd: nexthop identity as path-list key, and per-route metric

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -27,21 +27,21 @@ Static Route Commands
 Static routing is a very fundamental feature of routing technology. It defines
 a static prefix and gateway, with several possible forms.
 
-.. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [tag TAG] [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [tag TAG] [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
    NETWORK is destination prefix with a valid v4 or v6 network based upon
    initial form of the command.
@@ -61,6 +61,16 @@ a static prefix and gateway, with several possible forms.
    Alternatively, the gateway can be specified as ``Null0`` or ``blackhole`` to create a blackhole
    route that drops all traffic. It can also be specified as ``reject`` to create an unreachable
    route that rejects traffic with ICMP "Destination Unreachable" messages.
+
+   TAG is an optional 32-bit unsigned integer (1–4294967295) that marks the
+   route entry in the RIB. See :ref:`static-route-tag` for details and
+   limitations.
+
+   DISTANCE is an optional administrative distance (1–255; default 1). See
+   :ref:`static-route-distance-metric` for details.
+
+   METRIC is an optional route metric (0–4294967295; default 0). See
+   :ref:`static-route-distance-metric` for details.
 
    WEIGHT is an optional parameter that specifies the weight attributed to a
    nexthop when multiple nexthops are configured for the same static route. The
@@ -164,6 +174,135 @@ but this time, the route command will apply to the VRF.
    vrf r1-cust1
     ip route 10.0.0.0/24 10.0.0.2
    exit-vrf
+
+
+.. _static-route-distance-metric:
+
+Administrative Distance and Metric
+===================================
+
+Static routes are grouped internally by ``(table-id, distance, metric)``.
+Nexthops that share the same tuple belong to the same *path group* and are
+installed in the RIB together as an ECMP set.  Nexthops in different path
+groups for the same prefix are independent: all path groups are present in
+the RIB, but only the group with the lowest distance (and, for the same
+distance, the lowest metric) is selected at any time.
+
+**ECMP** — Multiple nexthops with the same ``(distance, metric)`` form an
+equal-cost multipath group and are active in the RIB together:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2
+   ip route 10.0.0.0/8 10.0.0.3
+
+Both nexthops share ``(distance=1, metric=0)`` and are active in the RIB as ECMP.
+
+**Floating static routes** — Nexthops with different ``(distance, metric)`` tuples
+form separate path groups.  All groups are present in the RIB; the group with
+the best preference (lowest distance, then lowest metric) is selected.  A
+lower-preference group is promoted when the higher-preference group becomes
+unreachable.
+
+Floating by distance:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2
+   ip route 10.0.0.0/8 10.0.0.3 200
+
+``10.0.0.2`` is the primary (distance 1); ``10.0.0.3`` is the fallback
+(distance 200), promoted only when ``10.0.0.2`` is gone.
+
+Floating by metric (same distance, different metric):
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 metric 100
+   ip route 10.0.0.0/8 10.0.0.3 metric 200
+
+``10.0.0.2`` is the primary (metric 100); ``10.0.0.3`` is the fallback
+(metric 200), promoted only when ``10.0.0.2`` is gone.
+
+**Nexthop uniqueness and automatic move** — A given nexthop (identified by
+its forwarding information: type, gateway address, and interface) may appear
+in at most one path group under a prefix at a time.  If a nexthop is
+reconfigured with a new distance or metric, FRR automatically removes it from
+the old path group and installs it in the new one:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 10
+   ! Reconfigure with a new distance — old entry is removed automatically:
+   ip route 10.0.0.0/8 10.0.0.2 20
+
+After the second command there is exactly one path group for ``10.0.0.2`` at
+distance 20; no stale distance-10 entry remains.  The same applies when
+metric is changed.
+
+**Removing routes** — FRR identifies the nexthop to remove by its nexthop
+identity (gateway address, interface, or blackhole type) and ignores the
+distance and metric arguments.  Because a given nexthop can appear in at most
+one path group for a prefix, the search is always unambiguous:
+
+.. code-block:: frr
+
+   no ip route 10.0.0.0/8 10.0.0.2
+   no ip route 10.0.0.0/8 10.0.0.2 10
+   no ip route 10.0.0.0/8 10.0.0.2 10 metric 50
+
+All three commands above remove the same nexthop ``10.0.0.2``, regardless of
+which distance or metric it was configured with.
+
+
+.. _static-route-tag:
+
+Route Tag
+=========
+
+TAG is a 32-bit unsigned integer (1–4294967295) that marks a route entry in
+the RIB.  It can be matched by routing policy (route-maps, prefix-lists) to
+filter or modify routes based on their tag value.
+
+The tag is a per-path-group attribute: it is shared by all nexthops in a path
+group and carried into the RIB.  Unlike distance and metric, tag is **not**
+part of the path group identity — two nexthops with the same ``(distance,
+metric)`` always belong to the same path group regardless of their configured
+tags.
+
+**Per-path-group tag** — Assigning a distinct tag to each path group lets
+routing policy distinguish primary from backup routes:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 tag 100 10
+   ip route 10.0.0.0/8 10.0.0.3 tag 200 20
+
+``10.0.0.2`` (distance 10) carries tag 100 and ``10.0.0.3`` (distance 20)
+carries tag 200.  Both tags are visible in the RIB simultaneously.
+
+.. note::
+
+   **Same (distance, metric), different tag:** because tag is not part of the
+   path group key, two nexthops with the same ``(distance, metric)`` belong to
+   the same path group and share a single tag in the RIB. When nexthops in the
+   same path group are configured with different tags, the tag with the maximum
+   value takes effect in the RIB. ``show running-config`` stores the
+   operator-configured value for each nexthop individually (YANG per-nexthop
+   state), while the RIB carries the maximum value tag for the whole group. When
+   a nexthop is removed, the path tag is automatically recomputed as the maximum
+   of the remaining configured tags:
+
+   .. code-block:: frr
+
+      ip route 10.0.0.0/8 10.0.0.2 tag 100 10
+      ip route 10.0.0.0/8 10.0.0.3 tag 200 10
+
+   Both nexthops are grouped at distance 10.  The RIB tag is 200 (the
+   maximum).  ``show running-config`` shows 100 for ``10.0.0.2`` and 200
+   for ``10.0.0.3``.  Removing ``10.0.0.3`` lowers the RIB tag to 100
+   (``10.0.0.2``'s configured tag).  To assign independent tags visible
+   separately in the RIB, use different distances or metrics.
 
 
 SR-TE Route Commands

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -25,8 +25,10 @@ const struct frr_yang_module_info frr_staticd_info = {
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list",
 			.cbs = {
+				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_apply_finish,
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_destroy,
+				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_pre_validate,
 			}
 		},
 		{
@@ -36,113 +38,110 @@ const struct frr_yang_module_info frr_staticd_info = {
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/distance",
 			.cbs = {
-				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish,
-				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy,
-				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_distance_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/bh-type",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bh-type",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_bh_type_modify,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_bh_type_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/weight",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/weight",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_weight_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_weight_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_weight_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_weight_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/onlink",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/onlink",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_onlink_modify,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_onlink_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srte-color",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srte-color",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_color_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_color_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srv6-segs-stack/entry",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srv6-segs-stack/entry",
 			.cbs = {
-				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_create,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_destroy,
+				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_create,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_destroy,
 
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srv6-segs-stack/entry/seg",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srv6-segs-stack/entry/seg",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_seg_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_seg_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_seg_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_seg_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srv6-segs-stack/encap-behavior",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srv6-segs-stack/encap-behavior",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_encap_behavior_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_encap_behavior_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_encap_behavior_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_encap_behavior_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry",
 			.cbs = {
-				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_create,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_destroy,
+				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_create,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_destroy,
 
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry/label",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry/label",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_label_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_label_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_label_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_label_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry/ttl",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_ttl_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_ttl_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry/traffic-class",
 			.cbs = {
-				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_modify,
-				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_destroy,
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_traffic_class_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_traffic_class_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/bfd-monitoring",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bfd-monitoring",
 			.cbs = {
 				.create = route_next_hop_bfd_create,
 				.destroy = route_next_hop_bfd_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/bfd-monitoring/source",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bfd-monitoring/source",
 			.cbs = {
 				.modify = route_next_hop_bfd_source_modify,
 				.destroy = route_next_hop_bfd_source_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/bfd-monitoring/multi-hop",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bfd-monitoring/multi-hop",
 			.cbs = {
 				.modify = route_next_hop_bfd_multi_hop_modify,
 			}
 		},
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/bfd-monitoring/profile",
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bfd-monitoring/profile",
 			.cbs = {
 				.modify = route_next_hop_bfd_profile_modify,
 				.destroy = route_next_hop_bfd_profile_destroy,

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -44,6 +44,12 @@ const struct frr_yang_module_info frr_staticd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/metric",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_metric_modify,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bh-type",
 			.cbs = {
 				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_bh_type_modify,

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -29,6 +29,8 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_tag_modify(
 	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_metric_modify(
+	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_distance_modify(
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_bh_type_modify(
@@ -146,6 +148,7 @@ int routing_control_plane_protocols_name_validate(
 	"path-list[table-id='%u'][nh-type='%s'][vrf='%s'][gateway='%s'][interface='%s']"
 
 #define FRR_STATIC_ROUTE_PATH_DISTANCE_XPATH "/distance"
+#define FRR_STATIC_ROUTE_PATH_METRIC_XPATH   "/metric"
 #define FRR_STATIC_ROUTE_PATH_TAG_XPATH "/tag"
 
 #define FRR_STATIC_ROUTE_NH_WEIGHT_XPATH "/weight"

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -29,49 +29,47 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_tag_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_distance_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_bh_type_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_weight_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_weight_destroy(
+	struct nb_cb_destroy_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_onlink_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_color_modify(
+	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_color_destroy(
+	struct nb_cb_destroy_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_create(
 	struct nb_cb_create_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_destroy(
 	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_bh_type_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_seg_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_weight_modify(
-	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_weight_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_seg_destroy(
 	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_onlink_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_encap_behavior_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_modify(
-	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_encap_behavior_destroy(
 	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_create(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_create(
 	struct nb_cb_create_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_destroy(
 	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_seg_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_label_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_seg_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_label_destroy(
 	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_encap_behavior_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_ttl_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_encap_behavior_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_ttl_destroy(
 	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_create(
-	struct nb_cb_create_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_destroy(
-	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_label_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_traffic_class_modify(
 	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_label_destroy(
-	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_modify(
-	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_destroy(
-	struct nb_cb_destroy_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_modify(
-	struct nb_cb_modify_args *args);
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_traffic_class_destroy(
 	struct nb_cb_destroy_args *args);
 int route_next_hop_bfd_create(struct nb_cb_create_args *args);
 int route_next_hop_bfd_destroy(struct nb_cb_destroy_args *args);
@@ -123,13 +121,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_segment_routi
 
 /* Optional 'apply_finish' callbacks. */
 
-void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish(
+void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_apply_finish(
 	struct nb_cb_apply_finish_args *args);
 void routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_apply_finish(
 	struct nb_cb_apply_finish_args *args);
 
 /* Optional 'pre_validate' callbacks. */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_pre_validate(
 	struct nb_cb_pre_validate_args *args);
 
 /*
@@ -140,26 +138,15 @@ int routing_control_plane_protocols_name_validate(
 	struct nb_cb_create_args *args);
 
 /* xpath macros */
-/* route-list */
-#define FRR_STATIC_ROUTE_INFO_KEY_XPATH                                                            \
-	"/frr-routing:routing/control-plane-protocols/"                                            \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                  \
-	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"             \
-	"path-list[table-id='%u'][distance='%u']"
+/* Full path-list key: table-id + nexthop identity */
+#define FRR_STATIC_ROUTE_INFO_KEY_XPATH                                                           \
+	"/frr-routing:routing/control-plane-protocols/"                                           \
+	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                 \
+	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"            \
+	"path-list[table-id='%u'][nh-type='%s'][vrf='%s'][gateway='%s'][interface='%s']"
 
-#define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                                                \
-	"/frr-routing:routing/control-plane-protocols/"                                            \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                  \
-	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"             \
-	"path-list[table-id='%u']"
-
-
+#define FRR_STATIC_ROUTE_PATH_DISTANCE_XPATH "/distance"
 #define FRR_STATIC_ROUTE_PATH_TAG_XPATH "/tag"
-
-/* route-list/frr-nexthops */
-#define FRR_STATIC_ROUTE_NH_KEY_XPATH                                          \
-	"/frr-nexthops/"                                                       \
-	"nexthop[nh-type='%s'][vrf='%s'][gateway='%s'][interface='%s']"
 
 #define FRR_STATIC_ROUTE_NH_WEIGHT_XPATH "/weight"
 
@@ -179,15 +166,8 @@ int routing_control_plane_protocols_name_validate(
 
 #define FRR_STATIC_ROUTE_NH_SRV6_ENCAP_BEHAVIOR_XPATH "/encap-behavior"
 
-/* route-list/frr-nexthops */
-#define FRR_DEL_S_ROUTE_NH_KEY_XPATH                                           \
-	FRR_STATIC_ROUTE_INFO_KEY_XPATH                                        \
-	FRR_STATIC_ROUTE_NH_KEY_XPATH
-
-/* route-list/frr-nexthops */
-#define FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH                               \
-	FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                            \
-	FRR_STATIC_ROUTE_NH_KEY_XPATH
+/* Deletion: path-list entry = nexthop, full key is sufficient */
+#define FRR_DEL_S_ROUTE_NH_KEY_XPATH FRR_STATIC_ROUTE_INFO_KEY_XPATH
 
 /* srv6 */
 #define FRR_STATIC_SRV6_INFO_KEY_XPATH                                                             \

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -24,12 +24,13 @@
 #include "static_debug.h"
 
 /* Accumulator passed to path_list_ecmp_iter_cb() to count nexthops in the
- * same ECMP group (those sharing table-id and distance) and track whether
- * the group contains blackhole or non-blackhole nexthops.
+ * same ECMP group (those sharing table-id, distance, and metric) and track
+ * whether the group contains blackhole or non-blackhole nexthops.
  */
 struct path_list_ecmp_check {
 	uint32_t table_id;
 	uint8_t distance;
+	uint32_t metric;
 	uint32_t count;
 	bool has_blackhole;
 	bool has_non_blackhole;
@@ -41,7 +42,8 @@ static int path_list_ecmp_iter_cb(const struct lyd_node *dnode, void *arg)
 	enum static_nh_type nh_type;
 
 	if (yang_dnode_get_uint32(dnode, "table-id") != ec->table_id ||
-	    yang_dnode_get_uint8(dnode, "distance") != ec->distance)
+	    yang_dnode_get_uint8(dnode, "distance") != ec->distance ||
+	    yang_dnode_get_uint32(dnode, "metric") != ec->metric)
 		return YANG_ITER_CONTINUE;
 
 	ec->count++;
@@ -56,10 +58,10 @@ static int path_list_ecmp_iter_cb(const struct lyd_node *dnode, void *arg)
 
 /*
  * Validate ECMP constraints for the path-list entry at path_list_dnode.
- * Counts existing nexthops in the same ECMP group (same table-id and
- * distance) and rejects blackhole/non-blackhole mixing or exceeding the
- * ECMP limit.  Called from NB_EV_VALIDATE in both path-list create and
- * distance_modify.
+ * Counts existing nexthops in the same ECMP group (same table-id, distance,
+ * and metric) and rejects blackhole/non-blackhole mixing or exceeding the
+ * ECMP limit.  Called from NB_EV_VALIDATE in path-list create,
+ * distance_modify, and metric_modify.
  */
 static int ecmp_path_list_validate(const struct lyd_node *path_list_dnode, char *errmsg,
 				   size_t errmsg_len)
@@ -67,6 +69,7 @@ static int ecmp_path_list_validate(const struct lyd_node *path_list_dnode, char 
 	struct path_list_ecmp_check ec = {
 		.table_id = yang_dnode_get_uint32(path_list_dnode, "table-id"),
 		.distance = yang_dnode_get_uint8(path_list_dnode, "distance"),
+		.metric = yang_dnode_get_uint32(path_list_dnode, "metric"),
 	};
 	const struct lyd_node *route_dnode;
 	enum static_nh_type nh_type;
@@ -101,6 +104,7 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	const struct lyd_node *vrf_dnode;
 	const char *vrf;
 	uint8_t distance;
+	uint32_t metric;
 	uint32_t table_id;
 	struct ipaddr ipaddr;
 	enum static_nh_type nh_type;
@@ -145,8 +149,9 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	case NB_EV_APPLY:
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		distance = yang_dnode_get_uint8(args->dnode, "distance");
+		metric = yang_dnode_get_uint32(args->dnode, "metric");
 		table_id = yang_dnode_get_uint32(args->dnode, "table-id");
-		pn = static_add_path(rn, table_id, distance);
+		pn = static_add_path(rn, table_id, distance, metric);
 
 		yang_dnode_get_ip(&ipaddr, args->dnode, "gateway");
 		nh_type = yang_dnode_get_enum(args->dnode, "nh-type");
@@ -235,14 +240,63 @@ static int static_path_list_tag_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
+/*
+ * Move nexthop nh from its current path to the path keyed by (table_id,
+ * distance, metric).  Called by distance_modify and metric_modify when
+ * the value actually changes.
+ *
+ * Old-path: remove nh from old_pn->nexthop_list, recalculate old_pn->tag
+ * if nh carried the max tag (so remaining ECMP peers get the correct tag
+ * in the route-UPDATE), uninstall via static_uninstall_nexthop(), and free
+ * old_pn when it is now empty.
+ *
+ * New-path: find or create the target static_path, attach nh, propagate the
+ * tag, and mark the nexthop for install via apply_finish().
+ */
+static void static_nexthop_move_path(struct static_nexthop *nh, uint8_t distance, uint32_t metric)
+{
+	struct static_path *old_pn = nh->pn;
+	struct route_node *rn = old_pn->rn;
+	uint32_t table_id = old_pn->table_id;
+	struct static_path *new_pn;
+
+	/*
+	 * Remove nh from old_pn before uninstalling so that
+	 * static_uninstall_nexthop() sees the correct nexthop count
+	 * (sends a route delete, not an update, when nh was the last
+	 * nexthop on the old path).  Recalculate old_pn->tag first:
+	 * if nh carried the max tag, any remaining ECMP nexthops must
+	 * get the correct tag in the route-update sent to zebra.
+	 */
+	static_nexthop_list_del(&old_pn->nexthop_list, nh);
+	if (old_pn->tag == nh->tag)
+		static_path_recalc_tag(old_pn);
+	static_uninstall_nexthop(nh);
+	if (static_nexthop_list_count(&old_pn->nexthop_list) == 0)
+		static_del_path(old_pn);
+
+	new_pn = static_add_path(rn, table_id, distance, metric);
+	nh->pn = new_pn;
+	static_nexthop_list_add_tail(&new_pn->nexthop_list, nh);
+	/*
+	 * Propagate the tag to the new path.  tag_modify does not
+	 * re-fire, so recalculate from the nexthops now on new_pn.
+	 */
+	static_path_recalc_tag(new_pn);
+	/*
+	 * static_uninstall_nexthop() does not reset nh->state, so it
+	 * can remain STATIC_INSTALLED after the old path is torn down.
+	 * Reset to STATIC_START so apply_finish() → static_install_nexthop()
+	 * → static_nht_update_path() issues a route ADD on the new path.
+	 */
+	nh->state = STATIC_START;
+}
+
 static int static_path_list_distance_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
-	struct static_path *old_pn, *new_pn;
-	struct route_node *rn;
 	const struct lyd_node *pl;
 	uint8_t distance;
-	uint32_t table_id;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -253,50 +307,38 @@ static int static_path_list_distance_modify(struct nb_cb_modify_args *args)
 		break;
 	case NB_EV_APPLY:
 		nh = nb_running_get_entry(args->dnode, NULL, true);
-		old_pn = nh->pn;
 		distance = yang_dnode_get_uint8(args->dnode, NULL);
 		/*
 		 * distance_modify fires during initial route creation as
 		 * well as on explicit distance changes.  Skip the
 		 * path-move when the value has not actually changed.
 		 */
-		if (distance == old_pn->distance)
-			break;
-		rn = old_pn->rn;
-		table_id = old_pn->table_id;
+		if (distance != nh->pn->distance)
+			static_nexthop_move_path(nh, distance, nh->pn->metric);
+		break;
+	}
 
-		/*
-		 * Remove nh from old_pn before uninstalling so that
-		 * static_uninstall_nexthop() sees the correct nexthop count
-		 * (sends a route delete, not an update, when nh was the last
-		 * nexthop on the old path).  Recalculate old_pn->tag first:
-		 * if nh carried the current max tag, any remaining ECMP
-		 * nexthops must get the correct tag in the route-update
-		 * sent to zebra.
-		 */
-		static_nexthop_list_del(&old_pn->nexthop_list, nh);
-		if (old_pn->tag == nh->tag)
-			static_path_recalc_tag(old_pn);
-		static_uninstall_nexthop(nh);
-		if (static_nexthop_list_count(&old_pn->nexthop_list) == 0)
-			static_del_path(old_pn);
+	return NB_OK;
+}
 
-		new_pn = static_add_path(rn, table_id, distance);
-		nh->pn = new_pn;
-		static_nexthop_list_add_tail(&new_pn->nexthop_list, nh);
-		/*
-		 * Propagate the tag to the new path.  tag_modify does not
-		 * re-fire, so recalculate from the nexthops now on new_pn.
-		 */
-		static_path_recalc_tag(new_pn);
-		/*
-		 * static_uninstall_nexthop() does not reset nh->state, so it
-		 * can remain STATIC_INSTALLED after the old path is torn down.
-		 * Reset to STATIC_START so apply_finish() →
-		 * static_install_nexthop() → static_nht_update_path() issues
-		 * a route ADD on the new path.
-		 */
-		nh->state = STATIC_START;
+static int static_path_list_metric_modify(struct nb_cb_modify_args *args)
+{
+	struct static_nexthop *nh;
+	const struct lyd_node *pl;
+	uint32_t metric;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		pl = yang_dnode_get_parent(args->dnode, "path-list");
+		return ecmp_path_list_validate(pl, args->errmsg, args->errmsg_len);
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		nh = nb_running_get_entry(args->dnode, NULL, true);
+		metric = yang_dnode_get_uint32(args->dnode, NULL);
+		if (metric != nh->pn->metric)
+			static_nexthop_move_path(nh, nh->pn->distance, metric);
 		break;
 	}
 
@@ -883,6 +925,16 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	struct nb_cb_modify_args *args)
 {
 	return static_path_list_distance_modify(args);
+}
+
+/*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/metric
+ */
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_metric_modify(
+	struct nb_cb_modify_args *args)
+{
+	return static_path_list_metric_modify(args);
 }
 
 /*

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -23,15 +23,89 @@
 #include "static_srv6.h"
 #include "static_debug.h"
 
+/* Accumulator passed to path_list_ecmp_iter_cb() to count nexthops in the
+ * same ECMP group (those sharing table-id and distance) and track whether
+ * the group contains blackhole or non-blackhole nexthops.
+ */
+struct path_list_ecmp_check {
+	uint32_t table_id;
+	uint8_t distance;
+	uint32_t count;
+	bool has_blackhole;
+	bool has_non_blackhole;
+};
+
+static int path_list_ecmp_iter_cb(const struct lyd_node *dnode, void *arg)
+{
+	struct path_list_ecmp_check *ec = arg;
+	enum static_nh_type nh_type;
+
+	if (yang_dnode_get_uint32(dnode, "table-id") != ec->table_id ||
+	    yang_dnode_get_uint8(dnode, "distance") != ec->distance)
+		return YANG_ITER_CONTINUE;
+
+	ec->count++;
+	nh_type = yang_dnode_get_enum(dnode, "nh-type");
+	if (nh_type == STATIC_BLACKHOLE)
+		ec->has_blackhole = true;
+	else
+		ec->has_non_blackhole = true;
+
+	return YANG_ITER_CONTINUE;
+}
+
+/*
+ * Validate ECMP constraints for the path-list entry at path_list_dnode.
+ * Counts existing nexthops in the same ECMP group (same table-id and
+ * distance) and rejects blackhole/non-blackhole mixing or exceeding the
+ * ECMP limit.  Called from NB_EV_VALIDATE in both path-list create and
+ * distance_modify.
+ */
+static int ecmp_path_list_validate(const struct lyd_node *path_list_dnode, char *errmsg,
+				   size_t errmsg_len)
+{
+	struct path_list_ecmp_check ec = {
+		.table_id = yang_dnode_get_uint32(path_list_dnode, "table-id"),
+		.distance = yang_dnode_get_uint8(path_list_dnode, "distance"),
+	};
+	const struct lyd_node *route_dnode;
+	enum static_nh_type nh_type;
+
+	route_dnode = yang_dnode_get_parent(path_list_dnode, "route-list");
+	yang_dnode_iterate(path_list_ecmp_iter_cb, &ec, route_dnode, "./path-list");
+
+	nh_type = yang_dnode_get_enum(path_list_dnode, "nh-type");
+	if (nh_type == STATIC_BLACKHOLE && ec.has_non_blackhole) {
+		snprintf(errmsg, errmsg_len,
+			 "Route cannot have blackhole and non-blackhole nexthops simultaneously");
+		return NB_ERR_VALIDATION;
+	}
+	if (nh_type != STATIC_BLACKHOLE && ec.has_blackhole) {
+		snprintf(errmsg, errmsg_len,
+			 "Route cannot have blackhole and non-blackhole nexthops simultaneously");
+		return NB_ERR_VALIDATION;
+	}
+	if (ec.count > zebra_ecmp_count) {
+		snprintf(errmsg, errmsg_len, "Route cannot have more than %u ECMP nexthops",
+			 zebra_ecmp_count);
+		return NB_ERR_VALIDATION;
+	}
+	return NB_OK;
+}
 
 static int static_path_list_create(struct nb_cb_create_args *args)
 {
 	struct route_node *rn;
 	struct static_path *pn;
+	struct static_nexthop *nh;
 	const struct lyd_node *vrf_dnode;
 	const char *vrf;
 	uint8_t distance;
 	uint32_t table_id;
+	struct ipaddr ipaddr;
+	enum static_nh_type nh_type;
+	const char *ifname;
+	const char *nh_vrf;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -53,7 +127,18 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 				"%% table param only available when running on netns-based vrfs");
 			return NB_ERR_VALIDATION;
 		}
-		break;
+		ifname = yang_dnode_get_string(args->dnode, "interface");
+		if (ifname != NULL) {
+			if (strcasecmp(ifname, "Null0") == 0 || strcasecmp(ifname, "reject") == 0 ||
+			    strcasecmp(ifname, "blackhole") == 0) {
+				snprintf(args->errmsg, args->errmsg_len,
+					 "%s: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)",
+					 ifname);
+				return NB_ERR_VALIDATION;
+			}
+		}
+
+		return ecmp_path_list_validate(args->dnode, args->errmsg, args->errmsg_len);
 	case NB_EV_ABORT:
 	case NB_EV_PREPARE:
 		break;
@@ -62,134 +147,20 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 		distance = yang_dnode_get_uint8(args->dnode, "distance");
 		table_id = yang_dnode_get_uint32(args->dnode, "table-id");
 		pn = static_add_path(rn, table_id, distance);
-		nb_running_set_entry(args->dnode, pn);
-	}
 
-	return NB_OK;
-}
-
-static int static_path_list_destroy(struct nb_cb_destroy_args *args)
-{
-	struct static_path *pn;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		pn = nb_running_unset_entry(args->dnode);
-		static_del_path(pn);
-		break;
-	}
-
-	return NB_OK;
-}
-
-static int static_path_list_tag_modify(struct nb_cb_modify_args *args)
-{
-	struct static_path *pn;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_ABORT:
-	case NB_EV_PREPARE:
-		break;
-	case NB_EV_APPLY:
-		pn = nb_running_get_entry(args->dnode, NULL, true);
-		pn->tag = yang_dnode_get_uint32(args->dnode, NULL);
-		static_install_path(pn);
-		break;
-	}
-
-	return NB_OK;
-}
-
-struct nexthop_iter {
-	uint32_t count;
-	bool blackhole;
-};
-
-static int nexthop_iter_cb(const struct lyd_node *dnode, void *arg)
-{
-	struct nexthop_iter *iter = arg;
-	enum static_nh_type nh_type;
-
-	nh_type = yang_dnode_get_enum(dnode, "nh-type");
-
-	if (nh_type == STATIC_BLACKHOLE)
-		iter->blackhole = true;
-
-	iter->count++;
-
-	return YANG_ITER_CONTINUE;
-}
-
-static bool static_nexthop_create(struct nb_cb_create_args *args)
-{
-	const struct lyd_node *pn_dnode;
-	struct nexthop_iter iter;
-	struct static_path *pn;
-	struct ipaddr ipaddr;
-	struct static_nexthop *nh;
-	enum static_nh_type nh_type;
-	const char *ifname;
-	const char *nh_vrf;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-		ifname = yang_dnode_get_string(args->dnode, "interface");
-		if (ifname != NULL) {
-			if (strcasecmp(ifname, "Null0") == 0
-			    || strcasecmp(ifname, "reject") == 0
-			    || strcasecmp(ifname, "blackhole") == 0) {
-				snprintf(args->errmsg, args->errmsg_len,
-					"%s: Nexthop interface name can not be from reserved keywords(Null0, reject, blackhole)",
-					ifname);
-				return NB_ERR_VALIDATION;
-			}
-		}
-
-		iter.count = 0;
-		iter.blackhole = false;
-
-		pn_dnode = yang_dnode_get_parent(args->dnode, "path-list");
-		yang_dnode_iterate(nexthop_iter_cb, &iter, pn_dnode,
-				   "./frr-nexthops/nexthop");
-
-		if (iter.blackhole && iter.count > 1) {
-			snprintf(
-				args->errmsg, args->errmsg_len,
-				"Route cannot have blackhole and non-blackhole nexthops simultaneously");
-			return NB_ERR_VALIDATION;
-		} else if (iter.count > zebra_ecmp_count) {
-			snprintf(args->errmsg, args->errmsg_len,
-				"Route cannot have more than %d ECMP nexthops",
-				 zebra_ecmp_count);
-			return NB_ERR_VALIDATION;
-		}
-		break;
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
 		yang_dnode_get_ip(&ipaddr, args->dnode, "gateway");
 		nh_type = yang_dnode_get_enum(args->dnode, "nh-type");
 		ifname = yang_dnode_get_string(args->dnode, "interface");
 		nh_vrf = yang_dnode_get_string(args->dnode, "vrf");
-		pn = nb_running_get_entry(args->dnode, NULL, true);
 
 		if (strmatch(ifname, "(null)"))
 			ifname = "";
 
 		if (!static_add_nexthop_validate(nh_vrf, nh_type, &ipaddr))
-			flog_warn(
-				EC_LIB_NB_CB_CONFIG_VALIDATE,
-				"Warning!! Local connected address is configured as Gateway IP((%s))",
-				yang_dnode_get_string(args->dnode,
-						      "./gateway"));
-		nh = static_add_nexthop(pn, nh_type, &ipaddr, ifname, nh_vrf,
-					0);
+			flog_warn(EC_LIB_NB_CB_CONFIG_VALIDATE,
+				  "Warning!! Local connected address is configured as Gateway IP((%s))",
+				  yang_dnode_get_string(args->dnode, "./gateway"));
+		nh = static_add_nexthop(pn, nh_type, &ipaddr, ifname, nh_vrf, 0);
 		nb_running_set_entry(args->dnode, nh);
 		break;
 	}
@@ -197,9 +168,10 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 	return NB_OK;
 }
 
-static bool static_nexthop_destroy(struct nb_cb_destroy_args *args)
+static int static_path_list_destroy(struct nb_cb_destroy_args *args)
 {
 	struct static_nexthop *nh;
+	struct static_path *pn;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -208,7 +180,123 @@ static bool static_nexthop_destroy(struct nb_cb_destroy_args *args)
 		break;
 	case NB_EV_APPLY:
 		nh = nb_running_unset_entry(args->dnode);
+		pn = nh->pn;
 		static_delete_nexthop(nh);
+		if (static_nexthop_list_count(&pn->nexthop_list) == 0)
+			static_del_path(pn);
+		break;
+	}
+
+	return NB_OK;
+}
+
+static int static_path_list_tag_modify(struct nb_cb_modify_args *args)
+{
+	struct static_nexthop *nh;
+	struct static_path *pn;
+	uint32_t old_tag;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		nh = nb_running_get_entry(args->dnode, NULL, true);
+		pn = nh->pn;
+
+		/*
+		 * Update nh->tag and recompute pn->tag (max-wins across the
+		 * path's nexthops).  Skip the install when the effective path
+		 * tag is unchanged — this also makes setting the same value
+		 * idempotent.
+		 */
+		nh->tag = yang_dnode_get_uint32(args->dnode, NULL);
+		old_tag = pn->tag;
+		static_path_recalc_tag(pn);
+		if (pn->tag == old_tag)
+			break;
+
+		/*
+		 * Do not call static_install_path() here; apply_finish()
+		 * fires after all per-leaf callbacks complete and performs
+		 * the single install for this path-list entry.
+		 *
+		 * Mark the nexthop as needing reinstall so that
+		 * static_nht_update_path() issues a route ADD when
+		 * apply_finish() calls static_install_nexthop() via the
+		 * NHT fast path (nh->state must be STATIC_START, not
+		 * STATIC_INSTALLED, for the update to reach zebra).
+		 */
+		nh->state = STATIC_START;
+		break;
+	}
+
+	return NB_OK;
+}
+
+static int static_path_list_distance_modify(struct nb_cb_modify_args *args)
+{
+	struct static_nexthop *nh;
+	struct static_path *old_pn, *new_pn;
+	struct route_node *rn;
+	const struct lyd_node *pl;
+	uint8_t distance;
+	uint32_t table_id;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		pl = yang_dnode_get_parent(args->dnode, "path-list");
+		return ecmp_path_list_validate(pl, args->errmsg, args->errmsg_len);
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		nh = nb_running_get_entry(args->dnode, NULL, true);
+		old_pn = nh->pn;
+		distance = yang_dnode_get_uint8(args->dnode, NULL);
+		/*
+		 * distance_modify fires during initial route creation as
+		 * well as on explicit distance changes.  Skip the
+		 * path-move when the value has not actually changed.
+		 */
+		if (distance == old_pn->distance)
+			break;
+		rn = old_pn->rn;
+		table_id = old_pn->table_id;
+
+		/*
+		 * Remove nh from old_pn before uninstalling so that
+		 * static_uninstall_nexthop() sees the correct nexthop count
+		 * (sends a route delete, not an update, when nh was the last
+		 * nexthop on the old path).  Recalculate old_pn->tag first:
+		 * if nh carried the current max tag, any remaining ECMP
+		 * nexthops must get the correct tag in the route-update
+		 * sent to zebra.
+		 */
+		static_nexthop_list_del(&old_pn->nexthop_list, nh);
+		if (old_pn->tag == nh->tag)
+			static_path_recalc_tag(old_pn);
+		static_uninstall_nexthop(nh);
+		if (static_nexthop_list_count(&old_pn->nexthop_list) == 0)
+			static_del_path(old_pn);
+
+		new_pn = static_add_path(rn, table_id, distance);
+		nh->pn = new_pn;
+		static_nexthop_list_add_tail(&new_pn->nexthop_list, nh);
+		/*
+		 * Propagate the tag to the new path.  tag_modify does not
+		 * re-fire, so recalculate from the nexthops now on new_pn.
+		 */
+		static_path_recalc_tag(new_pn);
+		/*
+		 * static_uninstall_nexthop() does not reset nh->state, so it
+		 * can remain STATIC_INSTALLED after the old path is torn down.
+		 * Reset to STATIC_START so apply_finish() →
+		 * static_install_nexthop() → static_nht_update_path() issues
+		 * a route ADD on the new path.
+		 */
+		nh->state = STATIC_START;
 		break;
 	}
 
@@ -594,7 +682,7 @@ static int static_nexthop_bh_type_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish(
+void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_apply_finish(
 	struct nb_cb_apply_finish_args *args)
 {
 	struct static_nexthop *nh;
@@ -604,7 +692,7 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_p
 	static_install_nexthop(nh);
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_pre_validate(
 	struct nb_cb_pre_validate_args *args)
 {
 	const struct lyd_node *mls_dnode;
@@ -789,25 +877,19 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/distance
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create(
-	struct nb_cb_create_args *args)
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_distance_modify(
+	struct nb_cb_modify_args *args)
 {
-	return static_nexthop_create(args);
-}
-
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	return static_nexthop_destroy(args);
+	return static_path_list_distance_modify(args);
 }
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/bh-type
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/bh-type
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_bh_type_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_bh_type_modify(
 	struct nb_cb_modify_args *args)
 {
 	return static_nexthop_bh_type_modify(args);
@@ -815,9 +897,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/weight
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/weight
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_weight_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_weight_modify(
 	struct nb_cb_modify_args *args)
 {
 	return static_nexthop_weight_modify(args);
@@ -825,9 +907,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/weight
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/weight
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_weight_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_weight_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	return static_nexthop_weight_destroy(args);
@@ -835,9 +917,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/onlink
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/onlink
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_onlink_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_onlink_modify(
 	struct nb_cb_modify_args *args)
 {
 	return static_nexthop_onlink_modify(args);
@@ -845,9 +927,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srte-color
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srte-color
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_color_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -864,7 +946,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	return NB_OK;
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_color_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_color_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	switch (args->event) {
@@ -882,15 +964,15 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srv6-segs-stack/entry
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srv6-segs-stack/entry
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_create(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_create(
 	struct nb_cb_create_args *args)
 {
 	return nexthop_srv6_segs_stack_entry_create(args);
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	return nexthop_srv6_segs_stack_entry_destroy(args);
@@ -898,9 +980,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srv6-segs-stack/entry/seg
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srv6-segs-stack/entry/seg
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_seg_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_seg_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -916,7 +998,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	return NB_OK;
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_entry_seg_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_entry_seg_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	/*
@@ -936,9 +1018,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/srv6-segs-stack/encap-behavior
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/srv6-segs-stack/encap-behavior
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_encap_behavior_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_encap_behavior_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -954,7 +1036,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	return NB_OK;
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_srv6_segs_stack_encap_behavior_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_srv6_segs_stack_encap_behavior_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	switch (args->event) {
@@ -972,15 +1054,15 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_create(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_create(
 	struct nb_cb_create_args *args)
 {
 	return nexthop_mpls_label_stack_entry_create(args);
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	return nexthop_mpls_label_stack_entry_destroy(args);
@@ -988,9 +1070,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry/label
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry/label
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_label_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_label_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -1006,7 +1088,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	return NB_OK;
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_label_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_label_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	/*
@@ -1026,9 +1108,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry/ttl
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry/ttl
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_ttl_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -1042,7 +1124,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	return NB_OK;
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_ttl_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	switch (args->event) {
@@ -1058,9 +1140,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 
 /*
  * XPath:
- * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/mpls-label-stack/entry/traffic-class
  */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_modify(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_traffic_class_modify(
 	struct nb_cb_modify_args *args)
 {
 	switch (args->event) {
@@ -1074,7 +1156,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	return NB_OK;
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_destroy(
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_mpls_label_stack_entry_traffic_class_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	switch (args->event) {
@@ -1144,13 +1226,12 @@ int route_next_hop_bfd_source_destroy(struct nb_cb_destroy_args *args)
 	sn = nb_running_get_entry(args->dnode, NULL, true);
 	static_next_hop_bfd_auto_source(sn);
 
-	/* NHT information are needed by BFD to automatically find the source
-	 *
-	 * Force zebra to resend the information to BFD by unregistering and
-	 * registering again NHT. The (...)/frr-nexthops/nexthop northbound
-	 * apply_finish function will trigger a call to static_install_nexthop()
-	 * that does a call to static_zebra_nht_register(nh, true);
-	 * static_zebra_nht_register(sn, false);
+	/*
+	 * NHT information is needed by BFD to automatically find the source.
+	 * Force zebra to resend the NHT data by unregistering and registering
+	 * again.  The path-list apply_finish callback calls
+	 * static_install_nexthop() which re-registers via
+	 * static_zebra_nht_register(nh, true).
 	 */
 	static_zebra_nht_register(sn, false);
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -325,12 +325,41 @@ void static_uninstall_nexthop(struct static_nexthop *nh)
 	static_uninstall_path(pn);
 }
 
+/*
+ * Recalculate pn->tag after a nexthop is added, removed, or migrated
+ * between paths.  Scans pn->nexthop_list and sets pn->tag to the maximum
+ * nh->tag value (max-wins).  Resets to 0 when the list is empty.
+ *
+ * Max-wins is order-independent: the result depends only on the set of
+ * configured nexthops, making the per-leaf callbacks idempotent.
+ */
+void static_path_recalc_tag(struct static_path *pn)
+{
+	struct static_nexthop *nh;
+	route_tag_t max_tag = 0;
+
+	frr_each (static_nexthop_list, &pn->nexthop_list, nh) {
+		if (nh->tag > max_tag)
+			max_tag = nh->tag;
+	}
+	pn->tag = max_tag;
+}
+
 void static_delete_nexthop(struct static_nexthop *nh)
 {
 	struct static_path *pn = nh->pn;
 	struct route_node *rn = pn->rn;
 
 	static_nexthop_list_del(&(pn->nexthop_list), nh);
+
+	/*
+	 * Recalculate pn->tag only when the deleted nexthop carried the
+	 * current maximum tag value (nh->tag == pn->tag).  Removing any
+	 * nexthop whose tag was below the max cannot change the max.
+	 */
+	if (pn->tag == nh->tag)
+		static_path_recalc_tag(pn);
+
 	/* Remove BFD session/configuration if any. */
 	bfd_sess_free(&nh->bsp);
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -141,11 +141,19 @@ bool static_add_nexthop_validate(const char *nh_vrf_name,
 	return true;
 }
 
-struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
-				    uint8_t distance)
+struct static_path *static_add_path(struct route_node *rn, uint32_t table_id, uint8_t distance,
+				    uint32_t metric)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
+
+	si = rn->info;
+
+	/* Return existing path if one already matches (table-id, distance, metric) */
+	frr_each (static_path_list, &si->path_list, pn) {
+		if (pn->table_id == table_id && pn->distance == distance && pn->metric == metric)
+			return pn;
+	}
 
 	route_lock_node(rn);
 
@@ -154,10 +162,10 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 
 	pn->rn = rn;
 	pn->distance = distance;
+	pn->metric = metric;
 	pn->table_id = table_id;
 	static_nexthop_list_init(&(pn->nexthop_list));
 
-	si = rn->info;
 	static_path_list_add_head(&(si->path_list), pn);
 
 	return pn;

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -143,6 +143,13 @@ struct static_nexthop {
 	/* Weight to be used by the nexthop for purposes of ECMP */
 	uint16_t weight;
 
+	/* Tag configured for this individual nexthop (YANG per-nexthop value).
+	 * pn->tag is the maximum nh->tag across the path's nexthops; this
+	 * field is read by static_path_recalc_tag() when nexthops are added,
+	 * removed, or migrated between paths.
+	 */
+	route_tag_t tag;
+
 	/*
 	 * Whether to pretend the nexthop is directly attached to the specified
 	 * link. Only meaningful when both a gateway address and interface name
@@ -215,6 +222,7 @@ static_add_nexthop(struct static_path *pn, enum static_nh_type type,
 extern void static_install_nexthop(struct static_nexthop *nh);
 extern void static_uninstall_nexthop(struct static_nexthop *nh);
 
+extern void static_path_recalc_tag(struct static_path *pn);
 extern void static_delete_nexthop(struct static_nexthop *nh);
 
 extern void static_ifindex_update(struct interface *ifp, bool up);

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -77,6 +77,48 @@ enum static_install_states {
 PREDECL_DLIST(static_path_list);
 PREDECL_DLIST(static_nexthop_list);
 
+/*
+ * Data model: prefix -> path-list -> nexthop-list
+ *
+ * Each prefix (route_node) has one static_route_info attached as rn->info.
+ * Under it is a list of static_path objects, each uniquely identified by
+ * (table-id, distance, metric).  Under each path is a list of static_nexthop
+ * objects that share those attributes.  Tag is a per-path attribute (not a key).
+ *
+ *   prefix (route_node / static_route_info)
+ *     |
+ *     +-- static_path  [table-id=0, distance=10, metric=0]  tag=100
+ *     |     +-- static_nexthop  NH1   \
+ *     |     +-- static_nexthop  NH2   /  ECMP group (same distance, metric)
+ *     |
+ *     +-- static_path  [table-id=0, distance=10, metric=20]  tag=200
+ *     |     +-- static_nexthop  NH3       metric-based floating static
+ *     |
+ *     +-- static_path  [table-id=0, distance=20, metric=0]  tag=300
+ *           +-- static_nexthop  NH4       AD-based floating static (standby)
+ *
+ * Route preference: AD and metric together determine which path is active in
+ * the RIB.  AD is the primary preference key; for the same AD, metric is
+ * the secondary key.  All paths are sent to zebra; zebra stores each
+ * (AD, metric) combination as a separate route_entry and rib_choose_best()
+ * selects the one with the lowest AD (and lowest metric for the same AD)
+ * for the RIB.  A path with a higher AD or metric is promoted only when all
+ * better paths become unreachable (floating static / backup route).
+ * Default: AD=1, metric=0.
+ *
+ * Tag: a 32-bit marker attached to a path and carried into the RIB.  Tag is
+ * shared by all nexthops in a path and is not part of the path identity.
+ * Nexthops at the same (distance, metric) always share one static_path
+ * regardless of their configured tag values; the maximum configured tag
+ * applies to the whole group.  To assign independent tags, use different
+ * distances or metrics.
+ *
+ * ECMP: multiple static_nexthop entries under the same static_path are
+ * installed together as an equal-cost multipath group.  The weight field
+ * on each nexthop lets operators bias the traffic distribution within the
+ * group.
+ */
+
 /* Static route information */
 struct static_route_info {
 	struct static_vrf *svrf;
@@ -93,6 +135,8 @@ struct static_path {
 	struct static_path_list_item list;
 	/* Administrative distance. */
 	uint8_t distance;
+	/* Metric */
+	uint32_t metric;
 	/* Tag */
 	route_tag_t tag;
 	/* Table-id */
@@ -235,8 +279,8 @@ extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 					   struct static_vrf *svrf);
 extern void static_del_route(struct route_node *rn);
 
-extern struct static_path *static_add_path(struct route_node *rn,
-					   uint32_t table_id, uint8_t distance);
+extern struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
+					   uint8_t distance, uint32_t metric);
 extern void static_del_path(struct static_path *pn);
 
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -55,6 +55,7 @@ struct static_route_args {
 	const char *flag;
 	const char *tag;
 	const char *distance;
+	const char *metric;
 	const char *label;
 	const char *table;
 	const char *color;
@@ -110,6 +111,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	char buf_nh_type[PREFIX_STRLEN] = {};
 	char buf_distance[PREFIX_STRLEN];
 	char buf_tag[PREFIX_STRLEN];
+	char buf_metric[PREFIX_STRLEN];
 	uint8_t label_stack_id = 0;
 	uint8_t segs_stack_id = 0;
 	char *orig_label = NULL, *orig_seg = NULL;
@@ -117,6 +119,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	struct ipaddr gate_ip;
 	uint8_t distance = ZEBRA_STATIC_DISTANCE_DEFAULT;
 	route_tag_t tag = 0;
+	uint32_t metric = 0;
 	uint32_t table_id = 0;
 	const struct lyd_node *dnode;
 	const struct lyd_node *vrf_dnode;
@@ -221,6 +224,10 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	if (args->tag)
 		tag = strtoul(args->tag, NULL, 10);
 
+	/* metric */
+	if (args->metric)
+		metric = strtoul(args->metric, NULL, 10);
+
 	/* TableID */
 	if (args->table)
 		table_id = strtol(args->table, NULL, 10);
@@ -255,6 +262,12 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_TAG_XPATH,
 			sizeof(ab_xpath));
 		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_tag);
+
+		/* Metric processing */
+		snprintf(buf_metric, sizeof(buf_metric), "%u", metric);
+		strlcpy(ab_xpath, xpath_prefix, sizeof(ab_xpath));
+		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_METRIC_XPATH, sizeof(ab_xpath));
+		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_metric);
 
 		/* The path-list entry is the nexthop; xpath_nexthop == xpath_prefix. */
 		strlcpy(xpath_nexthop, xpath_prefix, sizeof(xpath_nexthop));
@@ -504,6 +517,7 @@ DEFPY_YANG (ip_mroute_dist,
        ip_mroute_dist_cmd,
        "[no] ip mroute A.B.C.D/M$prefix <A.B.C.D$gate|INTERFACE$ifname> [{"
        "(1-255)$distance"
+       "|metric (0-4294967295)"
        "|bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}]"
        "}]",
        NO_STR
@@ -513,6 +527,8 @@ DEFPY_YANG (ip_mroute_dist,
        "Nexthop address\n"
        "Nexthop interface name\n"
        "Distance\n"
+       "Route metric\n"
+       "Metric value\n"
        BFD_INTEGRATION_STR
        BFD_INTEGRATION_MULTI_HOP_STR
        BFD_INTEGRATION_SOURCE_STR
@@ -528,6 +544,7 @@ DEFPY_YANG (ip_mroute_dist,
 		.gateway = gate_str,
 		.interface_name = ifname,
 		.distance = distance_str,
+		.metric = metric_str,
 		.bfd = !!bfd,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
@@ -546,6 +563,7 @@ DEFPY_YANG(ip_route_blackhole,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+	  |metric (0-4294967295)                                              \
 	  |vrf NAME                                                           \
 	  |label WORD                                                         \
           |table (1-4294967295)                                               \
@@ -560,6 +578,8 @@ DEFPY_YANG(ip_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Route metric\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -574,6 +594,7 @@ DEFPY_YANG(ip_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -590,6 +611,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+	  |metric (0-4294967295)                                              \
 	  |label WORD                                                         \
 	  |table (1-4294967295)                                               \
           }]",
@@ -603,6 +625,8 @@ DEFPY_YANG(ip_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Route metric\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -616,6 +640,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -640,6 +665,7 @@ DEFPY_YANG(ip_route_address_interface,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |vrf NAME                                    \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
@@ -662,6 +688,8 @@ DEFPY_YANG(ip_route_address_interface,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Route metric\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -694,6 +722,7 @@ DEFPY_YANG(ip_route_address_interface,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -721,6 +750,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
 	  |nexthop-vrf NAME                            \
@@ -742,6 +772,8 @@ DEFPY_YANG(ip_route_address_interface_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Route metric\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -773,6 +805,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -799,6 +832,7 @@ DEFPY_YANG(ip_route,
 	[{                                             	   \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |vrf NAME                                        \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
@@ -820,6 +854,8 @@ DEFPY_YANG(ip_route,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Route metric\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -851,6 +887,7 @@ DEFPY_YANG(ip_route,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -876,6 +913,7 @@ DEFPY_YANG(ip_route_vrf,
 	[{                                                 \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
 	  |nexthop-vrf NAME                                \
@@ -896,6 +934,8 @@ DEFPY_YANG(ip_route_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Route metric\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -926,6 +966,7 @@ DEFPY_YANG(ip_route_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -950,6 +991,7 @@ DEFPY_YANG(ipv6_route_blackhole,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
             |table (1-4294967295)                          \
@@ -965,6 +1007,8 @@ DEFPY_YANG(ipv6_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Route metric\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -979,6 +1023,7 @@ DEFPY_YANG(ipv6_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -994,6 +1039,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
             |table (1-4294967295)                          \
           }]",
@@ -1008,6 +1054,8 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Route metric\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -1021,6 +1069,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -1043,6 +1092,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1063,7 +1113,10 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Route metric\n"
+	   "Metric value\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1089,6 +1142,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1115,6 +1169,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1134,7 +1189,10 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Route metric\n"
+	   "Metric value\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1160,6 +1218,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1184,6 +1243,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1203,7 +1263,10 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Route metric\n"
+	   "Metric value\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1228,6 +1291,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1252,6 +1316,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1270,7 +1335,10 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Route metric\n"
+	   "Metric value\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1295,6 +1363,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1678,6 +1747,13 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	if (distance != ZEBRA_STATIC_DISTANCE_DEFAULT || show_defaults)
 		vty_out(vty, " %" PRIu8, distance);
 
+	if (yang_dnode_exists(path, "metric")) {
+		uint32_t metric = yang_dnode_get_uint32(path, "metric");
+
+		if (metric != 0 || show_defaults)
+			vty_out(vty, " metric %" PRIu32, metric);
+	}
+
 	iter.vty = vty;
 	iter.first = true;
 	yang_dnode_iterate(mpls_label_iter_cb, &iter, nexthop,
@@ -1847,6 +1923,7 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 {
 	uint32_t table_id1, table_id2;
 	uint8_t distance1, distance2;
+	uint32_t metric1, metric2;
 
 	table_id1 = yang_dnode_get_uint32(dnode1, "table-id");
 	table_id2 = yang_dnode_get_uint32(dnode2, "table-id");
@@ -1860,7 +1937,13 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 	if (distance1 != distance2)
 		return (int)distance1 - (int)distance2;
 
-	/* Within the same (table-id, distance) group, sort by nexthop identity */
+	metric1 = yang_dnode_get_uint32(dnode1, "metric");
+	metric2 = yang_dnode_get_uint32(dnode2, "metric");
+
+	if (metric1 != metric2)
+		return (metric1 > metric2) ? 1 : -1;
+
+	/* Within the same (table-id, distance, metric) group, sort by nexthop identity */
 	return static_nexthop_cli_cmp(dnode1, dnode2);
 }
 

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -108,6 +108,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	char buf_prefix[PREFIX_STRLEN];
 	char buf_src_prefix[PREFIX_STRLEN] = "::/0";
 	char buf_nh_type[PREFIX_STRLEN] = {};
+	char buf_distance[PREFIX_STRLEN];
 	char buf_tag[PREFIX_STRLEN];
 	uint8_t label_stack_id = 0;
 	uint8_t segs_stack_id = 0;
@@ -226,31 +227,27 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 
 	static_get_nh_type(type, buf_nh_type, sizeof(buf_nh_type));
 	if (!args->delete) {
-		snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH,
-			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
-			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, buf_nh_type,
-			 args->nexthop_vrf, buf_gate_str, args->interface_name);
-
-		/*
-		 * If there's already the same nexthop but with a different
-		 * distance, then remove it for the replacement.
-		 */
-		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
-		if (dnode) {
-			dnode = yang_get_subtree_with_no_sibling(dnode);
-			assert(dnode);
-			yang_dnode_get_path(dnode, ab_xpath, XPATH_MAXLEN);
-
-			nb_cli_enqueue_change(vty, ab_xpath, NB_OP_DESTROY,
-					      NULL);
-		}
-
-		/* route + path processing */
+		/* Each path-list entry represents one nexthop; build its xpath. */
 		snprintf(xpath_prefix, sizeof(xpath_prefix), FRR_STATIC_ROUTE_INFO_KEY_XPATH,
 			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
-			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance);
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+			 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
 
-		nb_cli_enqueue_change(vty, xpath_prefix, NB_OP_CREATE, NULL);
+		/*
+		 * Only CREATE when the path-list entry is new; if it already
+		 * exists the MODIFY operations below (distance, tag, metric)
+		 * are sufficient — the respective _modify callbacks handle
+		 * the data-plane update.
+		 */
+		dnode = yang_dnode_get(vty->candidate_config->dnode, xpath_prefix);
+		if (!dnode)
+			nb_cli_enqueue_change(vty, xpath_prefix, NB_OP_CREATE, NULL);
+
+		/* Distance processing */
+		strlcpy(ab_xpath, xpath_prefix, sizeof(ab_xpath));
+		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_DISTANCE_XPATH, sizeof(ab_xpath));
+		snprintf(buf_distance, sizeof(buf_distance), "%u", distance);
+		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_distance);
 
 		/* Tag processing */
 		snprintf(buf_tag, sizeof(buf_tag), "%u", tag);
@@ -259,14 +256,8 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 			sizeof(ab_xpath));
 		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_tag);
 
-		/* nexthop processing */
-
-		snprintf(ab_xpath, sizeof(ab_xpath),
-			 FRR_STATIC_ROUTE_NH_KEY_XPATH, buf_nh_type,
-			 args->nexthop_vrf, buf_gate_str, args->interface_name);
+		/* The path-list entry is the nexthop; xpath_nexthop == xpath_prefix. */
 		strlcpy(xpath_nexthop, xpath_prefix, sizeof(xpath_nexthop));
-		strlcat(xpath_nexthop, ab_xpath, sizeof(xpath_nexthop));
-		nb_cli_enqueue_change(vty, xpath_nexthop, NB_OP_CREATE, NULL);
 
 		if (type == STATIC_BLACKHOLE) {
 			strlcpy(ab_xpath, xpath_nexthop, sizeof(ab_xpath));
@@ -413,40 +404,41 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 			strlcpy(xpath_segs, xpath_nexthop, sizeof(xpath_segs));
 			strlcat(xpath_segs, FRR_STATIC_ROUTE_NH_SRV6_SEGS_XPATH,
 				sizeof(xpath_segs));
-			nb_cli_enqueue_change(vty, xpath_segs, NB_OP_DESTROY,
-					      NULL);
+			nb_cli_enqueue_change(vty, xpath_segs, NB_OP_DESTROY, NULL);
 		}
 		if (args->bfd) {
 			char xpath_bfd[XPATH_MAXLEN];
 
+			strlcpy(xpath_bfd, xpath_nexthop, sizeof(xpath_bfd));
+			strlcat(xpath_bfd, "/frr-staticd:bfd-monitoring/source", sizeof(xpath_bfd));
 			if (args->bfd_source) {
-				strlcpy(xpath_bfd, xpath_nexthop,
-					sizeof(xpath_bfd));
-				strlcat(xpath_bfd,
-					"/frr-staticd:bfd-monitoring/source",
-					sizeof(xpath_bfd));
-				nb_cli_enqueue_change(vty, xpath_bfd,
-						      NB_OP_MODIFY,
+				nb_cli_enqueue_change(vty, xpath_bfd, NB_OP_MODIFY,
 						      args->bfd_source);
+			} else if (yang_dnode_get(vty->candidate_config->dnode, xpath_bfd)) {
+				/*
+				 * Explicitly destroy the source leaf when it is
+				 * absent from the current command so that
+				 * re-entering the route without "source X"
+				 * triggers the bfd_source_destroy NB callback
+				 * and the BFD session switches to auto-source.
+				 */
+				nb_cli_enqueue_change(vty, xpath_bfd, NB_OP_DESTROY, NULL);
 			}
 
 			strlcpy(xpath_bfd, xpath_nexthop, sizeof(xpath_bfd));
-			strlcat(xpath_bfd,
-				"/frr-staticd:bfd-monitoring/multi-hop",
+			strlcat(xpath_bfd, "/frr-staticd:bfd-monitoring/multi-hop",
 				sizeof(xpath_bfd));
 			nb_cli_enqueue_change(vty, xpath_bfd, NB_OP_MODIFY,
-					      args->bfd_multi_hop ? "true"
-								  : "false");
+					      args->bfd_multi_hop ? "true" : "false");
 
+			strlcpy(xpath_bfd, xpath_nexthop, sizeof(xpath_bfd));
+			strlcat(xpath_bfd, "/frr-staticd:bfd-monitoring/profile",
+				sizeof(xpath_bfd));
 			if (args->bfd_profile) {
-				strlcpy(xpath_bfd, xpath_nexthop,
-					sizeof(xpath_bfd));
-				strlcat(xpath_bfd,
-					"/frr-staticd:bfd-monitoring/profile",
-					sizeof(xpath_bfd));
-				nb_cli_enqueue_change(vty, xpath_bfd,
-						      NB_OP_MODIFY,
+				nb_cli_enqueue_change(vty, xpath_bfd, NB_OP_MODIFY,
 						      args->bfd_profile);
+			} else if (yang_dnode_get(vty->candidate_config->dnode, xpath_bfd)) {
+				nb_cli_enqueue_change(vty, xpath_bfd, NB_OP_DESTROY, NULL);
 			}
 		}
 
@@ -457,18 +449,11 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		if (orig_seg)
 			XFREE(MTYPE_TMP, orig_seg);
 	} else {
-		if (args->distance)
-			snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_XPATH,
-				 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix,
-				 buf_src_prefix, yang_afi_safi_value2identity(args->afi, args->safi),
-				 table_id, distance, buf_nh_type, args->nexthop_vrf, buf_gate_str,
-				 args->interface_name);
-		else
-			snprintf(ab_xpath, sizeof(ab_xpath),
-				 FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH, "frr-staticd:staticd",
-				 "staticd", args->vrf, buf_prefix, buf_src_prefix,
-				 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
-				 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
+		/* Delete the path-list entry identified by nexthop identity. */
+		snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_XPATH,
+			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+			 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
 
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (!dnode) {
@@ -1763,11 +1748,10 @@ static void static_nexthop_cli_show(struct vty *vty,
 				    const struct lyd_node *dnode,
 				    bool show_defaults)
 {
-	const struct lyd_node *path = yang_dnode_get_parent(dnode, "path-list");
-	const struct lyd_node *route =
-		yang_dnode_get_parent(path, "route-list");
+	const struct lyd_node *route = yang_dnode_get_parent(dnode, "route-list");
 
-	nexthop_cli_show(vty, route, path, dnode, show_defaults);
+	/* The path-list entry is the nexthop; pass dnode for both args. */
+	nexthop_cli_show(vty, route, dnode, dnode, show_defaults);
 }
 
 static int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
@@ -1873,7 +1857,11 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 	distance1 = yang_dnode_get_uint8(dnode1, "distance");
 	distance2 = yang_dnode_get_uint8(dnode2, "distance");
 
-	return (int)distance1 - (int)distance2;
+	if (distance1 != distance2)
+		return (int)distance1 - (int)distance2;
+
+	/* Within the same (table-id, distance) group, sort by nexthop identity */
+	return static_nexthop_cli_cmp(dnode1, dnode2);
 }
 
 static void static_segment_routing_cli_show(struct vty *vty, const struct lyd_node *dnode,
@@ -2037,14 +2025,8 @@ const struct frr_yang_module_info frr_staticd_cli_info = {
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list",
 			.cbs = {
-				.cli_cmp = static_path_list_cli_cmp,
-			}
-		},
-		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop",
-			.cbs = {
 				.cli_show = static_nexthop_cli_show,
-				.cli_cmp = static_nexthop_cli_cmp,
+				.cli_cmp = static_path_list_cli_cmp,
 			}
 		},
 		{

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -441,6 +441,8 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);
 		api.distance = pn->distance;
 	}
+	SET_FLAG(api.message, ZAPI_MESSAGE_METRIC);
+	api.metric = pn->metric;
 	if (pn->tag) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_TAG);
 		api.tag = pn->tag;

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -444,8 +444,7 @@ void grpc_client_run_test(void)
 		snprintf(xpath_buf + slen, sizeof(xpath_buf) - slen,
 			 "[prefix='13.0.%d.0/24']"
 			 "[afi-safi='frr-routing:ipv4-unicast']/"
-			 "path-list[table-id='0'][distance='1']/"
-			 "frr-nexthops/nexthop[nh-type='blackhole']"
+			 "path-list[table-id='0'][nh-type='blackhole']"
 			 "[vrf='default'][gateway=''][interface='(null)']",
 			 i);
 		client.EditCandidate(cid, xpath_buf, "");
@@ -583,20 +582,14 @@ const char *json_expect1 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               }
@@ -637,17 +630,11 @@ const char *json_loadconf1 = R"NONCE(
                 "path-list": [
                   {
                     "table-id": 0,
-                    "distance": 1,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)"
-                        }
-                      ]
-                    }
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
+                    "distance": 1
                   }
                 ]
               }
@@ -682,20 +669,14 @@ const char *json_expect2 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -705,20 +686,14 @@ const char *json_expect2 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -728,20 +703,14 @@ const char *json_expect2 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -751,20 +720,14 @@ const char *json_expect2 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -774,20 +737,14 @@ const char *json_expect2 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               }
@@ -827,20 +784,14 @@ const char *json_expect3 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -850,20 +801,14 @@ const char *json_expect3 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -873,20 +818,14 @@ const char *json_expect3 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -896,20 +835,14 @@ const char *json_expect3 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -919,20 +852,14 @@ const char *json_expect3 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               },
@@ -942,20 +869,14 @@ const char *json_expect3 = R"NONCE({
                 "path-list": [
                   {
                     "table-id": 0,
+                    "nh-type": "blackhole",
+                    "vrf": "default",
+                    "gateway": "",
+                    "interface": "(null)",
                     "distance": 1,
                     "tag": 0,
-                    "frr-nexthops": {
-                      "nexthop": [
-                        {
-                          "nh-type": "blackhole",
-                          "vrf": "default",
-                          "gateway": "",
-                          "interface": "(null)",
-                          "bh-type": "null",
-                          "onlink": false
-                        }
-                      ]
-                    }
+                    "bh-type": "null",
+                    "onlink": false
                   }
                 ]
               }

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -180,7 +180,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -193,7 +193,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -250,7 +250,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -263,7 +263,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
                 "mgmt commit apply",
             ]
         }
@@ -303,7 +303,7 @@ def test_mgmt_commit_abort(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit abort",
             ]
         }
@@ -355,7 +355,7 @@ def test_mgmt_delete_config(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -671,7 +671,7 @@ def test_mgmt_chaos_stop_start_frr(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -747,7 +747,7 @@ def test_mgmt_chaos_kill_daemon(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }

--- a/tests/topotests/static_route_distance/r1/frr.conf
+++ b/tests/topotests/static_route_distance/r1/frr.conf
@@ -1,0 +1,11 @@
+interface r1-eth0
+  ip address 192.0.2.1/24
+  ipv6 address 2001:db8:0:1::1/64
+
+interface r1-eth1
+  ip address 198.51.100.1/24
+  ipv6 address 2001:db8:0:2::1/64
+
+interface r1-eth2
+  ip address 203.0.113.1/24
+  ipv6 address 2001:db8:0:3::1/64

--- a/tests/topotests/static_route_distance/test_static_route_apply_finish.py
+++ b/tests/topotests/static_route_distance/test_static_route_apply_finish.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test that apply_finish correctly batches NB per-leaf callbacks.
+
+The YANG path-list is keyed by nexthop identity (nh-type, vrf, gateway,
+interface); distance, metric, and tag are non-key leaf attributes.  The NB
+framework fires individual per-leaf callbacks (tag_modify, distance_modify,
+metric_modify) followed by apply_finish on the same path-list node once all
+leaf callbacks complete.
+
+apply_finish is the single installation point.  Per-leaf callbacks update
+in-memory state and set nh->state = STATIC_START when a reinstall is needed;
+apply_finish then calls static_install_nexthop() once per nexthop.
+
+Test cases:
+
+  1. Tag + metric combined: changing tag and metric in one command fires
+     tag_modify and metric_modify followed by a single apply_finish.  The
+     route must end up at the new (metric, tag) with the old metric entry
+     gone from the RIB.
+
+  2. Distance + metric combined: changing distance and metric together fires
+     distance_modify and metric_modify followed by one apply_finish.  The
+     route must move to the new (distance, metric) with no stale entry.
+
+  3. Tag + distance + metric combined: all three attributes change in one
+     command.  apply_finish fires once.  The route must reflect all three
+     new values with no stale entry.
+
+  4. Tag no-op + apply_finish: when tag_modify fires but the effective path
+     tag (pn->tag) does not change after static_path_recalc_tag(), the
+     no-op guard breaks early without setting nh->state = STATIC_START.
+     apply_finish still fires.  The route must remain correctly installed.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_attr_set(router, prefix, ipv6=False):
+    """Return set of (distance, metric, tag) tuples for all RIB entries."""
+    return {
+        (e.get("distance", 0), e.get("metric", 0), e.get("tag", 0))
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _route_tag(router, prefix, ipv6=False):
+    """Return the tag of the first RIB entry for prefix, or None if absent."""
+    entries = _route_entries(router, prefix, ipv6)
+    return entries[0].get("tag", 0) if entries else None
+
+
+def _active_nexthop_ips(router, prefix, ipv6=False):
+    """Return set of nexthop IPs from all RIB entries for prefix."""
+    result = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        for nh in entry.get("nexthops", []):
+            ip = nh.get("ip", "")
+            if ip:
+                result.add(ip)
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [line.strip() for line in output.splitlines() if keyword in line]
+
+
+def _check_attrs(router, prefix, expected, ipv6=False):
+    actual = _route_attr_set(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_tag(router, prefix, expected, ipv6=False):
+    actual = _route_tag(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_nhs(router, prefix, expected, ipv6=False):
+    actual = _active_nexthop_ips(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_attrs(router, prefix, expected, ipv6=False):
+    fn = functools.partial(_check_attrs, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(fn, None, count=15, wait=1)
+    return result
+
+
+def _expect_tag(router, prefix, expected, ipv6=False):
+    fn = functools.partial(_check_tag, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(fn, None, count=15, wait=1)
+    return result
+
+
+def _expect_nhs(router, prefix, expected, ipv6=False):
+    fn = functools.partial(_check_nhs, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(fn, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    fn = functools.partial(_check_running, router, prefix, expected_lines, ipv6)
+    _, result = topotest.run_and_expect(fn, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: tag + metric combined change
+# ---------------------------------------------------------------------------
+
+
+def run_tag_metric_combined(ipv6=False):
+    """
+    Changing tag and metric in one command fires tag_modify and metric_modify
+    followed by a single apply_finish.
+
+    Steps:
+      1. Install NH1 at distance 10, metric 100, tag 100.
+      2. Verify RIB has (dist=10, metric=100, tag=100).
+      3. Reconfigure NH1 with metric 200 and tag 200 (one command).
+      4. Verify RIB has (dist=10, metric=200, tag=200); old metric=100 is gone.
+      5. Verify running-config shows the updated entry.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100 tag 100\n"
+    )
+
+    # Step 2
+    result = _expect_attrs(r1, prefix, {(10, 100, 100)}, ipv6)
+    assert result is None, (
+        f"tag+metric combined [2]: expected {{(10,100,100)}}, got {result}"
+    )
+
+    # Step 3: change both tag and metric in one command
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200 tag 200\n"
+    )
+
+    # Step 4: new attrs present, old metric=100 entry gone
+    result = _expect_attrs(r1, prefix, {(10, 200, 200)}, ipv6)
+    assert result is None, (
+        f"tag+metric combined [4]: expected {{(10,200,200)}}, got {result}"
+    )
+
+    # Step 5: running-config
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 10 metric 200"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"tag+metric combined [5]: running-config mismatch; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 200 tag 200\n"
+    )
+    result = _expect_attrs(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"tag+metric combined [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_tag_metric_combined_ipv4():
+    "IPv4: tag and metric change together; tag_modify+metric_modify then one apply_finish."
+    run_tag_metric_combined(ipv6=False)
+
+
+def test_tag_metric_combined_ipv6():
+    "IPv6: tag and metric change together; tag_modify+metric_modify then one apply_finish."
+    run_tag_metric_combined(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: distance + metric combined change
+# ---------------------------------------------------------------------------
+
+
+def run_distance_metric_combined(ipv6=False):
+    """
+    Changing distance and metric in one command fires distance_modify and
+    metric_modify followed by a single apply_finish.
+
+    Steps:
+      1. Install NH1 at distance 10, metric 100.
+      2. Verify RIB has (dist=10, metric=100, tag=0).
+      3. Reconfigure NH1 at distance 20, metric 200 (one command).
+      4. Verify RIB has only (dist=20, metric=200, tag=0); old entry is gone.
+      5. Verify running-config shows the updated entry.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+
+    # Step 2
+    result = _expect_attrs(r1, prefix, {(10, 100, 0)}, ipv6)
+    assert result is None, (
+        f"dist+metric combined [2]: expected {{(10,100,0)}}, got {result}"
+    )
+
+    # Step 3: change distance and metric together
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20 metric 200\n")
+
+    # Step 4: new attrs present, old (dist=10, metric=100) entry gone
+    result = _expect_attrs(r1, prefix, {(20, 200, 0)}, ipv6)
+    assert result is None, (
+        f"dist+metric combined [4]: expected {{(20,200,0)}}, got {result}"
+    )
+
+    # Step 5: running-config
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 20 metric 200"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"dist+metric combined [5]: running-config mismatch; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 20 metric 200\n")
+    result = _expect_attrs(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"dist+metric combined [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_distance_metric_combined_ipv4():
+    "IPv4: distance and metric change together; distance_modify+metric_modify then one apply_finish."
+    run_distance_metric_combined(ipv6=False)
+
+
+def test_distance_metric_combined_ipv6():
+    "IPv6: distance and metric change together; distance_modify+metric_modify then one apply_finish."
+    run_distance_metric_combined(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: tag + distance + metric combined change
+# ---------------------------------------------------------------------------
+
+
+def run_tag_distance_metric_combined(ipv6=False):
+    """
+    Changing tag, distance, and metric in one command fires all three per-leaf
+    callbacks followed by a single apply_finish.
+
+    Steps:
+      1. Install NH1 at distance 10, metric 100, tag 100.
+      2. Verify RIB has (dist=10, metric=100, tag=100).
+      3. Reconfigure NH1 at distance 20, metric 200, tag 200 (one command).
+      4. Verify RIB has only (dist=20, metric=200, tag=200); old entry is gone.
+      5. Verify running-config shows the updated entry.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100 tag 100\n"
+    )
+
+    # Step 2
+    result = _expect_attrs(r1, prefix, {(10, 100, 100)}, ipv6)
+    assert result is None, (
+        f"tag+dist+metric [2]: expected {{(10,100,100)}}, got {result}"
+    )
+
+    # Step 3: change all three in one command
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 20 metric 200 tag 200\n"
+    )
+
+    # Step 4: new attrs present, old (dist=10, metric=100, tag=100) entry gone
+    result = _expect_attrs(r1, prefix, {(20, 200, 200)}, ipv6)
+    assert result is None, (
+        f"tag+dist+metric [4]: expected {{(20,200,200)}}, got {result}"
+    )
+
+    # Step 5: running-config
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 20 metric 200"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"tag+dist+metric [5]: running-config mismatch; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 20 metric 200 tag 200\n"
+    )
+    result = _expect_attrs(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"tag+dist+metric [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_tag_distance_metric_combined_ipv4():
+    "IPv4: tag, distance, and metric all change in one command; apply_finish fires once."
+    run_tag_distance_metric_combined(ipv6=False)
+
+
+def test_tag_distance_metric_combined_ipv6():
+    "IPv6: tag, distance, and metric all change in one command; apply_finish fires once."
+    run_tag_distance_metric_combined(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: tag no-op + apply_finish
+# ---------------------------------------------------------------------------
+
+
+def run_tag_noop_apply_finish(ipv6=False):
+    """
+    When tag_modify fires but pn->tag is unchanged after static_path_recalc_tag(),
+    the no-op guard breaks early without setting nh->state = STATIC_START.
+    apply_finish still fires and must leave the route correctly installed.
+
+    Setup: NH1 and NH2 share the same (distance, metric) ECMP path.
+    pn->tag is the maximum nh->tag across the group (max-wins).
+
+    Steps:
+      1. Install NH1 with tag 50 at distance 10.
+      2. Install NH2 with tag 100 at distance 10.
+         pn->tag = max(50, 100) = 100.
+      3. Verify both NH1 and NH2 are active ECMP nexthops with tag 100.
+      4. Reconfigure NH1 with tag 100 (matches the current pn->tag).
+         tag_modify fires for NH1: nh->tag updates 50 → 100; recalc gives
+         max(100, 100) = 100 (unchanged) → no-op guard breaks without
+         setting nh->state = STATIC_START.  apply_finish fires for NH1's
+         path-list entry.
+      5. Verify both NH1 and NH2 are still active with tag 100.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 at distance 10 with tag 50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 50\n")
+
+    # Step 2: NH2 at distance 10 with tag 100; max-wins → pn->tag = 100
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 tag 100\n")
+
+    # Step 3: both NH1 and NH2 active; path tag = 100
+    result = _expect_nhs(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"tag no-op [3]: expected both nexthops active, got {result}"
+    )
+    result = _expect_tag(r1, prefix, 100, ipv6)
+    assert result is None, f"tag no-op [3]: expected tag 100, got {result}"
+
+    # Step 4: raise NH1's tag to 100 (matches current max → no-op in tag_modify)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n")
+
+    # Step 5: both NH1 and NH2 still active with tag 100
+    result = _expect_nhs(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"tag no-op [5]: expected both nexthops active after no-op, got {result}"
+    )
+    result = _expect_tag(r1, prefix, 100, ipv6)
+    assert result is None, f"tag no-op [5]: expected tag 100 after no-op, got {result}"
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 tag 100\n"
+    )
+    result = _expect_attrs(r1, prefix, set(), ipv6)
+    assert result is None, f"tag no-op [cleanup]: RIB not empty; got {result}"
+
+
+def test_tag_noop_apply_finish_ipv4():
+    "IPv4: tag no-op (pn->tag unchanged) leaves apply_finish handling the nexthop correctly."
+    run_tag_noop_apply_finish(ipv6=False)
+
+
+def test_tag_noop_apply_finish_ipv6():
+    "IPv6: tag no-op (pn->tag unchanged) leaves apply_finish handling the nexthop correctly."
+    run_tag_noop_apply_finish(ipv6=True)

--- a/tests/topotests/static_route_distance/test_static_route_distance.py
+++ b/tests/topotests/static_route_distance/test_static_route_distance.py
@@ -1,0 +1,1300 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path administrative distance for static routes.
+
+Design: administrative distance, metric, and tag live in static_path, which
+is keyed by (table-id, distance, metric).  Tag is a modifiable leaf shared by
+all nexthops in a path.  Different distances or metrics produce separate path
+objects, enabling floating static routes (primary/backup) under a single
+prefix.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. AD replacement: reconfiguring the same nexthop with a new AD must
+     update the existing RIB entry in place (NB_OP_MODIFY) and remove the
+     stale old-distance zebra entry — not create a duplicate.
+
+  2. Floating static route: two nexthops at different ADs under the same
+     prefix; the lower-AD nexthop is active in the FIB and the higher-AD
+     standby is promoted when the primary is removed.
+
+  3. ECMP: two nexthops at the same AD are both active in the FIB.
+     Removing one ECMP member leaves the other active at the same AD.
+
+  4. ECMP with floating standby: primary ECMP group (NH1+NH2, AD 10) plus
+     a standby (NH3, AD 20).  Removing primaries one by one shrinks the
+     active group; the standby is promoted only when the last primary is
+     removed.
+
+  5. ECMP AD change (promote/demote): a nexthop moves in and out of the
+     ECMP group by having its AD changed — covering both promotion
+     (standby joins the ECMP group) and demotion (ECMP member becomes
+     standby), and re-promotion back into the group.
+
+  6. Delete standby only: deleting the standby nexthop must leave the
+     primary completely unaffected; the standby RIB entry is fully
+     withdrawn from zebra.
+
+  7. Delete primary then standby: deleting the primary promotes the
+     standby; deleting the standby fully withdraws the route from both
+     RIB and FIB.
+
+  8. Delete without distance and metric: deletion always uses a lazy search
+     keyed on nexthop identity; distance and metric arguments are ignored.
+     'no ip route X/M via Y' removes the route regardless of the configured
+     AD or metric.
+
+  9. ECMP validation — blackhole/non-blackhole mixing: adding a blackhole
+     (Null0) nexthop to a prefix that already has a non-blackhole nexthop
+     (or vice-versa) at the same (table-id, distance, metric) is rejected
+     at configuration time with an error; the route is left unchanged.
+
+ 10. ECMP validation — count limit: zebra is started with -e 2, so at most
+     two nexthops may share the same (table-id, distance, metric).  Adding a
+     third nexthop to an already-full ECMP group is rejected at configuration
+     time; the existing two-nexthop group is unaffected.
+
+ 11. ECMP count limit — distance modify: moving a nexthop into a full group
+     by changing its distance is rejected; the nexthop stays at its original
+     distance and the target group is unaffected.
+
+ 12. ECMP count limit — metric modify: same as 11, but via a metric change.
+
+ 13. Blackhole mixing — distance modify: moving a Null0 nexthop into a
+     non-blackhole group (or vice-versa) by changing its distance is
+     rejected; both groups are left unchanged.
+
+ 14. Blackhole mixing — metric modify: same as 13, but via a metric change.
+"""
+#
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+# Three nexthop addresses reachable via r1-eth0, eth1, eth2 respectively.
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        # Start zebra with -e 2 so that zebra_ecmp_count is 2.  This lets
+        # test 10 drive the ECMP count limit with the three nexthops available
+        # in the topology without needing an impractically large nexthop set.
+        # All other tests use at most two nexthops per ECMP group so -e 2 does
+        # not affect their correctness.
+        router.load_frr_config(
+            os.path.join(CWD, "r1/frr.conf"),
+            daemons=[(TopoRouter.RD_ZEBRA, "-e 2")],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _route_distances(router, prefix, ipv6=False):
+    """Return the set of administrative distances present in the RIB for prefix."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    if prefix not in json_data:
+        return set()
+    return {entry["distance"] for entry in json_data[prefix]}
+
+
+def _route_nexthops(router, prefix, ipv6=False):
+    """Return the set of nexthop IPs from the selected (best-path) route entry.
+
+    The nexthop-level 'fib' flag in the JSON output indicates whether the nexthop group is installed
+    in the kernel nexhop table — it can be true even for non-selected routes that
+    share a nexhop group.  The route-level 'selected' flag is the correct
+    indicator of which entry is the active best path.
+    """
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    if prefix not in json_data:
+        return set()
+    active = set()
+    for entry in json_data[prefix]:
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("active"):
+                active.add(nh.get("ip", nh.get("interfaceName", "")))
+    return active
+
+
+def _check_distances(router, prefix, expected, ipv6=False):
+    """Return None when RIB distances equal expected, else return the actual set."""
+    actual = _route_distances(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_route(router, prefix, expected, ipv6=False):
+    """Return None when active route nexthops equal expected, else return the actual set."""
+    actual = _route_nexthops(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_distances(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_distances, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_route(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_route, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return the list of static-route lines for prefix in 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    """Return None when running-config lines match expected_lines (as a set), else actual."""
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    expected = set(expected_lines)
+    return None if actual == expected else actual
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(
+        _check_running, router, prefix, expected_lines, ipv6
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test: AD replacement
+# ---------------------------------------------------------------------------
+
+def run_ad_replacement(ipv6=False):
+    """
+    Same nexthop reconfigured with a new AD must replace the old RIB entry
+    and leave running-config with exactly one entry at the new AD.
+
+    Steps:
+      1. Install route via NH1 at AD 10.
+      2. Reconfigure the same route via NH1 at AD 20.
+      3. Verify only AD 20 is present in RIB; AD 10 entry is gone.
+      4. Verify running-config shows exactly 'ip route ... NH1 20', not the old '... 10'.
+      5. Clean up; verify running-config is empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"AD replacement [1]: expected {{10}}, got {result}"
+
+    # Step 2: same nexthop, new AD — must replace, not duplicate
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_distances(r1, prefix, {20}, ipv6)
+    assert result is None, (
+        f"AD replacement [2]: stale AD 10 present or AD 20 missing; got {result}"
+    )
+
+    # Step 3: running-config must show exactly one entry at AD 20, not AD 10
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"AD replacement [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"AD replacement [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"AD replacement [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ad_replacement_ipv4():
+    "Same IPv4 nexthop reconfigured with new AD replaces old RIB entry."
+    run_ad_replacement(ipv6=False)
+
+
+def test_ad_replacement_ipv6():
+    "Same IPv6 nexthop reconfigured with new AD replaces old RIB entry."
+    run_ad_replacement(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: floating static route (two different nexthops, different ADs)
+# ---------------------------------------------------------------------------
+
+def run_floating_static(ipv6=False):
+    """
+    Two nexthops under the same prefix with independent ADs.
+
+    Steps:
+      1. Install primary NH1 at AD 10 and standby NH2 at AD 20.
+      2. Verify NH1 is active in FIB (lower AD wins).
+      3. Remove NH1; verify NH2 is promoted to active.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Floating static [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: lower-AD nexthop active
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, f"Floating static [2]: expected {nh1} active, got {result}"
+
+    # Step 3: remove primary → standby promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Floating static [3]: expected {nh2} active after primary removed, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"Floating static [cleanup]: route not removed; got {result}"
+
+
+def test_floating_static_ipv4():
+    "IPv4 floating static: lower-AD nexthop active, standby promoted on primary removal."
+    run_floating_static(ipv6=False)
+
+
+def test_floating_static_ipv6():
+    "IPv6 floating static: lower-AD nexthop active, standby promoted on primary removal."
+    run_floating_static(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP (multiple nexthops at the same AD)
+# ---------------------------------------------------------------------------
+
+def run_ecmp(ipv6=False):
+    """
+    Two nexthops at the same AD are both active in the FIB (ECMP).
+    Removing one ECMP member leaves the remaining one active.
+
+    Steps:
+      1. Install NH1 and NH2 both at AD 10.
+      2. Verify both are active in FIB.
+      3. Remove NH1; verify NH2 remains active at AD 10.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"ECMP [1]: expected single AD {{10}}, got {result}"
+
+    # Step 2: both nexthops active (ECMP)
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, f"ECMP [2]: expected both {nh1},{nh2} active, got {result}"
+
+    # Step 3: remove one ECMP member
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP [3]: expected only {nh2} active after {nh1} removed, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"ECMP [3]: AD should still be {{10}}, got {result}"
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_ipv4():
+    "IPv4 ECMP: two nexthops at same AD both active; removing one leaves the other."
+    run_ecmp(ipv6=False)
+
+
+def test_ecmp_ipv6():
+    "IPv6 ECMP: two nexthops at same AD both active; removing one leaves the other."
+    run_ecmp(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP with floating standby
+# ---------------------------------------------------------------------------
+
+def run_ecmp_with_standby(ipv6=False):
+    """
+    ECMP primary group (NH1+NH2 at AD 10) plus a floating standby (NH3 at AD 20).
+
+    Steps:
+      1. Install NH1, NH2 at AD 10 and NH3 at AD 20.
+      2. Verify NH1 and NH2 are active (ECMP); NH3 is in RIB but not FIB.
+      3. Remove NH1; verify NH2 is the sole active nexhop at AD 10.
+         NH3 remains standby (still not in FIB).
+      4. Remove NH2 (last primary); verify NH3 is promoted to active.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: ECMP primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+        f"ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"ECMP+standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: NH1+NH2 active (ECMP), NH3 standby (not in FIB)
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [2]: expected {nh1},{nh2} active (ECMP), got {result}"
+    )
+
+    # Step 3: remove NH1 — NH2 sole primary, NH3 still standby
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected only {nh2} active, NH3 still standby, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected {{10,20}} in RIB, got {result}"
+    )
+
+    # Step 4: remove last primary NH2 — standby NH3 promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_route(r1, prefix, {nh3}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [4]: expected {nh3} promoted after all primaries removed, got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh3} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP+standby [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_with_standby_ipv4():
+    "IPv4 ECMP primary group with floating standby; standby promoted when all primaries removed."
+    run_ecmp_with_standby(ipv6=False)
+
+
+def test_ecmp_with_standby_ipv6():
+    "IPv6 ECMP primary group with floating standby; standby promoted when all primaries removed."
+    run_ecmp_with_standby(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: promote/demote nexthops by changing AD
+# ---------------------------------------------------------------------------
+
+def run_ecmp_ad_change(ipv6=False):
+    """
+    A nexthop moves in and out of the ECMP group by having its AD changed.
+
+    Steps:
+      1. NH1 at AD 10 (sole primary), NH2 at AD 20 (standby).
+         Verify NH1 active, NH2 not in FIB.
+      2. Change NH2 AD 20 → 10: NH2 joins the ECMP group.
+         Verify both NH1 and NH2 active; only AD 10 in RIB (AD 20 gone).
+      3. Change NH1 AD 10 → 20: NH1 leaves the ECMP group and becomes standby.
+         Verify NH2 sole primary at AD 10; NH1 standby at AD 20.
+      4. Change NH1 AD 20 → 10: NH1 rejoins the ECMP group.
+         Verify both NH1 and NH2 active again at AD 10.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 primary at AD 10, NH2 standby at AD 20
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, f"ECMP AD change [1]: expected only {nh1} active, got {result}"
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"ECMP AD change [1]: expected {{10,20}} in RIB, got {result}"
+
+    # Step 2: promote NH2 into ECMP group (AD 20 → 10)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [2]: expected both {nh1},{nh2} active after NH2 promoted, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [2]: stale AD 20 still present after NH2 promoted, got {result}"
+    )
+    # running-config: both nexthops at AD 10, no stale AD 20 entry
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} 10",
+         f"ip{ip_ver} route {prefix} {nh2} 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [2]: running-config mismatch after NH2 promoted; got {result}"
+    )
+
+    # Step 3: demote NH1 to standby (AD 10 → 20)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [3]: expected only {nh2} active after NH1 demoted, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [3]: expected {{10,20}} in RIB after NH1 demoted, got {result}"
+    )
+    # running-config: NH2 at AD 10 (primary), NH1 at AD 20 (standby), no duplicate
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh2} 10",
+         f"ip{ip_ver} route {prefix} {nh1} 20"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [3]: running-config mismatch after NH1 demoted; got {result}"
+    )
+
+    # Step 4: NH1 rejoins ECMP group (AD 20 → 10)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [4]: expected both {nh1},{nh2} active after NH1 rejoined, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [4]: stale AD 20 still present after NH1 rejoined, got {result}"
+    )
+    # running-config: both nexthops at AD 10, no stale AD 20 entry
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} 10",
+         f"ip{ip_ver} route {prefix} {nh2} 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [4]: running-config mismatch after NH1 rejoined; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP AD change [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"ECMP AD change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ecmp_ad_change_ipv4():
+    "IPv4: nexthop moves in and out of ECMP group by changing its AD."
+    run_ecmp_ad_change(ipv6=False)
+
+
+def test_ecmp_ad_change_ipv6():
+    "IPv6: nexthop moves in and out of ECMP group by changing its AD."
+    run_ecmp_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: targeted deletion scenarios
+# ---------------------------------------------------------------------------
+
+def run_delete_standby(ipv6=False):
+    """
+    Deleting the standby nexhop must not affect the active primary.
+
+    Steps:
+      1. NH1 at AD 10 (primary), NH2 at AD 20 (standby).
+      2. Delete NH2 (standby only).
+      3. Verify NH1 still active; AD 20 entry completely gone from RIB.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Delete standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: delete standby only
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+
+    # Step 3: primary unaffected; standby RIB entry completely withdrawn
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"Delete standby [3]: expected only {{10}} in RIB after standby deleted, got {result}"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Delete standby [3]: primary {nh1} should still be active, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"Delete standby [cleanup]: route not fully removed, got {result}"
+
+
+def run_delete_primary_then_standby(ipv6=False):
+    """
+    Delete primary first (standby takes over), then delete standby; route must
+    be completely withdrawn from RIB and FIB after the last nexhop is removed.
+
+    Steps:
+      1. NH1 at AD 10 (primary), NH2 at AD 20 (standby).
+      2. Delete NH1; verify NH2 promoted and AD 10 entry gone.
+      3. Delete NH2; verify route is completely gone from RIB and FIB.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Delete primary+standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: delete primary — standby promoted, AD 10 entry gone
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, {20}, ipv6)
+    assert result is None, (
+        f"Delete primary+standby [2]: expected only {{20}} after primary deleted, got {result}"
+    )
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Delete primary+standby [2]: expected {nh2} promoted to active, got {result}"
+    )
+
+    # Step 3: delete standby — route fully withdrawn
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete primary+standby [3]: route should be fully gone, got {result}"
+    )
+    result = _expect_route(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete primary+standby [3]: FIB entry should be gone, got {result}"
+    )
+
+
+def test_delete_standby_ipv4():
+    "IPv4: deleting the standby nexhop leaves the primary completely unaffected."
+    run_delete_standby(ipv6=False)
+
+
+def test_delete_standby_ipv6():
+    "IPv6: deleting the standby nexhop leaves the primary completely unaffected."
+    run_delete_standby(ipv6=True)
+
+
+def test_delete_primary_then_standby_ipv4():
+    "IPv4: delete primary (standby promoted), then delete standby (route fully withdrawn)."
+    run_delete_primary_then_standby(ipv6=False)
+
+
+def test_delete_primary_then_standby_ipv6():
+    "IPv6: delete primary (standby promoted), then delete standby (route fully withdrawn)."
+    run_delete_primary_then_standby(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: deletion without specifying distance
+# ---------------------------------------------------------------------------
+
+def run_delete_without_distance(ipv6=False):
+    """
+    Deletion always uses a lazy search keyed on nexthop identity; distance and
+    metric arguments are ignored.  'no ip route X/M via Y' finds and removes
+    the nexthop regardless of what AD or metric was configured.
+
+    Steps:
+      1. Install route via NH1 at non-default AD 50.
+      2. Delete using 'no ip route X/M via NH1' with no distance specified.
+      3. Verify route is completely gone.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at non-default AD 50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 50\n")
+    result = _expect_distances(r1, prefix, {50}, ipv6)
+    assert result is None, f"Delete without distance [1]: expected {{50}}, got {result}"
+
+    # Step 2: delete without specifying distance
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+
+    # Step 3: route must be gone from RIB and running-config
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete without distance [3]: AD 50 route not removed without distance; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Delete without distance [3]: stale running-config entry after delete; got {result}"
+    )
+
+
+def test_delete_without_distance_ipv4():
+    "IPv4: 'no ip route X/M via Y' removes route regardless of configured AD or metric."
+    run_delete_without_distance(ipv6=False)
+
+
+def test_delete_without_distance_ipv6():
+    "IPv6: 'no ip route X/M via Y' removes route regardless of configured AD or metric."
+    run_delete_without_distance(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP validation — blackhole/non-blackhole mixing
+# ---------------------------------------------------------------------------
+
+def run_ecmp_blackhole_mixing(ipv6=False):
+    """
+    Adding a blackhole nexthop to a route that already has a non-blackhole
+    nexthop at the same (table-id, distance, metric) must be rejected at
+    configuration time; the route is left unchanged.
+
+    Steps:
+      1. Install a regular route via NH1.
+      2. Attempt to add a Null0 (blackhole) nexthop for the same prefix at
+         the same implicit (distance=1, metric=0).  The commit must fail.
+      3. Verify that "% Configuration failed" appears in the VTY output.
+      4. Verify that the Null0 nexthop is absent from running-config.
+      5. Verify that the original NH1 route is still active.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install a regular route via NH1 (distance=1, metric=0)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1}\n")
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Blackhole mixing [1]: expected {nh1} active, got {result}"
+    )
+
+    # Step 2: attempt to add a Null0 nexthop — must be rejected
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip{ip_ver} route {prefix} Null0\n"
+    )
+
+    # Step 3: VTY must report a configuration failure
+    assert "% Configuration failed" in output, (
+        f"Blackhole mixing [3]: expected config failure, got: {output!r}"
+    )
+
+    # Step 4: Null0 must not appear in running-config
+    running = _running_config_routes(r1, prefix, ipv6)
+    assert not any("Null0" in line for line in running), (
+        f"Blackhole mixing [4]: Null0 unexpectedly in running-config: {running}"
+    )
+
+    # Step 5: original NH1 route must still be active
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Blackhole mixing [5]: expected {nh1} still active, got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Blackhole mixing [cleanup]: route not removed; got {result}"
+    )
+
+
+def test_ecmp_blackhole_mixing_ipv4():
+    "IPv4: adding Null0 to a non-blackhole route at same distance/metric is rejected."
+    run_ecmp_blackhole_mixing(ipv6=False)
+
+
+def test_ecmp_blackhole_mixing_ipv6():
+    "IPv6: adding Null0 to a non-blackhole route at same distance/metric is rejected."
+    run_ecmp_blackhole_mixing(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP validation — count limit (zebra started with -e 2)
+# ---------------------------------------------------------------------------
+
+def run_ecmp_count_limit(ipv6=False):
+    """
+    With zebra_ecmp_count=2 (zebra -e 2), a third nexthop at the same
+    (table-id, distance, metric) is rejected at configuration time.
+    The existing two-nexthop ECMP group is unaffected.
+
+    Steps:
+      1. Install NH1 and NH2 at the same implicit (distance=1, metric=0).
+         Both must succeed (count=2 == limit).
+      2. Attempt to add NH3 at the same (distance, metric).
+         The commit must fail (count would be 3 > 2).
+      3. Verify "% Configuration failed" is in the VTY output.
+      4. Verify NH3 is absent from running-config.
+      5. Verify both NH1 and NH2 are still active (ECMP group intact).
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops — must succeed (fills the ECMP group exactly)
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1}\n"
+        f"ip{ip_ver} route {prefix} {nh2}\n"
+    )
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP count limit [1]: expected {nh1},{nh2} active, got {result}"
+    )
+
+    # Step 2: third nexthop — must be rejected (would exceed the limit of 2)
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip{ip_ver} route {prefix} {nh3}\n"
+    )
+
+    # Step 3: VTY must report a configuration failure
+    assert "% Configuration failed" in output, (
+        f"ECMP count limit [3]: expected config failure, got: {output!r}"
+    )
+
+    # Step 4: NH3 must not appear in running-config
+    running = _running_config_routes(r1, prefix, ipv6)
+    assert not any(nh3 in line for line in running), (
+        f"ECMP count limit [4]: {nh3} unexpectedly in running-config: {running}"
+    )
+
+    # Step 5: original ECMP group (NH1+NH2) must still be active
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP count limit [5]: expected {nh1},{nh2} still active, got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1}\n"
+        f"no ip{ip_ver} route {prefix} {nh2}\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"ECMP count limit [cleanup]: route not removed; got {result}"
+    )
+
+
+def test_ecmp_count_limit_ipv4():
+    "IPv4: a third nexthop in a full ECMP group (limit=2) is rejected at config time."
+    run_ecmp_count_limit(ipv6=False)
+
+
+def test_ecmp_count_limit_ipv6():
+    "IPv6: a third nexthop in a full ECMP group (limit=2) is rejected at config time."
+    run_ecmp_count_limit(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP count limit enforced when distance is modified
+# ---------------------------------------------------------------------------
+
+def run_ecmp_count_limit_distance_modify(ipv6=False):
+    """
+    Moving a nexthop into a full ECMP group by changing its distance must
+    be rejected.  The existing group and the nexthop being moved must be
+    left unchanged.
+
+    Steps:
+      1. Install NH1 and NH2 at AD=10 (fills the group; count=2=limit).
+      2. Install NH3 at AD=20 (a separate group; succeeds).
+      3. Attempt to change NH3's distance to AD=10.  The commit must fail
+         because the target group already has 2 nexthops.
+      4. Verify "% Configuration failed" in VTY output.
+      5. Verify NH3 is still present at AD=20 in running-config.
+      6. Verify NH1 and NH2 are still active at AD=10.
+      7. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1+2: fill AD=10 group, add NH3 at AD=20
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+        f"ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Count limit distance modify [1]: expected {nh1},{nh2} active, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"Count limit distance modify [2]: expected distances {{10,20}}, got {result}"
+    )
+
+    # Step 3: try to move NH3 into the full AD=10 group
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip{ip_ver} route {prefix} {nh3} 10\n"
+    )
+
+    # Step 4: must fail
+    assert "% Configuration failed" in output, (
+        f"Count limit distance modify [4]: expected config failure, got: {output!r}"
+    )
+
+    # Step 5: NH3 must still be at AD=20 in running-config
+    running = _running_config_routes(r1, prefix, ipv6)
+    nh3_lines = [l for l in running if nh3 in l]
+    assert any(f"{nh3} 20" in l for l in nh3_lines), (
+        f"Count limit distance modify [5]: NH3 not at AD=20 in running-config: {running}"
+    )
+    assert not any(f"{nh3} 10" in l for l in nh3_lines), (
+        f"Count limit distance modify [5]: NH3 unexpectedly at AD=10: {running}"
+    )
+
+    # Step 6: ECMP group at AD=10 intact
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Count limit distance modify [6]: expected {nh1},{nh2} still active, got {result}"
+    )
+
+    # Step 7: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10\n"
+        f"no ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Count limit distance modify [cleanup]: route not removed; got {result}"
+    )
+
+
+def test_ecmp_count_limit_distance_modify_ipv4():
+    "IPv4: moving a nexthop into a full ECMP group via distance change is rejected."
+    run_ecmp_count_limit_distance_modify(ipv6=False)
+
+
+def test_ecmp_count_limit_distance_modify_ipv6():
+    "IPv6: moving a nexthop into a full ECMP group via distance change is rejected."
+    run_ecmp_count_limit_distance_modify(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP count limit enforced when metric is modified
+# ---------------------------------------------------------------------------
+
+def run_ecmp_count_limit_metric_modify(ipv6=False):
+    """
+    Moving a nexthop into a full ECMP group by changing its metric must
+    be rejected.
+
+    Steps:
+      1. Install NH1 and NH2 at metric=0 (fills the group; count=2=limit).
+      2. Install NH3 at metric=100 (a separate group; succeeds).
+      3. Attempt to change NH3's metric to 0.  The commit must fail.
+      4. Verify "% Configuration failed" in VTY output.
+      5. Verify NH3 is still at metric=100 in running-config.
+      6. Verify NH1 and NH2 are still active.
+      7. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1+2: fill metric=0 group, add NH3 at metric=100
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1}\n"
+        f"ip{ip_ver} route {prefix} {nh2}\n"
+        f"ip{ip_ver} route {prefix} {nh3} metric 100\n"
+    )
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Count limit metric modify [1]: expected {nh1},{nh2} active, got {result}"
+    )
+
+    # Step 3: try to move NH3 into the full metric=0 group
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip{ip_ver} route {prefix} {nh3}\n"
+    )
+
+    # Step 4: must fail
+    assert "% Configuration failed" in output, (
+        f"Count limit metric modify [4]: expected config failure, got: {output!r}"
+    )
+
+    # Step 5: NH3 must still show metric=100 in running-config
+    running = _running_config_routes(r1, prefix, ipv6)
+    nh3_lines = [l for l in running if nh3 in l]
+    assert any("metric 100" in l for l in nh3_lines), (
+        f"Count limit metric modify [5]: NH3 not at metric=100 in running-config: {running}"
+    )
+
+    # Step 6: ECMP group at metric=0 intact
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Count limit metric modify [6]: expected {nh1},{nh2} still active, got {result}"
+    )
+
+    # Step 7: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1}\n"
+        f"no ip{ip_ver} route {prefix} {nh2}\n"
+        f"no ip{ip_ver} route {prefix} {nh3} metric 100\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Count limit metric modify [cleanup]: route not removed; got {result}"
+    )
+
+
+def test_ecmp_count_limit_metric_modify_ipv4():
+    "IPv4: moving a nexthop into a full ECMP group via metric change is rejected."
+    run_ecmp_count_limit_metric_modify(ipv6=False)
+
+
+def test_ecmp_count_limit_metric_modify_ipv6():
+    "IPv6: moving a nexthop into a full ECMP group via metric change is rejected."
+    run_ecmp_count_limit_metric_modify(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: blackhole mixing enforced when distance is modified
+# ---------------------------------------------------------------------------
+
+def run_ecmp_blackhole_mixing_distance_modify(ipv6=False):
+    """
+    Moving a blackhole nexthop into a group with non-blackhole nexthops
+    by changing its distance must be rejected, and vice-versa.
+
+    Steps:
+      1. Install NH1 (non-blackhole) at AD=10.
+      2. Install Null0 at AD=20.
+      3. Attempt to change Null0's distance to AD=10.  Must fail.
+      4. Verify "% Configuration failed" in VTY output.
+      5. Verify Null0 is still at AD=20 in running-config.
+      6. Verify NH1 is still active at AD=10.
+      7. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1+2
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} Null0 20\n"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Blackhole mixing distance modify [1]: expected {nh1} active, got {result}"
+    )
+
+    # Step 3: try to move Null0 into the non-blackhole AD=10 group
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip{ip_ver} route {prefix} Null0 10\n"
+    )
+
+    # Step 4: must fail
+    assert "% Configuration failed" in output, (
+        f"Blackhole mixing distance modify [4]: expected config failure, got: {output!r}"
+    )
+
+    # Step 5: Null0 must still be at AD=20
+    running = _running_config_routes(r1, prefix, ipv6)
+    null0_lines = [l for l in running if "Null0" in l]
+    assert any("Null0 20" in l for l in null0_lines), (
+        f"Blackhole mixing distance modify [5]: Null0 not at AD=20: {running}"
+    )
+    assert not any("Null0 10" in l for l in null0_lines), (
+        f"Blackhole mixing distance modify [5]: Null0 moved to AD=10: {running}"
+    )
+
+    # Step 6: NH1 still active
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Blackhole mixing distance modify [6]: expected {nh1} active, got {result}"
+    )
+
+    # Step 7: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"no ip{ip_ver} route {prefix} Null0 20\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Blackhole mixing distance modify [cleanup]: route not removed; got {result}"
+    )
+
+
+def test_ecmp_blackhole_mixing_distance_modify_ipv4():
+    "IPv4: moving Null0 into a non-blackhole group via distance change is rejected."
+    run_ecmp_blackhole_mixing_distance_modify(ipv6=False)
+
+
+def test_ecmp_blackhole_mixing_distance_modify_ipv6():
+    "IPv6: moving Null0 into a non-blackhole group via distance change is rejected."
+    run_ecmp_blackhole_mixing_distance_modify(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: blackhole mixing enforced when metric is modified
+# ---------------------------------------------------------------------------
+
+def run_ecmp_blackhole_mixing_metric_modify(ipv6=False):
+    """
+    Moving a blackhole nexthop into a group with non-blackhole nexthops
+    by changing its metric must be rejected.
+
+    Steps:
+      1. Install NH1 (non-blackhole) at metric=0.
+      2. Install Null0 at metric=100.
+      3. Attempt to change Null0's metric to 0.  Must fail.
+      4. Verify "% Configuration failed" in VTY output.
+      5. Verify Null0 is still at metric=100 in running-config.
+      6. Verify NH1 is still active.
+      7. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1+2
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1}\n"
+        f"ip{ip_ver} route {prefix} Null0 metric 100\n"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Blackhole mixing metric modify [1]: expected {nh1} active, got {result}"
+    )
+
+    # Step 3: try to move Null0 into the non-blackhole metric=0 group
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip{ip_ver} route {prefix} Null0\n"
+    )
+
+    # Step 4: must fail
+    assert "% Configuration failed" in output, (
+        f"Blackhole mixing metric modify [4]: expected config failure, got: {output!r}"
+    )
+
+    # Step 5: Null0 must still be at metric=100
+    running = _running_config_routes(r1, prefix, ipv6)
+    null0_lines = [l for l in running if "Null0" in l]
+    assert any("metric 100" in l for l in null0_lines), (
+        f"Blackhole mixing metric modify [5]: Null0 not at metric=100: {running}"
+    )
+
+    # Step 6: NH1 still active
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Blackhole mixing metric modify [6]: expected {nh1} active, got {result}"
+    )
+
+    # Step 7: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1}\n"
+        f"no ip{ip_ver} route {prefix} Null0 metric 100\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Blackhole mixing metric modify [cleanup]: route not removed; got {result}"
+    )
+
+
+def test_ecmp_blackhole_mixing_metric_modify_ipv4():
+    "IPv4: moving Null0 into a non-blackhole group via metric change is rejected."
+    run_ecmp_blackhole_mixing_metric_modify(ipv6=False)
+
+
+def test_ecmp_blackhole_mixing_metric_modify_ipv6():
+    "IPv6: moving Null0 into a non-blackhole group via metric change is rejected."
+    run_ecmp_blackhole_mixing_metric_modify(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/static_route_distance/test_static_route_metric.py
+++ b/tests/topotests/static_route_distance/test_static_route_metric.py
@@ -1,0 +1,893 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path metric for static routes.
+
+Design: metric is a non-key path-list attribute; the path-list is keyed by
+nexthop identity (table-id, nh-type, gateway, interface, vrf).  Nexthops
+sharing the same (table-id, distance, metric) tuple form one ECMP group.
+Zebra keeps separate route_entry objects for routes with the same
+(type, instance, distance) but different metrics because rib_compare_routes()
+treats static routes with different metrics as non-equal, and the
+process_subq_early_route_delete() loop skips entries whose metric does not
+match the delete request.  Zebra selects the lower-metric entry as best —
+enabling metric-based floating routes within the same administrative distance.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. Metric replacement: reconfiguring the same nexthop with a new metric
+     must update the existing RIB entry (including the active metric value
+     reported by zebra) and remove the stale old-metric entry — not
+     duplicate it.
+
+  2. ECMP at same (distance, metric): two nexthops with matching distance
+     and metric are both active in the FIB.  Removing one leaves the other
+     active at the same (distance, metric).
+
+  3. Metric-based floating within same distance: NH1@(AD=10, metric=100)
+     and NH2@(AD=10, metric=200) are kept as separate RIB entries; the lower
+     metric wins in zebra.  Removing NH1 promotes NH2.
+
+  4. Metric change (promote/demote): a nexthop moves in and out of the
+     ECMP group by having its metric changed — covering both promotion
+     (standby joins ECMP group) and demotion (ECMP member becomes standby),
+     and re-promotion back into the group.
+
+  5. Nexthop-identity deletion: deletion always uses a lazy search keyed on
+     nexthop identity (gateway address, interface, or blackhole type);
+     distance and metric arguments are ignored.  Any form of 'no ip route
+     X/M via Y' removes the route regardless of which distance or metric it
+     was installed with.  A two-nexthop scenario verifies that deleting one
+     nexthop leaves the other intact — exercising zebra's delete-lookup loop
+     metric check (rib_compare_routes / process_subq_early_route_delete).
+
+  6. Running-config format: metric appears after distance in the
+     'show running-config' output; distance=default is omitted; metric=0
+     is omitted.
+
+  7. ECMP primaries + metric-based standby: NH1 and NH2 at metric=100 form
+     an ECMP primary group; NH3 at metric=200 is the standby.  Removing NH1
+     shrinks the ECMP group to NH2 alone without promoting NH3.  Removing NH2
+     (the last primary) promotes NH3 to active.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_keys(router, prefix, ipv6=False):
+    """Return set of (distance, metric) tuples present in the RIB for prefix."""
+    return {
+        (e.get("distance", 0), e.get("metric", 0))
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _active_nexthops(router, prefix, ipv6=False):
+    """Return set of nexthop IPs from the selected (best-path) route entry."""
+    active = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("active"):
+                active.add(nh.get("ip", nh.get("interfaceName", "")))
+    return active
+
+
+def _active_metric(router, prefix, ipv6=False):
+    """Return the metric of the selected (best-path) RIB entry, or None if absent."""
+    for entry in _route_entries(router, prefix, ipv6):
+        if entry.get("selected"):
+            return entry.get("metric", 0)
+    return None
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_keys(router, prefix, expected, ipv6=False):
+    actual = _route_keys(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_nexthops(router, prefix, expected, ipv6=False):
+    actual = _active_nexthops(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_metric(router, prefix, expected, ipv6=False):
+    actual = _active_metric(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_keys(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_keys, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_nexthops(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_nexthops, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_metric(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_metric, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(_check_running, router, prefix, expected_lines, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Metric replacement
+# ---------------------------------------------------------------------------
+
+
+def run_metric_replacement(ipv6=False):
+    """
+    Same nexthop reconfigured with a new metric must replace the old RIB
+    entry and leave running-config with exactly one entry at the new metric.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100).
+      2. Reconfigure NH1 at (AD=10, metric=200) — must replace, not duplicate.
+      3. Verify only (10, 200) is in RIB; (10, 100) entry is gone.
+      4. Verify running-config shows '... NH1 10 metric 200', not 'metric 100'.
+      5. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at (AD=10, metric=100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric replacement [1]: expected {{(10,100)}}, got {result}"
+
+    # Step 2: same nexthop, new metric — must replace, not duplicate
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, {(10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric replacement [2]: stale metric 100 present or metric 200 missing; got {result}"
+    )
+
+    # Verify zebra reports the updated metric value
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"Metric replacement [2]: active metric should be 200 in RIB; got {result}"
+    )
+
+    # Step 3: running-config shows exactly one entry at metric 200
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 10 metric 200"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Metric replacement [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric replacement [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric replacement [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_metric_replacement_ipv4():
+    "IPv4: same nexthop reconfigured with new metric replaces old RIB entry."
+    run_metric_replacement(ipv6=False)
+
+
+def test_metric_replacement_ipv6():
+    "IPv6: same nexthop reconfigured with new metric replaces old RIB entry."
+    run_metric_replacement(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: ECMP at same (distance, metric)
+# ---------------------------------------------------------------------------
+
+
+def run_ecmp_same_metric(ipv6=False):
+    """
+    Two nexthops at the same (distance, metric) are both active in the FIB.
+    Removing one ECMP member leaves the other active at the same (distance, metric).
+
+    Steps:
+      1. Install NH1 and NH2 both at (AD=10, metric=100).
+      2. Verify both are active (ECMP); only one (10, 100) entry in RIB.
+      3. Remove NH1; verify NH2 remains active at (10, 100).
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same (AD, metric)
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 100\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"ECMP same metric [1]: expected {{(10,100)}}, got {result}"
+
+    # Step 2: both nexthops active (ECMP)
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [2]: expected both {nh1},{nh2} active, got {result}"
+    )
+
+    # Step 3: remove one ECMP member
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [3]: expected only {nh2} active after {nh1} removed, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [3]: RIB key should still be {{(10,100)}}, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP same metric [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_same_metric_ipv4():
+    "IPv4 ECMP: two nexthops at same (distance, metric) both active; removing one leaves the other."
+    run_ecmp_same_metric(ipv6=False)
+
+
+def test_ecmp_same_metric_ipv6():
+    "IPv6 ECMP: two nexthops at same (distance, metric) both active; removing one leaves the other."
+    run_ecmp_same_metric(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Metric-based floating within same distance
+# ---------------------------------------------------------------------------
+
+
+def run_metric_floating(ipv6=False):
+    """
+    Two nexthops at the same distance but different metrics are kept as
+    separate RIB entries (ZEBRA_FLAG_RR_USE_METRIC).  Zebra selects the
+    lower-metric path as best; the higher-metric path is standby.
+    Removing the primary promotes the standby.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100) and NH2 at (AD=10, metric=200).
+      2. Verify RIB has both keys; NH1 is active (lower metric wins).
+      3. Remove NH1; verify NH2 is promoted to active.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary (lower metric) + standby (higher metric), same distance
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric floating [1]: expected {{(10,100),(10,200)}}, got {result}"
+    )
+
+    # Step 2: lower-metric nexthop is active
+    result = _expect_nexthops(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Metric floating [2]: expected {nh1} active (lower metric), got {result}"
+    )
+    result = _expect_metric(r1, prefix, 100, ipv6)
+    assert result is None, (
+        f"Metric floating [2]: expected active metric=100, got {result}"
+    )
+
+    # Step 3: remove primary → standby promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Metric floating [3]: expected {nh2} promoted after {nh1} removed, got {result}"
+    )
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"Metric floating [3]: expected active metric=200 after promotion, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric floating [cleanup]: route not removed; got {result}"
+
+
+def test_metric_floating_ipv4():
+    "IPv4: NH at lower metric active; higher-metric NH is standby and promoted on primary removal."
+    run_metric_floating(ipv6=False)
+
+
+def test_metric_floating_ipv6():
+    "IPv6: NH at lower metric active; higher-metric NH is standby and promoted on primary removal."
+    run_metric_floating(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Metric change (promote/demote)
+# ---------------------------------------------------------------------------
+
+
+def run_metric_change(ipv6=False):
+    """
+    A nexthop moves in and out of the ECMP group by having its metric changed.
+
+    Steps:
+      1. NH1 at (AD=10, metric=100) sole primary; NH2 at (AD=10, metric=200) standby.
+         Verify NH1 active, NH2 not.
+      2. Change NH2 metric=200 → 100: NH2 joins the ECMP group.
+         Verify both NH1 and NH2 active; only (10,100) in RIB (old (10,200) gone).
+      3. Change NH1 metric=100 → 200: NH1 demoted to standby.
+         Verify NH2 sole primary at (10,100); NH1 standby at (10,200).
+      4. Change NH1 metric=200 → 100: NH1 rejoins ECMP group.
+         Verify both NH1 and NH2 active at (10,100).
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 primary at metric=100, NH2 standby at metric=200
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_nexthops(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Metric change [1]: expected only {nh1} active, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric change [1]: expected {{(10,100),(10,200)}} in RIB, got {result}"
+    )
+
+    # Step 2: promote NH2 into ECMP group (metric=200 → 100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [2]: expected both {nh1},{nh2} active after NH2 promoted, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric change [2]: stale (10,200) still present after NH2 promoted, got {result}"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} 10 metric 100",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Metric change [2]: running-config mismatch after NH2 promoted; got {result}"
+    )
+
+    # Step 3: demote NH1 to standby (metric=100 → 200)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [3]: expected only {nh2} active after NH1 demoted, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric change [3]: expected {{(10,100),(10,200)}} in RIB after NH1 demoted, got {result}"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh2} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 200",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Metric change [3]: running-config mismatch after NH1 demoted; got {result}"
+    )
+
+    # Step 4: NH1 rejoins ECMP group (metric=200 → 100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [4]: expected both {nh1},{nh2} active after NH1 rejoined, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric change [4]: stale (10,200) still present after NH1 rejoined, got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 metric 100\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric change [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_metric_change_ipv4():
+    "IPv4: nexthop moves in and out of ECMP group by changing its metric."
+    run_metric_change(ipv6=False)
+
+
+def test_metric_change_ipv6():
+    "IPv6: nexthop moves in and out of ECMP group by changing its metric."
+    run_metric_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Metric-aware deletion
+# ---------------------------------------------------------------------------
+
+
+def run_nexthop_identity_deletion(ipv6=False):
+    """
+    Verify deletion always uses nexthop identity (lazy search); distance and
+    metric arguments are ignored:
+
+      a. Both distance and metric specified — removes the route.
+      b. Distance only (no metric) — still removes the route; metric is ignored.
+      c. Neither distance nor metric — removes the route.
+      d. Two nexthops at different metrics; deleting one by nexthop identity
+         leaves the other intact — directly exercises zebra's delete-lookup
+         loop metric check (rib_compare_routes /
+         process_subq_early_route_delete).
+      e. Metric only (no distance) — removes the route regardless of the
+         metric value supplied.
+
+    Steps (case a):
+      1. Install NH1 at (AD=10, metric=100).
+      2. Delete: 'no ip route ... NH1 10 metric 100'.
+      3. Verify route is gone.
+
+    Steps (case b):
+      4. Install NH1 at (AD=10, metric=100).
+      5. Delete without metric: 'no ip route ... NH1 10'.
+         Lazy search finds NH1 regardless of metric.
+      6. Verify route is gone.
+
+    Steps (case c):
+      7. Install NH1 at (AD=10, metric=100).
+      8. Delete without distance or metric: 'no ip route ... NH1'.
+      9. Verify route is gone.
+
+    Steps (case d):
+      10. Install NH1 at (AD=10, metric=100) and NH2 at (AD=10, metric=200).
+      11. Verify both {(10,100),(10,200)} are in the RIB.
+      12. Delete NH1 by nexthop identity: 'no ip route ... NH1 10 metric 100'.
+      13. Verify only {(10,200)} remains.
+      14. Cleanup: delete NH2.
+
+    Steps (case e):
+      15. Install NH1 at (AD=1 default, metric=100).
+      16. Delete with a different metric value: 'no ip route ... NH1 metric 200'.
+          Lazy search finds NH1 regardless of the metric argument.
+      17. Verify route is gone.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Case (a): exact-key delete removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (a) [1]: expected {{(10,100)}}, got {result}"
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (a) [2]: exact-key delete failed; got {result}"
+    )
+
+    # Case (b): delete with distance but no metric — lazy search removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (b) [4]: expected {{(10,100)}}, got {result}"
+
+    # Delete without metric — lazy search finds NH1 regardless of metric
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (b) [5]: lazy delete (distance only) should remove route; got {result}"
+    )
+
+    # Case (c): lazy delete (no distance, no metric) finds and removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (c) [7]: expected {{(10,100)}}, got {result}"
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (c) [8]: lazy delete should remove route at any metric; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric deletion (c) [9]: stale running-config after lazy delete; got {result}"
+    )
+
+    # Case (d): two routes at different metrics; delete one; the other must survive.
+    # NH1 and NH2 are used so both path-lists co-exist (nexthop uniqueness only
+    # enforces one path-list per nexthop address, not per prefix).
+    # This directly exercises zebra's delete-lookup loop: the loop must skip the
+    # metric=200 entry and remove only metric=100.
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (d) [11]: expected {{(10,100),(10,200)}}; got {result}"
+    )
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (d) [13]: metric=200 entry should survive deletion of "
+        f"metric=100; got {result}"
+    )
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric deletion (d) [cleanup]: got {result}"
+
+    # Case (e): metric-only delete (no distance) — lazy search removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} metric 100\n")
+    result = _expect_keys(r1, prefix, {(1, 100)}, ipv6)
+    assert result is None, f"Metric deletion (e) [15]: expected {{(1,100)}}; got {result}"
+
+    # Metric value in 'no' command is ignored — lazy search finds NH1 and removes it
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (e) [16]: lazy delete (metric-only) should remove route; got {result}"
+    )
+
+
+def test_nexthop_identity_deletion_ipv4():
+    "IPv4: deletion always uses nexthop identity; distance and metric arguments are ignored."
+    run_nexthop_identity_deletion(ipv6=False)
+
+
+def test_nexthop_identity_deletion_ipv6():
+    "IPv6: deletion always uses nexthop identity; distance and metric arguments are ignored."
+    run_nexthop_identity_deletion(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Running-config format
+# ---------------------------------------------------------------------------
+
+
+def run_running_config_format(ipv6=False):
+    """
+    Verify that metric appears after distance in 'show running-config' output,
+    that a zero metric is omitted, and that the default distance (1) is omitted.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100): expect '... NH1 10 metric 100'.
+      2. Install NH2 at (AD=1 default, metric=50): expect '... NH2 metric 50'
+         (distance 1 is default → omitted).
+      3. Install NH3 at (AD=20, metric=0 default): expect '... NH3 20'
+         (metric 0 is default → omitted).
+      4. Clean up all three.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: non-default AD, non-zero metric
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_running(
+        r1, prefix, [f"ip{ip_ver} route {prefix} {nh1} 10 metric 100"], ipv6
+    )
+    assert result is None, (
+        f"Running-config format [1]: expected '... NH1 10 metric 100'; got {result}"
+    )
+
+    # Step 2: default AD (omitted), non-zero metric
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} metric 50\n")
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} metric 50",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Running-config format [2]: expected '... NH2 metric 50' (no distance); got {result}"
+    )
+
+    # Step 3: non-default AD, zero metric (omitted)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh3} 20\n")
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} metric 50",
+            f"ip{ip_ver} route {prefix} {nh3} 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Running-config format [3]: expected '... NH3 20' (no metric); got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2}\n"
+        f"no ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Running-config format [cleanup]: route not fully removed; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Running-config format [cleanup]: stale running-config; got {result}"
+    )
+
+
+def test_running_config_format_ipv4():
+    "IPv4: metric appears after distance in running-config; defaults (dist=1, metric=0) omitted."
+    run_running_config_format(ipv6=False)
+
+
+def test_running_config_format_ipv6():
+    "IPv6: metric appears after distance in running-config; defaults (dist=1, metric=0) omitted."
+    run_running_config_format(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: ECMP primaries + metric-based standby — partial ECMP removal
+# ---------------------------------------------------------------------------
+
+def run_ecmp_primary_metric_standby(ipv6=False):
+    """
+    Two nexthops at the same (distance, metric) form an ECMP primary group;
+    a third nexthop at a higher metric is the standby.  Verify that removing
+    one primary nexthop shrinks the ECMP group without promoting the standby,
+    and that removing the last primary promotes the standby.
+
+    Steps:
+      1. Install NH1 and NH2 at (AD=1, metric=100); NH3 at (AD=1, metric=200).
+         NH1/NH2 are the active ECMP pair; NH3 is the metric-based standby.
+      2. Verify RIB: NH1 and NH2 active as ECMP (metric=100); NH3 inactive
+         (metric=200, higher metric → standby).
+      3. Remove NH1.  NH2 stays active (still the best metric group); NH3
+         remains standby.  Verify only NH2 is active in the RIB.
+      4. Remove NH2 (last primary).  NH3 is now promoted to active.
+         Verify only NH3 is in the RIB.
+      5. Clean up NH3; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two primaries at metric=100, one standby at metric=200
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh3} metric 200\n"
+    )
+
+    # Step 2: NH1 and NH2 active (metric=100 wins); NH3 inactive standby
+    result = _expect_keys(r1, prefix, {(1, 100), (1, 200)}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [2]: expected path keys {{(1,100),(1,200)}}; got {result}"
+    )
+    result = _expect_metric(r1, prefix, 100, ipv6)
+    assert result is None, (
+        f"ECMP+standby [2]: expected selected metric=100; got {result}"
+    )
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [2]: expected NH1+NH2 active; got {result}"
+    )
+
+    # Step 3: remove NH1 → NH2 alone at metric=100 (still best); NH3 still standby
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1}\n"
+    )
+    result = _expect_keys(r1, prefix, {(1, 100), (1, 200)}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: NH3 standby entry disappeared; got {result}"
+    )
+    result = _expect_metric(r1, prefix, 100, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected selected metric still 100; got {result}"
+    )
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected only NH2 active; got {result}"
+    )
+
+    # Step 4: remove NH2 (last primary) → NH3 promoted to active
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2}\n"
+    )
+    result = _expect_keys(r1, prefix, {(1, 200)}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [4]: expected only metric=200 path remaining; got {result}"
+    )
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"ECMP+standby [4]: expected selected metric=200 after NH3 promoted; got {result}"
+    )
+    result = _expect_nexthops(r1, prefix, {nh3}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [4]: expected NH3 active after promotion; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh3}\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"ECMP+standby [cleanup]: route not fully removed; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"ECMP+standby [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ecmp_primary_metric_standby_ipv4():
+    "IPv4: removing one ECMP primary shrinks the group without promoting the metric-based standby."
+    run_ecmp_primary_metric_standby(ipv6=False)
+
+
+def test_ecmp_primary_metric_standby_ipv6():
+    "IPv6: removing one ECMP primary shrinks the group without promoting the metric-based standby."
+    run_ecmp_primary_metric_standby(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/static_route_distance/test_static_route_tag.py
+++ b/tests/topotests/static_route_distance/test_static_route_tag.py
@@ -1,0 +1,1394 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path tag for static routes.
+
+Design: tag lives in static_path alongside distance and metric.  The
+path-list key is nexthop identity (table-id, nh-type, vrf, gateway,
+interface); distance, metric, and tag are non-key attributes.  Nexthops
+sharing the same (distance, metric) form one ECMP group; tag is shared by
+all nexthops in a group and is not part of the group identity.
+
+Max-wins: when multiple nexthops in the same path group carry different
+tags, the maximum nh->tag is used for the RIB.  On nexthop deletion, if
+the deleted nexthop carried the current maximum, the tag is recalculated
+to the maximum of the remaining nexthops' tags.  Max-wins is order-
+independent, so the per-leaf callbacks are idempotent.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. Basic tag: install a route with a tag; verify the tag appears in
+     the RIB (show ip route json) and in running-config.
+
+  2. Tag per path: NH1@AD10+tag=100 and NH2@AD20+tag=200.  Each path
+     carries an independent tag.  Verify both paths have the correct
+     tags in the RIB and running-config.
+
+  3. Tag change: change the tag on an existing path; verify the new tag
+     is reflected in the RIB and running-config, and the old tag is gone.
+
+  4. Tag with AD change: NH1@AD10+tag=100 reconfigured to AD20+tag=200.
+     Verify running-config shows exactly one entry at the new (AD, tag)
+     with no stale entry at the old (AD, tag).
+
+  4b. Tag preserved on AD-only change: NH1@AD10+tag=100 reconfigured to
+     AD20+tag=100.  tag_modify does not re-fire; static_path_recalc_tag()
+     must carry the tag to the new struct static_path.  Verify tag=100
+     survives in the RIB and running-config.
+
+  5. Same AD, different tag: NH1@AD10+tag=100 and NH2@AD10+tag=200.  Both
+     share one struct static_path.  Max-wins: pn->tag = max(100, 200) =
+     200.  YANG stores the operator-configured values per nexthop.  When
+     NH2 (the max-tag holder) is removed, recalculation drops pn->tag to
+     NH1's tag (100) in the RIB.
+
+  6. Delete non-max: with NH1/tag=100 and NH2/tag=200 (max is 200),
+     removing NH1 (the non-max nexthop) leaves pn->tag unchanged at 200.
+     No recalculation fires when the deleted nexthop's tag is below the
+     current max.
+
+  7. Three nexthops, delete max-tag holder: NH1/tag=100, NH2/tag=200,
+     NH3/tag=300 at the same AD.  pn->tag = 300.  Removing NH3 triggers
+     recalculation; max(100, 200) = 200.  NH1 and NH2 remain as a
+     two-nexthop ECMP group.
+
+  8. Running-config format (tag + distance + metric): verify that all three
+     non-default attributes appear correctly — 'ip route PREFIX NH tag T D
+     metric M' — and that the default distance (1) is omitted when not set.
+
+  9. Re-add a max-tag holder: NH2 is removed (recalc → NH1's tag becomes
+     the new max), then re-added with a higher tag.  The re-added NH2
+     becomes the new max and its tag takes effect.  A second removal of
+     NH2 again recalculates correctly to NH1's tag.
+
+  10. Tag recalculated when max-tag holder changes distance: NH2/tag=50
+     and NH1/tag=100 share the same path at AD=10; NH1 carries the max
+     (pn->tag=100).  Changing NH1's distance to 20 moves it to a new
+     path.  The old path (AD=10, NH2 only) must reflect NH2's tag (50);
+     the new path (AD=20, NH1) carries tag=100.
+
+  11. Tag recalculated when max-tag holder changes metric: same setup as
+     test 10 but NH1's metric changes from 100 to 200.  The old path
+     (metric=100, NH2 only) must reflect NH2's tag (50); the new path
+     (metric=200, NH1) carries tag=100.
+
+  12. Tag preserved when non-max nexthop changes distance: NH2/tag=50 and
+     NH1/tag=100 share AD=10; NH1 carries the max.  Changing NH2's (non-
+     max) distance to 20 skips the old-path recalculation (the
+     if (old_pn->tag == nh->tag) branch is false).  The old path (AD=10,
+     NH1 only) must retain tag=100 unchanged.
+
+  13. Tag recalculated when nexthop moves onto an existing tagged path:
+     NH1@AD10+tag=50 and NH2@AD20+tag=100.  NH2 is reconfigured to AD=10,
+     joining NH1's existing path.  static_path_recalc_tag(new_pn) selects
+     NH2's tag because max(50, 100) = 100; the path tag becomes 100.
+     The old AD=20 path is deleted.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return the list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_tag_by_distance(router, prefix, ipv6=False):
+    """Return dict mapping distance -> tag for RIB entries of prefix.
+
+    Only valid when at most one entry exists per distance value.  When
+    multiple entries share the same distance (different tags), use
+    _route_nexthop_tags() instead.
+    """
+    return {
+        e.get("distance", 0): e.get("tag", 0)
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _route_nexthop_tags(router, prefix, ipv6=False):
+    """Return set of (nexthop_ip, tag) tuples from RIB entries for prefix.
+
+    Iterates all route entries and all nexthops within each entry,
+    pairing each nexthop IP with the route-entry level tag.
+    """
+    result = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        tag = entry.get("tag", 0)
+        for nh in entry.get("nexthops", []):
+            ip = nh.get("ip", "")
+            if ip:
+                result.add((ip, tag))
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_rib_tags(router, prefix, expected, ipv6=False):
+    """Return None when {distance: tag} map equals expected, else actual."""
+    actual = _route_tag_by_distance(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    """Return None when running-config lines equal expected (as set), else actual."""
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_rib_tags(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_rib_tags, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(
+        _check_running, router, prefix, expected_lines, ipv6
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _route_tag_by_dist_metric(router, prefix, ipv6=False):
+    """Return dict mapping (distance, metric) -> tag for RIB entries of prefix."""
+    return {
+        (e.get("distance", 0), e.get("metric", 0)): e.get("tag", 0)
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _check_rib_tags_by_dist_metric(router, prefix, expected, ipv6=False):
+    """Return None when {(dist, metric): tag} map equals expected, else actual."""
+    actual = _route_tag_by_dist_metric(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_rib_tags_by_dist_metric(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_rib_tags_by_dist_metric, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: basic tag
+# ---------------------------------------------------------------------------
+
+def run_basic_tag(ipv6=False):
+    """
+    Install a route with a tag; verify tag in RIB and running-config.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Verify RIB entry at AD 10 carries tag 100.
+      3. Verify running-config shows 'ip route ... NH1 tag 100 10'.
+      4. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install with tag
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+
+    # Step 2: RIB shows tag 100 at AD 10
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Basic tag [2]: expected {{10: 100}}, got {result}"
+
+    # Step 3: running-config shows tag
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 100 10"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, f"Basic tag [3]: running-config mismatch; got {result}"
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Basic tag [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Basic tag [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_basic_tag_ipv4():
+    "IPv4: route with tag appears with correct tag in RIB and running-config."
+    run_basic_tag(ipv6=False)
+
+
+def test_basic_tag_ipv6():
+    "IPv6: route with tag appears with correct tag in RIB and running-config."
+    run_basic_tag(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: tag per path
+# ---------------------------------------------------------------------------
+
+def run_tag_per_path(ipv6=False):
+    """
+    Two nexthops at different ADs carry independent tags.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, NH2 at AD 20 with tag 200.
+      2. Verify RIB: AD 10 entry has tag 100, AD 20 entry has tag 200.
+      3. Verify running-config shows both lines with correct tags.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two paths with different tags
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20 tag 200\n"
+    )
+
+    # Step 2: each path has its own tag in the RIB
+    result = _expect_rib_tags(r1, prefix, {10: 100, 20: 200}, ipv6)
+    assert result is None, (
+        f"Tag per path [2]: expected {{10:100, 20:200}}, got {result}"
+    )
+
+    # Step 3: running-config shows both lines with correct tags
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 100 10",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Tag per path [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 20 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag per path [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag per path [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_per_path_ipv4():
+    "IPv4: two paths at different ADs carry independent tags."
+    run_tag_per_path(ipv6=False)
+
+
+def test_tag_per_path_ipv6():
+    "IPv6: two paths at different ADs carry independent tags."
+    run_tag_per_path(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: tag change
+# ---------------------------------------------------------------------------
+
+def run_tag_change(ipv6=False):
+    """
+    Changing the tag on an existing path updates the RIB and running-config.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure with tag 200 (same nexthop, same AD).
+      3. Verify RIB shows tag 200; old tag 100 is gone.
+      4. Verify running-config shows 'tag 200', not 'tag 100'.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install with tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: reconfigure with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 200\n"
+    )
+
+    # Step 3: RIB shows tag 200
+    result = _expect_rib_tags(r1, prefix, {10: 200}, ipv6)
+    assert result is None, (
+        f"Tag change [3]: expected {{10:200}}, got {result}"
+    )
+
+    # Step 4: running-config shows tag 200, not tag 100
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 10"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag change [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_change_ipv4():
+    "IPv4: changing the tag on a path updates RIB and running-config."
+    run_tag_change(ipv6=False)
+
+
+def test_tag_change_ipv6():
+    "IPv6: changing the tag on a path updates RIB and running-config."
+    run_tag_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: tag with AD change
+# ---------------------------------------------------------------------------
+
+def run_tag_with_ad_change(ipv6=False):
+    """
+    Moving a nexthop to a new AD with a new tag leaves exactly one entry.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure NH1 at AD 20 with tag 200 (single command; move logic
+         removes the old entry automatically).
+      3. Verify RIB has only AD 20 with tag 200; AD 10 entry is gone.
+      4. Verify running-config shows exactly 'ip route ... NH1 tag 200 20'.
+      5. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10, tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag+AD change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: move to AD 20 with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 20 tag 200\n"
+    )
+
+    # Step 3: only AD 20 with tag 200 in RIB
+    result = _expect_rib_tags(r1, prefix, {20: 200}, ipv6)
+    assert result is None, (
+        f"Tag+AD change [3]: expected {{20:200}}, stale AD 10 present or tag wrong; got {result}"
+    )
+
+    # Step 4: running-config shows exactly one entry at (AD 20, tag 200)
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag+AD change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 20 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag+AD change [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag+AD change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_with_ad_change_ipv4():
+    "IPv4: nexthop moved to new AD with new tag leaves exactly one RIB/config entry."
+    run_tag_with_ad_change(ipv6=False)
+
+
+def test_tag_with_ad_change_ipv6():
+    "IPv6: nexthop moved to new AD with new tag leaves exactly one RIB/config entry."
+    run_tag_with_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4b: tag preserved when only AD changes (tag_modify does not re-fire)
+# ---------------------------------------------------------------------------
+
+def run_tag_preserved_on_ad_change(ipv6=False):
+    """
+    When only the AD changes (tag stays the same), the tag must survive the
+    nexthop move.  tag_modify does not re-fire in this case, so the path
+    relies on static_path_recalc_tag() to carry the tag to the new
+    struct static_path.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure NH1 at AD 20, keeping tag 100.
+      3. Verify RIB has only AD 20 with tag 100 (tag not lost).
+      4. Verify running-config shows 'ip route ... NH1 tag 100 20'.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10, tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag preserved AD change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: change only the AD to 20 (tag 100 unchanged)
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 20 tag 100\n"
+    )
+
+    # Step 3: RIB must show AD 20 with tag 100, not 0
+    result = _expect_rib_tags(r1, prefix, {20: 100}, ipv6)
+    assert result is None, (
+        f"Tag preserved AD change [3]: tag lost after AD move; expected {{20:100}}, got {result}"
+    )
+
+    # Step 4: running-config shows the new entry
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 100 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag preserved AD change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 20 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag preserved AD change [cleanup]: RIB not empty; got {result}"
+
+
+def test_tag_preserved_on_ad_change_ipv4():
+    "IPv4: tag survives a change to AD alone (tag_modify does not re-fire on AD change)."
+    run_tag_preserved_on_ad_change(ipv6=False)
+
+
+def test_tag_preserved_on_ad_change_ipv6():
+    "IPv6: tag survives a change to AD alone (tag_modify does not re-fire on AD change)."
+    run_tag_preserved_on_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for same-AD tests
+# ---------------------------------------------------------------------------
+
+def _check_nexthop_tags(router, prefix, expected, ipv6=False):
+    """Return None when (nexthop_ip, tag) set equals expected, else actual."""
+    actual = _route_nexthop_tags(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_nexthop_tags(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_nexthop_tags, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: same AD, different tag
+# ---------------------------------------------------------------------------
+
+def run_same_ad_different_tag(ipv6=False):
+    """
+    Both nexthops share one struct static_path (keyed by distance+metric).
+    Max-wins in the RIB: pn->tag is the maximum nh->tag across the path.
+
+    YANG stores what each nexthop was individually configured with.
+    The C backend holds one shared path tag (pn->tag) and recalculates it
+    as the new max when a nexthop is removed.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, NH2 at AD 10 with tag 200.
+      2. Verify running-config shows NH1 with tag 100 and NH2 with tag 200
+         (YANG stores the operator-configured values per nexthop).
+      3. Verify RIB has both NHs as ECMP at AD 10, both with tag 200
+         (max(100, 200) = 200).
+      4. Remove NH2 (the max-tag holder); verify pn->tag is recalculated
+         to max(100) = 100 — NH1 survives in config and RIB with tag 100.
+      5. Clean up NH1; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD with independent tags
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 tag 200\n"
+    )
+
+    # Step 2: YANG datastore stores the operator-configured values, so
+    # running-config shows NH1 with tag 100 and NH2 with tag 200.
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 100 10",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 10",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Same-AD diff-tag [2]: running-config mismatch; got {result}"
+    )
+
+    # Step 3: RIB shows both NHs as ECMP at AD 10, both with tag 200.
+    # Max-wins: max(100, 200) = 200.
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 200), (nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [3]: expected ECMP {{(NH1,200),(NH2,200)}}; got {result}"
+    )
+
+    # Step 4: remove NH2 (the max-tag holder, tag=200).
+    # pn->tag == nh->tag (200 == 200) triggers recalculation: max of the
+    # remaining nexthops is NH1's tag (100), so pn->tag = 100.
+    # Verify NH1 in running-config with tag 100 and in RIB with tag 100.
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} tag 100 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"Same-AD diff-tag [4]: NH1 config wrong after removing NH2; got {result}"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100)}, ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [4]: NH1 not in RIB with tag 100 after removing NH2; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_same_ad_different_tag_ipv4():
+    "IPv4: same-AD nexthops share RIB tag via max-wins; YANG stores per-nexthop values."
+    run_same_ad_different_tag(ipv6=False)
+
+
+def test_same_ad_different_tag_ipv6():
+    "IPv6: same-AD nexthops share RIB tag via max-wins; YANG stores per-nexthop values."
+    run_same_ad_different_tag(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: delete non-max leaves RIB tag unchanged
+# ---------------------------------------------------------------------------
+
+def run_delete_non_max(ipv6=False):
+    """
+    Deleting a nexthop whose tag is below the current max leaves the RIB
+    tag intact.
+
+    NH1/tag=100 and NH2/tag=200 share AD=10; pn->tag = max(100, 200) = 200.
+    NH1's tag (100) is below the max, so removing NH1 must not trigger a
+    recalculation; the RIB tag stays at 200 and NH2 remains.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, NH2 at AD 10 with tag 200.
+      2. Verify RIB: both NHs as ECMP, tag 200 (max-wins).
+      3. Remove NH1 (below the max; pn->tag != nh->tag, no recalc).
+      4. Verify RIB tag stays at 200; NH2 alone remains in RIB.
+      5. Verify running-config shows only NH2 with tag 200.
+      6. Clean up NH2; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD with different tags
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 tag 200\n"
+    )
+
+    # Step 2: RIB shows both NHs as ECMP, both with tag 200 (max-wins)
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 200), (nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Delete non-max [2]: expected ECMP {{(NH1,200),(NH2,200)}}; got {result}"
+    )
+
+    # Step 3: remove NH1 (below max; pn->tag=200 != nh->tag=100, no recalc)
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n"
+    )
+
+    # Step 4: RIB tag stays at 200; NH2 alone remains
+    result = _expect_nexthop_tags(r1, prefix, {(nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Delete non-max [4]: expected {{(NH2,200)}}; got {result}"
+    )
+
+    # Step 5: running-config shows only NH2 with tag 200
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh2} tag 200 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"Delete non-max [5]: running-config mismatch; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete non-max [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Delete non-max [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_delete_non_max_ipv4():
+    "IPv4: removing a below-max nexthop leaves the RIB tag unchanged."
+    run_delete_non_max(ipv6=False)
+
+
+def test_delete_non_max_ipv6():
+    "IPv6: removing a below-max nexthop leaves the RIB tag unchanged."
+    run_delete_non_max(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: three nexthops, delete max-tag holder — recalc picks new max
+# ---------------------------------------------------------------------------
+
+def run_three_nexthops_delete_max(ipv6=False):
+    """
+    With three nexthops at the same AD, deleting the max-tag holder causes
+    the recalculation to pick the new max from the survivors.
+
+    NH1/tag=100, NH2/tag=200, NH3/tag=300.  pn->tag = max = 300.  After
+    removing NH3, the recalc gives max(100, 200) = 200.  NH1 and NH2 both
+    remain as a two-nexthop ECMP group with tag 200.
+
+    Steps:
+      1. Install NH1/tag=100, NH2/tag=200, NH3/tag=300, all at AD 10.
+      2. Verify RIB: all three NHs as ECMP with tag 300 (max-wins).
+      3. Remove NH3 (the max-tag holder).
+      4. Verify RIB tag is recalculated to 200 (the new max); NH1 and NH2
+         remain as a two-nexthop ECMP group.
+      5. Clean up NH1 and NH2; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: three nexthops at same AD with distinct tags
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 tag 200\n"
+        f"ip{ip_ver} route {prefix} {nh3} 10 tag 300\n"
+    )
+
+    # Step 2: RIB shows all three NHs as ECMP with tag 300 (max-wins)
+    result = _expect_nexthop_tags(
+        r1, prefix, {(nh1, 300), (nh2, 300), (nh3, 300)}, ipv6
+    )
+    assert result is None, (
+        f"3-NH delete max [2]: expected ECMP {{(NH1,300),(NH2,300),(NH3,300)}}; "
+        f"got {result}"
+    )
+
+    # Step 3: remove NH3 (the max-tag holder)
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh3} 10\n"
+    )
+
+    # Step 4: pn->tag recalculated to max(100, 200) = 200.  NH1 and NH2
+    # remain as a two-nexthop ECMP group, both with tag 200.
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 200), (nh2, 200)}, ipv6)
+    assert result is None, (
+        f"3-NH delete max [4]: expected {{(NH1,200),(NH2,200)}}; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"3-NH delete max [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"3-NH delete max [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_three_nexthops_delete_max_ipv4():
+    "IPv4: with 3 same-AD nexthops, deleting the max-tag holder recalculates to the new max."
+    run_three_nexthops_delete_max(ipv6=False)
+
+
+def test_three_nexthops_delete_max_ipv6():
+    "IPv6: with 3 same-AD nexthops, deleting the max-tag holder recalculates to the new max."
+    run_three_nexthops_delete_max(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: running-config format with tag + non-default distance + non-default metric
+# ---------------------------------------------------------------------------
+
+def run_running_config_tag_metric(ipv6=False):
+    """
+    Verify the full running-config format when tag, distance, and metric are
+    all non-default: 'ip route PREFIX NEXTHOP tag TAG DISTANCE metric METRIC'.
+
+    Steps:
+      1. Install NH1 at AD=10, metric=50, tag=100.
+      2. Verify running-config shows 'ip route ... NH1 tag 100 10 metric 50'.
+      3. Install NH2 at AD=1 (default), metric=20, tag=200.
+      4. Verify running-config shows 'ip route ... NH2 tag 200 metric 20'
+         (distance 1 is default → omitted).
+      5. Clean up both; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: non-default AD + non-zero metric + tag
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100 metric 50\n"
+    )
+
+    # Step 2: full format: tag before distance, metric after distance
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 100 10 metric 50"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag+metric format [2]: expected '{expected_line}'; got {result}"
+    )
+
+    # Step 3: default AD (omitted) + non-zero metric + tag
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh2} tag 200 metric 20\n"
+    )
+
+    # Step 4: distance 1 is default → omitted in running-config
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 100 10 metric 50",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 metric 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Tag+metric format [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1}\n"
+        f"no ip{ip_ver} route {prefix} {nh2}\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, (
+        f"Tag+metric format [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag+metric format [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_running_config_tag_metric_ipv4():
+    "IPv4: tag + non-default distance + non-default metric all appear correctly in running-config."
+    run_running_config_tag_metric(ipv6=False)
+
+
+def test_running_config_tag_metric_ipv6():
+    "IPv6: tag + non-default distance + non-default metric all appear correctly in running-config."
+    run_running_config_tag_metric(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 9: re-add max-tag holder after recalculation
+# ---------------------------------------------------------------------------
+
+def run_readd_max_tag_holder(ipv6=False):
+    """
+    Re-adding a previously deleted max-tag holder with a higher tag makes
+    it the new max and pn->tag is updated.  After a second deletion of the
+    re-added nexthop, the recalc gives the surviving nexthop's tag.
+
+    Steps:
+      1. Install NH1/tag=100, NH2/tag=200 at AD 10.
+         pn->tag = max(100, 200) = 200.
+      2. Remove NH2 (the max-tag holder) → recalc → pn->tag = 100.
+      3. Re-add NH2 with tag=300.  300 is the new max, so pn->tag=300.
+      4. Verify RIB: NH1 and NH2 as ECMP with tag 300.
+      5. Remove NH2 again → recalc → NH1 is the only remaining nexthop;
+         pn->tag=100.
+      6. Clean up NH1; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1/tag=100 then NH2/tag=200 → max(100, 200) = 200
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 tag 200\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 200), (nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Re-add max [1]: expected ECMP {{(NH1,200),(NH2,200)}}; got {result}"
+    )
+
+    # Step 2: remove NH2 → recalc restores NH1's tag=100
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100)}, ipv6)
+    assert result is None, (
+        f"Re-add max [2]: expected {{(NH1,100)}} after removing NH2; got {result}"
+    )
+
+    # Step 3: re-add NH2 with tag=300; 300 is the new max
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh2} 10 tag 300\n"
+    )
+
+    # Step 4: RIB shows NH1 + NH2 as ECMP with tag 300 (NH2 is the new max)
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 300), (nh2, 300)}, ipv6)
+    assert result is None, (
+        f"Re-add max [4]: expected ECMP {{(NH1,300),(NH2,300)}}; got {result}"
+    )
+
+    # Step 5: remove NH2 again → recalc → NH1's tag=100 is restored
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100)}, ipv6)
+    assert result is None, (
+        f"Re-add max [5]: expected {{(NH1,100)}} after second removal of NH2; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Re-add max [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Re-add max [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_readd_max_tag_holder_ipv4():
+    "IPv4: re-adding the max-tag holder with a higher tag makes it win; re-deleting restores survivor."
+    run_readd_max_tag_holder(ipv6=False)
+
+
+def test_readd_max_tag_holder_ipv6():
+    "IPv6: re-adding the max-tag holder with a higher tag makes it win; re-deleting restores survivor."
+    run_readd_max_tag_holder(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 10: tag recalculated when tag-owning nexthop changes distance
+# ---------------------------------------------------------------------------
+
+
+def run_tag_recalc_on_distance_move(ipv6=False):
+    """
+    When the max-tag-holder nexthop changes its administrative distance,
+    the remaining ECMP nexthop on the old path must receive the correct
+    recalculated tag in the route-UPDATE sent to zebra.
+
+    Setup:
+      NH2/tag=50 and NH1/tag=100 share AD=10; pn->tag = max(50, 100) = 100.
+
+    Steps:
+      1. Install NH2 at AD=10 with tag=50.
+      2. Install NH1 at AD=10 with tag=100; max-wins gives pn->tag=100.
+      3. Verify RIB: both NHs as ECMP at AD=10 with tag=100.
+      4. Change NH1's distance to 20 (distance_modify fires, NH1 moves).
+      5. Verify old path (AD=10, NH2 only) now has tag=50 (recalculated);
+         new path (AD=20, NH1) has tag=100.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH2 with tag=50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 tag 50\n")
+
+    # Step 2: NH1 with tag=100 → max(50, 100) = 100
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n")
+
+    # Step 3: both NHs ECMP at AD=10 with tag=100 (max-wins)
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100), (nh2, 100)}, ipv6)
+    assert result is None, (
+        f"Tag recalc on dist move [3]: expected ECMP {{(NH1,100),(NH2,100)}}; got {result}"
+    )
+
+    # Step 4: change NH1's distance to 20; distance_modify fires and moves NH1
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20 tag 100\n")
+
+    # Step 5: old path (AD=10) retains NH2 whose tag must be recalculated to 50.
+    # New path (AD=20) has NH1 with tag=100.
+    result = _expect_nexthop_tags(r1, prefix, {(nh2, 50), (nh1, 100)}, ipv6)
+    assert result is None, (
+        f"Tag recalc on dist move [5]: expected {{(NH2,50),(NH1,100)}}; got {result}"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 50, 20: 100}, ipv6)
+    assert result is None, (
+        f"Tag recalc on dist move [5]: expected {{10:50, 20:100}}; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 tag 50\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 20 tag 100\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Tag recalc on dist move [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_tag_recalc_on_distance_move_ipv4():
+    "IPv4: remaining ECMP peer gets correct recalculated tag when max-tag holder changes distance."
+    run_tag_recalc_on_distance_move(ipv6=False)
+
+
+def test_tag_recalc_on_distance_move_ipv6():
+    "IPv6: remaining ECMP peer gets correct recalculated tag when max-tag holder changes distance."
+    run_tag_recalc_on_distance_move(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 11: tag recalculated when max-tag-holder nexthop changes metric
+# ---------------------------------------------------------------------------
+
+
+def run_tag_recalc_on_metric_move(ipv6=False):
+    """
+    When the max-tag-holder nexthop changes its metric, the remaining ECMP
+    nexthop on the old path must receive the correct recalculated tag in
+    the route-UPDATE sent to zebra.
+
+    Setup:
+      NH2/tag=50 and NH1/tag=100 share (AD=10, metric=100);
+      pn->tag = max(50, 100) = 100.
+
+    Steps:
+      1. Install NH2 at AD=10, metric=100, tag=50.
+      2. Install NH1 at AD=10, metric=100, tag=100; max-wins gives pn->tag=100.
+      3. Verify RIB: both NHs ECMP at (AD=10, metric=100) with tag=100.
+      4. Change NH1's metric to 200 (metric_modify fires, NH1 moves).
+      5. Verify old path (metric=100, NH2 only) now has tag=50 (recalculated);
+         new path (metric=200, NH1) has tag=100.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH2 at (AD=10, metric=100, tag=50)
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh2} 10 metric 100 tag 50\n"
+    )
+
+    # Step 2: NH1 at (AD=10, metric=100, tag=100) → max(50, 100) = 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100 tag 100\n"
+    )
+
+    # Step 3: both NHs ECMP at (AD=10, metric=100) with tag=100 (max-wins)
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100), (nh2, 100)}, ipv6)
+    assert result is None, (
+        f"Tag recalc on metric move [3]: expected ECMP {{(NH1,100),(NH2,100)}}; "
+        f"got {result}"
+    )
+
+    # Step 4: change NH1's metric to 200; metric_modify fires and moves NH1
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200 tag 100\n"
+    )
+
+    # Step 5: old path (metric=100) retains NH2; tag must be recalculated to 50.
+    # New path (metric=200) has NH1 with tag=100.
+    result = _expect_nexthop_tags(r1, prefix, {(nh2, 50), (nh1, 100)}, ipv6)
+    assert result is None, (
+        f"Tag recalc on metric move [5]: expected {{(NH2,50),(NH1,100)}}; got {result}"
+    )
+    result = _expect_rib_tags_by_dist_metric(r1, prefix, {(10, 100): 50, (10, 200): 100}, ipv6)
+    assert result is None, (
+        f"Tag recalc on metric move [5]: expected {{(10,100):50,(10,200):100}}; "
+        f"got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 metric 100 tag 50\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 200 tag 100\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Tag recalc on metric move [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_tag_recalc_on_metric_move_ipv4():
+    "IPv4: remaining ECMP peer gets correct recalculated tag when max-tag holder changes metric."
+    run_tag_recalc_on_metric_move(ipv6=False)
+
+
+def test_tag_recalc_on_metric_move_ipv6():
+    "IPv6: remaining ECMP peer gets correct recalculated tag when max-tag holder changes metric."
+    run_tag_recalc_on_metric_move(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 12: tag preserved when non-max nexthop changes distance
+# ---------------------------------------------------------------------------
+
+
+def run_tag_preserved_when_non_max_moves(ipv6=False):
+    """
+    When a non-max nexthop changes its distance, the remaining max-tag
+    holder on the old path must retain its tag unchanged.  The
+    if (old_pn->tag == nh->tag) branch is false, so no recalculation fires.
+
+    Setup:
+      NH2/tag=50 and NH1/tag=100 share AD=10; pn->tag = max(50, 100) = 100
+      and NH1 carries the max.
+
+    Steps:
+      1. Install NH2 at AD=10 with tag=50.
+      2. Install NH1 at AD=10 with tag=100; max-wins gives pn->tag=100.
+      3. Verify RIB: both NHs ECMP at AD=10 with tag=100.
+      4. Change NH2's distance to 20 (non-max moves; no recalc on old path).
+      5. Verify old path (AD=10, NH1 only) retains tag=100 (unchanged);
+         new path (AD=20, NH2) has tag=50.
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH2 with tag=50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 tag 50\n")
+
+    # Step 2: NH1 with tag=100 → max(50, 100) = 100
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n")
+
+    # Step 3: both NHs ECMP at AD=10 with tag=100 (max-wins)
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100), (nh2, 100)}, ipv6)
+    assert result is None, (
+        f"Tag preserved nonmax move [3]: expected ECMP {{(NH1,100),(NH2,100)}}; "
+        f"got {result}"
+    )
+
+    # Step 4: change NH2's distance to 20; NH2 is non-max so no recalc on old path
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 20 tag 50\n")
+
+    # Step 5: old path (AD=10) retains NH1 with tag=100 (no recalc fired);
+    # new path (AD=20) has NH2 with tag=50.
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100), (nh2, 50)}, ipv6)
+    assert result is None, (
+        f"Tag preserved nonmax move [5]: expected {{(NH1,100),(NH2,50)}}; got {result}"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100, 20: 50}, ipv6)
+    assert result is None, (
+        f"Tag preserved nonmax move [5]: expected {{10:100, 20:50}}; got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 20 tag 50\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Tag preserved nonmax move [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_tag_preserved_when_non_max_moves_ipv4():
+    "IPv4: max-tag holder's tag on old path unchanged when a non-max nexthop changes distance."
+    run_tag_preserved_when_non_max_moves(ipv6=False)
+
+
+def test_tag_preserved_when_non_max_moves_ipv6():
+    "IPv6: max-tag holder's tag on old path unchanged when a non-max nexthop changes distance."
+    run_tag_preserved_when_non_max_moves(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 13: tag recalculated when nexthop moves onto an existing tagged path
+# ---------------------------------------------------------------------------
+
+
+def run_tag_recalc_on_move_to_existing_path(ipv6=False):
+    """
+    When a nexthop moves onto a path that already has a tagged nexthop,
+    static_path_recalc_tag(new_pn) must apply max-wins across the
+    pre-existing and arriving nexthops.
+
+    Setup:
+      NH1 at AD=10, tag=50; NH2 at AD=20, tag=100.
+
+    Steps:
+      1. Install NH1 at AD=10 with tag=50.
+      2. Install NH2 at AD=20 with tag=100.
+      3. Verify: AD=10 has tag=50 (NH1 sole); AD=20 has tag=100 (NH2 sole).
+      4. Change NH2's distance to 10: NH2 joins NH1's existing path.
+         static_path_recalc_tag(new_pn) sets pn->tag = max(50, 100) = 100.
+      5. Verify: AD=10 path (NH1+NH2) has tag=100 (max-wins);
+         AD=20 is gone (NH2 was its sole nexthop → deleted).
+      6. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 at AD=10, tag=50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 50\n")
+
+    # Step 2: NH2 at AD=20, tag=100
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 20 tag 100\n")
+
+    # Step 3: each path carries its own tag
+    result = _expect_rib_tags(r1, prefix, {10: 50, 20: 100}, ipv6)
+    assert result is None, (
+        f"Tag recalc move to existing [3]: expected {{10:50, 20:100}}; got {result}"
+    )
+
+    # Step 4: NH2 changes distance from 20 to 10; NH2 joins NH1's existing
+    # path; static_path_recalc_tag(new_pn) sets pn->tag = max(50, 100) = 100.
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 tag 100\n")
+
+    # Step 5: AD=10 path (NH1+NH2) now has tag=100 (max-wins); AD=20 gone.
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, (
+        f"Tag recalc move to existing [5]: expected {{10:100}}; got {result}"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 100), (nh2, 100)}, ipv6)
+    assert result is None, (
+        f"Tag recalc move to existing [5]: expected {{(NH1,100),(NH2,100)}}; "
+        f"got {result}"
+    )
+
+    # Step 6: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 tag 50\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 tag 100\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Tag recalc move to existing [cleanup]: RIB not empty; got {result}"
+    )
+
+
+def test_tag_recalc_on_move_to_existing_path_ipv4():
+    "IPv4: max-wins tag recalc when nexthop joins an existing tagged path."
+    run_tag_recalc_on_move_to_existing_path(ipv6=False)
+
+
+def test_tag_recalc_on_move_to_existing_path_ipv6():
+    "IPv6: max-wins tag recalc when nexthop joins an existing tagged path."
+    run_tag_recalc_on_move_to_existing_path(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -63,6 +63,15 @@ module frr-staticd {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2026-04-19 {
+    description
+      "Add 'metric' as a non-key path-list attribute with default 0.
+       Nexthops sharing (table-id, distance, metric) form one ECMP group
+       in the RIB; nexthops with different metrics are separate RIB entries
+       enabling metric-based floating static routes.";
+    reference "FRRouting";
+  }
+
   revision 2026-04-18 {
     description
       "Flatten path-list: replace the two-level path-list/nexthop hierarchy
@@ -97,8 +106,9 @@ module frr-staticd {
       key "table-id nh-type vrf gateway interface";
       description
         "List of paths associated with a staticd prefix.  Each entry
-         represents one nexthop; entries sharing the same table-id and
-         administrative distance are installed as ECMP in the RIB.";
+         represents one nexthop; entries sharing the same table-id,
+         administrative distance, and metric are installed as ECMP in
+         the RIB.";
       leaf table-id {
         type uint32;
         description
@@ -112,6 +122,15 @@ module frr-staticd {
         default "1";
         description
           "Admin distance associated with this route.";
+      }
+
+      leaf metric {
+        type uint32;
+        default "0";
+        description
+          "Route metric.  Nexthops sharing the same (table-id, distance,
+           metric) form one ECMP group; nexthops with different metrics
+           are separate RIB entries enabling metric-based floating routes.";
       }
 
       leaf tag {

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -63,6 +63,15 @@ module frr-staticd {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2026-04-18 {
+    description
+      "Flatten path-list: replace the two-level path-list/nexthop hierarchy
+       with a single flat list keyed by table-id and nexthop identity
+       (nh-type, vrf, gateway, interface).  Distance becomes a non-key
+       attribute with a default of 1.";
+    reference "FRRouting";
+  }
+
   revision 2026-01-23 {
     description
       "Augments the nexthop container with a 'weight' leaf.";
@@ -85,17 +94,22 @@ module frr-staticd {
     description
       "Grouping for staticd prefix attributes.";
     list path-list {
-      key "table-id distance";
+      key "table-id nh-type vrf gateway interface";
       description
-        "List of paths associated with a staticd prefix.";
+        "List of paths associated with a staticd prefix.  Each entry
+         represents one nexthop; entries sharing the same table-id and
+         administrative distance are installed as ECMP in the RIB.";
       leaf table-id {
         type uint32;
         description
-          "Table-id";
+          "Table-id associated with this route.";
       }
+
+      uses frr-nexthop:frr-nexthop-attributes;
 
       leaf distance {
         type frr-rt:administrative-distance;
+        default "1";
         description
           "Admin distance associated with this route.";
       }
@@ -107,7 +121,22 @@ module frr-staticd {
           "Route tag";
       }
 
-      uses frr-nexthop:frr-nexthop;
+      leaf weight {
+        type uint16 {
+          range "1..65535";
+        }
+        description
+          "Weight to be used by the nexthop for purposes of ECMP.";
+      }
+
+      container bfd-monitoring {
+        when "../nh-type = 'ip4' or ../nh-type = 'ip4-ifindex' or
+              ../nh-type = 'ip6' or ../nh-type = 'ip6-ifindex'";
+        presence
+          "Present if BFD configuration is available.";
+        description "BFD monitoring options.";
+        uses frr-bfdd:bfd-monitoring;
+      }
     }
   }
 
@@ -209,32 +238,7 @@ module frr-staticd {
             "AFI-SAFI type.";
         }
 
-        uses staticd-prefix-attributes {
-          augment "path-list/frr-nexthops/nexthop" {
-            description
-              "Augments the nexthop container with BFD monitoring options.";
-            container bfd-monitoring {
-              when "../nh-type = 'ip4' or ../nh-type = 'ip4-ifindex' or
-                    ../nh-type = 'ip6' or ../nh-type = 'ip6-ifindex'";
-              presence
-                "Present if BFD configuration is available.";
-              description "BFD monitoring options.";
-
-              uses frr-bfdd:bfd-monitoring;
-            }
-          }
-          augment "path-list/frr-nexthops/nexthop" {
-            description
-              "Augments the 'nexthop' container to add a 'weight' leaf for ECMP purposes.";
-            leaf weight {
-              type uint16 {
-                range "1..65535";
-              }
-              description
-                "Weight to be used by the nexthop for purposes of ECMP";
-            }
-          }
-        }
+        uses staticd-prefix-attributes;
       }
 
       container segment-routing {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1607,7 +1607,8 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    re->distance != dplane_ctx_get_old_distance(ctx)) {
+			    (re->distance != dplane_ctx_get_old_distance(ctx) ||
+			     re->metric != dplane_ctx_get_old_metric(ctx))) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_old_metric(ctx)) {
@@ -1633,7 +1634,8 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    re->distance != dplane_ctx_get_distance(ctx)) {
+			    (re->distance != dplane_ctx_get_distance(ctx) ||
+			     re->metric != dplane_ctx_get_metric(ctx))) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_metric(ctx)) {
@@ -1686,13 +1688,12 @@ static bool rib_compare_routes(const struct route_entry *re1, const struct route
 	if (re1->instance != re2->instance)
 		return false;
 
-	if (re1->type == ZEBRA_ROUTE_KERNEL) {
-		if (re1->metric != re2->metric)
-			return false;
+	if ((re1->type == ZEBRA_ROUTE_KERNEL || re1->type == ZEBRA_ROUTE_STATIC) &&
+	    re1->metric != re2->metric)
+		return false;
 
-		if (!replace)
-			return false;
-	}
+	if (re1->type == ZEBRA_ROUTE_KERNEL && !replace)
+		return false;
 
 	if (CHECK_FLAG(re1->flags, ZEBRA_FLAG_RR_USE_DISTANCE) &&
 	    re1->distance != re2->distance)
@@ -2954,7 +2955,7 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 		    ere->re->distance != re->distance)
 			continue;
 
-		if (re->type == ZEBRA_ROUTE_KERNEL &&
+		if ((re->type == ZEBRA_ROUTE_KERNEL || re->type == ZEBRA_ROUTE_STATIC) &&
 		    re->metric != ere->re->metric)
 			continue;
 		if ((re->type == ZEBRA_ROUTE_CONNECT ||


### PR DESCRIPTION
This patch series restructures the staticd YANG schema and adds per-route metric support for static routes.           
                                                                                                                        
  **YANG schema (nexthop identity as path-list key)**                                                                       
                                                                                                                        
  The previous schema keyed path-list on [table-id, distance] with a nested nexthop-list. Since distance is not part of 
  nexthop identity, the same nexthop could appear under multiple path-list entries at different distances without YANG
  detecting a conflict, creating state that the CLI could not always handle correctly.                                  
                                                            
  The new schema uses a single list keyed by full nexthop identity:                                                     
   
  path-list [table-id, nh-type, vrf, gateway, interface]                                                                
                                                            
  Distance and metric become non-key leaf attributes (defaults 1 and 0). Changing either on an existing nexthop is now a
   leaf MODIFY — the NB callback migrates the nexthop to the appropriate internal struct static_path without withdrawing
   the route. Weight and BFD monitoring, previously attached via augment blocks on the nested nexthop container, become direct leaves of the path-list entry.                     

  **Per-route metric**                                                                                                      
   
  metric is added alongside distance and tag as a non-key path-list attribute. Nexthops sharing the same (table-id,     
  distance, metric) form one ECMP group in the RIB; nexthops with different metrics are separate RIB entries, enabling
  metric-based floating static routes. Zebra is extended to treat static routes at the same distance but different      
  metrics as distinct route entries.                        

  **Also included**                                                                                                         
   
  - Documentation for administrative distance, metric, and tag                                                          
  - Topotests for per-path distance, tag, and metric (including ECMP, floating routes, lazy deletion, and running-config
   round-trip)                                                                                                          
  - Updates to mgmt and gRPC test fixtures for the new path-list xpaths

Please see the individual commits for details.