### PR TITLE
ospf6d: update auth sequence number after validating digest

### DIFF
--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -452,15 +452,12 @@ int ospf6_auth_validate_pkt(struct ospf6_interface *oi, unsigned int *pkt_len,
 	*pkt_len = (*pkt_len) - (*at_len) - (*lls_block_len);
 
 	if (on) {
+		/* Check sequence number */
 		oh_seqnum_h = ntohl(ospf6_auth_info.seqnum_h);
 		oh_seqnum_l = ntohl(ospf6_auth_info.seqnum_l);
-		if ((oh_seqnum_h > on->seqnum_h[oh->type]) ||
+		if ((oh_seqnum_h < on->seqnum_h[oh->type]) ||
 		    (oh_seqnum_h == on->seqnum_h[oh->type] &&
-		     oh_seqnum_l > on->seqnum_l[oh->type])) {
-			/* valid sequence number received */
-			on->seqnum_h[oh->type] = oh_seqnum_h;
-			on->seqnum_l[oh->type] = oh_seqnum_l;
-		} else {
+		     oh_seqnum_l <= on->seqnum_l[oh->type])) {
 			if (IS_OSPF6_DEBUG_AUTH_RX) {
 				zlog_err(
 					"RECV[%s] : Nbr(%s) Auth Sequence number mismatch in %s ",
@@ -488,6 +485,7 @@ int ospf6_auth_check_digest(struct ospf6_header *oh, struct ospf6_interface *oi,
 	unsigned char apad[hash_len];
 	unsigned char temp_hash[hash_len];
 	struct ospf6_auth_hdr *ospf6_auth;
+	struct ospf6_neighbor *on = NULL;
 	uint32_t ipv6_addr_size = sizeof(struct in6_addr);
 	struct keychain *keychain = NULL;
 	struct key *key = NULL;
@@ -495,6 +493,8 @@ int ospf6_auth_check_digest(struct ospf6_header *oh, struct ospf6_interface *oi,
 	uint16_t auth_len = 0;
 	uint8_t hash_algo = 0;
 	uint16_t oh_len = ntohs(oh->length);
+	uint32_t oh_seqnum_h = 0;
+	uint32_t oh_seqnum_l = 0;
 	int ret = 0;
 
 	if (oi->at_data.flags == 0)
@@ -575,8 +575,18 @@ int ospf6_auth_check_digest(struct ospf6_header *oh, struct ospf6_interface *oi,
 #else
 	ret = memcmp(temp_hash, ospf6_auth->data, hash_len);
 #endif
-	if (ret == 0)
+	if (ret == 0) {
+		on = ospf6_neighbor_lookup(oh->router_id, oi);
+		if (on) {
+			/* Update valid sequence number received */
+			oh_seqnum_h = ntohl(ospf6_auth->seqnum_h);
+			oh_seqnum_l = ntohl(ospf6_auth->seqnum_l);
+			on->seqnum_h[oh->type] = oh_seqnum_h;
+			on->seqnum_l[oh->type] = oh_seqnum_l;
+		}
+
 		return OSPF6_AUTH_VALIDATE_SUCCESS;
+	}
 
 	return OSPF6_AUTH_VALIDATE_FAILURE;
 }


### PR DESCRIPTION
Test for valid sequence number before validating auth digest, but don't update the neighbor's sequence number value until after validating.
