### PR TITLE
lib: mgmt: expose short-circuit bool as `is_mgmtd`

### DIFF
--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -787,9 +787,8 @@ DEFPY(debug_mgmt_client_fe, debug_mgmt_client_fe_cmd,
  * Initialize library and try connecting with MGMTD.
  */
 struct mgmt_fe_client *mgmt_fe_client_create(const char *client_name,
-					     struct mgmt_fe_client_cbs *cbs,
-					     uintptr_t user_data,
-					     struct event_loop *event_loop)
+					     struct mgmt_fe_client_cbs *cbs, uintptr_t user_data,
+					     bool is_mgmtd, struct event_loop *event_loop)
 {
 	struct mgmt_fe_client *client;
 	char server_path[MAXPATHLEN];
@@ -809,12 +808,10 @@ struct mgmt_fe_client *mgmt_fe_client_create(const char *client_name,
 
 	snprintf(server_path, sizeof(server_path), MGMTD_FE_SOCK_NAME);
 
-	msg_client_init(&client->client, event_loop, server_path,
-			mgmt_fe_client_notify_connect,
-			mgmt_fe_client_notify_disconnect,
-			mgmt_fe_client_process_msg, MGMTD_FE_MAX_NUM_MSG_PROC,
-			MGMTD_FE_MAX_NUM_MSG_WRITE, MGMTD_FE_MAX_MSG_LEN, true,
-			"FE-client", debug_check_fe_client());
+	msg_client_init(&client->client, event_loop, server_path, mgmt_fe_client_notify_connect,
+			mgmt_fe_client_notify_disconnect, mgmt_fe_client_process_msg,
+			MGMTD_FE_MAX_NUM_MSG_PROC, MGMTD_FE_MAX_NUM_MSG_WRITE,
+			MGMTD_FE_MAX_MSG_LEN, is_mgmtd, "FE-client", debug_check_fe_client());
 
 	debug_fe_client("Initialized client '%s'", client_name);
 

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -118,20 +118,18 @@ extern struct debug mgmt_dbg_fe_client;
 	DEBUG_MODE_CHECK(&mgmt_dbg_fe_client, DEBUG_MODE_ALL)
 
 /*
- * Initialize library and try connecting with MGMTD FrontEnd interface.
+ * mgmt_fe_client_create() - Create a mgmt front-end client connection
+ * @client_name: Name of the client (used for logging and debugging).
+ * @cbs: Callbacks for the client to receive notifications for various events.
+ * @user_data: Opaque data passed to client callbacks.
+ * @is_mgmtd: True if the client being created is for mgmtd itself, false otherwise.
+ * @event_loop: Event loop to use for processing events for this client.
  *
- * params
- *    Frontend client parameters.
- *
- * master_thread
- *    Thread master.
- *
- * Returns:
- *    Frontend client lib handler (nothing but address of mgmt_fe_client)
  */
-extern struct mgmt_fe_client *
-mgmt_fe_client_create(const char *client_name, struct mgmt_fe_client_cbs *cbs,
-		      uintptr_t user_data, struct event_loop *event_loop);
+extern struct mgmt_fe_client *mgmt_fe_client_create(const char *client_name,
+						    struct mgmt_fe_client_cbs *cbs,
+						    uintptr_t user_data, bool is_mgmtd,
+						    struct event_loop *event_loop);
 
 /*
  * Initialize library vty (adds debug support).

--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -891,7 +891,7 @@ void vty_mgmt_init(void)
 	assert(mm->master);
 	assert(!mgmt_fe_client);
 	snprintf(name, sizeof(name), "vty-%s-%ld", frr_get_progname(), (long)getpid());
-	mgmt_fe_client = mgmt_fe_client_create(name, &mgmt_cbs, 0, mm->master);
+	mgmt_fe_client = mgmt_fe_client_create(name, &mgmt_cbs, 0, true, mm->master);
 	vty_new_mgmt_cb = vty_new_mgmt;
 	vty_close_mgmt_cb = vty_close_mgmt;
 	assert(mgmt_fe_client);


### PR DESCRIPTION
Currently the only user of the front-end client library is mgmtd, and the code was always requesting short-circuit connections. Expose a `is_mgmtd` parameter so that short-circuit is not selected for non-mgmtd users.

closes #21407