### PR TITLE
bgpd: support brief json for bgp v4 and v6 neighbors route

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13525,12 +13525,12 @@ static void bgp_fib_flags_info(struct vty *vty, struct bgp *bgp, struct bgp_dest
 		if (json_flags)
 			json_object_boolean_true_add(json_flags, "fibInstalled");
 		else
-			vty_out(vty, "\"fibInstalled\": \"true\" ");
+			vty_out(vty, ",\"fibInstalled\": \"true\" ");
 	} else {
 		if (json_flags)
 			json_object_boolean_false_add(json_flags, "fibInstalled");
 		else
-			vty_out(vty, "\"fibInstalled\": \"false\" ");
+			vty_out(vty, ",\"fibInstalled\": \"false\" ");
 	}
 
 	if (CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING)) {
@@ -13550,6 +13550,7 @@ static void bgp_fib_flags_info(struct vty *vty, struct bgp *bgp, struct bgp_dest
 			json_object_boolean_true_add(json_flags, "fibSuppress");
 		else
 			vty_out(vty, ",\"fibSuppress\": \"true\" ");
+
 		if (!CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED) &&
 		    !CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING)) {
 			if (json_flags)
@@ -13567,6 +13568,11 @@ static void bgp_fib_flags_info(struct vty *vty, struct bgp *bgp, struct bgp_dest
 			json_object_boolean_false_add(json_flags, "fibSuppress");
 		else
 			vty_out(vty, ",\"fibSuppress\": \"false\" ");
+
+		if (json_flags)
+			json_object_boolean_false_add(json_flags, "fibInstallFailed");
+		else
+			vty_out(vty, ",\"fibInstallFailed\": \"false\" ");
 	}
 }
 
@@ -17673,9 +17679,8 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
 	return CMD_SUCCESS;
 }
 
-static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer,
-				   afi_t afi, safi_t safi,
-				   enum bgp_show_type type, bool use_json)
+static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
+				   enum bgp_show_type type, bool use_json, bool brief)
 {
 	uint16_t show_flags = 0;
 
@@ -17702,7 +17707,7 @@ static int bgp_show_neighbor_route(struct vty *vty, struct peer *peer,
 		safi = SAFI_UNICAST;
 
 	return bgp_show(vty, peer->bgp, afi, safi, type, &peer->connection->su, show_flags,
-			RPKI_NOT_BEING_USED, false);
+			RPKI_NOT_BEING_USED, brief);
 }
 
 /*
@@ -17745,9 +17750,9 @@ DEFPY(show_ip_bgp_vrf_afi_safi_routes_detailed,
 			RPKI_NOT_BEING_USED, false);
 }
 
-DEFUN (show_ip_bgp_neighbor_routes,
+DEFPY (show_ip_bgp_neighbor_routes,
        show_ip_bgp_neighbor_routes_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] neighbors <A.B.C.D|X:X::X:X|WORD> <flap-statistics|dampened-routes|routes> [json]",
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] neighbors <A.B.C.D|X:X::X:X|WORD> <flap-statistics|dampened-routes|routes> [json$uj [brief$brief]]",
        SHOW_STR
        IP_STR
        BGP_STR
@@ -17761,7 +17766,8 @@ DEFUN (show_ip_bgp_neighbor_routes,
        "Display flap statistics of the routes learned from neighbor\n"
        "Display the dampened routes received from neighbor\n"
        "Display routes learned from neighbor\n"
-       JSON_STR)
+       JSON_STR
+       "Brief JSON output\n")
 {
 	char *peerstr = NULL;
 	struct bgp *bgp = NULL;
@@ -17770,7 +17776,6 @@ DEFUN (show_ip_bgp_neighbor_routes,
 	struct peer *peer;
 	enum bgp_show_type sh_type = bgp_show_type_neighbor;
 	int idx = 0;
-	bool uj = use_json(argc, argv);
 
 	if (uj)
 		argc--;
@@ -17795,7 +17800,12 @@ DEFUN (show_ip_bgp_neighbor_routes,
 	else if (argv_find(argv, argc, "routes", &idx))
 		sh_type = bgp_show_type_neighbor;
 
-	return bgp_show_neighbor_route(vty, peer, afi, safi, sh_type, uj);
+	if (brief && sh_type != bgp_show_type_neighbor) {
+		vty_out(vty, "%% brief option is only supported with 'routes'\n");
+		return CMD_WARNING;
+	}
+
+	return bgp_show_neighbor_route(vty, peer, afi, safi, sh_type, uj, brief);
 }
 
 struct bgp_table *bgp_distance_table[AFI_MAX][SAFI_MAX];

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5086,6 +5086,23 @@ incoming/outgoing directions.
    ``... advertised-routes json brief``); it selects compact per-prefix JSON
    without per-path detail, like other ``show bgp`` ``json brief`` forms.
 
+.. clicmd:: show [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6> [unicast|...]] neighbors <A.B.C.D|X:X::X:X|WORD> <flap-statistics|dampened-routes|routes> [json [brief]]
+
+   Display routes learned from a BGP neighbor, flap statistics for that
+   neighbor, or dampened routes received from that neighbor, for the given
+   address family.
+
+   The ``routes`` keyword shows routes in the BGP table that were received
+   from this peer and accepted by inbound policy. The ``flap-statistics``
+   keyword shows flap statistics for routes learned from this neighbor. The
+   ``dampened-routes`` keyword shows dampened paths received from this
+   neighbor.
+
+   If ``json`` is specified, output is in JSON format. The ``brief``
+   keyword may only be used with ``json``; it produces a brief JSON view
+   (prefix-level path and multipath counts and flags, without per-path
+   details) for unicast neighbor routes.
+
 .. clicmd:: show [ip] bgp [afi] [safi] [all] detail-routes [internal]
 
    Display the detailed version of all routes. The same format as using

--- a/tests/topotests/bgp_soo/cpe1/bgpd.conf
+++ b/tests/topotests/bgp_soo/cpe1/bgpd.conf
@@ -3,8 +3,17 @@ router bgp 65000
  neighbor 192.168.1.2 remote-as external
  neighbor 192.168.1.2 timers 1 3
  neighbor 192.168.1.2 timers connect 1
+ neighbor 2001:db8:1::2 remote-as external
+ neighbor 2001:db8:1::2 timers 1 3
+ neighbor 2001:db8:1::2 timers connect 1
  neighbor 10.0.0.2 remote-as internal
+ neighbor 2001:db8:10::2 remote-as internal
  address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::2 activate
+  neighbor 2001:db8:10::2 activate
   redistribute connected
  exit-address-family
 !

--- a/tests/topotests/bgp_soo/cpe1/zebra.conf
+++ b/tests/topotests/bgp_soo/cpe1/zebra.conf
@@ -1,12 +1,16 @@
 !
 interface lo
  ip address 172.16.255.1/32
+ ipv6 address 2001:db8:254:1::1/128
 !
 interface cpe1-eth0
  ip address 192.168.1.1/24
+ ipv6 address 2001:db8:1::1/64
 !
 interface cpe1-eth1
  ip address 10.0.0.1/24
+ ipv6 address 2001:db8:10::1/64
 !
 ip forwarding
+ipv6 forwarding
 !

--- a/tests/topotests/bgp_soo/cpe2/bgpd.conf
+++ b/tests/topotests/bgp_soo/cpe2/bgpd.conf
@@ -7,11 +7,13 @@ router bgp 65000
  neighbor 2001:db8:2::2 timers 1 3
  neighbor 2001:db8:2::2 timers connect 1
  neighbor 10.0.0.1 remote-as internal
+ neighbor 2001:db8:10::1 remote-as internal
  address-family ipv4 unicast
   redistribute connected
  exit-address-family
  address-family ipv6 unicast
   neighbor 2001:db8:2::2 activate
+  neighbor 2001:db8:10::1 activate
   redistribute connected
  exit-address-family
 !

--- a/tests/topotests/bgp_soo/cpe2/zebra.conf
+++ b/tests/topotests/bgp_soo/cpe2/zebra.conf
@@ -5,6 +5,7 @@ interface cpe2-eth0
 !
 interface cpe2-eth1
  ip address 10.0.0.2/24
+ ipv6 address 2001:db8:10::2/64
 !
 ip forwarding
 ipv6 forwarding

--- a/tests/topotests/bgp_soo/pe1/bgpd.conf
+++ b/tests/topotests/bgp_soo/pe1/bgpd.conf
@@ -7,6 +7,9 @@ router bgp 65001
  address-family ipv4 vpn
   neighbor 10.10.10.20 activate
  exit-address-family
+ address-family ipv6 vpn
+  neighbor 10.10.10.20 activate
+ exit-address-family
 !
 router bgp 65001 vrf RED
  bgp router-id 192.168.1.2
@@ -14,9 +17,22 @@ router bgp 65001 vrf RED
  neighbor 192.168.1.1 remote-as external
  neighbor 192.168.1.1 timers 1 3
  neighbor 192.168.1.1 timers connect 1
+ neighbor 2001:db8:1::1 remote-as external
+ neighbor 2001:db8:1::1 timers 1 3
+ neighbor 2001:db8:1::1 timers connect 1
  address-family ipv4 unicast
   neighbor 192.168.1.1 as-override
   neighbor 192.168.1.1 soo 65000:1
+  label vpn export 1111
+  rd vpn export 192.168.1.2:2
+  rt vpn import 192.168.2.2:2 192.168.1.2:2
+  rt vpn export 192.168.1.2:2
+  export vpn
+  import vpn
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::1 as-override
+  neighbor 2001:db8:1::1 soo 65000:1
   label vpn export 1111
   rd vpn export 192.168.1.2:2
   rt vpn import 192.168.2.2:2 192.168.1.2:2

--- a/tests/topotests/bgp_soo/pe1/zebra.conf
+++ b/tests/topotests/bgp_soo/pe1/zebra.conf
@@ -4,9 +4,11 @@ interface lo
 !
 interface pe1-eth0 vrf RED
  ip address 192.168.1.2/24
+ ipv6 address 2001:db8:1::2/64
 !
 interface pe1-eth1
  ip address 10.0.1.1/24
 !
 ip forwarding
+ipv6 forwarding
 !

--- a/tests/topotests/bgp_soo/test_bgp_soo.py
+++ b/tests/topotests/bgp_soo/test_bgp_soo.py
@@ -171,6 +171,224 @@ def test_bgp_soo():
     assert result is None, "SoO filtering does not work from pe2"
 
 
+def test_bgp_soo_pe1_neighbor_routes_json():
+    """
+    PE1 (VRF RED): routes learned from CPE1 (192.168.1.1) as full JSON — four
+    VPN prefixes with path arrays; totals match RIB size for this view.
+    """
+    tgen = get_topogen()
+
+    pe1 = tgen.gears["pe1"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _pe1_routes_json():
+        output = json.loads(
+            pe1.vtysh_cmd(
+                "show bgp vrf RED ipv4 unicast neighbors 192.168.1.1 routes json"
+            )
+        )
+        expected = {
+            "routes": {
+                "10.0.0.0/24": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "network": "10.0.0.0/24",
+                        "peerId": "192.168.1.1",
+                    }
+                ],
+                "172.16.255.1/32": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "network": "172.16.255.1/32",
+                        "peerId": "192.168.1.1",
+                    }
+                ],
+                "192.168.1.0/24": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "network": "192.168.1.0/24",
+                        "peerId": "192.168.1.1",
+                    }
+                ],
+                "192.168.2.0/24": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "network": "192.168.2.0/24",
+                        "peerId": "192.168.1.1",
+                    }
+                ],
+            },
+            "totalRoutes": 4,
+            "totalPaths": 12,
+            "numRoutes": 4,
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_pe1_routes_json)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert (
+        result is None
+    ), "PE1 vrf RED neighbor 192.168.1.1 routes json missing expected prefixes or totals"
+
+
+def test_bgp_soo_pe1_neighbor_routes_brief_json():
+    """
+    PE1 (VRF RED): neighbor routes json brief — per-prefix pathCount, multipath
+    aggregate, and bestPathExists under routes{}.
+    """
+    tgen = get_topogen()
+
+    pe1 = tgen.gears["pe1"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _pe1_routes_brief_json():
+        output = json.loads(
+            pe1.vtysh_cmd(
+                "show bgp vrf RED ipv4 unicast neighbors 192.168.1.1 "
+                "routes json brief"
+            )
+        )
+        expected = {
+            "routes": {
+                "10.0.0.0/24": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 2,
+                },
+                "172.16.255.1/32": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 2,
+                },
+                "192.168.1.0/24": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 2,
+                },
+                "192.168.2.0/24": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 2,
+                },
+            },
+            "totalRoutes": 4,
+            "totalPaths": 12,
+            "numRoutes": 4,
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_pe1_routes_brief_json)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert (
+        result is None
+    ), "PE1 vrf RED neighbor routes json brief does not match expected shape"
+
+
+def test_bgp_soo_cpe1_neighbor_ipv6_routes_json():
+    """
+    CPE1 (default vrf): IPv6 neighbor routes JSON from iBGP peer cpe2
+    (2001:db8:10::2). PE vrf RED may have no IPv6 CE session; this topology
+    still exercises neighbor routes json on CPE. Remote 2001:db8:2::/64 is
+    best; peering 2001:db8:10::/64 is valid from peer but has no best path in
+    this neighbor view (local connected / duplicate resolution).
+    """
+    tgen = get_topogen()
+
+    cpe1 = tgen.gears["cpe1"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _cpe1_routes_v6_json():
+        output = json.loads(
+            cpe1.vtysh_cmd(
+                "show bgp vrf default ipv6 unicast neighbors 2001:db8:10::2 "
+                "routes json"
+            )
+        )
+        expected = {
+            "routes": {
+                "2001:db8:2::/64": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "network": "2001:db8:2::/64",
+                        "peerId": "2001:db8:10::2",
+                    }
+                ],
+                "2001:db8:10::/64": [
+                    {
+                        "valid": True,
+                        "bestpath": None,
+                        "network": "2001:db8:10::/64",
+                        "peerId": "2001:db8:10::2",
+                    }
+                ],
+            },
+            "totalRoutes": 2,
+            "totalPaths": 5,
+            "numRoutes": 2,
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_cpe1_routes_v6_json)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert result is None, (
+        "CPE1 default ipv6 neighbor 2001:db8:10::2 routes json does not match "
+        "expected prefixes or totals"
+    )
+
+
+def test_bgp_soo_cpe1_neighbor_ipv6_routes_json_brief():
+    """CPE1 (default): neighbor IPv6 routes json brief — two-prefix iBGP view."""
+    tgen = get_topogen()
+
+    cpe1 = tgen.gears["cpe1"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _cpe1_routes_v6_brief():
+        output = json.loads(
+            cpe1.vtysh_cmd(
+                "show bgp vrf default ipv6 unicast neighbors 2001:db8:10::2 "
+                "routes json brief"
+            )
+        )
+        expected = {
+            "routes": {
+                "2001:db8:2::/64": {
+                    "flags": {"bestPathExists": True},
+                    "pathCount": 1,
+                    "multiPathCount": 1,
+                },
+                "2001:db8:10::/64": {
+                    "flags": {"bestPathExists": False},
+                    "pathCount": 1,
+                    "multiPathCount": 0,
+                },
+            },
+            "totalRoutes": 2,
+            "totalPaths": 5,
+            "numRoutes": 2,
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_cpe1_routes_v6_brief)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert (
+        result is None
+    ), "CPE1 default ipv6 neighbor routes json brief does not match expected shape"
+
+
 def test_bgp_soo_ipv4_advertised_routes_brief_json():
     """
     CPE1 (vrf default): neighbor advertised-routes json brief lists redistributed
@@ -194,7 +412,7 @@ def test_bgp_soo_ipv4_advertised_routes_brief_json():
             "advertisedRoutes": {
                 "10.0.0.0/24": {
                     "flags": {"bestPathExists": True},
-                    "pathCount": 2,
+                    "pathCount": 3,
                     "multiPathCount": 1,
                 },
                 "172.16.255.1/32": {
@@ -209,8 +427,8 @@ def test_bgp_soo_ipv4_advertised_routes_brief_json():
                 },
                 "192.168.2.0/24": {
                     "flags": {"bestPathExists": True},
-                    "pathCount": 1,
-                    "multiPathCount": 1,
+                    "pathCount": 2,
+                    "multiPathCount": 2,
                 },
             }
         }


### PR DESCRIPTION
brief-json support is added for show bgp v4 and v6 unicast neighbour routes.
    
Commands supported:
show bgp vrf <vrf> ipv4 unicast neighbors <neigh> routes brief json
show bgp vrf <vrf> ipv6 unicast neighbors <neigh> routes brief json

cpe1# show bgp vrf default ipv6 unicast neighbors 2001:db8:10::2 routes json brief
{
 "routes": { "2001:db8:2::/64": {
"pathCount":1
,"multiPathCount":1
,"flags": {"bestPathExists":true,"fibInstalled":false,"fibWaitForInstall":false,"fibSuppress":false,"fibInstallFailed":false}
} ,"2001:db8:10::/64": {
"pathCount":1
,"multiPathCount":0
,"flags": {"bestPathExists":false,"fibInstalled":true,"fibWaitForInstall":false,"fibSuppress":false,"fibInstallFailed":false}
}  } , "totalRoutes": 2, "totalPaths": 5,"numRoutes":2
 } 
cpe1# 
cpe1# show bgp vrf default ipv6 unicast neighbors 2001:db8:10::2 routes json
{
 "vrfId": 0,
 "vrfName": "default",
 "tableVersion": 4,
 "routerId": "172.16.255.1",
 "defaultLocPrf": 100,
 "localAS": 65000,
 "routes": { "2001:db8:2::/64": [{"valid":true,"bestpath":true,"selectionReason":"First path received","pathFrom":"internal","prefix":"2001:db8:2::","prefixLen":64,"network":"2001:db8:2::/64","version":3,"metric":0,"locPrf":100,"weight":0,"peerId":"2001:db8:10::2","path":"","origin":"incomplete","nexthops":[{"ip":"2001:db8:10::2","hostname":"cpe2","afi":"ipv6","scope":"global","linkLocalOnly":false,"length":32},{"ip":"fe80::c00b:65ff:feab:769f","hostname":"cpe2","afi":"ipv6","scope":"link-local","used":true}]}]
,"2001:db8:10::/64": [{"valid":true,"pathFrom":"internal","prefix":"2001:db8:10::","prefixLen":64,"network":"2001:db8:10::/64","version":2,"metric":0,"locPrf":100,"weight":0,"peerId":"2001:db8:10::2","path":"","origin":"incomplete","nexthops":[{"ip":"2001:db8:10::2","hostname":"cpe2","afi":"ipv6","scope":"global","linkLocalOnly":false,"length":32},{"ip":"fe80::c00b:65ff:feab:769f","hostname":"cpe2","afi":"ipv6","scope":"link-local","used":true}]}]
 } , "totalRoutes": 2, "totalPaths": 5,"numRoutes":2
 } 
cpe1# 
pe1# show bgp vrf RED ipv4 unicast neighbors 192.168.1.1 routes json brief
{
 "routes": { "10.0.0.0/24": {
"pathCount":1
,"multiPathCount":2
,"flags": {"bestPathExists":true,"fibInstalled":false,"fibWaitForInstall":false,"fibSuppress":false,"fibInstallFailed":false}
} ,"172.16.255.1/32": {
"pathCount":1
,"multiPathCount":2
,"flags": {"bestPathExists":true,"fibInstalled":false,"fibWaitForInstall":false,"fibSuppress":false,"fibInstallFailed":false}
} ,"192.168.1.0/24": {
"pathCount":1
,"multiPathCount":2
,"flags": {"bestPathExists":true,"fibInstalled":false,"fibWaitForInstall":false,"fibSuppress":false,"fibInstallFailed":false}
} ,"192.168.2.0/24": {
"pathCount":1
,"multiPathCount":2
,"flags": {"bestPathExists":true,"fibInstalled":false,"fibWaitForInstall":false,"fibSuppress":false,"fibInstallFailed":false}
}  } , "totalRoutes": 4, "totalPaths": 12,"numRoutes":4
 } 
pe1# 


pe1# show bgp vrf RED ipv4 unicast neighbors 192.168.1.1 routes json
{
 "vrfId": 4,
 "vrfName": "RED",
 "tableVersion": 12,
 "routerId": "192.168.1.2",
 "defaultLocPrf": 100,
 "localAS": 65001,
 "routes": { "10.0.0.0/24": [{"valid":true,"bestpath":true,"selectionReason":"Peer Type","multipath":true,"pathFrom":"external","prefix":"10.0.0.0","prefixLen":24,"network":"10.0.0.0/24","version":9,"metric":0,"weight":0,"peerId":"192.168.1.1","path":"65000","origin":"incomplete","nexthops":[{"ip":"192.168.1.1","hostname":"cpe1","afi":"ipv4","used":true}]}]
,"172.16.255.1/32": [{"valid":true,"bestpath":true,"selectionReason":"Peer Type","multipath":true,"pathFrom":"external","prefix":"172.16.255.1","prefixLen":32,"network":"172.16.255.1/32","version":11,"metric":0,"weight":0,"peerId":"192.168.1.1","path":"65000","origin":"incomplete","nexthops":[{"ip":"192.168.1.1","hostname":"cpe1","afi":"ipv4","used":true}]}]
,"192.168.1.0/24": [{"valid":true,"bestpath":true,"selectionReason":"Peer Type","multipath":true,"pathFrom":"external","prefix":"192.168.1.0","prefixLen":24,"network":"192.168.1.0/24","version":12,"metric":0,"weight":0,"peerId":"192.168.1.1","path":"65000","origin":"incomplete","nexthops":[{"ip":"192.168.1.1","hostname":"cpe1","afi":"ipv4","used":true}]}]
,"192.168.2.0/24": [{"valid":true,"bestpath":true,"selectionReason":"Peer Type","multipath":true,"pathFrom":"external","prefix":"192.168.2.0","prefixLen":24,"network":"192.168.2.0/24","version":10,"weight":0,"peerId":"192.168.1.1","path":"65000","origin":"incomplete","nexthops":[{"ip":"192.168.1.1","hostname":"cpe1","afi":"ipv4","used":true}]}]
 } , "totalRoutes": 4, "totalPaths": 12,"numRoutes":4
 } 
pe1# 



