### PR TITLE
pceplib: obj is already de-refed, no need to check for NULL

### DIFF
--- a/pceplib/pcep_msg_objects_encoding.c
+++ b/pceplib/pcep_msg_objects_encoding.c
@@ -1877,7 +1877,7 @@ struct pcep_object_header *pcep_decode_obj_ro(struct pcep_object_header *hdr,
 			break;
 	}
 
-	if (err_p && obj) {
+	if (err_p) {
 		pcep_obj_free_object((struct pcep_object_header *)obj);
 		obj = NULL;
 	}


### PR DESCRIPTION
obj is created via common_object_create() which never returns a NULL pointer.  There is no need to test
for it being NULL.