### PR TITLE
tests: Remove `show running bgpd` from the topotests

### DIFF
--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -776,7 +776,7 @@ def test_bgp_norib():
     logger.info("Checking BGP configuration for 'bgp no-rib'")
 
     norib_cfg = (
-        tgen.net["r1"].cmd('vtysh -c "show running bgpd" | grep "^bgp no-rib"').rstrip()
+        tgen.net["r1"].cmd('vtysh -c "show running" | grep "^bgp no-rib"').rstrip()
     )
 
     assertmsg = "'bgp no-rib' configuration applied, but not visible in configuration"
@@ -847,9 +847,7 @@ def test_bgp_disable_norib():
     logger.info("Checking BGP configuration for 'bgp no-rib'")
 
     norib_cfg = (
-        tgen.net["r1"]
-        .cmd('vtysh -c "show running bgpd" | grep "^ bgp no-rib"')
-        .rstrip()
+        tgen.net["r1"].cmd('vtysh -c "show running" | grep "^ bgp no-rib"').rstrip()
     )
 
     assertmsg = (

--- a/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
+++ b/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
@@ -130,7 +130,7 @@ def test_show_running_remote_as_peer_group():
     output = (
         tgen.gears["r1"]
         .cmd(
-            'vtysh -c "show running bgpd" | grep "^ neighbor 192.168.252.2 remote-as 65004"'
+            'vtysh -c "show running" | grep "^ neighbor 192.168.252.2 remote-as 65004"'
         )
         .rstrip()
     )


### PR DESCRIPTION
In the future bgp is going to transition to using mgmtd and the `show running-config bgpd` command is going to dissapear. Let's facilitate this by going ahead and removing this special case code for the future.