### PR TITLE
isisd: Use LAN End.X context for SRv6 sub-sub-TLV parsing

### DIFF
--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -341,7 +341,8 @@ void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup, struct li
 		ladj_sid->weight = 0;
 		ladj_sid->behavior = sra->behavior;
 		ladj_sid->sid = sra->sid;
-		ladj_sid->subsubtlvs = isis_alloc_subsubtlvs(ISIS_CONTEXT_SUBSUBTLV_SRV6_ENDX_SID);
+		ladj_sid->subsubtlvs =
+			isis_alloc_subsubtlvs(ISIS_CONTEXT_SUBSUBTLV_SRV6_LAN_ENDX_SID);
 		ladj_sid->subsubtlvs->srv6_sid_structure =
 			XCALLOC(MTYPE_ISIS_SUBSUBTLV,
 				sizeof(*ladj_sid->subsubtlvs->srv6_sid_structure));

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1915,10 +1915,10 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 				subsubtlv_len = stream_getc(s);
 
 				lan->subsubtlvs = isis_alloc_subsubtlvs(
-					ISIS_CONTEXT_SUBSUBTLV_SRV6_ENDX_SID);
+					ISIS_CONTEXT_SUBSUBTLV_SRV6_LAN_ENDX_SID);
 
 				bool unpacked_known_tlvs = false;
-				if (unpack_tlvs(ISIS_CONTEXT_SUBSUBTLV_SRV6_ENDX_SID,
+				if (unpack_tlvs(ISIS_CONTEXT_SUBSUBTLV_SRV6_LAN_ENDX_SID,
 						subsubtlv_len, s, log, lan->subsubtlvs, indent + 4,
 						&unpacked_known_tlvs)) {
 					XFREE(MTYPE_ISIS_SUBTLV, lan);


### PR DESCRIPTION
When decoding nested TLVs, the code passes a context value that identifies the parent TLV type. The unpacker uses this value to choose the handler table for nested TLVs.

In the LAN End.X path, the code passes the End.X context instead of the LAN End.X context. This works today because both contexts currently resolve to the same nested TLV handling, but it uses the wrong context and may break if the two paths diverge in the future.

Use the LAN End.X context for allocation and unpacking so nested TLVs are associated with the correct parent type and dispatched through the intended handler table.