### PR TITLE
lib: fix missing config hooks in no-split-config mode

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1051,6 +1051,17 @@ static void frr_config_read_in(struct event *t)
 	hook_call(frr_config_post, master);
 }
 
+/*
+ * Some modules hook frr_config_pre and frr_config_post for post-fork
+ * initialization. We still need to invoke these hooks in FRR_NO_SPLIT_CONFIG
+ * mode even though no config file is read by this daemon.
+ */
+static void frr_config_hooks_only(struct event *t)
+{
+	hook_call(frr_config_pre, master);
+	hook_call(frr_config_post, master);
+}
+
 void frr_config_fork(void)
 {
 	hook_call(frr_late_init, master);
@@ -1064,6 +1075,8 @@ void frr_config_fork(void)
 
 		event_add_event(master, frr_config_read_in, NULL, 0,
 				&di->read_in);
+	} else {
+		event_add_event(master, frr_config_hooks_only, NULL, 0, NULL);
 	}
 
 	if (di->daemon_mode || di->terminal)


### PR DESCRIPTION
When a daemon (e.g., mgmtd) is started with the
FRR_NO_SPLIT_CONFIG flag, the frr_config_read_in event is skipped. This unintentionally prevents the frr_config_pre and frr_config_post hooks from being called, which breaks external modules (like sysrepo) that rely on these hooks to initialize after fork().

This patch introduces a dummy event callback (frr_config_hooks_only) to explicitly trigger the pre and post hooks when the configuration file is not read. Passing NULL to event_add_event ensures this hook event is not unexpectedly cancelled by the core event loop.