### PR TITLE
Handle changes in libyang API

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1763,71 +1763,6 @@ static enum nb_error lib_interface_vrf_get(const struct nb_node *nb_node, const 
 }
 
 /*
- * XPath: /frr-interface:lib/interface/state/if-index
- */
-static enum nb_error lib_interface_state_if_index_get(const struct nb_node *nb_node,
-						      const void *list_entry,
-						      struct lyd_node *parent)
-{
-	const struct lysc_node *snode = nb_node->snode;
-	const struct interface *ifp = list_entry;
-	int32_t value = ifp->ifindex;
-
-	if (yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-			      LYD_NEW_PATH_UPDATE, NULL))
-		return NB_ERR_RESOURCE;
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/state/mtu[6]
- */
-static enum nb_error lib_interface_state_mtu_get(const struct nb_node *nb_node,
-						 const void *list_entry, struct lyd_node *parent)
-{
-	const struct lysc_node *snode = nb_node->snode;
-	const struct interface *ifp = list_entry;
-	uint32_t value = ifp->mtu;
-
-	if (yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-			      LYD_NEW_PATH_UPDATE, NULL))
-		return NB_ERR_RESOURCE;
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/state/speed
- */
-static enum nb_error lib_interface_state_speed_get(const struct nb_node *nb_node,
-						   const void *list_entry, struct lyd_node *parent)
-{
-	const struct lysc_node *snode = nb_node->snode;
-	const struct interface *ifp = list_entry;
-	uint32_t value = ifp->speed;
-
-	if (yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-			      LYD_NEW_PATH_UPDATE, NULL))
-		return NB_ERR_RESOURCE;
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/state/metric
- */
-static enum nb_error lib_interface_state_metric_get(const struct nb_node *nb_node,
-						    const void *list_entry, struct lyd_node *parent)
-{
-	const struct lysc_node *snode = nb_node->snode;
-	const struct interface *ifp = list_entry;
-	uint32_t value = ifp->metric;
-
-	if (yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-			      LYD_NEW_PATH_UPDATE, NULL))
-		return NB_ERR_RESOURCE;
-	return NB_OK;
-}
-
-/*
  * XPath: /frr-interface:lib/interface/state/phy-address
  */
 static struct yang_data *
@@ -1877,31 +1812,36 @@ const struct frr_yang_module_info frr_interface_info = {
 		{
 			.xpath = "/frr-interface:lib/interface/state/if-index",
 			.cbs = {
-				.get = lib_interface_state_if_index_get,
+				.get = nb_oper_int32_get,
+				.get_elem = (void *)(intptr_t)offsetof(struct interface, ifindex),
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/mtu",
 			.cbs = {
-				.get = lib_interface_state_mtu_get,
+				.get = nb_oper_uint32_get,
+				.get_elem = (void *)(intptr_t)offsetof(struct interface, mtu),
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/mtu6",
 			.cbs = {
-				.get = lib_interface_state_mtu_get,
+				.get = nb_oper_uint32_get,
+				.get_elem = (void *)(intptr_t)offsetof(struct interface, mtu),
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/speed",
 			.cbs = {
-				.get = lib_interface_state_speed_get,
+				.get = nb_oper_uint32_get,
+				.get_elem = (void *)(intptr_t)offsetof(struct interface, speed),
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/metric",
 			.cbs = {
-				.get = lib_interface_state_metric_get,
+				.get = nb_oper_uint32_get,
+				.get_elem = (void *)(intptr_t)offsetof(struct interface, metric),
 			}
 		},
 		{

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -851,7 +851,7 @@ static void be_client_handle_rpc(struct mgmt_be_client *client, uint64_t txn_id,
 		 * It is especially needed for actions, because their parents
 		 * may hold necessary information.
 		 */
-		err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, 0, NULL, &input);
+		err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &input);
 	}
 	if (err) {
 		be_client_send_error(client, txn_id, rpc_msg->req_id, false, -EINVAL,
@@ -859,7 +859,7 @@ static void be_client_handle_rpc(struct mgmt_be_client *client, uint64_t txn_id,
 		return;
 	}
 
-	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, 0, NULL, &output);
+	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &output);
 	if (err) {
 		lyd_free_all(input);
 		be_client_send_error(client, txn_id, rpc_msg->req_id, false,

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -1244,15 +1244,16 @@ static enum nb_error clients_client_state_candidate_config_version_get(
 	const struct nb_node *nb_node, const void *parent_list_entry, struct lyd_node *parent)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	uint64_t value;
+	uint64_t version;
+	char value[21]; /* UINT64_MAX has 20 digits */
 
 	if (__be_client->config_txn)
-		value = __be_client->config_txn->candidate_config->version;
+		version = __be_client->config_txn->candidate_config->version;
 	else
-		value = __be_client->running_config->version;
+		version = __be_client->running_config->version;
 
-	if (yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-			      LYD_NEW_PATH_UPDATE, NULL))
+	snprintfrr(value, sizeof(value), "%" PRIu64, version);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
 		return NB_ERR_RESOURCE;
 
 	return NB_OK;
@@ -1266,10 +1267,11 @@ static enum nb_error clients_client_state_running_config_version_get(const struc
 								     struct lyd_node *parent)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	uint64_t value = __be_client->running_config->version;
+	uint64_t version = __be_client->running_config->version;
+	char value[21]; /* UINT64_MAX has 20 digits */
 
-	if (yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-			      LYD_NEW_PATH_UPDATE, NULL))
+	snprintfrr(value, sizeof(value), "%" PRIu64, version);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
 		return NB_ERR_RESOURCE;
 
 	return NB_OK;

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -738,7 +738,7 @@ static LY_ERR dnode_create(struct nb_config *candidate, const char *xpath, const
 	struct lyd_node *dnode = NULL;
 	LY_ERR err;
 
-	err = yang_new_path2(candidate->dnode, ly_native_ctx, xpath, value, 0, 0, options, NULL,
+	err = yang_new_path2(candidate->dnode, ly_native_ctx, xpath, value, 0, options, NULL,
 			     &dnode);
 	if (err) {
 		flog_warn(EC_LIB_LIBYANG, "%s: lyd_new_path(%s) failed: %d",
@@ -907,8 +907,7 @@ static int nb_candidate_edit_tree_add(struct nb_config *candidate,
 	 * merged later with candidate.
 	 */
 	if (parent_xpath) {
-		err = yang_new_path2(NULL, ly_native_ctx, parent_xpath, NULL, 0, 0, 0, &tree,
-				     &parent);
+		err = yang_new_path2(NULL, ly_native_ctx, parent_xpath, NULL, 0, 0, &tree, &parent);
 		if (err) {
 			yang_print_errors(ly_native_ctx, errmsg, errmsg_len);
 			ret = NB_ERR;

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -1610,6 +1610,24 @@ extern void *nb_oper_walk_finish_arg(void *walk);
 extern void *nb_oper_walk_cb_arg(void *walk);
 
 /* Generic getter functions */
+extern enum nb_error nb_oper_int8_get(const struct nb_node *nb_node,
+				      const void *parent_list_entry, struct lyd_node *parent);
+
+extern enum nb_error nb_oper_int16_get(const struct nb_node *nb_node,
+				       const void *parent_list_entry, struct lyd_node *parent);
+
+extern enum nb_error nb_oper_int32_get(const struct nb_node *nb_node,
+				       const void *parent_list_entry, struct lyd_node *parent);
+
+extern enum nb_error nb_oper_int64_get(const struct nb_node *nb_node,
+				       const void *parent_list_entry, struct lyd_node *parent);
+
+extern enum nb_error nb_oper_uint8_get(const struct nb_node *nb_node,
+				       const void *parent_list_entry, struct lyd_node *parent);
+
+extern enum nb_error nb_oper_uint16_get(const struct nb_node *nb_node,
+					const void *parent_list_entry, struct lyd_node *parent);
+
 extern enum nb_error nb_oper_uint32_get(const struct nb_node *nb_node,
 					const void *parent_list_entry, struct lyd_node *parent);
 

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -298,7 +298,7 @@ int nb_cli_rpc(struct vty *vty, const char *xpath, struct lyd_node **output_p)
 	}
 
 	/* create input tree */
-	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, 0, NULL, &input);
+	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &input);
 	assert(err == LY_SUCCESS);
 
 	for (size_t i = 0; i < vty->num_rpc_params; i++) {
@@ -319,7 +319,7 @@ int nb_cli_rpc(struct vty *vty, const char *xpath, struct lyd_node **output_p)
 	assert(err == LY_SUCCESS);
 
 	/* create output tree root for population in the callback */
-	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, 0, NULL, &output);
+	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &output);
 	assert(err == LY_SUCCESS);
 
 	ret = nb_callback_rpc(nb_node, xpath, input, output, errmsg,

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1032,8 +1032,7 @@ grpc::Status HandleUnaryExecute(
 				    "Unknown data path");
 
 	// Create input data tree.
-	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, (LYD_ANYDATA_VALUETYPE)0, 0,
-			     NULL, &input_tree);
+	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &input_tree);
 	if (err != LY_SUCCESS) {
 		return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
 				    "Invalid data path");
@@ -1061,8 +1060,7 @@ grpc::Status HandleUnaryExecute(
 	}
 
 	// Create output data tree.
-	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, (LYD_ANYDATA_VALUETYPE)0, 0,
-			     NULL, &output_tree);
+	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &output_tree);
 	if (err != LY_SUCCESS) {
 		lyd_free_tree(input_tree);
 		return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -1555,10 +1555,9 @@ static enum nb_error _walk(struct nb_op_yield_state *ys, bool is_resume)
 					ys->non_specific_predicate[at_clevel] = true;
 				else {
 					flog_err(EC_LIB_NB_OPERATIONAL_DATA,
-						  "%s: unable to create node for specific query string: %s: %s",
-						  __func__,
-						  ys->query_tokens[at_clevel],
-						  yang_ly_strerrcode(err));
+						 "%s: unable to create node for specific query string: %s: %s",
+						 __func__, ys->query_tokens[at_clevel],
+						 ly_strerrcode(err));
 					ret = NB_ERR;
 					goto done;
 				}
@@ -2226,7 +2225,7 @@ static void *nb_op_root_walk_branch_finished(struct nb_op_yield_state *ys, enum 
 				if (err) {
 					flog_err(EC_LIB_NB_OPERATIONAL_DATA,
 						 "%s: unable to merge data tree: %s", __func__,
-						 yang_ly_strerrcode(err));
+						 ly_strerrcode(err));
 					ret = NB_ERR_RESOURCE;
 					break;
 				}

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -441,7 +441,7 @@ static enum nb_error nb_op_xpath_to_trunk(const char *xpath_in, char **xpath_out
 
 	ly_temp_log_options(&llopts);
 	for (;;) {
-		err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, LYD_NEW_PATH_UPDATE,
+		err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, LYD_NEW_PATH_UPDATE,
 				     NULL, trunk);
 		if (err == LY_SUCCESS)
 			break;

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -2345,50 +2345,130 @@ enum nb_error nb_oper_iterate_legacy(const char *xpath,
 	return ret;
 }
 
-static const char *_adjust_ptr(struct lysc_node_leaf *lsnode, const char *valuep, size_t *size)
+enum nb_error nb_oper_int8_get(const struct nb_node *nb_node, const void *parent_list_entry,
+			       struct lyd_node *parent)
 {
-	switch (lsnode->type->basetype) {
-	case LY_TYPE_INT8:
-	case LY_TYPE_UINT8:
-#if BYTE_ORDER == BIG_ENDIAN
-		valuep += 7;
-#endif
-		*size = 1;
-		break;
-	case LY_TYPE_INT16:
-	case LY_TYPE_UINT16:
-#if BYTE_ORDER == BIG_ENDIAN
-		valuep += 6;
-#endif
-		*size = 2;
-		break;
-	case LY_TYPE_INT32:
-	case LY_TYPE_UINT32:
-#if BYTE_ORDER == BIG_ENDIAN
-		valuep += 4;
-#endif
-		*size = 4;
-		break;
-	case LY_TYPE_INT64:
-	case LY_TYPE_UINT64:
-		*size = 8;
-		break;
-	case LY_TYPE_UNKNOWN:
-	case LY_TYPE_BINARY:
-	case LY_TYPE_STRING:
-	case LY_TYPE_BITS:
-	case LY_TYPE_BOOL:
-	case LY_TYPE_DEC64:
-	case LY_TYPE_EMPTY:
-	case LY_TYPE_ENUM:
-	case LY_TYPE_IDENT:
-	case LY_TYPE_INST:
-	case LY_TYPE_LEAFREF:
-	case LY_TYPE_UNION:
-	default:
-		assert(0);
-	}
-	return valuep;
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[5]; /* INT8_MIN has a sign and then 3 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_INT8)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRId8, *(int8_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
+}
+
+enum nb_error nb_oper_int16_get(const struct nb_node *nb_node, const void *parent_list_entry,
+				struct lyd_node *parent)
+{
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[7]; /* INT16_MIN has a sign and then 5 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_INT16)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRId16, *(int16_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
+}
+
+enum nb_error nb_oper_int32_get(const struct nb_node *nb_node, const void *parent_list_entry,
+				struct lyd_node *parent)
+{
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[12]; /* INT32_MIN has a sign and then 10 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_INT32)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRId32, *(int32_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
+}
+
+enum nb_error nb_oper_int64_get(const struct nb_node *nb_node, const void *parent_list_entry,
+				struct lyd_node *parent)
+{
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[22]; /* INT64_MIN has a sign and then 20 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_INT64)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRId64, *(int64_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
+}
+
+enum nb_error nb_oper_uint8_get(const struct nb_node *nb_node, const void *parent_list_entry,
+				struct lyd_node *parent)
+{
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[4]; /* UINT8_MAX has 3 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_UINT8)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRIu8, *(uint8_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
+}
+
+enum nb_error nb_oper_uint16_get(const struct nb_node *nb_node, const void *parent_list_entry,
+				 struct lyd_node *parent)
+{
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[6]; /* UINT16_MAX has 5 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_UINT16)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRIu16, *(uint16_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
+}
+
+enum nb_error nb_oper_uint32_get(const struct nb_node *nb_node, const void *parent_list_entry,
+				 struct lyd_node *parent)
+{
+	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
+	struct lysc_node *snode = &lsnode->node;
+	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[11]; /* UINT32_MAX has 10 digits */
+
+	if (lsnode->type->basetype != LY_TYPE_UINT32)
+		return NB_ERR_VALIDATION;
+
+	snprintfrr(value, sizeof(value), "%" PRIu32, *(uint32_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
 }
 
 enum nb_error nb_oper_uint64_get(const struct nb_node *nb_node, const void *parent_list_entry,
@@ -2397,31 +2477,14 @@ enum nb_error nb_oper_uint64_get(const struct nb_node *nb_node, const void *pare
 	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
 	struct lysc_node *snode = &lsnode->node;
 	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
-	uint64_t ubigval = *(uint64_t *)((char *)parent_list_entry + offset);
-	const char *valuep;
-	size_t size;
+	void *valuep = (char *)parent_list_entry + offset;
+	char value[21]; /* UINT64_MAX has 20 digits */
 
-	valuep = _adjust_ptr(lsnode, (const char *)&ubigval, &size);
-	if (yang_new_term_bin(parent, snode->module, snode->name, valuep, size,
-			      LYD_NEW_PATH_UPDATE, NULL))
-		return NB_ERR_RESOURCE;
-	return NB_OK;
-}
+	if (lsnode->type->basetype != LY_TYPE_UINT64)
+		return NB_ERR_VALIDATION;
 
-
-enum nb_error nb_oper_uint32_get(const struct nb_node *nb_node, const void *parent_list_entry,
-				 struct lyd_node *parent)
-{
-	struct lysc_node_leaf *lsnode = (struct lysc_node_leaf *)nb_node->snode;
-	struct lysc_node *snode = &lsnode->node;
-	ssize_t offset = (ssize_t)nb_node->cbs.get_elem;
-	uint64_t ubigval = *(uint64_t *)((char *)parent_list_entry + offset);
-	const char *valuep;
-	size_t size;
-
-	valuep = _adjust_ptr(lsnode, (const char *)&ubigval, &size);
-	if (yang_new_term_bin(parent, snode->module, snode->name, valuep, size,
-			      LYD_NEW_PATH_UPDATE, NULL))
+	snprintfrr(value, sizeof(value), "%" PRIu64, *(uint64_t *)valuep);
+	if (lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL))
 		return NB_ERR_RESOURCE;
 	return NB_OK;
 }

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -1717,9 +1717,7 @@ LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx, struct lyd_node *parent,
  */
 
 #undef lyd_new_term_bin
-#undef lyd_change_term_bin
 #undef lyd_new_path2
-#undef lyd_new_ext_term
 
 #if (LY_VERSION_MAJOR >= 4)
 #define LY_SZ(x) ((x)*8)
@@ -1734,11 +1732,6 @@ LY_ERR yang_new_term_bin(struct lyd_node *parent, const struct lys_module *modul
 	return lyd_new_term_bin(parent, module, name, value, LY_SZ(size), options, node);
 }
 
-LY_ERR yang_change_term_bin(struct lyd_node *term, const void *value, uint32_t size)
-{
-	return lyd_change_term_bin(term, value, LY_SZ(size));
-}
-
 LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path,
 		      const void *value, uint32_t size, LYD_ANYDATA_VALUETYPE value_type,
 		      uint32_t options, struct lyd_node **new_parent, struct lyd_node **new_node)
@@ -1747,11 +1740,4 @@ LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const c
 			     new_parent, new_node);
 }
 
-#if (LY_VERSION_MAJOR >= 3) && (LY_VERSION_MAJOR < 5)
-LY_ERR yang_new_ext_term(const struct lysc_ext_instance *ext, const char *name, const void *value,
-			 uint32_t size, uint32_t options, struct lyd_node **node)
-{
-	return lyd_new_ext_term(ext, name, value, LY_SZ(size), options, node);
-}
-#endif
 #undef LY_SZ

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -1715,7 +1715,6 @@ LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx, struct lyd_node *parent,
  * Handle NBC API changes between versions of Libyang
  */
 
-#undef lyd_new_term_bin
 #undef lyd_new_path2
 
 #if (LY_VERSION_MAJOR >= 4)
@@ -1723,13 +1722,6 @@ LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx, struct lyd_node *parent,
 #else
 #define LY_SZ(x) (x)
 #endif
-
-LY_ERR yang_new_term_bin(struct lyd_node *parent, const struct lys_module *module,
-			 const char *name, const void *value, uint32_t size, uint32_t options,
-			 struct lyd_node **node)
-{
-	return lyd_new_term_bin(parent, module, name, value, LY_SZ(size), options, node);
-}
 
 LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path,
 		      const void *value, uint32_t value_size_bytes, uint32_t options,

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -1604,9 +1604,8 @@ LY_ERR yang_lyd_trim_xpath(struct lyd_node **root, const char *xpath)
 #ifdef HAVE_LYD_TRIM_XPATH
 	err = lyd_trim_xpath(root, xpath, NULL);
 	if (err) {
-		flog_err_sys(EC_LIB_LIBYANG,
-			     "cannot obtain specific result for xpath \"%s\": %s",
-			     xpath, yang_ly_strerrcode(err));
+		flog_err_sys(EC_LIB_LIBYANG, "cannot obtain specific result for xpath \"%s\": %s",
+			     xpath, ly_strerrcode(err));
 		return err;
 	}
 	return LY_SUCCESS;
@@ -1621,9 +1620,8 @@ LY_ERR yang_lyd_trim_xpath(struct lyd_node **root, const char *xpath)
 	err = yang_lyd_find_xpath3(NULL, *root, xpath, LY_VALUE_JSON, NULL,
 				   NULL, &set);
 	if (err) {
-		flog_err_sys(EC_LIB_LIBYANG,
-			     "cannot obtain specific result for xpath \"%s\": %s",
-			     xpath, yang_ly_strerrcode(err));
+		flog_err_sys(EC_LIB_LIBYANG, "cannot obtain specific result for xpath \"%s\": %s",
+			     xpath, ly_strerrcode(err));
 		return err;
 	}
 	/*
@@ -1757,82 +1755,3 @@ LY_ERR yang_new_ext_term(const struct lysc_ext_instance *ext, const char *name, 
 }
 #endif
 #undef LY_SZ
-
-/*
- * Safe to remove after libyang v2.1.128 is required
- */
-const char *yang_ly_strerrcode(LY_ERR err)
-{
-#ifdef HAVE_LY_STRERRCODE
-	return ly_strerrcode(err);
-#else
-	switch (err) {
-	case LY_SUCCESS:
-		return "ok";
-	case LY_EMEM:
-		return "out of memory";
-	case LY_ESYS:
-		return "system error";
-	case LY_EINVAL:
-		return "invalid value given";
-	case LY_EEXIST:
-		return "item exists";
-	case LY_ENOTFOUND:
-		return "item not found";
-	case LY_EINT:
-		return "operation interrupted";
-	case LY_EVALID:
-		return "validation failed";
-	case LY_EDENIED:
-		return "access denied";
-	case LY_EINCOMPLETE:
-		return "incomplete";
-	case LY_ERECOMPILE:
-		return "compile error";
-	case LY_ENOT:
-		return "not";
-	case LY_EPLUGIN:
-	case LY_EOTHER:
-		return "other";
-	default:
-		return "unknown";
-	}
-#endif
-}
-
-/*
- * Safe to remove after libyang v2.1.128 is required
- */
-const char *yang_ly_strvecode(LY_VECODE vecode)
-{
-#ifdef HAVE_LY_STRVECODE
-	return ly_strvecode(vecode);
-#else
-	switch (vecode) {
-	case LYVE_SUCCESS:
-		return "";
-	case LYVE_SYNTAX:
-		return "syntax";
-	case LYVE_SYNTAX_YANG:
-		return "yang-syntax";
-	case LYVE_SYNTAX_YIN:
-		return "yin-syntax";
-	case LYVE_REFERENCE:
-		return "reference";
-	case LYVE_XPATH:
-		return "xpath";
-	case LYVE_SEMANTICS:
-		return "semantics";
-	case LYVE_SYNTAX_XML:
-		return "xml-syntax";
-	case LYVE_SYNTAX_JSON:
-		return "json-syntax";
-	case LYVE_DATA:
-		return "data";
-	case LYVE_OTHER:
-		return "other";
-	default:
-		return "unknown";
-	}
-#endif
-}

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -707,7 +707,7 @@ struct lyd_node *yang_state_new(struct lyd_node *tree, const char *path, const c
 	struct lyd_node *dnode, *parent;
 	LY_ERR err;
 
-	err = yang_new_path2(tree, ly_native_ctx, path, value, 0, 0, LYD_NEW_PATH_UPDATE, &parent,
+	err = yang_new_path2(tree, ly_native_ctx, path, value, 0, LYD_NEW_PATH_UPDATE, &parent,
 			     &dnode);
 	assert(err == LY_SUCCESS);
 
@@ -916,7 +916,7 @@ LY_ERR yang_parse_data(const char *xpath, LYD_FORMAT format, bool as_subtree, bo
 		 * a common YANG JSON technique (vs XML which starts all
 		 * data trees from the root).
 		 */
-		err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, 0, &parent, &subtree);
+		err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, &parent, &subtree);
 		if (err != LY_SUCCESS)
 			goto done;
 		err = lyd_find_path(parent, xpath, false, &subtree);
@@ -1016,7 +1016,7 @@ LY_ERR yang_parse_restconf_rpc(const char *xpath, LYD_FORMAT format, const char 
 		return LY_ENOTFOUND;
 	}
 	/* Get the tree for the RPC/Action */
-	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, 0, NULL, &dnode);
+	err = yang_new_path2(NULL, ly_native_ctx, xpath, NULL, 0, 0, NULL, &dnode);
 	if (err) {
 		zlog_err("Failed to create parent node for action: %s", ly_last_errmsg());
 		goto done;
@@ -1070,8 +1070,7 @@ LY_ERR yang_parse_rpc(const char *xpath, LYD_FORMAT format, const char *data, bo
 			return LY_EINVAL;
 		}
 
-		err = yang_new_path2(NULL, ly_native_ctx, parent_xpath, NULL, 0, 0, 0, NULL,
-				     &parent);
+		err = yang_new_path2(NULL, ly_native_ctx, parent_xpath, NULL, 0, 0, NULL, &parent);
 		XFREE(MTYPE_TMP, parent_xpath);
 		if (err) {
 			zlog_err("Failed to create parent node for action: %s",
@@ -1733,10 +1732,10 @@ LY_ERR yang_new_term_bin(struct lyd_node *parent, const struct lys_module *modul
 }
 
 LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path,
-		      const void *value, uint32_t size, LYD_ANYDATA_VALUETYPE value_type,
-		      uint32_t options, struct lyd_node **new_parent, struct lyd_node **new_node)
+		      const void *value, uint32_t value_size_bytes, uint32_t options,
+		      struct lyd_node **new_parent, struct lyd_node **new_node)
 {
-	return lyd_new_path2(parent, ctx, path, value, LY_SZ(size), value_type, options,
+	return lyd_new_path2(parent, ctx, path, value, LY_SZ(value_size_bytes), 0, options,
 			     new_parent, new_node);
 }
 

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -958,8 +958,7 @@ extern LY_ERR yang_new_term_bin(struct lyd_node *parent, const struct lys_module
 	_Pragma("GCC error \"Use yang_new_term_bin() instead of lyd_new_term_bin()\"")
 
 extern LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path,
-			     const void *value, uint32_t value_size_bits,
-			     LYD_ANYDATA_VALUETYPE value_type, uint32_t options,
+			     const void *value, uint32_t value_size_bytes, uint32_t options,
 			     struct lyd_node **new_parent, struct lyd_node **new_node);
 #define lyd_new_path2(...) _Pragma("GCC error \"Use yang_new_path2() instead of lyd_new_path2()\"")
 

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -936,8 +936,6 @@ extern LY_ERR yang_resolve_snode_xpath(struct ly_ctx *ly_ctx, const char *xpath,
 /*
  * Libyang future functions
  */
-extern const char *yang_ly_strerrcode(LY_ERR err);
-extern const char *yang_ly_strvecode(LY_VECODE vecode);
 extern LY_ERR yang_lyd_new_list(struct lyd_node *parent, const struct lysc_node *snode,
 				const struct yang_list_keys *keys, struct lyd_node **nodes);
 extern LY_ERR yang_lyd_trim_xpath(struct lyd_node **rootp, const char *xpath);

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -957,23 +957,11 @@ extern LY_ERR yang_new_term_bin(struct lyd_node *parent, const struct lys_module
 #define lyd_new_term_bin(...)                                                                     \
 	_Pragma("GCC error \"Use yang_new_term_bin() instead of lyd_new_term_bin()\"")
 
-LY_ERR yang_change_term_bin(struct lyd_node *term, const void *value, uint32_t value_size_bits);
-#define lyd_change_term_bin(...)                                                                  \
-	_Pragma("GCC error \"Use yang_change_term_bin() instead of lyd_new_change_term_bin()\"")
-
 extern LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path,
 			     const void *value, uint32_t value_size_bits,
 			     LYD_ANYDATA_VALUETYPE value_type, uint32_t options,
 			     struct lyd_node **new_parent, struct lyd_node **new_node);
 #define lyd_new_path2(...) _Pragma("GCC error \"Use yang_new_path2() instead of lyd_new_path2()\"")
-
-#if (LY_VERSION_MAJOR >= 3) && (LY_VERSION_MAJOR < 5)
-extern LY_ERR yang_new_ext_term(const struct lysc_ext_instance *ext, const char *name,
-				const void *value, uint32_t value_size_bits, uint32_t options,
-				struct lyd_node **node);
-#define lyd_new_ext_term(...)                                                                     \
-	_Pragma("GCC error \"Use yang_new_ext_term() instead of lyd_new_ext_term()\"")
-#endif
 
 #ifdef __cplusplus
 }

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -950,13 +950,6 @@ extern LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx,
  * Handle NBC API changes between versions of Libyang
  */
 
-/* Use this helper function to deal with change in value_size units */
-extern LY_ERR yang_new_term_bin(struct lyd_node *parent, const struct lys_module *module,
-				const char *name, const void *value, uint32_t value_size,
-				uint32_t options, struct lyd_node **node);
-#define lyd_new_term_bin(...)                                                                     \
-	_Pragma("GCC error \"Use yang_new_term_bin() instead of lyd_new_term_bin()\"")
-
 extern LY_ERR yang_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path,
 			     const void *value, uint32_t value_size_bytes, uint32_t options,
 			     struct lyd_node **new_parent, struct lyd_node **new_node);

--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -219,9 +219,9 @@ static void vty_out_yang_error(struct vty *vty, LYD_FORMAT format, const struct 
 	else if (ei->level == LY_LLWRN)
 		severity = "warning";
 
-	ecode = yang_ly_strerrcode(err);
+	ecode = ly_strerrcode(err);
 	if (err == LY_EVALID && ei->vecode != LYVE_SUCCESS)
-		evalid = yang_ly_strvecode(ei->vecode);
+		evalid = ly_strvecode(ei->vecode);
 
 	switch (format) {
 	case LYD_XML:

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -249,12 +249,11 @@ static enum nb_error frr_test_module_c2cont_c2value_get(const struct nb_node *nb
 							struct lyd_node *parent)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	uint32_t value = htole32(0xAB010203);
+	char value[11]; /* UINT32_MAX has 10 digits */
 	LY_ERR err;
 
-	/* Note that this api expects 'value' to be in little-endian form */
-	err = yang_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
-				LYD_NEW_PATH_UPDATE, NULL);
+	snprintfrr(value, sizeof(value), "%" PRIu32, 0xAB010203);
+	err = lyd_new_term(parent, snode->module, snode->name, value, LYD_NEW_PATH_UPDATE, NULL);
 	assert(err == LY_SUCCESS);
 
 	return NB_OK;


### PR DESCRIPTION
This resolves issues caused by these API changes in libyang:

- `lyd_change_term_bin()` and `lyd_new_ext_term()` were removed
- `lyd_new_path2()` has a different signature that takes a `uint32_t` instead of a `LYD_ANYDATA_VALUETYPE` (which was removed)

A small number of other issues were fixed at the same time in the code that used these functions. Building was tested with libyang 2.1.128, 2.1.148, 3.13.5, and 5.4.9.

Cc: @choppsv1