### PR TITLE
eigrpd: reject invalid prefix mask len (10.3 backport)

### DIFF
--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -1091,6 +1091,7 @@ struct TLV_IPv4_Internal_type *eigrp_read_ipv4_tlv(struct stream *s)
 {
 	struct TLV_IPv4_Internal_type *tlv;
 	uint32_t destination_tmp;
+	size_t bytes;
 
 	tlv = eigrp_IPv4_InternalTLV_new();
 
@@ -1110,7 +1111,26 @@ struct TLV_IPv4_Internal_type *eigrp_read_ipv4_tlv(struct stream *s)
 
 	tlv->prefix_length = stream_getc(s);
 
-	destination_tmp = stream_getc(s) << 24;
+	if (tlv->prefix_length > 32) {
+		eigrp_IPv4_InternalTLV_free(tlv);
+		return NULL;
+	}
+
+	/* Validate additional length needed based on prefix length */
+	bytes = 1;
+	if (tlv->prefix_length > 24)
+		bytes = 4;
+	else if (tlv->prefix_length > 16)
+		bytes = 3;
+	else if (tlv->prefix_length > 8)
+		bytes = 2;
+
+	if (STREAM_READABLE(s) < bytes) {
+		eigrp_IPv4_InternalTLV_free(tlv);
+		return NULL;
+	}
+
+	destination_tmp = (uint32_t)stream_getc(s) << 24;
 	if (tlv->prefix_length > 8)
 		destination_tmp |= stream_getc(s) << 16;
 	if (tlv->prefix_length > 16)


### PR DESCRIPTION
Reject invalid prefix mask lengths for ipv4 tlvs - manual backport of #21539 
