### PR TITLE
isisd: Preserve flags when copying SRv6 End SID sub-TLV

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -2466,6 +2466,7 @@ static struct isis_item *copy_item_srv6_end_sid(struct isis_item *i)
 	struct isis_srv6_end_sid_subtlv *sid = (struct isis_srv6_end_sid_subtlv *)i;
 	struct isis_srv6_end_sid_subtlv *rv = XCALLOC(MTYPE_ISIS_SUBTLV, sizeof(*rv));
 
+	rv->flags = sid->flags;
 	rv->behavior = sid->behavior;
 	rv->sid = sid->sid;
 	rv->subsubtlvs = isis_copy_subsubtlvs(sid->subsubtlvs);


### PR DESCRIPTION
Preserve the flags field when duplicating an SRv6 End SID sub-TLV by copying it into the cloned entry.