### PR TITLE
bgpd: v4/v6 neigh advertised & received routes brief json

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13485,6 +13485,69 @@ static int bgp_show_community(struct vty *vty, struct bgp *bgp,
 			      const char *comstr, int exact, afi_t afi,
 			      safi_t safi, uint16_t show_flags);
 
+static void bgp_fib_flags_info(struct vty *vty, struct bgp *bgp, struct bgp_dest *dest,
+			       json_object *json_flags, bool best_path_selected)
+{
+	if (best_path_selected) {
+		if (json_flags)
+			json_object_boolean_true_add(json_flags, "bestPathExists");
+		else
+			vty_out(vty, "\"bestPathExists\": \"true\" ");
+	} else {
+		if (json_flags)
+			json_object_boolean_false_add(json_flags, "bestPathExists");
+		else
+			vty_out(vty, "\"bestPathExists\": \"false\" ");
+	}
+	if (CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED)) {
+		if (json_flags)
+			json_object_boolean_true_add(json_flags, "fibInstalled");
+		else
+			vty_out(vty, "\"fibInstalled\": \"true\" ");
+	} else {
+		if (json_flags)
+			json_object_boolean_false_add(json_flags, "fibInstalled");
+		else
+			vty_out(vty, "\"fibInstalled\": \"false\" ");
+	}
+
+	if (CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING)) {
+		if (json_flags)
+			json_object_boolean_true_add(json_flags, "fibWaitForInstall");
+		else
+			vty_out(vty, ",\"fibWaitForInstall\": \"true\" ");
+	} else {
+		if (json_flags)
+			json_object_boolean_false_add(json_flags, "fibWaitForInstall");
+		else
+			vty_out(vty, ",\"fibWaitForInstall\": \"false\" ");
+	}
+
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING)) {
+		if (json_flags)
+			json_object_boolean_true_add(json_flags, "fibSuppress");
+		else
+			vty_out(vty, ",\"fibSuppress\": \"true\" ");
+		if (!CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED) &&
+		    !CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING)) {
+			if (json_flags)
+				json_object_boolean_true_add(json_flags, "fibInstallFailed");
+			else
+				vty_out(vty, ",\"fibInstallFailed\": \"true\" ");
+		} else {
+			if (json_flags)
+				json_object_boolean_false_add(json_flags, "fibInstallFailed");
+			else
+				vty_out(vty, ",\"fibInstallFailed\": \"false\" ");
+		}
+	} else {
+		if (json_flags)
+			json_object_boolean_false_add(json_flags, "fibSuppress");
+		else
+			vty_out(vty, ",\"fibSuppress\": \"false\" ");
+	}
+}
+
 static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 			  struct bgp_table *table, enum bgp_show_type type, void *output_arg,
 			  const char *rd, int is_last, unsigned long *output_cum,
@@ -13967,16 +14030,8 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 			if (json_detail_header_used || brief) {
 				json_object *json_flags = json_object_new_object();
 
-				json_object_boolean_add(json_flags, "bestPathExists",
-							best_path_selected);
-				if (CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING)) {
-					if (CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED))
-						json_object_boolean_true_add(json_flags,
-									     "fibInstalled");
-					if (CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING))
-						json_object_boolean_true_add(json_flags,
-									     "fibWaitForInstall");
-				}
+				/* Display fib flags */
+				bgp_fib_flags_info(vty, bgp, dest, json_flags, best_path_selected);
 
 				if (brief)
 					vty_out(vty, "\"pathCount\":%d\n", prefix_path_count);
@@ -14486,6 +14541,9 @@ static void bgp_show_path_info(const struct prefix_rd *pfx_rd, struct bgp_dest *
 	int header = 1;
 	json_object *json_header = NULL;
 	json_object *json_paths = NULL;
+	json_object *json_flags = NULL;
+	bool best_path_selected = false;
+
 	const struct prefix *p = bgp_dest_get_prefix(bgp_node);
 
 	for (pi = bgp_dest_get_bgp_path_info(bgp_node); pi; pi = pi->next) {
@@ -14502,6 +14560,8 @@ static void bgp_show_path_info(const struct prefix_rd *pfx_rd, struct bgp_dest *
 		if (json && !json_paths) {
 			/* Instantiate json_paths only if path is valid */
 			json_paths = json_object_new_array();
+			json_flags = json_object_new_object();
+
 			if (pfx_rd)
 				json_header = json_object_new_object();
 			else
@@ -14510,12 +14570,14 @@ static void bgp_show_path_info(const struct prefix_rd *pfx_rd, struct bgp_dest *
 
 		if (header) {
 			route_vty_out_detail_header(vty, bgp, bgp_node,
-						    bgp_dest_get_prefix(bgp_node),
-						    pfx_rd, AFI_IP, safi,
-						    json_header, false, false);
+						    bgp_dest_get_prefix(bgp_node), pfx_rd, AFI_IP,
+						    safi, json_header, false, false);
 			header = 0;
 		}
 		(*display)++;
+
+		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+			best_path_selected = true;
 
 		if (pathtype == BGP_PATH_SHOW_ALL
 		    || (pathtype == BGP_PATH_SHOW_BESTPATH
@@ -14530,6 +14592,9 @@ static void bgp_show_path_info(const struct prefix_rd *pfx_rd, struct bgp_dest *
 
 	if (json && json_paths) {
 		json_object_object_add(json_header, "paths", json_paths);
+
+		bgp_fib_flags_info(vty, bgp, bgp_node, json_flags, best_path_selected);
+		json_object_object_add(json_header, "flags", json_flags);
 
 		if (pfx_rd)
 			json_object_object_addf(
@@ -14611,8 +14676,9 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp, struct bgp_
 				continue;
 			}
 
-			bgp_show_path_info((struct prefix_rd *)dest_p, rm, vty, bgp, afi, safi, json,
-					   pathtype, &display, rpki_target_state, NULL, show_opts);
+			bgp_show_path_info((struct prefix_rd *)dest_p, rm, vty, bgp, afi, safi,
+					   json, pathtype, &display, rpki_target_state, NULL,
+					   show_opts);
 
 			bgp_dest_unlock_node(rm);
 		}
@@ -14671,8 +14737,9 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp, struct bgp_
 			rm = longest_pfx;
 			bgp_dest_lock_node(rm);
 
-			bgp_show_path_info((struct prefix_rd *)dest_p, rm, vty, bgp, afi, safi, json,
-					   pathtype, &display, rpki_target_state, NULL, show_opts);
+			bgp_show_path_info((struct prefix_rd *)dest_p, rm, vty, bgp, afi, safi,
+					   json, pathtype, &display, rpki_target_state, NULL,
+					   show_opts);
 
 			bgp_dest_unlock_node(rm);
 		}
@@ -16682,7 +16749,7 @@ static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table 
 
 			bgp_show_path_info(NULL /* prefix_rd */, dest, vty, bgp, afi, safi,
 					   json_net, BGP_PATH_SHOW_ALL, &display,
-					   RPKI_NOT_BEING_USED, NULL, show_flags);
+					   RPKI_NOT_BEING_USED, &attr, show_flags);
 			if (use_json)
 				json_object_object_addf(json_ar, json_net,
 							"%pFX", rn_p);
@@ -16867,10 +16934,11 @@ static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table 
 					if (detail) {
 						if (use_json)
 							json_net = json_object_new_object();
-						bgp_show_path_info(NULL, dest, vty, bgp, afi, safi,
-								   json_net, BGP_PATH_SHOW_ALL,
-								   &display, RPKI_NOT_BEING_USED,
-								   adj->attr, show_flags);
+						bgp_show_path_info(NULL /* prefix_rd */, dest, vty,
+								   bgp, afi, safi, json_net,
+								   BGP_PATH_SHOW_ALL, &display,
+								   RPKI_NOT_BEING_USED, &attr,
+								   show_flags);
 						if (use_json)
 							json_object_object_addf(json_ar, json_net,
 										"%pFX", rn_p);
@@ -16952,10 +17020,149 @@ static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table 
 	}
 }
 
-static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
-			   safi_t safi, enum bgp_show_adj_route_type type,
-			   const char *rmap_name, const struct prefix *match,
-			   uint16_t show_flags)
+static void bgp_prefix_json_info_add(struct vty *vty, json_object *json_flags,
+				     json_object *json_info, int prefix_path_count,
+				     int multi_path_count)
+{
+	json_object_object_add(json_info, "flags", json_flags);
+	json_object_int_add(json_info, "pathCount", prefix_path_count);
+	/* add +1 to the multipath count because
+	 * it does not include the best path
+	 * itself
+	 */
+	json_object_int_add(json_info, "multiPathCount", multi_path_count + 1);
+}
+
+static int peer_adj_routes_brief(struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
+				 enum bgp_show_adj_route_type type, const char *rmap_name,
+				 const struct prefix *match, uint16_t show_flags)
+{
+	struct bgp *bgp;
+	struct bgp_table *table;
+	json_object *json_prefix = NULL; /* JSON per prefix */
+	struct bgp_dest *dest;
+
+	/*
+	 * JSON shape depends on the caller:
+	 * - Single AFI: caller printed "{" only; emit object fields (e.g. "warning":...).
+	 * - all AFIs: caller printed "<afi-safi>": ; emit one JSON value, e.g. {"warning":...}.
+	 */
+	if (!peer || !peer->afc[afi][safi]) {
+		if (CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_ALL))
+			vty_out(vty, "{\"warning\":\"No such neighbor or address family\"}\n");
+		else
+			vty_out(vty, "\"warning\":\"No such neighbor or address family\"\n");
+		return CMD_WARNING;
+	}
+	if ((type == bgp_show_adj_route_received || type == bgp_show_adj_route_filtered) &&
+	    !CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG)) {
+		if (CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_ALL))
+			vty_out(vty,
+				"{\"warning\":\"Inbound soft reconfiguration not enabled\"}\n");
+		else
+			vty_out(vty, "\"warning\":\"Inbound soft reconfiguration not enabled\"\n");
+		return CMD_WARNING;
+	}
+
+	json_prefix = json_object_new_object();
+	bgp = peer->bgp;
+
+	/* labeled-unicast routes live in the unicast table */
+	if (safi == SAFI_LABELED_UNICAST)
+		table = bgp->rib[afi][SAFI_UNICAST];
+	else
+		table = bgp->rib[afi][safi];
+
+	if (type == bgp_show_adj_route_advertised)
+		vty_out(vty, "\"advertisedRoutes\": ");
+	if (type == bgp_show_adj_route_received)
+		vty_out(vty, "\"receivedRoutes\": ");
+
+	/* Walk over all dests */
+	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
+		const struct prefix *rn_p = bgp_dest_get_prefix(dest);
+
+		if (type == bgp_show_adj_route_received) {
+			bool found_match = false;
+			struct bgp_adj_in *ain;
+			struct bgp_path_info *pi;
+			int prefix_path_count = 0;
+			int multi_path_count = 0;
+			bool best_path_selected = false;
+
+			for (ain = dest->adj_in; ain; ain = ain->next) {
+				if (ain->peer != peer)
+					continue;
+				found_match = true;
+				break;
+			}
+			if (!found_match)
+				continue;
+
+			for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
+				if (CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH))
+					multi_path_count++;
+				if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+					best_path_selected = true;
+				prefix_path_count++;
+			}
+
+			json_object *json_info = json_object_new_object();
+			json_object *json_flags = json_object_new_object();
+
+			json_object_boolean_add(json_flags, "bestPathExists", best_path_selected);
+			bgp_prefix_json_info_add(vty, json_flags, json_info, prefix_path_count,
+						 multi_path_count);
+			json_object_object_addf(json_prefix, json_info, "%pFX", rn_p);
+		} else if (type == bgp_show_adj_route_advertised) {
+			bool found_match = false;
+			struct bgp_adj_out *adj;
+			struct peer_af *paf;
+			struct bgp_path_info *pi;
+			int prefix_path_count = 0;
+			int multi_path_count = 0;
+			bool best_path_selected = false;
+
+			RB_FOREACH (adj, bgp_adj_out_rb, &dest->adj_out) {
+				SUBGRP_FOREACH_PEER (adj->subgroup, paf) {
+					if (paf->peer != peer || !adj->attr)
+						continue;
+					found_match = true;
+					break;
+				}
+				if (found_match)
+					break;
+			}
+			if (!found_match)
+				continue;
+
+			pi = bgp_dest_get_bgp_path_info(dest);
+			for (; pi; pi = pi->next) {
+				multi_path_count += !!CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH);
+				best_path_selected = best_path_selected ||
+						     CHECK_FLAG(pi->flags, BGP_PATH_SELECTED);
+				prefix_path_count++;
+			}
+
+			json_object *json_info = json_object_new_object();
+			json_object *json_flags = json_object_new_object();
+
+			json_object_boolean_add(json_flags, "bestPathExists", best_path_selected);
+			bgp_prefix_json_info_add(vty, json_flags, json_info, prefix_path_count,
+						 multi_path_count);
+			json_object_object_addf(json_prefix, json_info, "%pFX", rn_p);
+		} else {
+			/* e.g. bgp_show_adj_route_filtered: no per-prefix brief JSON here */
+			continue;
+		}
+	}
+	vty_json_no_pretty(vty, json_prefix); /* Free's all the JSON's associted with prefix */
+	return CMD_SUCCESS;
+}
+
+static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
+			   enum bgp_show_adj_route_type type, const char *rmap_name,
+			   const struct prefix *match, uint16_t show_flags, bool brief)
 {
 	struct bgp *bgp;
 	struct bgp_table *table;
@@ -16964,6 +17171,14 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 	bool use_json = CHECK_FLAG(show_flags, BGP_SHOW_OPT_JSON);
 	bool first = true;
 	struct update_subgroup *subgrp;
+
+	int ret;
+
+	if (use_json && brief) {
+		ret = peer_adj_routes_brief(vty, peer, afi, safi, type, rmap_name, match,
+					    show_flags);
+		return ret;
+	}
 
 	/* Init BGP headers here so they're only displayed once
 	 * even if 'table' is 2-tier (MPLS_VPN, ENCAP, EVPN).
@@ -17057,6 +17272,7 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 		if (type == bgp_show_adj_route_advertised || type == bgp_show_adj_route_received) {
 			if (header1) {
 				int version = table ? table->version : 0;
+
 				vty_out(vty, "\"bgpTableVersion\":%d", version);
 				vty_out(vty, ",\"bgpLocalRouterId\":\"%pI4\"", &bgp->router_id);
 				vty_out(vty, ",\"defaultLocPrf\":%u", bgp->default_local_pref);
@@ -17066,6 +17282,7 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 					vty_out(vty, ",\"bgpOriginatingDefaultNetwork\":\"%s\"",
 						(afi == AFI_IP) ? "0.0.0.0/0" : "::/0");
 			}
+
 
 			if (type == bgp_show_adj_route_advertised)
 				vty_out(vty, ",\"advertisedRoutes\": ");
@@ -17226,34 +17443,30 @@ DEFPY (show_ip_bgp_instance_neighbor_bestpath_route,
 	if (!peer)
 		return CMD_WARNING;
 
-	return peer_adj_routes(vty, peer, afi, safi, type, rmap_name, NULL,
-			       show_flags);
+	return peer_adj_routes(vty, peer, afi, safi, type, rmap_name, NULL, show_flags, false);
 }
 
 DEFPY(show_ip_bgp_instance_neighbor_advertised_route,
-      show_ip_bgp_instance_neighbor_advertised_route_cmd,
-      "show [ip] bgp [<view|vrf> VIEWVRFNAME] [" BGP_AFI_CMD_STR " [" BGP_SAFI_WITH_LABEL_CMD_STR "]] [all$all] neighbors <A.B.C.D|X:X::X:X|WORD> <advertised-routes|received-routes|filtered-routes> [route-map RMAP_NAME$route_map] [<A.B.C.D/M|X:X::X:X/M>$prefix | detail$detail] [json$uj | wide$wide]",
-      SHOW_STR
-      IP_STR
-      BGP_STR
-      BGP_INSTANCE_HELP_STR
-      BGP_AFI_HELP_STR
-      BGP_SAFI_WITH_LABEL_HELP_STR
-      "Display the entries for all address families\n"
-      "Detailed information on TCP and BGP neighbor connections\n"
-      "Neighbor to display information about\n"
-      "Neighbor to display information about\n"
-      "Neighbor on BGP configured interface\n"
-      "Display the routes advertised to a BGP neighbor\n"
-      "Display the received routes from neighbor\n"
-      "Display the filtered routes received from neighbor\n"
-      "Route-map to modify the attributes\n"
-      "Name of the route map\n"
-      "IPv4 prefix\n"
-      "IPv6 prefix\n"
-      "Display detailed version of routes\n"
-      JSON_STR
-      "Increase table width for longer prefixes\n")
+	show_ip_bgp_instance_neighbor_advertised_route_cmd,
+	"show [ip] bgp [<view|vrf> VIEWVRFNAME] [" BGP_AFI_CMD_STR " [" BGP_SAFI_WITH_LABEL_CMD_STR
+	"]] [all$all] neighbors <A.B.C.D|X:X::X:X|WORD> <advertised-routes|received-routes|filtered-routes> [route-map RMAP_NAME$route_map] [<A.B.C.D/M|X:X::X:X/M>$prefix | detail$detail] [json$uj [brief$brief] | wide$wide]",
+	SHOW_STR IP_STR BGP_STR BGP_INSTANCE_HELP_STR BGP_AFI_HELP_STR BGP_SAFI_WITH_LABEL_HELP_STR
+	"Display the entries for all address families\n"
+	"Detailed information on TCP and BGP neighbor connections\n"
+	"Neighbor to display information about\n"
+	"Neighbor to display information about\n"
+	"Neighbor on BGP configured interface\n"
+	"Display the routes advertised to a BGP neighbor\n"
+	"Display the received routes from neighbor\n"
+	"Display the filtered routes received from neighbor\n"
+	"Route-map to modify the attributes\n"
+	"Name of the route map\n"
+	"IPv4 prefix\n"
+	"IPv6 prefix\n"
+	"Display detailed version of routes\n"
+	JSON_STR
+	"Brief JSON output\n"
+	"Increase table width for longer prefixes\n")
 {
 	afi_t afi = AFI_IP6;
 	safi_t safi = SAFI_UNICAST;
@@ -17315,7 +17528,7 @@ DEFPY(show_ip_bgp_instance_neighbor_advertised_route,
 				vty_out(vty, "{\n");
 
 		ret = peer_adj_routes(vty, peer, afi, safi, type, route_map,
-				      prefix_str ? prefix : NULL, show_flags);
+				      prefix_str ? prefix : NULL, show_flags, brief);
 		if (uj)
 			if (type == bgp_show_adj_route_advertised ||
 			    type == bgp_show_adj_route_received)
@@ -17350,8 +17563,8 @@ DEFPY(show_ip_bgp_instance_neighbor_advertised_route,
 						get_afi_safi_str(afi, safi,
 								 false));
 
-				peer_adj_routes(vty, peer, afi, safi, type,
-						route_map, prefix, show_flags);
+				peer_adj_routes(vty, peer, afi, safi, type, route_map, prefix,
+						show_flags, brief);
 			}
 		}
 	} else {
@@ -17374,8 +17587,8 @@ DEFPY(show_ip_bgp_instance_neighbor_advertised_route,
 						get_afi_safi_str(afi, safi,
 								 false));
 
-				peer_adj_routes(vty, peer, afi, safi, type,
-						route_map, prefix, show_flags);
+				peer_adj_routes(vty, peer, afi, safi, type, route_map, prefix,
+						show_flags, brief);
 			}
 		}
 	}

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5046,7 +5046,7 @@ incoming/outgoing directions.
 
    If the ``json`` option is specified, output is displayed in JSON format.
 
-.. clicmd:: show [ip] bgp [afi] [safi] [all] neighbors A.B.C.D [advertised-routes|received-routes|filtered-routes] [<A.B.C.D/M|X:X::X:X/M> | detail] [json|wide]
+.. clicmd:: show [ip] bgp [afi] [safi] [all] neighbors A.B.C.D [advertised-routes|received-routes|filtered-routes] [<A.B.C.D/M|X:X::X:X/M> | detail] [json [brief] | wide]
 
    Display the routes advertised to a BGP neighbor or received routes
    from neighbor or filtered routes received from neighbor based on the
@@ -5072,6 +5072,9 @@ incoming/outgoing directions.
    prefixes.
 
    If ``json`` option is specified, output is displayed in JSON format.
+   ``brief`` is only valid immediately after ``json`` (e.g.
+   ``... advertised-routes json brief``); it selects compact per-prefix JSON
+   without per-path detail, like other ``show bgp`` ``json brief`` forms.
 
 .. clicmd:: show [ip] bgp [afi] [safi] [all] detail-routes [internal]
 

--- a/tests/topotests/bgp_soo/cpe2/bgpd.conf
+++ b/tests/topotests/bgp_soo/cpe2/bgpd.conf
@@ -3,8 +3,15 @@ router bgp 65000
  neighbor 192.168.2.2 remote-as external
  neighbor 192.168.2.2 timers 1 3
  neighbor 192.168.2.2 timers connect 1
+ neighbor 2001:db8:2::2 remote-as external
+ neighbor 2001:db8:2::2 timers 1 3
+ neighbor 2001:db8:2::2 timers connect 1
  neighbor 10.0.0.1 remote-as internal
  address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor 2001:db8:2::2 activate
   redistribute connected
  exit-address-family
 !

--- a/tests/topotests/bgp_soo/cpe2/zebra.conf
+++ b/tests/topotests/bgp_soo/cpe2/zebra.conf
@@ -1,9 +1,11 @@
 !
 interface cpe2-eth0
  ip address 192.168.2.1/24
+ ipv6 address 2001:db8:2::1/64
 !
 interface cpe2-eth1
  ip address 10.0.0.2/24
 !
 ip forwarding
+ipv6 forwarding
 !

--- a/tests/topotests/bgp_soo/pe2/bgpd.conf
+++ b/tests/topotests/bgp_soo/pe2/bgpd.conf
@@ -14,6 +14,9 @@ router bgp 65001 vrf RED
  neighbor 192.168.2.1 remote-as external
  neighbor 192.168.2.1 timers 1 3
  neighbor 192.168.2.1 timers connect 1
+ neighbor 2001:db8:2::1 remote-as external
+ neighbor 2001:db8:2::1 timers 1 3
+ neighbor 2001:db8:2::1 timers connect 1
  address-family ipv4 unicast
   neighbor 192.168.2.1 as-override
   neighbor 192.168.2.1 route-map cpe2-in in
@@ -23,6 +26,11 @@ router bgp 65001 vrf RED
   rt vpn export 192.168.2.2:2
   export vpn
   import vpn
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor 2001:db8:2::1 activate
+  neighbor 2001:db8:2::1 as-override
+  neighbor 2001:db8:2::1 route-map cpe2-in in
  exit-address-family
 !
 ! To prefer internal MPLS route over eBGP

--- a/tests/topotests/bgp_soo/pe2/zebra.conf
+++ b/tests/topotests/bgp_soo/pe2/zebra.conf
@@ -4,9 +4,11 @@ interface lo
 !
 interface pe2-eth1 vrf RED
  ip address 192.168.2.2/24
+ ipv6 address 2001:db8:2::2/64
 !
 interface pe2-eth0
  ip address 10.0.1.2/24
 !
 ip forwarding
+ipv6 forwarding
 !

--- a/tests/topotests/bgp_soo/test_bgp_soo.py
+++ b/tests/topotests/bgp_soo/test_bgp_soo.py
@@ -89,6 +89,9 @@ def setup_module(mod):
 
     tgen.start_router()
 
+    for _, (_, router) in enumerate(router_list.items(), 1):
+        router.run("sysctl -w net.ipv6.conf.all.forwarding=1")
+
 
 def teardown_module(mod):
     tgen = get_topogen()
@@ -166,6 +169,95 @@ def test_bgp_soo():
     test_func = functools.partial(_bgp_soo_unconfigured)
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
     assert result is None, "SoO filtering does not work from pe2"
+
+
+def test_bgp_soo_ipv4_advertised_routes_brief_json():
+    """
+    CPE1 (vrf default): neighbor advertised-routes json brief lists redistributed
+    and learned prefixes with flags and path counts.
+    """
+    tgen = get_topogen()
+
+    cpe1 = tgen.gears["cpe1"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _ipv4_adv_brief():
+        output = json.loads(
+            cpe1.vtysh_cmd(
+                "show bgp vrf default ipv4 unicast neighbors 192.168.1.2 "
+                "advertised-routes json brief"
+            )
+        )
+        expected = {
+            "advertisedRoutes": {
+                "10.0.0.0/24": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 2,
+                    "multiPathCount": 1,
+                },
+                "172.16.255.1/32": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 1,
+                },
+                "192.168.1.0/24": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 1,
+                },
+                "192.168.2.0/24": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 1,
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_ipv4_adv_brief)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert (
+        result is None
+    ), "IPv4 advertised-routes json brief on cpe1 does not match expected prefixes/shape"
+
+
+def test_bgp_soo_ipv6_advertised_routes_brief_json():
+    """
+    CPE2 runs BGP in vrf default; IPv6 eBGP to PE2 (2001:db8:2::2). Redistributed
+    connected 2001:db8:2::/64 appears in neighbor advertised-routes json brief.
+    """
+    tgen = get_topogen()
+
+    cpe2 = tgen.gears["cpe2"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _ipv6_adv_brief():
+        output = json.loads(
+            cpe2.vtysh_cmd(
+                "show bgp vrf default ipv6 unicast neighbors 2001:db8:2::2 "
+                "advertised-routes json brief"
+            )
+        )
+        expected = {
+            "advertisedRoutes": {
+                "2001:db8:2::/64": {
+                    "flags": {"bestPathExists": "*"},
+                    "pathCount": "*",
+                    "multiPathCount": "*",
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_ipv6_adv_brief)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert (
+        result is None
+    ), "IPv6 advertised-routes json brief missing 2001:db8:2::/64 or expected shape on cpe2"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1)JSON brief support is added for bgp neighbor advertised-routes and received-routes commnds.
2)Optimizations for the fib flag handling code

Commands:
cpe1# show bgp vrf default ipv4 unicast neighbors 192.168.1.2 advertised-routes json brief
{
"advertisedRoutes": {"10.0.0.0/24":{"flags":{"bestPathExists":true},"pathCount":2,"multiPathCount":1},"172.16.255.1/32":{"flags":{"bestPathExists":true},"pathCount":1,"multiPathCount":1},"192.168.1.0/24":{"flags":{"bestPathExists":true},"pathCount":1,"multiPathCount":1},"192.168.2.0/24":{"flags":{"bestPathExists":true},"pathCount":1,"multiPathCount":1}}
}
cpe1# 
cpe1# show bgp vrf default ipv4 unicast neighbors 192.168.1.2 advertised-routes json
{
"bgpTableVersion":4,"bgpLocalRouterId":"172.16.255.1","defaultLocPrf":100,"localAS":65000,"advertisedRoutes": {"10.0.0.0/24":{"addrPrefix":"10.0.0.0","prefixLen":24,"network":"10.0.0.0/24","nextHop":"0.0.0.0","metric":0,"weight":0,"path":"","origin":"incomplete","valid":true,"best":true},"172.16.255.1/32":{"addrPrefix":"172.16.255.1","prefixLen":32,"network":"172.16.255.1/32","nextHop":"0.0.0.0","metric":0,"weight":0,"path":"","origin":"incomplete","valid":true,"best":true},"192.168.1.0/24":{"addrPrefix":"192.168.1.0","prefixLen":24,"network":"192.168.1.0/24","nextHop":"0.0.0.0","metric":0,"weight":0,"path":"","origin":"incomplete","valid":true,"best":true},"192.168.2.0/24":{"addrPrefix":"192.168.2.0","prefixLen":24,"network":"192.168.2.0/24","nextHop":"0.0.0.0","weight":0,"path":"","origin":"incomplete","valid":true,"best":true}}
,"totalPrefixCounter":4,"filteredPrefixCounter":0,"totalPathsCount":4}
cpe1# 
cpe2# show bgp vrf default ipv6 unicast neighbors 2001:db8:2::2 advertised-routes json brief
{
"advertisedRoutes": {"2001:db8:2::/64":{"flags":{"bestPathExists":true},"pathCount":2,"multiPathCount":1}}
}
cpe2# show bgp vrf default ipv6 unicast neighbors 2001:db8:2::2 advertised-routes json
{
"bgpTableVersion":1,"bgpLocalRouterId":"192.168.2.1","defaultLocPrf":100,"localAS":65000,"advertisedRoutes": {"2001:db8:2::/64":{"addrPrefix":"2001:db8:2::","prefixLen":64,"network":"2001:db8:2::/64","nextHopGlobal":"::","metric":0,"weight":0,"path":"","origin":"incomplete","valid":true,"best":true}}
,"totalPrefixCounter":1,"filteredPrefixCounter":0,"totalPathsCount":1}
cpe2# 

