### PR TITLE
isisd: consume leftover bytes after FAD sub-sub-TLV loop

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -5244,6 +5244,14 @@ static int unpack_tlv_router_cap(enum isis_tlv_context context, uint8_t tlv_type
 				}
 				subsubtlvs_len -= 2 + subsubtlv_len;
 			}
+			/* consume any leftover bytes (e.g. subsubtlvs_len 1-2,
+			 * too small for another sub-sub-TLV header) so the
+			 * stream stays in sync with the declared subtlv length.
+			 * Only skip on normal loop exit (1-2 bytes remain);
+			 * the error-break path already consumed the bytes.
+			 */
+			if (subsubtlvs_len > 0 && subsubtlvs_len <= 2)
+				stream_forward_getp(s, subsubtlvs_len);
 			break;
 #endif /* ifndef FABRICD */
 		case ISIS_SUBTLV_SRV6_CAPABILITIES:


### PR DESCRIPTION
The Flex-Algorithm sub-sub-TLV loop condition is `while (subsubtlvs_len > 2)`, so when 1 or 2 bytes remain after the last iteration, they are not consumed. The stream position then falls behind the declared subtlv length, desynchronizing subsequent subtlv parsing in the outer loop.

Skip any leftover bytes after the while loop exits.

Signed-off-by: Tristan Madani <tristan@live.fr>