### PR TITLE
bfdd: Move bfdproflist declaration to header

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -328,6 +328,9 @@ struct bfd_config_timers {
 	uint32_t required_min_echo_rx;
 };
 
+/** BFD profiles list. */
+extern struct bfdproflist bplist;
+
 #define BFD_RTT_SAMPLE 8
 
 /*

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -1303,7 +1303,6 @@ struct cmd_node bfd_profile_node = {
 
 static void bfd_profile_var(vector comps, struct cmd_token *token)
 {
-	extern struct bfdproflist bplist;
 	struct bfd_profile *bp;
 
 	TAILQ_FOREACH (bp, &bplist, entry) {


### PR DESCRIPTION
Refactor extern variable to be declared outside of C functions.

Fixes: ccc9ada86814 ("bfdd: implement BFD session configuration profiles")