### PR TITLE
lib: ignore gcc warning in 10.3 zlog lttng code

### DIFF
--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -695,6 +695,8 @@ void vzlogx(const struct xref_logmsg *xref, int prio,
 	va_copy(copy, ap);
 	char *msg = vasprintfrr(MTYPE_LOG_MESSAGE, fmt, copy);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 	switch (prio) {
 	case LOG_ERR:
 		frrtracelog(TRACE_ERR, msg);
@@ -716,6 +718,7 @@ void vzlogx(const struct xref_logmsg *xref, int prio,
 
 	va_end(copy);
 	XFREE(MTYPE_LOG_MESSAGE, msg);
+#pragma GCC diagnostic pop
 #endif
 
 	if (zlog_tls)


### PR DESCRIPTION
Port the gcc pragma to ignore a format string warning in the lttng path in vzlogx to the 10.3 branch. This lets the 10.3 branch build cleanly with lttng enabled in configure.