### PR TITLE
bgpd: fix neighbor IP comparison for IPv6 memcmp return values

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1810,7 +1810,8 @@ int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 
 	ret = sockunion_cmp(peer_new->connection->su_remote, peer_exist->connection->su_remote);
 
-	if (ret == 1) {
+	/* IPv6 uses memcmp in sockunion_cmp — ret may be any +/- value, not only ±1 */
+	if (ret > 0) {
 		*reason = bgp_path_selection_neighbor_ip;
 		if (debug)
 			zlog_debug("%s: %s loses to %s due to Neighbor IP comparison",
@@ -1818,7 +1819,7 @@ int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 		return 0;
 	}
 
-	if (ret == -1) {
+	if (ret < 0) {
 		*reason = bgp_path_selection_neighbor_ip;
 		if (debug)
 			zlog_debug("%s: %s wins over %s due to Neighbor IP comparison",


### PR DESCRIPTION
Rootcause and fix:
In bgp bestpath selection,IPv6 peer addresses are ordered with memcmp in sockunion_cmp(), so the return value can be any negative or positive integer (e.g. 2), not only -1, 0, or 1. The BGP neighbor-IP step compared ret to exactly ±1, so other positive/negative values fell through to the default branch and leading to select the wrong path. Using ret > 0 and ret < 0 instead.