### PR TITLE
bgpd: add configurable advertisement delay for suppress-fib-pending

### DIFF
--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -33,8 +33,8 @@ enum bgp_fsm_state_progress {
 		if (BGP_SUPPRESS_FIB_ENABLED(peer->bgp) &&                            \
 		    PEER_ROUTE_ADV_DELAY(peer))                                       \
 			event_add_timer_msec(bm->master, (F), connection,             \
-					     (BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * \
-					      1000),                                  \
+					     bgp_suppress_fib_get_adv_delay(      \
+						     peer->bgp),                  \
 					     (T));                                    \
 		else                                                                  \
 			event_add_timer_msec(bm->master, (F), connection, 0,          \

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2084,26 +2084,37 @@ DEFPY(bgp_community_alias, bgp_community_alias_cmd,
 
 DEFPY (bgp_global_suppress_fib_pending,
        bgp_global_suppress_fib_pending_cmd,
-       "[no] bgp suppress-fib-pending",
+       "[no] bgp suppress-fib-pending [(0-10000)$delay]",
        NO_STR
        BGP_STR
-       "Advertise only routes that are programmed in kernel to peers globally\n")
+       "Advertise only routes that are programmed in kernel to peers globally\n"
+       "Advertisement delay in milliseconds after FIB installation (default 1000)\n")
 {
-	bm_wait_for_fib_set(!no);
+	uint16_t adv_delay = BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY;
+
+	if (!no && delay_str)
+		adv_delay = delay;
+
+	bm_wait_for_fib_set(!no, adv_delay);
 
 	return CMD_SUCCESS;
 }
 
 DEFPY (bgp_suppress_fib_pending,
        bgp_suppress_fib_pending_cmd,
-       "[no] bgp suppress-fib-pending",
+       "[no] bgp suppress-fib-pending [(0-10000)$delay]",
        NO_STR
        BGP_STR
-       "Advertise only routes that are programmed in kernel to peers\n")
+       "Advertise only routes that are programmed in kernel to peers\n"
+       "Advertisement delay in milliseconds after FIB installation (default 1000)\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	uint16_t adv_delay = BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY;
 
-	bgp_suppress_fib_pending_set(bgp, !no);
+	if (!no && delay_str)
+		adv_delay = delay;
+
+	bgp_suppress_fib_pending_set(bgp, !no, adv_delay);
 	return CMD_SUCCESS;
 }
 
@@ -20879,8 +20890,13 @@ int bgp_config_write(struct vty *vty)
 		vty_out(vty, "\n");
 	}
 
-	if (bm->wait_for_fib)
-		vty_out(vty, "bgp suppress-fib-pending\n");
+	if (bm->wait_for_fib) {
+		if (bm->suppress_fib_adv_delay != BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY)
+			vty_out(vty, "bgp suppress-fib-pending %u\n",
+				bm->suppress_fib_adv_delay);
+		else
+			vty_out(vty, "bgp suppress-fib-pending\n");
+	}
 
 	if (bm->stalepath_time != BGP_DEFAULT_STALEPATH_TIME)
 		vty_out(vty, "bgp graceful-restart stalepath-time %u\n",
@@ -20966,8 +20982,15 @@ int bgp_config_write(struct vty *vty)
 				&bgp->router_id_static);
 
 		/* Suppress fib pending */
-		if (CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING))
-			vty_out(vty, " bgp suppress-fib-pending\n");
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING)) {
+			if (bgp->suppress_fib_adv_delay !=
+			    BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY)
+				vty_out(vty,
+					" bgp suppress-fib-pending %u\n",
+					bgp->suppress_fib_adv_delay);
+			else
+				vty_out(vty, " bgp suppress-fib-pending\n");
+		}
 
 		/* BGP log-neighbor-changes. */
 		if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -447,17 +447,23 @@ void bgp_router_id_static_set(struct bgp *bgp, struct in_addr id)
 			  true /* is config */);
 }
 
-void bm_wait_for_fib_set(bool set)
+void bm_wait_for_fib_set(bool set, uint16_t adv_delay)
 {
 	bool send_msg = false;
 	struct bgp *bgp;
 	struct peer *peer;
 	struct listnode *next, *node;
 
-	if (bm->wait_for_fib == set)
+	/* If only the delay changed, update it without resetting peers */
+	if (bm->wait_for_fib == set) {
+		if (set && bm->suppress_fib_adv_delay != adv_delay)
+			bm->suppress_fib_adv_delay = adv_delay;
 		return;
+	}
 
 	bm->wait_for_fib = set;
+	bm->suppress_fib_adv_delay = adv_delay;
+
 	if (set) {
 		if (bgp_suppress_fib_count == 0)
 			send_msg = true;
@@ -498,7 +504,7 @@ void bm_wait_for_fib_set(bool set)
 }
 
 /* Set the suppress fib pending for the bgp configuration */
-void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set)
+void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set, uint16_t adv_delay)
 {
 	bool send_msg = false;
 	bool is_retry = false;
@@ -514,9 +520,16 @@ void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set)
 		UNSET_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING_OP_DEFERRED);
 	}
 
-	/* Do nothing if already in a desired state, unless this is a retry */
-	if (!is_retry && set == !!CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING))
+	/* If only the delay changed, update it without resetting peers */
+	if (!is_retry && set == !!CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING)) {
+		if (set && bgp->suppress_fib_adv_delay != adv_delay) {
+			bgp->suppress_fib_adv_delay = adv_delay;
+			return;
+		}
 		return;
+	}
+
+	bgp->suppress_fib_adv_delay = adv_delay;
 
 	if (!bgp_zclient || bgp_zclient->sock < 0) {
 		/* Socket not ready - mark operation as failed */
@@ -604,8 +617,22 @@ void bgp_zebra_suppress_fib_pending_config_retry(void)
 				   __func__, desired_enable ? "enable" : "disable",
 				   bgp->name_pretty, bgp_suppress_fib_count);
 
-		bgp_suppress_fib_pending_set(bgp, desired_enable);
+		bgp_suppress_fib_pending_set(bgp, desired_enable,
+					     bgp->suppress_fib_adv_delay);
 	}
+}
+
+/*
+ * Return the effective suppress-fib advertisement delay for a BGP instance.
+ * Per-instance value takes precedence; falls back to the global bm value.
+ */
+uint16_t bgp_suppress_fib_get_adv_delay(struct bgp *bgp)
+{
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING))
+		return bgp->suppress_fib_adv_delay;
+	if (bm->wait_for_fib)
+		return bm->suppress_fib_adv_delay;
+	return BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY;
 }
 
 /* BGP's cluster-id control. */
@@ -3796,6 +3823,7 @@ peer_init:
 	bgp->lb_handling = BGP_LINK_BW_ECMP;
 	bgp->reject_as_sets = true;
 	bgp->condition_check_period = DEFAULT_CONDITIONAL_ROUTES_POLL_TIME;
+	bgp->suppress_fib_adv_delay = BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY;
 	bgp_addpath_init_bgp_data(&bgp->tx_addpath);
 	bgp->fast_convergence = false;
 	bgp->llgr_stale_time = BGP_DEFAULT_LLGR_STALE_TIME;
@@ -9066,6 +9094,7 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	bm->terminating = false;
 	bm->socket_buffer = buffer_size;
 	bm->wait_for_fib = false;
+	bm->suppress_fib_adv_delay = BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY;
 	bm->ip_tos = IPTOS_PREC_INTERNETCONTROL;
 	bm->inq_limit = BM_DEFAULT_Q_LIMIT;
 	bm->outq_limit = BM_DEFAULT_Q_LIMIT;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -182,6 +182,9 @@ struct bgp_master {
 	/* Should we do wait for fib install globally? */
 	bool wait_for_fib;
 
+	/* Advertisement delay (ms) for suppress-fib-pending (global) */
+	uint16_t suppress_fib_adv_delay;
+
 	/* EVPN multihoming */
 	struct bgp_evpn_mh_info *mh_info;
 
@@ -1049,6 +1052,9 @@ struct bgp {
 	uint32_t condition_check_period;
 	uint32_t condition_filter_count;
 	struct event *t_condition_check;
+
+	/* Advertisement delay (ms) for suppress-fib-pending */
+	uint16_t suppress_fib_adv_delay;
 
 
 	/* BGP L3 service VPN SRv6 backend */
@@ -2478,6 +2484,7 @@ struct bgp_nlri {
 #define BGP_DEFAULT_SELECT_DEFERRAL_TIME       120
 #define BGP_DEFAULT_RIB_STALE_TIME             500
 #define BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME  1
+#define BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY     1000 /* ms */
 
 /* BGP Long-lived Graceful Restart */
 #define BGP_DEFAULT_LLGR_STALE_TIME 0
@@ -2706,8 +2713,10 @@ extern int bgp_handle_socket(struct bgp *bgp, struct vrf *vrf,
 extern void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *prefix);
 extern void bgp_router_id_static_set(struct bgp *bgp, struct in_addr router_id);
 
-extern void bm_wait_for_fib_set(bool set);
-extern void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set);
+extern void bm_wait_for_fib_set(bool set, uint16_t adv_delay);
+extern void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set,
+					  uint16_t adv_delay);
+extern uint16_t bgp_suppress_fib_get_adv_delay(struct bgp *bgp);
 extern void bgp_cluster_id_set(struct bgp *bgp, struct in_addr *cluster_id);
 extern void bgp_cluster_id_unset(struct bgp *bgp);
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5574,12 +5574,34 @@ status in FIB:
 7. If the route which is already installed in dataplane is removed for some
    reason, sending withdraw message to peers is not currently supported.
 
-.. clicmd:: bgp suppress-fib-pending
+.. clicmd:: bgp suppress-fib-pending [(0-10000)]
 
    This command is applicable at the global level and at an individual
    bgp level.  If applied at the global level all bgp instances will
    wait for fib installation before announcing routes and there is no
    way to turn it off for a particular bgp vrf.
+
+   An optional advertisement delay in milliseconds can be specified to control
+   how long BGP waits after FIB installation before advertising routes to
+   peers. This provides a batching window that groups multiple route
+   advertisements into fewer BGP UPDATE messages.
+
+   The default delay is 1000 milliseconds. Setting the delay to ``0``
+   disables the batching window and advertises routes immediately after FIB
+   confirmation, which reduces convergence latency at the cost of more frequent
+   UPDATE messages. During bulk convergence, zebra already batch-processes FIB
+   confirmations, providing natural batching even with a low delay value.
+
+   Examples::
+
+      ! Enable with default 1000ms delay
+      bgp suppress-fib-pending
+
+      ! Enable with custom 50ms delay for low-latency environments
+      bgp suppress-fib-pending 50
+
+      ! Enable with no post-FIB batching delay
+      bgp suppress-fib-pending 0
 
 .. _routing-policy:
 

--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -248,6 +248,133 @@ def test_ip_protocol_any_fib_filter():
     test_bgp_route()
 
 
+def test_bgp_suppress_fib_adv_delay():
+    """Test configurable advertisement delay for suppress-fib-pending"""
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    # Verify default: suppress-fib-pending is already configured without
+    # explicit delay, so running-config should show bare command
+    output = r2.vtysh_cmd("show running-config")
+    assert "bgp suppress-fib-pending" in output
+    assert "bgp suppress-fib-pending 1000" not in output, \
+        "Default delay should not appear in running-config"
+
+    # Wait for peers to be established before testing delay changes
+    def _check_peers_established():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        peers = output.get("ipv4Unicast", {}).get("peers", {})
+        for peer_info in peers.values():
+            if peer_info.get("state") != "Established":
+                return False
+        return True
+
+    _, result = topotest.run_and_expect(_check_peers_established, True,
+                                        count=30, wait=1)
+    assert result is True, "Peers should be established before delay test"
+
+    # Record peer uptime before delay change
+    output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+    peers_before = output.get("ipv4Unicast", {}).get("peers", {})
+    pfx_rcvd_before = {
+        peer: info.get("pfxRcd", 0) for peer, info in peers_before.items()
+    }
+
+    # Change delay while suppress-fib is already enabled (delay-only change)
+    r2.vtysh_cmd("conf\nrouter bgp 2\nbgp suppress-fib-pending 50")
+    output = r2.vtysh_cmd("show running-config")
+    assert "bgp suppress-fib-pending 50" in output, \
+        "Custom delay should appear in running-config"
+
+    # Verify peers were NOT reset — they should still be Established
+    # with the same prefix count (no session flap)
+    output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+    peers_after = output.get("ipv4Unicast", {}).get("peers", {})
+    for peer, info in peers_after.items():
+        assert info.get("state") == "Established", \
+            "Peer {} should remain Established after delay-only change".format(peer)
+        assert info.get("pfxRcd", 0) == pfx_rcvd_before.get(peer, 0), \
+            "Peer {} prefix count should not change on delay-only update".format(peer)
+
+    # Change delay to 0 (no batching) — still delay-only, no reset
+    r2.vtysh_cmd("conf\nrouter bgp 2\nbgp suppress-fib-pending 0")
+    output = r2.vtysh_cmd("show running-config")
+    assert "bgp suppress-fib-pending 0" in output, \
+        "Zero delay should appear in running-config"
+
+    output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+    peers_after = output.get("ipv4Unicast", {}).get("peers", {})
+    for peer, info in peers_after.items():
+        assert info.get("state") == "Established", \
+            "Peer {} should remain Established after delay change to 0".format(peer)
+
+    # Change delay to >1000ms — validates extended range up to 10000
+    r2.vtysh_cmd("conf\nrouter bgp 2\nbgp suppress-fib-pending 5000")
+    output = r2.vtysh_cmd("show running-config")
+    assert "bgp suppress-fib-pending 5000" in output, \
+        "Extended delay (5000ms) should appear in running-config"
+
+    output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+    peers_after = output.get("ipv4Unicast", {}).get("peers", {})
+    for peer, info in peers_after.items():
+        assert info.get("state") == "Established", \
+            "Peer {} should remain Established after delay change to 5000".format(peer)
+
+    # Restore default delay (no explicit value)
+    r2.vtysh_cmd("conf\nrouter bgp 2\nbgp suppress-fib-pending")
+    output = r2.vtysh_cmd("show running-config")
+    assert "bgp suppress-fib-pending" in output
+    assert "bgp suppress-fib-pending 1000" not in output, \
+        "Default delay should not appear after restore"
+
+    # Verify routes still work after delay changes
+    r3 = tgen.gears["r3"]
+    json_file = "{}/r3/v4_route.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+
+    test_func = partial(
+        topotest.router_json_cmp,
+        r3,
+        "show ip route 40.0.0.0 json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Routes should still be present after delay changes"
+
+
+def test_bgp_suppress_fib_adv_delay_global():
+    """Test configurable advertisement delay at global (CONFIG_NODE) level"""
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Enable global suppress-fib-pending with custom delay
+    r1.vtysh_cmd("conf\nbgp suppress-fib-pending 100")
+    output = r1.vtysh_cmd("show running-config")
+    assert "bgp suppress-fib-pending 100" in output, \
+        "Global custom delay should appear in running-config"
+
+    # Disable global suppress-fib-pending
+    r1.vtysh_cmd("conf\nno bgp suppress-fib-pending")
+    output = r1.vtysh_cmd("show running-config")
+    # After 'no', the command should not appear at global level
+    lines = output.split("\n")
+    global_lines = [l for l in lines if l.strip() == "bgp suppress-fib-pending"
+                    or "bgp suppress-fib-pending" in l and not l.startswith(" ")]
+    # Filter out per-instance lines (indented with space)
+    assert not any(not l.startswith(" ") and "bgp suppress-fib-pending" in l
+                   for l in lines), \
+        "Global suppress-fib-pending should be removed after 'no'"
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
### Summary

When `bgp suppress-fib-pending` is enabled, `BGP_UPDATE_GROUP_TIMER_ON` in `bgp_fsm.h` adds a 1-second batching delay (`BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * 1000`) after FIB confirmation before advertising routes to peers.

This delay adds unnecessary latency for deployments that force-enable suppress-fib-pending (e.g., SONiC via bgpcfgd). During bulk convergence, zebra already batch-processes FIB confirmations, providing natural batching that makes the large window redundant.

This change adds an optional delay parameter to the existing CLI:

```
[no] bgp suppress-fib-pending [(0-10000)]
```

- **Default**: 1000ms — preserves backward compatibility, no behavior change for existing configs
- **Range**: 0–10000 milliseconds
- **No argument**: uses default 1000ms
- **`no` form**: disables suppress-fib entirely (same as before)
- **Running-config**: only shows the delay value when non-default

Changing the delay at runtime does **not** reset peer sessions — only enabling/disabling suppress-fib triggers peer resets (same as before).

#### Files changed

| File | Change |
|------|--------|
| `bgpd/bgpd.h` | Add `suppress_fib_adv_delay` field to `struct bgp` and `struct bgp_master`, add `BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY` constant, update function signatures |
| `bgpd/bgpd.c` | Store and propagate delay in `bm_wait_for_fib_set()` and `bgp_suppress_fib_pending_set()`; add `bgp_suppress_fib_get_adv_delay()` helper; early return for delay-only changes |
| `bgpd/bgp_fsm.h` | `BGP_UPDATE_GROUP_TIMER_ON` reads per-instance delay via `bgp_suppress_fib_get_adv_delay()` instead of hardcoded constant |
| `bgpd/bgp_vty.c` | Extend both DEFPY commands (CONFIG_NODE global and BGP_NODE per-instance) with optional `[(0-1000)]` parameter; update running-config output |
| `doc/user/bgp.rst` | Document new optional parameter with examples |
| `tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py` | Add tests for configurable delay at both per-instance and global levels; verify peers stay Established during delay-only changes |

#### Test Results

**Topotest** (`tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py`):

```
bgp_suppress_fib/test_bgp_suppress_fib.py::test_bgp_route                           PASSED
bgp_suppress_fib/test_bgp_suppress_fib.py::test_bgp_better_admin_won                PASSED
bgp_suppress_fib/test_bgp_suppress_fib.py::test_bgp_allow_as_in                     PASSED
bgp_suppress_fib/test_bgp_suppress_fib.py::test_local_vs_non_local                  PASSED
bgp_suppress_fib/test_bgp_suppress_fib.py::test_ip_protocol_any_fib_filter          PASSED
bgp_suppress_fib/test_bgp_suppress_fib.py::test_bgp_suppress_fib_adv_delay          PASSED  ← NEW
bgp_suppress_fib/test_bgp_suppress_fib.py::test_bgp_suppress_fib_adv_delay_global   PASSED  ← NEW
============================== 7 passed in 18.41s ==============================
```

All 5 existing tests pass (no regression). Two new tests verify:
- Per-instance delay config: running-config output, peers stay Established during delay-only changes, routes work after changes
- Global delay config: enable/disable with custom delay at CONFIG_NODE level

**Integration test** ([sonic-net/sonic-mgmt#23390](https://github.com/sonic-net/sonic-mgmt/pull/23390)): BGP UPDATE relay latency dropped from 1062ms to 113ms with a 50ms delay on a 4-peer T0 topology.

### Related Issue

Closes #21298

### Components

bgpd, doc, tests