### PR TITLE
bgpd: make peer_delete() idempotent to prevent double-deletion

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2971,7 +2971,9 @@ int peer_delete(struct peer *peer)
 	int accept_peer;
 	bool clear_queue_lock_held = false;
 
-	assert(peer->connection->status != Deleted);
+	/* Prevent double-deletion if already deleted */
+	if (peer->connection->status == Deleted)
+		return 0;
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s: peer %pBP", __func__, peer);


### PR DESCRIPTION
Encountered assert/abort in peer_delete() in testing. The crash occurred while BGP sessions were flapping. Analysis revealed this happened on a doppelganger (accept peer).

peer_delete() is called in a number of places. Although currently the condition "status != Deleted" is also checked by many callers before calling peer_delete(), that is error-prone.

Replace the assertion with an early return when "status == Deleted". This makes peer_delete() idempotent and safe to call multiple times, preventing crashes while maintaining correct deletion semantics.

This approach is simpler and more robust than checking at every call site, as it protects against all current and future callers.