### PR TITLE
pimd: fix crash due to double free

### DIFF
--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -197,6 +197,7 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 {
 	int result;
 	struct pim_interface *pim_oif = oif->info;
+	struct channel_oil *live;
 
 	tib_sg_proxy_join_prune_check(pim, sg, oif, false);
 
@@ -216,6 +217,9 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	 access an invalid pointer.
 	*/
 	if (pim->stopping)
+		return;
+
+	if (!*oilp)
 		return;
 
 	result = pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
@@ -254,5 +258,17 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	 */
 	pim_ifchannel_local_membership_del(oif, &sg);
 
-	*oilp = pim_channel_oil_del(*oilp, __func__);
+	/*
+	 * local_membership_del may delete the ifchannel and last upstream,
+	 * which runs pim_channel_oil_upstream_deref() and frees the channel_oil.
+	 * IGMP still holds *oilp in that case; a second pim_channel_oil_del()
+	 * corrupts the RB tree (typed_rb_remove on freed / zeroed links).
+	 */
+
+	live = pim_find_channel_oil(pim, &sg);
+
+	if (live == *oilp)
+		*oilp = pim_channel_oil_del(live, __func__);
+	else
+		*oilp = NULL;
 }


### PR DESCRIPTION
local_membership_del may delete the ifchannel and last upstream, which runs pim_channel_oil_upstream_deref() and frees the channel_oil. IGMP still holds *oilp in that case; a second pim_channel_oil_del() corrupts the RB tree (typed_rb_remove on freed / zeroed links).