### PR TITLE
zebra: map table ID to VRF via direct hash table (Fixes #5982)

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -216,7 +216,7 @@ static void connected_remove_kernel_for_connected(afi_t afi, safi_t safi, struct
 		return;
 
 	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_KERNEL, 0, 0, p, NULL, nh, 0,
-		   zvrf->table_id, 0, 0, false);
+		   zvrf_table_id(zvrf), 0, 0, false);
 }
 
 /* Called from if_up(). */
@@ -331,18 +331,18 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		connected_remove_kernel_for_connected(afi, SAFI_UNICAST, zvrf, &p, &nh);
 
 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0, flags, &p,
-			NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0, false, true);
+			NULL, &nh, 0, zvrf_table_id(zvrf), metric, 0, 0, 0, false, true);
 
 		connected_remove_kernel_for_connected(afi, SAFI_MULTICAST, zvrf, &p, &nh);
 		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0, flags, &p,
-			NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0, false, true);
+			NULL, &nh, 0, zvrf_table_id(zvrf), metric, 0, 0, 0, false, true);
 	}
 
 	if (install_local) {
 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags, &plocal,
-			NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
+			NULL, &nh, 0, zvrf_table_id(zvrf), 0, 0, 0, 0, false, true);
 		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags,
-			&plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
+			&plocal, NULL, &nh, 0, zvrf_table_id(zvrf), 0, 0, 0, 0, false, true);
 	}
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
@@ -532,21 +532,21 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 	if (!CHECK_FLAG(ifc->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
 		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
 			   ZEBRA_ROUTE_CONNECT, 0, 0, &p, NULL, &nh, 0,
-			   zvrf->table_id, 0, 0, false);
+			   zvrf_table_id(zvrf), 0, 0, false);
 
 		rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
 			   ZEBRA_ROUTE_CONNECT, 0, 0, &p, NULL, &nh, 0,
-			   zvrf->table_id, 0, 0, false);
+			   zvrf_table_id(zvrf), 0, 0, false);
 	}
 
 	if (remove_local) {
 		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
 			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
-			   zvrf->table_id, 0, 0, false);
+			   zvrf_table_id(zvrf), 0, 0, false);
 
 		rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
 			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
-			   zvrf->table_id, 0, 0, false);
+			   zvrf_table_id(zvrf), 0, 0, false);
 	}
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1574,7 +1574,7 @@ static void interface_vrf_change(enum dplane_op_e op, ifindex_t ifindex,
 		 * during the vrf_enable callbacks.
 		 */
 		zvrf = (struct zebra_vrf *)vrf->info;
-		zvrf->table_id = tableid;
+		zebra_vrf_set_table_id(zvrf, tableid);
 
 		/* Enable the created VRF. */
 		if (!vrf_enable(vrf)) {

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -174,7 +174,7 @@ static bool zebra_redistribute_is_table_direct(const struct route_entry *re)
 	struct zebra_vrf *zvrf;
 
 	zvrf = zebra_vrf_lookup_by_id(re->vrf_id);
-	if (re->vrf_id == VRF_DEFAULT && zvrf->table_id != re->table)
+	if (re->vrf_id == VRF_DEFAULT && zvrf_table_id(zvrf) != re->table)
 		return true;
 	return false;
 }
@@ -196,7 +196,7 @@ static bool zebra_redistribute_check(const struct route_node *rn,
 
 	afi = family2afi(rn->p.family);
 	zvrf = zebra_vrf_lookup_by_id(re->vrf_id);
-	if (zvrf->table_id != re->table) {
+	if (zvrf_table_id(zvrf) != re->table) {
 		/*
 		 * Routes with table ID different from VRFs can be used as
 		 * `table-direct` if enabled.
@@ -777,7 +777,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct rou
 	UNSET_FLAG(import_flags, ZEBRA_FLAG_RR_USE_DISTANCE);
 
 	newre = zebra_rib_route_entry_new(0, ZEBRA_ROUTE_TABLE, re->table, import_flags,
-					  re->nhe_id, zvrf->table_id, re->metric, re->mtu,
+					  re->nhe_id, zvrf_table_id(zvrf), re->metric, re->mtu,
 					  zebra_import_table_distance[afi][safi][re->table],
 					  re->tag);
 
@@ -800,7 +800,7 @@ int zebra_del_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct rou
 	prefix_copy(&p, &rn->p);
 
 	rib_delete(afi, safi, zvrf->vrf->vrf_id, ZEBRA_ROUTE_TABLE, re->table, re->flags, &p, NULL,
-		   re->nhe->nhg.nexthop, re->nhe_id, zvrf->table_id, re->metric, re->distance,
+		   re->nhe->nhg.nexthop, re->nhe_id, zvrf_table_id(zvrf), re->metric, re->distance,
 		   false);
 
 	return 0;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2962,7 +2962,7 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	 * the zvrf table_id for the default table as RT_TABLE_MAIN
 	 * which is what the normal routing table for ip routing is.
 	 * This change caused this to break our lookups of sg data
-	 * because prior to this change the zvrf->table_id was 0
+	 * because prior to this change the zvrf_table_id(zvrf) was 0
 	 * and when the pim multicast kernel code saw a 0,
 	 * it was auto-translated to RT_TABLE_DEFAULT.  But since
 	 * we are now passing in RT_TABLE_MAIN there is no auto-translation
@@ -2970,11 +2970,11 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	 * are trying to give me.  So now we have this little hack.
 	 */
 	if (mroute->family == AF_INET)
-		actual_table = (zvrf->table_id == rt_table_main_id)
+		actual_table = (zvrf_table_id(zvrf) == rt_table_main_id)
 				       ? RT_TABLE_DEFAULT
-				       : zvrf->table_id;
+				       : zvrf_table_id(zvrf);
 	else
-		actual_table = zvrf->table_id;
+		actual_table = zvrf_table_id(zvrf);
 
 	if (!nl_attr_put32(&req.n, sizeof(req), RTA_TABLE, actual_table)) {
 		zlog_err("%s: Failed to put RTA_TABLE nl attribute", __func__);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -102,7 +102,7 @@ static void zserv_encode_vrf(struct stream *s, struct zebra_vrf *zvrf)
 	const char *netns_name = zvrf_ns_name(zvrf);
 
 	memset(&data, 0, sizeof(data));
-	data.l.table_id = zvrf->table_id;
+	data.l.table_id = zvrf_table_id(zvrf);
 
 	if (netns_name)
 		strlcpy(data.l.netns_name, basename((char *)netns_name),
@@ -2171,7 +2171,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	/* Allocate new route. */
 	re = zebra_rib_route_entry_new(
 		vrf_id, api.type, api.instance, api.flags, api.nhgid,
-		api.tableid ? api.tableid : zvrf->table_id, api.metric, api.mtu,
+		api.tableid ? api.tableid : zvrf_table_id(zvrf), api.metric, api.mtu,
 		api.distance, api.tag);
 
 	if (!CHECK_FLAG(api.message, ZAPI_MESSAGE_NHG)
@@ -2324,7 +2324,7 @@ static void zread_route_del(ZAPI_HANDLER_ARGS)
 	if (api.tableid)
 		table_id = api.tableid;
 	else
-		table_id = zvrf->table_id;
+		table_id = zvrf_table_id(zvrf);
 
 	if (IS_ZEBRA_DEBUG_RECV)
 		zlog_debug("%s: p=(%u:%u)%pFX, msg flags=0x%x, flags=0x%x",

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -303,13 +303,13 @@ const void *lib_vrf_zebra_ribs_rib_get_next(struct nb_cb_get_next_args *args)
 		afi = AFI_IP;
 		safi = SAFI_UNICAST;
 
-		zrt = zebra_router_find_zrt(zvrf, zvrf->table_id, afi, safi);
+		zrt = zebra_router_find_zrt(zvrf, zvrf_table_id(zvrf), afi, safi);
 		if (zrt == NULL)
 			return NULL;
 	} else {
 		zrt = RB_NEXT(zebra_router_table_head, zrt);
 		/* vrf_id/ns_id do not match, only walk for the given VRF */
-		while (zrt && (zrt->tableid != zvrf->table_id ||
+		while (zrt && (zrt->tableid != zvrf_table_id(zvrf) ||
 			       zrt->ns_id != zvrf->zns->ns_id))
 			zrt = RB_NEXT(zebra_router_table_head, zrt);
 	}
@@ -348,7 +348,7 @@ lib_vrf_zebra_ribs_rib_lookup_entry(struct nb_cb_lookup_entry_args *args)
 	table_id = yang_str2uint32(args->keys->key[1]);
 	/* table_id 0 assume vrf's table_id. */
 	if (!table_id)
-		table_id = zvrf->table_id;
+		table_id = zvrf_table_id(zvrf);
 
 	return zebra_router_find_zrt(zvrf, table_id, afi, safi);
 }
@@ -370,7 +370,7 @@ lib_vrf_zebra_ribs_rib_lookup_next(struct nb_cb_lookup_entry_args *args)
 	table_id = yang_str2uint32(args->keys->key[1]);
 	/* table_id 0 assume vrf's table_id. */
 	if (!table_id)
-		table_id = zvrf->table_id;
+		table_id = zvrf_table_id(zvrf);
 
 	return zebra_router_find_next_zrt(zvrf, table_id, afi, safi);
 }

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1906,7 +1906,7 @@ static void rib_process_result_import_table_del(const struct zebra_dplane_ctx *c
 			continue;
 
 		rib_delete(afi, safi, zvrf->vrf->vrf_id, ZEBRA_ROUTE_TABLE, table_id, flags, p,
-			   NULL, nhg ? nhg->nexthop : NULL, nhe_id, zvrf->table_id, metric,
+			   NULL, nhg ? nhg->nexthop : NULL, nhe_id, zvrf_table_id(zvrf), metric,
 			   distance, false);
 	}
 }
@@ -4414,7 +4414,7 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p, struct prefix_ip
 			 * no matter what.  Since FRR will not have connected routes
 			 * in them.
 			 */
-			if (re->table == zvrf->table_id || re->table == RT_TABLE_MAIN) {
+			if (re->table == zvrf_table_id(zvrf) || re->table == RT_TABLE_MAIN) {
 				if (connected &&
 				    !CHECK_FLAG(connected->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
 					zebra_nhg_free(n);
@@ -4605,7 +4605,7 @@ void rib_update_table(struct route_table *table, enum rib_update_event event,
 			   table->info ? afi2str(
 				   ((struct rib_table_info *)table->info)->afi)
 				       : "Unknown",
-			   VRF_LOGNAME(vrf), zvrf ? zvrf->table_id : 0,
+			   VRF_LOGNAME(vrf), zvrf ? zvrf_table_id(zvrf) : 0,
 			   rib_update_event2str(event), zebra_route_string(rtype));
 	}
 

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -259,6 +259,7 @@ void zebra_router_terminate(void)
 	hash_iterate(zrouter.nhgs_id, zebra_nhg_hash_free_zero_id, NULL);
 	hash_clean_and_free(&zrouter.nhgs_id, zebra_nhg_hash_free);
 	hash_clean_and_free(&zrouter.nhgs, NULL);
+	zvrf_table_id_hash_fini(&zrouter.vrf_table_hash);
 
 	hash_clean_and_free(&zrouter.rules_hash, zebra_pbr_rules_free);
 
@@ -319,6 +320,8 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_ne
 	zrouter.ipset_hash =
 		hash_create_size(8, zebra_pbr_ipset_hash_key,
 				 zebra_pbr_ipset_hash_equal, "IPset Hash");
+
+	zvrf_table_id_hash_init(&zrouter.vrf_table_hash);
 
 	zrouter.ipset_entry_hash = hash_create_size(
 		8, zebra_pbr_ipset_entry_hash_key,

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -240,6 +240,10 @@ struct zebra_router {
 	uint64_t nexthop_weight_scale_value;
 
 	bool backup_nhs_installed;
+	/*
+	 * VRF table ID hash table (typesafe)
+	 */
+	struct zvrf_table_id_hash_head vrf_table_hash;
 };
 
 #define GRACEFUL_RESTART_TIME 60

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -465,7 +465,7 @@ static void do_show_srv6_sid_json(struct vty *vty, json_object **json, struct sr
 
 			zvrf = vrf_info_lookup(sid_ctx->ctx.vrf_id);
 			if (zvrf)
-				json_object_int_add(json_sid_ctx, "table", zvrf->table_id);
+				json_object_int_add(json_sid_ctx, "table", zvrf_table_id(zvrf));
 		}
 		if (sid_ctx->ctx.ifindex) {
 			json_object_int_add(json_sid_ctx, "interfaceIndex", sid_ctx->ctx.ifindex);

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -42,6 +42,44 @@ static void zebra_rnhtable_node_cleanup(struct route_table *table,
 DEFINE_MTYPE_STATIC(ZEBRA, ZEBRA_VRF, "ZEBRA VRF");
 DEFINE_MTYPE_STATIC(ZEBRA, OTHER_TABLE, "Other Table");
 
+/*
+ * Inserts a zebra_vrf into the VRF table_id hash.
+ *
+ * zvrf: Pointer to zebra_vrf to insert.
+ */
+static inline void zebra_vrf_hash_insert(struct zebra_vrf *zvrf)
+{
+	zvrf_table_id_hash_add(&zrouter.vrf_table_hash, zvrf);
+}
+
+/*
+ * Removes a zebra_vrf from the VRF table_id hash.
+ *
+ * zvrf: Pointer to zebra_vrf to remove.
+ */
+static inline void zebra_vrf_hash_remove(struct zebra_vrf *zvrf)
+{
+	zvrf_table_id_hash_del(&zrouter.vrf_table_hash, zvrf);
+}
+
+/*
+ * Updates the table_id of a zebra_vrf and adjusts the hash accordingly.
+ *
+ * zvrf: Pointer to zebra_vrf to update.
+ * table_id: New table_id.
+ */
+void zebra_vrf_set_table_id(struct zebra_vrf *zvrf, uint32_t table_id)
+{
+	if (zvrf->_table_id == table_id) {
+		zebra_vrf_hash_insert(zvrf);
+		return;
+	}
+
+	zebra_vrf_hash_remove(zvrf);
+	zvrf->_table_id = table_id;
+	zebra_vrf_hash_insert(zvrf);
+}
+
 /* VRF information update. */
 static void zebra_vrf_add_update(struct zebra_vrf *zvrf)
 {
@@ -219,7 +257,7 @@ static void zebra_vrf_disable_update_vrfid(struct zebra_vrf *zvrf, afi_t afi, sa
 	}
 
 	if (empty_table)
-		zebra_router_release_table(zvrf, zvrf->table_id, afi, safi);
+		zebra_router_release_table(zvrf, zvrf_table_id(zvrf), afi, safi);
 	zvrf->table[afi][safi] = NULL;
 }
 
@@ -286,7 +324,7 @@ static int zebra_vrf_disable(struct vrf *vrf)
 		 */
 		for (safi = SAFI_UNICAST; safi <= SAFI_MULTICAST; safi++) {
 			if (!zvrf->table[afi][safi] || vrf->vrf_id == VRF_DEFAULT) {
-				zebra_router_release_table(zvrf, zvrf->table_id, afi, safi);
+				zebra_router_release_table(zvrf, zvrf_table_id(zvrf), afi, safi);
 				zvrf->table[afi][safi] = NULL;
 				continue;
 			}
@@ -336,6 +374,8 @@ static int zebra_vrf_delete(struct vrf *vrf)
 	list_delete_all_node(zvrf->rid6_all_sorted_list);
 	list_delete_all_node(zvrf->rid6_lo_sorted_list);
 
+	zebra_vrf_hash_remove(zvrf);
+
 	otable_fini(&zvrf->other_tables);
 	XFREE(MTYPE_ZEBRA_VRF, zvrf);
 
@@ -367,7 +407,7 @@ struct route_table *zebra_vrf_lookup_table_with_table_id(afi_t afi, safi_t safi,
 	if (afi >= AFI_MAX || safi >= SAFI_MAX)
 		return NULL;
 
-	if (table_id == zvrf->table_id)
+	if (table_id == zvrf_table_id(zvrf))
 		return zebra_vrf_table(afi, safi, vrf_id);
 
 	ort.afi = afi;
@@ -438,7 +478,7 @@ static void zebra_vrf_table_create(struct zebra_vrf *zvrf, afi_t afi,
 	 * Otherwise, create a new table.
 	 */
 	zvrf->table[afi][safi] =
-		zebra_router_get_table(zvrf, zvrf->table_id, afi, safi);
+		zebra_router_get_table(zvrf, zvrf_table_id(zvrf), afi, safi);
 
 	/* If the table existed before the VRF was created, info->zvrf was
 	 * referring to the default VRF.
@@ -484,8 +524,9 @@ struct zebra_vrf *zebra_vrf_alloc(struct vrf *vrf)
 	zebra_vxlan_init_tables(zvrf);
 	zebra_mpls_init_tables(zvrf);
 	zebra_pw_init_vrf(zvrf);
-	zvrf->table_id = rt_table_main_id;
+	zvrf->_table_id = rt_table_main_id;
 	/* by default table ID is default one */
+	zebra_vrf_hash_insert(zvrf);
 
 	if (DFLT_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT) {
 		zvrf->zebra_rnh_ip_default_route = true;
@@ -495,31 +536,25 @@ struct zebra_vrf *zebra_vrf_alloc(struct vrf *vrf)
 	return zvrf;
 }
 
-/*
- * Pending: create an efficient table_id (in a tree/hash) based lookup)
- */
 vrf_id_t zebra_vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 {
-	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
+	struct zebra_vrf lookup;
 
-	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
-		zvrf = vrf->info;
-
-		if (zvrf == NULL)
-			continue;
-		/* case vrf with netns : match the netnsid */
-		if (vrf_is_backend_netns()) {
-			if (ns_id == zvrf_id(zvrf))
-				return zvrf_id(zvrf);
-		} else {
-			/* VRF is VRF_BACKEND_VRF_LITE */
-			if (zvrf->table_id != table_id)
-				continue;
-
+	/* case vrf with netns : match the netnsid */
+	if (vrf_is_backend_netns()) {
+		zvrf = zebra_vrf_lookup_by_id((vrf_id_t)ns_id);
+		if (zvrf)
 			return zvrf_id(zvrf);
-		}
+		return VRF_DEFAULT;
 	}
+
+	/* VRF is VRF_BACKEND_VRF_LITE */
+	memset(&lookup, 0, sizeof(lookup));
+	lookup._table_id = table_id;
+	zvrf = zvrf_table_id_hash_find(&zrouter.vrf_table_hash, &lookup);
+	if (zvrf)
+		return zvrf_id(zvrf);
 
 	return VRF_DEFAULT;
 }
@@ -538,7 +573,7 @@ int zebra_vrf_lookup_tableid(vrf_id_t vrf_id, ns_id_t ns_id)
 		zvrf = vrf_info_lookup(vrf_id);
 
 	if (zvrf)
-		return zvrf->table_id;
+		return zvrf_table_id(zvrf);
 	else
 		return ZEBRA_ROUTE_TABLE_UNKNOWN;
 }

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -40,6 +40,7 @@ struct zebra_rmap {
 };
 
 PREDECL_RBTREE_UNIQ(otable);
+PREDECL_HASH(zvrf_table_id_hash);
 
 struct other_route_table {
 	struct otable_item next;
@@ -67,7 +68,16 @@ struct zebra_vrf {
 #define ZEBRA_VRF_RETAIN          (1 << 0)
 #define ZEBRA_PIM_SEND_VXLAN_SG   (1 << 1)
 
-	uint32_t table_id;
+	/*
+	 * Table ID for this VRF. This field is used as a hash key in
+	 * zrouter.vrf_table_hash. All writes MUST go through
+	 * zebra_vrf_set_table_id() to keep the hash in sync.
+	 * Use zvrf_table_id() to read this value.
+	 */
+	uint32_t _table_id;
+
+	/* Typesafe hash linkage for VRF table-id lookup */
+	struct zvrf_table_id_hash_item vrf_table_hash_item;
 
 	/* Routing table.  */
 	struct route_table *table[AFI_MAX][SAFI_MAX];
@@ -179,6 +189,42 @@ struct zebra_vrf {
 	bool zebra_rnh_ipv6_default_route;
 	bool zebra_mpls_fec_nexthop_resolution;
 };
+
+/*
+ * Typesafe hash compare function for VRF Table ID lookup.
+ *
+ * a: First zebra_vrf.
+ * b: Second zebra_vrf.
+ * Returns: 0 if table_ids match, non-zero otherwise.
+ */
+static inline int zvrf_table_id_hash_cmp(const struct zebra_vrf *a,
+					 const struct zebra_vrf *b)
+{
+	return numcmp(a->_table_id, b->_table_id);
+}
+
+/*
+ * Typesafe hash key function for VRF Table ID lookup.
+ *
+ * zvrf: Pointer to zebra_vrf.
+ * Returns: The table_id as the hash key.
+ */
+static inline uint32_t zvrf_table_id_hash_key(const struct zebra_vrf *zvrf)
+{
+	return zvrf->_table_id;
+}
+
+DECLARE_HASH(zvrf_table_id_hash, struct zebra_vrf, vrf_table_hash_item,
+	     zvrf_table_id_hash_cmp, zvrf_table_id_hash_key);
+
+/*
+ * Read accessor for the VRF table ID. Always use this instead of
+ * accessing _table_id directly.
+ */
+static inline uint32_t zvrf_table_id(const struct zebra_vrf *zvrf)
+{
+	return zvrf->_table_id;
+}
 #define PROTO_RM_NAME(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].name
 #define NHT_RM_NAME(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].name
 #define PROTO_RM_MAP(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].map
@@ -252,6 +298,8 @@ extern vrf_id_t zebra_vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id);
 extern struct zebra_vrf *zebra_vrf_alloc(struct vrf *vrf);
 extern struct route_table *zebra_vrf_table(afi_t afi, safi_t safi, vrf_id_t vrf_id);
 int zebra_vrf_lookup_tableid(vrf_id_t vrf_id, ns_id_t ns_id);
+
+extern void zebra_vrf_set_table_id(struct zebra_vrf *zvrf, uint32_t table_id);
 
 /*
  * API to associate a VRF with a NETNS.

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2741,7 +2741,7 @@ DEFUN (show_vrf,
 				zvrf_ns_name(zvrf));
 		else
 			vty_out(vty, "id %u table %u", zvrf_id(zvrf),
-				zvrf->table_id);
+				zvrf_table_id(zvrf));
 		if (vrf_is_user_cfged(vrf))
 			vty_out(vty, " (configured)");
 		vty_out(vty, "\n");


### PR DESCRIPTION
Replaces the RB_FOREACH loop in zebra_vrf_lookup_by_table() with a hash table lookup keyed on table_id, making VRF resolution O(1) instead of O(n). The hash is maintained on VRF alloc, deletion, and table ID changes. Callers like rt_netlink.c benefit automatically.

Fixes https://github.com/FRRouting/frr/issues/5982