### PR TITLE
zebra: Send enough NHG information to dplane to support RIB/FIB

### DIFF
--- a/tests/topotests/zebra_nhg_fib/r1/frr.conf
+++ b/tests/topotests/zebra_nhg_fib/r1/frr.conf
@@ -1,0 +1,19 @@
+hostname r1
+log file /tmp/r1-zebra.log debug
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+ip route 192.168.1.0/24 Null0
+!
+router bgp 65001
+ bgp router-id 10.255.255.1
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.2 remote-as 65002
+ address-family ipv4 unicast
+  network 192.168.1.0/24
+ !
+!
+line vty
+!
+end

--- a/tests/topotests/zebra_nhg_fib/r2/frr.conf
+++ b/tests/topotests/zebra_nhg_fib/r2/frr.conf
@@ -1,0 +1,14 @@
+hostname r2
+log file /tmp/r2-zebra.log debug
+!
+interface r2-eth0
+ ip address 10.0.0.2/24
+!
+router bgp 65002
+ bgp router-id 10.255.255.2
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.1 remote-as 65001
+!
+line vty
+!
+end

--- a/tests/topotests/zebra_nhg_fib/test_zebra_nhg_fib.py
+++ b/tests/topotests/zebra_nhg_fib/test_zebra_nhg_fib.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+test_zebra_nhg_fib.py: Testing zebra NHG FIB mode (--nhg-fib flag)
+
+This test verifies the RIB/FIB separation feature:
+1. Received NHGs (nhe_received) are marked with NEXTHOP_GROUP_RECEIVED flag
+   and skip kernel installation, but are sent to FPM
+2. Resolved NHGs are installed to kernel normally
+3. Recursive NHGs in nhg-fib mode skip resolve and are sent to FPM as-is
+4. The depends/dependents lists are properly populated in dplane context
+5. The nh_grp_full list contains all recursive dependencies
+"""
+
+import os
+import sys
+import json
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+
+def _is_installed(info):
+    """An NHG is "installed" if either flag is set.
+
+    In nhg-fib mode, RECURSIVE/RECEIVED NHEs go through skip_kernel and are
+    marked installedFpmOnly instead of installed. Plain leaf NHEs that go to
+    kernel get the regular installed flag.
+    """
+    return info.get("installed", False) or info.get("installedFpmOnly", False)
+
+
+def build_topo(tgen):
+    """
+    Build topology for NHG FIB testing:
+
+         r1 (AS 65001)              r2 (AS 65002)
+    +------------------+       +------------------+
+    |  lo: 192.168.1.1 |       |  eth0: 10.0.0.2  |
+    |  eth0: 10.0.0.1  |-------|  static routes   |
+    |  BGP neighbor    |       |  BGP neighbor    |
+    +------------------+       +------------------+
+
+    r1 announces 192.168.1.0/24 via BGP
+    r2 receives it and resolves via connected nexthop 10.0.0.1
+
+    This creates:
+    - nhe_received: original BGP nexthop (unresolved, marked RECEIVED)
+    - nhe: resolved nexthop pointing to 10.0.0.1 (installed to kernel)
+    """
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(module):
+    """Setup topology with --nhg-fib flag"""
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, "--nhg-fib"),
+                (TopoRouter.RD_BGP, None),
+                (TopoRouter.RD_STATIC, None),
+            ],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    """Teardown the pytest environment"""
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_nhg_fib_enabled():
+    """Verify zebra is running with --nhg-fib flag"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify zebra started with --nhg-fib via show zebra")
+
+    output = tgen.gears["r2"].cmd('vtysh -c "show zebra"')
+    assert "NHG FIB mode" in output and "On" in output, \
+        "NHG FIB mode not enabled. show zebra output:\n{}".format(output)
+
+
+def test_bgp_session_established():
+    """Test that BGP session establishes in nhg-fib mode"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Wait for BGP session to establish")
+
+    def check_bgp():
+        output = tgen.gears["r2"].cmd('vtysh -c "show bgp ipv4 unicast summary json"')
+        try:
+            bgp = json.loads(output)
+            return bgp.get("failedPeers", 1) == 0
+        except (json.JSONDecodeError, KeyError):
+            return False
+
+    success, _ = topotest.run_and_expect(check_bgp, True, count=60, wait=1)
+    assert success, "BGP session failed to establish"
+
+
+def test_received_nhe_skip_kernel():
+    """
+    Verify that received NHG (nhe_received) is marked RECEIVED and skips kernel.
+
+    In nhg-fib mode:
+    - nhe_received should have NEXTHOP_GROUP_RECEIVED flag set
+    - nhe_received should NOT be installed to kernel (skip_kernel)
+    - The route's RIB NHG points to nhe_received (unresolved)
+    - The route's FIB NHG points to nhe (resolved)
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify received NHG has RECEIVED flag and skips kernel")
+
+    # Wait for BGP route to appear
+    def check_route_exists():
+        output = tgen.gears["r2"].cmd('vtysh -c "show ip route 192.168.1.0/24 json"')
+        try:
+            route_data = json.loads(output)
+            if "192.168.1.0/24" not in route_data:
+                return "Route 192.168.1.0/24 not found"
+            for routes in route_data.values():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        return None
+            return "BGP route not found"
+        except (json.JSONDecodeError, KeyError) as e:
+            return "JSON error: {}".format(e)
+
+    _, result = topotest.run_and_expect(check_route_exists, None, count=60, wait=1)
+    assert result is None, "BGP route was not learned: {}".format(result)
+
+    # Get the route data directly
+    output = tgen.gears["r2"].cmd('vtysh -c "show ip route 192.168.1.0/24 json"')
+    route_data = json.loads(output)
+    route = None
+    for routes in route_data.values():
+        for r in routes:
+            if r.get("protocol") == "bgp":
+                route = r
+                break
+        if route:
+            break
+    assert route is not None, "BGP route not found after wait"
+
+    # Verify route has nexthopGroupId (resolved NHG installed to kernel)
+    nhg_id = route.get("nexthopGroupId")
+    assert nhg_id, "Route missing nexthopGroupId (resolved NHG should be installed)"
+
+    # Verify route is installed in FIB
+    assert route.get("installed", False), \
+        "Route not installed in FIB (resolved NHG should be installed)"
+
+    # Verify nexthops point to resolved address
+    nexthops = route.get("nexthops", [])
+    assert len(nexthops) > 0, "No resolved nexthops found"
+
+    # The nexthop should be 10.0.0.1 (r1's interface)
+    nh_addr = nexthops[0].get("ip", "")
+    assert "10.0.0.1" in nh_addr, \
+        "Resolved nexthop should be 10.0.0.1, got: {}".format(nh_addr)
+
+    # Verify resolved NHG is installed
+    nhg_output = tgen.gears["r2"].cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(nhg_id)
+    )
+    nhg_data = json.loads(nhg_output)
+    nhg_info = nhg_data.get(str(nhg_id), {})
+    assert _is_installed(nhg_info), \
+        "Resolved NHG should be installed (kernel or FPM-only): {}".format(nhg_info)
+
+    # For directly connected nexthop (10.0.0.1), receivedNexthopGroupId and
+    # nexthopGroupId point to the same NHG (the connected NHG).
+    # RECEIVED flag check is done in test_recursive_nhg_no_resolve where
+    # the received NHG is a distinct, independent entry.
+    received_nhg_id = route.get("receivedNexthopGroupId")
+    if received_nhg_id:
+        received_nhg_output = tgen.gears["r2"].cmd(
+            'vtysh -c "show nexthop-group rib {} json"'.format(received_nhg_id)
+        )
+        received_nhg_data = json.loads(received_nhg_output)
+        received_nhg_info = received_nhg_data.get(str(received_nhg_id), {})
+        assert _is_installed(received_nhg_info), \
+            "Received NHG {} should be installed (kernel or FPM-only): {}".format(
+                received_nhg_id, received_nhg_info)
+
+
+def test_recursive_nhg_no_resolve():
+    """
+    Verify that recursive NHGs skip resolve in nhg-fib mode.
+
+    Topology:
+      r1 announces 1.1.1.1/32 via BGP
+      r2 learns 1.1.1.1/32 via BGP (nexthop 10.0.0.1)
+      r2 has static route 10.10.10.0/24 via 1.1.1.1 (recursive)
+
+    In nhg-fib mode:
+      - The recursive NHG (1.1.1.1) has RECURSIVE flag
+      - The NHG is NOT resolved (keeps 1.1.1.1, not resolved to 10.0.0.1)
+      - The NHG is sent to FPM with recursive nexthop info
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Configure r1 loopback and announce 1.1.1.1/32 via BGP")
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface lo
+         ip address 1.1.1.1/32
+        router bgp 65001
+         address-family ipv4 unicast
+          network 1.1.1.1/32
+    """)
+
+    step("Wait for r2 to learn 1.1.1.1/32 via BGP")
+
+    def check_route_1111():
+        output = r2.cmd('vtysh -c "show ip route 1.1.1.1/32 json"')
+        try:
+            route_data = json.loads(output)
+            if "1.1.1.1/32" not in route_data:
+                return "Route 1.1.1.1/32 not found"
+            for routes in route_data.values():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        return None
+            return "BGP route not found"
+        except (json.JSONDecodeError, KeyError) as e:
+            return "JSON error: {}".format(e)
+
+    _, result = topotest.run_and_expect(check_route_1111, None, count=60, wait=1)
+    assert result is None, "r2 did not learn 1.1.1.1/32 via BGP: {}".format(result)
+
+    step("Add static route with recursive nexthop 1.1.1.1")
+
+    r2.vtysh_cmd("""
+        configure terminal
+        ip route 10.10.10.0/24 1.1.1.1
+    """)
+
+    step("Verify recursive NHG keeps original nexthop in nhg-fib mode")
+
+    def check_recursive_route():
+        output = r2.cmd('vtysh -c "show ip route 10.10.10.0/24 json"')
+        try:
+            route_data = json.loads(output)
+            if "10.10.10.0/24" not in route_data:
+                return "Route 10.10.10.0/24 not found"
+            for routes in route_data.values():
+                for route in routes:
+                    if route.get("protocol") == "static":
+                        return None
+            return "Static route not found"
+        except (json.JSONDecodeError, KeyError) as e:
+            return "JSON error: {}".format(e)
+
+    _, result = topotest.run_and_expect(check_recursive_route, None, count=60, wait=1)
+    assert result is None, "Static route 10.10.10.0/24 not found: {}".format(result)
+
+    # Get the route data directly
+    output = r2.cmd('vtysh -c "show ip route 10.10.10.0/24 json"')
+    route_data = json.loads(output)
+    static_route = None
+    for routes in route_data.values():
+        for r in routes:
+            if r.get("protocol") == "static":
+                static_route = r
+                break
+        if static_route:
+            break
+    assert static_route is not None, "Static route not found after wait"
+
+    # Get the recursive NHG details
+    nhg_id = static_route.get("nexthopGroupId")
+    assert nhg_id, "Static route missing nexthopGroupId"
+
+    nhg_output = r2.cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(nhg_id)
+    )
+    nhg_data = json.loads(nhg_output)
+    nhg_info = nhg_data.get(str(nhg_id), {})
+    nexthops = nhg_info.get("nexthops", [])
+
+    step("Recursive NHG {} info: {}".format(nhg_id, nhg_info))
+    step("Recursive NHG {} nexthops: {}".format(nhg_id, nexthops))
+
+    # In nhg-fib mode, the recursive NHG should keep 1.1.1.1 as nexthop
+    # (not resolved to 10.0.0.1)
+    if len(nexthops) == 1:
+        nh_ip = nexthops[0].get("ip", "")
+        assert "1.1.1.1" in nh_ip, \
+            "Recursive NHG should keep original nexthop 1.1.1.1, got: {}".format(nh_ip)
+
+    # Verify RECURSIVE flag is set (JSON has individual boolean fields)
+    assert nhg_info.get("recursive", False), \
+        "Recursive NHG missing RECURSIVE flag: {}".format(nhg_info)
+
+    # Step 1: Verify recursive NHG (NHG-C) depends on resolved NHG (NHG-B)
+    depends = nhg_info.get("depends", [])
+    step("Recursive NHG {} depends: {}".format(nhg_id, depends))
+    assert len(depends) > 0, \
+        "Recursive NHG should have depends (the NHG for 1.1.1.1)"
+
+    resolved_nhg_id = depends[0]
+
+    # Step 2: Verify resolved NHG (NHG-B) has recursive NHG in dependents
+    resolved_nhg_output = r2.cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(resolved_nhg_id)
+    )
+    resolved_nhg_data = json.loads(resolved_nhg_output)
+    resolved_nhg_info = resolved_nhg_data.get(str(resolved_nhg_id), {})
+    resolved_dependents = resolved_nhg_info.get("dependents", [])
+    resolved_depends = resolved_nhg_info.get("depends", [])
+
+    step("Resolved NHG {} info: {}".format(resolved_nhg_id, resolved_nhg_info))
+    step("Resolved NHG {} dependents: {}".format(resolved_nhg_id, resolved_dependents))
+    step("Resolved NHG {} depends: {}".format(resolved_nhg_id, resolved_depends))
+
+    assert nhg_id in resolved_dependents or str(nhg_id) in [str(d) for d in resolved_dependents], \
+        "Resolved NHG {} should have recursive NHG {} in dependents".format(
+            resolved_nhg_id, nhg_id)
+
+    # Step 3: Verify resolved NHG (NHG-B) is installed.
+    # The resolved NHG may or may not have further depends (a connected NHG).
+    # For a directly connected nexthop like 10.0.0.1, the resolved NHG itself
+    # is the leaf node with the nexthop+interface encoded directly.
+    # Step 4: Verify all NHGs in the chain are installed (dplane processed them).
+    # In nhg-fib mode, RECURSIVE NHEs go through skip_kernel and are marked
+    # installedFpmOnly instead of installed; the connected (leaf) NHE still
+    # goes to kernel and gets installed.
+    assert _is_installed(nhg_info), \
+        "Recursive NHG {} should be installed (kernel or FPM-only): {}".format(
+            nhg_id, nhg_info)
+    assert _is_installed(resolved_nhg_info), \
+        "Resolved NHG {} should be installed (kernel or FPM-only): {}".format(
+            resolved_nhg_id, resolved_nhg_info)
+
+    if len(resolved_depends) > 0:
+        connected_nhg_id = resolved_depends[0]
+        connected_nhg_output = r2.cmd(
+            'vtysh -c "show nexthop-group rib {} json"'.format(connected_nhg_id)
+        )
+        connected_nhg_data = json.loads(connected_nhg_output)
+        connected_nhg_info = connected_nhg_data.get(str(connected_nhg_id), {})
+        step("Connected NHG {} info: {}".format(connected_nhg_id, connected_nhg_info))
+
+        assert _is_installed(connected_nhg_info), \
+            "Connected NHG {} should be installed (kernel or FPM-only): {}".format(
+                connected_nhg_id, connected_nhg_info)
+
+        step("Complete dependency chain verified:")
+        step("  NHG-C (recursive {}) -> depends -> NHG-B (resolved {})".format(
+            nhg_id, resolved_nhg_id))
+        step("  NHG-B (resolved {}) -> depends -> NHG-A (connected {})".format(
+            resolved_nhg_id, connected_nhg_id))
+        step("  NHG-A (connected {}) is leaf node".format(connected_nhg_id))
+    else:
+        step("Complete dependency chain verified:")
+        step("  NHG-C (recursive {}) -> depends -> NHG-B (resolved {})".format(
+            nhg_id, resolved_nhg_id))
+        step("  NHG-B (resolved {}) is leaf node (directly connected nexthop)".format(
+            resolved_nhg_id))
+
+
+def test_nhg_depends_dependents():
+    """
+    Verify that depends and dependents lists are properly populated.
+
+    When a route has a nexthop group with multiple members:
+    - The parent NHG's depends list should contain child NHG IDs
+    - Each child NHG's dependents list should contain the parent NHG ID
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify NHG depends/dependents relationship")
+
+    # Use the BGP route's NHG to check depends
+    def check_nhg_deps():
+        output = tgen.gears["r2"].cmd('vtysh -c "show ip route 192.168.1.0/24 json"')
+        try:
+            route_data = json.loads(output)
+            if "192.168.1.0/24" not in route_data:
+                return "Route not found"
+
+            for routes in route_data.values():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        nhg_id = route.get("nexthopGroupId")
+                        if not nhg_id:
+                            return "NHG ID not found"
+                        return None
+            return "BGP route not found"
+        except (json.JSONDecodeError, KeyError) as e:
+            return "JSON error: {}".format(e)
+
+    _, result = topotest.run_and_expect(check_nhg_deps, None, count=60, wait=1)
+    assert result is None, "Could not find NHG ID for BGP route: {}".format(result)
+
+    # Get NHG ID directly
+    output = tgen.gears["r2"].cmd('vtysh -c "show ip route 192.168.1.0/24 json"')
+    route_data = json.loads(output)
+    nhg_id = None
+    for routes in route_data.values():
+        for route in routes:
+            if route.get("protocol") == "bgp":
+                nhg_id = route.get("nexthopGroupId")
+                break
+        if nhg_id:
+            break
+    assert nhg_id, "NHG ID not found after wait"
+
+    # Get NHG details
+    nhg_output = tgen.gears["r2"].cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(nhg_id)
+    )
+    nhg_data = json.loads(nhg_output)
+    nhg_info = nhg_data.get(str(nhg_id), {})
+
+    # Verify NHG has nexthops
+    nexthops = nhg_info.get("nexthops", [])
+    assert len(nexthops) > 0, "NHG {} has no nexthops".format(nhg_id)
+
+    # Verify BGP route NHG is installed
+    assert _is_installed(nhg_info), \
+        "BGP route NHG {} should be installed (kernel or FPM-only): {}".format(
+            nhg_id, nhg_info)
+
+    # Log the full NHG info for debugging
+    step("NHG {} details:".format(nhg_id))
+    step("  info: {}".format(nhg_info))
+    step("  nexthops: {}".format(nexthops))
+
+
+def test_zebra_stability():
+    """
+    Verify zebra remains stable in nhg-fib mode without crashes.
+
+    This is a regression test for the OOM/crash issue that occurred
+    with nhg-fib enabled due to excessive DPlane context allocation.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify zebra is running stably in nhg-fib mode")
+
+    # Check zebra process is running
+    result = tgen.gears["r2"].cmd("pidof zebra")
+    assert result.strip(), "Zebra is not running"
+
+    # Check dplane is responsive
+    dplane_output = tgen.gears["r2"].cmd('vtysh -c "show zebra dplane"')
+    assert "dplane" in dplane_output.lower() or "Dplane" in dplane_output, \
+        "Dplane not responding"
+
+    # Verify no crash occurred during tests
+    step("Verify zebra has not crashed during test execution")
+    uptime = tgen.gears["r2"].cmd('vtysh -c "show zebra" | grep -i uptime')
+    step("Zebra uptime: {}".format(uptime.strip()))
+
+
+def test_nhg_grp_full_list():
+    """
+    Verify nh_grp_full is populated correctly in nhg-fib mode.
+
+    nh_grp_full is internal dplane data (not visible via vtysh).
+    We verify indirectly by:
+    1. Checking dplane processes NHG updates without errors
+    2. Verifying recursive NHG's depends chain is complete
+    3. Checking zebra logs for nh_grp_full_count (if debug enabled)
+    """
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify nh_grp_full dependency chain is complete")
+
+    # Get the recursive route's NHG
+    output = r2.cmd('vtysh -c "show ip route 10.10.10.0/24 json"')
+    route_data = json.loads(output)
+
+    recursive_nhg_id = None
+    for routes in route_data.values():
+        for route in routes:
+            if route.get("protocol") == "static":
+                recursive_nhg_id = route.get("nexthopGroupId")
+                break
+        if recursive_nhg_id:
+            break
+
+    assert recursive_nhg_id, "No NHG ID found for recursive route"
+
+    # Get recursive NHG JSON to verify depends chain
+    nhg_output = r2.cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(recursive_nhg_id)
+    )
+    nhg_data = json.loads(nhg_output)
+    nhg_info = nhg_data.get(str(recursive_nhg_id), {})
+    depends = nhg_info.get("depends", [])
+
+    step("Recursive NHG {} depends: {}".format(recursive_nhg_id, depends))
+
+    # The recursive NHG should have at least one depend
+    assert len(depends) > 0, \
+        "Recursive NHG should have depends (resolved NHG for 1.1.1.1)"
+
+    # Verify the resolved NHG exists and is in the depends chain
+    resolved_nhg_id = depends[0]
+    resolved_output = r2.cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(resolved_nhg_id)
+    )
+    resolved_data = json.loads(resolved_output)
+    resolved_info = resolved_data.get(str(resolved_nhg_id), {})
+
+    step("Resolved NHG {} info: {}".format(resolved_nhg_id, resolved_info))
+
+    # Verify resolved NHG is installed
+    assert _is_installed(resolved_info), \
+        "Resolved NHG {} should be installed (kernel or FPM-only): {}".format(
+            resolved_nhg_id, resolved_info)
+
+    # Resolved NHG may or may not have further depends (connected NHG).
+    # For a directly connected nexthop, the resolved NHG is the leaf node.
+    resolved_depends = resolved_info.get("depends", [])
+
+    if len(resolved_depends) > 0:
+        connected_nhg_id = resolved_depends[0]
+        connected_output = r2.cmd(
+            'vtysh -c "show nexthop-group rib {} json"'.format(connected_nhg_id)
+        )
+        connected_data = json.loads(connected_output)
+        connected_info = connected_data.get(str(connected_nhg_id), {})
+
+        step("Connected NHG {} info: {}".format(connected_nhg_id, connected_info))
+
+        # Connected NHG should be installed and have no further depends
+        assert _is_installed(connected_info), \
+            "Connected NHG {} should be installed (kernel or FPM-only): {}".format(
+                connected_nhg_id, connected_info)
+        assert len(connected_info.get("depends", [])) == 0, \
+            "Connected NHG should be leaf node"
+
+        # The full chain: recursive NHG -> resolved NHG -> connected NHG
+        # nh_grp_full should contain [resolved_nhg_id, connected_nhg_id] in dplane context
+        step("Complete dependency chain verified:")
+        step("  recursive {} -> resolved {} -> connected {}".format(
+            recursive_nhg_id, resolved_nhg_id, connected_nhg_id))
+        step("  nh_grp_full should contain [{}, {}]".format(
+            resolved_nhg_id, connected_nhg_id))
+    else:
+        # Resolved NHG is the leaf node (directly connected nexthop)
+        # nh_grp_full should contain [resolved_nhg_id] in dplane context
+        step("Complete dependency chain verified:")
+        step("  recursive {} -> resolved {} (leaf)".format(
+            recursive_nhg_id, resolved_nhg_id))
+        step("  nh_grp_full should contain [{}]".format(resolved_nhg_id))
+
+
+def test_dependents_add_remove():
+    """
+    Verify dependents list is updated correctly when a recursive NHG
+    is added/removed, and the resolved NHG gets re-sent to FPM via the
+    NEXTHOP_GROUP_REINSTALL_FPM_ONLY flag.
+
+    Scenario:
+      Existing: 10.10.10.0/24 via 1.1.1.1 -> recursive NHG-C1 -> resolved NHG-B
+      Add:      20.20.20.0/24 via 2.2.2.2 -> recursive NHG-C2 -> resolved NHG-B
+        (2.2.2.2 resolves to same 10.0.0.1, so NHG-C2 depends on same NHG-B)
+        => NHG-B's dependents should grow by 1 and contain NHG-C2
+      Remove:   20.20.20.0/24
+        => NHG-B's dependents should shrink back
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Set NHG keep timer to 1s so freed NHGs are cleaned up quickly")
+
+    r2.vtysh_cmd("""
+        configure terminal
+        zebra nexthop-group keep 1
+    """)
+
+    step("Announce 2.2.2.2/32 from r1 via BGP")
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface lo
+         ip address 2.2.2.2/32
+        router bgp 65001
+         address-family ipv4 unicast
+          network 2.2.2.2/32
+    """)
+
+    def check_route_2222():
+        out = r2.cmd('vtysh -c "show ip route 2.2.2.2/32 json"')
+        try:
+            data = json.loads(out)
+            if "2.2.2.2/32" not in data:
+                return "Route 2.2.2.2/32 not found"
+            for routes in data.values():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        return None
+            return "BGP route not found"
+        except (json.JSONDecodeError, KeyError) as e:
+            return "JSON error: {}".format(e)
+
+    _, result = topotest.run_and_expect(check_route_2222, None, count=60, wait=1)
+    assert result is None, "r2 did not learn 2.2.2.2/32 via BGP: {}".format(result)
+
+    step("Get the resolved NHG (NHG-B) from existing recursive route 10.10.10.0/24")
+
+    output = r2.cmd('vtysh -c "show ip route 10.10.10.0/24 json"')
+    route_data = json.loads(output)
+    recursive_c1_id = None
+    for routes in route_data.values():
+        for r in routes:
+            if r.get("protocol") == "static":
+                recursive_c1_id = r.get("nexthopGroupId")
+                break
+        if recursive_c1_id:
+            break
+    assert recursive_c1_id, "Recursive NHG-C1 for 10.10.10.0/24 not found"
+
+    nhg_output = r2.cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(recursive_c1_id)
+    )
+    nhg_info = json.loads(nhg_output).get(str(recursive_c1_id), {})
+    depends = nhg_info.get("depends", [])
+    assert len(depends) > 0, "NHG-C1 should depend on resolved NHG-B"
+    resolved_b_id = depends[0]
+
+    def get_dependents(nhg_id):
+        out = r2.cmd('vtysh -c "show nexthop-group rib {} json"'.format(nhg_id))
+        info = json.loads(out).get(str(nhg_id), {})
+        return [int(d) for d in info.get("dependents", [])]
+
+    baseline = get_dependents(resolved_b_id)
+    step("Baseline NHG-B {} dependents: {}".format(resolved_b_id, baseline))
+    assert recursive_c1_id in baseline, \
+        "NHG-C1 {} should be in NHG-B {} dependents baseline {}".format(
+            recursive_c1_id, resolved_b_id, baseline)
+
+    step("Add recursive route 20.20.20.0/24 via 2.2.2.2")
+
+    r2.vtysh_cmd("""
+        configure terminal
+        ip route 20.20.20.0/24 2.2.2.2
+    """)
+
+    def check_route_added():
+        out = r2.cmd('vtysh -c "show ip route 20.20.20.0/24 json"')
+        try:
+            data = json.loads(out)
+            if "20.20.20.0/24" not in data:
+                return "route not yet present"
+            for routes in data.values():
+                for r in routes:
+                    if r.get("protocol") == "static" and r.get("nexthopGroupId"):
+                        return None
+            return "static route not yet resolved"
+        except (json.JSONDecodeError, KeyError) as e:
+            return "json error: {}".format(e)
+
+    _, result = topotest.run_and_expect(check_route_added, None, count=30, wait=1)
+    assert result is None, "20.20.20.0/24 not installed: {}".format(result)
+
+    output = r2.cmd('vtysh -c "show ip route 20.20.20.0/24 json"')
+    route_data = json.loads(output)
+    recursive_c2_id = None
+    for routes in route_data.values():
+        for r in routes:
+            if r.get("protocol") == "static":
+                recursive_c2_id = r.get("nexthopGroupId")
+                break
+        if recursive_c2_id:
+            break
+    assert recursive_c2_id, "Recursive NHG-C2 for 20.20.20.0/24 not found"
+    assert recursive_c2_id != recursive_c1_id, \
+        "NHG-C2 should be a distinct NHG from NHG-C1 (different nexthop)"
+
+    step("Verify NHG-B dependents grew to include NHG-C2")
+
+    # NHG-C2 should also depend on same NHG-B (both resolve to 10.0.0.1)
+    nhg_c2_output = r2.cmd(
+        'vtysh -c "show nexthop-group rib {} json"'.format(recursive_c2_id)
+    )
+    nhg_c2_info = json.loads(nhg_c2_output).get(str(recursive_c2_id), {})
+    c2_depends = nhg_c2_info.get("depends", [])
+    step("NHG-C2 {} depends: {}".format(recursive_c2_id, c2_depends))
+    assert len(c2_depends) > 0, "NHG-C2 should have depends"
+    assert c2_depends[0] == resolved_b_id, \
+        "NHG-C2 should depend on same NHG-B {}. Got: {}".format(
+            resolved_b_id, c2_depends[0])
+
+    def dependents_contains_c2():
+        deps = get_dependents(resolved_b_id)
+        return recursive_c2_id in deps
+
+    success, _ = topotest.run_and_expect(dependents_contains_c2, True, count=30, wait=1)
+    after_add = get_dependents(resolved_b_id)
+    assert success, \
+        "NHG-C2 {} not added to NHG-B {} dependents: {}".format(
+            recursive_c2_id, resolved_b_id, after_add)
+    assert len(after_add) == len(baseline) + 1, \
+        "Dependents count expected {} got {}: {}".format(
+            len(baseline) + 1, len(after_add), after_add)
+    assert recursive_c1_id in after_add, \
+        "NHG-C1 {} should still be in dependents: {}".format(recursive_c1_id, after_add)
+
+    step("Remove recursive route and withdraw 2.2.2.2/32 from BGP")
+
+    r2.vtysh_cmd("""
+        configure terminal
+        no ip route 20.20.20.0/24 2.2.2.2
+    """)
+
+    r1.vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+         address-family ipv4 unicast
+          no network 2.2.2.2/32
+        interface lo
+         no ip address 2.2.2.2/32
+    """)
+
+    def dependents_back_to_baseline():
+        deps = get_dependents(resolved_b_id)
+        return recursive_c2_id not in deps and len(deps) == len(baseline)
+
+    success, _ = topotest.run_and_expect(
+        dependents_back_to_baseline, True, count=60, wait=1)
+    after_remove = get_dependents(resolved_b_id)
+    assert success, \
+        "Dependents not restored after remove. Expected {} got {}".format(
+            baseline, after_remove)
+    assert recursive_c1_id in after_remove, \
+        "NHG-C1 {} should still be in dependents: {}".format(
+            recursive_c1_id, after_remove)
+
+    step("Dependents add/remove verified: baseline={} after_add={} after_remove={}".format(
+        baseline, after_add, after_remove))
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -66,6 +66,9 @@ struct mgmt_be_client *mgmt_be_client;
 /* Route retain mode flag. */
 int retain_mode = 0;
 
+/* Enable NHG Full encoding via sonic-fib (set by --nhg-fib flag). */
+bool zebra_nhg_fib_enabled;
+
 /* Receive buffer size for kernel control sockets */
 #define RCVBUFSIZE_MIN 4194304
 #ifdef HAVE_NETLINK
@@ -80,6 +83,7 @@ uint32_t rt_table_main_id = RT_TABLE_MAIN;
 #define OPTION_ASIC_OFFLOAD    2001
 #define OPTION_V6_WITH_V4_NEXTHOP 2002
 #define OPTION_NEXTHOP_WEIGHT_16_BIT 2003
+#define OPTION_NHG_FIB		     2004
 
 /* Command line options. */
 const struct option longopts[] = {
@@ -91,6 +95,7 @@ const struct option longopts[] = {
 	{ "asic-offload", optional_argument, NULL, OPTION_ASIC_OFFLOAD },
 	{ "v6-with-v4-nexthops", no_argument, NULL, OPTION_V6_WITH_V4_NEXTHOP },
 	{ "nexthop-weight-16-bit", no_argument, NULL, OPTION_NEXTHOP_WEIGHT_16_BIT },
+	{ "nhg-fib", no_argument, NULL, OPTION_NHG_FIB },
 #ifdef HAVE_NETLINK
 	{ "vrfwnetns", no_argument, NULL, 'n' },
 	{ "nl-bufsize", required_argument, NULL, 's' },
@@ -417,7 +422,8 @@ int main(int argc, char **argv)
 #else
 		    "  -s,                         Set kernel socket receive buffer size\n"
 #endif /* HAVE_NETLINK */
-		    "  -R, --routing-table         Set kernel routing table\n");
+		    "  -R, --routing-table         Set kernel routing table\n"
+		    "      --nhg-fib               Enable NHG Full encoding via sonic-fib\n");
 
 	while (1) {
 		int opt = frr_getopt(argc, argv, NULL);
@@ -489,6 +495,9 @@ int main(int argc, char **argv)
 			break;
 		case OPTION_V6_WITH_V4_NEXTHOP:
 			v6_with_v4_nexthop = true;
+			break;
+		case OPTION_NHG_FIB:
+			zebra_nhg_fib_enabled = true;
 			break;
 #endif /* HAVE_NETLINK */
 		case OPTION_NEXTHOP_WEIGHT_16_BIT:

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -29,6 +29,7 @@
 #include "zebra/zebra_neigh.h"
 #include "zebra/zebra_tc.h"
 #include "zebra/zebra_trace.h"
+#include "zebra/zebra_errors.h"
 #include "printfrr.h"
 
 /* Memory types */
@@ -80,6 +81,14 @@ const uint32_t DPLANE_DEFAULT_NEW_WORK = 100;
 #endif	/* DPLANE_DEBUG */
 
 /*
+ * Maximum size of nh_grp_full array. We use 2x MULTIPATH_NUM because
+ * in practice it is unlikely to have more than two levels of fully
+ * expanded ECMP recursion. This may be increased if deeper recursion
+ * is needed in the future.
+ */
+#define NH_GRP_FULL_NUM (MULTIPATH_NUM * 2)
+
+/*
  * Nexthop information captured for nexthop/nexthop group updates
  */
 struct dplane_nexthop_info {
@@ -88,10 +97,20 @@ struct dplane_nexthop_info {
 	afi_t afi;
 	vrf_id_t vrf_id;
 	int type;
+	uint32_t nhg_flags;
 
 	struct nexthop_group ng;
 	struct nh_grp nh_grp[MULTIPATH_NUM];
 	uint16_t nh_grp_count;
+
+	struct nh_grp_full nh_grp_full[NH_GRP_FULL_NUM + 1];
+	uint32_t nh_grp_full_count;
+
+	uint32_t depends[MULTIPATH_NUM + 1];
+	uint32_t depends_count;
+
+	uint32_t dependents[MULTIPATH_NUM + 1];
+	uint32_t dependents_count;
 };
 
 /*
@@ -140,6 +159,7 @@ struct dplane_route_info {
 
 	/* Nexthop hash entry info */
 	struct dplane_nexthop_info nhe;
+	struct dplane_nexthop_info nhe_received;
 
 	/* Nexthops */
 	uint32_t zd_nhg_id;
@@ -2484,6 +2504,12 @@ uint32_t dplane_ctx_get_old_nhe_id(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.rinfo.nhe.old_id;
 }
 
+uint32_t dplane_ctx_get_nhe_received_id(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe_received.id;
+}
+
 afi_t dplane_ctx_get_nhe_afi(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -2500,6 +2526,12 @@ int dplane_ctx_get_nhe_type(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 	return ctx->u.rinfo.nhe.type;
+}
+
+uint32_t dplane_ctx_get_nhe_nhg_flags(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.nhg_flags;
 }
 
 const struct nexthop_group *
@@ -2520,6 +2552,42 @@ uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 	return ctx->u.rinfo.nhe.nh_grp_count;
+}
+
+const struct nh_grp_full *dplane_ctx_get_nhe_nh_grp_full(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.nh_grp_full;
+}
+
+uint32_t dplane_ctx_get_nhe_nh_grp_full_count(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.nh_grp_full_count;
+}
+
+const uint32_t *dplane_ctx_get_nhe_depends(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.depends;
+}
+
+uint32_t dplane_ctx_get_nhe_depends_count(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.depends_count;
+}
+
+const uint32_t *dplane_ctx_get_nhe_dependents(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.dependents;
+}
+
+uint32_t dplane_ctx_get_nhe_dependents_count(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.nhe.dependents_count;
 }
 
 /* Accessors for LSP information */
@@ -4119,9 +4187,14 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 
 		ctx->u.rinfo.nhe.id = nhe->id;
 		ctx->u.rinfo.nhe.old_id = 0;
+
+		if (re->nhe_received && zebra_nhg_fib_enabled) {
+			ctx->u.rinfo.nhe_received.id = re->nhe_received->id;
+			ctx->u.rinfo.nhe_received.old_id = 0;
+		}
 		/*
-		 * Check if the nhe is installed/queued before doing anything
-		 * with this route.
+		 * Check if the nhe is installed/queued (kernel or FPM-only)
+		 * before doing anything with this route.
 		 *
 		 * If its a delete we only use the prefix anyway, so this only
 		 * matters for INSTALL/UPDATE.
@@ -4129,6 +4202,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		if (zebra_nhg_kernel_nexthops_enabled() &&
 		    (((op == DPLANE_OP_ROUTE_INSTALL) || (op == DPLANE_OP_ROUTE_UPDATE)) &&
 		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
+		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY) &&
 		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED))) {
 			frrtrace(4, frr_zebra, dplane_ctx_route_kernel_nhg_not_ready, op, nhe->id,
 				 nhe->flags, re->vrf_id);
@@ -4244,6 +4318,80 @@ static int dplane_ctx_tc_filter_init(struct zebra_dplane_ctx *ctx,
 }
 
 /**
+ * dplane_ctx_nexthop_fill_arrays() - Fill nh_grp_full, depends, and dependents
+ * arrays in ctx for nhg-fib mode.
+ *
+ * @ctx:	Dataplane context being initialized
+ * @nhe:	Nexthop group hash entry
+ *
+ * Return:	true on success, false on any array overflow.
+ */
+static bool dplane_ctx_nexthop_fill_arrays(struct zebra_dplane_ctx *ctx, struct nhg_hash_entry *nhe)
+{
+	struct nhg_connected *rb_node_dep = NULL;
+	struct nhg_connected *rb_node_dependent = NULL;
+
+	if (!zebra_nhg_depends_is_empty(nhe)) {
+		/* Fill nh_grp_full array with all depends nhe ids, including recursive ones */
+		ctx->u.rinfo.nhe.nh_grp_full_count =
+			zebra_nhg_nhe2grp_full(ctx->u.rinfo.nhe.nh_grp_full, nhe,
+					       NH_GRP_FULL_NUM + 1);
+		if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+			zlog_debug("%s: NHG id=%u full grp_full_count=%u", __func__, nhe->id,
+				   ctx->u.rinfo.nhe.nh_grp_full_count);
+		}
+
+		if (ctx->u.rinfo.nhe.nh_grp_full_count > NH_GRP_FULL_NUM) {
+			flog_err(EC_ZEBRA_NHG_FIB_UPDATE,
+				 "%s: NHG id=%u nh_grp_full overflow (count %u > max %u), aborting",
+				 __func__, nhe->id, ctx->u.rinfo.nhe.nh_grp_full_count,
+				 NH_GRP_FULL_NUM);
+			return false;
+		}
+
+		/* Fill depends array with direct depends IDs */
+		ctx->u.rinfo.nhe.depends_count = 0;
+		frr_each (nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+			if (ctx->u.rinfo.nhe.depends_count >= array_size(ctx->u.rinfo.nhe.depends)) {
+				flog_err(EC_ZEBRA_NHG_FIB_UPDATE,
+					 "%s: NHG id=%u depends overflow (max %zu), aborting",
+					 __func__, nhe->id, array_size(ctx->u.rinfo.nhe.depends));
+				return false;
+			}
+			ctx->u.rinfo.nhe.depends[ctx->u.rinfo.nhe.depends_count] =
+				rb_node_dep->nhe->id;
+			ctx->u.rinfo.nhe.depends_count++;
+		}
+
+		if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+			zlog_debug("%s: NHG id=%u depends_count=%u", __func__, nhe->id,
+				   ctx->u.rinfo.nhe.depends_count);
+		}
+	}
+
+	/* Fill dependents array with dependent IDs */
+	ctx->u.rinfo.nhe.dependents_count = 0;
+	frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dependent) {
+		if (ctx->u.rinfo.nhe.dependents_count >= array_size(ctx->u.rinfo.nhe.dependents)) {
+			flog_err(EC_ZEBRA_NHG_FIB_UPDATE,
+				 "%s: NHG id=%u dependents overflow (max %zu), aborting", __func__,
+				 nhe->id, array_size(ctx->u.rinfo.nhe.dependents));
+			return false;
+		}
+		ctx->u.rinfo.nhe.dependents[ctx->u.rinfo.nhe.dependents_count] =
+			rb_node_dependent->nhe->id;
+		ctx->u.rinfo.nhe.dependents_count++;
+	}
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+		zlog_debug("%s: NHG id=%u, %p, dependents_count=%u", __func__, nhe->id, nhe,
+			   ctx->u.rinfo.nhe.dependents_count);
+	}
+
+	return true;
+}
+
+/**
  * dplane_ctx_nexthop_init() - Initialize a context block for a nexthop update
  *
  * @ctx:	Dataplane context to init
@@ -4270,6 +4418,7 @@ int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	ctx->u.rinfo.nhe.afi = nhe->afi;
 	ctx->u.rinfo.nhe.vrf_id = nhe->vrf_id;
 	ctx->u.rinfo.nhe.type = nhe->type;
+	ctx->u.rinfo.nhe.nhg_flags = nhe->flags;
 
 	nexthop_group_copy(&(ctx->u.rinfo.nhe.ng), &(nhe->nhg));
 
@@ -4288,6 +4437,29 @@ int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		ctx->u.rinfo.nhe.nh_grp_count = zebra_nhg_nhe2grp(
 			ctx->u.rinfo.nhe.nh_grp, nhe, MULTIPATH_NUM);
 
+	/*
+	 * Populate nh_grp_full / depends / dependents arrays for nhg-fib mode
+	 * dplane processing. Bail out on overflow.
+	 */
+	if (zebra_nhg_fib_enabled && !dplane_ctx_nexthop_fill_arrays(ctx, nhe)) {
+		ret = ERANGE;
+		return ret;
+	}
+
+	/*
+	 * Both RECEIVED and RECURSIVE NHGs should not be installed to kernel.
+	 * RECEIVED NHGs are unresolved protocol-original groups for only FPM.
+	 * RECURSIVE NHGs represent intermediate routing hops and are never
+	 * programmed to kernel.
+	 */
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECEIVED) ||
+	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE)) {
+		dplane_ctx_set_skip_kernel(ctx);
+		if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+			zlog_debug("%s: NHG id=%u is received or recursive, marking to skip kernel programming",
+				   __func__, nhe->id);
+		}
+	}
 	zvrf = vrf_info_lookup(nhe->vrf_id);
 
 	/*
@@ -4859,6 +5031,8 @@ dplane_route_update_internal(struct route_node *rn,
 			ctx->u.rinfo.zd_old_distance = old_re->distance;
 			ctx->u.rinfo.zd_old_metric = old_re->metric;
 			ctx->u.rinfo.nhe.old_id = old_re->nhe->id;
+			if (old_re->nhe_received && zebra_nhg_fib_enabled)
+				ctx->u.rinfo.nhe_received.old_id = old_re->nhe_received->id;
 
 #ifndef HAVE_NETLINK
 			/* For bsd, capture previous re's nexthops too, sigh.
@@ -5052,6 +5226,20 @@ dplane_nexthop_update_internal(struct nhg_hash_entry *nhe, enum dplane_op_e op)
 	if (ret == AOK) {
 		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL))
 			dplane_ctx_set_skip_kernel(ctx);
+
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY)) {
+			/* Skip kernel if already installed (kernel or FPM-only) */
+			if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
+			    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY))
+				dplane_ctx_set_skip_kernel(ctx);
+			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY);
+		}
+
+		if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+			zlog_debug("%s: NHG id=%u flags=0x%x enqueuing to dplane, nh_grp_count=%u, nh_grp_full_count=%u",
+				   __func__, nhe->id, nhe->flags, ctx->u.rinfo.nhe.nh_grp_count,
+				   ctx->u.rinfo.nhe.nh_grp_full_count);
+		}
 
 		ret = dplane_update_enqueue(ctx);
 	}

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -659,14 +659,22 @@ dplane_ctx_get_old_backup_ng(const struct zebra_dplane_ctx *ctx);
 /* Accessors for nexthop information */
 uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_old_nhe_id(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_nhe_received_id(const struct zebra_dplane_ctx *ctx);
 afi_t dplane_ctx_get_nhe_afi(const struct zebra_dplane_ctx *ctx);
 vrf_id_t dplane_ctx_get_nhe_vrf_id(const struct zebra_dplane_ctx *ctx);
 int dplane_ctx_get_nhe_type(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_nhe_nhg_flags(const struct zebra_dplane_ctx *ctx);
 const struct nexthop_group *
 dplane_ctx_get_nhe_ng(const struct zebra_dplane_ctx *ctx);
 const struct nh_grp *
 dplane_ctx_get_nhe_nh_grp(const struct zebra_dplane_ctx *ctx);
 uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx);
+const struct nh_grp_full *dplane_ctx_get_nhe_nh_grp_full(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_nhe_nh_grp_full_count(const struct zebra_dplane_ctx *ctx);
+const uint32_t *dplane_ctx_get_nhe_depends(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_nhe_depends_count(const struct zebra_dplane_ctx *ctx);
+const uint32_t *dplane_ctx_get_nhe_dependents(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_nhe_dependents_count(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for LSP information */
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -256,12 +256,38 @@ static void zebra_nhg_dependents_del(struct nhg_hash_entry *from,
 				     struct nhg_hash_entry *dependent)
 {
 	nhg_connected_tree_del_nhe(&from->nhg_dependents, dependent);
+
+	/*
+	 * If nhg fib is enabled and the tree owner is already installed
+	 * (or its install is in flight), reinstall it so FPM gets the
+	 * updated dependents list. The QUEUED case is handled at install
+	 * completion: after INSTALLED is set, the dplane callback will
+	 * see REINSTALL_FPM_ONLY and trigger another install.
+	 */
+	if (zebra_nhg_fib_enabled && (CHECK_FLAG(from->flags, NEXTHOP_GROUP_INSTALLED) ||
+				      CHECK_FLAG(from->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY) ||
+				      CHECK_FLAG(from->flags, NEXTHOP_GROUP_QUEUED))) {
+		SET_FLAG(from->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY);
+	}
 }
 
 static void zebra_nhg_dependents_add(struct nhg_hash_entry *to,
 				     struct nhg_hash_entry *dependent)
 {
 	nhg_connected_tree_add_nhe(&to->nhg_dependents, dependent);
+
+	/*
+	 * If nhg fib is enabled and the tree owner is already installed
+	 * (or its install is in flight), reinstall it so FPM gets the
+	 * updated dependents list. The QUEUED case is handled at install
+	 * completion: after INSTALLED is set, the dplane callback will
+	 * see REINSTALL_FPM_ONLY and trigger another install.
+	 */
+	if (zebra_nhg_fib_enabled && (CHECK_FLAG(to->flags, NEXTHOP_GROUP_INSTALLED) ||
+				      CHECK_FLAG(to->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY) ||
+				      CHECK_FLAG(to->flags, NEXTHOP_GROUP_QUEUED))) {
+		SET_FLAG(to->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY);
+	}
 }
 
 static void zebra_nhg_dependents_init(struct nhg_hash_entry *nhe)
@@ -1144,8 +1170,10 @@ static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe, bool valid)
 		/* If we're in shutdown, this interface event needs to clean
 		 * up installed NHGs, so don't clear that flag directly.
 		 */
-		if (!zebra_router_in_shutdown())
+		if (!zebra_router_in_shutdown()) {
 			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY);
+		}
 	}
 
 	/* Update validity of nexthops depending on it */
@@ -1278,9 +1306,10 @@ static void zebra_nhg_handle_install(struct nhg_hash_entry *nhe, bool install)
 
 	frr_each_safe (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
 		zebra_nhg_set_valid(rb_node_dep->nhe, true);
-		/* install dependent NHG into kernel */
+		/* install dependent NHG into kernel or FPM */
 		if (install) {
-			if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
+			if ((CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
+			     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY)) &&
 			    CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_RECURSIVE)) {
 				nhg_handle_install_one(rb_node_dep);
 			}
@@ -1310,6 +1339,7 @@ static void zebra_nhg_handle_kernel_state_change(struct nhg_hash_entry *nhe,
 			(is_delete ? "deleted" : "updated"), nhe);
 
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY);
 		zebra_nhg_install_kernel(nhe, ZEBRA_ROUTE_MAX);
 	} else
 		zebra_nhg_handle_uninstall(nhe);
@@ -1894,6 +1924,8 @@ void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 
 	if (!zebra_router_in_shutdown() && nhe->refcnt <= 0 &&
 	    (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
+	     CHECK_FLAG(nhe->flags,
+			NEXTHOP_GROUP_INSTALLED_FPM_ONLY) || /* FPM-only also keeps around */
 	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) &&
 	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND)) {
 		nhe->refcnt = 1;
@@ -1922,6 +1954,20 @@ void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe)
 		event_cancel(&nhe->timer);
 		nhe->refcnt--;
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND);
+		/* NHG is already installed in kernel but FPM/SONiC needs
+		 * re-notification for PIC HW update since the NHG was
+		 * previously marked for deletion and its HW NHG content
+		 * may be updated during PIC handling.
+		 * Need to trigger an update to dplane to update HW NHG contents.
+		 */
+		if (zebra_nhg_fib_enabled) {
+			struct nhg_connected *rb_node_dep = NULL;
+
+			SET_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY);
+			frr_each (nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+				SET_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY);
+			}
+		}
 	}
 
 	if (!zebra_nhg_depends_is_empty(nhe))
@@ -3535,12 +3581,240 @@ uint16_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe, int m
 	return zebra_nhg_nhe2grp_internal(grp, 0, nhe, nhe, max_num);
 }
 
+/**
+ * Walk through the nexthops to check if this NHG is for SRv6.
+ */
+static bool is_srv6_nhg(struct nhg_hash_entry *nhe)
+{
+	bool is_srv6 = false;
+	struct nexthop *nhop = NULL;
+
+	for (ALL_NEXTHOPS_PTR(&nhe->nhg, nhop)) {
+		if (nhop->nh_srv6 != NULL) {
+			is_srv6 = true;
+			break;
+		}
+	}
+
+	return is_srv6;
+}
+
+/*
+ * Check if a NHE should be skipped for nh_grp_full array inclusion.
+ *
+ * SRv6 NHGs are always included.
+ * For normal NHGs:
+ *   - Recursive ones only require VALID.
+ *   - Non-recursive (leaf) ones must be VALID and INSTALLED/INSTALLED_FPM_ONLY or QUEUED.
+ */
+static bool is_skipable_node(struct nhg_hash_entry *nhe)
+{
+	if (is_srv6_nhg(nhe))
+		return false;
+
+	if (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: NHG ID (%u) not valid, skip", __func__, nhe->id);
+		return true;
+	}
+
+	/* Recursive NHGs only require VALID */
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))
+		return false;
+
+	/* Non-recursive (leaf) NHGs must be INSTALLED/INSTALLED_FPM_ONLY or QUEUED */
+	if (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY) &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: NHG ID (%u) not installed or queued, skip", __func__,
+				   nhe->id);
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Recursively construct a group array of full depends' IDs.
+ *
+ * This function allows us to account for groups within groups,
+ * by converting them into a flat array of IDs, like zebra_nhg_nhe2grp
+ * but with recursive ones to keep depending relations.
+ */
+static uint32_t zebra_nhg_nhe2grp_full_internal(struct nh_grp_full *grp_full, uint32_t curr_index,
+						struct nhg_hash_entry *nhe,
+						struct nhg_hash_entry *original, uint32_t max_num)
+{
+	struct nhg_connected *rb_node_dep = NULL;
+	struct nhg_hash_entry *curr_node = NULL;
+	struct nexthop *nexthop;
+	uint32_t i = curr_index;
+
+	/* NOTE: We do NOT write the current node itself here.
+	 * We only write its direct depends in the array.
+	 */
+	/* go through all depends from current node */
+	frr_each (nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+		if (i >= max_num) {
+			zlog_err("%s:   BREAK: i=%u >= max_num=%u", __func__, i, max_num);
+			goto done;
+		}
+
+		curr_node = rb_node_dep->nhe;
+
+		if (is_skipable_node(curr_node))
+			continue;
+
+		/* If it's queued, we just log but not skip */
+		if (CHECK_FLAG(curr_node->flags, NEXTHOP_GROUP_QUEUED)) {
+			if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG)
+				zlog_debug("%s: NHG ID (%u) queued, dependency being installed, we add it to nh_grp_full array.",
+					   __func__, curr_node->id);
+		}
+
+		if (!zebra_nhg_depends_is_empty(curr_node)) {
+			/* This is a group within a group */
+			/* First, write the depend node itself with num_direct */
+			if (i < max_num) {
+				uint32_t sub_depend_count = 0;
+				struct nhg_connected *sub_rb_node = NULL;
+
+				/* Count how many sub-depends this node has */
+				frr_each (nhg_connected_tree, &curr_node->nhg_depends,
+					  sub_rb_node) {
+					if (is_skipable_node(sub_rb_node->nhe))
+						continue;
+					sub_depend_count++;
+				}
+
+				grp_full[i].id = curr_node->id;
+				grp_full[i].weight = 0;
+				grp_full[i].num_direct = sub_depend_count;
+
+				i++;
+			}
+
+			/* Then, recursively write its sub-depends */
+			i = zebra_nhg_nhe2grp_full_internal(grp_full, i, curr_node, original,
+							    max_num);
+		} else {
+			/* Go through the resolved nexthops to get weight,
+			 * but we do not use this to determine if put in this node.
+			 * We put in all depends nodes, and set the state flag of them.
+			 */
+			bool found = false;
+
+			for (ALL_NEXTHOPS_PTR(&original->nhg, nexthop)) {
+				if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+					continue;
+
+				if (nexthop_cmp_no_weight(curr_node->nhg.nexthop, nexthop) != 0)
+					continue;
+
+				found = true;
+				break;
+			}
+
+			/* If there's no resolved nexthop for a leaf node,
+			 * that means it's not a valid nhg and we record it.
+			 */
+			if (!found) {
+				if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG)
+					zlog_debug("%s: Nexthop ID (%u) unable to find nexthop in Nexthop Group Entry, something is terribly wrong",
+						   __func__, curr_node->id);
+			}
+
+			if (i < max_num) {
+				grp_full[i].id = curr_node->id;
+				grp_full[i].weight = found ? nexthop->weight : 0;
+				grp_full[i].num_direct = 0;
+
+				i++;
+			}
+		}
+	}
+
+	if (nhe->backup_info == NULL || nhe->backup_info->nhe == NULL)
+		goto done;
+
+	/* We are not supporting backup things temporarily, so we just record */
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: skipping backup nhe", __func__);
+
+done:
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL) {
+		zlog_debug("%s: dumping grp_full array from [%u] to [%u]:", __func__, curr_index,
+			   i > 0 ? i - 1 : 0);
+
+		for (uint32_t idx = curr_index; idx < i && idx < max_num; idx++) {
+			zlog_debug("%s:   grp_full[%u] = {id=%u, weight=%u, num_direct=%u}",
+				   __func__, idx, grp_full[idx].id, grp_full[idx].weight,
+				   grp_full[idx].num_direct);
+		}
+	}
+
+	return i;
+}
+
+/* Convert a nhe into a group array with full depends */
+uint32_t zebra_nhg_nhe2grp_full(struct nh_grp_full *grp_full, struct nhg_hash_entry *nhe,
+				uint32_t max_num)
+{
+	/* Call into the recursive function */
+	return zebra_nhg_nhe2grp_full_internal(grp_full, 0, nhe, nhe, max_num);
+}
+
+/*
+ * Mark receive flag and valid flag for a given NHE and its dependents
+ */
+void zebra_nhg_mark_received_flag(struct nhg_hash_entry *nhe)
+{
+	struct nhg_connected *rb_node_dep = NULL;
+
+	if (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECEIVED)) {
+		/*
+		 * Mark the nexthop group as received  and valid together
+		 *
+		 * Valid flag is used to indicate whether this nexthop group is valid for use for dplane.
+		 * It is set together with received flag since this NHG's contents are received from
+		 * protocol clients and would not be updated in zebra.
+		 */
+		SET_FLAG(nhe->flags, NEXTHOP_GROUP_RECEIVED);
+		SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: Marking nhg %pNG as received", __func__, nhe);
+	}
+	/* Make sure all depends are marked as well */
+	frr_each (nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+		zebra_nhg_mark_received_flag(rb_node_dep->nhe);
+	}
+}
+
 void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 {
 	struct nhg_connected *rb_node_dep = NULL;
 
-	/* Resolve it first */
-	nhe = zebra_nhg_resolve(nhe);
+	/*
+	 * Resolve it first in normal cases.
+	 *
+	 * In nhg-fib mode, skip resolve for RECEIVED and RECURSIVE NHGs
+	 * so they enter dplane in their original form for FPM.
+	 * RECEIVED: protocol-original NHG, FPM needs unresolved contents.
+	 * RECURSIVE: intermediate hop, FPM needs recursive address for backwalk.
+	 * Both are marked skip_kernel in dplane_ctx_nexthop_init().
+	 */
+	if (!(zebra_nhg_fib_enabled && (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECEIVED) ||
+					CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE)))) {
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: resolving nhg %pNG before install since it is not marked as received",
+				   __func__, nhe);
+		nhe = zebra_nhg_resolve(nhe);
+	} else {
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: nhg %pNG is not needed to resolve before install since it is marked as received",
+				   __func__, nhe);
+	}
 
 	if (zebra_nhg_set_valid_if_active(nhe)) {
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
@@ -3553,6 +3827,7 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL);
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY);
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED);
 	}
 
@@ -3561,9 +3836,17 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 		zebra_nhg_install_kernel(rb_node_dep->nhe, type);
 	}
 
+	/*
+	 * Inform dplane when nhe is valid, not in queue  and one of the following cases
+	 *  INSTALL (kernel or FPM-only)
+	 *  REINSTALL
+	 *  REINSTALL_FPM_ONLY
+	 */
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID) &&
-	    (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
-	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL)) &&
+	    (!(CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
+	       CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY)) ||
+	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL) ||
+	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY)) &&
 	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
 		/* Change its type to us since we are installing it */
 		if (!ZEBRA_NHG_CREATED(nhe)) {
@@ -3596,8 +3879,8 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe)
 {
 	/*
-	 * Clearly if the nexthop group is installed we should
-	 * remove it.  Additionally If the nexthop is already
+	 * Clearly if the nexthop group is installed (to kernel or FPM-only),
+	 * we should remove it. Additionally If the nexthop is already
 	 * QUEUED for installation, we should also just send
 	 * a deletion down as well.  We cannot necessarily pluck
 	 * the installation out of the queue ( since it may have
@@ -3605,6 +3888,7 @@ void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe)
 	 * main pthread ).
 	 */
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
+	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY) ||
 	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
 		int ret = dplane_nexthop_delete(nhe);
 
@@ -3621,6 +3905,7 @@ void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe)
 			break;
 		case ZEBRA_DPLANE_REQUEST_SUCCESS:
 			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY);
 			break;
 		}
 	}
@@ -3670,7 +3955,18 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL);
 		switch (status) {
 		case ZEBRA_DPLANE_REQUEST_SUCCESS:
-			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+			/*
+			 * For RECEIVED/RECURSIVE NHEs in nhg-fib mode, set
+			 * INSTALLED_FPM_ONLY instead of INSTALLED since they
+			 * are not actually programmed to kernel.
+			 */
+			if (zebra_nhg_fib_enabled &&
+			    (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECEIVED) ||
+			     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))) {
+				SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY);
+			} else {
+				SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+			}
 			zebra_nhg_handle_install(nhe, true);
 
 			/* If daemon nhg, send it an update */
@@ -3678,6 +3974,19 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 				zsend_nhg_notify(nhe->type, nhe->zapi_instance,
 						 nhe->zapi_session, nhe->id,
 						 ZAPI_NHG_INSTALLED);
+
+			/*
+			 * If REINSTALL_FPM_ONLY was set while this install was
+			 * in flight (e.g. a dependent was added/removed while
+			 * QUEUED), trigger another install now so FPM sees the
+			 * updated dependents list. QUEUED is already cleared
+			 * and INSTALLED is now set, so the install condition in
+			 * zebra_nhg_install_kernel() will fire on the
+			 * REINSTALL_FPM_ONLY branch.
+			 */
+			if (zebra_nhg_fib_enabled &&
+			    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL_FPM_ONLY))
+				zebra_nhg_install_kernel(nhe, ZEBRA_ROUTE_MAX);
 			break;
 		case ZEBRA_DPLANE_REQUEST_FAILURE:
 			/*
@@ -3804,6 +4113,7 @@ static void zebra_nhg_mark_keep_entry(struct hash_bucket *bucket, void *arg)
 	struct nhg_hash_entry *nhe = bucket->data;
 
 	UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+	UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY);
 }
 
 /*
@@ -4290,6 +4600,12 @@ void dump_nhg_flags(uint32_t flags, char *buf, size_t len)
 		if (!first)
 			strlcat(buf, ", ", len);
 		strlcat(buf, "Installed", len);
+		first = false;
+	}
+	if (CHECK_FLAG(flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY)) {
+		if (!first)
+			strlcat(buf, ", ", len);
+		strlcat(buf, "Installed (FPM only)", len);
 		first = false;
 	}
 	if (CHECK_FLAG(flags, NEXTHOP_GROUP_QUEUED)) {

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -25,6 +25,12 @@ struct nh_grp {
 	uint16_t weight;
 };
 
+struct nh_grp_full {
+	uint32_t id;
+	uint16_t weight;
+	uint32_t num_direct;
+};
+
 PREDECL_RBTREE_UNIQ(nhg_connected_tree);
 
 /*
@@ -178,6 +184,32 @@ struct nhg_hash_entry {
  * by the NHG layer, not the EVPN-MH layer.
  */
 #define NEXTHOP_GROUP_STALE_FDB (1 << 11)
+
+/*
+ * NHG received from a routing protocol (e.g. BGP) representing the
+ * original unresolved nexthop group (nhe_received).
+ * In --nhg-fib mode, these NHGs enter dplane so FPM can receive them,
+ * but skip kernel installation (dplane_ctx_set_skip_kernel).
+ *
+ * This is distinct from NEXTHOP_GROUP_RECEIVED_FROM_EXTERNAL which marks
+ * kernel-owned NHGs received via netlink. Those are already installed
+ * in kernel and never enter dplane again.
+ * RECEIVED: protocol tells zebra the original NHG, zebra forwards to FPM.
+ * RECEIVED_FROM_EXTERNAL: kernel tells zebra about an existing NHG.
+ */
+#define NEXTHOP_GROUP_RECEIVED (1 << 12)
+
+/*
+ * Reinstall NHG to FPM Only
+ */
+#define NEXTHOP_GROUP_REINSTALL_FPM_ONLY (1 << 13)
+
+/*
+ * NHG delivered to FPM only, not actually installed in kernel.
+ * Used in RIBFIB (--nhg-fib) mode for RECEIVED or RECURSIVE NHEs
+ * that go through skip_kernel path. Community INSTALLED semantics unaffected.
+ */
+#define NEXTHOP_GROUP_INSTALLED_FPM_ONLY (1 << 14)
 };
 
 /* Upper 4 bits of the NHG are reserved for indicating the NHG type */
@@ -395,10 +427,20 @@ extern void zebra_nhg_check_valid(struct nhg_hash_entry *nhe);
 /* Convert nhe depends to a grp context that can be passed around safely */
 extern uint16_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe, int size);
 
+/* Global flag set by zebra --nhg-fib command-line option. */
+extern bool zebra_nhg_fib_enabled;
+
+/* Convert nhe full depends to a grp context that can be passed around safely */
+extern uint32_t zebra_nhg_nhe2grp_full(struct nh_grp_full *grp_full, struct nhg_hash_entry *nhe,
+				       uint32_t max_num);
+
 /* Dataplane install/uninstall */
 extern void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type);
 extern void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe);
 extern void zebra_interface_nhg_reinstall(struct interface *ifp);
+
+/* Mark the received flag for a nexthop group */
+void zebra_nhg_mark_received_flag(struct nhg_hash_entry *nhe);
 
 /* Forward ref of dplane update context type */
 struct zebra_dplane_ctx;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -476,6 +476,18 @@ static void route_entry_attach_ref(struct route_entry *re,
 static void route_entry_update_original_nhe(struct route_entry *re, struct nhg_hash_entry *nhe)
 {
 	re->nhe_received = nhe;
+
+	if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: re (%p) set nhe_received %p, (%pNG) ", __func__, re, nhe, nhe);
+
+	/*
+	 * We only mark the protocol-received flag in nhg-fib mode
+	 * to pass the full NHG to FPM.
+	 * In normal mode, we skip this to avoid breaking other features.
+	 */
+	if (zebra_nhg_fib_enabled)
+		zebra_nhg_mark_received_flag(nhe);
+
 	zebra_nhg_increment_ref(nhe);
 }
 
@@ -694,6 +706,8 @@ void rib_install_kernel(struct route_node *rn, struct route_entry *re,
 	 * Install the resolved nexthop object first.
 	 */
 	zebra_nhg_install_kernel(re->nhe, re->type);
+	if (re->nhe_received && zebra_nhg_fib_enabled)
+		zebra_nhg_install_kernel(re->nhe_received, re->type);
 
 	/*
 	 * If this is a replace to a new RE let the originator of the RE
@@ -2597,6 +2611,10 @@ static void rib_re_nhg_free(struct route_entry *re)
 	 * points to a different NHG than nhe (e.g., after route resolution).
 	 */
 	if (re->nhe_received) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG_DETAIL) {
+			zlog_debug("%s: re (%p) clear nhe_received %p, (%pNG) ", __func__, re,
+				   re->nhe_received, re->nhe_received);
+		}
 		zebra_nhg_decrement_ref(re->nhe_received);
 		re->nhe_received = NULL;
 	}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1224,6 +1224,8 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 			json_object_boolean_true_add(json, "reInstall");
 		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED))
 			json_object_boolean_true_add(json, "installed");
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED_FPM_ONLY))
+			json_object_boolean_true_add(json, "installedFpmOnly");
 		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL))
 			json_object_boolean_true_add(json, "initialDelay");
 		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED))
@@ -3951,6 +3953,8 @@ DEFUN (show_zebra,
 
 	ttable_add_row(table, "Kernel NHG|%s",
 		       zrouter.zav.supports_nhgs ? "Available" : "Unavailable");
+
+	ttable_add_row(table, "NHG FIB mode|%s", zebra_nhg_fib_enabled ? "On" : "Off");
 
 	ttable_add_row(table, "Allow Non FRR route deletion|%s",
 		       zrouter.allow_delete ? "No" : "Yes");


### PR DESCRIPTION
This change extends the zebra dataplane with richer nexthop group information and introduces a new --nhg-fib mode to enable RIB/FIB separation for SONiC FIBconstruction via FPM.

This commit makes the following changes:

1 Richer NHG context in dplane
The dplane NHG context is extended with a nh_grp_full array that captures the complete dependency tree including intermediate recursive nodes. Each entry carries a num_direct count so consumers can reconstruct the recursive hierarchy from the flat array. depends/dependents ID arrays and the NHG flag bitmask are also added so FPM can reconstruct the full forwarding topology.

2 Forwarding received NHGs to dplane
A new NEXTHOP_GROUP_RECEIVED flag is introduced to mark protocol-owned NHGs that should not have their addresses overwritten by zebra resolution. zebra_nhg_mark_received_flag() recursively sets this flag together with NEXTHOP_GROUP_VALID on the NHE and all its depends. The nhe_received field is now installed into the dplane alongside the resolved NHE so FPM providers can access both representations.

3 --nhg-fib command-line option
When --nhg-fib is set, recursive and received NHGs are sent to the dplane with skip_kernel, allowing FPM to perform backwalk and recursive nexthop resolution while keeping them out of the kernel. zebra_nhg_install_kernel() skips zebra_nhg_resolve() for these NHGs so they enter dplane in their original form.

4 FPM-only reinstall on dependent changes
A new NEXTHOP_GROUP_REINSTALL_FPM_ONLY flag is introduced to handle the case where an NHG's dependents list changes (add/remove) while the NHG itself is already installed in the kernel. When triggered, the NHG is re-enqueued to dplane with skip_kernel so FPM receives the updated dependents without redundant kernel programming.If the change occurs while an install is already in-flight (QUEUED), the flag is deferred and picked up in zebra_nhg_dplane_result() upon completion.

Topotests covering the above scenarios have been added.

