### PR TITLE
ospfd,tests: fix OSPF connected overlapping prefix bug

### DIFF
--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1028,10 +1028,17 @@ int ospf_distribute_check_connected(struct ospf *ospf, struct external_info *ei)
 	struct listnode *node;
 	struct ospf_interface *oi;
 
+	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi)) {
+		struct prefix address;
 
-	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi))
-		if (prefix_match(oi->address, (struct prefix *)&ei->p))
+		/* Clean up the address by removing the mask part */
+		prefix_copy(&address, oi->address);
+		apply_mask(&address);
+
+		if (prefix_same(&address, (struct prefix *)&ei->p))
 			return 0;
+	}
+
 	return 1;
 }
 

--- a/tests/topotests/ospf_connected_overlapping_prefix/r1/frr.conf
+++ b/tests/topotests/ospf_connected_overlapping_prefix/r1/frr.conf
@@ -1,0 +1,15 @@
+interface r1-eth0
+ ip address 10.0.0.1/24
+ ip ospf area 0
+ ip ospf dead-interval 8
+ ip ospf hello-interval 2
+exit
+!
+interface r1-eth1
+ ip address 10.0.0.129/30
+exit
+!
+router ospf
+ ospf router-id 10.254.254.1
+ redistribute connected
+exit

--- a/tests/topotests/ospf_connected_overlapping_prefix/r2/frr.conf
+++ b/tests/topotests/ospf_connected_overlapping_prefix/r2/frr.conf
@@ -1,0 +1,10 @@
+interface r2-eth0
+ ip address 10.0.0.2/24
+ ip ospf area 0
+ ip ospf dead-interval 8
+ ip ospf hello-interval 2
+exit
+!
+router ospf
+ ospf router-id 10.254.254.2
+exit

--- a/tests/topotests/ospf_connected_overlapping_prefix/test_ospf_connected_overlapping_prefix.py
+++ b/tests/topotests/ospf_connected_overlapping_prefix/test_ospf_connected_overlapping_prefix.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_ospf_connected_overlapping_prefix.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_ospf_connected_overlapping_prefix.py: test OSPF overlapping prefix bug.
+"""
+
+import os
+import sys
+from functools import partial
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+
+# Required to instantiate the topology builder class.
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def setup_module(mod):
+    topodef = {
+        "s1": ("r1", "r2"),
+        "s2": "r1"
+    }
+
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(f"{CWD}/{rname}/frr.conf")
+
+    tgen.start_router()
+
+
+def expect_ospf_neighbor(router, neighbor):
+    tgen = get_topogen()
+
+    expected = {
+        "neighbors": {
+            neighbor: [{
+                "converged": "Full"
+            }]
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show ip ospf neighbor json",
+        expected)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Router {router} failed to converge"
+
+
+def test_ospf_neighbor_convergence():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    expect_ospf_neighbor("r1", "10.254.254.2")
+    expect_ospf_neighbor("r2", "10.254.254.1")
+
+
+def test_ospf_connected_overlapping_prefix():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def expect_r2_route():
+        out = tgen.gears["r2"].vtysh_cmd("show ip ospf route json", isjson=True)
+        return topotest.json_cmp(out, {
+            "10.0.0.128/30": {
+                "routeType": "N E2"
+            }
+        })
+
+    # Expect that the overlapped connected route shows up as external
+    _, result = topotest.run_and_expect(expect_r2_route, None, count=30, wait=1)
+    assert result is None, f"Router r2 should have learned external route"
+
+
+def test_ospf_connected_prefix_not_in_external():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def expect_r2_route():
+        out = tgen.gears["r2"].vtysh_cmd("show ip ospf route json", isjson=True)
+        return topotest.json_cmp(out, {
+            "10.0.0.0/24": {
+                "routeType": "N"
+            }
+        })
+
+    # Expect that the connected route shows up as non external
+    _, result = topotest.run_and_expect(expect_r2_route, None, count=30, wait=1)
+    assert result is None, f"Router r2 should not have learned external route"
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
When two distinct interfaces have overlapping prefixes (example: 10.0.0.1/24 and 10.0.0.129/30) the more specific prefix gets omitted due to the wrong comparison in `ospf_distribute_check_connected`: `if (prefix_match(oi->address, (struct prefix *)&ei->p))`.

Fix the `ospf_distribute_check_connected` to use `prefix_same()` in order to rightfully generate the external route for this case.