### PR TITLE
zebra: fix EVPN zero-RMAC in some situations

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2685,7 +2685,7 @@ static void process_subq_early_route_add(struct zebra_early_route *ere)
 			early_route_memory_free(ere);
 			return;
 		}
-		for (ALL_NEXTHOPS(nhe->nhg, tmp_nh)) {
+		for (ALL_NEXTHOPS(ere->re_nhe->nhg, tmp_nh)) {
 			if (CHECK_FLAG(tmp_nh->flags, NEXTHOP_FLAG_EVPN)) {
 				struct ipaddr vtep_ip = {};
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1862,9 +1862,20 @@ static int zl3vni_remote_nh_add(struct zebra_l3vni *zl3vni,
 		}
 
 		/* install the nh neigh in kernel */
-		zl3vni_nh_install(zl3vni, nh);
+		if (!is_zero_mac(rmac))
+			zl3vni_nh_install(zl3vni, nh);
 	} else if (memcmp(&nh->emac, rmac, ETH_ALEN) != 0) {
 		nh->gr_refresh_time = monotime(NULL);
+
+		/*
+		 * Don't let a zero RMAC (e.g. from type-2 MAC/IP imports)
+		 * overwrite a valid RMAC previously installed by a type-5
+		 * prefix route.
+		 */
+		if (is_zero_mac(rmac)) {
+			rb_find_or_add_host(&nh->host_rb, host_prefix);
+			return 0;
+		}
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
 				"L3VNI %u RMAC change(%pEA --> %pEA) for nexthop %pIA, prefix %pFX",

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1938,6 +1938,9 @@ static int svd_remote_nh_add(struct zebra_l3vni *zl3vni,
 		}
 
 	} else if (memcmp(&nh->emac, rmac, ETH_ALEN) != 0) {
+		if (is_zero_mac(rmac))
+			return 0;
+
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("SVD RMAC change(%pEA --> %pEA) for nexthop %pIA, prefix %pFX refcnt %u",
 				   &nh->emac, rmac, vtep_ip, host_prefix,
@@ -1964,7 +1967,7 @@ static int svd_remote_nh_add(struct zebra_l3vni *zl3vni,
 	 * Install the nh neigh in kernel if this is the first time we
 	 * have seen it.
 	 */
-	if (nh->refcnt == 1)
+	if (nh->refcnt == 1 && !is_zero_mac(rmac))
 		svd_nh_install(zl3vni, nh);
 
 	return 0;


### PR DESCRIPTION
Fixes two independent bugs in zebra RMAC handling:

1. zebra_rib.c: Read RMAC from the incoming route entry (`ere->re_nhe->nhg`) instead of the cached NHE (`nhe->nhg`).
2. zebra_vxlan.c: In zl3vni_remote_nh_add(), skip RMAC overwrite when the incoming RMAC is all-zeros and a valid RMAC already exists. The host prefix is still added to the NH's host_rb tree.

It was uncovered by a configuration mishap where the route-targets of L3VNIs was used for L3VNIs, leading to BGP UPDATEs without extended community for RMACs attached, ultimately ending in all-zero RMACs being used.

Topotests would require a certain order of imports (probably some kind of synthetic BGP UPDATEs to FRR instead of trying to replicate this behaviour with an FRR peer). Let me know if I should add one or not.

Disclaimer: GitHub Copilot was used to find the bug and generate the respective changes. It was only found because Copilot thought it would be a good idea to have the same RT on the L2VNI as the L3VNI, leading to this situation. However I still think this is meaningful hardening.
