### PR TITLE
bgp_evpn: fix memleak when configuring rd

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2396,6 +2396,8 @@ static void evpn_configure_rd(struct bgp *bgp, struct bgpevpn *vpn,
 	if (is_vni_live(vpn))
 		bgp_evpn_handle_rd_change(bgp, vpn, 1);
 
+	if (vpn->prd_pretty)
+		XFREE(MTYPE_BGP_NAME, vpn->prd_pretty);
 	/* update RD */
 	memcpy(&vpn->prd, rd, sizeof(struct prefix_rd));
 	vpn->prd_pretty = XSTRDUP(MTYPE_BGP_NAME, rd_pretty);


### PR DESCRIPTION
Direct leak of 14 byte(s) in 1 object(s) allocated from:
    #0 0x7bea082f74e8 in strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:578
    #1 0x7bea07e3ca5a in qstrdup lib/memory.c:123
    #2 0x63e8ac7e7349 in evpn_configure_rd bgpd/bgp_evpn_vty.c:2401
    #3 0x63e8ac7e7349 in bgp_evpn_vni_rd bgpd/bgp_evpn_vty.c:6439
    #4 0x7bea07db2926 in cmd_execute_command_real lib/command.c:1011
    #5 0x7bea07db2c88 in cmd_execute_command lib/command.c:1070
    #6 0x7bea07db31e5 in cmd_execute lib/command.c:1236
    #7 0x7bea07f13a9f in vty_command lib/vty.c:593
    #8 0x7bea07f14f2c in vty_execute lib/vty.c:1356

Existing string is not freed on replace.