### PR TITLE
mgmtd/bgpd: register bgpd backend client and add frr-bgp-peer operational data support[DRAFT]

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -27,6 +27,7 @@
 #include "libfrr.h"
 #include "ns.h"
 #include "libagentx.h"
+#include "mgmt_be_client.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_attr.h"
@@ -50,6 +51,7 @@
 #include "bgpd/bgp_evpn_mh.h"
 #include "bgpd/bgp_nhg.h"
 #include "bgpd/bgp_routemap_nb.h"
+#include "bgpd/bgp_peer_nb.h"
 #include "bgpd/bgp_community_alias.h"
 
 DEFINE_HOOK(bgp_hook_config_write_vrf, (struct vty *vty, struct vrf *vrf),
@@ -61,6 +63,8 @@ DEFINE_HOOK(bgp_hook_config_write_vrf, (struct vty *vty, struct vrf *vrf),
 
 DEFINE_HOOK(bgp_hook_vrf_update, (struct vrf *vrf, bool enabled),
 	    (vrf, enabled));
+
+static struct mgmt_be_client *mgmt_be_client;
 
 /* bgpd options, we use GNU getopt library. */
 static const struct option longopts[] = { { "bgp_port", required_argument, NULL, 'p' },
@@ -135,6 +139,11 @@ FRR_NORETURN void sigint(void)
 
 	/* Disable BFD events to avoid wasting processing. */
 	bfd_protocol_integration_set_shutdown(true);
+
+	if (mgmt_be_client) {
+		mgmt_be_client_destroy(mgmt_be_client);
+		mgmt_be_client = NULL;
+	}
 
 	bgp_terminate();
 
@@ -374,11 +383,13 @@ static void bgp_vrf_terminate(void)
 }
 
 static const struct frr_yang_module_info *const bgpd_yang_modules[] = {
+	&frr_backend_info,
 	&frr_filter_info,
 	&frr_interface_info,
 	&frr_route_map_info,
 	&frr_vrf_info,
 	&frr_bgp_route_map_info,
+	&frr_bgp_peer_info,
 };
 
 /* clang-format off */
@@ -393,8 +404,38 @@ FRR_DAEMON_INFO(bgpd, BGP,
 
 	.yang_modules = bgpd_yang_modules,
 	.n_yang_modules = array_size(bgpd_yang_modules),
+
+	.flags = FRR_MGMTD_BACKEND,
 );
 /* clang-format on */
+
+static const char *const bgpd_config_xpaths[] = {
+	"/frr-host:host",
+	"/frr-logging:logging",
+	"/frr-interface:lib/interface",
+	"/frr-route-map:lib",
+	"/frr-vrf:lib",
+	"/frr-rt:routing",
+};
+
+static const char *const bgpd_oper_xpaths[] = {
+	"/frr-backend:clients",
+	"/frr-rt:routing",
+	"/frr-bgp-peer:lib/vrf",
+};
+
+static const char *const bgpd_rpc_xpaths[] = {
+	"/frr-logging",
+};
+
+static struct mgmt_be_client_cbs bgpd_be_client_data = {
+	.config_xpaths = bgpd_config_xpaths,
+	.nconfig_xpaths = array_size(bgpd_config_xpaths),
+	.oper_xpaths = bgpd_oper_xpaths,
+	.noper_xpaths = array_size(bgpd_oper_xpaths),
+	.rpc_xpaths = bgpd_rpc_xpaths,
+	.nrpc_xpaths = array_size(bgpd_rpc_xpaths),
+};
 
 #define DEPRECATED_OPTIONS ""
 
@@ -541,6 +582,10 @@ int main(int argc, char **argv)
 	}
 
 	bgp_if_init();
+
+	/* Initialize mgmtd backend registration for bgpd. */
+	mgmt_be_client =
+		mgmt_be_client_create("bgpd", &bgpd_be_client_data, 0, bm->master);
 
 	frr_config_fork();
 	/* must be called after fork() */

--- a/bgpd/bgp_peer_nb.c
+++ b/bgpd/bgp_peer_nb.c
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+#include <zebra.h>
+
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_updgrp.h"
@@ -261,7 +263,7 @@ static struct yang_data *lib_vrf_peer_last_established_get_elem(struct nb_cb_get
 	uptime = monotime(NULL);
 	uptime -= peer->uptime;
 	epoch_tbuf = time(NULL) - uptime;
-	return yang_data_new_uint64(args->xpath, epoch_tbuf);
+	return yang_data_new_uint64(args->xpath, (uint64_t)epoch_tbuf);
 }
 
 /* XPath: /frr-bgp-peer:lib/vrf/peer/peer-group */

--- a/bgpd/bgp_peer_nb.c
+++ b/bgpd/bgp_peer_nb.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_updgrp.h"

--- a/bgpd/bgp_peer_nb.c
+++ b/bgpd/bgp_peer_nb.c
@@ -1,0 +1,654 @@
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_debug.h"
+#include "bgpd/bgp_updgrp.h"
+#include "northbound.h"
+#include "bgpd/bgp_peer_nb.h"
+#include "lib/vrf.h"
+
+static const char *peer_name_resolve(struct peer *peer, char *buf, size_t buflen)
+{
+	if (!peer)
+		return NULL;
+
+	if (peer->conf_if)
+		return peer->conf_if;
+	if (peer->host)
+		return peer->host;
+
+	if (peer->connection && peer->connection->su.sa.sa_family == AF_INET) {
+		inet_ntop(AF_INET, &peer->connection->su.sin.sin_addr, buf, buflen);
+		return buf;
+	}
+
+	if (peer->connection && peer->connection->su.sa.sa_family == AF_INET6) {
+		if (inet_ntop(AF_INET6, &peer->connection->su.sin6.sin6_addr, buf, buflen))
+			return buf;
+	}
+
+	return NULL;
+}
+
+static const char *peer_type_to_str(enum bgp_peer_sort sort)
+{
+	switch (sort) {
+	case BGP_PEER_IBGP:
+		return "internal";
+	case BGP_PEER_EBGP:
+		return "external";
+	case BGP_PEER_INTERNAL:
+		return "unspecified";
+	case BGP_PEER_CONFED:
+		return "confederation";
+	case BGP_PEER_UNSPECIFIED:
+	default:
+		return "unspecified";
+	}
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf */
+static const void *lib_vrf_get_next(struct nb_cb_get_next_args *args)
+{
+	struct vrf *vrfp = (struct vrf *)args->list_entry;
+
+	if (!args->list_entry)
+		return RB_MIN(vrf_name_head, &vrfs_by_name);
+
+	return RB_NEXT(vrf_name_head, vrfp);
+}
+
+static int lib_vrf_get_keys(struct nb_cb_get_keys_args *args)
+{
+	struct vrf *vrfp = (struct vrf *)args->list_entry;
+
+	args->keys->num = 1;
+	strlcpy(args->keys->key[0], vrfp->name, sizeof(args->keys->key[0]));
+	return NB_OK;
+}
+
+static const void *lib_vrf_lookup_entry(struct nb_cb_lookup_entry_args *args)
+{
+	return vrf_lookup_by_name(args->keys->key[0]);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/id */
+static struct yang_data *lib_vrf_id_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct vrf *vrfp = (struct vrf *)args->list_entry;
+
+	return yang_data_new_uint32(args->xpath, vrfp->vrf_id);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer */
+static const void *lib_vrf_peer_get_next(struct nb_cb_get_next_args *args)
+{
+	struct bgp *bgp;
+	struct peer *peer = (struct peer *)args->list_entry;
+	struct listnode *node;
+	struct vrf *vrfp = (struct vrf *)args->parent_list_entry;
+
+	if (!vrfp)
+		return NULL;
+
+	bgp = vrfp->vrf_id ? bgp_lookup_by_vrf_id(vrfp->vrf_id) : bgp_get_default();
+	if (!bgp || !bgp->peer)
+		return NULL;
+
+	if (!peer) {
+		node = listnode_head(bgp->peer);
+		return node ? listgetdata(node) : NULL;
+	}
+
+	node = listnode_lookup(bgp->peer, peer);
+	node = node ? listnextnode(node) : NULL;
+	return node ? listgetdata(node) : NULL;
+}
+
+static int lib_vrf_peer_get_keys(struct nb_cb_get_keys_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+	char addrbuf[INET6_ADDRSTRLEN];
+	const char *name;
+
+	args->keys->num = 1;
+	name = peer_name_resolve(peer, addrbuf, sizeof(addrbuf));
+	strlcpy(args->keys->key[0], name ? name : "", sizeof(args->keys->key[0]));
+	return NB_OK;
+}
+
+static const void *lib_vrf_peer_lookup_entry(struct nb_cb_lookup_entry_args *args)
+{
+	const char *peer_str = args->keys->key[0];
+	struct vrf *vrfp = (struct vrf *)args->parent_list_entry;
+	struct bgp *bgp;
+	union sockunion su;
+	struct peer *peer;
+	int ret;
+
+	if (!vrfp)
+		return NULL;
+
+	bgp = vrfp->vrf_id ? bgp_lookup_by_vrf_id(vrfp->vrf_id) : bgp_get_default();
+	if (!bgp || !bgp->peer)
+		return NULL;
+
+	ret = str2sockunion(peer_str, &su);
+	if (ret >= 0)
+		return peer_lookup(bgp, &su);
+
+	peer = peer_lookup_by_hostname(bgp, peer_str);
+	if (!peer)
+		peer = peer_lookup_by_conf_if(bgp, peer_str);
+	return peer;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/name */
+static struct yang_data *lib_vrf_peer_name_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+	char addrbuf[INET6_ADDRSTRLEN];
+	const char *name = peer_name_resolve(peer, addrbuf, sizeof(addrbuf));
+
+	return yang_data_new_string(args->xpath, name ? name : "");
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/status */
+static struct yang_data *lib_vrf_peer_status_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer || !peer->connection)
+		return NULL;
+
+	return yang_data_new_string(args->xpath,
+				    lookup_msg(bgp_status_msg, peer->connection->status, NULL));
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/local-as */
+static struct yang_data *lib_vrf_peer_local_as_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	return peer ? yang_data_new_uint32(args->xpath, peer->local_as) : NULL;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/peer-as */
+static struct yang_data *lib_vrf_peer_as_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	return peer ? yang_data_new_uint32(args->xpath, peer->as) : NULL;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/description */
+static struct yang_data *lib_vrf_peer_description_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	return yang_data_new_string(args->xpath, (peer && peer->desc) ? peer->desc : "");
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/neighbor-address */
+static struct yang_data *lib_vrf_peer_neighbor_address_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+	char addrbuf[INET6_ADDRSTRLEN];
+	const char *name = peer_name_resolve(peer, addrbuf, sizeof(addrbuf));
+
+	return yang_data_new_string(args->xpath, name ? name : "");
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/total-msgs-sent */
+static struct yang_data *lib_vrf_peer_total_msgs_sent_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	return peer ? yang_data_new_uint32(args->xpath, PEER_TOTAL_TX(peer)) : NULL;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/total-msgs-recvd */
+static struct yang_data *lib_vrf_peer_total_msgs_recvd_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	return peer ? yang_data_new_uint32(args->xpath, PEER_TOTAL_RX(peer)) : NULL;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/established-transitions */
+static struct yang_data *lib_vrf_peer_established_transitions_get_elem(
+	struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	return peer ? yang_data_new_uint32(args->xpath, peer->established) : NULL;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/in-queue */
+static struct yang_data *lib_vrf_peer_in_queue_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer || !peer->connection || !peer->connection->ibuf)
+		return NULL;
+	return yang_data_new_uint32(args->xpath, peer->connection->ibuf->count);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/out-queue */
+static struct yang_data *lib_vrf_peer_out_queue_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer || !peer->connection || !peer->connection->obuf)
+		return NULL;
+	return yang_data_new_uint32(args->xpath, peer->connection->obuf->count);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/last-established */
+static struct yang_data *lib_vrf_peer_last_established_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+	time_t uptime;
+	time_t epoch_tbuf;
+
+	if (!peer)
+		return NULL;
+	uptime = monotime(NULL);
+	uptime -= peer->uptime;
+	epoch_tbuf = time(NULL) - uptime;
+	return yang_data_new_uint64(args->xpath, epoch_tbuf);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/peer-group */
+static struct yang_data *lib_vrf_peer_group_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer)
+		return NULL;
+	return yang_data_new_string(args->xpath,
+				    (peer->group && peer->group->name) ? peer->group->name : "");
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/peer-type */
+static struct yang_data *lib_vrf_peer_type_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer)
+		return NULL;
+	return yang_data_new_string(args->xpath, peer_type_to_str(peer_sort_lookup(peer)));
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/messages/sent/last-notification-error-code */
+static struct yang_data *lib_vrf_peer_messages_sent_last_notification_error_code_get_elem(
+	struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer || !peer->notify.code)
+		return yang_data_new_string(args->xpath, "");
+	return yang_data_new_string(args->xpath, bgp_notify_code_str(peer->notify.code));
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/messages/received/last-notification-error-code */
+static struct yang_data *lib_vrf_peer_messages_received_last_notification_error_code_get_elem(
+	struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer || !peer->notify.code)
+		return yang_data_new_string(args->xpath, "");
+	return yang_data_new_string(args->xpath, bgp_notify_code_str(peer->notify.code));
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/messages/sent/updates */
+static struct yang_data *lib_vrf_peer_tx_updates_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+	int update_out = 0;
+
+	if (!peer)
+		return NULL;
+	update_out = atomic_load_explicit(&peer->update_out, memory_order_relaxed);
+	return yang_data_new_uint32(args->xpath, update_out);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/messages/received/updates */
+static struct yang_data *lib_vrf_peer_rx_updates_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+	int update_in = 0;
+
+	if (!peer)
+		return NULL;
+	update_in = atomic_load_explicit(&peer->update_in, memory_order_relaxed);
+	return yang_data_new_uint32(args->xpath, update_in);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/graceful-shutdown */
+static struct yang_data *lib_vrf_peer_graceful_shutdown_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer *peer = (struct peer *)args->list_entry;
+
+	if (!peer)
+		return NULL;
+	return yang_data_new_bool(args->xpath,
+				  bgp_in_graceful_shutdown(peer->bgp)
+					  || CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_SHUTDOWN));
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi */
+static const void *lib_vrf_peer_afi_safi_get_next(struct nb_cb_get_next_args *args)
+{
+	struct peer *peer;
+	struct peer_af *paf;
+	int idx;
+
+	if (!args || !args->parent_list_entry)
+		return NULL;
+
+	peer = (struct peer *)args->parent_list_entry;
+
+	if (!args->list_entry) {
+		for (idx = BGP_AF_START; idx < BGP_AF_MAX; idx++) {
+			if (peer->peer_af_array[idx])
+				return peer->peer_af_array[idx];
+		}
+		return NULL;
+	}
+
+	paf = (struct peer_af *)args->list_entry;
+	for (idx = paf->afid + 1; idx < BGP_AF_MAX; idx++) {
+		if (peer->peer_af_array[idx])
+			return peer->peer_af_array[idx];
+	}
+	return NULL;
+}
+
+static int lib_vrf_peer_afi_safi_get_keys(struct nb_cb_get_keys_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+	const char *id;
+
+	if (!paf)
+		return NB_ERR;
+
+	args->keys->num = 1;
+	id = yang_afi_safi_value2identity(paf->afi, paf->safi);
+	strlcpy(args->keys->key[0], id ? id : "", sizeof(args->keys->key[0]));
+	return NB_OK;
+}
+
+static const void *lib_vrf_peer_afi_safi_lookup_entry(struct nb_cb_lookup_entry_args *args)
+{
+	struct peer *peer = (struct peer *)args->parent_list_entry;
+	int idx;
+	const char *name;
+
+	if (!peer)
+		return NULL;
+
+	for (idx = BGP_AF_START; idx < BGP_AF_MAX; idx++) {
+		if (!peer->peer_af_array[idx])
+			continue;
+		name = yang_afi_safi_value2identity(peer->peer_af_array[idx]->afi,
+						    peer->peer_af_array[idx]->safi);
+		if (name && strcmp(name, args->keys->key[0]) == 0)
+			return peer->peer_af_array[idx];
+	}
+	return NULL;
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi/afi-safi-name */
+static struct yang_data *lib_vrf_peer_afi_safi_name_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+	const char *id;
+
+	if (!paf)
+		return NULL;
+	id = yang_afi_safi_value2identity(paf->afi, paf->safi);
+	return yang_data_new_string(args->xpath, id ? id : "");
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi/rcvd-pfx */
+static struct yang_data *lib_vrf_peer_afi_safi_rcvd_pfx_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+
+	if (!paf || !paf->peer)
+		return NULL;
+	return yang_data_new_uint32(args->xpath, paf->peer->pcount[paf->afi][paf->safi]);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi/rcvd-pfx-installed */
+static struct yang_data *lib_vrf_peer_afi_safi_rcvd_pfx_installed_get_elem(
+	struct nb_cb_get_elem_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+
+	if (!paf || !paf->peer)
+		return NULL;
+	/* Some FRR trees don't keep a separate installed counter. */
+	return yang_data_new_uint32(args->xpath, paf->peer->pcount[paf->afi][paf->safi]);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi/pfx-sent */
+static struct yang_data *lib_vrf_peer_afi_safi_pfx_sent_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+
+	if (!paf || !PAF_SUBGRP(paf))
+		return NULL;
+	return yang_data_new_uint32(args->xpath, PAF_SUBGRP(paf)->scount);
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi/afi */
+static struct yang_data *lib_vrf_peer_afi_safi_afi_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+
+	if (!paf)
+		return NULL;
+	return yang_data_new_string(args->xpath, afi2str(paf->afi));
+}
+
+/* XPath: /frr-bgp-peer:lib/vrf/peer/afi-safi/safi */
+static struct yang_data *lib_vrf_peer_afi_safi_safi_get_elem(struct nb_cb_get_elem_args *args)
+{
+	struct peer_af *paf = (struct peer_af *)args->list_entry;
+
+	if (!paf)
+		return NULL;
+	return yang_data_new_string(args->xpath, safi2str(paf->safi));
+}
+
+/* clang-format off */
+const struct frr_yang_module_info frr_bgp_peer_info = {
+	.name = "frr-bgp-peer",
+	.nodes = {
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf",
+			.cbs = {
+				.get_next = lib_vrf_get_next,
+				.get_keys = lib_vrf_get_keys,
+				.lookup_entry = lib_vrf_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/id",
+			.cbs = {
+				.get_elem = lib_vrf_id_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer",
+			.cbs = {
+				.get_next = lib_vrf_peer_get_next,
+				.get_keys = lib_vrf_peer_get_keys,
+				.lookup_entry = lib_vrf_peer_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/name",
+			.cbs = {
+				.get_elem = lib_vrf_peer_name_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/status",
+			.cbs = {
+				.get_elem = lib_vrf_peer_status_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/established-transitions",
+			.cbs = {
+				.get_elem = lib_vrf_peer_established_transitions_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/in-queue",
+			.cbs = {
+				.get_elem = lib_vrf_peer_in_queue_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/out-queue",
+			.cbs = {
+				.get_elem = lib_vrf_peer_out_queue_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/local-as",
+			.cbs = {
+				.get_elem = lib_vrf_peer_local_as_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/peer-as",
+			.cbs = {
+				.get_elem = lib_vrf_peer_as_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/last-established",
+			.cbs = {
+				.get_elem = lib_vrf_peer_last_established_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/description",
+			.cbs = {
+				.get_elem = lib_vrf_peer_description_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/peer-group",
+			.cbs = {
+				.get_elem = lib_vrf_peer_group_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/peer-type",
+			.cbs = {
+				.get_elem = lib_vrf_peer_type_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/neighbor-address",
+			.cbs = {
+				.get_elem = lib_vrf_peer_neighbor_address_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/messages/sent/last-notification-error-code",
+			.cbs = {
+				.get_elem = lib_vrf_peer_messages_sent_last_notification_error_code_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/messages/sent/updates",
+			.cbs = {
+				.get_elem = lib_vrf_peer_tx_updates_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/messages/received/last-notification-error-code",
+			.cbs = {
+				.get_elem = lib_vrf_peer_messages_received_last_notification_error_code_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/messages/received/updates",
+			.cbs = {
+				.get_elem = lib_vrf_peer_rx_updates_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi",
+			.cbs = {
+				.get_next = lib_vrf_peer_afi_safi_get_next,
+				.get_keys = lib_vrf_peer_afi_safi_get_keys,
+				.lookup_entry = lib_vrf_peer_afi_safi_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi/afi-safi-name",
+			.cbs = {
+				.get_elem = lib_vrf_peer_afi_safi_name_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi/rcvd-pfx",
+			.cbs = {
+				.get_elem = lib_vrf_peer_afi_safi_rcvd_pfx_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi/rcvd-pfx-installed",
+			.cbs = {
+				.get_elem = lib_vrf_peer_afi_safi_rcvd_pfx_installed_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi/pfx-sent",
+			.cbs = {
+				.get_elem = lib_vrf_peer_afi_safi_pfx_sent_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi/afi",
+			.cbs = {
+				.get_elem = lib_vrf_peer_afi_safi_afi_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/afi-safi/safi",
+			.cbs = {
+				.get_elem = lib_vrf_peer_afi_safi_safi_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/graceful-shutdown",
+			.cbs = {
+				.get_elem = lib_vrf_peer_graceful_shutdown_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/total-msgs-sent",
+			.cbs = {
+				.get_elem = lib_vrf_peer_total_msgs_sent_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bgp-peer:lib/vrf/peer/total-msgs-recvd",
+			.cbs = {
+				.get_elem = lib_vrf_peer_total_msgs_recvd_get_elem,
+			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};
+/* clang-format on */

--- a/bgpd/bgp_peer_nb.c
+++ b/bgpd/bgp_peer_nb.c
@@ -84,6 +84,8 @@ static const void *lib_vrf_peer_get_next(struct nb_cb_get_next_args *args)
 	struct bgp *bgp;
 	struct peer *peer = (struct peer *)args->list_entry;
 	struct listnode *node;
+	struct peer *it;
+	bool return_next = false;
 	struct vrf *vrfp = (struct vrf *)args->parent_list_entry;
 
 	if (!vrfp)
@@ -93,14 +95,18 @@ static const void *lib_vrf_peer_get_next(struct nb_cb_get_next_args *args)
 	if (!bgp || !bgp->peer)
 		return NULL;
 
-	if (!peer) {
-		node = listnode_head(bgp->peer);
-		return node ? listgetdata(node) : NULL;
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, it)) {
+		if (!peer)
+			return it;
+
+		if (return_next)
+			return it;
+
+		if (it == peer)
+			return_next = true;
 	}
 
-	node = listnode_lookup(bgp->peer, peer);
-	node = node ? listnextnode(node) : NULL;
-	return node ? listgetdata(node) : NULL;
+	return NULL;
 }
 
 static int lib_vrf_peer_get_keys(struct nb_cb_get_keys_args *args)

--- a/bgpd/bgp_peer_nb.h
+++ b/bgpd/bgp_peer_nb.h
@@ -1,0 +1,14 @@
+#ifndef _FRR_BGP_PEER_NB_H_
+#define _FRR_BGP_PEER_NB_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const struct frr_yang_module_info frr_bgp_peer_info;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bgpd/bgp_peer_nb.h
+++ b/bgpd/bgp_peer_nb.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #ifndef _FRR_BGP_PEER_NB_H_
 #define _FRR_BGP_PEER_NB_H_
 

--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -63,6 +63,7 @@ bgpd_libbgp_a_SOURCES = \
 	bgpd/bgp_nht.c \
 	bgpd/bgp_open.c \
 	bgpd/bgp_packet.c \
+	bgpd/bgp_peer_nb.c \
 	bgpd/bgp_pbr.c \
 	bgpd/bgp_rd.c \
 	bgpd/bgp_regex.c \
@@ -152,6 +153,7 @@ noinst_HEADERS += \
 	bgpd/bgp_nht.h \
 	bgpd/bgp_open.h \
 	bgpd/bgp_packet.h \
+	bgpd/bgp_peer_nb.h \
 	bgpd/bgp_pbr.h \
 	bgpd/bgp_rd.h \
 	bgpd/bgp_regex.h \
@@ -239,6 +241,7 @@ nodist_bgpd_bgpd_SOURCES = \
 	yang/frr-bgp-common-multiprotocol.yang.c \
 	yang/frr-bgp-neighbor.yang.c \
 	yang/frr-bgp-peer-group.yang.c \
+	yang/frr-bgp-peer.yang.c \
 	yang/frr-bgp-bmp.yang.c \
 	yang/frr-bgp-rpki.yang.c \
 	yang/frr-deviations-bgp-datacenter.yang.c \

--- a/doc/user/mgmtd.rst
+++ b/doc/user/mgmtd.rst
@@ -166,6 +166,39 @@ API:
  - NOTIFY_SELECT (send) - specify the sub-set of notifications the front-end
    wishes to receive, rather than the default of receiving all.
 
+Native NOTIFY_SELECT Mode Semantics
+-----------------------------------
+
+Native ``NOTIFY_SELECT`` supports mode-based delivery control through
+``struct mgmt_msg_notify_select`` (``lib/mgmt_msg_native.h``):
+
+ - ``mode``: notification mode.
+ - ``mode_data``: mode-specific data.
+
+The following modes are defined:
+
+ - ``NOTIFY_MODE_ON_CHANGE``: on-change notifications. ``mode_data`` must be
+   ``0``.
+ - ``NOTIFY_MODE_PERIODIC``: periodic notifications. ``mode_data`` is the
+   sample interval in milliseconds and must be non-zero.
+
+Invalid ``mode``/``mode_data`` combinations are rejected with native ``ERROR``
+(for example, ``-EINVAL``).
+
+In periodic mode, mgmtd maintains a per-session timer. On each timer expiry,
+mgmtd requests refreshed operational data for that session's selectors and
+forwards notifications to the front-end client.
+
+Front-end C clients can use:
+
+.. code-block:: c
+
+   int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client,
+                                      uint64_t session_id, uint64_t req_id,
+                                      bool replace, uint8_t mode,
+                                      uint32_t mode_data,
+                                      const char **selectors);
+
 
 Please refer to the MGMT Frontend Client Developers Reference and Guide
 (coming soon) for more details.

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -315,6 +315,7 @@ int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client, uint64_t sessi
 	msg->replace = replace;
 	msg->get_only = 0;
 	msg->subscribing = 0;
+	/* FE clients control delivery semantics via mode/mode_data. */
 	msg->mode = mode;
 	msg->mode_data = mode_data;
 

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -299,6 +299,38 @@ int mgmt_fe_send_commit_req(struct mgmt_fe_client *client, uint64_t session_id, 
 	return ret;
 }
 
+int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client, uint64_t session_id,
+				   uint64_t req_id, bool replace, uint8_t mode,
+				   uint32_t mode_data, const char **selectors)
+{
+	struct mgmt_msg_notify_select *msg;
+	uint i;
+	int ret;
+
+	msg = mgmt_msg_native_alloc_msg(struct mgmt_msg_notify_select, 0,
+					MTYPE_MSG_NATIVE_NOTIFY_SELECT);
+	msg->refer_id = session_id;
+	msg->req_id = req_id;
+	msg->code = MGMT_MSG_CODE_NOTIFY_SELECT;
+	msg->replace = replace;
+	msg->get_only = 0;
+	msg->subscribing = 0;
+	msg->mode = mode;
+	msg->mode_data = mode_data;
+
+	darr_foreach_i (selectors, i)
+		mgmt_msg_native_add_str(msg, selectors[i]);
+
+	debug_fe_client("Sending NOTIFY_SELECT session-id %" PRIu64 " req-id %" PRIu64
+			" mode=%u mode-data=%u selectors=%u",
+			session_id, req_id, msg->mode, msg->mode_data,
+			darr_len(selectors));
+
+	ret = mgmt_msg_native_send_msg(&client->client.conn, msg, false);
+	ret = fe_client_push_sent_msg(client, (struct mgmt_msg_header *)msg, ret);
+	return ret;
+}
+
 /*
  * Send get-data request.
  */

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -256,7 +256,9 @@ extern int mgmt_fe_send_commit_req(struct mgmt_fe_client *client, uint64_t sessi
  *    Notification mode (e.g. NOTIFY_MODE_ON_CHANGE, NOTIFY_MODE_PERIODIC).
  *
  * mode_data
- *    Mode-specific data. For periodic mode, interval in msec.
+ *    Mode-specific data:
+ *      - ON_CHANGE: must be 0.
+ *      - PERIODIC: interval in msec, must be non-zero.
  *
  * selectors
  *    Array of xpath selectors.

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -238,6 +238,38 @@ extern int mgmt_fe_send_commit_req(struct mgmt_fe_client *client, uint64_t sessi
 				   bool unlock);
 
 /*
+ * Send NOTIFY-SELECT to MGMTD daemon.
+ *
+ * client
+ *    Client object.
+ *
+ * session_id
+ *    Client session ID.
+ *
+ * req_id
+ *    Client request ID.
+ *
+ * replace
+ *    TRUE to replace existing selectors, FALSE to append selectors.
+ *
+ * mode
+ *    Notification mode (e.g. NOTIFY_MODE_ON_CHANGE, NOTIFY_MODE_PERIODIC).
+ *
+ * mode_data
+ *    Mode-specific data. For periodic mode, interval in msec.
+ *
+ * selectors
+ *    Array of xpath selectors.
+ *
+ * Returns:
+ *    0 on success, otherwise msg_conn_send_msg() return values.
+ */
+extern int mgmt_fe_send_notify_select_req(struct mgmt_fe_client *client,
+					  uint64_t session_id, uint64_t req_id, bool replace,
+					  uint8_t mode, uint32_t mode_data,
+					  const char **selectors);
+
+/*
  * Send GET-DATA to MGMTD daemon.
  *
  * client

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -225,6 +225,10 @@ const char *mgmt_msg_code_name(uint code);
 #define MGMT_MSG_FORMAT_BINARY 3 /* non-standard libyang internal format */
 #define MGMT_MSG_FORMAT_LAST   3
 
+/* notify mode values */
+#define NOTIFY_MODE_ON_CHANGE 0
+#define NOTIFY_MODE_PERIODIC  1
+
 /*
  * Now we're using LYD_FORMAT directly to avoid mapping code, but having our
  * own definitions allows us to create such a mapping in the future if libyang
@@ -501,13 +505,16 @@ _Static_assert(sizeof(struct mgmt_msg_rpc_reply) ==
  * @selectors: the xpath prefixes to selectors notifications through.
  * @replace: if true replace existing selectors with `selectors`.
  * @get_only: [backend-only]: if true do get op, don't change selectors.
+ * @mode: on-change or periodic mode.
+ * @mode_data: mode-specific data. For periodic mode, interval in msec.
  */
 struct mgmt_msg_notify_select {
 	struct mgmt_msg_header;
 	uint8_t replace;
 	uint8_t get_only;
 	uint8_t subscribing;
-	uint8_t resv2[5];
+	uint8_t mode;
+	uint32_t mode_data;
 
 	alignas(8) char selectors[];
 };

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -506,7 +506,9 @@ _Static_assert(sizeof(struct mgmt_msg_rpc_reply) ==
  * @replace: if true replace existing selectors with `selectors`.
  * @get_only: [backend-only]: if true do get op, don't change selectors.
  * @mode: on-change or periodic mode.
- * @mode_data: mode-specific data. For periodic mode, interval in msec.
+ * @mode_data: mode-specific data.
+ *            - NOTIFY_MODE_ON_CHANGE: must be 0.
+ *            - NOTIFY_MODE_PERIODIC: interval in msec, must be non-zero.
  */
 struct mgmt_msg_notify_select {
 	struct mgmt_msg_header;

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -38,8 +38,11 @@ struct mgmt_fe_session_ctx {
 	uint64_t txn_id;
 	uint64_t cfg_txn_id;
 	uint8_t notify_format;
+	uint8_t notify_mode;
+	uint32_t notify_mode_data;
 	uint8_t ds_locked[MGMTD_DS_MAX_ID];
 	const char **notify_xpaths;
+	struct event *sample_timer;
 	struct event *proc_cfg_txn_clnp;
 	struct event *proc_show_txn_clnp;
 
@@ -77,6 +80,7 @@ DECLARE_RBTREE_UNIQ(ns_string, struct ns_string, link, ns_string_compare);
 
 static struct msg_conn *fe_adapter_create(int conn_fd, union sockunion *from);
 static void fe_session_compute_commit_timers(struct mgmt_commit_stats *cmt_stats);
+static void fe_session_schedule_sample_timer(struct mgmt_fe_session_ctx *session);
 
 /* ---------------- */
 /* Global variables */
@@ -242,6 +246,49 @@ void mgmt_fe_ns_string_add_be_client(uint client_id, const char **selectors)
 	uint64_t session_id = MGMT_BE_CLIENT_TO_SESSION_ID(client_id);
 
 	ns_string_add_session(0, selectors, session_id, false, 0);
+}
+
+static uint64_t fe_session_notify_clients(struct mgmt_fe_session_ctx *session)
+{
+	const char **sp;
+	uint64_t clients = 0;
+
+	darr_foreach_p (session->notify_xpaths, sp)
+		clients |= mgmt_be_interested_clients(*sp, MGMT_BE_XPATH_SUBSCR_TYPE_OPER,
+						      "sample-timer");
+
+	return clients;
+}
+
+static void fe_session_sample_timer(struct event *event)
+{
+	struct mgmt_fe_session_ctx *session = EVENT_ARG(event);
+	uint64_t clients;
+
+	session->sample_timer = NULL;
+
+	if (session->notify_mode != NOTIFY_MODE_PERIODIC || !session->notify_mode_data ||
+	    !darr_len(session->notify_xpaths))
+		return;
+
+	clients = fe_session_notify_clients(session);
+	if (clients)
+		mgmt_txn_send_notify_selectors(0, session->session_id, clients, false,
+					       session->notify_xpaths);
+
+	fe_session_schedule_sample_timer(session);
+}
+
+static void fe_session_schedule_sample_timer(struct mgmt_fe_session_ctx *session)
+{
+	event_cancel(&session->sample_timer);
+
+	if (session->notify_mode != NOTIFY_MODE_PERIODIC || !session->notify_mode_data ||
+	    !darr_len(session->notify_xpaths))
+		return;
+
+	event_add_timer_msec(mgmt_loop, fe_session_sample_timer, session,
+			     session->notify_mode_data, &session->sample_timer);
 }
 
 uint64_t *mgmt_fe_ns_string_select(struct nb_node *nb_node, const char *notif)
@@ -502,6 +549,7 @@ static void fe_session_cleanup(struct mgmt_fe_session_ctx **sessionp)
 	rm_clients = ns_string_remove_session(session->session_id);
 	if (rm_clients && !mm->terminating)
 		mgmt_txn_send_notify_selectors(0, MGMTD_SESSION_ID_NONE, rm_clients, false, NULL);
+	event_cancel(&session->sample_timer);
 	darr_free_free(session->notify_xpaths);
 	hash_release(mgmt_fe_sessions, session);
 	XFREE(MTYPE_MGMTD_FE_SESSION, session);
@@ -523,6 +571,8 @@ static struct mgmt_fe_session_ctx *fe_session_create(struct mgmt_fe_client_adapt
 	session->client_id = client_id;
 	session->adapter = adapter;
 	session->notify_format = notify_format;
+	session->notify_mode = NOTIFY_MODE_ON_CHANGE;
+	session->notify_mode_data = 0;
 	session->txn_id = MGMTD_TXN_ID_NONE;
 	session->cfg_txn_id = MGMTD_TXN_ID_NONE;
 	LIST_INSERT_HEAD(&adapter->sessions, session, link);
@@ -1339,6 +1389,28 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 		}
 	}
 
+	if (msg->mode != NOTIFY_MODE_ON_CHANGE && msg->mode != NOTIFY_MODE_PERIODIC) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "Invalid mode: %u", msg->mode);
+		darr_free_free(selectors);
+		return;
+	}
+	if (msg->mode == NOTIFY_MODE_ON_CHANGE && msg->mode_data) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "mode_data must be 0 for on-change mode");
+		darr_free_free(selectors);
+		return;
+	}
+	if (msg->mode == NOTIFY_MODE_PERIODIC && !msg->mode_data) {
+		fe_session_send_error(session, req_id, false, -EINVAL,
+				      "mode_data must be non-zero for periodic mode");
+		darr_free_free(selectors);
+		return;
+	}
+
+	session->notify_mode = msg->mode;
+	session->notify_mode_data = msg->mode_data;
+
 	/* Validate all selectors, they need to resolve to actual northbound_nodes */
 	darr_foreach_p (selectors, sp) {
 		nb_nodes = nb_nodes_find(*sp);
@@ -1369,11 +1441,13 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	}
 
 	if (session->notify_xpaths && DEBUG_MODE_CHECK(&mgmt_debug_fe, DEBUG_MODE_ALL)) {
-		_dbg("Update NOTIFY selectors '%pSAd' (replace: %d) for session-id: %Lu",
-		     session->notify_xpaths, msg->replace, session->session_id);
+		_dbg("Update NOTIFY selectors '%pSAd' (replace: %d mode: %u mode-data: %u) for session-id: %Lu",
+		     session->notify_xpaths, msg->replace, session->notify_mode,
+		     session->notify_mode_data, session->session_id);
 	}
 
 	ns_string_add_session(req_id, selectors, session->session_id, msg->replace, rm_clients);
+	fe_session_schedule_sample_timer(session);
 done:
 	if (session->notify_xpaths != selectors)
 		darr_free(selectors);

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -253,6 +253,7 @@ static uint64_t fe_session_notify_clients(struct mgmt_fe_session_ctx *session)
 	const char **sp;
 	uint64_t clients = 0;
 
+	/* Resolve BE adapters that can serve the session's selector set. */
 	darr_foreach_p (session->notify_xpaths, sp)
 		clients |= mgmt_be_interested_clients(*sp, MGMT_BE_XPATH_SUBSCR_TYPE_OPER,
 						      "sample-timer");
@@ -267,12 +268,17 @@ static void fe_session_sample_timer(struct event *event)
 
 	session->sample_timer = NULL;
 
+	/* Timer is only active for periodic mode with a non-empty selector set. */
 	if (session->notify_mode != NOTIFY_MODE_PERIODIC || !session->notify_mode_data ||
 	    !darr_len(session->notify_xpaths))
 		return;
 
 	clients = fe_session_notify_clients(session);
 	if (clients)
+		/*
+		 * Use get_only flow (session-id refer_id) to request current state
+		 * and forward it as NOTIFY data to this FE session.
+		 */
 		mgmt_txn_send_notify_selectors(0, session->session_id, clients, false,
 					       session->notify_xpaths);
 
@@ -283,6 +289,7 @@ static void fe_session_schedule_sample_timer(struct mgmt_fe_session_ctx *session
 {
 	event_cancel(&session->sample_timer);
 
+	/* Don't arm a timer unless the subscription is periodic and valid. */
 	if (session->notify_mode != NOTIFY_MODE_PERIODIC || !session->notify_mode_data ||
 	    !darr_len(session->notify_xpaths))
 		return;
@@ -1395,12 +1402,14 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 		darr_free_free(selectors);
 		return;
 	}
+	/* ON_CHANGE must not carry interval data. */
 	if (msg->mode == NOTIFY_MODE_ON_CHANGE && msg->mode_data) {
 		fe_session_send_error(session, req_id, false, -EINVAL,
 				      "mode_data must be 0 for on-change mode");
 		darr_free_free(selectors);
 		return;
 	}
+	/* PERIODIC requires a non-zero interval in msec. */
 	if (msg->mode == NOTIFY_MODE_PERIODIC && !msg->mode_data) {
 		fe_session_send_error(session, req_id, false, -EINVAL,
 				      "mode_data must be non-zero for periodic mode");

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -604,6 +604,8 @@ void mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t session_id, uint64
 	msg->replace = selectors == NULL;
 	msg->get_only = session_id != MGMTD_SESSION_ID_NONE;
 	msg->subscribing = subscribing;
+	msg->mode = NOTIFY_MODE_ON_CHANGE;
+	msg->mode_data = 0;
 
 	if (selectors == NULL) {
 		/* Get selectors for all sessions */

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -604,6 +604,11 @@ void mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t session_id, uint64
 	msg->replace = selectors == NULL;
 	msg->get_only = session_id != MGMTD_SESSION_ID_NONE;
 	msg->subscribing = subscribing;
+	/*
+	 * MGMTd owns periodic scheduling for FE sessions. Backend selector-update
+	 * messages stay in on-change mode; periodic behavior is driven by MGMTd's
+	 * per-session timer and get_only polling flow.
+	 */
 	msg->mode = NOTIFY_MODE_ON_CHANGE;
 	msg->mode_data = 0;
 

--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -108,3 +108,9 @@ nodist_mgmtd_libmgmt_be_nb_la_SOURCES += \
 	# end
 endif
 
+if BGPD
+nodist_mgmtd_mgmtd_SOURCES += \
+	yang/frr-bgp-peer.yang.c \
+	# end
+endif
+

--- a/tests/topotests/lib/fe_client.py
+++ b/tests/topotests/lib/fe_client.py
@@ -79,7 +79,10 @@ NOTIFY_OP_DELETE = 2
 NOTIFY_OP_PATCH = 3
 NOTIFY_OP_GET_SYNC = 4
 
-MSG_FMT_NOTIFY_SELECT = "=B7x"
+NOTIFY_MODE_ON_CHANGE = 0
+NOTIFY_MODE_PERIODIC = 1
+
+MSG_FMT_NOTIFY_SELECT = "=BBBBI"
 
 MSG_FMT_SESSION_REQ = "=B7x"
 
@@ -369,21 +372,29 @@ class Session:
         logging.debug("Received GET: %s: %s", mfixed, mdata)
         return result
 
-    def add_notify_select(self, replace, notif_xpaths):
+    def add_notify_select(
+        self,
+        replace,
+        notif_xpaths,
+        mode=NOTIFY_MODE_ON_CHANGE,
+        mode_data=0,
+    ):
         """Send a request to add notification subscriptions to the given XPaths.
 
         Args:
             replace (bool): Whether to replace existing notification subscriptions.
             notif_xpaths (list of str): List of XPaths to subscribe to notifications on.
+            mode (int): Notification mode, e.g. ON_CHANGE or PERIODIC.
+            mode_data (int): Mode-specific data. For periodic mode, interval in msec.
         """
         mdata, _ = self.get_native_msg_header(MSG_CODE_NOTIFY_SELECT)
-        mdata += struct.pack(MSG_FMT_NOTIFY_SELECT, replace)
+        mdata += struct.pack(MSG_FMT_NOTIFY_SELECT, int(replace), 0, 0, mode, mode_data)
 
         for xpath in notif_xpaths:
             mdata += xpath.encode("utf-8") + b"\x00"
 
         self.send_native_msg(mdata)
-        logging.debug("Sent NOTIFY_SELECT")
+        logging.debug("Sent NOTIFY_SELECT mode=%s mode_data=%s", mode, mode_data)
 
     def recv_notify(self, xpaths=None):
         """Receive a notification message, optionally setting up XPath filters first.
@@ -434,6 +445,23 @@ def __parse_args():
         help="Number of notifications to listen for 0 for infinite",
     )
     parser.add_argument(
+        "--notify-mode",
+        choices=["on-change", "periodic"],
+        default="on-change",
+        help="Notification mode for --listen subscriptions",
+    )
+    parser.add_argument(
+        "--notify-mode-data",
+        type=int,
+        default=0,
+        help="Mode-specific data (msec for periodic mode)",
+    )
+    parser.add_argument(
+        "--allow-invalid-mode-data",
+        action="store_true",
+        help="Allow sending invalid mode/mode_data combinations for negative tests",
+    )
+    parser.add_argument(
         "-b", "--both", action="store_true", help="return both config and data"
     )
     parser.add_argument(
@@ -448,6 +476,12 @@ def __parse_args():
     parser.add_argument("-s", "--server", default=MPATH, help="path to server socket")
     parser.add_argument("-v", "--verbose", action="store_true", help="Be verbose")
     args = parser.parse_args()
+
+    if not args.allow_invalid_mode_data:
+        if args.notify_mode == "on-change" and args.notify_mode_data != 0:
+            parser.error("--notify-mode-data must be 0 for --notify-mode on-change")
+        if args.notify_mode == "periodic" and args.notify_mode_data <= 0:
+            parser.error("--notify-mode-data must be > 0 for --notify-mode periodic")
 
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(level=level, format="%(asctime)s %(levelname)s: %(message)s")
@@ -493,8 +527,16 @@ def __main():
 
     if args.listen is not None:
         i = args.notify_count
+        notify_mode = (
+            NOTIFY_MODE_PERIODIC if args.notify_mode == "periodic" else NOTIFY_MODE_ON_CHANGE
+        )
         if args.listen:
-            sess.add_notify_select(True, args.listen)
+            sess.add_notify_select(
+                True,
+                args.listen,
+                mode=notify_mode,
+                mode_data=args.notify_mode_data,
+            )
         while i > 0 or args.notify_count == 0:
             result_type, op, xpath, notif = sess.recv_notify()
             if op == NOTIFY_OP_NOTIFICATION:

--- a/yang/frr-bgp-peer.yang
+++ b/yang/frr-bgp-peer.yang
@@ -1,0 +1,206 @@
+module frr-bgp-peer {
+  yang-version 1.1;
+  namespace "http://frrouting.org/yang/bgp-peer";
+  prefix frr-bgp-peer;
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import frr-routing {
+    prefix frr-rt;
+  }
+
+  organization
+    "Free Range Routing";
+  contact
+    "FRR Users List:       <mailto:frog@lists.frrouting.org>
+     FRR Development List: <mailto:dev@lists.frrouting.org>";
+  description
+    "This module defines bgp route map settings";
+
+  revision 2020-01-02 {
+    description
+      "Initial revision";
+  }
+
+  container lib {
+     list vrf {
+       config false;
+       key "id";
+       description
+         "Vrf.";
+       leaf id {
+         type string;
+         description
+           "VRF Id";
+       }
+       list peer {
+          config false;
+          key "name";
+          description
+            "Peer.";
+          leaf name {
+            type string;
+            description
+              "Peer name";
+          }
+          leaf status {
+            config false;
+            type string;
+            description
+              "Peer status";
+          }
+          leaf established-transitions {
+            config false;
+            type uint32;
+            description
+               "Transitions";
+          }
+          leaf in-queue {
+            config false;
+            type uint32;
+            description
+               "Input buffer queue";
+          }
+          leaf out-queue {
+            config false;
+            type uint32;
+            description
+               "Output buffer queue";
+          }
+          leaf local-as {
+            config false;
+            type uint32;
+            description
+                "Local Autonomous System Number";
+          }
+          leaf peer-as {
+            config false;
+            type uint32;
+            description
+                "AS Number of BGP peer";
+          }
+          leaf last-established {
+            config false;
+            type uint64;
+            description
+                "Last Established Time";
+          }
+          leaf description {
+            config false;
+            type string;
+            description
+                "Description of peer";
+          }
+          leaf peer-group {
+            config false;
+            type string;
+            description
+                "Name of peer-group";
+          }
+          leaf peer-type {
+            config false;
+            type string;
+            description
+                "Type of peer";
+          }
+          leaf neighbor-address {
+            config false;
+            type string;
+            description
+                "IP Address of BGP peer";
+          }
+          container messages {
+            description
+              "Counters for BGP messages sent and received from the
+              neighbor";
+            container sent {
+              description
+                "Counters relating to BGP messages sent to the neighbor";
+              uses bgp-peer-message;
+            }
+            container received {
+              description
+                "Counters for BGP messages received from the neighbor";
+              uses bgp-peer-message;
+            }
+          }
+          list afi-safi {
+            config false;
+            key "afi-safi-name";
+            description
+              "AFI-SAFI.";
+            leaf afi-safi-name {
+              config false;
+              type string;
+              description
+                "AFI SAFI name";
+            }
+            leaf rcvd-pfx {
+              config false;
+              type uint32;
+              description
+                 "Recvd prefixes post policy";
+            }
+            leaf rcvd-pfx-installed {
+              config false;
+              type uint32;
+              description
+                "Recvd prefixes installed post policy";
+            }
+            leaf pfx-sent {
+              config false;
+              type uint32;
+              description
+                 "Prefixes sent from the peer";
+            }
+            leaf afi {
+              config false;
+              type string;
+              description
+                  "Address family";
+            }
+            leaf safi {
+               config false;
+               type string;
+               description
+                  "Subsequent Address family";
+            }
+          }
+          leaf total-msgs-sent {
+            config false;
+            type uint32;
+            description
+               "Total messages sent";
+          }
+          leaf total-msgs-recvd {
+            config false;
+            type uint32;
+            description
+               "Total messages recieved";
+          }
+          leaf graceful-shutdown {
+            config false;
+            type boolean;
+            description
+                "Gaceful shutdown status";
+          }
+      }
+    }
+  }
+  grouping bgp-peer-message{
+    leaf last-notification-error-code{
+      config false;
+      type string;
+      description
+          "Error sent or received on peering session";
+    }
+    leaf updates {
+      config false;
+      type uint32;
+      description
+          "Update Messages sent/recieved";
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -95,6 +95,7 @@ dist_yangmodels_DATA += yang/frr-bgp-common.yang
 dist_yangmodels_DATA += yang/frr-bgp-common-multiprotocol.yang
 dist_yangmodels_DATA += yang/frr-bgp-neighbor.yang
 dist_yangmodels_DATA += yang/frr-bgp-peer-group.yang
+dist_yangmodels_DATA += yang/frr-bgp-peer.yang
 dist_yangmodels_DATA += yang/frr-deviations-bgp-datacenter.yang
 dist_yangmodels_DATA += yang/frr-bgp-rpki.yang
 dist_yangmodels_DATA += yang/frr-bgp-bmp.yang


### PR DESCRIPTION
Register bgpd as an mgmtd backend client (config/oper/rpc path wiring).
Add and wire frr-bgp-peer operational model/callback support under /frr-bgp-peer:lib/vrf.
Expose per-peer and per-AFI/SAFI operational fields through vtysh and FE periodic sampling.
Include compatibility and iterator hardening fixes to keep oper walks stable across FRR variants.
Stacked:

This branch is intentionally stacked on top of periodic notify/select support from https://github.com/FRRouting/frr/pull/21253
Changes:

bgpd backend client wiring and operational xpath registration for /frr-bgp-peer:lib/vrf.
bgpd/bgp_peer_nb.c + bgpd/bgp_peer_nb.h callback implementation for:
peer identity/state, ASNs, queues, transitions, message counters, graceful-shutdown
AFI/SAFI list and counters
Build/YANG wiring updates required for bgpd/mgmtd integration.
Safe peer iteration in oper walk path to prevent runtime aborts.
Version-compatible callback handling for notify/AFI-SAFI lookup differences.

Testing:

```
`IPv4 Unicast Summary:
BGP router identifier 1.1.1.1, local AS number 65000 VRF default vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 29 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
10.0.0.2        4      65001         0         0        0    0    0    never         Idle        0 N/A

Total number of neighbors 1
sudo python3 tests/topotests/lib/fe_client.py --server /var/run/frr/mgmtd_fe.sock --listen "/frr-bgp-peer:lib/vrf" --notify-mode periodic --notify-mode-data 2000 --notify-count 3 -v
{"frr-bgp-peer:lib":{"vrf":[{"id":"default","peer":[{"name":"10.0.0.2","status":"Idle","established-transitions":0,"in-queue":0,"out-queue":0,"local-as":65000,"peer-as":65001,"last-established":"1774068977","description":"","peer-group":"","peer-type":"external","neighbor-address":"10.0.0.2","messages":{"sent":{"last-notification-error-code":"","updates":0},"received":{"last-notification-error-code":"","updates":0}},"afi-safi":[{"afi-safi-name":"frr-routing:ipv4-unicast","rcvd-pfx":0,"rcvd-pfx-installed":0,"afi":"IPv4","safi":"unicast"}],"total-msgs-sent":0,"total-msgs-recvd":0,"graceful-shutdown":false}]}]}}
2026-03-22 20:02:15,777 DEBUG: Connecting to server on /var/run/frr/mgmtd_fe.sock
2026-03-22 20:02:15,778 INFO: Connected to server on /var/run/frr/mgmtd_fe.sock
2026-03-22 20:02:15,778 DEBUG: Sent native SESSION-REQ
2026-03-22 20:02:15,778 DEBUG: Recv native SESSION-REPLY Message: sess-id 1005: fixed: (1,): b''
2026-03-22 20:02:15,778 DEBUG: Sent NOTIFY_SELECT mode=1 mode_data=2000
2026-03-22 20:02:15,778 DEBUG: Waiting for Notify Message
2026-03-22 20:02:15,789 DEBUG: Received Notify Message: (2, 4): b'/frr-bgp-peer:lib/vrf\x00{"frr-bgp-peer:lib":{"vrf":[{"id":"default","peer":[{"name":"10.0.0.2","status":"Idle","established-transitions":0,"in-queue":0,"out-queue":0,"local-as":65000,"peer-as":65001,"last-established":"1774068976","description":"","peer-group":"","peer-type":"external","neighbor-address":"10.0.0.2","messages":{"sent":{"last-notification-error-code":"","updates":0},"received":{"last-notification-error-code":"","updates":0}},"afi-safi":[{"afi-safi-name":"frr-routing:ipv4-unicast","rcvd-pfx":0,"rcvd-pfx-installed":0,"afi":"IPv4","safi":"unicast"}],"total-msgs-sent":0,"total-msgs-recvd":0,"graceful-shutdown":false}]}]}}\x00'
2026-03-22 20:02:15,789 WARNING: ignoring datastore notification op: 4 xpath: /frr-bgp-peer:lib/vrf data: {"frr-bgp-peer:lib":{"vrf":[{"id":"default","peer":[{"name":"10.0.0.2","status":"Idle","established-transitions":0,"in-queue":0,"out-queue":0,"local-as":65000,"peer-as":65001,"last-established":"1774068976","description":"","peer-group":"","peer-type":"external","neighbor-address":"10.0.0.2","messages":{"sent":{"last-notification-error-code":"","updates":0},"received":{"last-notification-error-code":"","updates":0}},"afi-safi":[{"afi-safi-name":"frr-routing:ipv4-unicast","rcvd-pfx":0,"rcvd-pfx-installed":0,"afi":"IPv4","safi":"unicast"}],"total-msgs-sent":0,"total-msgs-recvd":0,"graceful-shutdown":false}]}]}}
2026-03-22 20:02:15,789 DEBUG: Waiting for Notify Message
2026-03-22 20:02:17,791 DEBUG: Received Notify Message: (2, 4): b'/frr-bgp-peer:lib/vrf\x00{"frr-bgp-peer:lib":{"vrf":[{"id":"default","peer":[{"name":"10.0.0.2","status":"Active","established-transitions":0,"in-queue":0,"out-queue":0,"local-as":65000,"peer-as":65001,"last-established":"1774068976","description":"","peer-group":"","peer-type":"external","neighbor-address":"10.0.0.2","messages":{"sent":{"last-notification-error-code":"","updates":0},"received":{"last-notification-error-code":"","updates":0}},"afi-safi":[{"afi-safi-name":"frr-routing:ipv4-unicast","rcvd-pfx":0,"rcvd-pfx-installed":0,"afi":"IPv4","safi":"unicast"}],"total-msgs-sent":0,"total-msgs-recvd":0,"graceful-shutdown":false}]}]}}\x00'
2026-03-22 20:02:17,791 WARNING: ignoring datastore notification op: 4 xpath: /frr-bgp-peer:lib/vrf data: {"frr-bgp-peer:lib":{"vrf":[{"id":"default","peer":[{"name":"10.0.0.2","status":"Active","established-transitions":0,"in-queue":0,"out-queue":0,"local-as":65000,"peer-as":65001,"last-established":"1774068976","description":"","peer-group":"","peer-type":"external","neighbor-address":"10.0.0.2","messages":{"sent":{"last-notification-error-code":"","updates":0},"received":{"last-notification-error-code":"","updates":0}},"afi-safi":[{"afi-safi-name":"frr-routing:ipv4-unicast","rcvd-pfx":0,"rcvd-pfx-installed":0,"afi":"IPv4","safi":"unicast"}],"total-msgs-sent":0,"total-msgs-recvd":0,"graceful-shutdown":false}]}]}}
2026-03-22 20:02:17,791 DEBUG: Waiting for Notify Message`
```