### PR TITLE
tests: update .gitignore for isis test

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -15,6 +15,7 @@ frr_northbound*
 /isisd/test_fuzz_isis_tlv
 /isisd/test_fuzz_isis_tlv_tests.h
 /isisd/test_isis_lspdb
+/isisd/test_isis_remove_excess_adjs
 /isisd/test_isis_spf
 /isisd/test_isis_vertex_queue
 /lib/cli/test_cli


### PR DESCRIPTION
Add a missed isis unit-test binary to .gitignore
