### PR TITLE
bgpd: add advertisement-delay to hold route advertisements after startup

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1004,6 +1004,30 @@ bool bgp_update_delay_configured(struct bgp *bgp)
 	return false;
 }
 
+bool bgp_advertisement_delay_applicable(struct bgp *bgp)
+{
+	/* advertisement_delay_over is set when the delay has completed;
+	 * until then, the delay is applicable.
+	 */
+	if (!bgp->advertisement_delay_over)
+		return true;
+	return false;
+}
+
+bool bgp_advertisement_delay_active(struct bgp *bgp)
+{
+	if (bgp->t_advertisement_delay)
+		return true;
+	return false;
+}
+
+bool bgp_advertisement_delay_configured(struct bgp *bgp)
+{
+	if (bgp->v_advertisement_delay)
+		return true;
+	return false;
+}
+
 /* Do the post-processing needed when bgp comes out of the read-only mode
    on ending the update delay. */
 void bgp_update_delay_end(struct bgp *bgp)
@@ -1296,6 +1320,65 @@ static void bgp_establish_wait_timer(struct event *event)
 	bgp = EVENT_ARG(event);
 	event_cancel(&bgp->t_establish_wait);
 	bgp_check_update_delay(bgp);
+}
+
+/* Advertisement-delay timer expiry callback.
+ * When both update-delay and advertisement-delay are configured, route
+ * advertisements are released at max(update-delay, advertisement-delay).
+ * Whichever finishes last clears main_peers_update_hold and calls
+ * bgp_start_routeadv(). The other release point is in bgp_route.c
+ * (bgp_process_main_one, end-of-initial-update path).
+ */
+static void bgp_advertisement_delay_timer(struct event *thread)
+{
+	struct bgp *bgp;
+
+	bgp = EVENT_ARG(thread);
+	event_cancel(&bgp->t_advertisement_delay);
+	bgp->advertisement_delay_over = 1;
+
+	/* Update-delay is still in progress or best-path/zebra post-processing
+	 * has not completed yet. Route advertisements will be released from
+	 * bgp_route.c once update-delay post-processing finishes.
+	 */
+	if (bgp_update_delay_active(bgp) || bgp->main_zebra_update_hold) {
+		zlog_info("Advertisement delay expired for %s, update-delay processing not yet complete",
+			  bgp->name_pretty);
+		return;
+	}
+
+	zlog_info("Advertisement delay ended for %s.", bgp->name_pretty);
+
+	frr_timestamp(3, bgp->advertisement_delay_resume_time,
+		      sizeof(bgp->advertisement_delay_resume_time));
+
+	bgp->main_peers_update_hold = 0;
+	bgp_start_routeadv(bgp);
+}
+
+/*
+ * Begin advertisement-delay.
+ * Set the hold flag and start the timer.
+ */
+static void bgp_advertisement_delay_begin(struct bgp *bgp)
+{
+	bgp->advertisement_delay_started = 1;
+	bgp->main_peers_update_hold = 1;
+	event_add_timer(bm->master, bgp_advertisement_delay_timer, bgp, bgp->v_advertisement_delay,
+			&bgp->t_advertisement_delay);
+	zlog_info("Advertisement delay started - %d seconds for %s", bgp->v_advertisement_delay,
+		  bgp->name_pretty);
+}
+
+/*
+ * Handle first peer Established for advertisement-delay.
+ */
+static void bgp_advertisement_delay_process_status_change(struct peer *peer)
+{
+	struct bgp *bgp = peer->bgp;
+
+	if (peer_established(peer->connection) && !bgp->advertisement_delay_started)
+		bgp_advertisement_delay_begin(bgp);
 }
 
 /* Steps to begin the update delay:
@@ -1963,11 +2046,20 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 			bgp->maxmed_onstartup_over = 1;
 	}
 
-	/* Check for GR restarter or update-delay processing. */
+	/* Check for GR restarter, update-delay, or advertisement-delay.
+	 * When GR is not applicable, both update-delay and advertisement-delay
+	 * can run independently.
+	 */
 	if (gr_path_select_deferral_applicable(bgp))
 		bgp_gr_process_peer_status_change(peer);
-	else if (bgp_update_delay_configured(bgp) && bgp_update_delay_applicable(bgp))
-		bgp_update_delay_process_status_change(peer);
+	else {
+		if (bgp_update_delay_configured(bgp) && bgp_update_delay_applicable(bgp))
+			bgp_update_delay_process_status_change(peer);
+
+		if (bgp_advertisement_delay_configured(bgp) &&
+		    bgp_advertisement_delay_applicable(bgp))
+			bgp_advertisement_delay_process_status_change(peer);
+	}
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s fd %d went from %s to %s for %s", peer->host, connection->fd,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4105,9 +4105,22 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 			if (bgp_fibupd_safi(safi))
 				bgp_zebra_announce_table(bgp, afi, safi);
 		}
-		bgp->main_peers_update_hold = 0;
 
-		bgp_start_routeadv(bgp);
+		/* When both update-delay and advertisement-delay are
+		 * configured, advertisements are released at
+		 * max(update-delay, advertisement-delay). If ad-delay
+		 * is still running, keep holding; otherwise release.
+		 * The other release point is
+		 * bgp_advertisement_delay_timer().
+		 */
+		if (bgp_advertisement_delay_configured(bgp) &&
+		    bgp_advertisement_delay_active(bgp)) {
+			zlog_info("%s: advertisement-delay timer still running, holding route advertisements",
+				  bgp->name_pretty);
+		} else {
+			bgp->main_peers_update_hold = 0;
+			bgp_start_routeadv(bgp);
+		}
 		return;
 	}
 
@@ -4188,7 +4201,8 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 		}
 
 		/* If there is a change of interest to peers, reannounce the
-		 * route. */
+		 * route.
+		 */
 		if (CHECK_FLAG(old_select->flags, BGP_PATH_ATTR_CHANGED) ||
 		    CHECK_FLAG(dest->flags, BGP_NODE_LABEL_CHANGED) ||
 		    bgp_zebra_has_route_changed(old_select)) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1286,8 +1286,12 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 		}
 
 		/* This is to apply read-only mode on this clear. */
-		if (stype == BGP_CLEAR_SOFT_NONE)
+		if (stype == BGP_CLEAR_SOFT_NONE) {
 			bgp->update_delay_over = 0;
+			event_cancel(&bgp->t_advertisement_delay);
+			bgp->advertisement_delay_started = 0;
+			bgp->advertisement_delay_over = 0;
+		}
 
 		if (afi_safi_unspec)
 			bgp_clearing_batch_end_event_start(bgp);
@@ -2571,6 +2575,13 @@ void bgp_config_write_update_delay(struct vty *vty, struct bgp *bgp)
 	}
 }
 
+void bgp_config_write_advertisement_delay(struct vty *vty, struct bgp *bgp)
+{
+	if (bgp_advertisement_delay_configured(bgp) &&
+	    bgp->v_advertisement_delay != bm->v_advertisement_delay)
+		vty_out(vty, " advertisement-delay %d\n", bgp->v_advertisement_delay);
+}
+
 /* Global update-delay configuration */
 DEFPY (bgp_global_update_delay,
        bgp_global_update_delay_cmd,
@@ -2620,6 +2631,94 @@ DEFPY (no_bgp_update_delay,
 	return bgp_update_delay_deconfig_vty(vty);
 }
 
+/* Global advertisement-delay configuration */
+DEFPY(bgp_global_advertisement_delay, bgp_global_advertisement_delay_cmd,
+      "bgp advertisement-delay (1-3600)$delay",
+      BGP_STR
+      "Hold route advertisements to peers for configured seconds after first peer establishes\n"
+      "Delay in seconds\n")
+{
+	struct listnode *node, *nnode;
+	struct bgp *bgp;
+
+	bm->v_advertisement_delay = delay;
+
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+		bgp->v_advertisement_delay = bm->v_advertisement_delay;
+
+	return CMD_SUCCESS;
+}
+
+/* Global advertisement-delay deconfiguration */
+DEFPY(no_bgp_global_advertisement_delay, no_bgp_global_advertisement_delay_cmd,
+      "no bgp advertisement-delay [(1-3600)]",
+      NO_STR BGP_STR
+      "Hold route advertisements to peers for configured seconds after first peer establishes\n"
+      "Delay in seconds\n")
+{
+	struct listnode *node, *nnode;
+	struct bgp *bgp;
+
+	bm->v_advertisement_delay = BGP_ADVERTISEMENT_DELAY_DEFAULT;
+
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		bgp->v_advertisement_delay = BGP_ADVERTISEMENT_DELAY_DEFAULT;
+		if (bgp->advertisement_delay_started && !bgp->advertisement_delay_over) {
+			event_cancel(&bgp->t_advertisement_delay);
+			bgp->advertisement_delay_started = 0;
+			bgp->advertisement_delay_over = 0;
+			if (!bgp_update_delay_active(bgp) && !bgp->main_zebra_update_hold) {
+				bgp->main_peers_update_hold = 0;
+				bgp_start_routeadv(bgp);
+			}
+		} else {
+			event_cancel(&bgp->t_advertisement_delay);
+			bgp->advertisement_delay_started = 0;
+			bgp->advertisement_delay_over = 0;
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
+/* Per-instance advertisement-delay configuration */
+DEFPY(bgp_advertisement_delay, bgp_advertisement_delay_cmd, "advertisement-delay (1-3600)$delay",
+      "Hold route advertisements to peers for configured seconds after first peer establishes\n"
+      "Delay in seconds\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+
+	bgp->v_advertisement_delay = delay;
+
+	return CMD_SUCCESS;
+}
+
+/* Per-instance advertisement-delay deconfiguration */
+DEFPY(no_bgp_advertisement_delay, no_bgp_advertisement_delay_cmd,
+      "no advertisement-delay [(1-3600)]",
+      NO_STR
+      "Hold route advertisements to peers for configured seconds after first peer establishes\n"
+      "Delay in seconds\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+
+	bgp->v_advertisement_delay = BGP_ADVERTISEMENT_DELAY_DEFAULT;
+	if (bgp->advertisement_delay_started && !bgp->advertisement_delay_over) {
+		event_cancel(&bgp->t_advertisement_delay);
+		bgp->advertisement_delay_started = 0;
+		bgp->advertisement_delay_over = 0;
+		if (!bgp_update_delay_active(bgp) && !bgp->main_zebra_update_hold) {
+			bgp->main_peers_update_hold = 0;
+			bgp_start_routeadv(bgp);
+		}
+	} else {
+		event_cancel(&bgp->t_advertisement_delay);
+		bgp->advertisement_delay_started = 0;
+		bgp->advertisement_delay_over = 0;
+	}
+
+	return CMD_SUCCESS;
+}
 
 static int bgp_wpkt_quanta_config_vty(struct vty *vty, uint32_t quanta,
 				      bool set)
@@ -12546,6 +12645,9 @@ DEFPY(show_bgp_router,
 				    zebra_announce_count(&bm->zebra_announce_early_head));
 		json_object_int_add(json, "bgpUpdateDelayTime", bm->v_update_delay);
 		json_object_int_add(json, "bgpEstablishWaitTime", bm->v_establish_wait);
+		if (bm->v_advertisement_delay != BGP_ADVERTISEMENT_DELAY_DEFAULT)
+			json_object_int_add(json, "bgpAdvertisementDelayTime",
+					    bm->v_advertisement_delay);
 		json_object_int_add(json, "bgpRmapDelayTimer", bm->rmap_update_timer);
 		json_object_int_add(json, "bgpRmapDelayTimerRemaining",
 				    event_timer_remain_second(bm->t_rmap_update));
@@ -12561,6 +12663,9 @@ DEFPY(show_bgp_router,
 		vty_out(vty, "BGP Global Update Delay Timers:\n");
 		vty_out(vty, "  Update Delay Time: %ds\n", bm->v_update_delay);
 		vty_out(vty, "  Establish Wait Time: %ds\n", bm->v_establish_wait);
+		if (bm->v_advertisement_delay != BGP_ADVERTISEMENT_DELAY_DEFAULT)
+			vty_out(vty, "  Advertisement Delay Time: %ds\n",
+				bm->v_advertisement_delay);
 
 		vty_out(vty, "BGP route-map Delay Timer: %ds (remaining: %lds)\n",
 			bm->rmap_update_timer, event_timer_remain_second(bm->t_rmap_update));
@@ -13336,6 +13441,105 @@ static bool bgp_show_summary_is_peer_filtered(struct peer *peer,
  * sure `Desc` is the latest column to show because it can contain
  * whitespaces and the whole output will be tricky.
  */
+static void bgp_show_summary_update_delay(struct vty *vty, struct bgp *bgp,
+					  json_object *json, bool use_json)
+{
+	if (!bgp_update_delay_configured(bgp))
+		return;
+
+	if (use_json) {
+		json_object_int_add(json, "updateDelayLimit",
+				    bgp->v_update_delay);
+		if (bgp->v_update_delay != bgp->v_establish_wait)
+			json_object_int_add(json, "updateDelayEstablishWait",
+					    bgp->v_establish_wait);
+		if (bgp_update_delay_active(bgp)) {
+			json_object_string_add(json,
+					       "updateDelayFirstNeighbor",
+					       bgp->update_delay_begin_time);
+			json_object_boolean_true_add(json,
+						     "updateDelayInProgress");
+		} else if (bgp->update_delay_over) {
+			json_object_string_add(json,
+					       "updateDelayFirstNeighbor",
+					       bgp->update_delay_begin_time);
+			json_object_string_add(json,
+					       "updateDelayBestpathResumed",
+					       bgp->update_delay_end_time);
+			json_object_string_add(
+				json, "updateDelayZebraUpdateResume",
+				bgp->update_delay_zebra_resume_time);
+			if (bgp->update_delay_peers_resume_time[0] != '\0')
+				json_object_string_add(
+					json, "updateDelayPeerUpdateResume",
+					bgp->update_delay_peers_resume_time);
+		}
+	} else {
+		vty_out(vty,
+			"Read-only mode update-delay limit: %d seconds\n",
+			bgp->v_update_delay);
+		if (bgp->v_update_delay != bgp->v_establish_wait)
+			vty_out(vty,
+				"                   Establish wait: %d seconds\n",
+				bgp->v_establish_wait);
+		if (bgp_update_delay_active(bgp)) {
+			vty_out(vty,
+				"  First neighbor established: %s\n",
+				bgp->update_delay_begin_time);
+			vty_out(vty, "  Delay in progress\n");
+		} else if (bgp->update_delay_over) {
+			vty_out(vty,
+				"  First neighbor established: %s\n",
+				bgp->update_delay_begin_time);
+			vty_out(vty,
+				"          Best-paths resumed: %s\n",
+				bgp->update_delay_end_time);
+			vty_out(vty,
+				"        zebra update resumed: %s\n",
+				bgp->update_delay_zebra_resume_time);
+			if (bgp->update_delay_peers_resume_time[0] != '\0')
+				vty_out(vty,
+					"        peers update resumed: %s\n",
+					bgp->update_delay_peers_resume_time);
+		}
+	}
+}
+
+static void bgp_show_summary_advertisement_delay(struct vty *vty,
+						  struct bgp *bgp,
+						  json_object *json,
+						  bool use_json)
+{
+	if (!bgp_advertisement_delay_configured(bgp))
+		return;
+
+	if (use_json) {
+		json_object_int_add(json, "advertisementDelay",
+				    bgp->v_advertisement_delay);
+		if (bgp_advertisement_delay_active(bgp)) {
+			json_object_boolean_true_add(
+				json, "advertisementDelayInProgress");
+			json_object_int_add(
+				json, "advertisementDelayRemainingSeconds",
+				event_timer_remain_second(
+					bgp->t_advertisement_delay));
+		} else if (bgp->advertisement_delay_resume_time[0] != '\0')
+			json_object_string_add(
+				json, "advertisementDelayResumeTime",
+				bgp->advertisement_delay_resume_time);
+	} else {
+		vty_out(vty, "Advertisement delay: %d seconds\n",
+			bgp->v_advertisement_delay);
+		if (bgp_advertisement_delay_active(bgp))
+			vty_out(vty, "  %lu seconds remaining\n",
+				event_timer_remain_second(
+					bgp->t_advertisement_delay));
+		else if (bgp->advertisement_delay_resume_time[0] != '\0')
+			vty_out(vty, "  advertisements resumed: %s\n",
+				bgp->advertisement_delay_resume_time);
+	}
+}
+
 static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 			    struct peer *fpeer, enum peer_asn_type as_type,
 			    as_t as, uint16_t show_flags)
@@ -13507,81 +13711,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				vty_out(vty, "\n");
 			}
 
-			if (bgp_update_delay_configured(bgp)) {
-				if (use_json) {
-					json_object_int_add(
-						json, "updateDelayLimit",
-						bgp->v_update_delay);
+			bgp_show_summary_update_delay(vty, bgp, json,
+						     use_json);
 
-					if (bgp->v_update_delay
-					    != bgp->v_establish_wait)
-						json_object_int_add(
-							json,
-							"updateDelayEstablishWait",
-							bgp->v_establish_wait);
-
-					if (bgp_update_delay_active(bgp)) {
-						json_object_string_add(
-							json,
-							"updateDelayFirstNeighbor",
-							bgp->update_delay_begin_time);
-						json_object_boolean_true_add(
-							json,
-							"updateDelayInProgress");
-					} else {
-						if (bgp->update_delay_over) {
-							json_object_string_add(
-								json,
-								"updateDelayFirstNeighbor",
-								bgp->update_delay_begin_time);
-							json_object_string_add(
-								json,
-								"updateDelayBestpathResumed",
-								bgp->update_delay_end_time);
-							json_object_string_add(
-								json,
-								"updateDelayZebraUpdateResume",
-								bgp->update_delay_zebra_resume_time);
-							json_object_string_add(
-								json,
-								"updateDelayPeerUpdateResume",
-								bgp->update_delay_peers_resume_time);
-						}
-					}
-				} else {
-					vty_out(vty,
-						"Read-only mode update-delay limit: %d seconds\n",
-						bgp->v_update_delay);
-					if (bgp->v_update_delay
-					    != bgp->v_establish_wait)
-						vty_out(vty,
-							"                   Establish wait: %d seconds\n",
-							bgp->v_establish_wait);
-
-					if (bgp_update_delay_active(bgp)) {
-						vty_out(vty,
-							"  First neighbor established: %s\n",
-							bgp->update_delay_begin_time);
-						vty_out(vty,
-							"  Delay in progress\n");
-					} else {
-						if (bgp->update_delay_over) {
-							vty_out(vty,
-								"  First neighbor established: %s\n",
-								bgp->update_delay_begin_time);
-							vty_out(vty,
-								"          Best-paths resumed: %s\n",
-								bgp->update_delay_end_time);
-							vty_out(vty,
-								"        zebra update resumed: %s\n",
-								bgp->update_delay_zebra_resume_time);
-							vty_out(vty,
-								"        peers update resumed: %s\n",
-								bgp->update_delay_peers_resume_time);
-						}
-					}
-				}
-			}
+			bgp_show_summary_advertisement_delay(vty, bgp, json,
+							     use_json);
 
 			if (use_json) {
 				if (bgp_maxmed_onstartup_configured(bgp)
@@ -20933,6 +21067,9 @@ int bgp_config_write(struct vty *vty)
 		vty_out(vty, "\n");
 	}
 
+	if (bm->v_advertisement_delay != BGP_ADVERTISEMENT_DELAY_DEFAULT)
+		vty_out(vty, "bgp advertisement-delay %d\n", bm->v_advertisement_delay);
+
 	if (bm->wait_for_fib) {
 		if (bm->suppress_fib_adv_delay != BGP_DEFAULT_SUPPRESS_FIB_ADV_DELAY)
 			vty_out(vty, "bgp suppress-fib-pending %u\n",
@@ -21213,6 +21350,9 @@ int bgp_config_write(struct vty *vty)
 
 		/* BGP update-delay. */
 		bgp_config_write_update_delay(vty, bgp);
+
+		/* BGP advertisement-delay. */
+		bgp_config_write_advertisement_delay(vty, bgp);
 
 		if (bgp->v_maxmed_onstartup
 		    != BGP_MAXMED_ONSTARTUP_UNCONFIGURED) {
@@ -22008,6 +22148,10 @@ void bgp_vty_init(void)
 	install_element(CONFIG_NODE, &bgp_global_update_delay_cmd);
 	install_element(CONFIG_NODE, &no_bgp_global_update_delay_cmd);
 
+	/* global bgp advertisement-delay command */
+	install_element(CONFIG_NODE, &bgp_global_advertisement_delay_cmd);
+	install_element(CONFIG_NODE, &no_bgp_global_advertisement_delay_cmd);
+
 	/* global bgp graceful-shutdown command */
 	install_element(CONFIG_NODE, &bgp_graceful_shutdown_cmd);
 	install_element(CONFIG_NODE, &no_bgp_graceful_shutdown_cmd);
@@ -22095,6 +22239,10 @@ void bgp_vty_init(void)
 	/* bgp update-delay command */
 	install_element(BGP_NODE, &bgp_update_delay_cmd);
 	install_element(BGP_NODE, &no_bgp_update_delay_cmd);
+
+	/* bgp advertisement-delay command */
+	install_element(BGP_NODE, &bgp_advertisement_delay_cmd);
+	install_element(BGP_NODE, &no_bgp_advertisement_delay_cmd);
 
 	install_element(BGP_NODE, &bgp_wpkt_quanta_cmd);
 	install_element(BGP_NODE, &bgp_rpkt_quanta_cmd);

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -162,6 +162,7 @@ extern int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,
 		       enum bgp_instance_type inst_type, const char *as_pretty,
 		       enum asnotation_mode asnotation);
 extern void bgp_config_write_update_delay(struct vty *vty, struct bgp *bgp);
+extern void bgp_config_write_advertisement_delay(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_wpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_rpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_listen(struct vty *vty, struct bgp *bgp);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3813,6 +3813,7 @@ peer_init:
 
 	bgp->v_update_delay = bm->v_update_delay;
 	bgp->v_establish_wait = bm->v_establish_wait;
+	bgp->v_advertisement_delay = bm->v_advertisement_delay;
 	bgp->default_local_pref = BGP_DEFAULT_LOCAL_PREF;
 	bgp->default_subgroup_pkt_queue_max =
 		BGP_DEFAULT_SUBGROUP_PKT_QUEUE_MAX;
@@ -4431,6 +4432,7 @@ int bgp_delete(struct bgp *bgp)
 	event_cancel(&bgp->t_maxmed_onstartup);
 	event_cancel(&bgp->t_update_delay);
 	event_cancel(&bgp->t_establish_wait);
+	event_cancel(&bgp->t_advertisement_delay);
 
 	/* If the clearing event is scheduled, there's an extra ref to
 	 * this 'bgp' - ensure we unlock.

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -191,6 +191,8 @@ struct bgp_master {
 	/* global update-delay timer values */
 	uint16_t v_update_delay;
 	uint16_t v_establish_wait;
+	/* global advertisement-delay timer value */
+	uint16_t v_advertisement_delay;
 
 	uint32_t flags;
 #define BM_FLAG_GRACEFUL_SHUTDOWN        (1 << 0)
@@ -681,6 +683,14 @@ struct bgp {
 	uint32_t restarted_peers;
 	uint32_t received_eors;
 #define BGP_UPDATE_DELAY_DEFAULT 0
+#define BGP_ADVERTISEMENT_DELAY_DEFAULT 0
+
+	/* Advertisement delay (hold route advertisements after first peer establishes) */
+	struct event *t_advertisement_delay;
+	bool advertisement_delay_over;
+	bool advertisement_delay_started;
+	uint16_t v_advertisement_delay;
+	char advertisement_delay_resume_time[64];
 
 	/* Reference bandwidth for BGP link-bandwidth. Used when
 	 * the LB value has to be computed based on some other
@@ -2745,6 +2755,9 @@ extern void bgp_listen_limit_unset(struct bgp *bgp);
 
 extern bool bgp_update_delay_active(struct bgp *bgp);
 extern bool bgp_update_delay_configured(struct bgp *bgp);
+extern bool bgp_advertisement_delay_active(struct bgp *bgp);
+extern bool bgp_advertisement_delay_applicable(struct bgp *bgp);
+extern bool bgp_advertisement_delay_configured(struct bgp *bgp);
 extern bool bgp_afi_safi_peer_exists(struct bgp *bgp, afi_t afi, safi_t safi);
 extern void peer_as_change(struct peer *peer, as_t as,
 			   enum peer_asn_type as_type, const char *as_str);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1573,6 +1573,104 @@ Redistribute routes from a routing table number into BGP.
 
    Default max-delay is 0, i.e. the feature is off by default.
 
+
+.. clicmd:: bgp advertisement-delay (1-3600)
+
+   With ``update-delay``, both FIB programming and advertisements are deferred,
+   meaning the restarting router cannot forward local traffic until the delay
+   completes.  ``advertisement-delay`` takes a different approach: it allows
+   best-path selection and FIB programming to proceed normally so local
+   forwarding works immediately, while holding only the advertisements to
+   prevent the router from attracting remote traffic before it has a complete
+   routing state.
+
+   After a non-graceful restart, peers detect the session loss and withdraw
+   routes to this router, so the receiver has no routes to this router at all.
+   ``advertisement-delay`` controls when this router re-announces itself,
+   ensuring it only attracts traffic once it has fully converged.  When
+   graceful-restart is active, ``advertisement-delay`` is not started -- the
+   GR restarter path handles route retention separately.
+
+   This feature holds route advertisements to peers for a configured number of
+   seconds after the first peer reaches Established status.  The delay applies
+   to all address families (AFI/SAFI).  Note that this command is configured at
+   the global level and applies to all bgp instances/vrfs.  It cannot be used
+   at the same time as the per-vrf ``advertisement-delay`` command described
+   below.  The global and per-vrf approaches are mutually exclusive.
+
+   When the first peer reaches Established, a timer for the configured delay is
+   started.  During this period, best-path selection and FIB programming proceed
+   normally, but route advertisements to peers are held.  When the timer
+   expires, advertisements are released to all established peers.
+
+   When both ``update-delay`` and ``advertisement-delay`` are configured, both
+   timers start when the first peer reaches Established.  Route advertisements
+   are released at ``max(update-delay, advertisement-delay)``; whichever
+   finishes last triggers the release.
+
+   This feature runs after startup and also re-triggers on
+   ``clear bgp *``, similar to ``update-delay``.
+   It does not re-trigger if peers flap after the delay has completed.
+
+   Changing or removing this configuration while the timer is running takes
+   effect from the next startup or next ``clear bgp *``.
+
+   This parameter is unrelated to the per-neighbor or per-peer-group
+   ``advertisement-interval``, which controls the minimum time between
+   individual route advertisements to a specific peer.
+
+   Default max-delay is 0, i.e. the feature is off by default.
+
+
+.. clicmd:: advertisement-delay (1-3600)
+
+   With ``update-delay``, both FIB programming and advertisements are deferred,
+   meaning the restarting router cannot forward local traffic until the delay
+   completes.  ``advertisement-delay`` takes a different approach: it allows
+   best-path selection and FIB programming to proceed normally so local
+   forwarding works immediately, while holding only the advertisements to
+   prevent the router from attracting remote traffic before it has a complete
+   routing state.
+
+   After a non-graceful restart, peers detect the session loss and withdraw
+   routes to this router, so the receiver has no routes to this router at all.
+   ``advertisement-delay`` controls when this router re-announces itself,
+   ensuring it only attracts traffic once it has fully converged.  When
+   graceful-restart is active, ``advertisement-delay`` is not started -- the
+   GR restarter path handles route retention separately.
+
+   This feature holds route advertisements to peers for a configured number of
+   seconds after the first peer reaches Established status.  Note that this
+   command is configured under the specific bgp instance/vrf that the feature
+   is enabled for.  It cannot be used at the same time as the global
+   ``bgp advertisement-delay`` described above.  The global and per-vrf
+   approaches are mutually exclusive.
+
+   When the first peer reaches Established, a timer for the configured delay is
+   started.  During this period, best-path selection and FIB programming proceed
+   normally, but route advertisements to peers are held.  When the timer
+   expires, advertisements are released to all established peers.
+
+   When both ``update-delay`` and ``advertisement-delay`` are configured, both
+   timers start when the first peer reaches Established.  Route advertisements
+   are released at ``max(update-delay, advertisement-delay)``; whichever
+   finishes last triggers the release.
+
+   The delay applies to all address families (AFI/SAFI).
+
+   This feature runs after startup and also re-triggers on
+   ``clear bgp *``, similar to ``update-delay``.
+   It does not re-trigger if peers flap after the delay has completed.
+
+   Changing or removing this configuration while the timer is running takes
+   effect from the next startup or next ``clear bgp *``.
+
+   This parameter is unrelated to the per-neighbor or per-peer-group
+   ``advertisement-interval``, which controls the minimum time between
+   individual route advertisements to a specific peer.
+
+   Default max-delay is 0, i.e. the feature is off by default.
+
 .. clicmd:: table-map ROUTE-MAP-NAME
 
    This feature is used to apply a route-map on route updates from BGP to

--- a/tests/topotests/bgp_advertisement_delay/r1/frr.conf
+++ b/tests/topotests/bgp_advertisement_delay/r1/frr.conf
@@ -1,0 +1,17 @@
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.12.1/24
+!
+ip forwarding
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ timers bgp 3 9
+ neighbor 192.168.12.2 remote-as 65002
+ neighbor 192.168.12.2 timers connect 10
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_advertisement_delay/r2/frr.conf
+++ b/tests/topotests/bgp_advertisement_delay/r2/frr.conf
@@ -1,0 +1,16 @@
+interface r2-eth0
+ ip address 192.168.12.2/24
+!
+interface r2-eth1
+ ip address 192.168.23.1/24
+!
+ip forwarding
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ timers bgp 3 9
+ neighbor 192.168.12.1 remote-as 65001
+ neighbor 192.168.23.2 remote-as 65003
+ neighbor 192.168.12.1 timers connect 10
+ neighbor 192.168.23.2 timers connect 10
+!

--- a/tests/topotests/bgp_advertisement_delay/r3/frr.conf
+++ b/tests/topotests/bgp_advertisement_delay/r3/frr.conf
@@ -1,0 +1,17 @@
+interface lo
+ ip address 172.16.253.254/32
+!
+interface r3-eth0
+ ip address 192.168.23.2/24
+!
+ip forwarding
+!
+router bgp 65003
+ no bgp ebgp-requires-policy
+ timers bgp 3 9
+ neighbor 192.168.23.1 remote-as 65002
+ neighbor 192.168.23.1 timers connect 10
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_advertisement_delay/test_bgp_advertisement_delay.py
+++ b/tests/topotests/bgp_advertisement_delay/test_bgp_advertisement_delay.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_advertisement_delay.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Karthikeya Venkat Muppalla <kmuppalla@nvidia.com>
+#
+
+"""
+Test the bgp advertisement-delay feature that holds route advertisements
+to peers for a configured number of seconds after the first peer reaches
+Established state.
+
+r1 -- r2 -- r3
+
+r2 is UUT and peers with r1 and r3 in the default BGP instance.
+r1 and r3 each have a loopback and redistribute connected.
+
+Test cases:
+
+1. Initial convergence with no delay configured -- routes exchanged promptly.
+2. Configure advertisement-delay, verify show bgp router json.
+3. Clear bgp, verify advertisement-delay in progress with pfxSnt=0.
+4. Verify r2 installs routes in RIB during the delay (only ads are held).
+5. Wait for delay to complete, verify pfxSnt>0 and advertisementDelayResumeTime.
+6. Verify r3 learns route from r1 via r2 after delay.
+7. Configure both update-delay and advertisement-delay (ad > ud), clear bgp,
+   verify ads are held until advertisement-delay ends even though update-delay
+   finishes earlier.
+8. Re-trigger advertisement-delay on clear ip bgp *.
+9. Remove advertisement-delay, verify routes advertised promptly.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2"), "s2": ("r2", "r3")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_initial_convergence():
+    """No delays configured -- routes are exchanged promptly."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "peers": {
+                    "192.168.12.1": {"state": "Established"},
+                    "192.168.23.2": {"state": "Established"},
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Peers did not reach Established state"
+
+    def _bgp_check_route_install():
+        output = json.loads(r2.vtysh_cmd("show ip route 172.16.255.254/32 json"))
+        expected = {"172.16.255.254/32": [{"protocol": "bgp"}]}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_check_route_install)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "r2 did not install route from r1 without any delays"
+
+
+def test_bgp_advertisement_delay_show_router_json():
+    """Configure advertisement-delay and verify show bgp router json."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.vtysh_cmd(
+        """
+          configure terminal
+            bgp advertisement-delay 15
+        """
+    )
+
+    def _check_router_json():
+        output = json.loads(r2.vtysh_cmd("show bgp router json"))
+        expected = {"bgpAdvertisementDelayTime": 15}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_router_json)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "bgpAdvertisementDelayTime not shown in show bgp router json"
+
+    def _check_summary_json():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        expected = {"ipv4Unicast": {"advertisementDelay": 15}}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_summary_json)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "advertisementDelay not shown in show bgp summary json"
+
+
+def test_bgp_advertisement_delay_in_progress():
+    """Clear bgp and verify advertisement-delay is in progress with pfxSnt=0."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.vtysh_cmd("clear ip bgp *")
+
+    def _check_delay_active_with_peers():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+
+        if not ipv4.get("advertisementDelayInProgress"):
+            return "advertisementDelayInProgress not set"
+
+        peers = ipv4.get("peers", {})
+        established_with_zero = False
+        for peer_addr, peer_data in peers.items():
+            if peer_data.get("state") == "Established":
+                if peer_data.get("pfxSnt", -1) != 0:
+                    return "pfxSnt is not 0 for {} during delay".format(peer_addr)
+                established_with_zero = True
+
+        if not established_with_zero:
+            return "No Established peers found yet"
+
+        return None
+
+    test_func = functools.partial(_check_delay_active_with_peers)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    assert result is None, (
+        "advertisement-delay not active with Established peers: {}".format(result)
+    )
+
+
+def test_bgp_advertisement_delay_route_installed_during_delay():
+    """r2 installs routes in its RIB even while advertisement-delay is active."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    def _check_route_in_rib():
+        output = json.loads(r2.vtysh_cmd("show ip route 172.16.255.254/32 json"))
+        expected = {"172.16.255.254/32": [{"protocol": "bgp"}]}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_route_in_rib)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, (
+        "r2 should install routes in RIB during advertisement-delay"
+    )
+
+
+def test_bgp_advertisement_delay_completed():
+    """Wait for advertisement-delay to end, verify pfxSnt>0."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    def _check_delay_completed():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+
+        if ipv4.get("advertisementDelayInProgress"):
+            return "advertisement-delay still in progress"
+
+        if "advertisementDelayResumeTime" not in ipv4:
+            return "advertisementDelayResumeTime not set"
+
+        peers = ipv4.get("peers", {})
+        for peer_data in peers.values():
+            if (
+                peer_data.get("state") == "Established"
+                and peer_data.get("pfxSnt", 0) > 0
+            ):
+                return None
+        return "No peer has pfxSnt > 0 after delay completed"
+
+    test_func = functools.partial(_check_delay_completed)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "advertisement-delay did not complete properly: {}".format(result)
+    )
+
+
+def test_bgp_advertisement_delay_route_on_peer():
+    """After delay, r3 learns route from r1 via r2."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r3 = tgen.gears["r3"]
+
+    def _check_route_on_r3():
+        output = json.loads(r3.vtysh_cmd("show ip route 172.16.255.254/32 json"))
+        expected = {"172.16.255.254/32": [{"protocol": "bgp"}]}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_route_on_r3)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "r3 did not learn 172.16.255.254/32 from r1 via r2"
+
+
+def test_bgp_update_delay_with_advertisement_delay():
+    """Both update-delay and advertisement-delay (ad > ud).
+
+    With all peers up, update-delay ends on EOR quickly (~2 s).
+    Advertisement-delay keeps running until its timer expires.
+    Advertisements are sent only after advertisement-delay ends.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.vtysh_cmd(
+        """
+          configure terminal
+            router bgp 65002
+              update-delay 10
+        """
+    )
+    r2.vtysh_cmd(
+        """
+          configure terminal
+            bgp advertisement-delay 20
+        """
+    )
+
+    r2.vtysh_cmd("clear ip bgp *")
+
+    def _check_both_configured():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "updateDelayLimit": 10,
+                "advertisementDelay": 20,
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_both_configured)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Both timers not shown in show bgp summary json"
+
+    def _check_ad_delay_holding_after_ud():
+        """update-delay done (EOR received), ad-delay still active, pfxSnt=0."""
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+
+        if ipv4.get("updateDelayInProgress"):
+            return "update-delay still in progress, waiting for EOR"
+
+        if not ipv4.get("advertisementDelayInProgress"):
+            return "advertisement-delay not in progress"
+
+        peers = ipv4.get("peers", {})
+        for peer_addr, peer_data in peers.items():
+            if peer_data.get("state") == "Established":
+                if peer_data.get("pfxSnt", -1) != 0:
+                    return "pfxSnt not 0 for {} while ad-delay active".format(
+                        peer_addr
+                    )
+        established = [p for p in peers.values() if p.get("state") == "Established"]
+        if not established:
+            return "No peers Established yet"
+        return None
+
+    test_func = functools.partial(_check_ad_delay_holding_after_ud)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, (
+        "ad-delay should hold ads after update-delay ends: {}".format(result)
+    )
+
+    def _check_both_completed():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+        if ipv4.get("advertisementDelayInProgress"):
+            return "advertisement-delay still in progress"
+        if "advertisementDelayResumeTime" not in ipv4:
+            return "advertisementDelayResumeTime not set"
+        peers = ipv4.get("peers", {})
+        for peer_data in peers.values():
+            if (
+                peer_data.get("state") == "Established"
+                and peer_data.get("pfxSnt", 0) > 0
+            ):
+                return None
+        return "No peer has pfxSnt > 0"
+
+    test_func = functools.partial(_check_both_completed)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Both timers did not complete properly: {}".format(result)
+
+
+def test_bgp_advertisement_delay_retrigger():
+    """Clear bgp again -- advertisement-delay re-triggers."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.vtysh_cmd("clear ip bgp *")
+
+    def _check_retrigger():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "advertisementDelayInProgress": True,
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_retrigger)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    assert result is None, "advertisement-delay did not re-trigger on clear bgp"
+
+
+def test_bgp_no_advertisement_delay():
+    """Remove advertisement-delay -- routes advertised promptly."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    def _wait_delay_done():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+        if ipv4.get("advertisementDelayInProgress"):
+            return "still in progress"
+        return None
+
+    test_func = functools.partial(_wait_delay_done)
+    topotest.run_and_expect(test_func, None, count=40, wait=1)
+
+    r2.vtysh_cmd(
+        """
+          configure terminal
+            no bgp advertisement-delay
+            router bgp 65002
+              no update-delay
+        """
+    )
+
+    r2.vtysh_cmd("clear ip bgp *")
+
+    def _check_no_delay():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+
+        if "advertisementDelay" in ipv4:
+            return "advertisementDelay should not be present"
+
+        peers = ipv4.get("peers", {})
+        for peer_data in peers.values():
+            if (
+                peer_data.get("state") == "Established"
+                and peer_data.get("pfxSnt", 0) > 0
+            ):
+                return None
+        return "No peer has pfxSnt > 0 yet"
+
+    test_func = functools.partial(_check_no_delay)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "Routes not advertised promptly without advertisement-delay: {}".format(result)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary
Add a new `advertisement-delay` CLI that holds route advertisements to peers
for a configured number of seconds after the first peer reaches Established
state. Unlike `update-delay`, which defers best-path and FIB programming,
`advertisement-delay` allows best-path selection and FIB installation to
proceed normally -- only peer advertisements are held.
Available as both a global command (`bgp advertisement-delay <1-3600>`) and
a per-instance command (`advertisement-delay <1-3600>` under `router bgp`).
### Behavior
- Timer starts when the first peer reaches Established (same trigger as
  update-delay).
- During the delay: routes are received, best-path runs, FIB is programmed.
  Only advertisements to peers are held (pfxSnt remains 0).
- When the timer expires: advertisements are released to all Established peers.
- With both update-delay and advertisement-delay configured: advertisements
  are released at max(update-delay result, T0 + advertisement-delay).
- Re-triggers on `clear ip bgp *`, following the same pattern as update-delay.
- Not started on the GR restarter path (warm reboot) -- only update-delay/
  advertisement-delay apply to cold start and clear events.
- `show bgp summary json` shows `advertisementDelay`, `advertisementDelayInProgress`,
  `advertisementDelayRemainingSeconds`, and `advertisementDelayResumeTime`.
- `show bgp router json` shows `bgpAdvertisementDelayTime`.
