### PR TITLE
ospf6d: Remove ospf6 route when connected wins

### DIFF
--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -797,6 +797,18 @@ struct ospf6_route *ospf6_route_add(struct ospf6_route *route,
 					(void *)table, (void *)route,
 					route->path.cost, (void *)next,
 					next->path.cost);
+
+			/*
+			 * When a connected route from zebra is seen, it `wins`
+			 * and we need to remove the ospf6 route that was
+			 * already installed that would shadow this connected
+			 * route in the zebra rib.  So let's just send an
+			 * explicit delete to cover this special case.
+			 */
+			if (route->connected && !next->connected &&
+			    table->scope_type == OSPF6_SCOPE_TYPE_GLOBAL)
+				ospf6_zebra_route_delete_prefix(route,
+								(struct ospf6 *)table->scope);
 		}
 
 		route->installed = now;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -539,6 +539,27 @@ void ospf6_zebra_route_update_remove(struct ospf6_route *request,
 	ospf6_zebra_route_update(REM, request, ospf6);
 }
 
+void ospf6_zebra_route_delete_prefix(struct ospf6_route *route, struct ospf6 *ospf6)
+{
+	struct zapi_route api;
+	int ret;
+
+	if (IS_OSPF6_DEBUG_ZEBRA(SEND))
+		zlog_debug("Send delete for route: %pFX a connected in Zebra now wins",
+			   &route->prefix);
+
+	zapi_route_init(&api);
+	api.vrf_id = ospf6->vrf_id;
+	api.type = ZEBRA_ROUTE_OSPF6;
+	api.safi = SAFI_UNICAST;
+	api.prefix = route->prefix;
+	ret = zclient_route_send(ZEBRA_ROUTE_DELETE, ospf6_zclient, &api);
+
+	if (ret == ZCLIENT_SEND_FAILURE)
+		flog_err(EC_LIB_ZAPI_SOCKET, "zclient_route_send() failed for prefix: %pFX",
+			 &route->prefix);
+}
+
 void ospf6_zebra_add_discard(struct ospf6_route *request, struct ospf6 *ospf6)
 {
 	struct zapi_route api;

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -41,6 +41,7 @@ extern void ospf6_zebra_no_redistribute(int type, vrf_id_t vrf_id);
 	vrf_bitmap_check(&ospf6_zclient->redist[AFI_IP6][type], vrf_id)
 extern void ospf6_zebra_init(struct event_loop *tm);
 extern void ospf6_zebra_import_default_route(struct ospf6 *ospf6, bool unreg);
+extern void ospf6_zebra_route_delete_prefix(struct ospf6_route *route, struct ospf6 *ospf6);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request,
 				    struct ospf6 *ospf6);
 extern void ospf6_zebra_delete_discard(struct ospf6_route *request,


### PR DESCRIPTION
Currently when ospf6 installs a route that is later covered by a connected, the ospf6 route is never removed. Modify the code to detect the case where the new route that `wins` in ospf6 notices that it is connected and the old route that was in was a ospf6 route.  If so send a specific route deletion for the ospf6 route.

This failure is happening infrequently in the ospf6_point_to_multipoint test due to timing issues on how connected routes are received into ospf6.