### PR TITLE
bgpd: migrate timers during peer_xfer_conn to fix stale route cleanup

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -128,6 +128,9 @@ static void peer_xfer_stats(struct peer *peer_dst, struct peer *peer_src)
 	peer_dst->dynamic_cap_out += peer_src->dynamic_cap_out;
 }
 
+static void bgp_graceful_stale_timer_expire(struct event *event);
+static void bgp_graceful_restart_timer_expire(struct event *event);
+
 static struct peer *peer_xfer_conn(struct peer *from_peer)
 {
 	struct peer *peer;
@@ -214,6 +217,34 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	keeper->peer = peer;
 	from_peer->connection = going_away;
 	going_away->peer = from_peer;
+
+	/*
+	 * Migrate GR timers from going_away to keeper.  These were
+	 * armed in bgp_stop() on the config peer's old connection.
+	 * Cancel and re-arm so EVENT_ARG points to keeper, not the
+	 * going_away connection that will be freed with the doppelganger.
+	 */
+	if (event_is_scheduled(going_away->t_gr_stale)) {
+		struct timeval remain = event_timer_remain(going_away->t_gr_stale);
+
+		event_cancel(&going_away->t_gr_stale);
+		event_add_timer_tv(bm->master, bgp_graceful_stale_timer_expire, keeper, &remain,
+				   &keeper->t_gr_stale);
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("%pBP %s: migrated stalepath timer (%ld sec remain) to keeper",
+				   peer, __func__, (long)remain.tv_sec);
+	}
+
+	if (event_is_scheduled(going_away->t_gr_restart)) {
+		struct timeval remain = event_timer_remain(going_away->t_gr_restart);
+
+		event_cancel(&going_away->t_gr_restart);
+		event_add_timer_tv(bm->master, bgp_graceful_restart_timer_expire, keeper, &remain,
+				   &keeper->t_gr_restart);
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("%pBP %s: migrated restart timer (%ld sec remain) to keeper",
+				   peer, __func__, (long)remain.tv_sec);
+	}
 
 	peer->as = from_peer->as;
 	peer->v_holdtime = from_peer->v_holdtime;


### PR DESCRIPTION
When a BGP session goes down on a GR-helper, bgp_stop() arms the stalepath timer (t_gr_stale) and restart timer (t_gr_restart) on the config peer's connection. If the restarting peer reconnects and a connection collision occurs (common in large-scale topologies like Fairwater with 256 sessions per leaf), peer_xfer_conn() swaps the connection pointers: the doppelganger's winning connection (keeper) is given to the config peer, and the config peer's old connection (going_away) is handed to the doppelganger for deletion.

The GR timers armed on going_away were not migrated during this swap. When the doppelganger was subsequently deleted, going_away was freed and the timers were silently lost. Without the stalepath timer safety net, stale routes were never removed even after the configured stalepath-time had long elapsed.

Fix:
Cancel the GR timers on going_away after the swap and re-arm them on keeper with the remaining time. A simple pointer copy is insufficient because EVENT_ARG (the callback context) must reference keeper, not the going_away connection that will be freed.

Custom debug logs:

Before fix - timer lost during xfer, stale routes never removed

  ```
bgp_stop: start stalepath timer 120 sec
  peer_xfer_conn: going_away t_gr_stale=armed rem_sec=98
  peer_xfer_conn: after xfer config_conn t_gr_stale=NULL    <-- LOST
  bgp_establish: t_gr_stale=NULL                            <-- never fires

```
After fix - timer migrated, stale routes removed on expiry

  ```
bgp_stop: start stalepath timer 120 sec
  peer_xfer_conn: going_away t_gr_stale=armed rem_sec=98
  peer_xfer_conn: migrated stalepath timer (98 sec remain)  <-- MIGRATED
  peer_xfer_conn: after xfer config_conn t_gr_stale=armed rem_sec=97
  bgp_establish: t_gr_stale=armed gr_stale_rem_sec=97
  stalepath timer expired                                   <-- FIRES
  bgp_clear_stale_route: entered (stale routes removed)
```