### PR TITLE
yang: Correct pyang errors in frr-pim-route-map.yang

### DIFF
--- a/yang/frr-pim-route-map.yang
+++ b/yang/frr-pim-route-map.yang
@@ -25,9 +25,18 @@ module frr-pim-route-map {
     "FRR Users List:       <mailto:frog@lists.frrouting.org>
      FRR Development List: <mailto:dev@lists.frrouting.org>";
 
+  description
+    "This module defines YANG augmentations for PIM route-map functionality.
+     It extends the FRR route-map module to support multicast-specific
+     match conditions for both IPv4 and IPv6 addresses, including source
+     and group address matching, prefix list matching, and interface-based filtering.";
+
   revision 2021-08-25 {
     description
       "Initial revision";
+
+    reference
+      "FRRouting";
   }
 
   identity ipv4-multicast-source {
@@ -85,11 +94,18 @@ module frr-pim-route-map {
   }
 
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:rmap-match-condition/frr-route-map:match-condition" {
+    description
+      "Augments the route-map match-condition to support PIM-specific match types
+       for multicast routing. This includes matching IPv4/IPv6 multicast source
+       addresses, group addresses, prefix lists, and interfaces.";
+
     case multicast-source {
       when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-source')";
 
       leaf ipv4-multicast-source-address {
         type inet:ipv4-address;
+        description
+          "IPv4 multicast source address to match";
       }
     }
 
@@ -98,6 +114,8 @@ module frr-pim-route-map {
 
       leaf ipv6-multicast-source-address {
         type inet:ipv6-address;
+        description
+          "IPv6 multicast source address to match";
       }
     }
 
@@ -106,6 +124,8 @@ module frr-pim-route-map {
 
       leaf ipv4-multicast-group-address {
         type inet:ipv4-address;
+        description
+          "IPv4 multicast group address to match";
       }
     }
 
@@ -114,6 +134,8 @@ module frr-pim-route-map {
 
       leaf ipv6-multicast-group-address {
         type inet:ipv6-address;
+        description
+          "IPv6 multicast group address to match";
       }
     }
 
@@ -122,6 +144,8 @@ module frr-pim-route-map {
 
       leaf multicast-interface {
         type frr-interface:interface-ref;
+        description
+          "Multicast interface to match";
       }
     }
 
@@ -133,6 +157,8 @@ module frr-pim-route-map {
 
       leaf list-name {
         type frr-filter:prefix-list-ref;
+        description
+          "Prefix list name to match";
       }
     }
   }


### PR DESCRIPTION
Correct pyang errors in frr-pim-route-map.yang

frr-pim-route-map.yang:1: error: RFC 8407: 4.8: statement "module" must have a "description" substatement
frr-pim-route-map.yang:28: error: RFC 8407: 4.8: statement "revision" must have a "reference" substatement
frr-pim-route-map.yang:87: error: RFC 8407: 4.14: statement "augment" must have a "description" substatement
frr-pim-route-map.yang:91: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-route-map.yang:99: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-route-map.yang:107: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-route-map.yang:115: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-route-map.yang:123: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-pim-route-map.yang:134: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement