### PR TITLE
bgpd: Fix copy-paste error in SRv6 DT46 SID duplicate install check (CID 1670455)

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -4039,7 +4039,7 @@ static int bgp_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 				if (sid_same(bgp_vrf->srv6_unicast[AFI_IP6].sid,
 					     bgp_vrf->srv6_unicast[AFI_IP].sid) &&
 				    sid_same(bgp_vrf->srv6_unicast[AFI_IP].zebra_sid_last_sent,
-					     bgp_vrf->srv6_unicast[AFI_IP6].sid)) {
+					     bgp_vrf->srv6_unicast[AFI_IP].sid)) {
 					XFREE(MTYPE_BGP_SRV6_SID,
 					      bgp_vrf->srv6_unicast[AFI_IP6].zebra_sid_last_sent);
 					bgp_vrf->srv6_unicast[AFI_IP6].zebra_sid_last_sent =


### PR DESCRIPTION
Fixes: Coverity CID 1670455 (COPY_PASTE_ERROR)

```
** CID 1670455:       Incorrect expression  (COPY_PASTE_ERROR)
/bgpd/bgp_zebra.c: 4003           in bgp_zebra_srv6_sid_notify()

_____________________________________________________________________________________________
*** CID 1670455:         Incorrect expression  (COPY_PASTE_ERROR)
/bgpd/bgp_zebra.c: 4003             in bgp_zebra_srv6_sid_notify()
3997     				 * set AFI_IP6 zebra_sid_last_sent to the same SID so AFI_IP6
3998     				 * does not send a duplicate ROUTE_ADD.
3999     				 */
4000     				if (sid_same(bgp_vrf->srv6_unicast[AFI_IP6].sid,
4001     					     bgp_vrf->srv6_unicast[AFI_IP].sid) &&
4002     				    sid_same(bgp_vrf->srv6_unicast[AFI_IP].zebra_sid_last_sent,
>>>     CID 1670455:         Incorrect expression  (COPY_PASTE_ERROR)
>>>     "sid" in "sid_same(bgp_vrf->srv6_unicast[AFI_IP].zebra_sid_last_sent, bgp_vrf->srv6_unicast[AFI_IP6].sid)" looks like a copy-paste error.
4003     					     bgp_vrf->srv6_unicast[AFI_IP6].sid)) {
4004     					XFREE(MTYPE_BGP_SRV6_SID,
4005     					      bgp_vrf->srv6_unicast[AFI_IP6].zebra_sid_last_sent);
4006     					bgp_vrf->srv6_unicast[AFI_IP6].zebra_sid_last_sent =
4007     						XCALLOC(MTYPE_BGP_SRV6_SID,
4008     							sizeof(struct in6_addr));
```