### PR TITLE
tests: topotests: cover libyang validation errors via mgmt edit

### DIFF
--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -642,6 +642,186 @@ def test_mgmt_edit_config(request):
     )
 
 
+def test_mgmt_edit_config_libyang_errors(request):
+    """
+    Verify mgmt edit config surfaces libyang validation errors with stable
+    diagnostic strings that external controllers (NETCONF/gNMI/RESTCONF)
+    depend on to classify failures. Six categories covered: malformed JSON,
+    pattern violation, invalid enumeration, missing mandatory leaf, delete
+    of a leaf inside a mandatory choice, and dangling formal leafref.
+    """
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    reset_config_on_routers(tgen)
+
+    r1 = tgen.gears["r1"]
+
+    # Seed a valid prefix-list so mandatory-choice delete (R2a) has a target.
+    seed = {
+        "frr-filter:prefix-list": [
+            {
+                "type": "ipv4",
+                "name": "pl-seed",
+                "entry": [
+                    {
+                        "sequence": 10,
+                        "action": "permit",
+                        "ipv4-prefix": "192.0.2.0/24",
+                    }
+                ],
+            }
+        ]
+    }
+    r1.vtysh_cmd(
+        "conf\nmgmt edit create /frr-filter:lib lock commit "
+        + json.dumps(seed, separators=(",", ":"))
+    )
+    # Positive check: the seed must now be queryable. Catches creation
+    # failures up front so R2a's mandatory-choice assertion doesn't have
+    # to absorb a confusing "path not found" error from the delete path.
+    assert (
+        router_json_cmp(
+            r1,
+            "show mgmt get-data /frr-filter:lib/prefix-list[type='ipv4'][name='pl-seed']"
+            " only-config exact",
+            seed,
+            exact=True,
+        )
+        is None
+    ), "Seed prefix-list creation failed; R2a cannot validate mandatory-choice delete"
+
+    # R4a — malformed JSON (unterminated object): libyang parse error.
+    ret = r1.vtysh_cmd(
+        'conf\nmgmt edit create /frr-filter:lib lock commit {"frr-filter:prefix-list":[{"type":"ipv4","name":"x"'
+    )
+    assert "Unexpected end-of-input" in ret or "Invalid character" in ret
+
+    # R4b — pattern violation: /33 is not a valid IPv4 prefix length.
+    bad_pattern = {
+        "frr-filter:prefix-list": [
+            {
+                "type": "ipv4",
+                "name": "pl-pattern",
+                "entry": [
+                    {
+                        "sequence": 10,
+                        "action": "permit",
+                        "ipv4-prefix": "192.0.2.0/33",
+                    }
+                ],
+            }
+        ]
+    }
+    ret = r1.vtysh_cmd(
+        "conf\nmgmt edit create /frr-filter:lib lock commit "
+        + json.dumps(bad_pattern, separators=(",", ":"))
+    )
+    assert "Unsatisfied pattern" in ret
+
+    # R4c — invalid enumeration value: action must be permit|deny.
+    bad_enum = {
+        "frr-filter:prefix-list": [
+            {
+                "type": "ipv4",
+                "name": "pl-enum",
+                "entry": [
+                    {
+                        "sequence": 10,
+                        "action": "allow",
+                        "ipv4-prefix": "192.0.2.0/24",
+                    }
+                ],
+            }
+        ]
+    }
+    ret = r1.vtysh_cmd(
+        "conf\nmgmt edit create /frr-filter:lib lock commit "
+        + json.dumps(bad_enum, separators=(",", ":"))
+    )
+    assert "Invalid enumeration value" in ret
+
+    # R4d — mandatory leaf missing: entry requires "action".
+    missing_mandatory = {
+        "frr-filter:prefix-list": [
+            {
+                "type": "ipv4",
+                "name": "pl-mand",
+                "entry": [{"sequence": 10, "ipv4-prefix": "192.0.2.0/24"}],
+            }
+        ]
+    }
+    ret = r1.vtysh_cmd(
+        "conf\nmgmt edit create /frr-filter:lib lock commit "
+        + json.dumps(missing_mandatory, separators=(",", ":"))
+    )
+    assert "Mandatory node" in ret and "does not exist" in ret
+
+    # R2a — delete a leaf that participates in a mandatory choice.
+    # /entry[sequence=N]/ipv4-prefix is in choice "value" (mandatory) and
+    # is itself declared mandatory true, so the delete leaves two
+    # simultaneous violations; libyang may report either the choice-level
+    # one ("Mandatory choice") or the leaf-level one ("Mandatory node")
+    # depending on validation order, both are valid diagnostics.
+    ret = r1.vtysh_cmd(
+        "conf\nmgmt edit delete "
+        "/frr-filter:lib/prefix-list[type='ipv4'][name='pl-seed']"
+        "/entry[sequence='10']/ipv4-prefix lock commit"
+    )
+    assert "Mandatory choice" in ret or "Mandatory node" in ret
+
+    # R5a — dangling formal leafref (require-instance=true).
+    # frr-affinity-map:affinity-map-ref is the only leafref in tree with
+    # require-instance=true. Consumed by zebra under interface/link-params.
+    # affinity-mode=extended avoids the "standard mode" must-expression.
+    # Uses `create` at interface target (matches the pattern of the earlier
+    # successful create in this file; merge semantics at container targets
+    # can reject payloads libyang expects to root at a list item).
+    dangling = {
+        "frr-interface:interface": [
+            {
+                "name": "eth0",
+                "frr-zebra:zebra": {
+                    "link-params": {
+                        "affinity-mode": "extended",
+                        "affinities": {"affinity": ["does-not-exist-map"]},
+                    }
+                },
+            }
+        ]
+    }
+    ret = r1.vtysh_cmd(
+        "conf\nmgmt edit create /frr-interface:lib lock commit "
+        + json.dumps(dangling, separators=(",", ":"))
+    )
+    assert "Invalid leafref value" in ret
+
+    # Sanity: the seed prefix-list survived every failed edit above.
+    assert (
+        router_json_cmp(
+            r1,
+            "show mgmt get-data "
+            "/frr-filter:lib/prefix-list[type='ipv4'][name='pl-seed']"
+            " only-config exact",
+            seed,
+            exact=True,
+        )
+        == None
+    )
+
+    # Cleanup the seed (idempotent via remove) so later tests inherit a
+    # clean candidate datastore.
+    r1.vtysh_cmd(
+        "conf\nmgmt edit remove "
+        "/frr-filter:lib/prefix-list[type='ipv4'][name='pl-seed'] lock commit"
+    )
+
+    write_test_footer(tc_name)
+
+
 def test_mgmt_chaos_stop_start_frr(request):
     """
     Kill mgmtd - verify that watch frr restarts.


### PR DESCRIPTION
## Summary

Adds upstream coverage for libyang validation error diagnostics surfaced by `mgmt edit`. Six substrings that external controllers (NETCONF/gNMI/RESTCONF clients) substring-match to classify failures now have regression tests, so a silent wording drift in libyang or mgmtd is caught by CI.

No production code touched; single new function in `tests/topotests/mgmt_tests/test_yang_mgmt.py`.

## Motivation

Declarative controllers can't crash on every `Code = -22` — they have to route different semantic failures to different remediation paths. Today they do that by substring-matching the libyang strings carried in `EDIT_REPLY.error.msg`. Those strings are de-facto API for programmatic clients, but no upstream topotest asserts on them, so accidental rewording ships silently.

The six cases covered are the categories a declarative reconciler realistically has to distinguish:

| Case | Trigger | Expected substring |
|---|---|---|
| R4a | Malformed JSON (unterminated) | `Unexpected end-of-input` |
| R4b | Pattern violation (`/33`) | `Unsatisfied pattern` |
| R4c | Invalid enumeration (`action: "allow"`) | `Invalid enumeration value` |
| R4d | Missing mandatory leaf (`action`) | `Mandatory node ... does not exist` |
| R2a | Delete leaf in mandatory choice | `Mandatory choice` or `Mandatory node` |
| R5a | Dangling formal leafref (require-instance=true) | `Invalid leafref value` |

R2a accepts either wording because the delete leaves two simultaneous mandatory violations (`choice value { mandatory true; }` enclosing a `leaf ipv4-prefix { mandatory true; }`); libyang is free to report either first.

## Scope

- Cases 1-5 target `/frr-filter:lib/prefix-list`, already loaded into mgmtd's libyang context via `frr_filter_cli_info` in `mgmtd/mgmt_main.c`.
- Case 6 uses `frr-affinity-map:affinity-map-ref` — the only leafref in tree with `require-instance true` explicit — consumed by zebra at `/frr-interface:lib/interface/frr-zebra:zebra/link-params/affinities/affinity`. `affinity-mode=extended` in the payload sidesteps the `must` expression at `yang/frr-zebra.yang:2309`, so the constraint reaching libyang is the leafref check alone.
- Reuses the existing module fixture — no new daemons, topology, or `frr.conf`.

## Validation

Run on a 10.7.0-dev build against `upstream/master 03024cb96d`.

```
$ cd tests/topotests
$ sudo python3 -m pytest mgmt_tests/test_yang_mgmt.py -v
...
======================== 8 passed, 2 warnings in 24.40s ========================
```

7 pre-existing tests plus the new `test_mgmt_edit_config_libyang_errors`. No regression.

`tools/checkpatch.pl --no-tree`: 0 errors, 0 warnings, 173 lines checked. `black --check` clean.

Exact libyang diagnostics captured empirically in the lab (`/tmp/topotests/mgmt_tests.test_yang_mgmt/r1/mgmtd.log`) — every assertion substring appears verbatim.

## Test plan

- [x] Suite `mgmt_tests/test_yang_mgmt.py` green (8/8)
- [x] New test `test_mgmt_edit_config_libyang_errors` green in isolation
- [x] `checkpatch.pl --no-tree` clean
- [x] `black --check` clean
- [x] Seed prefix-list re-verified via `show mgmt get-data` after each failed edit (locks down atomic rollback)
