### PR TITLE
lib: stabilize frr_daemon_info layout across configure flags

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -136,9 +136,14 @@ struct frr_daemon_info {
 	const char *config_file;
 	const char *backup_config_file;
 	const char *pid_file;
-#ifdef HAVE_SQLITE3
+	/*
+	 * db_file: always present in the struct for ABI stability across
+	 * configure flags. The runtime path that uses it remains gated by
+	 * HAVE_SQLITE3 in lib/libfrr.c. External clients built with
+	 * HAVE_SQLITE3 mismatching libfrr's build would otherwise see a
+	 * shifted struct layout, silently corrupting all subsequent fields.
+	 */
 	const char *db_file;
-#endif
 	const char *vty_path;
 	const char *module_path;
 	const char *script_path;


### PR DESCRIPTION
## Summary

The `frr_daemon_info` struct in `lib/libfrr.h` had a single conditional field, `db_file`, gated by `#ifdef HAVE_SQLITE3`. This made the struct layout depend on configure flags, causing silent ABI mismatch between an external client and libfrr when they were built with different `HAVE_SQLITE3` settings.

This patch removes the `#ifdef` from the struct definition (the field is now always present) while leaving the runtime path that uses it gated by `HAVE_SQLITE3` in `lib/libfrr.c`. Cost is one 8-byte pointer in the static struct; behavior is unchanged for both SQLITE3 and non-SQLITE3 builds.

## Failure mode

A client built with `HAVE_SQLITE3=1` against a libfrr built without SQLITE3 sees `.privs` (and all subsequent fields) at offsets shifted by 8 bytes:

- **Best case:** NULL detected at `zprivs_preinit()` and the daemon exits with a clear message.
- **Worst case:** garbage pointer treated as valid, `pthread_mutex_init` called on arbitrary memory, eventual undiagnosable crash.

This was discovered while reproducing #21407 in lab. The reproducer attached to that issue (`app.tar.gz`) ships a `config.h` with `HAVE_SQLITE3=1`. When linked against a libfrr built without SQLITE3, the reproducer fails with `zprivs_init: called with NULL arg!` before reaching the `msg_client_connect_short_circuit` bug — masking the actual issue.

## Lab validation

| libfrr config | client config | UB-12 patch | Result | iters |
|---|---|---|---|---|
| no-SQLITE3 | `HAVE_SQLITE3=1` | no | `zprivs_init: called with NULL arg!` exit 1 | n/a |
| no-SQLITE3 | `HAVE_SQLITE3=1` | **yes** | clean (`Starting FE Client event loop...`) | 1/1 |
| no-SQLITE3 | no-SQLITE3 | yes | clean | 3/3 |

Pre-patch sizeof: `sizeof(frr_daemon_info)=400`, `privs_offset=368`
Post-patch sizeof: `sizeof(frr_daemon_info)=408`, `privs_offset=376` (matches client built with `HAVE_SQLITE3=1` regardless of libfrr config)

Full evidence: https://gist.github.com/reinaldosaraiva/11ac675a42a22dc0b442eb5270de673b

## Test plan

- [x] Build with `HAVE_SQLITE3` enabled — runtime path unchanged
- [x] Build with `HAVE_SQLITE3` disabled — field present but unused, no warnings
- [x] External client cross-config (HAVE_SQLITE3=1 vs no-SQLITE3 libfrr) reaches expected init
- [x] Same-config build does not regress (3/3 iters clean)
- [x] Reference reproducer for #21407 still triggers original bug pre-fix (UB-12 does not mask)