### PR TITLE
doc: document common daemon options and link -w references

### DIFF
--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -185,8 +185,8 @@ present and the :file:`frr.conf` is read instead.
 
 .. program:: pathd
 
-:abbr:`PATH` supports all the common FRR daemon start options which are
-documented elsewhere.
+:abbr:`PATH` supports all the common FRR daemon start options
+(:ref:`common-invocation-options`).
 
 PCEP Support
 ============

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -19,8 +19,8 @@ Starting PBR
 
 .. program:: pbrd
 
-:abbr:`PBR` supports all the common FRR daemon start options, which are
-documented elsewhere.
+:abbr:`PBR` supports all the common FRR daemon start options
+(:ref:`common-invocation-options`).
 
 .. _pbr-nexthop-groups:
 

--- a/doc/user/setup.rst
+++ b/doc/user/setup.rst
@@ -133,7 +133,19 @@ user instead of root.
 The next set of lines controls what options are passed to daemons when started
 from the service script. Usually daemons will have ``--daemon`` and ``-A
 <address>`` specified in order to daemonize and listen for VTY commands on a
-particular address.
+particular address. For the full list of options available to all daemons, see
+:ref:`common-invocation-options`.
+
+To pass the same option to every daemon at once, use the
+``frr_global_options`` variable. For example, to enable VRF-backed network
+namespaces on all daemons:
+
+::
+
+   frr_global_options="-w"
+
+Options set in ``frr_global_options`` are prepended to each daemon's individual
+options.
 
 The remaining file content regarding `watchfrr_options` and `*_wrap` settings
 should not normally be needed;  refer to the comments in case they are.

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -17,8 +17,8 @@ Starting SHARP
 
 .. program:: sharpd
 
-:abbr:`SHARP` supports all the common FRR daemon start options which are
-documented elsewhere.
+:abbr:`SHARP` supports all the common FRR daemon start options
+(:ref:`common-invocation-options`).
 
 .. _using-sharp:
 

--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -14,8 +14,8 @@ Starting STATIC
 
 .. program:: staticd
 
-:abbr:`STATIC` supports all the common FRR daemon start options which are
-documented elsewhere.
+:abbr:`STATIC` supports all the common FRR daemon start options
+(:ref:`common-invocation-options`).
 
 .. include:: config-include.rst
 

--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -28,8 +28,8 @@ Starting VRRP
 
 .. program:: vrrpd
 
-:abbr:`VRRP` supports all the common FRR daemon start options which are
-documented elsewhere.
+:abbr:`VRRP` supports all the common FRR daemon start options
+(:ref:`common-invocation-options`).
 
 .. _vrrp-protocol-overview:
 

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -52,15 +52,17 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
 .. option:: -n, --vrfwnetns
 
+   .. deprecated:: 10.3
+      Use the global :ref:`-w / --vrfwnetns <common-invocation-options>`
+      option instead, which applies to all daemons uniformly.
+
    When *Zebra* starts with this option, the VRF backend is based on Linux
    network namespaces. That implies that all network namespaces discovered by
    ZEBRA will create an associated VRF. The other daemons will operate on the VRF
-   VRF defined by *Zebra*, as usual. If this option is specified when running
+   defined by *Zebra*, as usual. If this option is specified when running
    *Zebra*, one must also specify the same option for *mgmtd*.
 
-   This options is deprecated. Please use the global -w option instead.
-
-   .. seealso:: :ref:`zebra-vrf`
+   .. seealso:: :ref:`zebra-vrf`, :ref:`common-invocation-options`
 
 .. option:: -z <path_to_socket>, --socket <path_to_socket>
 
@@ -539,7 +541,7 @@ to find the next route table to use to look for a route match.  As such if
 your VRF table does not have a default blackhole route with a high metric
 VRF route lookup will leave the table specified by the VRF, which is undesirable.
 
-If the :option:`-w` option is chosen, then the *Linux network namespace* will
+If the :ref:`-w <common-invocation-options>` option is chosen, then the *Linux network namespace* will
 be mapped over the *Zebra* VRF. That implies that *Zebra* is able to configure
 several *Linux network namespaces*.  The routing table associated to that VRF
 is the whole routing tables located in that namespace. For instance, this mode
@@ -564,12 +566,12 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    *Zebra* is launched with default settings, this will be the ``TABLENO`` of
    the VRF configured on the kernel, thanks to information provided in
    https://www.kernel.org/doc/Documentation/networking/vrf.txt. If *Zebra* is
-   launched with :option:`-w` option, this will be the default routing table of
+   launched with :ref:`-w <common-invocation-options>` option, this will be the default routing table of
    the *Linux network namespace* ``VRF``.
 
 .. clicmd:: show ip route vrf VRF table TABLENO
 
-   The show command is only available with :option:`-w` option. This command
+   The show command is only available with :ref:`-w <common-invocation-options>` option. This command
    will dump the routing table ``TABLENO`` of the *Linux network namespace*
    ``VRF``.
 


### PR DESCRIPTION
The common invocation options (defined in lib/libfrr.c) are already documented in basic.rst under the common-invocation-options label, but several daemon pages refer to them only as "documented elsewhere" without an actual reference.

- Replace all "documented elsewhere" occurences with a proper :ref:`common-invocation-options` link in pathd, pbr, sharp, static, and vrrp docs
- Document the frr_global_options variable in setup.rst, including a cross-reference to the common options and an example showing how to pass -w to all daemons at once
- Deprecate zebra's -n/--vrfwnetns in favour of the global -w option using a proper .. deprecated:: directive with a link to the common options section
- Replace bare :option:`-w` references in zebra.rst (which Sphinx couldn't resolve) with :ref:`-w <common-invocation-options>` links (this also fixes some build errors we've been getting)


This should help avoid misunderstandings like #20992.