### PR TITLE
lib: northbound: distinguish unknown schema node from key mismatch

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -938,8 +938,27 @@ static int nb_candidate_edit_tree_add(struct nb_config *candidate,
 	/* verify that list keys are the same in the xpath and the data tree */
 	if (!root && (operation == NB_OP_REPLACE || operation == NB_OP_MODIFY)) {
 		if (lyd_find_path(tree, xpath, 0, NULL)) {
-			snprintf(errmsg, errmsg_len,
-				 "List keys in xpath and data tree are different");
+			/*
+			 * lyd_find_path fails for two distinct reasons: the
+			 * xpath names a schema node that does not exist (typo),
+			 * or the xpath resolves but its key predicates diverge
+			 * from the keys carried in the payload. Distinguish
+			 * them via a schema-only lookup so the operator sees
+			 * which case happened.
+			 *
+			 * lys_find_path (not yang_resolve_snode_xpath) is
+			 * intentional: edit-config xpaths are canonical
+			 * instance-identifiers (vtysh, NETCONF, RESTCONF,
+			 * gNMI), not arbitrary XPath expressions, so the
+			 * two-step fallback in yang_resolve_snode_xpath is
+			 * unnecessary here.
+			 */
+			if (!lys_find_path(ly_native_ctx, NULL, xpath, 0))
+				snprintf(errmsg, errmsg_len, "Unknown schema node in xpath: %s",
+					 xpath);
+			else
+				snprintf(errmsg, errmsg_len,
+					 "List keys in xpath and data tree are different");
 			ret = NB_ERR;
 			goto done;
 		}

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -499,6 +499,15 @@ def test_mgmt_edit_config(request):
     )
     assert "List keys in xpath and data tree are different" in ret
 
+    # check error on replace when xpath names a schema node that does not exist
+    data = {"frr-interface:interface": [{"name": "eth0", "description": "d"}]}
+    payload = json.dumps(data, separators=(",", ":"))
+    ret = r1.vtysh_cmd(
+        "conf\nmgmt edit replace /frr-interface:lib/interfac[name='eth0'] lock commit "
+        + payload
+    )
+    assert "Unknown schema node in xpath" in ret
+
     # check deleting an existing object using "delete"
     r1.vtysh_cmd(
         f"conf\nmgmt edit delete /frr-interface:lib/interface[name='eth0'] lock commit"


### PR DESCRIPTION
## Summary

`mgmtd` currently emits `"List keys in xpath and data tree are different"` for two distinct `edit-config` failure modes:

- the xpath names a schema node that does not exist (typo, e.g. `interfac` instead of `interface`); and
- the xpath resolves to a valid schema node, but the key predicates do not match the keys carried in the payload.

The combined message makes the first case hard to debug — operators and external controllers cannot tell the schema name is wrong without cross-referencing the YANG tree by hand.

This patch calls `lys_find_path()` on the schema context **only on the error path**: if the xpath does not resolve to any schema node, emit `"Unknown schema node in xpath: <xpath>"`; otherwise keep the existing message. Happy path is unaffected.

## Test plan

- [x] `tools/checkpatch.pl --no-tree -g HEAD` → 0 errors, 0 warnings
- [x] Existing `tests/topotests/mgmt_tests/test_yang_mgmt.py:500` still passes — it asserts the key-mismatch message which is preserved verbatim
- [x] Empirical probes on mgmtd 10.7-dev standalone:
  - `mgmt edit replace /frr-interface:lib/interfac[name='eth0'] ...` → `% Unknown schema node in xpath: /frr-interface:lib/interfac[name='eth0']`
  - `mgmt edit replace /frr-interface:lib/interface[name='eth0'] ...` (payload with `name='eth1'`) → `% List keys in xpath and data tree are different`

## Why this is safe

- Changes only the error message text; return code (`NB_ERR`) is unchanged.
- `lys_find_path` runs exclusively when `lyd_find_path` already failed.
- No ABI or API change; no new includes.