### PR TITLE
isisd: Reject duplicate SRv6 SID Structure Sub-Sub-TLV

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -2295,6 +2295,12 @@ static int unpack_subsubtlv_srv6_sid_structure(enum isis_tlv_context context, ui
 		return 1;
 	}
 
+	if (subsubtlvs->srv6_sid_structure) {
+		sbuf_push(log, indent,
+			  "Duplicate SRv6 SID Structure Sub-Sub-TLV. Parent sub-TLV is invalid.\n");
+		return 1;
+	}
+
 	sid_struct.loc_block_len = stream_getc(s);
 	sid_struct.loc_node_len = stream_getc(s);
 	sid_struct.func_len = stream_getc(s);


### PR DESCRIPTION
RFC 9352 Section 9 states that the SRv6 SID Structure Sub-Sub-TLV MUST NOT appear more than once within its parent sub-TLV, and if it does the parent sub-TLV MUST be ignored. Without this check, a crafted IS-IS PDU can include multiple SID Structure sub-sub-TLVs; the last one silently overwrites the first, violating the RFC and potentially hiding malformed structure values from validation.

Add an early-return error when a second SID Structure sub-sub-TLV is encountered while one has already been parsed for the same parent.