### PR TITLE
staticd: fix static_disable_vrf() to always send a route DELETE

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -580,7 +580,7 @@ static void static_disable_vrf(struct route_table *stable,
 		if (!si)
 			continue;
 		frr_each(static_path_list, &si->path_list, pn)
-			static_uninstall_path(pn);
+			static_zebra_route_add(pn, false);
 	}
 }
 


### PR DESCRIPTION
static_disable_vrf() called static_uninstall_path() to remove routes belonging to a VRF being disabled.  However, static_uninstall_path() sends a ZAPI ADD (not a DELETE) when nexthops are still in the list, so the routes were never actually withdrawn from zebra.

Replace with static_zebra_route_add(pn, false) to unconditionally send a DELETE for each path, which is the correct behavior when tearing down a VRF's own static routes.