### PR TITLE
bgpd: dynamic neighbors not up with md5 in non default vrf

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -990,12 +990,48 @@ int bgp_getsockname(struct peer_connection *connection)
 	return 0;
 }
 
+/*
+ * Non-default VRF: apply TCP MD5 on the listen socket for one listen-range
+ * prefix (see bgp_listener).
+ *
+ * Returns 0 on success or when MD5 is not configured for this range; on
+ * failure returns bgp_md5_set_socket()'s value (negative, not always -1).
+ */
+static int bgp_listener_md5_listen_range(struct bgp_listener *listener, struct peer_group *group,
+					 struct prefix *prefix, struct peer *peer)
+{
+	union sockunion su;
+	int md5_ret;
+
+	if (!peer || !peer->password)
+		return 0;
+
+	/* bgp_listener() is per-socket (AF_INET vs AF_INET6); skip wrong family */
+	if (listener->su.sa.sa_family != prefix->family)
+		return 0;
+
+	prefix2sockunion(prefix, &su);
+	md5_ret = bgp_md5_set_socket(listener->fd, &su, prefix->prefixlen, peer->password);
+	if (md5_ret < 0) {
+		int md5_errno = errno;
+
+		flog_err(EC_BGP_NO_TCP_MD5,
+			 "%s: TCP MD5 not applied on listen socket (fd %d) for peer-group %s listen range %pFX: %s",
+			 listener->name ? listener->name : VRF_DEFAULT_NAME, listener->fd,
+			 group->name ? group->name : "?", prefix, safe_strerror(md5_errno));
+		return md5_ret;
+	}
+	return 0;
+}
 
 static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 			struct bgp *bgp)
 {
 	struct bgp_listener *listener;
 	int ret, en;
+	bool md5_ok = true;
+	struct listnode *node, *nnode;
+	struct peer_group *group;
 
 	sockopt_reuseaddr(sock);
 	sockopt_reuseport(sock);
@@ -1035,9 +1071,56 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 		listener->bgp = bgp;
 
 	memcpy(&listener->su, sa, salen);
+
+	/*
+	 * Default VRF: listen-range MD5 is applied from bgp_md5_set_prefix()
+	 * when the password / range is configured. Non-default VRF listeners
+	 * have listener->bgp set and are skipped by that path, so apply MD5
+	 * here when the socket is created, before registering the listener so
+	 * a failure does not require cancelling the read event or removing the
+	 * socket from the global list.
+	 */
+	if (bgp->vrf_id == VRF_DEFAULT) {
+		event_add_read(bm->master, bgp_accept, listener, sock, &listener->event);
+		listnode_add(bm->listen_sockets, listener);
+		return 0;
+	}
+
+	frr_with_privs (&bgpd_privs) {
+		for (ALL_LIST_ELEMENTS(bgp->group, node, nnode, group)) {
+			struct listnode *ln;
+			struct prefix *prefix;
+			struct peer *peer = group->conf;
+
+			for (ALL_LIST_ELEMENTS_RO(group->listen_range[AFI_IP], ln, prefix)) {
+				if (bgp_listener_md5_listen_range(listener, group, prefix, peer) <
+				    0) {
+					md5_ok = false;
+					break;
+				}
+			}
+			if (!md5_ok)
+				break;
+
+			for (ALL_LIST_ELEMENTS_RO(group->listen_range[AFI_IP6], ln, prefix)) {
+				if (bgp_listener_md5_listen_range(listener, group, prefix, peer) <
+				    0) {
+					md5_ok = false;
+					break;
+				}
+			}
+			if (!md5_ok)
+				break;
+		}
+	}
+	if (!md5_ok) {
+		XFREE(MTYPE_BGP_LISTENER, listener->name);
+		XFREE(MTYPE_BGP_LISTENER, listener);
+		return -1;
+	}
+
 	event_add_read(bm->master, bgp_accept, listener, sock, &listener->event);
 	listnode_add(bm->listen_sockets, listener);
-
 	return 0;
 }
 

--- a/tests/topotests/bgp_vrf_dynamic_md5_listen_late/switch1/frr.conf
+++ b/tests/topotests/bgp_vrf_dynamic_md5_listen_late/switch1/frr.conf
@@ -1,0 +1,44 @@
+! DUT: default BGP first, then vrf1 dynamic listen + MD5 (ordering matters).
+!
+frr defaults traditional
+!
+vrf vrf1
+exit-vrf
+!
+interface switch1-eth0 vrf vrf1
+ ip address 10.10.12.1/24
+!
+interface switch1-eth1
+ ip address 10.10.13.1/24
+!
+ip forwarding
+!
+router bgp 65001
+ bgp router-id 10.10.13.1
+ no bgp ebgp-requires-policy
+ neighbor peergroup2 peer-group
+ neighbor peergroup2 remote-as external
+ neighbor peergroup2 password secret2
+ neighbor peergroup2 timers 3 10
+ neighbor peergroup2 timers connect 1
+ neighbor 10.10.13.2 peer-group peergroup2
+ !
+ address-family ipv4 unicast
+  neighbor peergroup2 activate
+ exit-address-family
+!
+router bgp 65001 vrf vrf1
+ bgp router-id 10.10.12.1
+ no bgp ebgp-requires-policy
+ neighbor peergroup1 peer-group
+ neighbor peergroup1 remote-as external
+ neighbor peergroup1 password secret1
+ neighbor peergroup1 timers 3 10
+ neighbor peergroup1 timers connect 1
+ bgp listen limit 50
+ bgp listen range 10.10.12.0/24 peer-group peergroup1
+ !
+ address-family ipv4 unicast
+  neighbor peergroup1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_vrf_dynamic_md5_listen_late/switch2/frr.conf
+++ b/tests/topotests/bgp_vrf_dynamic_md5_listen_late/switch2/frr.conf
@@ -1,0 +1,30 @@
+! switch2: static neighbor to switch1 in vrf1, MD5 via peergroup1
+!
+frr defaults traditional
+!
+vrf vrf1
+exit-vrf
+!
+interface switch2-eth0 vrf vrf1
+ ip address 10.10.12.2/24
+!
+ip forwarding
+!
+router bgp 65002 vrf vrf1
+ bgp router-id 10.10.12.2
+ no bgp ebgp-requires-policy
+ bgp disable-ebgp-connected-route-check
+ neighbor peergroup1 peer-group
+ neighbor peergroup1 remote-as external
+ neighbor peergroup1 password secret1
+ neighbor peergroup1 timers 3 10
+ neighbor peergroup1 timers connect 1
+ neighbor peergroup1 disable-connected-check
+ neighbor 10.10.12.1 peer-group peergroup1
+ neighbor 10.10.12.1 update-source switch2-eth0
+ neighbor 10.10.12.1 disable-connected-check
+ !
+ address-family ipv4 unicast
+  neighbor peergroup1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_vrf_dynamic_md5_listen_late/switch3/frr.conf
+++ b/tests/topotests/bgp_vrf_dynamic_md5_listen_late/switch3/frr.conf
@@ -1,0 +1,24 @@
+! switch3: neighbor to switch1 in default VRF, MD5 via peergroup2
+!
+frr defaults traditional
+!
+interface switch3-eth0
+ ip address 10.10.13.2/24
+!
+ip forwarding
+!
+router bgp 65003
+ bgp router-id 10.10.13.2
+ no bgp ebgp-requires-policy
+ neighbor peergroup2 peer-group
+ neighbor peergroup2 remote-as external
+ neighbor peergroup2 password secret2
+ neighbor peergroup2 timers 3 10
+ neighbor peergroup2 timers connect 1
+ neighbor 10.10.13.1 peer-group peergroup2
+ neighbor 10.10.13.1 update-source switch3-eth0
+ !
+ address-family ipv4 unicast
+  neighbor peergroup2 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_vrf_dynamic_md5_listen_late/test_bgp_vrf_dynamic_md5_listen_late.py
+++ b/tests/topotests/bgp_vrf_dynamic_md5_listen_late/test_bgp_vrf_dynamic_md5_listen_late.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026 by FRRouting / topology test authors
+#
+"""
+Description: dynamic BGP + MD5 in a non-default VRF on the DUT while also
+peering in the default VRF (switch3). Expected failure mode is that switch1
+does not show the vrf1 dynamic neighbor as Established in
+``show bgp vrf all summary`` while the default-VRF session may be up.
+
+Topology :
+  switch1 (DUT) -- vrf1 -- switch2
+  switch1 -------- default -- switch3
+
+Each router uses a single integrated ``switchN/frr.conf`` (zebra + BGP; on the
+DUT, default BGP instance before VRF BGP). Config is loaded with
+``load_frr_config()`` (standard topotest unified ``frr.conf`` path).
+"""
+
+import functools
+import json
+import os
+import platform
+import re
+import sys
+import time
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.checkping import check_ping
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+VRF_NAME = "vrf1"
+VRF_TABLE_S1 = 11001
+VRF_TABLE_S2 = 11002
+PEER_S2 = "10.10.12.2"
+PEER_S3 = "10.10.13.2"
+DUT_ADDR_VRF1 = "10.10.12.1"
+
+
+def build_topo(tgen):
+    s1 = tgen.add_router("switch1")
+    s2 = tgen.add_router("switch2")
+    s3 = tgen.add_router("switch3")
+    tgen.add_link(s1, s2)
+    tgen.add_link(s1, s3)
+
+
+def _peer_state_vrf_all_summary(summary, vrf, addr):
+    """Return BGP FSM state string for addr under vrf (handles dynamic * prefix)."""
+    if not isinstance(summary, dict):
+        return None
+    try:
+        peers = summary[vrf]["ipv4Unicast"]["peers"]
+    except (KeyError, TypeError):
+        return None
+    if not isinstance(peers, dict):
+        return None
+    for key in (addr, "*{}".format(addr)):
+        ent = peers.get(key)
+        if isinstance(ent, dict):
+            return ent.get("state")
+    for key, ent in peers.items():
+        if isinstance(ent, dict) and key.lstrip("*") == addr:
+            return ent.get("state")
+    return None
+
+
+def _extract_running_config_block(config, header_line):
+    """Return the `router bgp ...` stanza starting at header_line, or a short note."""
+    if not config or header_line not in config:
+        return "(block start {!r} not found in running-config)".format(header_line)
+    i = config.index(header_line)
+    rest = config[i:]
+    m = re.search(r"\nrouter ", rest[1:])
+    if m:
+        return rest[: m.start() + 1].strip()
+    return rest.strip()[:8000]
+
+
+def _failure_md5_diagnostic_bundle(dut, peer, vrf_name):
+    """
+    Commands to separate:
+      - switch2 NHT / eBGP-connected (not the original MD5/listener issue)
+      - TCP :179 not ESTAB (often MD5 mismatch or no accept)
+      - Listeners OK on DUT but no dynamic peer (DUT accept / MD5 on listen socket)
+    """
+    parts = []
+
+    def _add(title, text):
+        parts.append("=== {} ===\n{}".format(title, (text or "").rstrip() or "(empty)"))
+
+    _add(
+        "switch1: show bgp vrf all summary json",
+        dut.vtysh_cmd("show bgp vrf all summary json"),
+    )
+    _add("switch1: show bgp listeners", dut.vtysh_cmd("show bgp listeners"))
+    _add(
+        "switch1: show bgp vrf {} ipv4 unicast summary json".format(vrf_name),
+        dut.vtysh_cmd(
+            "show bgp vrf {} ipv4 unicast summary json".format(vrf_name)
+        ),
+    )
+    _add(
+        "switch1: show bgp vrf {} neighbors".format(vrf_name),
+        dut.vtysh_cmd("show bgp vrf {} neighbors".format(vrf_name)),
+    )
+    _add(
+        "switch1: show ip route vrf {} json".format(vrf_name),
+        dut.vtysh_cmd("show ip route vrf {} json".format(vrf_name)),
+    )
+    _add(
+        "switch1: ss tcp (vrf {}, lines mentioning :179)".format(vrf_name),
+        dut.cmd(
+            "ip vrf exec {} ss -tn 2>/dev/null | grep -E ':179|State' | head -80".format(
+                vrf_name
+            )
+        ),
+    )
+    rc1 = dut.vtysh_cmd("show running-config")
+    _add(
+        "switch1: running-config (BGP vrf instance only)",
+        _extract_running_config_block(
+            rc1, "router bgp 65001 vrf {}".format(vrf_name)
+        ),
+    )
+
+    _add(
+        "switch2: show bgp vrf {} neighbors {}".format(vrf_name, DUT_ADDR_VRF1),
+        peer.vtysh_cmd(
+            "show bgp vrf {} neighbors {}".format(vrf_name, DUT_ADDR_VRF1)
+        ),
+    )
+    _add(
+        "switch2: show bgp vrf {} ipv4 unicast summary json".format(vrf_name),
+        peer.vtysh_cmd(
+            "show bgp vrf {} ipv4 unicast summary json".format(vrf_name)
+        ),
+    )
+    _add(
+        "switch2: show ip route vrf {} json".format(vrf_name),
+        peer.vtysh_cmd("show ip route vrf {} json".format(vrf_name)),
+    )
+    _add(
+        "switch2: ss tcp (vrf {}, lines mentioning :179)".format(vrf_name),
+        peer.cmd(
+            "ip vrf exec {} ss -tn 2>/dev/null | grep -E ':179|State' | head -80".format(
+                vrf_name
+            )
+        ),
+    )
+    rc2 = peer.vtysh_cmd("show running-config")
+    _add(
+        "switch2: running-config (BGP vrf instance only)",
+        _extract_running_config_block(
+            rc2, "router bgp 65002 vrf {}".format(vrf_name)
+        ),
+    )
+
+    parts.append(
+        "=== how to read (original issue = DUT vrf1 dynamic + MD5 listen) ===\n"
+        "- switch2: 'No path to specified Neighbor' / Opens 0 / Nexthop 0.0.0.0 → "
+        "peer-side NHT or eBGP-connected check; fix switch2 config before blaming "
+        "DUT MD5 listen.\n"
+        "- switch1: vrf1 listeners on 0.0.0.0:179 but 'No BGP neighbors' and ss "
+        "shows no ESTAB to :179 → TCP+MD5 not completing (typical MD5 listen / "
+        "accept path).\n"
+        "- switch2 Established to 10.10.12.1 but switch1 vrf1 still empty → "
+        "focus on DUT dynamic neighbor creation / vrf1 instance."
+    )
+    return "\n\n".join(parts)
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    s1 = tgen.gears["switch1"]
+    s2 = tgen.gears["switch2"]
+    s3 = tgen.gears["switch3"]
+
+    s1.cmd_raises("ip link add {} type vrf table {}".format(VRF_NAME, VRF_TABLE_S1))
+    s1.cmd_raises("ip link set up dev {}".format(VRF_NAME))
+    s1.cmd_raises("ip link set switch1-eth0 master {}".format(VRF_NAME))
+    s1.cmd_raises("ip link set up dev switch1-eth0")
+    s1.cmd_raises("ip link set up dev switch1-eth1")
+
+    s2.cmd_raises("ip link add {} type vrf table {}".format(VRF_NAME, VRF_TABLE_S2))
+    s2.cmd_raises("ip link set up dev {}".format(VRF_NAME))
+    s2.cmd_raises("ip link set switch2-eth0 master {}".format(VRF_NAME))
+    s2.cmd_raises("ip link set up dev switch2-eth0")
+
+    s3.cmd_raises("ip link set up dev switch3-eth0")
+
+    for r in (s1, s2, s3):
+        r.cmd_raises("sysctl -w net.ipv4.tcp_l3mdev_accept=1")
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, rname, "frr.conf"))
+
+    tgen.start_router()
+
+    # VRF: must use ip vrf exec — ping -I<source> does not reliably pick vrf1 FIB here.
+    ping_ok = False
+    for _ in range(30):
+        out = s2.cmd(
+            "ip vrf exec {} ping -c1 -W1 {} 2>/dev/null".format(VRF_NAME, DUT_ADDR_VRF1)
+        )
+        if out and "1 received" in out:
+            ping_ok = True
+            break
+        time.sleep(1)
+    if not ping_ok:
+        pytest.fail("L3: no ping from switch2 (vrf1) to switch1 {}".format(DUT_ADDR_VRF1))
+
+    check_ping("switch3", "10.10.13.1", True, 10, 1)
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_vrf_dynamic_md5_listen_late():
+    """
+    1. DUT switch1: dynamic BGP listen range in vrf1 (MD5 peergroup1).
+    2. switch2: BGP toward switch1 in vrf1 (MD5 peergroup1).
+    3. switch3: BGP toward switch1 in default VRF (MD5 peergroup2).
+    4. On switch1, ``show bgp vrf all summary``: vrf1 neighbor switch2 must be
+       Established (dynamic). Known product issue: this stays down while default
+       may be up.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    if topotest.version_cmp(platform.release(), "5.3") < 0:
+        pytest.skip("Kernel < 5.3 (tcp_l3mdev_accept / VRF TCP)")
+
+    dut = tgen.gears["switch1"]
+    s2 = tgen.gears["switch2"]
+
+    def _check():
+        try:
+            summary = json.loads(dut.vtysh_cmd("show bgp vrf all summary json"))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return {"err": "bad json", "raw": None}
+
+        def_v = _peer_state_vrf_all_summary(summary, "default", PEER_S3)
+        v1_v = _peer_state_vrf_all_summary(summary, VRF_NAME, PEER_S2)
+
+        if def_v == "Established" and v1_v == "Established":
+            return None
+        return {
+            "default_peer_{}".format(PEER_S3): def_v,
+            "vrf1_peer_{}".format(PEER_S2): v1_v,
+            "summary_keys": sorted(summary.keys()) if isinstance(summary, dict) else [],
+        }
+
+    ok, last = topotest.run_and_expect(functools.partial(_check), None, count=60, wait=1)
+    if ok:
+        assert last is None
+        return
+
+    bundle = _failure_md5_diagnostic_bundle(dut, s2, VRF_NAME)
+    assert False, (
+        "Expected switch1: default->{} and vrf1->{} Established "
+        "(show bgp vrf all summary json). Last poll: {}.\n"
+        "Goal: reproduce DUT vrf1 dynamic listen + peer-group MD5; use the "
+        "bundle below to see if switch2 is still stuck at NHT (not MD5) vs "
+        "TCP:179/accept on switch1.\n"
+        "If you patched bgpd, ensure the topotest runs that rebuilt binary "
+        "(e.g. install to /usr/lib/frr).\n\n{}".format(
+            PEER_S3,
+            PEER_S2,
+            json.dumps(last, indent=2),
+            bundle,
+        )
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Issue:
When non default vrf, bgp instance and peer group with dynamic neighbors
and md5 config are configured together, bgp peer config happens first.
But bgp vrf enable notification is received later.
BGP listerner socket get created now, but the md5 password is not set on
listening FD. Due to this tcp session not getting established.
    
Fix: walk through the bgp peer group listening socket range for dynamic
neighbors and set md5 password when the listener socket is created for
non default vrf.