### PR TITLE
lib: routemap_nb: validate list-name reference family and existence

### DIFF
--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -12,6 +12,7 @@
 #include "lib/log.h"
 #include "lib/northbound.h"
 #include "lib/routemap.h"
+#include "lib/yang.h"
 
 /*
  * Auxiliary functions to avoid code duplication:
@@ -547,6 +548,65 @@ static int lib_route_map_entry_match_condition_interface_destroy(
 }
 
 /*
+ * Observability hook: when a route-map match `list-name` references an
+ * access-list or prefix-list that does not exist in the candidate
+ * configuration -- or exists only under a different address family --
+ * emit a single informational log line so that declarative controllers
+ * (NETCONF / gNMI) driving FRR can surface the drift without having to
+ * tail runtime DENY traces.
+ *
+ * This is deliberately non-blocking: partial configuration (entering the
+ * match before creating the list, or vice versa) is a first-class FRR
+ * workflow. The existing runtime behaviour -- an unresolved match returns
+ * DENY -- is preserved verbatim. The hook only adds a diagnostic signal.
+ */
+static void routemap_match_list_name_log_unresolved(const struct lyd_node *dnode)
+{
+	const char *acl = yang_dnode_get_string(dnode, NULL);
+	const char *condition = yang_dnode_get_string(dnode, "../../condition");
+	const char *list_node = NULL;
+	const char *list_type = NULL;
+	char xpath[XPATH_MAXLEN];
+
+	if (IS_MATCH_IPv4_ADDRESS_LIST(condition) || IS_MATCH_IPv4_NEXTHOP_LIST(condition)) {
+		list_node = "access-list";
+		list_type = "ipv4";
+	} else if (IS_MATCH_IPv6_ADDRESS_LIST(condition) || IS_MATCH_IPv6_NEXTHOP_LIST(condition)) {
+		list_node = "access-list";
+		list_type = "ipv6";
+	} else if (IS_MATCH_IPv4_PREFIX_LIST(condition) ||
+		   IS_MATCH_IPv4_NEXTHOP_PREFIX_LIST(condition)) {
+		list_node = "prefix-list";
+		list_type = "ipv4";
+	} else if (IS_MATCH_IPv6_PREFIX_LIST(condition) ||
+		   IS_MATCH_IPv6_NEXTHOP_PREFIX_LIST(condition)) {
+		list_node = "prefix-list";
+		list_type = "ipv6";
+	} else {
+		/* Other condition types do not use list-name. */
+		return;
+	}
+
+	/*
+	 * `access-list-name` has no pattern restriction, so a name containing
+	 * a single quote would produce a malformed XPath predicate. Skip the
+	 * lookup in that case; the signal is advisory and we do not want an
+	 * exotic name to produce a misleading "unresolved" log line.
+	 */
+	if (strchr(acl, '\'') != NULL)
+		return;
+
+	snprintf(xpath, sizeof(xpath), "/frr-filter:lib/%s[type='%s'][name='%s']", list_node,
+		 list_type, acl);
+
+	if (yang_dnode_exists(dnode, xpath))
+		return;
+
+	zlog_info("route-map match %s references %s '%s' (type %s) that does not exist in candidate config; match will DENY at apply time until the list is defined",
+		  condition, list_node, acl, list_type);
+}
+
+/*
  * XPath: /frr-route-map:lib/route-map/entry/match-condition/list-name
  */
 static int lib_route_map_entry_match_condition_list_name_modify(
@@ -556,6 +616,11 @@ static int lib_route_map_entry_match_condition_list_name_modify(
 	const char *acl;
 	const char *condition;
 	int rv;
+
+	if (args->event == NB_EV_VALIDATE) {
+		routemap_match_list_name_log_unresolved(args->dnode);
+		return NB_OK;
+	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;

--- a/tests/topotests/mgmt_match_list_validation/r1/frr.conf
+++ b/tests/topotests/mgmt_match_list_validation/r1/frr.conf
@@ -1,0 +1,5 @@
+log file frr.log debug
+!
+hostname r1
+!
+end

--- a/tests/topotests/mgmt_match_list_validation/test_match_list_validation.py
+++ b/tests/topotests/mgmt_match_list_validation/test_match_list_validation.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: ISC
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+#
+# Copyright (c) 2026, Reinaldo Saraiva
+#
+"""
+Test observability hook for route-map match list-name references.
+
+The `list-name` leaf of a route-map match condition does not reject commits
+with unresolved references -- partial configuration is a first-class FRR
+workflow. Instead, mgmtd emits an informational log line so declarative
+controllers (NETCONF/gNMI) can surface the drift without tailing runtime
+DENY traces.
+
+This test locks down four properties:
+
+  - happy path (v4 condition + v4 prefix-list) commits without the warning;
+  - same-batch create-and-reference (list and match defined in the same
+    vtysh batch) commits without the warning, because NB_EV_VALIDATE runs
+    over the merged candidate tree;
+  - dangling reference (non-existent list) commits, running-config retains
+    the match, and the warning appears in the log;
+  - cross-family reference (v4 condition -> v6 list, or v6 -> v4) commits,
+    running-config retains the match, and the warning appears in the log.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+from lib.topogen import Topogen
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+WARN_PATTERN = re.compile(
+    r"route-map match \S+ references (access|prefix)-list '\S+' \(type ipv[46]\) "
+    r"that does not exist in candidate config"
+)
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+    tgen.gears["r1"].load_frr_config("frr.conf")
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+def _vtysh_config(router, cmds):
+    """Run a config sequence and assert mgmtd accepted it.
+
+    The `"end"` token is silently stripped by `vtysh -f` (see
+    `vtysh_config_from_file`); batched edits commit atomically at end-of-file
+    via the `XFRR_start_configuration` / `XFRR_end_configuration` protocol, so
+    `NB_EV_VALIDATE` sees the merged candidate tree regardless of how many
+    statements appear in `cmds`.
+    """
+    output = router.vtysh_multicmd(
+        "\n".join(["configure terminal", *cmds, "end"]),
+        pretty_output=False,
+    )
+    # Child daemons (zebra/staticd) emit noise like
+    # "% Unknown command[4]: configure terminal" and
+    # "Configuration file[...] processing failure: 2" because mgmtd owns
+    # config reception -- these are not commit failures. The real signal is
+    # the mgmtd marker "% Configuration failed." or "commit failed session-id".
+    for marker in ("% Configuration failed.", "commit failed session-id"):
+        assert marker not in output, (
+            f"mgmtd rejected the commit (marker={marker!r}):\n{output}"
+        )
+    return output
+
+
+def _zebra_log(router):
+    """Return current contents of the zebra log file.
+
+    The route-map northbound callbacks run in the zebra backend (mgmtd
+    delegates the frr-route-map module), so the observability log line
+    lands in zebra.log rather than mgmtd.log.
+    """
+    logdir = router.logdir
+    candidates = [
+        os.path.join(logdir, router.name, "zebra.log"),
+        os.path.join(logdir, "zebra.log"),
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            with open(path) as fh:
+                return fh.read()
+    raise AssertionError(f"zebra.log not found in {candidates}")
+
+
+def _warn_count(router):
+    return len(WARN_PATTERN.findall(_zebra_log(router)))
+
+
+def _running_config(router):
+    return router.vtysh_cmd("show running-config")
+
+
+def test_matching_family_accepted_no_warning(tgen):
+    """Happy path: v4 condition + v4 prefix-list commits, no warning."""
+    r1 = tgen.gears["r1"]
+    before = _warn_count(r1)
+    _vtysh_config(
+        r1,
+        [
+            "ip prefix-list pl-v4 seq 5 permit 10.0.0.0/8",
+            "route-map rm-happy permit 10",
+            " match ip address prefix-list pl-v4",
+            " exit",
+        ],
+    )
+    running = _running_config(r1)
+    assert "match ip address prefix-list pl-v4" in running
+    after = _warn_count(r1)
+    assert after == before, (
+        f"expected no new unresolved-ref warning; delta={after - before}"
+    )
+
+
+def test_cross_family_commits_with_warning(tgen):
+    """v4 condition referencing v6 prefix-list: commits, warning in log."""
+    r1 = tgen.gears["r1"]
+    before = _warn_count(r1)
+    _vtysh_config(r1, ["ipv6 prefix-list pl-v6-only seq 5 permit 2001:db8::/32"])
+    _vtysh_config(
+        r1,
+        [
+            "route-map rm-cross-v4 permit 10",
+            " match ip address prefix-list pl-v6-only",
+            " exit",
+        ],
+    )
+    running = _running_config(r1)
+    assert "match ip address prefix-list pl-v6-only" in running
+    after = _warn_count(r1)
+    assert after > before, (
+        f"expected unresolved-ref warning; delta={after - before}, log tail:\n"
+        f"{_zebra_log(r1)[-2000:]}"
+    )
+
+
+def test_same_transaction_create_and_reference_no_warning(tgen):
+    """Same-batch create-and-reference: no warning (candidate tree has the list)."""
+    r1 = tgen.gears["r1"]
+    before = _warn_count(r1)
+    _vtysh_config(
+        r1,
+        [
+            "ip prefix-list pl-samebatch seq 5 permit 10.20.0.0/16",
+            "route-map rm-samebatch permit 10",
+            " match ip address prefix-list pl-samebatch",
+            " exit",
+        ],
+    )
+    running = _running_config(r1)
+    assert "match ip address prefix-list pl-samebatch" in running
+    after = _warn_count(r1)
+    assert after == before, (
+        f"expected no new unresolved-ref warning (list created in same batch); "
+        f"delta={after - before}, log tail:\n{_zebra_log(r1)[-2000:]}"
+    )
+
+
+def test_dangling_reference_commits_with_warning(tgen):
+    """Reference to non-existent list: commits, warning in log."""
+    r1 = tgen.gears["r1"]
+    before = _warn_count(r1)
+    _vtysh_config(
+        r1,
+        [
+            "route-map rm-dangling permit 10",
+            " match ip address prefix-list pl-does-not-exist",
+            " exit",
+        ],
+    )
+    running = _running_config(r1)
+    assert "match ip address prefix-list pl-does-not-exist" in running
+    after = _warn_count(r1)
+    assert after > before, (
+        f"expected unresolved-ref warning; delta={after - before}, log tail:\n"
+        f"{_zebra_log(r1)[-2000:]}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))


### PR DESCRIPTION
## Summary

Observability hook for route-map `match ... list-name` references at northbound
validate time. When the referenced `access-list` / `prefix-list` does not
resolve in the candidate configuration — either because the name does not
exist, or because the referenced list has a different address family from the
one implied by the sibling `condition` identity — the owning backend emits a
single `zlog_info` line describing the unresolved reference, so the drift is
visible in that backend's log at validate time rather than only at apply time.

The hook is deliberately non-blocking: it always returns `NB_OK`, no commit is
rejected, and the existing runtime semantics (an unresolved match returns DENY
at apply time) are preserved verbatim. Partial configuration — entering the
match before creating the referenced list, or vice versa — remains a
first-class CLI workflow.

Empirical reproduction on `master` (10.7-dev), with no fix applied:

```
mgmtd# configure terminal
mgmtd(config)# ipv6 prefix-list pl-v6-only seq 5 permit 2001:db8::/32
mgmtd(config)# route-map rm permit 10
mgmtd(config-route-map)# match ip address prefix-list pl-v6-only
mgmtd(config-route-map)# end
!-- silently accepted; running-config now carries a match that can never fire,
!-- and the drift is only observable via apply-time DENY traces.
```

With this change, the commit is still accepted (preserving the partial-config
workflow) but the backend emits:

```
route-map match frr-route-map:ipv4-prefix-list references prefix-list
'pl-v6-only' (type ipv4) that does not exist in candidate config; match will
DENY at apply time until the list is defined
```

## Fix

A new helper `routemap_match_list_name_log_unresolved()` is called from the
existing `NB_EV_VALIDATE` branch of
`lib_route_map_entry_match_condition_list_name_modify`. It looks up
`/frr-filter:lib/{access-list,prefix-list}[type=X][name=Y]` in the candidate
tree, where `(X, Y)` is derived from the sibling `condition` identity, and
logs when no match is found. The lookup is skipped when the name contains a
single quote, since the YANG typedef `filter:access-list-name` places no
pattern restriction on the leaf and unescaped quotes would produce a
malformed XPath predicate.

Covers the eight condition types that consume `list-name`:

* `ipv4-address-list`, `ipv6-address-list` → `access-list[type=ipv4|ipv6]`
* `ipv4-next-hop-list`, `ipv6-next-hop-list` → `access-list[type=ipv4|ipv6]`
* `ipv4-prefix-list`, `ipv6-prefix-list` → `prefix-list[type=ipv4|ipv6]`
* `ipv4-next-hop-prefix-list`, `ipv6-next-hop-prefix-list` → `prefix-list[type=ipv4|ipv6]`

No changes to YANG schema or to CLI DEFPYs. The lookup runs over the post-merge
candidate tree, so a commit that creates the list and adds the match in the
same batch does not warn.

## Where the log line lands

The callback runs in whichever backend owns `/frr-route-map:lib`. In typical
stock setups that is `zebra`; `ripd` and `ripngd` also subscribe as owners
when present. The diagnostic is written via `zlog_info`, so it lands in the
owning backend's log file (`zebra.log` in the common case).

## Behavioural notes

- No YANG schema change, no CLI change, no wire-protocol change.
- No commit is ever rejected by this hook.
- Running-configurations with cross-family or dangling `list-name` references
  continue to load and commit without error.
- Existing topotests that deliberately configure `match ip address prefix-list
  <name>` with `<name>` not defined in the same router (e.g.
  `bgp_suppress_fib/r1/bgpd.conf:14`, `bgp_suppress_fib/r3/bgpd.conf:7`) will
  now log one extra `zlog_info` line per zebra startup. No test assertion in
  `bgp_suppress_fib/test_bgp_suppress_fib.py` depends on `zebra.log` content
  at that granularity; this is a log delta, not a behavioural change.

## Test plan

New topotest under `tests/topotests/mgmt_match_list_validation/` asserting
four invariants:

- `test_matching_family_accepted_no_warning` — v4 condition + v4 prefix-list
  commits, no warning.
- `test_cross_family_commits_with_warning` — v4 condition + v6 prefix-list
  commits, running-config retains the match, and the warning appears in the
  backend log.
- `test_same_transaction_create_and_reference_no_warning` — prefix-list and
  match defined in the same `vtysh` batch commits without the warning, because
  `NB_EV_VALIDATE` runs over the merged candidate tree.
- `test_dangling_reference_commits_with_warning` — reference to a non-existent
  list commits, running-config retains the match, and the warning appears in
  the backend log.

All four scenarios pass locally:

```
tests/topotests/mgmt_match_list_validation/test_match_list_validation.py::test_matching_family_accepted_no_warning PASSED
tests/topotests/mgmt_match_list_validation/test_match_list_validation.py::test_cross_family_commits_with_warning PASSED
tests/topotests/mgmt_match_list_validation/test_match_list_validation.py::test_same_transaction_create_and_reference_no_warning PASSED
tests/topotests/mgmt_match_list_validation/test_match_list_validation.py::test_dangling_reference_commits_with_warning PASSED
======================== 4 passed, 2 warnings in 3.73s =========================
```