### PR TITLE
bgpd: Skip oversized BGP-LS Node and Link Name TLVs

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -3410,6 +3410,14 @@ static int parse_node_name(struct stream *s, uint16_t length, struct bgp_ls_attr
 	if (length == 0)
 		return 0;
 
+	if (length > BGP_LS_MAX_NODE_NAME_LEN) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: Node Name TLV length %u exceeds maximum %u, skipping TLV",
+			  length, BGP_LS_MAX_NODE_NAME_LEN);
+		stream_forward_getp(s, length);
+		return 0;
+	}
+
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_NODE_NAME_BIT)) {
 		flog_warn(EC_BGP_UPDATE_RCV, "BGP-LS: duplicate Node Name TLV");
 		return -1;
@@ -3653,6 +3661,14 @@ static int parse_link_name(struct stream *s, uint16_t length, struct bgp_ls_attr
 {
 	if (length == 0)
 		return 0;
+
+	if (length > BGP_LS_MAX_LINK_NAME_LEN) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: Link Name TLV length %u exceeds maximum %u, skipping TLV",
+			  length, BGP_LS_MAX_LINK_NAME_LEN);
+		stream_forward_getp(s, length);
+		return 0;
+	}
 
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_LINK_NAME_BIT)) {
 		flog_warn(EC_BGP_UPDATE_RCV, "BGP-LS: duplicate Link Name TLV");

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -252,6 +252,8 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_MAX_UNRESV_BW  8	 /* 8 priority classes */
 #define BGP_LS_MAX_ROUTE_TAGS 16 /* Maximum route tags */
 #define BGP_LS_MAX_EXT_ADMIN_GROUPS 256 /* Maximum number of admin groups in Extended Admin Group TLV */
+#define BGP_LS_MAX_NODE_NAME_LEN 255	/* Maximum node name length */
+#define BGP_LS_MAX_LINK_NAME_LEN 255	/* Maximum link name length */
 
 /*
  * Bit positions for attribute presence bitmasks


### PR DESCRIPTION
`parse_node_name()` and `parse_link_name()` accept a length parameter from the BGP-LS TLV header and allocate a buffer of that size without bounds checking. A malicious peer can send TLVs with length fields up to 64KB, causing per-advertisement memory exhaustion that accumulates across many updates.

Fix by adding separate constants `BGP_LS_MAX_NODE_NAME_LEN` and `BGP_LS_MAX_LINK_NAME_LEN` (255 bytes each) and checking the length before allocation. TLVs exceeding these limits are skipped: the stream is advanced past the oversized payload and the function returns without storing anything.

This prevents unbounded memory allocation on untrusted input. Only the oversized TLV is discarded; parsing continues for remaining TLVs in the attribute.