### PR TITLE
zebra: fix wrong comparision for nexthop

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -461,7 +461,7 @@ bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh
 	if (nh1 == nh2)
 		return true;
 
-	return nexthop_cmp_internal(nh1, nh2, true, false);
+	return (nexthop_cmp_internal(nh1, nh2, true, false) == 0);
 }
 
 bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2)

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -162,11 +162,35 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
 	if (next1->vrf_id > next2->vrf_id)
 		return 1;
 
-	if (next1->type < next2->type)
-		return -1;
+	/*
+	 * When not using ifindex, ignore the type difference
+	 * between resolved and unresolved nexthops.
+	 */
+	if (use_ifindex) {
+		if (next1->type < next2->type)
+			return -1;
 
-	if (next1->type > next2->type)
-		return 1;
+		if (next1->type > next2->type)
+			return 1;
+	} else {
+		enum nexthop_types_t t1 = next1->type;
+		enum nexthop_types_t t2 = next2->type;
+
+		if (t1 == NEXTHOP_TYPE_IPV4_IFINDEX)
+			t1 = NEXTHOP_TYPE_IPV4;
+		if (t2 == NEXTHOP_TYPE_IPV4_IFINDEX)
+			t2 = NEXTHOP_TYPE_IPV4;
+		if (t1 == NEXTHOP_TYPE_IPV6_IFINDEX)
+			t1 = NEXTHOP_TYPE_IPV6;
+		if (t2 == NEXTHOP_TYPE_IPV6_IFINDEX)
+			t2 = NEXTHOP_TYPE_IPV6;
+
+		if (t1 < t2)
+			return -1;
+
+		if (t1 > t2)
+			return 1;
+	}
 
 	if (use_weight) {
 		if (next1->weight < next2->weight)


### PR DESCRIPTION
### commit 1
By accident, i found the "same" field in log of the nexthop was actually opposite. Regardless of whether it is active or not, "same" field should be true.

Before:
```
ZEBRA: [M8H8E-HFGSQ] zebra_nhg_nexthop_compare: 3.3.3.3/32 Comparing via 192.168.0.1, enp2s0(1) ACTIVE: 1 to old: via 192.168.0.1, enp2s0(3) ACTIVE: 1 nexthop same: 0
```

After:
```
ZEBRA: [M8H8E-HFGSQ] zebra_nhg_nexthop_compare: 3.3.3.3/32 Comparing via 192.168.0.1, enp2s0(1) ACTIVE: 1 to old: via 192.168.0.1, enp2s0(3) ACTIVE: 1 nexthop same: 1
```

And this commit should affect the scenarios where `nexthop_same_no_ifindex` is introduced.

Only with commit 1, CI of zebra_nhg_check failed. So add commit 2 to fix it.

commit 2 fixes the old commit 46044a45 ( zebra: Allow nhg's to be reused when multiple interfaces are going amuck )

### commit 2
When an interface goes down, the nexthop will be with type NEXTHOP_TYPE_IPV4.
Meanwhile, the same nexthop was previously resolved as type NEXTHOP_TYPE_IPV4_IFINDEX.

Fix this by normalizing IPV4_IFINDEX to IPV4 (and IPV6_IFINDEX to IPV6)
in the type comparison when use_ifindex is false. The gateway address
equality is still verified by the subsequent comparisons.


======================================

This matters in recursive nexthop scenarios: when an interface goes
down and a BGP session drops, BGP re-advertises routes with the
original unresolved nexthop (type IPV4, marked inactive later). The old NHE still contains
the resolved form (type IPV4_IFINDEX, marked inactive).

Without this PR, that CI test wrongly passed for this lucky reason: (use the old commit's example)

````
Old:

  nexthop A  <inactive>
  nexthop B  <inactive>
  nexthop C
  nexthop D

New:

   nexthop B  <inactive>
   nexthop C
   nexthop D
```

When comparing the old nexthop A and the new nexthop B, it wrongly skipped A and B for the wrong `nexthop_same_no_ifindex`. Then skipped the old nexthop B for nexthop C is active. So all inactive nexthops are fortunately skipped.

