### PR TITLE
bgpd: fix last Reset timer losing day part after 24 hours

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -15673,7 +15673,6 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 	if (show_brief) {
 		if (use_json) {
 			time_t uptime;
-			struct tm tm;
 
 			if (p->hostname)
 				json_object_string_add(json_neigh, "hostname", p->hostname);
@@ -15691,10 +15690,9 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 
 			uptime = monotime(NULL);
 			uptime -= p->resettime;
-			gmtime_r(&uptime, &tm);
+
 			json_object_int_add(json_neigh, "lastResetTimerMsecs",
-					    (tm.tm_sec * 1000) + (tm.tm_min * 60000) +
-						    (tm.tm_hour * 3600000));
+					    (int64_t)uptime * 1000);
 			json_stat = json_object_new_object();
 			json_object_int_add(json_stat, "totalSent", PEER_TOTAL_TX(p));
 			json_object_int_add(json_stat, "totalRecv", PEER_TOTAL_RX(p));
@@ -17228,16 +17226,12 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 	} else {
 		if (use_json) {
 			time_t uptime;
-			struct tm tm;
 
 			uptime = monotime(NULL);
 			uptime -= p->resettime;
-			gmtime_r(&uptime, &tm);
 
 			json_object_int_add(json_neigh, "lastResetTimerMsecs",
-					    (tm.tm_sec * 1000)
-						    + (tm.tm_min * 60000)
-						    + (tm.tm_hour * 3600000));
+					    (int64_t)uptime * 1000);
 			bgp_show_peer_reset(NULL, p, json_neigh, true);
 		} else {
 			vty_out(vty, "  Last reset %s, ",


### PR DESCRIPTION
The lastResetTimerMsecs JSON field was computed using gmtime_r() and only accounted for hours, minutes, and seconds (tm_hour, tm_min, tm_sec), but missed the day field (tm_yday). This caused the value to wrap around and lose days when elapsed time exceeded 24 hours. Use direct multiplication (uptime * 1000) instead, matching how bgpTimerUpMsec is correctly computed.

UT >>
Before fix
leaf-11# show bgp neighbors brief json
{
  "swp1":{
    "hostname":"spine-1",
    "remoteAs":652000,
    "localAs":651001,
    "lastResetDueTo":"No AFI\/SAFI activated for peer",
    "bgpState":"Established",
    "bgpTimerUpMsec":87806000,
    "bgpTimerUpString":"1d00h23m",
    "bgpTimerUpEstablishedEpoch":1775536142,
    "lastResetTimerMsecs":1431000,<<<<<<<<<<<<<<lastResetTimerMsecs is less than bgpTimerUpMsec, also doesnt have day part
    "messageStats":{
      "totalSent":29397,
      "totalRecv":29397
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":5,
        "sentPrefixCounter":9
      },
      "l2VpnEvpn":{
        "acceptedPrefixCounter":64,
        "sentPrefixCounter":173
      }
    }
  },

After fix>>
leaf-11# show bgp neighbors brief json
{
  "swp1":{
    "hostname":"spine-1",
    "remoteAs":652000,
    "localAs":651001,
    "lastResetDueTo":"Waiting for peer OPEN",
    "bgpState":"Established",
    "bgpTimerUpMsec":86839000,
    "bgpTimerUpString":"1d00h07m",
    "bgpTimerUpEstablishedEpoch":1775627763,
    "lastResetTimerMsecs":86848000, >>>>>>>lastResetTimerMsecs >= bgpTimerUpMsec
    "messageStats":{
      "totalSent":29051,
      "totalRecv":29048
    },
    "addressFamilyInfo":{
      "ipv4Unicast":{
        "acceptedPrefixCounter":5,
        "sentPrefixCounter":9
      },
      "l2VpnEvpn":{
        "acceptedPrefixCounter":64,
        "sentPrefixCounter":173
      }
    }
  }
