### PR TITLE
zebra: EVPN prevent stale mbr_zifs entries from early return

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1914,27 +1914,28 @@ static void interface_bridge_vlan_update(struct zebra_dplane_ctx *ctx,
 	uint16_t vid_range_start = 0;
 	int32_t i;
 
+	/* Could we have multiple bridge vlan infos? */
+	bvarray = dplane_ctx_get_ifp_bridge_vlan_info_array(ctx);
+	if (!bvarray)
+		return;
+
 	/* cache the old bitmap addrs */
 	old_vlan_bitmap = zif->vlan_bitmap;
 	/* create a new bitmap space for re-eval */
 	bf_init(zif->vlan_bitmap, IF_VLAN_BITMAP_MAX);
 
-	/* Could we have multiple bridge vlan infos? */
-	bvarray = dplane_ctx_get_ifp_bridge_vlan_info_array(ctx);
-	if (bvarray) {
-		for (i = 0; i < bvarray->count; i++) {
-			bvinfo = bvarray->array[i];
+	for (i = 0; i < bvarray->count; i++) {
+		bvinfo = bvarray->array[i];
 
-			if (bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_BEGIN) {
-				vid_range_start = bvinfo.vid;
-				continue;
-			}
-
-			if (!(bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_END))
-				vid_range_start = bvinfo.vid;
-
-			zebra_vlan_bitmap_compute(ifp, vid_range_start, bvinfo.vid);
+		if (bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_BEGIN) {
+			vid_range_start = bvinfo.vid;
+			continue;
 		}
+
+		if (!(bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_END))
+			vid_range_start = bvinfo.vid;
+
+		zebra_vlan_bitmap_compute(ifp, vid_range_start, bvinfo.vid);
 	}
 
 	zebra_vlan_mbr_re_eval(ifp, old_vlan_bitmap);


### PR DESCRIPTION
Prematurely resetting zif->vlan_bitmap in interface_bridge_vlan_update() leads to inconsistent state if the function bails out early because the kernel AF_BRIDGE netlink notification arrived without VLAN info (no IFLA_BRIDGE_VLAN_INFO).

Because the old bitmap is replaced by an empty one before the NULL check on bvarray, the early return skips zebra_vlan_mbr_re_eval() and leaks the old bitmap. The interface's zif pointer is left behind in acc_bd->mbr_zifs.

Later, when RTM_DELLINK is received for that
interface, zebra_evpn_if_cleanup() iterates the now-empty vlan_bitmap and finds no VIDs to deref, so the stale zif is never removed from acc_bd->mbr_zifs. This leads to a use-after-free when the member list is subsequently iterated (e.g., show evpn access-vlan detail).

[PR-20350](https://github.com/FRRouting/frr/pull/20350) commit [6781514fe0b ](https://github.com/FRRouting/frr/pull/20350/changes/6781514fe0b502cb1339142a78a87a3b6e876aa6) **version would incorrectly deref all VLAN memberships on any AF_BRIDGE notification that happens to lack VLAN info.**
This could cause valid members to be removed from acc_bd->mbr_zifs spuriously, breaking EVPN-MH ES/EVI setup.

**The early-return approach is the safer choice, it treats missing VLAN info as "not relevant, do nothing."**


Signed-off-by: Chirag Shah <chirag@nvidia.com>