### PR TITLE
isisd: Reject SRv6 Locator TLV with Loc-Size of zero

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -6085,7 +6085,7 @@ static int unpack_item_srv6_locator(uint16_t mtid, uint8_t len, struct stream *s
 
 	rv->prefix.family = AF_INET6;
 	rv->prefix.prefixlen = stream_getc(s);
-	if (rv->prefix.prefixlen > IPV6_MAX_BITLEN) {
+	if (rv->prefix.prefixlen == 0 || rv->prefix.prefixlen > IPV6_MAX_BITLEN) {
 		sbuf_push(log, indent, "Loc Size %u is implausible for SRv6\n",
 			  rv->prefix.prefixlen);
 		goto out;


### PR DESCRIPTION
RFC 9352 Section 7.1 requires Loc-Size to be in the range 1-128. A value of zero is invalid and must cause the entire TLV to be ignored. The existing check only rejects values greater than 128, allowing zero through and producing a zero-length prefix that can confuse downstream consumers.

Fix this by extending the condition to also reject zero:

```
  if (rv->prefix.prefixlen == 0 || rv->prefix.prefixlen > IPV6_MAX_BITLEN)
```