### PR TITLE
bgpd: Replace `update-delay` with `convergence-wait`

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -948,53 +948,52 @@ static void bgp_graceful_deferral_timer_expire(struct event *event)
 	bgp_do_deferred_path_selection(bgp, afi, safi);
 }
 
-static bool bgp_update_delay_applicable(struct bgp *bgp)
+static bool bgp_convergence_wait_applicable(struct bgp *bgp)
 {
-	/* update_delay_over flag should be reset (set to 0) for any new
-	   applicability of the update-delay during BGP process lifetime.
-	   And it should be set after an occurrence of the update-delay is
+	/* convergence_wait_over flag should be reset (set to 0) for any new
+	   applicability of the convergence-wait during BGP process lifetime.
+	   And it should be set after an occurrence of the convergence-wait is
 	   over)*/
-	if (!bgp->update_delay_over)
+	if (!bgp->convergence_wait_over)
 		return true;
 	return false;
 }
 
-bool bgp_update_delay_active(struct bgp *bgp)
+bool bgp_convergence_wait_active(struct bgp *bgp)
 {
-	if (bgp->t_update_delay)
+	if (bgp->t_convergence_wait)
 		return true;
 	return false;
 }
 
-bool bgp_update_delay_configured(struct bgp *bgp)
+bool bgp_convergence_wait_configured(struct bgp *bgp)
 {
-	if (bgp->v_update_delay)
+	if (bgp->v_convergence_wait)
 		return true;
 	return false;
 }
 
 /* Do the post-processing needed when bgp comes out of the read-only mode
-   on ending the update delay. */
-void bgp_update_delay_end(struct bgp *bgp)
+   on ending the convergence wait. */
+void bgp_convergence_wait_end(struct bgp *bgp)
 {
-	event_cancel(&bgp->t_update_delay);
+	event_cancel(&bgp->t_convergence_wait);
 	event_cancel(&bgp->t_establish_wait);
 
-	/* Reset update-delay related state */
-	bgp->update_delay_over = 1;
+	/* Reset convergence-wait related state */
+	bgp->convergence_wait_over = 1;
 	bgp->established = 0;
 	bgp->restarted_peers = 0;
 	bgp->received_eors = 0;
 
-	frr_timestamp(3, bgp->update_delay_end_time,
-		      sizeof(bgp->update_delay_end_time));
+	frr_timestamp(3, bgp->convergence_wait_end_time, sizeof(bgp->convergence_wait_end_time));
 
 	/*
 	 * Add an end-of-initial-update marker to the main process queues so
 	 * that
 	 * the route advertisement timer for the peers can be started. Also set
 	 * the zebra and peer update hold flags. These flags are used to achieve
-	 * three stages in the update-delay post processing:
+	 * three stages in the convergence-wait post processing:
 	 *  1. Finish best-path selection for all the prefixes held on the
 	 * queues.
 	 *     (routes in BGP are updated, and peers sync queues are populated
@@ -1019,9 +1018,9 @@ void bgp_update_delay_end(struct bgp *bgp)
 	 */
 	work_queue_unplug(bgp->process_queue);
 
-	/* Re-announce the routes once the update-delay timer expires.
+	/* Re-announce the routes once the convergence-wait timer expires.
 	 * This is needed to ensure that the routes are re-advertised to the
-	 * peers after the update-delay is over. E.g. default-originate.
+	 * peers after the convergence-wait is over. E.g. default-originate.
 	 */
 	update_group_announce(bgp);
 }
@@ -1040,8 +1039,8 @@ void bgp_start_routeadv(struct bgp *bgp)
 	if (bgp->main_peers_update_hold)
 		return;
 
-	frr_timestamp(3, bgp->update_delay_peers_resume_time,
-		      sizeof(bgp->update_delay_peers_resume_time));
+	frr_timestamp(3, bgp->convergence_wait_peers_resume_time,
+		      sizeof(bgp->convergence_wait_peers_resume_time));
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 		struct peer_connection *connection = peer->connection;
@@ -1243,16 +1242,16 @@ static void bgp_maxmed_onstartup_process_status_change(struct peer *peer)
 	}
 }
 
-/* The update delay timer expiry callback. */
-static void bgp_update_delay_timer(struct event *event)
+/* The convergence wait timer expiry callback. */
+static void bgp_convergence_wait_timer(struct event *event)
 {
 	struct bgp *bgp;
 
 	zlog_info("Update delay ended - timer expired.");
 
 	bgp = EVENT_ARG(event);
-	event_cancel(&bgp->t_update_delay);
-	bgp_update_delay_end(bgp);
+	event_cancel(&bgp->t_convergence_wait);
+	bgp_convergence_wait_end(bgp);
 }
 
 /* The establish wait timer expiry callback. */
@@ -1264,14 +1263,14 @@ static void bgp_establish_wait_timer(struct event *event)
 
 	bgp = EVENT_ARG(event);
 	event_cancel(&bgp->t_establish_wait);
-	bgp_check_update_delay(bgp);
+	bgp_check_convergence_wait(bgp);
 }
 
-/* Steps to begin the update delay:
+/* Steps to begin the convergence wait:
      - initialize queues if needed
      - stop the queue processing
      - start the timer */
-static void bgp_update_delay_begin(struct bgp *bgp)
+static void bgp_convergence_wait_begin(struct bgp *bgp)
 {
 	struct listnode *node, *nnode;
 	struct peer *peer;
@@ -1280,43 +1279,43 @@ static void bgp_update_delay_begin(struct bgp *bgp)
 	work_queue_plug(bgp->process_queue);
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
-		peer->update_delay_over = 0;
+		peer->convergence_wait_over = 0;
 
-	/* Start the update-delay timer */
-	event_add_timer(bm->master, bgp_update_delay_timer, bgp,
-			bgp->v_update_delay, &bgp->t_update_delay);
+	/* Start the convergence-wait timer */
+	event_add_timer(bm->master, bgp_convergence_wait_timer, bgp, bgp->v_convergence_wait,
+			&bgp->t_convergence_wait);
 
-	if (bgp->v_establish_wait != bgp->v_update_delay)
+	if (bgp->v_establish_wait != bgp->v_convergence_wait)
 		event_add_timer(bm->master, bgp_establish_wait_timer, bgp,
 				bgp->v_establish_wait, &bgp->t_establish_wait);
 
-	frr_timestamp(3, bgp->update_delay_begin_time,
-		      sizeof(bgp->update_delay_begin_time));
+	frr_timestamp(3, bgp->convergence_wait_begin_time,
+		      sizeof(bgp->convergence_wait_begin_time));
 }
 
-static void bgp_update_delay_process_status_change(struct peer *peer)
+static void bgp_convergence_wait_process_status_change(struct peer *peer)
 {
 	struct bgp *bgp = peer->bgp;
 
 	if (peer_established(peer->connection)) {
 		if (!bgp->established++) {
-			bgp_update_delay_begin(bgp);
-			zlog_info("Begin read-only mode - update-delay timer %d seconds",
-				  bgp->v_update_delay);
+			bgp_convergence_wait_begin(bgp);
+			zlog_info("Begin read-only mode - convergence-wait timer %d seconds",
+				  bgp->v_convergence_wait);
 		}
 		if (CHECK_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_R_BIT_RCV))
 			bgp_update_restarted_peers(peer);
 	}
-	if (peer->connection->ostatus == Established && bgp_update_delay_active(bgp)) {
-		/* Adjust the update-delay state to account for this flap.
+	if (peer->connection->ostatus == Established && bgp_convergence_wait_active(bgp)) {
+		/* Adjust the convergence-wait state to account for this flap.
 		   NOTE: Intentionally skipping adjusting implicit_eors or
 		   explicit_eors
-		   counters. Extra sanity check in bgp_check_update_delay()
+		   counters. Extra sanity check in bgp_check_convergence_wait()
 		   should
 		   be enough to take care of any additive discrepancy in bgp eor
 		   counters */
 		bgp->established--;
-		peer->update_delay_over = 0;
+		peer->convergence_wait_over = 0;
 	}
 }
 
@@ -1932,11 +1931,11 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 			bgp->maxmed_onstartup_over = 1;
 	}
 
-	/* Check for GR restarter or update-delay processing. */
+	/* Check for GR restarter or convergence-wait processing. */
 	if (gr_path_select_deferral_applicable(bgp))
 		bgp_gr_process_peer_status_change(peer);
-	else if (bgp_update_delay_configured(bgp) && bgp_update_delay_applicable(bgp))
-		bgp_update_delay_process_status_change(peer);
+	else if (bgp_convergence_wait_configured(bgp) && bgp_convergence_wait_applicable(bgp))
+		bgp_convergence_wait_process_status_change(peer);
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s fd %d went from %s to %s for %s", peer->host, connection->fd,
@@ -2840,7 +2839,7 @@ bgp_establish(struct peer_connection *connection)
 	 * end
 	 * of read-only mode.
 	 */
-	if (!bgp_update_delay_active(bgp)) {
+	if (!bgp_convergence_wait_active(bgp)) {
 		event_cancel(&peer->connection->t_routeadv);
 		BGP_TIMER_ON(peer->connection->t_routeadv, bgp_routeadv_timer,
 			     0);

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -118,7 +118,7 @@ extern void bgp_routeadv_timer(struct event *event);
 extern void bgp_fsm_change_status(struct peer_connection *connection,
 				  enum bgp_fsm_status status);
 extern const char *const peer_down_str[];
-extern void bgp_update_delay_end(struct bgp *bgp);
+extern void bgp_convergence_wait_end(struct bgp *bgp);
 extern void bgp_maxmed_update(struct bgp *bgp);
 extern bool bgp_maxmed_onstartup_configured(struct bgp *bgp);
 extern bool bgp_maxmed_onstartup_active(struct bgp *bgp);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -205,14 +205,14 @@ static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 }
 
 /* Called when there is a change in the EOR(implicit or explicit) status of a
- * peer. Ends the update-delay if all expected peers are done with EORs. */
-void bgp_check_update_delay(struct bgp *bgp)
+ * peer. Ends the convergence-wait if all expected peers are done with EORs. */
+void bgp_check_convergence_wait(struct bgp *bgp)
 {
 	struct listnode *node, *nnode;
 	struct peer *peer = NULL;
 
 	if (bgp_debug_neighbor_events(peer))
-		zlog_debug("Checking update delay, T: %d R: %d E: %d", bgp->established,
+		zlog_debug("Checking convergence wait, T: %d R: %d E: %d", bgp->established,
 			   bgp->restarted_peers, bgp->received_eors);
 
 	if (bgp->established <= bgp->restarted_peers + bgp->received_eors) {
@@ -220,18 +220,14 @@ void bgp_check_update_delay(struct bgp *bgp)
 		 * This is an extra sanity check to make sure we wait for all
 		 * the eligible configured peers. This check is performed if
 		 * establish wait timer is on, or establish wait option is not
-		 * given with the update-delay command
+		 * given with the convergence-wait command
 		 */
-		if (bgp->t_establish_wait
-		    || (bgp->v_establish_wait == bgp->v_update_delay))
+		if (bgp->t_establish_wait || (bgp->v_establish_wait == bgp->v_convergence_wait))
 			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-				if (CHECK_FLAG(peer->flags,
-					       PEER_FLAG_CONFIG_NODE)
-				    && !CHECK_FLAG(peer->flags,
-						   PEER_FLAG_SHUTDOWN)
-				    && !CHECK_FLAG(peer->bgp->flags,
-						   BGP_FLAG_SHUTDOWN)
-				    && !peer->update_delay_over) {
+				if (CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE) &&
+				    !CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN) &&
+				    !CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHUTDOWN) &&
+				    !peer->convergence_wait_over) {
 					if (bgp_debug_neighbor_events(peer))
 						zlog_debug(
 							" Peer %s pending, continuing read-only mode",
@@ -242,7 +238,7 @@ void bgp_check_update_delay(struct bgp *bgp)
 
 		zlog_info("Update delay ended, restarted: %d, EORs: %d", bgp->restarted_peers,
 			  bgp->received_eors);
-		bgp_update_delay_end(bgp);
+		bgp_convergence_wait_end(bgp);
 	}
 }
 
@@ -252,18 +248,18 @@ void bgp_check_update_delay(struct bgp *bgp)
  */
 void bgp_update_restarted_peers(struct peer *peer)
 {
-	if (!bgp_update_delay_active(peer->bgp))
-		return; /* BGP update delay has ended */
-	if (peer->update_delay_over)
+	if (!bgp_convergence_wait_active(peer->bgp))
+		return; /* BGP convergence wait has ended */
+	if (peer->convergence_wait_over)
 		return; /* This peer has already been considered */
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("Peer %s: Checking restarted", peer->host);
 
 	if (peer_established(peer->connection)) {
-		peer->update_delay_over = 1;
+		peer->convergence_wait_over = 1;
 		peer->bgp->restarted_peers++;
-		bgp_check_update_delay(peer->bgp);
+		bgp_check_convergence_wait(peer->bgp);
 	}
 }
 
@@ -276,9 +272,9 @@ static void bgp_update_explicit_eors(struct peer *peer)
 	afi_t afi;
 	safi_t safi;
 
-	if (!bgp_update_delay_active(peer->bgp))
-		return; /* BGP update delay has ended */
-	if (peer->update_delay_over)
+	if (!bgp_convergence_wait_active(peer->bgp))
+		return; /* BGP convergence wait has ended */
+	if (peer->convergence_wait_over)
 		return; /* This peer has already been considered */
 
 	if (bgp_debug_neighbor_events(peer))
@@ -296,9 +292,9 @@ static void bgp_update_explicit_eors(struct peer *peer)
 		}
 	}
 
-	peer->update_delay_over = 1;
+	peer->convergence_wait_over = 1;
 	peer->bgp->received_eors++;
-	bgp_check_update_delay(peer->bgp);
+	bgp_check_convergence_wait(peer->bgp);
 }
 
 /**
@@ -440,13 +436,12 @@ void bgp_generate_updgrp_packets(struct event *event)
 	/*
 	 * The code beyond this part deals with update packets, proceed only
 	 * if peer is Established and updates are not on hold (as part of
-	 * update-delay processing).
+	 * convergence-wait processing).
 	 */
 	if (!peer_established(peer->connection))
 		return;
 
-	if ((peer->bgp->main_peers_update_hold)
-	    || bgp_update_delay_active(peer->bgp))
+	if ((peer->bgp->main_peers_update_hold) || bgp_convergence_wait_active(peer->bgp))
 		return;
 
 	/* If the MRAI timer is running and we have conditional advertisement
@@ -2281,7 +2276,7 @@ static void bgp_update_receive_eor(struct bgp *bgp, struct peer *peer, afi_t afi
 	if (!CHECK_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_EOR_RECEIVED)) {
 		SET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_EOR_RECEIVED);
 
-		/* update-delay related processing */
+		/* convergence-wait related processing */
 		bgp_update_explicit_eors(peer);
 
 		/* graceful-restart related processing */

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -71,7 +71,7 @@ extern int bgp_nlri_parse(struct peer *peer, struct attr *attr,
 			  struct bgp_nlri *nlri, bool mp_withdraw);
 
 extern void bgp_update_restarted_peers(struct peer *peer);
-extern void bgp_check_update_delay(struct bgp *peer);
+extern void bgp_check_convergence_wait(struct bgp *peer);
 
 extern int bgp_packet_set_marker(struct stream *s, uint8_t type);
 extern void bgp_packet_set_size(struct stream *s);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4098,8 +4098,8 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 	}
 	/* Is it end of initial update? (after startup) */
 	if (!dest) {
-		frr_timestamp(3, bgp->update_delay_zebra_resume_time,
-			      sizeof(bgp->update_delay_zebra_resume_time));
+		frr_timestamp(3, bgp->convergence_wait_zebra_resume_time,
+			      sizeof(bgp->convergence_wait_zebra_resume_time));
 
 		bgp->main_zebra_update_hold = 0;
 		FOREACH_AFI_SAFI (afi, safi) {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -613,7 +613,7 @@ struct meta_queue {
 };
 
 /*
- * When the update-delay expires, BGP inserts an EOIU (End-Of-Initial-Update) marker
+ * When the convergence-wait expires, BGP inserts an EOIU (End-Of-Initial-Update) marker
  * into the BGP_PROCESS_QUEUE_EOIU_MARKER meta queue. This meta queue holds only
  * bgp_dest structures. To process the EOIU marker, we need to call bgp_process_main_one()
  * on the corresponding BGP instance. Since the marker itself isn't a real route

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -419,9 +419,8 @@ static void subgroup_coalesce_timer(struct event *event)
 	 * to
 	 * announce, this is the method currently employed to trigger the EOR.
 	 */
-	if (!bgp_update_delay_active(SUBGRP_INST(subgrp)) &&
+	if (!bgp_convergence_wait_active(SUBGRP_INST(subgrp)) &&
 	    !(bgp_fibupd_safi(safi) && BGP_SUPPRESS_FIB_ENABLED(bgp))) {
-
 		struct peer_af *paf;
 		struct peer *peer;
 
@@ -966,7 +965,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 	bgp = peer->bgp;
 	from = bgp->peer_self;
 
-	if (bgp_update_delay_active(peer->bgp))
+	if (bgp_convergence_wait_active(peer->bgp))
 		return;
 
 	bgp_attr_default_set(&attr, bgp, BGP_ORIGIN_IGP);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1293,7 +1293,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 		/* This is to apply read-only mode on this clear. */
 		if (stype == BGP_CLEAR_SOFT_NONE)
-			bgp->update_delay_over = 0;
+			bgp->convergence_wait_over = 0;
 
 		if (afi_safi_unspec)
 			bgp_clearing_batch_end_event_start(bgp);
@@ -2435,24 +2435,22 @@ DEFUN (no_bgp_maxmed_onstartup,
 	return CMD_SUCCESS;
 }
 
-static int bgp_global_update_delay_config_vty(struct vty *vty,
-					      uint16_t update_delay,
-					      uint16_t establish_wait)
+static int bgp_global_convergence_wait_config_vty(struct vty *vty, uint16_t convergence_wait,
+						  uint16_t establish_wait)
 {
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 	bool vrf_cfg = false;
 
 	/*
-	 * See if update-delay is set per-vrf and warn user to delete it
+	 * See if convergence-wait is set per-vrf and warn user to delete it
 	 * Note that we only need to check this if this is the first time
 	 * setting the global config.
 	 */
-	if (bm->v_update_delay == BGP_UPDATE_DELAY_DEFAULT) {
+	if (bm->v_convergence_wait == BGP_UPDATE_DELAY_DEFAULT) {
 		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-			if (bgp->v_update_delay != BGP_UPDATE_DELAY_DEFAULT) {
-				vty_out(vty,
-					"%% update-delay configuration found in vrf %s\n",
+			if (bgp->v_convergence_wait != BGP_UPDATE_DELAY_DEFAULT) {
+				vty_out(vty, "%% convergence-wait configuration found in vrf %s\n",
 					bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT
 						? VRF_DEFAULT_NAME
 						: bgp->name);
@@ -2462,112 +2460,124 @@ static int bgp_global_update_delay_config_vty(struct vty *vty,
 	}
 
 	if (vrf_cfg) {
-		vty_out(vty,
-			"%%Failed: global update-delay config not permitted\n");
+		vty_out(vty, "%%Failed: global convergence-wait config not permitted\n");
 		return CMD_WARNING;
 	}
 
-	if (!establish_wait) { /* update-delay <delay> */
-		bm->v_update_delay = update_delay;
-		bm->v_establish_wait = bm->v_update_delay;
+	if (!establish_wait) { /* convergence-wait <delay> */
+		bm->v_convergence_wait = convergence_wait;
+		bm->v_establish_wait = bm->v_convergence_wait;
 	} else {
-		/* update-delay <delay> <establish-wait> */
-		if (update_delay < establish_wait) {
-			vty_out(vty,
-				"%%Failed: update-delay less than the establish-wait!\n");
+		/* convergence-wait <delay> <establish-wait> */
+		if (convergence_wait < establish_wait) {
+			vty_out(vty, "%%Failed: convergence-wait less than the establish-wait!\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 
-		bm->v_update_delay = update_delay;
+		bm->v_convergence_wait = convergence_wait;
 		bm->v_establish_wait = establish_wait;
 	}
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		bgp->v_update_delay = bm->v_update_delay;
+		bgp->v_convergence_wait = bm->v_convergence_wait;
 		bgp->v_establish_wait = bm->v_establish_wait;
 	}
 
 	return CMD_SUCCESS;
 }
 
-static int bgp_global_update_delay_deconfig_vty(struct vty *vty)
+static int bgp_global_convergence_wait_deconfig_vty(struct vty *vty)
 {
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 
-	bm->v_update_delay = BGP_UPDATE_DELAY_DEFAULT;
-	bm->v_establish_wait = bm->v_update_delay;
+	bm->v_convergence_wait = BGP_UPDATE_DELAY_DEFAULT;
+	bm->v_establish_wait = bm->v_convergence_wait;
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		bgp->v_update_delay = bm->v_update_delay;
+		bgp->v_convergence_wait = bm->v_convergence_wait;
 		bgp->v_establish_wait = bm->v_establish_wait;
 	}
 
 	return CMD_SUCCESS;
 }
 
-static int bgp_update_delay_config_vty(struct vty *vty, uint16_t update_delay,
-				       uint16_t establish_wait)
+static int bgp_convergence_wait_config_vty(struct vty *vty, uint16_t convergence_wait,
+					   uint16_t establish_wait)
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	/* if configured globally, per-instance config is not allowed */
-	if (bm->v_update_delay) {
+	if (bm->v_convergence_wait) {
 		vty_out(vty,
-			"%%Failed: per-vrf update-delay config not permitted with global update-delay\n");
+			"%%Failed: per-vrf convergence-wait config not permitted with global convergence-wait\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 
-	if (!establish_wait) /* update-delay <delay> */
+	if (!establish_wait) /* convergence-wait <delay> */
 	{
-		bgp->v_update_delay = update_delay;
-		bgp->v_establish_wait = bgp->v_update_delay;
+		bgp->v_convergence_wait = convergence_wait;
+		bgp->v_establish_wait = bgp->v_convergence_wait;
 		return CMD_SUCCESS;
 	}
 
-	/* update-delay <delay> <establish-wait> */
-	if (update_delay < establish_wait) {
-		vty_out(vty,
-			"%%Failed: update-delay less than the establish-wait!\n");
+	/* convergence-wait <delay> <establish-wait> */
+	if (convergence_wait < establish_wait) {
+		vty_out(vty, "%%Failed: convergence-wait less than the establish-wait!\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	bgp->v_update_delay = update_delay;
+	bgp->v_convergence_wait = convergence_wait;
 	bgp->v_establish_wait = establish_wait;
 
 	return CMD_SUCCESS;
 }
 
-static int bgp_update_delay_deconfig_vty(struct vty *vty)
+static int bgp_convergence_wait_deconfig_vty(struct vty *vty)
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	/* If configured globally, cannot remove from one bgp instance */
-	if (bm->v_update_delay) {
+	if (bm->v_convergence_wait) {
 		vty_out(vty,
-			"%%Failed: bgp update-delay configured globally. Delete per-vrf not permitted\n");
+			"%%Failed: bgp convergence-wait configured globally. Delete per-vrf not permitted\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
-	bgp->v_update_delay = BGP_UPDATE_DELAY_DEFAULT;
-	bgp->v_establish_wait = bgp->v_update_delay;
+	bgp->v_convergence_wait = BGP_UPDATE_DELAY_DEFAULT;
+	bgp->v_establish_wait = bgp->v_convergence_wait;
 
 	return CMD_SUCCESS;
 }
 
-void bgp_config_write_update_delay(struct vty *vty, struct bgp *bgp)
+void bgp_config_write_convergence_wait(struct vty *vty, struct bgp *bgp)
 {
 	/* If configured globally, no need to display per-instance value */
-	if (bgp->v_update_delay != bm->v_update_delay) {
-		vty_out(vty, " update-delay %d", bgp->v_update_delay);
-		if (bgp->v_update_delay != bgp->v_establish_wait)
+	if (bgp->v_convergence_wait != bm->v_convergence_wait) {
+		vty_out(vty, " convergence-wait %d", bgp->v_convergence_wait);
+		if (bgp->v_convergence_wait != bgp->v_establish_wait)
 			vty_out(vty, " %d", bgp->v_establish_wait);
 		vty_out(vty, "\n");
 	}
 }
 
-/* Global update-delay configuration */
-DEFPY (bgp_global_update_delay,
+#if CONFDATE > 20290325
+CPP_NOTICE("Remove the hidden update-delay code and remove json that depends on it")
+#endif
+
+/* Global convergence-wait configuration */
+DEFPY (bgp_global_convergence_wait,
+       bgp_global_convergence_wait_cmd,
+       "bgp convergence-wait (0-3600)$delay [(1-3600)$wait]",
+       BGP_STR
+       "Force initial delay for best-path and updates for all bgp instances\n"
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
+{
+	return bgp_global_convergence_wait_config_vty(vty, delay, wait);
+}
+
+DEFPY_HIDDEN (bgp_global_update_delay,
        bgp_global_update_delay_cmd,
        "bgp update-delay (0-3600)$delay [(1-3600)$wait]",
        BGP_STR
@@ -2575,10 +2585,22 @@ DEFPY (bgp_global_update_delay,
        "Max delay in seconds\n"
        "Establish wait in seconds\n")
 {
-	return bgp_global_update_delay_config_vty(vty, delay, wait);
+	return bgp_global_convergence_wait_config_vty(vty, delay, wait);
 }
 
-/* Global update-delay deconfiguration */
+/* Global convergence-wait deconfiguration */
+DEFPY (no_bgp_global_convergence_wait,
+       no_bgp_global_convergence_wait_cmd,
+       "no bgp convergence-wait [(0-3600) [(1-3600)]]",
+       NO_STR
+       BGP_STR
+       "Force initial delay for best-path and updates\n"
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
+{
+	return bgp_global_convergence_wait_deconfig_vty(vty);
+}
+
 DEFPY (no_bgp_global_update_delay,
        no_bgp_global_update_delay_cmd,
        "no bgp update-delay [(0-3600) [(1-3600)]]",
@@ -2588,31 +2610,52 @@ DEFPY (no_bgp_global_update_delay,
        "Max delay in seconds\n"
        "Establish wait in seconds\n")
 {
-	return bgp_global_update_delay_deconfig_vty(vty);
+	return bgp_global_convergence_wait_deconfig_vty(vty);
 }
 
 /* Update-delay configuration */
 
-DEFPY (bgp_update_delay,
+DEFPY (bgp_convergence_wait,
+       bgp_convergence_wait_cmd,
+       "convergence-wait (0-3600)$delay [(1-3600)$wait]",
+       "Force initial delay for best-path and updates\n"
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
+{
+	return bgp_convergence_wait_config_vty(vty, delay, wait);
+}
+
+DEFPY_HIDDEN (bgp_update_delay,
        bgp_update_delay_cmd,
        "update-delay (0-3600)$delay [(1-3600)$wait]",
        "Force initial delay for best-path and updates\n"
        "Max delay in seconds\n"
        "Establish wait in seconds\n")
 {
-	return bgp_update_delay_config_vty(vty, delay, wait);
+	return bgp_convergence_wait_config_vty(vty, delay, wait);
 }
 
 /* Update-delay deconfiguration */
-DEFPY (no_bgp_update_delay,
-       no_bgp_update_delay_cmd,
-       "no update-delay [(0-3600) [(1-3600)]]",
+DEFPY (no_bgp_convergence_wait,
+       no_bgp_convergence_wait_cmd,
+       "no convergence-wait [(0-3600) [(1-3600)]]",
        NO_STR
        "Force initial delay for best-path and updates\n"
        "Max delay in seconds\n"
        "Establish wait in seconds\n")
 {
-	return bgp_update_delay_deconfig_vty(vty);
+	return bgp_convergence_wait_deconfig_vty(vty);
+}
+
+DEFPY_HIDDEN (no_bgp_update_delay,
+       no_bgp_update_delay_cmd,
+       "no convergence-wait [(0-3600) [(1-3600)]]",
+       NO_STR
+       "Force initial delay for best-path and updates\n"
+       "Max delay in seconds\n"
+       "Establish wait in seconds\n")
+{
+	return bgp_convergence_wait_deconfig_vty(vty);
 }
 
 
@@ -12537,7 +12580,9 @@ DEFPY(show_bgp_router,
 		json_object_int_add(json, "bgpOutputQueueLimit", bm->outq_limit);
 		json_object_int_add(json, "zebraAnnounceCount",
 				    zebra_announce_count(&bm->zebra_announce_head));
-		json_object_int_add(json, "bgpUpdateDelayTime", bm->v_update_delay);
+		json_object_int_add(json, "bgpConvergenceWaitTime", bm->v_convergence_wait);
+		json_object_int_add(json, "bgpUpdateDelayTime", bm->v_convergence_wait);
+		json_object_int_add(json, "bgpconvergenceWaitTime", bm->v_convergence_wait);
 		json_object_int_add(json, "bgpEstablishWaitTime", bm->v_establish_wait);
 		json_object_int_add(json, "bgpRmapDelayTimer", bm->rmap_update_timer);
 		json_object_int_add(json, "bgpRmapDelayTimerRemaining",
@@ -12550,7 +12595,7 @@ DEFPY(show_bgp_router,
 			zebra_announce_count(&bm->zebra_announce_head));
 
 		vty_out(vty, "BGP Global Update Delay Timers:\n");
-		vty_out(vty, "  Update Delay Time: %ds\n", bm->v_update_delay);
+		vty_out(vty, "  Update Delay Time: %ds\n", bm->v_convergence_wait);
 		vty_out(vty, "  Establish Wait Time: %ds\n", bm->v_establish_wait);
 
 		vty_out(vty, "BGP route-map Delay Timer: %ds (remaining: %lds)\n",
@@ -13498,77 +13543,96 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				vty_out(vty, "\n");
 			}
 
-			if (bgp_update_delay_configured(bgp)) {
+			if (bgp_convergence_wait_configured(bgp)) {
 				if (use_json) {
-					json_object_int_add(
-						json, "updateDelayLimit",
-						bgp->v_update_delay);
+					json_object_int_add(json, "convergenceWaitLimit",
+							    bgp->v_convergence_wait);
+					json_object_int_add(json, "updateDelayLimit",
+							    bgp->v_convergence_wait);
 
-					if (bgp->v_update_delay
-					    != bgp->v_establish_wait)
+					if (bgp->v_convergence_wait != bgp->v_establish_wait) {
+						json_object_int_add(json,
+								    "convergenceDelayEstablishWait",
+								    bgp->v_establish_wait);
 						json_object_int_add(
 							json,
 							"updateDelayEstablishWait",
 							bgp->v_establish_wait);
+					}
 
-					if (bgp_update_delay_active(bgp)) {
-						json_object_string_add(
-							json,
-							"updateDelayFirstNeighbor",
-							bgp->update_delay_begin_time);
+					if (bgp_convergence_wait_active(bgp)) {
+						json_object_string_add(json,
+								       "convergenceDelayFirstNeighbor",
+								       bgp->convergence_wait_begin_time);
+						json_object_boolean_true_add(json,
+									     "convergenceDelayInProgress");
+						json_object_string_add(json,
+								       "updateDelayFirstNeighbor",
+								       bgp->convergence_wait_begin_time);
 						json_object_boolean_true_add(
 							json,
 							"updateDelayInProgress");
 					} else {
-						if (bgp->update_delay_over) {
+						if (bgp->convergence_wait_over) {
 							json_object_string_add(
 								json,
-								"updateDelayFirstNeighbor",
-								bgp->update_delay_begin_time);
+								"convergenceWaitFirstNeighbor",
+								bgp->convergence_wait_begin_time);
 							json_object_string_add(
 								json,
-								"updateDelayBestpathResumed",
-								bgp->update_delay_end_time);
+								"convergenceWaitBestpathResumed",
+								bgp->convergence_wait_end_time);
+							json_object_string_add(
+								json,
+								"convergenceWaitZebraUpdateResume",
+								bgp->convergence_wait_zebra_resume_time);
+							json_object_string_add(
+								json,
+								"convergenceWaitPeerUpdateResume",
+								bgp->convergence_wait_peers_resume_time);
+							json_object_string_add(
+								json, "updateDelayFirstNeighbor",
+								bgp->convergence_wait_begin_time);
+							json_object_string_add(
+								json, "updateDelayBestpathResumed",
+								bgp->convergence_wait_end_time);
 							json_object_string_add(
 								json,
 								"updateDelayZebraUpdateResume",
-								bgp->update_delay_zebra_resume_time);
+								bgp->convergence_wait_zebra_resume_time);
 							json_object_string_add(
-								json,
-								"updateDelayPeerUpdateResume",
-								bgp->update_delay_peers_resume_time);
+								json, "updateDelayPeerUpdateResume",
+								bgp->convergence_wait_peers_resume_time);
 						}
 					}
 				} else {
 					vty_out(vty,
-						"Read-only mode update-delay limit: %d seconds\n",
-						bgp->v_update_delay);
-					if (bgp->v_update_delay
-					    != bgp->v_establish_wait)
+						"Read-only mode convergence-wait limit: %d seconds\n",
+						bgp->v_convergence_wait);
+					if (bgp->v_convergence_wait != bgp->v_establish_wait)
 						vty_out(vty,
 							"                   Establish wait: %d seconds\n",
 							bgp->v_establish_wait);
 
-					if (bgp_update_delay_active(bgp)) {
-						vty_out(vty,
-							"  First neighbor established: %s\n",
-							bgp->update_delay_begin_time);
+					if (bgp_convergence_wait_active(bgp)) {
+						vty_out(vty, "  First neighbor established: %s\n",
+							bgp->convergence_wait_begin_time);
 						vty_out(vty,
 							"  Delay in progress\n");
 					} else {
-						if (bgp->update_delay_over) {
+						if (bgp->convergence_wait_over) {
 							vty_out(vty,
 								"  First neighbor established: %s\n",
-								bgp->update_delay_begin_time);
+								bgp->convergence_wait_begin_time);
 							vty_out(vty,
 								"          Best-paths resumed: %s\n",
-								bgp->update_delay_end_time);
+								bgp->convergence_wait_end_time);
 							vty_out(vty,
 								"        zebra update resumed: %s\n",
-								bgp->update_delay_zebra_resume_time);
+								bgp->convergence_wait_zebra_resume_time);
 							vty_out(vty,
 								"        peers update resumed: %s\n",
-								bgp->update_delay_peers_resume_time);
+								bgp->convergence_wait_peers_resume_time);
 						}
 					}
 				}
@@ -17171,20 +17235,25 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 							p->update_source);
 		}
 
-		/* update-delay timer */
+		/* convergence-wait timer */
 		json_object_int_add(json_neigh, "bgpUpdateDelayTimerMsecs",
-				    bgp->v_update_delay * 1000);
+				    bgp->v_convergence_wait * 1000);
+		json_object_int_add(json_neigh, "bgpConvergenceWaitTimerMsecs",
+				    bgp->v_convergence_wait * 1000);
 		json_object_int_add(json_neigh, "bgpUpdateDelayTimerMsecsRemaining",
-				    event_timer_remain_second(bgp->t_update_delay) * 1000);
+				    event_timer_remain_second(bgp->t_convergence_wait) * 1000);
+		json_object_int_add(json_neigh, "bgpConvergenceWaitTimerMsecsRemaining",
+				    event_timer_remain_second(bgp->t_convergence_wait) * 1000);
 	} else {
 		/* advertisement-interval */
 		vty_out(vty,
 			"  Minimum time between advertisement runs is %d seconds\n",
 			p->v_routeadv);
 
-		/* update delay timer */
+		/* convergence wait timer */
 		vty_out(vty, "  Update delay timer is %u seconds (remaining: %lu)\n",
-			bgp->v_update_delay, event_timer_remain_second(bgp->t_update_delay));
+			bgp->v_convergence_wait,
+			event_timer_remain_second(bgp->t_convergence_wait));
 
 		/* Update-source. */
 		if (p->update_if || p->update_source) {
@@ -20868,9 +20937,9 @@ int bgp_config_write(struct vty *vty)
 		vty_out(vty, "bgp route-map delay-timer %u\n",
 			bm->rmap_update_timer);
 
-	if (bm->v_update_delay != BGP_UPDATE_DELAY_DEFAULT) {
-		vty_out(vty, "bgp update-delay %d", bm->v_update_delay);
-		if (bm->v_update_delay != bm->v_establish_wait)
+	if (bm->v_convergence_wait != BGP_UPDATE_DELAY_DEFAULT) {
+		vty_out(vty, "bgp convergence-wait %d", bm->v_convergence_wait);
+		if (bm->v_convergence_wait != bm->v_establish_wait)
 			vty_out(vty, " %d", bm->v_establish_wait);
 		vty_out(vty, "\n");
 	}
@@ -21141,8 +21210,8 @@ int bgp_config_write(struct vty *vty)
 					? ""
 					: "no ");
 
-		/* BGP update-delay. */
-		bgp_config_write_update_delay(vty, bgp);
+		/* BGP convergence-wait. */
+		bgp_config_write_convergence_wait(vty, bgp);
 
 		if (bgp->v_maxmed_onstartup
 		    != BGP_MAXMED_ONSTARTUP_UNCONFIGURED) {
@@ -21934,7 +22003,9 @@ void bgp_vty_init(void)
 	/* bgp ipv6-auto-ra command */
 	install_element(BGP_NODE, &bgp_ipv6_auto_ra_cmd);
 
-	/* global bgp update-delay command */
+	/* global bgp convergence-wait command */
+	install_element(CONFIG_NODE, &bgp_global_convergence_wait_cmd);
+	install_element(CONFIG_NODE, &no_bgp_global_convergence_wait_cmd);
 	install_element(CONFIG_NODE, &bgp_global_update_delay_cmd);
 	install_element(CONFIG_NODE, &no_bgp_global_update_delay_cmd);
 
@@ -22022,7 +22093,7 @@ void bgp_vty_init(void)
 	install_element(BGP_NODE, &bgp_disable_connected_route_check_cmd);
 	install_element(BGP_NODE, &no_bgp_disable_connected_route_check_cmd);
 
-	/* bgp update-delay command */
+	/* bgp convergence-wait command */
 	install_element(BGP_NODE, &bgp_update_delay_cmd);
 	install_element(BGP_NODE, &no_bgp_update_delay_cmd);
 

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -157,7 +157,7 @@ extern const char *get_afi_safi_str(afi_t afi, safi_t safi, bool for_json);
 extern int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,
 		       enum bgp_instance_type inst_type, const char *as_pretty,
 		       enum asnotation_mode asnotation);
-extern void bgp_config_write_update_delay(struct vty *vty, struct bgp *bgp);
+extern void bgp_config_write_convergence_wait(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_wpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_rpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_listen(struct vty *vty, struct bgp *bgp);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3780,7 +3780,7 @@ peer_init:
 		memset(&bgp->gr_info[afi][safi], 0, sizeof(struct graceful_restart_info));
 	}
 
-	bgp->v_update_delay = bm->v_update_delay;
+	bgp->v_convergence_wait = bm->v_convergence_wait;
 	bgp->v_establish_wait = bm->v_establish_wait;
 	bgp->default_local_pref = BGP_DEFAULT_LOCAL_PREF;
 	bgp->default_subgroup_pkt_queue_max =
@@ -4387,7 +4387,7 @@ int bgp_delete(struct bgp *bgp)
 	event_cancel(&bgp->t_condition_check);
 	event_cancel(&bgp->t_startup);
 	event_cancel(&bgp->t_maxmed_onstartup);
-	event_cancel(&bgp->t_update_delay);
+	event_cancel(&bgp->t_convergence_wait);
 	event_cancel(&bgp->t_establish_wait);
 
 	/* If the clearing event is scheduled, there's an extra ref to
@@ -9052,7 +9052,7 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	bm->start_time = monotime(NULL);
 	bm->t_rmap_update = NULL;
 	bm->rmap_update_timer = RMAP_DEFAULT_UPDATE_TIMER;
-	bm->v_update_delay = BGP_UPDATE_DELAY_DEFAULT;
+	bm->v_convergence_wait = BGP_UPDATE_DELAY_DEFAULT;
 	bm->v_establish_wait = BGP_UPDATE_DELAY_DEFAULT;
 	bm->terminating = false;
 	bm->socket_buffer = buffer_size;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -184,8 +184,8 @@ struct bgp_master {
 	/* EVPN multihoming */
 	struct bgp_evpn_mh_info *mh_info;
 
-	/* global update-delay timer values */
-	uint16_t v_update_delay;
+	/* global convergence-wait timer values */
+	uint16_t v_convergence_wait;
 	uint16_t v_establish_wait;
 
 	uint32_t flags;
@@ -669,20 +669,20 @@ struct bgp {
 	uint8_t maxmed_active; /* 1/0 if max-med is active or not */
 	uint32_t maxmed_value; /* Max-med value when its active */
 
-	/* BGP update delay on startup */
-	struct event *t_update_delay;
+	/* BGP convergence wait on startup */
+	struct event *t_convergence_wait;
 	struct event *t_establish_wait;
 	struct event *t_revalidate[AFI_MAX][SAFI_MAX];
 
-	uint8_t update_delay_over;
+	uint8_t convergence_wait_over;
 	uint8_t main_zebra_update_hold;
 	uint8_t main_peers_update_hold;
-	uint16_t v_update_delay;
+	uint16_t v_convergence_wait;
 	uint16_t v_establish_wait;
-	char update_delay_begin_time[64];
-	char update_delay_end_time[64];
-	char update_delay_zebra_resume_time[64];
-	char update_delay_peers_resume_time[64];
+	char convergence_wait_begin_time[64];
+	char convergence_wait_end_time[64];
+	char convergence_wait_zebra_resume_time[64];
+	char convergence_wait_peers_resume_time[64];
 	uint32_t established;
 	uint32_t restarted_peers;
 	uint32_t received_eors;
@@ -2045,7 +2045,7 @@ struct peer {
 	uint32_t dropped;     /* Dropped */
 
 	/* Update delay related fields */
-	uint8_t update_delay_over; /* When this is set, BGP is no more waiting
+	uint8_t convergence_wait_over; /* When this is set, BGP is no more waiting
 				     for EOR */
 
 	time_t synctime;
@@ -2744,8 +2744,8 @@ extern void bgp_default_subgroup_pkt_queue_max_unset(struct bgp *bgp);
 extern void bgp_listen_limit_set(struct bgp *bgp, int listen_limit);
 extern void bgp_listen_limit_unset(struct bgp *bgp);
 
-extern bool bgp_update_delay_active(struct bgp *bgp);
-extern bool bgp_update_delay_configured(struct bgp *bgp);
+extern bool bgp_convergence_wait_active(struct bgp *bgp);
+extern bool bgp_convergence_wait_configured(struct bgp *bgp);
 extern bool bgp_afi_safi_peer_exists(struct bgp *bgp, afi_t afi, safi_t safi);
 extern void peer_as_change(struct peer *peer, as_t as,
 			   enum peer_asn_type as_type, const char *as_str);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1498,16 +1498,16 @@ Redistribute routes from a routing table number into BGP.
    instance. Shows which protocols are being redistributed into BGP along with
    their associated metrics, instances, and route-maps if configured.
 
-.. clicmd:: bgp update-delay MAX-DELAY
+.. clicmd:: bgp convergence-wait MAX-DELAY
 
-.. clicmd:: bgp update-delay MAX-DELAY ESTABLISH-WAIT
+.. clicmd:: bgp convergence-wait MAX-DELAY ESTABLISH-WAIT
 
    This feature is used to enable read-only mode on BGP process restart or when
    a BGP process is cleared using 'clear ip bgp \*'. Note that this command is
    configured at the global level and applies to all bgp instances/vrfs.  It
-   cannot be used at the same time as the "update-delay" command described below,
+   cannot be used at the same time as the "convergence-wait" command described below,
    which is entered in each bgp instance/vrf desired to delay update installation
-   and advertisements. The global and per-vrf approaches to defining update-delay
+   and advertisements. The global and per-vrf approaches to defining convergence-wait
    are mutually exclusive.
 
    When applicable, read-only mode would begin as soon as the first peer reaches
@@ -1519,7 +1519,7 @@ Redistribute routes from a routing table number into BGP.
       (End-Of-RIB) or an implicit-EOR. The first keep-alive after BGP has reached
       Established is considered an implicit-EOR.
       If the establish-wait optional value is given, then BGP will wait for
-      peers to reach established from the beginning of the update-delay till the
+      peers to reach established from the beginning of the convergence-wait till the
       establish-wait period is over, i.e. the minimum set of established peers for
       which EOR is expected would be peers established during the establish-wait
       window, not necessarily all the configured neighbors.
@@ -1530,17 +1530,21 @@ Redistribute routes from a routing table number into BGP.
 
    Default max-delay is 0, i.e. the feature is off by default.
 
+   This command is replacing the `update-delay` version of this command as that
+   update-delay does not fully describe what is happening and it was felt that
+   convergence-delay better described the process of what was actually happening.
 
-.. clicmd:: update-delay MAX-DELAY
 
-.. clicmd:: update-delay MAX-DELAY ESTABLISH-WAIT
+.. clicmd:: convergence-wait MAX-DELAY
+
+.. clicmd:: convergence-wait MAX-DELAY ESTABLISH-WAIT
 
    This feature is used to enable read-only mode on BGP process restart or when
    a BGP process is cleared using 'clear ip bgp \*'.  Note that this command is
    configured under the specific bgp instance/vrf that the feature is enabled for.
-   It cannot be used at the same time as the global "bgp update-delay" described
+   It cannot be used at the same time as the global "bgp convergence-wait" described
    above, which is entered at the global level and applies to all bgp instances.
-   The global and per-vrf approaches to defining update-delay are mutually
+   The global and per-vrf approaches to defining convergence-wait are mutually
    exclusive.
 
    When applicable, read-only mode would begin as soon as the first peer reaches
@@ -1552,7 +1556,7 @@ Redistribute routes from a routing table number into BGP.
       (End-Of-RIB) or an implicit-EOR. The first keep-alive after BGP has reached
       Established is considered an implicit-EOR.
       If the establish-wait optional value is given, then BGP will wait for
-      peers to reach established from the beginning of the update-delay till the
+      peers to reach established from the beginning of the convergence-wait till the
       establish-wait period is over, i.e. the minimum set of established peers for
       which EOR is expected would be peers established during the establish-wait
       window, not necessarily all the configured neighbors.
@@ -1562,6 +1566,10 @@ Redistribute routes from a routing table number into BGP.
    and generates updates to its peers.
 
    Default max-delay is 0, i.e. the feature is off by default.
+
+   This command is replacing the `update-delay` version of this command as that
+   update-delay does not fully describe what is happening and it was felt that
+   convergence-delay better described the process of what was actually happening.
 
 .. clicmd:: table-map ROUTE-MAP-NAME
 

--- a/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
+++ b/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
@@ -129,13 +129,13 @@ def test_bgp_update_delay():
 
     def _bgp_check_update_delay(router):
         output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
-        expected = {"ipv4Unicast": {"updateDelayLimit": 20}}
+        expected = {"ipv4Unicast": {"convergenceDelayLimit": 20}}
 
         return topotest.json_cmp(output, expected)
 
     def _bgp_check_update_delay_in_progress(router):
         output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
-        expected = {"ipv4Unicast": {"updateDelayInProgress": True}}
+        expected = {"ipv4Unicast": {"convergenceDelayInProgress": True}}
 
         return topotest.json_cmp(output, expected)
 
@@ -148,21 +148,21 @@ def test_bgp_update_delay():
     def _bgp_check_update_delay_and_wait(router):
         output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
         expected = {
-            "ipv4Unicast": {"updateDelayLimit": 20, "updateDelayEstablishWait": 10}
+            "ipv4Unicast": {"convergenceDelayLimit": 20, "convergenceWaitEstablishWait": 10}
         }
 
         return topotest.json_cmp(output, expected)
 
     def _bgp_check_update_delay(router):
         output = json.loads(router.vtysh_cmd("show ip bgp sum json"))
-        expected = {"ipv4Unicast": {"updateDelayLimit": 20}}
+        expected = {"ipv4Unicast": {"convergenceDelayLimit": 20}}
 
         return topotest.json_cmp(output, expected)
 
     def _bgp_check_vrf_update_delay_and_wait(router):
         output = json.loads(router.vtysh_cmd("show ip bgp vrf vrf1 sum json"))
         expected = {
-            "ipv4Unicast": {"updateDelayLimit": 20, "updateDelayEstablishWait": 10}
+            "ipv4Unicast": {"convergenceDelayLimit": 20, "convergenceWaitEstablishWait": 10}
         }
 
         return topotest.json_cmp(output, expected)


### PR DESCRIPTION
The `update-delay` command implies that FRR is just waiting for some time before actually sending updates to a peer.  This is not what actually happens.  What actually happens is that all bestpath processing is delayed until after this timer pops as well. In an interest of clarifying behavior, especially in light of a desire to add more control to when certain actions happen in bgp.  We are changing what the command name is in FRR.