### PR TITLE
bgpd: Move rpki strict check to bgp_accept() (backport)

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -47,6 +47,13 @@ DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer));
 DEFINE_HOOK(peer_status_changed, (struct peer * peer), (peer));
 DEFINE_HOOK(bgp_rpki_connection_status, (const char *vrf_name), (vrf_name));
 
+bool bgp_rpki_cache_connected(struct bgp *bgp)
+{
+	struct vrf *vrf = vrf_lookup_by_id(bgp->vrf_id);
+
+	return hook_call(bgp_rpki_connection_status, vrf ? vrf->name : VRF_DEFAULT_NAME);
+}
+
 /* Definition of display strings corresponding to FSM events. This should be
  * kept consistent with the events defined in bgpd.h
  */
@@ -2096,8 +2103,6 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 {
 	struct peer *peer = connection->peer;
 	enum connect_result status;
-	bool rpki_cache_connected;
-	struct vrf *vrf = vrf_lookup_by_id(peer->bgp->vrf_id);
 
 	bgp_peer_conf_if_to_su_update(connection);
 
@@ -2131,17 +2136,14 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 	/* Clear peer capability flag. */
 	peer->cap = 0;
 
-	if (peergroup_flag_check(peer, PEER_FLAG_RPKI_STRICT)) {
-		rpki_cache_connected = hook_call(bgp_rpki_connection_status,
-						 vrf ? vrf->name : VRF_DEFAULT_NAME);
-		if (!rpki_cache_connected) {
-			if (bgp_debug_neighbor_events(peer))
-				flog_err(EC_BGP_FSM,
-					 "%s [FSM] RPKI strict mode enabled, but RPKI cache is not connected",
-					 peer->host);
-			peer_set_last_reset(peer, PEER_DOWN_RPKI_DOWN);
-			return BGP_FSM_FAILURE;
-		}
+	if (peergroup_flag_check(peer, PEER_FLAG_RPKI_STRICT) &&
+	    !bgp_rpki_cache_connected(peer->bgp)) {
+		if (bgp_debug_neighbor_events(peer))
+			flog_err(EC_BGP_FSM,
+				 "%s [FSM] RPKI strict mode enabled, but RPKI cache is not connected",
+				 peer->host);
+		peer_set_last_reset(peer, PEER_DOWN_RPKI_DOWN);
+		return BGP_FSM_FAILURE;
 	}
 
 	if (peer->bgp->vrf_id == VRF_UNKNOWN) {
@@ -2384,7 +2386,6 @@ bgp_establish(struct peer_connection *connection)
 	struct peer *other;
 	struct peer *peer = connection->peer;
 	struct bgp *bgp = peer->bgp;
-	bool rpki_cache_connected;
 	struct vrf *vrf = NULL;
 
 	other = peer->doppelganger;
@@ -2406,19 +2407,6 @@ bgp_establish(struct peer_connection *connection)
 		if (other && other->connection)
 			(void)hash_get(bgp->connectionhash, other->connection, hash_alloc_intern);
 		return BGP_FSM_FAILURE;
-	}
-
-	if (peergroup_flag_check(peer, PEER_FLAG_RPKI_STRICT)) {
-		rpki_cache_connected = hook_call(bgp_rpki_connection_status,
-						 vrf ? vrf->name : VRF_DEFAULT_NAME);
-		if (!rpki_cache_connected) {
-			if (bgp_debug_neighbor_events(peer))
-				flog_err(EC_BGP_FSM,
-					 "%s [FSM] RPKI strict mode enabled, but RPKI cache is not connected",
-					 peer->host);
-			peer_set_last_reset(peer, PEER_DOWN_RPKI_DOWN);
-			return BGP_FSM_FAILURE;
-		}
 	}
 
 	/*

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -169,4 +169,5 @@ const char *print_global_gr_cmd(enum global_gr_command gl_gr_cmd);
 int bgp_peer_reg_with_nht(struct peer *peer);
 void bgp_gr_check_path_select(struct bgp *bgp, afi_t afi, safi_t safi);
 void bgp_gr_start_all_deferral_timers(struct bgp *bgp);
+extern bool bgp_rpki_cache_connected(struct bgp *bgp);
 #endif /* _QUAGGA_BGP_FSM_H */

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -32,6 +32,7 @@
 #include "bgpd/bgp_network.h"
 #include "bgpd/bgp_zebra.h"
 #include "bgpd/bgp_nht.h"
+#include "bgpd/bgp_vty.h"
 
 extern struct zebra_privs_t bgpd_privs;
 
@@ -512,6 +513,16 @@ static void bgp_accept(struct event *thread)
 		struct peer *dynamic_peer = peer_lookup_dynamic_neighbor(bgp, &su);
 
 		if (dynamic_peer) {
+			if (peergroup_flag_check(dynamic_peer, PEER_FLAG_RPKI_STRICT) &&
+			    !bgp_rpki_cache_connected(dynamic_peer->bgp)) {
+				if (bgp_debug_neighbor_events(dynamic_peer))
+					zlog_debug("[Event] Incoming BGP connection rejected from %s due to RPKI cache not connected (strict mode)",
+						   dynamic_peer->host);
+				peer_delete(dynamic_peer);
+				close(bgp_sock);
+				return;
+			}
+
 			incoming = dynamic_peer->connection;
 			/* Dynamic neighbor has been created, let it proceed */
 			incoming->fd = bgp_sock;
@@ -631,6 +642,16 @@ static void bgp_accept(struct event *thread)
 		zlog_warn("[Event] Incoming BGP connection rejected from %s due missing BGP identifier, set it with `bgp router-id`",
 			  peer->host);
 		peer_set_last_reset(peer, PEER_DOWN_ROUTER_ID_ZERO);
+		close(bgp_sock);
+		return;
+	}
+
+	if (peergroup_flag_check(peer, PEER_FLAG_RPKI_STRICT) &&
+	    !bgp_rpki_cache_connected(peer->bgp)) {
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("[Event] Incoming BGP connection rejected from %s due to RPKI cache not connected (strict mode)",
+				   peer->host);
+		peer_set_last_reset(peer, PEER_DOWN_RPKI_DOWN);
 		close(bgp_sock);
 		return;
 	}


### PR DESCRIPTION
Current code checks on bgp_start and bgp_establish() to prevent incoming and outgoing connections when rpki strict mode is on and bgp is not connected to rpki.  Modify the code such that the bgp_establish() code is no longer the place to check this it should be in bgp_accept().  Without this there is a very reproducible crash that happens because the check in bgp_establish() is immediately after a doppelganger move that is not properly handled when that situation happens.