### PR TITLE
eigrpd: enforce minimum TLV length in Hello handler

### DIFF
--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -348,8 +348,8 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 		type = ntohs(tlv_header->type);
 		length = ntohs(tlv_header->length);
 
-		/* Validate tlv length */
-		if ((length > 0) && (length <= size)) {
+		/* Validate tlv length: must be at least header size (4 bytes) */
+		if ((length >= EIGRP_TLV_HDR_LENGTH) && (length <= size)) {
 			if (IS_DEBUG_EIGRP_PACKET(0, RECV))
 				zlog_debug(
 					"  General TLV(%s)",


### PR DESCRIPTION
The Hello TLV parser accepts TLVs with length 1, 2, or 3 because the condition only checks `length > 0`. Since the TLV header itself is 4 bytes (type + length), a declared length smaller than `EIGRP_TLV_HDR_LENGTH` causes the pointer to advance by less than one header width, misaligning all subsequent TLV reads.

Tighten the check to require `length >= EIGRP_TLV_HDR_LENGTH`.

Signed-off-by: Tristan Madani <tristan@live.fr>