### PR TITLE
bgpd: Modify early route processing to include send to zebra

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5382,6 +5382,21 @@ void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgpevpn *vpn)
 	struct bgp_bp_install_node *inode = NULL;
 	struct bgp_bp_install_node *inode_next = NULL;
 
+	for (inode = zebra_announce_first(&bm->zebra_announce_early_head); inode;
+	     inode = inode_next) {
+		inode_next = zebra_announce_next(&bm->zebra_announce_early_head, inode);
+		if (inode->type != BGP_BP_INSTALL_ROUTE)
+			continue;
+		dest = inode->ptr;
+		if (dest->za_vpn == vpn) {
+			zebra_announce_del(&bm->zebra_announce_early_head, inode);
+			bgp_dest_table(dest)->bgp->zebra_announce_queue_cnt--;
+			bgp_path_info_unlock(dest->za_bgp_pi);
+			dest->za_inode = NULL;
+			bgp_dest_unlock_node(dest);
+			XFREE(MTYPE_BGP_BP_INSTALL_NODE, inode);
+		}
+	}
 	for (inode = zebra_announce_first(&bm->zebra_announce_head); inode; inode = inode_next) {
 		inode_next = zebra_announce_next(&bm->zebra_announce_head, inode);
 		if (inode->type != BGP_BP_INSTALL_ROUTE)

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -194,6 +194,7 @@ static FRR_NORETURN void bgp_exit(int status)
 	bgp_nhg_finish();
 
 	zebra_announce_fini(&bm->zebra_announce_head);
+	zebra_announce_fini(&bm->zebra_announce_early_head);
 	zebra_l2_vni_fini(&bm->zebra_l2_vni_head);
 
 	/* reverse bgp_dump_init */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4214,6 +4214,7 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 		UNSET_FLAG(old_select->flags, BGP_PATH_MULTIPATH_CHG);
 		UNSET_FLAG(old_select->flags, BGP_PATH_LINK_BW_CHG);
 		bgp_zebra_clear_route_change_flags(dest);
+		UNSET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
 		UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 		return;
 	}
@@ -4323,6 +4324,7 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 	/* Clear any route change flags. */
 	bgp_zebra_clear_route_change_flags(dest);
 
+	UNSET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
 	UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 
 	/* Reap old select bgp_path_info, if it has been removed */
@@ -5135,10 +5137,13 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 	SET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 	bgp_dest_lock_node(dest);
 
-	if (early_process)
+	if (early_process) {
+		SET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
 		early_route_process(bgp, dest);
-	else
+	} else {
+		UNSET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
 		other_route_process(bgp, dest);
+	}
 
 	return;
 }
@@ -13433,6 +13438,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 			json_object_boolean_true_add(json_path, "fibPending");
 		if (CHECK_FLAG(bn->flags, BGP_NODE_NHT_RESOLVED_NODE))
 			json_object_boolean_true_add(json_path, "earlyProcessing");
+		if (CHECK_FLAG(bn->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY))
+			json_object_boolean_true_add(json_path, "zebraAnnouncePriority");
 
 		if (json_nexthop_global || json_nexthop_ll) {
 			json_nexthops = json_object_new_array();

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -112,6 +112,7 @@ struct bgp_dest {
 #define BGP_NODE_SCHEDULE_FOR_INSTALL	(1 << 10)
 #define BGP_NODE_SCHEDULE_FOR_DELETE	(1 << 11)
 #define BGP_NODE_NHT_RESOLVED_NODE	(1 << 12)
+#define BGP_NODE_ZEBRA_ANNOUNCE_EARLY	(1 << 13)
 
 	struct bgp_addpath_node_data tx_addpath;
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12537,6 +12537,8 @@ DEFPY(show_bgp_router,
 		json_object_int_add(json, "bgpOutputQueueLimit", bm->outq_limit);
 		json_object_int_add(json, "zebraAnnounceCount",
 				    zebra_announce_count(&bm->zebra_announce_head));
+		json_object_int_add(json, "zebraAnnounceEarlyCount",
+				    zebra_announce_count(&bm->zebra_announce_early_head));
 		json_object_int_add(json, "bgpUpdateDelayTime", bm->v_update_delay);
 		json_object_int_add(json, "bgpEstablishWaitTime", bm->v_establish_wait);
 		json_object_int_add(json, "bgpRmapDelayTimer", bm->rmap_update_timer);
@@ -12546,7 +12548,9 @@ DEFPY(show_bgp_router,
 	} else {
 		vty_out(vty, "BGP Input Queue Limit: %d\n", bm->inq_limit);
 		vty_out(vty, "BGP Output Queue Limit: %d\n", bm->outq_limit);
-		vty_out(vty, "Zebra Announce Count: %zu\n",
+		vty_out(vty, "Zebra announce queue (priority): %zu\n",
+			zebra_announce_count(&bm->zebra_announce_early_head));
+		vty_out(vty, "Zebra announce queue (normal): %zu\n",
 			zebra_announce_count(&bm->zebra_announce_head));
 
 		vty_out(vty, "BGP Global Update Delay Timers:\n");

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1851,6 +1851,32 @@ enum zclient_send_status bgp_zebra_withdraw_actual(struct bgp_dest *dest,
  * continue processing items on list.
  */
 #define ZEBRA_ANNOUNCEMENTS_LIMIT 1000
+
+/* Prefer underlay / early-processed routes: drain early FIFO before default. */
+static struct bgp_bp_install_node *bgp_zebra_announce_pop_priority(void)
+{
+	struct bgp_bp_install_node *inode;
+
+	inode = zebra_announce_pop(&bm->zebra_announce_early_head);
+	if (!inode)
+		inode = zebra_announce_pop(&bm->zebra_announce_head);
+	return inode;
+}
+
+static void bgp_zebra_announce_inode_requeue(struct bgp_bp_install_node *inode, bool want_early)
+{
+	if (inode->early_queue == want_early)
+		return;
+	if (inode->early_queue) {
+		zebra_announce_del(&bm->zebra_announce_early_head, inode);
+		zebra_announce_add_tail(&bm->zebra_announce_head, inode);
+	} else {
+		zebra_announce_del(&bm->zebra_announce_head, inode);
+		zebra_announce_add_tail(&bm->zebra_announce_early_head, inode);
+	}
+	inode->early_queue = want_early;
+}
+
 static void bgp_handle_route_announcements_to_zebra(struct event *e)
 {
 	bool is_evpn = false;
@@ -1865,7 +1891,7 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 	while (count < ZEBRA_ANNOUNCEMENTS_LIMIT) {
 		is_evpn = false;
 
-		inode = zebra_announce_pop(&bm->zebra_announce_head);
+		inode = bgp_zebra_announce_pop_priority();
 
 		if (!inode)
 			break;
@@ -1948,7 +1974,8 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 	}
 
 	if (status != ZCLIENT_SEND_BUFFERED &&
-	    zebra_announce_count(&bm->zebra_announce_head))
+	    (zebra_announce_count(&bm->zebra_announce_early_head) ||
+	     zebra_announce_count(&bm->zebra_announce_head)))
 		event_add_event(bm->master,
 				bgp_handle_route_announcements_to_zebra, NULL,
 				0, &bm->t_bgp_zebra_route);
@@ -2059,11 +2086,17 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 
 	if (!CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL) &&
 	    !CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_DELETE)) {
+		bool want_early = CHECK_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
+
 		assert(!dest->za_inode);
 		inode = XCALLOC(MTYPE_BGP_BP_INSTALL_NODE, sizeof(*inode));
 		inode->type = BGP_BP_INSTALL_ROUTE;
 		inode->ptr = dest;
-		zebra_announce_add_tail(&bm->zebra_announce_head, inode);
+		inode->early_queue = want_early;
+		if (want_early)
+			zebra_announce_add_tail(&bm->zebra_announce_early_head, inode);
+		else
+			zebra_announce_add_tail(&bm->zebra_announce_head, inode);
 		bgp->zebra_announce_queue_cnt++;
 		/*
 		 * If neither flag is set and za_bgp_pi is not set then it is a bug
@@ -2076,12 +2109,18 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 	} else if (CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL)) {
 		assert(dest->za_inode);
 		assert(dest->za_bgp_pi);
+		bgp_zebra_announce_inode_requeue(dest->za_inode,
+						 CHECK_FLAG(dest->flags,
+							    BGP_NODE_ZEBRA_ANNOUNCE_EARLY));
 		bgp_path_info_unlock(dest->za_bgp_pi);
 		bgp_path_info_lock(info);
 		dest->za_bgp_pi = info;
 	} else if (CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_DELETE)) {
 		assert(dest->za_inode);
 		assert(dest->za_bgp_pi);
+		bgp_zebra_announce_inode_requeue(dest->za_inode,
+						 CHECK_FLAG(dest->flags,
+							    BGP_NODE_ZEBRA_ANNOUNCE_EARLY));
 		bgp_path_info_unlock(dest->za_bgp_pi);
 		bgp_path_info_lock(info);
 		dest->za_bgp_pi = info;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4267,6 +4267,31 @@ void bgp_instance_down(struct bgp *bgp)
 	bgp_set_redist_vrf_bitmaps(bgp, false);
 }
 
+/* Remove this instance's pending zebra announce dests from one global queue. */
+static void bgp_delete_zebra_announce_queue(struct zebra_announce_head *head, struct bgp *bgp)
+{
+	struct bgp_bp_install_node *inode;
+	struct bgp_bp_install_node *inode_next;
+	struct bgp_dest *dest;
+	struct bgp_table *dest_table;
+
+	for (inode = zebra_announce_first(head); inode; inode = inode_next) {
+		inode_next = zebra_announce_next(head, inode);
+		if (inode->type != BGP_BP_INSTALL_ROUTE)
+			continue;
+		dest = inode->ptr;
+		dest_table = bgp_dest_table(dest);
+		if (dest_table->bgp == bgp) {
+			zebra_announce_del(head, inode);
+			bgp->zebra_announce_queue_cnt--;
+			bgp_path_info_unlock(dest->za_bgp_pi);
+			dest->za_inode = NULL;
+			bgp_dest_unlock_node(dest);
+			XFREE(MTYPE_BGP_BP_INSTALL_NODE, inode);
+		}
+	}
+}
+
 /* Delete BGP instance. */
 int bgp_delete(struct bgp *bgp)
 {
@@ -4279,10 +4304,6 @@ int bgp_delete(struct bgp *bgp)
 	int i;
 	uint32_t vni_count;
 	struct bgpevpn *vpn = NULL;
-	struct bgp_dest *dest = NULL;
-	struct bgp_bp_install_node *inode = NULL;
-	struct bgp_bp_install_node *inode_next = NULL;
-	struct bgp_table *dest_table = NULL;
 	struct graceful_restart_info *gr_info;
 	struct bgp *bgp_default = bgp_get_default();
 	struct bgp_clearing_info *cinfo;
@@ -4298,37 +4319,8 @@ int bgp_delete(struct bgp *bgp)
 	 */
 	b_ann_cnt = zebra_announce_count(&bm->zebra_announce_head) +
 		    zebra_announce_count(&bm->zebra_announce_early_head);
-	for (inode = zebra_announce_first(&bm->zebra_announce_early_head); inode;
-	     inode = inode_next) {
-		inode_next = zebra_announce_next(&bm->zebra_announce_early_head, inode);
-		if (inode->type != BGP_BP_INSTALL_ROUTE)
-			continue;
-		dest = inode->ptr;
-		dest_table = bgp_dest_table(dest);
-		if (dest_table->bgp == bgp) {
-			zebra_announce_del(&bm->zebra_announce_early_head, inode);
-			bgp->zebra_announce_queue_cnt--;
-			bgp_path_info_unlock(dest->za_bgp_pi);
-			dest->za_inode = NULL;
-			bgp_dest_unlock_node(dest);
-			XFREE(MTYPE_BGP_BP_INSTALL_NODE, inode);
-		}
-	}
-	for (inode = zebra_announce_first(&bm->zebra_announce_head); inode; inode = inode_next) {
-		inode_next = zebra_announce_next(&bm->zebra_announce_head, inode);
-		if (inode->type != BGP_BP_INSTALL_ROUTE)
-			continue;
-		dest = inode->ptr;
-		dest_table = bgp_dest_table(dest);
-		if (dest_table->bgp == bgp) {
-			zebra_announce_del(&bm->zebra_announce_head, inode);
-			bgp->zebra_announce_queue_cnt--;
-			bgp_path_info_unlock(dest->za_bgp_pi);
-			dest->za_inode = NULL;
-			bgp_dest_unlock_node(dest);
-			XFREE(MTYPE_BGP_BP_INSTALL_NODE, inode);
-		}
-	}
+	bgp_delete_zebra_announce_queue(&bm->zebra_announce_early_head, bgp);
+	bgp_delete_zebra_announce_queue(&bm->zebra_announce_head, bgp);
 
 	/*
 	 * Pop all VPNs yet to be processed for remote routes install if the
@@ -4551,6 +4543,7 @@ int bgp_delete(struct bgp *bgp)
 	/* Free memory allocated with aggregate address configuration. */
 	FOREACH_AFI_SAFI (afi, safi) {
 		struct bgp_aggregate *aggregate = NULL;
+		struct bgp_dest *dest;
 
 		for (dest = bgp_table_top(bgp->aggregate[afi][safi]);
 		     dest; dest = bgp_route_next(dest)) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4296,7 +4296,24 @@ int bgp_delete(struct bgp *bgp)
 	 * Iterate the pending dest list and remove all the dest pertaining to
 	 * the bgp under delete.
 	 */
-	b_ann_cnt = zebra_announce_count(&bm->zebra_announce_head);
+	b_ann_cnt = zebra_announce_count(&bm->zebra_announce_head) +
+		    zebra_announce_count(&bm->zebra_announce_early_head);
+	for (inode = zebra_announce_first(&bm->zebra_announce_early_head); inode;
+	     inode = inode_next) {
+		inode_next = zebra_announce_next(&bm->zebra_announce_early_head, inode);
+		if (inode->type != BGP_BP_INSTALL_ROUTE)
+			continue;
+		dest = inode->ptr;
+		dest_table = bgp_dest_table(dest);
+		if (dest_table->bgp == bgp) {
+			zebra_announce_del(&bm->zebra_announce_early_head, inode);
+			bgp->zebra_announce_queue_cnt--;
+			bgp_path_info_unlock(dest->za_bgp_pi);
+			dest->za_inode = NULL;
+			bgp_dest_unlock_node(dest);
+			XFREE(MTYPE_BGP_BP_INSTALL_NODE, inode);
+		}
+	}
 	for (inode = zebra_announce_first(&bm->zebra_announce_head); inode; inode = inode_next) {
 		inode_next = zebra_announce_next(&bm->zebra_announce_head, inode);
 		if (inode->type != BGP_BP_INSTALL_ROUTE)
@@ -4328,7 +4345,8 @@ int bgp_delete(struct bgp *bgp)
 	}
 
 	if (BGP_DEBUG(zebra, ZEBRA)) {
-		a_ann_cnt = zebra_announce_count(&bm->zebra_announce_head);
+		a_ann_cnt = zebra_announce_count(&bm->zebra_announce_head) +
+			    zebra_announce_count(&bm->zebra_announce_early_head);
 		a_l2_cnt = zebra_l2_vni_count(&bm->zebra_l2_vni_head);
 		zlog_debug("FIFO Cleanup Count during BGP %s deletion :: Zebra Announce - before %u after %u :: BGP L2_VNI - before %u after %u",
 			   bgp->name_pretty, b_ann_cnt, a_ann_cnt, b_l2_cnt, a_l2_cnt);
@@ -9043,6 +9061,7 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	pthread_mutex_init(&bm->peer_connection_mtx, NULL);
 
 	zebra_announce_init(&bm->zebra_announce_head);
+	zebra_announce_init(&bm->zebra_announce_early_head);
 	zebra_l2_vni_init(&bm->zebra_l2_vni_head);
 	bm->bgp = list_new();
 	bm->listen_sockets = list_new();

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -29,6 +29,7 @@ struct bgp_bp_install_node {
 	struct zebra_announce_item zai;
 	enum bgp_bp_install_type type;
 	void *ptr;
+	bool early_queue;
 };
 
 /* For union sockunion.  */
@@ -229,6 +230,7 @@ struct bgp_master {
 
 	/* To preserve ordering of installations into zebra across all Vrfs */
 	struct zebra_announce_head zebra_announce_head;
+	struct zebra_announce_head zebra_announce_early_head;
 
 	struct event *t_bgp_zebra_l2_vni;
 	/* To preserve ordering of processing of L2 VNIs in BGP */


### PR DESCRIPTION
Currently after route processing, all bgp dest nodes are placed on a FIFO to be sent to zebra.  This is to allow BGP to work with backpressure from zebra.  Currently if we have a route that we moved to the front of the bgp processing queue in bgp we just place it at the end of the send to zebra FIFO.  In cases where zebra is backed up, this delays the processing of the route that is important.  This is especially important when BGP is using itself as a underlay and a overlay.  Modify the code such that there are two fifo queues to send to zebra, allow the early processed routes to go to the front.