### PR TITLE
bfdd fix 'ignore non-handled path' error messages

### DIFF
--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -117,7 +117,6 @@ static struct frr_signal_t bfd_signals[] = {
 static const struct frr_yang_module_info *const bfdd_yang_modules[] = {
 	/* CLI-only filter YANG; do not use frr_filter_info (no filter backend). */
 	&frr_filter_cli_info,
-	&frr_interface_info,
 	&frr_bfdd_info,
 	&frr_vrf_info,
 };


### PR DESCRIPTION
When running some toptotests with BFD, configuring interface leads to error messages in bfdd.

> 2026/04/14 14:30:44.935 BFD: [YDKB1-KBVT7] nb_candidate_edit_config_change: ignoring non-handled path: /frr-interface:lib/interface[name='lo']/frr-zebra:zeb\
> ra/ipv4-addrs[ip='1.1.1.1'][prefix-length='32']
> 2026/04/14 14:30:44.935 BFD: [YDKB1-KBVT7] nb_candidate_edit_config_change: ignoring non-handled path: /frr-interface:lib/interface[name='lo']/frr-zebra:zeb\
> ra/ipv6-addrs[ip='::ffff:1.1.1.1'][prefix-length='128']
> 2026/04/14 14:30:44.935 BFD: [YDKB1-KBVT7] nb_candidate_edit_config_change: ignoring non-handled path: /frr-interface:lib/interface[name='eth-rt2']/frr-zebr\
> a:zebra/ipv4-addrs[ip='10.0.1.1'][prefix-length='24']
> [..]
> 2026/04/14 14:30:44.936 BFD: [SWK28-M149C] northbound callback: event [validate] op [create] xpath [/frr-interface:lib/interface[name='lo']] value [(none)]
> 2026/04/14 14:30:44.936 BFD: [SWK28-M149C] northbound callback: event [validate] op [create] xpath [/frr-interface:lib/interface[name='eth-rt2']] value [(no\
> ne)]
> 2026/04/14 14:30:44.936 BFD: [SWK28-M149C] northbound callback: event [prepare] op [create] xpath [/frr-interface:lib/interface[name='lo']] value [(none)]
> 2026/04/14 14:30:44.936 BFD: [SWK28-M149C] northbound callback: event [prepare] op [create] xpath [/frr-interface:lib/interface[name='eth-rt2']] value [(non\
> e)]
> 2026/04/14 14:30:44.936 BFD: [M7Q4P-46WDR] vty[16]@(config)# debu northbound libyang
>
> 2026/04/14 14:30:44.936 BFD: [M7Q4P-46WDR] vty[16]@(config)# debu northbound notifications
>
> 2026/04/14 14:30:44.937 BFD: [M7Q4P-46WDR] vty[16]@(config)# bfd
>
> 2026/04/14 14:30:44.937 BFD: [SWK28-M149C] northbound callback: event [apply] op [create] xpath [/frr-interface:lib/interface[name='lo']] value [(none)]
> 2026/04/14 14:30:44.937 BFD: [SWK28-M149C] northbound callback: event [apply] op [create] xpath [/frr-interface:lib/interface[name='eth-rt2']] value [(none)\
> ]
> 2026/04/14 14:30:44.938 BFD: [M7Q4P-46WDR] vty[16]@(config-bfd)#  peer 10.0.1.2 interface eth-rt2
>
> 2026/04/14 14:30:44.938 BFD: [M7Q4P-46WDR] vty[16]@(config-bfd)# line vty
>
> 2026/04/14 14:30:44.939 BFD: [M7Q4P-46WDR] vty[16]@(config-line)# XFRR_end_configuration
> 2026/04/14 14:30:44.939 BFD: [VTVCM-Y2NW3] Configuration Read in Took: 00:00:00
> 2026/04/14 14:30:44.939 BFD: [G6NKK-8C6DV] end_config: VTY:0x622ef034ab70, pending SET-CFG: 0
> 2026/04/14 14:30:44.939 BFD: [M7Q4P-46WDR] vty[16]@(config)# end
> 2026/04/14 14:30:44.939 BFD: [M7Q4P-46WDR] vty[16]@# disable
> 2026/04/14 14:30:45.426 BFD: [M7Q4P-46WDR] vty[5]@> enable

The per-interface commands are received by BFD, whereas BFD has no need to receive such commands. Remove it.

Fixes: adc26455bff1 ("bfdd: migrate session commands to northbound")