### PR TITLE
bgpd: Fix wrong union member access in `bgp_ls_nlri_display()`

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -4798,9 +4798,30 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 	char ipaddr_str[INET6_ADDRSTRLEN];
 	const char *nlri_type_str = NULL;
 	const char *protocol_str = NULL;
+	enum bgp_ls_protocol_id protocol_id = BGP_LS_PROTO_RESERVED;
+	uint64_t identifier = 0;
 
 	if (!nlri)
 		return;
+
+	/* Extract common fields from the active union member */
+	switch (nlri->nlri_type) {
+	case BGP_LS_NLRI_TYPE_NODE:
+		protocol_id = nlri->nlri_data.node.protocol_id;
+		identifier = nlri->nlri_data.node.identifier;
+		break;
+	case BGP_LS_NLRI_TYPE_LINK:
+		protocol_id = nlri->nlri_data.link.protocol_id;
+		identifier = nlri->nlri_data.link.identifier;
+		break;
+	case BGP_LS_NLRI_TYPE_IPV4_PREFIX:
+	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
+		protocol_id = nlri->nlri_data.prefix.protocol_id;
+		identifier = nlri->nlri_data.prefix.identifier;
+		break;
+	case BGP_LS_NLRI_TYPE_RESERVED:
+		break;
+	}
 
 	/* Determine NLRI type string */
 	switch (nlri->nlri_type) {
@@ -4822,7 +4843,7 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 	}
 
 	/* Determine protocol string */
-	switch (nlri->nlri_data.node.protocol_id) {
+	switch (protocol_id) {
 	case BGP_LS_PROTO_ISIS_L1:
 		protocol_str = "ISIS L1";
 		break;
@@ -4851,7 +4872,7 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 
 	vty_out(vty, "NLRI Type: %s\n", nlri_type_str);
 	vty_out(vty, "Protocol: %s\n", protocol_str);
-	vty_out(vty, "Identifier: 0x%" PRIx64 "\n", nlri->nlri_data.node.identifier);
+	vty_out(vty, "Identifier: 0x%" PRIx64 "\n", identifier);
 
 	/* Display Local Node Descriptor */
 	vty_out(vty, "Local Node Descriptor:\n");


### PR DESCRIPTION
BGP-LS NLRIs carry different data depending on their type (Node, Link, or Prefix). Internally the data is stored in a C union, where only the member matching the active NLRI type is valid to read.

`bgp_ls_nlri_display()` always reads the `protocol_id` and `identifier` fields through the node union member, even when the NLRI is actually a Link or Prefix. Reading the wrong union member is undefined behavior in C; it works by coincidence because the fields happen to sit at the same memory offset in all three variants today, but would silently break if the structs were ever reordered or padded differently.

Fix by adding an upfront switch on `nlri->nlri_type` that reads `protocol_id` and `identifier` from whichever union member is actually active, storing them in local variables used for the rest of the function. This matches the pattern already used in the same function for the `local_node` field.