### PR TITLE
tests: Fix time re in all_protocol_startup/test_all_protocol_startup 

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -853,7 +853,7 @@ def test_ospfv2_interfaces():
 
             # Drop time in next due
             actual = re.sub(
-                r"Hello due in [-0-9\.]+s", "Hello due in XX.XXXs", actual
+                r"Hello due in [-0-9\.]+( usec)?s", "Hello due in XX.XXXs", actual
             )
             # Fix 'MTU mismatch detection: enabled' vs 'MTU mismatch detection:enabled' - accept both
             actual = re.sub(


### PR DESCRIPTION
There was failure in test with diff:

```
 -    Hello due in 932 usecs
 +    Hello due in XX.XXXs
 ```

Regular expression expected for format SECONDS.MSECs only.

Added `usec` support to regular expression.

`ospf_timeval_dump` can also output  weeks, days, hours, but probably there is no need to support that.

Or should I add weeks, days, hours just in case?..

I couldn't reproduce failure, but tested regular expression with `Hello due in 932 usecs` and `Hello due in 12.32s` manually.

Failure URL:  https://github.com/FRRouting/frr/pull/21376/checks?check_run_id=68874454155

Full output:

```
AssertionError: SHOW IP OSPF INTERFACE failed for router r1:
 --- actual SHOW IP OSPF INTERFACE
 +++ expected SHOW IP OSPF INTERFACE
 @@ -22,7 +22,7 @@
    No backup designated router on this network
    Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
    Timer intervals configured, Hello 1s, Dead 5s, Wait 5s, Retransmit 5
 -    Hello due in 932 usecs
 +    Hello due in XX.XXXs
    Neighbor Count is 0, Adjacent neighbor count is 0
    Graceful Restart hello delay: 10s
    LSA retransmissions: 0
assert 1 == 0
E   AssertionError: SHOW IP OSPF INTERFACE failed for router r1:
     --- actual SHOW IP OSPF INTERFACE
     +++ expected SHOW IP OSPF INTERFACE
     @@ -22,7 +22,7 @@
        No backup designated router on this network
        Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
        Timer intervals configured, Hello 1s, Dead 5s, Wait 5s, Retransmit 5
     -    Hello due in 932 usecs
     +    Hello due in XX.XXXs
        Neighbor Count is 0, Adjacent neighbor count is 0
        Graceful Restart hello delay: 10s
        LSA retransmissions: 0
   assert 1 == 0
   ```