### PR TITLE
lib: bound masklen values, don't assert

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -711,9 +711,16 @@ done:
 }
 
 /* Convert masklen into IP address's netmask (network byte order). */
-void masklen2ip(const int masklen, struct in_addr *netmask)
+void masklen2ip(int masklen, struct in_addr *netmask)
 {
-	assert(masklen >= 0 && masklen <= IPV4_MAX_BITLEN);
+	if (masklen < 0) {
+		zlog_warn("%s: invalid masklen %d, set to 0", __func__, masklen);
+		masklen = 0;
+	} else if (masklen > IPV4_MAX_BITLEN) {
+		zlog_warn("%s: invalid masklen %d, set to %d", __func__, masklen,
+			  IPV4_MAX_BITLEN);
+		masklen = IPV4_MAX_BITLEN;
+	}
 
 	/* left shift is only defined for less than the size of the type.
 	 * we unconditionally use long long in case the target platform
@@ -822,9 +829,16 @@ int ip6_masklen(struct in6_addr netmask)
 	return 128;
 }
 
-void masklen2ip6(const int masklen, struct in6_addr *netmask)
+void masklen2ip6(int masklen, struct in6_addr *netmask)
 {
-	assert(masklen >= 0 && masklen <= IPV6_MAX_BITLEN);
+	if (masklen < 0) {
+		zlog_warn("%s: invalid masklen %d, set to 0", __func__, masklen);
+		masklen = 0;
+	} else if (masklen > IPV6_MAX_BITLEN) {
+		zlog_warn("%s: invalid masklen %d, set to %d", __func__, masklen,
+			  IPV6_MAX_BITLEN);
+		masklen = IPV6_MAX_BITLEN;
+	}
 
 	if (masklen == 0) {
 		/* note << 32 is undefined */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -454,7 +454,7 @@ extern int prefix_ipv4_any(const struct prefix_ipv4 *p);
 extern void apply_classful_mask_ipv4(struct prefix_ipv4 *p);
 
 extern uint8_t ip_masklen(struct in_addr addr);
-extern void masklen2ip(const int length, struct in_addr *addr);
+extern void masklen2ip(int length, struct in_addr *addr);
 /* given the address of a host on a network and the network mask length,
  * calculate the broadcast address for that network;
  * special treatment for /31 according to RFC3021 section 3.3 */
@@ -469,7 +469,7 @@ extern int str2prefix_ipv6(const char *str, struct prefix_ipv6 *p);
 extern void apply_mask_ipv6(struct prefix_ipv6 *p);
 
 extern int ip6_masklen(struct in6_addr netmask);
-extern void masklen2ip6(const int masklen, struct in6_addr *netmask);
+extern void masklen2ip6(int masklen, struct in6_addr *netmask);
 
 extern int is_zero_mac(const struct ethaddr *mac);
 extern bool is_mcast_mac(const struct ethaddr *mac);


### PR DESCRIPTION
don't assert in the masklen2ip() and masklen2ip6() utilities: these are called from many places, including packet-reading paths. Impose bounds on their masklen arguments instead.
