### PR TITLE
ci: gate github-ci  Build/Test jobs on non-doc paths; add HTML doc job

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -23,8 +23,35 @@ defaults:
     shell: bash
 
 jobs:
-  Prepare-MIB-Cache:
+  # Classify changes: doc/ vs everything else (skip Docker build/tests when only doc/ changed).
+  doc-path-filter:
     if: ${{ github.event_name != 'pull_request' || github.actor != 'mergify[bot]' }}
+    runs-on: ubuntu-latest
+    name: Documentation path filter
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      doc: ${{ steps.filter.outputs.doc }}
+      non_doc: ${{ steps.filter.outputs.non_doc }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            doc:
+              - 'doc/**'
+            non_doc:
+              - '**'
+              - '!doc/**'
+
+  Prepare-MIB-Cache:
+    needs: doc-path-filter
+    if: ${{ needs.doc-path-filter.outputs.non_doc == 'true' }}
     runs-on: ubuntu-latest
     name: Prepare shared MIB cache
     timeout-minutes: 20
@@ -75,8 +102,44 @@ jobs:
           fetch_to_cache https://www.ieee802.org/1/files/public/MIBs/IEEE8021-CFM-MIB.mib IEEE8021-CFM-MIB
           fetch_to_cache https://www.ieee802.org/1/files/public/MIBs/LLDP-MIB-200505060000Z.mib LLDP-MIB
 
+  Documentation-HTML:
+    needs: doc-path-filter
+    if: ${{ needs.doc-path-filter.outputs.doc == 'true' }}
+    runs-on: ubuntu-latest
+    name: HTML documentation (user + developer)
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Install Sphinx dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo apt-get install -y python3-sphinx python3-sphinx-rtd-theme graphviz
+      - name: Build HTML documentation
+        run: |
+          set -euo pipefail
+          python3 -m sphinx -b html -d doc/user/_build/.doctrees \
+            doc/user doc/user/_build/html
+          python3 -m sphinx -b html -d doc/developer/_build/.doctrees \
+            doc/developer doc/developer/_build/html
+      - name: Stage HTML for artifact
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          cp -a doc/user/_build/html artifact/user
+          cp -a doc/developer/_build/html artifact/developer
+      - name: Upload HTML documentation
+        uses: actions/upload-artifact@v7
+        with:
+          name: documentation-html
+          path: artifact/
+          retention-days: 14
+          if-no-files-found: error
+
   Build:
-    if: ${{ github.event_name != 'pull_request' || github.actor != 'mergify[bot]' }}
     runs-on: ${{ matrix.cfg.os }}
     needs: Prepare-MIB-Cache
     name: ${{ matrix.cfg.name }}
@@ -155,7 +218,6 @@ jobs:
         run: rm -rf test-results-${{ matrix.cfg.platform }}* /tmp/frr-${{ matrix.cfg.platform }}.tar
 
   Test:
-    if: ${{ github.event_name != 'pull_request' || github.actor != 'mergify[bot]' }}
     runs-on: ${{ matrix.cfg.os }}
     needs: Build
     name: ${{ matrix.cfg.name }}

--- a/doc/developer/building-doc.rst
+++ b/doc/developer/building-doc.rst
@@ -60,3 +60,33 @@ PDF can then be built by:
    make pdf
 
 The generated PDF file will be saved at ``_build/latex/FRR.pdf``
+
+Building HTML without configuring FRR
+-------------------------------------
+
+The ``make html`` targets under ``doc/user`` and ``doc/developer`` call into the
+top-level build system and expect a tree that has been through ``./configure``
+(and usually ``./bootstrap.sh`` first if you build from Git).
+
+If you only need HTML and have **not** configured the repository, run Sphinx
+from the **repository root**. Install ``python3-sphinx`` as above. For the
+developer manual you should also install ``graphviz`` (diagrams) and, if you
+want the same HTML theme as a full build, ``python3-sphinx-rtd-theme``.
+
+.. code-block:: console
+
+   cd frr
+   python3 -m sphinx -b html -d doc/user/_build/.doctrees \
+      doc/user doc/user/_build/html
+   python3 -m sphinx -b html -d doc/developer/_build/.doctrees \
+      doc/developer doc/developer/_build/html
+
+The generated trees are ``doc/user/_build/html/`` and
+``doc/developer/_build/html/``, each with ``index.html`` at the top.
+
+When ``config.status`` is absent, ``conf.py`` uses built-in defaults for version
+and install-path substitutions; values are filled from ``config.status`` when
+you build inside a configured tree.
+
+PDF, Info, and other formats are still built through ``make`` in a configured
+build directory, since those flows rely on the Automake/Sphinx integration.


### PR DESCRIPTION
- Add doc-path-filter job (dorny/paths-filter) for doc/** vs rest of tree.
- Run Prepare-MIB-Cache, Build, and Test only when changes exist outside doc/.
- Add Documentation-HTML job (sphinx user + developer) when doc/ changes.
- Skip Documentation-HTML when doc/ is unchanged.