### PR TITLE
zebra: Add minimal kernel mode filtering for netlink events

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -6,6 +6,7 @@
 
 #include <zebra.h>
 
+#include <regex.h>
 #ifdef GNU_LINUX
 
 /* The following definition is to workaround an issue in the Linux kernel
@@ -63,6 +64,7 @@
 #include "zebra/zebra_l2.h"
 #include "zebra/netconf_netlink.h"
 #include "zebra/zebra_trace.h"
+#include "zebra/zebra_router.h"
 #include "lib/netlink_parser.h"
 
 extern struct zebra_privs_t zserv_privs;
@@ -1119,6 +1121,13 @@ int netlink_interface_addr_dplane(struct nlmsghdr *h, ns_id_t ns_id,
 
 	ifa = NLMSG_DATA(h);
 
+	/* Check if kernel address events should be ignored */
+	if (zrouter.ignore_kernel_addr) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: ignoring kernel address event (minimal kernel mode enabled)", __func__);
+		return 0;
+	}
+
 	/* Validate message types */
 	if (h->nlmsg_type != RTM_NEWADDR && h->nlmsg_type != RTM_DELADDR)
 		return 0;
@@ -1410,6 +1419,19 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (tb[IFLA_IFNAME] == NULL)
 		return -1;
 	name = (char *)RTA_DATA(tb[IFLA_IFNAME]);
+
+	/* Check if interface should be ignored based on regex patterns */
+	if (zrouter.ignore_regex_count > 0) {
+		for (uint32_t i = 0; i < zrouter.ignore_regex_count; i++) {
+			if (zrouter.ignore_regex[i].compiled &&
+			    regexec(&zrouter.ignore_regex[i].regex, name, 0, NULL, 0) == 0) {
+				if (IS_ZEBRA_DEBUG_KERNEL)
+					zlog_debug("%s: ignoring interface %s (matches regex: %s)",
+						   __func__, name, zrouter.ignore_regex[i].pattern);
+				return 0;
+			}
+		}
+	}
 
 	/* Must be valid string. */
 	len = RTA_PAYLOAD(tb[IFLA_IFNAME]);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1133,6 +1133,13 @@ static int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
 	frrtrace(3, frr_zebra, netlink_route_change_read_unicast, h, ns_id,
 		 startup);
 
+	/* Check if kernel routes should be ignored */
+	if (zrouter.ignore_kernel_routes) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: ignoring kernel route event (minimal kernel mode enabled)", __func__);
+		return 0;
+	}
+
 	rtm = NLMSG_DATA(h);
 
 	if (startup && h->nlmsg_type != RTM_NEWROUTE)
@@ -4794,6 +4801,13 @@ int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id)
 {
 	int len;
 	struct ndmsg *ndm;
+
+	/* Check if kernel neighbor events should be ignored */
+	if (zrouter.ignore_kernel_neigh) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: ignoring kernel neighbor event (minimal kernel mode enabled)", __func__);
+		return 0;
+	}
 
 	if (!(h->nlmsg_type == RTM_NEWNEIGH || h->nlmsg_type == RTM_DELNEIGH
 	      || h->nlmsg_type == RTM_GETNEIGH))

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4481,6 +4481,13 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, unsigned short in
 	struct nexthop nexthop = {};
 	struct nexthop_group ng = {};
 
+	/* Check if NHT should be disabled for kernel routes */
+	if (type == ZEBRA_ROUTE_KERNEL && zrouter.ignore_kernel_nht) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+			zlog_debug("%s: ignoring NHT for kernel route (minimal kernel mode enabled)", __func__);
+		return 0;
+	}
+
 	/* Allocate new route_entry structure. */
 	re = zebra_rib_route_entry_new(vrf_id, type, instance, flags, nhe_id,
 				       table_id, metric, mtu, distance, tag);

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -6,6 +6,7 @@
 #ifndef __ZEBRA_ROUTER_H__
 #define __ZEBRA_ROUTER_H__
 
+#include <regex.h>
 #include "lib/mlag.h"
 #include "lib/hook.h"
 
@@ -240,6 +241,19 @@ struct zebra_router {
 	uint64_t nexthop_weight_scale_value;
 
 	bool backup_nhs_installed;
+
+	/* Minimal kernel mode filtering */
+#define ZEBRA_MAX_IGNORE_REGEX 32
+	struct zebra_if_ignore_regex {
+		char pattern[256];
+		regex_t regex;
+		bool compiled;
+	} ignore_regex[ZEBRA_MAX_IGNORE_REGEX];
+	uint32_t ignore_regex_count;
+	bool ignore_kernel_routes;
+	bool ignore_kernel_addr;
+	bool ignore_kernel_neigh;
+	bool ignore_kernel_nht;
 };
 
 #define GRACEFUL_RESTART_TIME 60

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <regex.h>
 
 #include "memory.h"
 #include "if.h"
@@ -3948,6 +3949,9 @@ DEFPY (zebra_nexthop_group_keep,
 	return CMD_SUCCESS;
 }
 
+/* Forward declaration for minimal kernel mode config write function */
+static int zebra_ignore_netlink_config_write(struct vty *vty);
+
 static int config_write_protocol(struct vty *vty)
 {
 	if (zrouter.allow_delete)
@@ -3991,6 +3995,9 @@ static int config_write_protocol(struct vty *vty)
 	/* Include netlink info */
 	netlink_config_write_helper(vty);
 #endif /* HAVE_NETLINK */
+
+	/* Write minimal kernel mode configuration */
+	zebra_ignore_netlink_config_write(vty);
 
 	return 1;
 }
@@ -4430,6 +4437,226 @@ DEFUN(zebra_on_rib_process_script, zebra_on_rib_process_script_cmd,
 
 #endif /* HAVE_SCRIPTING */
 
+/* Minimal kernel mode filtering commands */
+/* Interface regex configuration */
+DEFUN(zebra_ignore_netlink_if_regex,
+      zebra_ignore_netlink_if_regex_cmd,
+      "zebra ignore-netlink interface-regex WORD",
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Interface name regex pattern\n"
+      "Regular expression pattern\n")
+{
+	int idx = 0;
+	const char *pattern = argv_find(argv, argc, "WORD", &idx) ? argv[idx]->arg : NULL;
+
+	if (!pattern) {
+		vty_out(vty, "%% Pattern required\n");
+		return CMD_WARNING;
+	}
+
+	/* Check if we've reached the maximum */
+	if (zrouter.ignore_regex_count >= ZEBRA_MAX_IGNORE_REGEX) {
+		vty_out(vty, "%% Maximum number of regex patterns (%d) reached\n",
+			ZEBRA_MAX_IGNORE_REGEX);
+		return CMD_WARNING;
+	}
+
+	/* Check for duplicates */
+	for (uint32_t i = 0; i < zrouter.ignore_regex_count; i++) {
+		if (strcmp(zrouter.ignore_regex[i].pattern, pattern) == 0) {
+			vty_out(vty, "%% Pattern already exists\n");
+			return CMD_WARNING;
+		}
+	}
+
+	/* Compile the regex */
+	struct zebra_if_ignore_regex *entry = &zrouter.ignore_regex[zrouter.ignore_regex_count];
+
+	strlcpy(entry->pattern, pattern, sizeof(entry->pattern));
+
+	int ret = regcomp(&entry->regex, pattern, REG_EXTENDED | REG_NOSUB);
+
+	if (ret != 0) {
+		char errbuf[256];
+
+		regerror(ret, &entry->regex, errbuf, sizeof(errbuf));
+		vty_out(vty, "%% Invalid regex pattern: %s\n", errbuf);
+		return CMD_WARNING;
+	}
+
+	entry->compiled = true;
+	zrouter.ignore_regex_count++;
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_zebra_ignore_netlink_if_regex,
+      no_zebra_ignore_netlink_if_regex_cmd,
+      "no zebra ignore-netlink interface-regex WORD",
+      NO_STR
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Interface name regex pattern\n"
+      "Regular expression pattern\n")
+{
+	int idx = 0;
+	const char *pattern = argv_find(argv, argc, "WORD", &idx) ? argv[idx]->arg : NULL;
+
+	if (!pattern) {
+		vty_out(vty, "%% Pattern required\n");
+		return CMD_WARNING;
+	}
+
+	/* Find and remove the pattern */
+	for (uint32_t i = 0; i < zrouter.ignore_regex_count; i++) {
+		if (strcmp(zrouter.ignore_regex[i].pattern, pattern) == 0) {
+			/* Free the compiled regex */
+			if (zrouter.ignore_regex[i].compiled)
+				regfree(&zrouter.ignore_regex[i].regex);
+
+			/* Shift remaining entries */
+			for (uint32_t j = i; j < zrouter.ignore_regex_count - 1; j++)
+				zrouter.ignore_regex[j] = zrouter.ignore_regex[j + 1];
+
+			zrouter.ignore_regex_count--;
+			return CMD_SUCCESS;
+		}
+	}
+
+	vty_out(vty, "%% Pattern not found\n");
+	return CMD_WARNING;
+}
+
+/* Boolean flag commands */
+DEFUN(zebra_ignore_netlink_kernel_routes,
+      zebra_ignore_netlink_kernel_routes_cmd,
+      "zebra ignore-netlink kernel-routes",
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel route events\n")
+{
+	zrouter.ignore_kernel_routes = true;
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_zebra_ignore_netlink_kernel_routes,
+      no_zebra_ignore_netlink_kernel_routes_cmd,
+      "no zebra ignore-netlink kernel-routes",
+      NO_STR
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel route events\n")
+{
+	zrouter.ignore_kernel_routes = false;
+	return CMD_SUCCESS;
+}
+
+DEFUN(zebra_ignore_netlink_kernel_address,
+      zebra_ignore_netlink_kernel_address_cmd,
+      "zebra ignore-netlink kernel-address",
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel address events\n")
+{
+	zrouter.ignore_kernel_addr = true;
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_zebra_ignore_netlink_kernel_address,
+      no_zebra_ignore_netlink_kernel_address_cmd,
+      "no zebra ignore-netlink kernel-address",
+      NO_STR
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel address events\n")
+{
+	zrouter.ignore_kernel_addr = false;
+	return CMD_SUCCESS;
+}
+
+DEFUN(zebra_ignore_netlink_kernel_neighbor,
+      zebra_ignore_netlink_kernel_neighbor_cmd,
+      "zebra ignore-netlink kernel-neighbor",
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel neighbor events\n")
+{
+	zrouter.ignore_kernel_neigh = true;
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_zebra_ignore_netlink_kernel_neighbor,
+      no_zebra_ignore_netlink_kernel_neighbor_cmd,
+      "no zebra ignore-netlink kernel-neighbor",
+      NO_STR
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel neighbor events\n")
+{
+	zrouter.ignore_kernel_neigh = false;
+	return CMD_SUCCESS;
+}
+
+DEFUN(zebra_ignore_netlink_kernel_nht,
+      zebra_ignore_netlink_kernel_nht_cmd,
+      "zebra ignore-netlink kernel-nht",
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel route nexthop tracking\n")
+{
+	zrouter.ignore_kernel_nht = true;
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_zebra_ignore_netlink_kernel_nht,
+      no_zebra_ignore_netlink_kernel_nht_cmd,
+      "no zebra ignore-netlink kernel-nht",
+      NO_STR
+      "Zebra configuration\n"
+      "Ignore netlink events\n"
+      "Ignore kernel route nexthop tracking\n")
+{
+	zrouter.ignore_kernel_nht = false;
+	return CMD_SUCCESS;
+}
+
+/* Configuration write function */
+static int zebra_ignore_netlink_config_write(struct vty *vty)
+{
+	int written = 0;
+
+	/* Write regex patterns */
+	for (uint32_t i = 0; i < zrouter.ignore_regex_count; i++) {
+		vty_out(vty, "zebra ignore-netlink interface-regex %s\n",
+			zrouter.ignore_regex[i].pattern);
+		written++;
+	}
+
+	/* Write boolean flags */
+	if (zrouter.ignore_kernel_routes) {
+		vty_out(vty, "zebra ignore-netlink kernel-routes\n");
+		written++;
+	}
+
+	if (zrouter.ignore_kernel_addr) {
+		vty_out(vty, "zebra ignore-netlink kernel-address\n");
+		written++;
+	}
+
+	if (zrouter.ignore_kernel_neigh) {
+		vty_out(vty, "zebra ignore-netlink kernel-neighbor\n");
+		written++;
+	}
+
+	if (zrouter.ignore_kernel_nht) {
+		vty_out(vty, "zebra ignore-netlink kernel-nht\n");
+		written++;
+	}
+
+	return written;
+}
+
 /* IP node for static routes. */
 static int zebra_ip_config(struct vty *vty);
 static struct cmd_node ip_node = {
@@ -4547,6 +4774,18 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &no_zebra_dplane_queue_limit_cmd);
 	install_element(VIEW_NODE, &show_zebra_metaq_counters_cmd);
 	install_element(VIEW_NODE, &zebra_test_metaq_plug_cmd);
+
+	/* Install minimal kernel mode commands */
+	install_element(CONFIG_NODE, &zebra_ignore_netlink_if_regex_cmd);
+	install_element(CONFIG_NODE, &no_zebra_ignore_netlink_if_regex_cmd);
+	install_element(CONFIG_NODE, &zebra_ignore_netlink_kernel_routes_cmd);
+	install_element(CONFIG_NODE, &no_zebra_ignore_netlink_kernel_routes_cmd);
+	install_element(CONFIG_NODE, &zebra_ignore_netlink_kernel_address_cmd);
+	install_element(CONFIG_NODE, &no_zebra_ignore_netlink_kernel_address_cmd);
+	install_element(CONFIG_NODE, &zebra_ignore_netlink_kernel_neighbor_cmd);
+	install_element(CONFIG_NODE, &no_zebra_ignore_netlink_kernel_neighbor_cmd);
+	install_element(CONFIG_NODE, &zebra_ignore_netlink_kernel_nht_cmd);
+	install_element(CONFIG_NODE, &no_zebra_ignore_netlink_kernel_nht_cmd);
 
 #ifdef HAVE_NETLINK
 	install_element(CONFIG_NODE, &zebra_kernel_netlink_batch_tx_buf_cmd);


### PR DESCRIPTION
Addresses the following [issue](https://github.com/FRRouting/frr/issues/21447)
We are having excessive kernel events and getting zebra overloading. So receiving kernel nexthop, neighbor, and route updates is redundant. In large clusters (e.g., ~150 nodes with many pods), we observed a significant number of events being processed by zebra, which leads to unnecessary overhead.

We would like to have an option to disable these updates and avoid spending cycles on handling them. 
```
zebra ignore-netlink interface-regex ^cali.*
zebra ignore-netlink interface-regex ^veth.*
zebra ignore-netlink kernel-routes
zebra ignore-netlink kernel-address
zebra ignore-netlink kernel-neighbor
zebra ignore-netlink kernel-nht
```
This patch working on large cluster for filtering events to avoid zebra overloading.