### PR TITLE
eigrpd: Handling for malformed update packets (10.5 version)

### DIFF
--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -548,6 +548,12 @@ void eigrp_read(struct event *thread)
 	/* Advance from IP header to EIGRP header (iph->ip_hl has been verified
 	   by eigrp_recv_packet() to be correct). */
 
+	if ((iph->ip_hl * 4) + EIGRP_HEADER_LEN > stream_get_endp(ibuf)) {
+		zlog_warn("Malformed packet: IP header extends beyond packet data. IP header len = %u endp = %zu",
+				 iph->ip_hl * 4, stream_get_endp(ibuf));
+		return;
+	}
+
 	stream_forward_getp(ibuf, (iph->ip_hl * 4));
 	eigrph = (struct eigrp_header *)stream_pnt(ibuf);
 

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -279,6 +279,13 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 
 	/*If there is topology information*/
 	while (s->endp > s->getp) {
+		/* Ensure we have at least 4 bytes for TLV header */
+		if (STREAM_READABLE(s) < 4) {
+			zlog_warn("Malformed packet: Unexpected early end of packet reached, stopping TLV processing");
+			stream_forward_getp(s, STREAM_READABLE(s));
+			break;
+		}
+
 		type = stream_getw(s);
 		switch (type) {
 		case EIGRP_TLV_IPv4_INT:
@@ -374,10 +381,23 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 		 *      for now, lets just not creash the box
 		 */
 		default:
+			/* Handle unknown TLV types gracefully */
+			zlog_warn("Unknown TLV type: 0x%04x", type);
+
+			/* Validate we have enough data for TLV length */
+			if (STREAM_READABLE(s) < 2) {
+				zlog_warn("Malformed packet: insufficient data for TLV length, skipping to end");
+				stream_forward_getp(s, STREAM_READABLE(s));
+				break;
+			}
+
 			length = stream_getw(s);
-			// -2 for type, -2 for len
-			for (length -= 4; length; length--) {
-				(void)stream_getc(s);
+
+			/* Validate TLV length */
+			if (length < 4) {
+				zlog_warn("Malformed packet: TLV length too small (%u), skipping to end", length);
+				stream_forward_getp(s, STREAM_READABLE(s));
+				break;
 			}
 
 			/* Check for reasonable TLV length */
@@ -399,6 +419,7 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 			if (IS_DEBUG_EIGRP_PACKET(0, RECV))
 				zlog_debug("Skipping unknown TLV: type=0x%04x, length=%u", type, length);
 			stream_forward_getp(s, length - 4);
+			break;
 		}
 	}
 


### PR DESCRIPTION
Backport of #19699  to stable/10.5. This fixes a loop problem and adds more validation for unknown TLVs. the original comment is:

-EIGRP daemon was crashing when the code was attempting to read more data from EIGRP update malformed packets than is available in the packets stream.
-Safety checks have been added before reading from the stream to prevent any crashes
-This patch addresses the Update packets carrying routes other than IPv4 Internal routes