### PR TITLE
tests: fix stop_router/start_router in static routing tests

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1123,6 +1123,40 @@ def stop_router(tgen, router):
     router_list[router].stop()
 
 
+def flush_zstatic_routes(tgen, router):
+    """
+    Delete all RTPROT_ZSTATIC (proto 196) routes left in the kernel after
+    stop_router().  Call this between stop_router() and start_router() to
+    prevent zebra from re-importing them as orphaned RIB entries on restart.
+
+    When FRR daemons are killed, the kernel retains routes installed with
+    RTPROT_ZSTATIC.  On the next start_router(), zebra scans the kernel
+    route table and re-imports every RTPROT_ZSTATIC route it finds as a
+    static entry in its RIB.  Because these orphaned entries have no
+    corresponding northbound (staticd) configuration,
+    reset_config_on_routers() cannot remove them via 'no ip route', and
+    they can interfere with subsequent tests.
+
+    Note: 'ip route flush proto 196' fails on some kernels with
+    'Invalid argument' for non-standard protocol numbers, so routes are
+    deleted individually.
+
+    * `tgen`  : topogen object
+    * `router`: Device under test
+    """
+    r = tgen.routers()[router]
+    for line in r.run("ip route show proto 196").splitlines():
+        if not line or line[0].isspace():
+            continue
+        pfx = line.split()[0]
+        r.run(f"ip route del {pfx} proto 196 2>/dev/null; true")
+    for line in r.run("ip -6 route show proto 196").splitlines():
+        if not line or line[0].isspace():
+            continue
+        pfx = line.split()[0]
+        r.run(f"ip -6 route del {pfx} proto 196 2>/dev/null; true")
+
+
 def start_router(tgen, router):
     """
     Router will be started and config would be loaded from /tmp/topotest/<suite>/<router> for each

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo1_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo1_ebgp.py
@@ -15,6 +15,9 @@
 
     -Verify RIB status when same route advertise via BGP and static route.
 
+Note: flush_zstatic_routes() is called between stop_router() and
+    start_router() to clean up residual RTPROT_ZSTATIC (proto 196)
+    kernel routes.  See common_config.flush_zstatic_routes() for details.
 """
 import sys
 import time
@@ -45,6 +48,7 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
+    flush_zstatic_routes,
 )
 from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
@@ -542,7 +546,7 @@ def test_static_route_2nh_p0_tc_1_ebgp(request):
         step("Reload the FRR router")
         # stop/start -> restart FRR router and verify
         stop_router(tgen, "r2")
-
+        flush_zstatic_routes(tgen, "r2")
         start_router(tgen, "r2")
 
         dut = "r2"
@@ -1036,7 +1040,7 @@ def test_static_route_2nh_admin_dist_p0_tc_2_ebgp(request):
         step("Reload the FRR router")
         # stop/start -> restart FRR router and verify
         stop_router(tgen, "r2")
-
+        flush_zstatic_routes(tgen, "r2")
         start_router(tgen, "r2")
 
         step(

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
@@ -23,6 +23,10 @@
     -Delete the static route and verify the RIB and FIB state
 
     -Verify 8 static route functionality with 8 ECMP next hop
+
+Note: flush_zstatic_routes() is called between stop_router() and
+    start_router() to clean up residual RTPROT_ZSTATIC (proto 196)
+    kernel routes.  See common_config.flush_zstatic_routes() for details.
 """
 import sys
 import time
@@ -53,6 +57,7 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
+    flush_zstatic_routes,
 )
 from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
@@ -489,6 +494,7 @@ def test_static_rte_with_8ecmp_nh_p1_tc9_ebgp(request):
     step("TC9: Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     step(
@@ -834,7 +840,7 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc6_ebgp(request):
     step("TC6: Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
-
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     for addr_type in ADDR_TYPES:
@@ -1118,7 +1124,7 @@ def test_static_route_8nh_diff_AD_ebgp_ecmp_p1_tc8_ebgp(request):
     step("TC8: Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
-
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     for addr_type in ADDR_TYPES:
@@ -1465,7 +1471,7 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc10_ebgp(request):
             step("Reload the FRR router")
             # stop/start -> restart FRR router and verify
             stop_router(tgen, "r2")
-
+            flush_zstatic_routes(tgen, "r2")
             start_router(tgen, "r2")
 
             step("After reloading, verify that routes are still present in R2.")

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
@@ -16,6 +16,9 @@
     -Verify BGP did not install the static route when it receive route
     with local next hop
 
+Note: flush_zstatic_routes() is called between stop_router() and
+    start_router() to clean up residual RTPROT_ZSTATIC (proto 196)
+    kernel routes.  See common_config.flush_zstatic_routes() for details.
 """
 import sys
 import time
@@ -45,6 +48,7 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
+    flush_zstatic_routes,
     create_route_maps,
     verify_ip_nht,
 )
@@ -396,6 +400,7 @@ def test_staticroute_with_ecmp_p0_tc3_ebgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     result = verify_rib(
@@ -702,6 +707,7 @@ def test_staticroute_with_ecmp_with_diff_AD_p0_tc4_ebgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     step(

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
@@ -15,6 +15,9 @@
 
     -Verify RIB status when same route advertise via BGP and static route
 
+Note: flush_zstatic_routes() is called between stop_router() and
+    start_router() to clean up residual RTPROT_ZSTATIC (proto 196)
+    kernel routes.  See common_config.flush_zstatic_routes() for details.
 """
 import sys
 import time
@@ -44,6 +47,7 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
+    flush_zstatic_routes,
 )
 from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
@@ -541,7 +545,7 @@ def test_static_route_2nh_p0_tc_1_ibgp(request):
         step("Reload the FRR router")
         # stop/start -> restart FRR router and verify
         stop_router(tgen, "r2")
-
+        flush_zstatic_routes(tgen, "r2")
         start_router(tgen, "r2")
 
         dut = "r2"
@@ -1027,7 +1031,7 @@ def test_static_route_2nh_admin_dist_p0_tc_2_ibgp(request):
         step("Reload the FRR router")
         # stop/start -> restart FRR router and verify
         stop_router(tgen, "r2")
-
+        flush_zstatic_routes(tgen, "r2")
         start_router(tgen, "r2")
 
         step(

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
@@ -23,6 +23,10 @@
     -Delete the static route and verify the RIB and FIB state
 
     -Verify 8 static route functionality with 8 ECMP next hop
+
+Note: flush_zstatic_routes() is called between stop_router() and
+    start_router() to clean up residual RTPROT_ZSTATIC (proto 196)
+    kernel routes.  See common_config.flush_zstatic_routes() for details.
 """
 import sys
 import time
@@ -52,6 +56,7 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
+    flush_zstatic_routes,
 )
 from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
@@ -491,6 +496,7 @@ def test_static_rte_with_8ecmp_nh_p1_tc9_ibgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     step(
@@ -863,7 +869,7 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc6_ibgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
-
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     for addr_type in ADDR_TYPES:
@@ -1268,7 +1274,7 @@ def test_static_route_8nh_diff_AD_ibgp_ecmp_p1_tc7_ibgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
-
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     for addr_type in ADDR_TYPES:
@@ -1692,7 +1698,7 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc10_ibgp(request):
             step("Reload the FRR router")
             # stop/start -> restart FRR router and verify
             stop_router(tgen, "r2")
-
+            flush_zstatic_routes(tgen, "r2")
             start_router(tgen, "r2")
 
             step("After reloading, verify that routes are still present in R2.")

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
@@ -16,6 +16,9 @@
     -Verify BGP did not install the static route when it receive route
     with local next hop
 
+Note: flush_zstatic_routes() is called between stop_router() and
+    start_router() to clean up residual RTPROT_ZSTATIC (proto 196)
+    kernel routes.  See common_config.flush_zstatic_routes() for details.
 """
 import sys
 import time
@@ -46,6 +49,7 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
+    flush_zstatic_routes,
 )
 from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
@@ -395,6 +399,7 @@ def test_staticroute_with_ecmp_p0_tc3_ibgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     result = verify_rib(
@@ -701,6 +706,7 @@ def test_staticroute_with_ecmp_with_diff_AD_p0_tc4_ibgp(request):
     step("Reload the FRR router")
     # stop/start -> restart FRR router and verify
     stop_router(tgen, "r2")
+    flush_zstatic_routes(tgen, "r2")
     start_router(tgen, "r2")
 
     step(


### PR DESCRIPTION
The original failing test was test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc6_ibgp in static_routing_with_ibgp/test_static_routes_topo2_ibgp.py.  The test was failing when run as part of the full suite (after tc9 which performs a stop/start), but passing in isolation.  The failure manifested as an IndexError: list index out of range in verify_rib() when checking FIB-active nexthops, because the orphaned [1/20] route was selected instead of the expected routes installed with admin-distance 10-80.

Root cause
When stop_router() kills the FRR daemons, the Linux kernel retains all routes that were installed with RTPROT_ZSTATIC (protocol number 196, defined as RTPROT_ZSTATIC in zebra/rt_netlink.h).  These kernel routes carry RTA_PRIORITY = NL_DEFAULT_ROUTE_METRIC = 20 (also defined in rt_netlink.h), regardless of the FRR metric field.

On the subsequent start_router(), zebra scans the kernel route table during startup and re-imports every RTPROT_ZSTATIC route it finds as a "static" entry in its RIB.  Because these orphaned entries have no corresponding northbound (staticd) configuration, reset_config_on_routers() cannot remove them via "no ip route".  They appear in the RIB as [1/20] (admin-distance 1, metric 20).

The problem surfaces when the test that performed the stop/start leaves behind routes for PREFIX1 (or NETWORK).  The next test calls reset_config_on_routers(), which removes the real [1/0] static routes but leaves the orphaned [1/20] route intact.  That route then wins over every route the next test tries to install with admin-distance >= 2 (in practice all diff-AD tests use distance 10*n), causing verify_rib() with fib=True to fail with an IndexError or AssertionError.

Why "ip route flush proto 196" does not work
The obvious fix would be to flush all proto-196 routes before restarting. However, "ip route flush proto <non-standard-number>" fails on this kernel with rc=2 / "Failed to send flush request: Invalid argument".  The kernel's fib_inetaddr_ifdown path only supports flush for well-known protocol numbers.  Individual "ip route del <prefix> proto 196" calls work fine.

Fix
Add flush_zstatic_routes(tgen, router) to lib/common_config.py.  It enumerates all RTPROT_ZSTATIC routes via "ip route show proto 196" and deletes them individually before zebra restarts.  Call it between stop_router() and start_router() in all six affected test files.