### PR TITLE
bgpd: remove unreachable json_paths free in evpn_show_all_routes()

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3350,8 +3350,6 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type, jso
 					if (!brief)
 						json_object_object_add(json_prefix, "paths",
 								       json_paths);
-					else if (json_paths)
-						json_object_free(json_paths);
 
 					json_flags = json_object_new_object();
 					json_object_boolean_add(json_flags, "bestPathExists",


### PR DESCRIPTION
When brief is true, json_paths is never allocated; the else branch was dead code and triggered Coverity CID 1670529 (DEADCODE).