### PR TITLE
tests: clean up a build warning in a unit-test

### DIFF
--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -187,7 +187,6 @@ static void test_rb_pop(void)
 {
 	int i;
 	struct rtree_head head;
-	struct item *ptr;
 
 	rtree_init(&head);
 


### PR DESCRIPTION
Remove an unused local from test_typelist...
