### PR TITLE
bgpd: Simplify BGP-LS NLRI TLV encoding by inlining helper functions

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -1466,60 +1466,6 @@ void bgp_ls_attr_unintern(struct bgp_ls_attr **pls_attr)
  */
 
 /*
- * Write TLV header (Type + Length) to stream
- *
- * Wire format (RFC 9552 Section 3.1):
- *  0                   1                   2                   3
- *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |              Type             |            Length             |
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *
- * Returns number of bytes written, or -1 on error
- */
-static inline int stream_put_tlv_hdr(struct stream *s, uint16_t type, uint16_t length)
-{
-	if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE)
-		return -1;
-
-	stream_putw(s, type);
-	stream_putw(s, length);
-	return BGP_LS_TLV_HDR_SIZE;
-}
-
-/*
- * Put a complete TLV (Type + Length + Value) into stream
- * Returns 0 on success, -1 on error
- */
-static inline int stream_put_tlv(struct stream *s, uint16_t type, uint16_t length,
-				 const void *value)
-{
-	if (stream_put_tlv_hdr(s, type, length) < 0)
-		return -1;
-
-	if (length > 0) {
-		if (STREAM_WRITEABLE(s) < length)
-			return -1;
-		stream_put(s, value, length);
-	}
-
-	return 0;
-}
-
-static inline int stream_putf_tlv(struct stream *s, uint16_t type, const float value)
-{
-	if (stream_put_tlv_hdr(s, type, 4) < 0)
-		return -1;
-
-	if (STREAM_WRITEABLE(s) < 4)
-		return -1;
-
-	stream_putf(s, value);
-
-	return 0;
-}
-
-/*
  * Encode Node Descriptor to wire format (RFC 9552 Section 5.2.1)
  *
  * Wire format:
@@ -1563,41 +1509,38 @@ int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_des
 
 	/* AS Number (TLV 512) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_AS_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_AS_NUMBER, BGP_LS_AS_NUMBER_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_AS_NUMBER_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_AS_NUMBER_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_AS_NUMBER);
+		stream_putw(s, BGP_LS_AS_NUMBER_SIZE);
 		stream_putl(s, desc->asn);
 	}
 
 	/* BGP-LS Identifier (TLV 513) - deprecated but may be present */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_LS_ID_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_BGP_LS_ID, BGP_LS_BGP_LS_ID_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_BGP_LS_ID_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_BGP_LS_ID_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_BGP_LS_ID);
+		stream_putw(s, BGP_LS_BGP_LS_ID_SIZE);
 		stream_putl(s, desc->bgp_ls_id);
 	}
 
 	/* OSPF Area ID (TLV 514) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_OSPF_AREA_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_OSPF_AREA_ID, BGP_LS_OSPF_AREA_ID_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_OSPF_AREA_ID_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_OSPF_AREA_ID_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_OSPF_AREA_ID);
+		stream_putw(s, BGP_LS_OSPF_AREA_ID_SIZE);
 		stream_putl(s, desc->ospf_area_id);
 	}
 
 	/* IGP Router ID (TLV 515) - MANDATORY */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IGP_ROUTER_ID, desc->igp_router_id_len) < 0)
+		if (STREAM_WRITEABLE(s) <
+		    (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)desc->igp_router_id_len)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < desc->igp_router_id_len)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IGP_ROUTER_ID);
+		stream_putw(s, desc->igp_router_id_len);
 		stream_put(s, desc->igp_router_id, desc->igp_router_id_len);
 	}
 
@@ -1639,75 +1582,68 @@ int bgp_ls_encode_link_descriptor(struct stream *s, const struct bgp_ls_link_des
 
 	/* Link Local/Remote Identifiers (TLV 258) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_LINK_ID_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_LINK_ID, BGP_LS_LINK_ID_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_LINK_ID_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_LINK_ID_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_LINK_ID);
+		stream_putw(s, BGP_LS_LINK_ID_SIZE);
 		stream_putl(s, desc->link_local_id);
 		stream_putl(s, desc->link_remote_id);
 	}
 
 	/* IPv4 Interface Address (TLV 259) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV4_INTF_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV4_INTF_ADDR, BGP_LS_IPV4_ADDR_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_IPV4_ADDR_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_IPV4_ADDR_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IPV4_INTF_ADDR);
+		stream_putw(s, BGP_LS_IPV4_ADDR_SIZE);
 		stream_put_ipv4(s, desc->ipv4_intf_addr.s_addr);
 	}
 
 	/* IPv4 Neighbor Address (TLV 260) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV4_NEIGH_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV4_NEIGH_ADDR, BGP_LS_IPV4_ADDR_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_IPV4_ADDR_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_IPV4_ADDR_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IPV4_NEIGH_ADDR);
+		stream_putw(s, BGP_LS_IPV4_ADDR_SIZE);
 		stream_put_ipv4(s, desc->ipv4_neigh_addr.s_addr);
 	}
 
 	/* IPv6 Interface Address (TLV 261) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV6_INTF_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV6_INTF_ADDR, BGP_LS_IPV6_ADDR_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_IPV6_ADDR_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_IPV6_ADDR_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IPV6_INTF_ADDR);
+		stream_putw(s, BGP_LS_IPV6_ADDR_SIZE);
 		stream_put(s, &desc->ipv6_intf_addr, BGP_LS_IPV6_ADDR_SIZE);
 	}
 
 	/* IPv6 Neighbor Address (TLV 262) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV6_NEIGH_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV6_NEIGH_ADDR, BGP_LS_IPV6_ADDR_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_IPV6_ADDR_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_IPV6_ADDR_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IPV6_NEIGH_ADDR);
+		stream_putw(s, BGP_LS_IPV6_ADDR_SIZE);
 		stream_put(s, &desc->ipv6_neigh_addr, BGP_LS_IPV6_ADDR_SIZE);
 	}
 
 	/* Multi-Topology ID (TLV 263) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT) &&
 	    desc->mt_id_count > 0) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_MT_ID,
-				       desc->mt_id_count * BGP_LS_MT_ID_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) <
+		    BGP_LS_TLV_HDR_SIZE + (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_MT_ID);
+		stream_putw(s, desc->mt_id_count * BGP_LS_MT_ID_SIZE);
 		for (i = 0; i < desc->mt_id_count; i++)
 			stream_putw(s, desc->mt_id[i]);
 	}
 
 	/* Remote AS Number (TLV 264) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_REMOTE_AS_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_REMOTE_AS_NUMBER, 4) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < 4)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_REMOTE_AS_NUMBER);
+		stream_putw(s, 4);
 		stream_putl(s, desc->remote_asn);
 	}
 
@@ -1745,46 +1681,41 @@ int bgp_ls_encode_prefix_descriptor(struct stream *s, const struct bgp_ls_prefix
 	/* Multi-Topology ID (TLV 263) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT) &&
 	    desc->mt_id_count > 0) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_MT_ID,
-				       desc->mt_id_count * BGP_LS_MT_ID_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) <
+		    BGP_LS_TLV_HDR_SIZE + (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_MT_ID);
+		stream_putw(s, desc->mt_id_count * BGP_LS_MT_ID_SIZE);
 		for (i = 0; i < desc->mt_id_count; i++)
 			stream_putw(s, desc->mt_id[i]);
 	}
 
 	/* OSPF Route Type (TLV 264) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_PREFIX_DESC_OSPF_ROUTE_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_OSPF_ROUTE_TYPE,
-				       BGP_LS_OSPF_ROUTE_TYPE_SIZE) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_OSPF_ROUTE_TYPE_SIZE)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < BGP_LS_OSPF_ROUTE_TYPE_SIZE)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_OSPF_ROUTE_TYPE);
+		stream_putw(s, BGP_LS_OSPF_ROUTE_TYPE_SIZE);
 		stream_putc(s, desc->ospf_route_type);
 	}
 
 	/* IP Reachability Information (TLV 265) - MANDATORY */
 	if (desc->prefix.family == AF_INET) {
 		prefix_len_bytes = (desc->prefix.prefixlen + 7) / 8;
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IP_REACH_INFO,
-				       BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes) < 0)
+		if (STREAM_WRITEABLE(s) <
+		    BGP_LS_TLV_HDR_SIZE + (size_t)BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IP_REACH_INFO);
+		stream_putw(s, BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes);
 		stream_putc(s, desc->prefix.prefixlen);
 		stream_put(s, &desc->prefix.u.prefix4, prefix_len_bytes);
 	} else if (desc->prefix.family == AF_INET6) {
 		prefix_len_bytes = (desc->prefix.prefixlen + 7) / 8;
-		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IP_REACH_INFO,
-				       BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes) < 0)
+		if (STREAM_WRITEABLE(s) <
+		    BGP_LS_TLV_HDR_SIZE + (size_t)BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes)
-			return -1;
+		stream_putw(s, BGP_LS_TLV_IP_REACH_INFO);
+		stream_putw(s, BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes);
 		stream_putc(s, desc->prefix.prefixlen);
 		stream_put(s, &desc->prefix.u.prefix6, prefix_len_bytes);
 	}
@@ -2046,8 +1977,11 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 
 	/* Node Flag Bits (TLV 1024) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_NODE_FLAGS_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_NODE_FLAG_BITS, 1, &attr->node_flags) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 1)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_NODE_FLAG_BITS);
+		stream_putw(s, 1);
+		stream_putc(s, attr->node_flags);
 	}
 
 	/* Node Name (TLV 1026) */
@@ -2055,100 +1989,130 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		if (attr->node_name) {
 			uint16_t len = strlen(attr->node_name);
 
-			if (stream_put_tlv(s, BGP_LS_ATTR_NODE_NAME, len, attr->node_name) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_NODE_NAME);
+			stream_putw(s, len);
+			stream_put(s, attr->node_name, len);
 		}
 	}
 
 	/* IS-IS Area Identifier (TLV 1027) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_ISIS_AREA_BIT)) {
 		if (attr->isis_area_id && attr->isis_area_id_len > 0) {
-			if (stream_put_tlv(s, BGP_LS_ATTR_ISIS_AREA_ID, attr->isis_area_id_len,
-					   attr->isis_area_id) < 0)
+			if (STREAM_WRITEABLE(s) <
+			    (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)attr->isis_area_id_len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_ISIS_AREA_ID);
+			stream_putw(s, attr->isis_area_id_len);
+			stream_put(s, attr->isis_area_id, attr->isis_area_id_len);
 		}
 	}
 
 	/* IPv4 Router-ID of Local Node (TLV 1028) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_IPV4_ROUTER_ID_LOCAL_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_IPV4_ROUTER_ID_LOCAL, 4,
-				   &attr->ipv4_router_id_local) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_IPV4_ROUTER_ID_LOCAL);
+		stream_putw(s, 4);
+		stream_put(s, &attr->ipv4_router_id_local, 4);
 	}
 
 	/* IPv6 Router-ID of Local Node (TLV 1029) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_IPV6_ROUTER_ID_LOCAL_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_IPV6_ROUTER_ID_LOCAL, 16,
-				   &attr->ipv6_router_id_local) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 16)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_IPV6_ROUTER_ID_LOCAL);
+		stream_putw(s, 16);
+		stream_put(s, &attr->ipv6_router_id_local, 16);
 	}
 
 	/* IPv4 Router-ID of Remote Node (TLV 1030) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_IPV4_ROUTER_ID_REMOTE_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_IPV4_ROUTER_ID_REMOTE, 4,
-				   &attr->ipv4_router_id_remote) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_IPV4_ROUTER_ID_REMOTE);
+		stream_putw(s, 4);
+		stream_put(s, &attr->ipv4_router_id_remote, 4);
 	}
 
 	/* IPv6 Router-ID of Remote Node (TLV 1031) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_IPV6_ROUTER_ID_REMOTE_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_IPV6_ROUTER_ID_REMOTE, 16,
-				   &attr->ipv6_router_id_remote) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 16)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_IPV6_ROUTER_ID_REMOTE);
+		stream_putw(s, 16);
+		stream_put(s, &attr->ipv6_router_id_remote, 16);
 	}
 
 	/* Administrative Group (TLV 1088) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_ADMIN_GROUP_BIT)) {
 		uint32_t admin_group_be = htonl(attr->admin_group);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_ADMIN_GROUP, 4, &admin_group_be) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_ADMIN_GROUP);
+		stream_putw(s, 4);
+		stream_put(s, &admin_group_be, 4);
 	}
 
 	/* Maximum Link Bandwidth (TLV 1089) - IEEE 754 floating point */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_MAX_LINK_BW_BIT)) {
-		if (stream_putf_tlv(s, BGP_LS_ATTR_MAX_LINK_BW, attr->max_link_bw) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_MAX_LINK_BW);
+		stream_putw(s, 4);
+		stream_putf(s, attr->max_link_bw);
 	}
 
 	/* Maximum Reservable Bandwidth (TLV 1090) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_MAX_RESV_BW_BIT)) {
-		if (stream_putf_tlv(s, BGP_LS_ATTR_MAX_RESV_BW, attr->max_resv_bw) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_MAX_RESV_BW);
+		stream_putw(s, 4);
+		stream_putf(s, attr->max_resv_bw);
 	}
 
 	/* Unreserved Bandwidth (TLV 1091) - 8 priority levels */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_UNRESV_BW_BIT)) {
-		if (stream_put_tlv_hdr(s, BGP_LS_ATTR_UNRESV_BW, 32) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 32)
 			return -1;
-		for (int i = 0; i < BGP_LS_MAX_UNRESV_BW; i++) {
-			if (STREAM_WRITEABLE(s) < 4)
-				return -1;
+		stream_putw(s, BGP_LS_ATTR_UNRESV_BW);
+		stream_putw(s, 32);
+		for (int i = 0; i < BGP_LS_MAX_UNRESV_BW; i++)
 			stream_putf(s, attr->unreserved_bw[i]);
-		}
 	}
 
 	/* TE Default Metric (TLV 1092) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_TE_METRIC_BIT)) {
 		uint32_t te_metric_be = htonl(attr->te_metric);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_TE_DEFAULT_METRIC, 4, &te_metric_be) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_TE_DEFAULT_METRIC);
+		stream_putw(s, 4);
+		stream_put(s, &te_metric_be, 4);
 	}
 
 	/* Link Protection Type (TLV 1093) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_LINK_PROTECTION_BIT)) {
 		uint16_t protection_be = htons(attr->link_protection);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_LINK_PROTECTION_TYPE, 2, &protection_be) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 2)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_LINK_PROTECTION_TYPE);
+		stream_putw(s, 2);
+		stream_put(s, &protection_be, 2);
 	}
 
 	/* MPLS Protocol Mask (TLV 1094) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_MPLS_PROTOCOL_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_MPLS_PROTOCOL_MASK, 1,
-				   &attr->mpls_protocol_mask) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 1)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_MPLS_PROTOCOL_MASK);
+		stream_putw(s, 1);
+		stream_putc(s, attr->mpls_protocol_mask);
 	}
 
 	/* IGP Metric (TLV 1095) - Variable length 1-3 bytes */
@@ -2168,8 +2132,11 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 				metric_buf[1] = (attr->igp_metric >> 8) & 0xFF;
 				metric_buf[2] = attr->igp_metric & 0xFF;
 			}
-			if (stream_put_tlv(s, BGP_LS_ATTR_IGP_METRIC, len, metric_buf) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_IGP_METRIC);
+			stream_putw(s, len);
+			stream_put(s, metric_buf, len);
 		}
 	}
 
@@ -2178,13 +2145,13 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		if (attr->srlg_values && attr->srlg_count > 0) {
 			uint16_t srlg_len = attr->srlg_count * 4;
 
-			if (stream_put_tlv_hdr(s, BGP_LS_ATTR_SRLG, srlg_len) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)srlg_len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_SRLG);
+			stream_putw(s, srlg_len);
 			for (int i = 0; i < attr->srlg_count; i++) {
 				uint32_t srlg_be = htonl(attr->srlg_values[i]);
 
-				if (STREAM_WRITEABLE(s) < 4)
-					return -1;
 				stream_put(s, &srlg_be, 4);
 			}
 		}
@@ -2195,8 +2162,11 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		if (attr->link_name) {
 			uint16_t len = strlen(attr->link_name);
 
-			if (stream_put_tlv(s, BGP_LS_ATTR_LINK_NAME, len, attr->link_name) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_LINK_NAME);
+			stream_putw(s, len);
+			stream_put(s, attr->link_name, len);
 		}
 	}
 
@@ -2207,16 +2177,15 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		if (nb_words > 0) {
 			uint16_t ag_len = nb_words * 4; /* Each word is 4 bytes */
 
-			if (stream_put_tlv_hdr(s, BGP_LS_ATTR_EXTENDED_ADMIN_GROUP, ag_len) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)ag_len)
 				return -1;
-
+			stream_putw(s, BGP_LS_ATTR_EXTENDED_ADMIN_GROUP);
+			stream_putw(s, ag_len);
 			/* Encode each 32-bit word */
 			for (size_t i = 0; i < nb_words; i++) {
 				uint32_t word = admin_group_get_offset(&attr->ext_admin_group, i);
 				uint32_t word_be = htonl(word);
 
-				if (STREAM_WRITEABLE(s) < 4)
-					return -1;
 				stream_put(s, &word_be, 4);
 			}
 		}
@@ -2226,8 +2195,11 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_DELAY_BIT)) {
 		uint32_t delay_be = htonl(attr->delay);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_UNIDIRECTIONAL_LINK_DELAY, 4, &delay_be) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_UNIDIRECTIONAL_LINK_DELAY);
+		stream_putw(s, 4);
+		stream_put(s, &delay_be, 4);
 	}
 
 	/* Min/Max Unidirectional Link Delay (TLV 1115) */
@@ -2235,11 +2207,10 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		uint32_t min_delay_be = htonl(attr->min_delay);
 		uint32_t max_delay_be = htonl(attr->max_delay);
 
-		if (stream_put_tlv_hdr(s, BGP_LS_ATTR_MIN_MAX_UNIDIRECTIONAL_LINK_DELAY, 8) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 8)
 			return -1;
-
-		if (STREAM_WRITEABLE(s) < 8)
-			return -1;
+		stream_putw(s, BGP_LS_ATTR_MIN_MAX_UNIDIRECTIONAL_LINK_DELAY);
+		stream_putw(s, 8);
 		stream_put(s, &min_delay_be, 4);
 		stream_put(s, &max_delay_be, 4);
 	}
@@ -2248,44 +2219,58 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_JITTER_BIT)) {
 		uint32_t jitter_be = htonl(attr->jitter);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_UNIDIRECTIONAL_DELAY_VARIATION, 4, &jitter_be) <
-		    0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_UNIDIRECTIONAL_DELAY_VARIATION);
+		stream_putw(s, 4);
+		stream_put(s, &jitter_be, 4);
 	}
 
 	/* Unidirectional Packet Loss (TLV 1117) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_PKT_LOSS_BIT)) {
 		uint32_t pkt_loss_be = htonl(attr->pkt_loss);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_UNIDIRECTIONAL_LINK_LOSS, 4, &pkt_loss_be) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_UNIDIRECTIONAL_LINK_LOSS);
+		stream_putw(s, 4);
+		stream_put(s, &pkt_loss_be, 4);
 	}
 
 	/* Unidirectional Residual Bandwidth (TLV 1118) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_RESIDUAL_BW_BIT)) {
-		if (stream_putf_tlv(s, BGP_LS_ATTR_UNIDIRECTIONAL_RESIDUAL_BANDWIDTH,
-				    attr->residual_bw) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_UNIDIRECTIONAL_RESIDUAL_BANDWIDTH);
+		stream_putw(s, 4);
+		stream_putf(s, attr->residual_bw);
 	}
 
 	/* Unidirectional Available Bandwidth (TLV 1119) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_AVAILABLE_BW_BIT)) {
-		if (stream_putf_tlv(s, BGP_LS_ATTR_UNIDIRECTIONAL_AVAILABLE_BANDWIDTH,
-				    attr->available_bw) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_UNIDIRECTIONAL_AVAILABLE_BANDWIDTH);
+		stream_putw(s, 4);
+		stream_putf(s, attr->available_bw);
 	}
 
 	/* Unidirectional Utilized Bandwidth (TLV 1120) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_UTILIZED_BW_BIT)) {
-		if (stream_putf_tlv(s, BGP_LS_ATTR_UNIDIRECTIONAL_UTILIZED_BANDWIDTH,
-				    attr->utilized_bw) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_UNIDIRECTIONAL_UTILIZED_BANDWIDTH);
+		stream_putw(s, 4);
+		stream_putf(s, attr->utilized_bw);
 	}
 
 	/* IGP Flags (TLV 1152) */
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_IGP_FLAGS_BIT)) {
-		if (stream_put_tlv(s, BGP_LS_ATTR_IGP_FLAGS, 1, &attr->igp_flags) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 1)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_IGP_FLAGS);
+		stream_putw(s, 1);
+		stream_putc(s, attr->igp_flags);
 	}
 
 	/* Route Tags (TLV 1153) */
@@ -2293,13 +2278,13 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		if (attr->route_tags && attr->route_tag_count > 0) {
 			uint16_t tag_len = attr->route_tag_count * 4;
 
-			if (stream_put_tlv_hdr(s, BGP_LS_ATTR_ROUTE_TAG, tag_len) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)tag_len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_ROUTE_TAG);
+			stream_putw(s, tag_len);
 			for (int i = 0; i < attr->route_tag_count; i++) {
 				uint32_t tag_be = htonl(attr->route_tags[i]);
 
-				if (STREAM_WRITEABLE(s) < 4)
-					return -1;
 				stream_put(s, &tag_be, 4);
 			}
 		}
@@ -2310,13 +2295,13 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		if (attr->extended_tags && attr->extended_tag_count > 0) {
 			uint16_t tag_len = attr->extended_tag_count * 8;
 
-			if (stream_put_tlv_hdr(s, BGP_LS_ATTR_EXTENDED_TAG, tag_len) < 0)
+			if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)tag_len)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_EXTENDED_TAG);
+			stream_putw(s, tag_len);
 			for (int i = 0; i < attr->extended_tag_count; i++) {
 				uint64_t tag_be = htonll(attr->extended_tags[i]);
 
-				if (STREAM_WRITEABLE(s) < 8)
-					return -1;
 				stream_put(s, &tag_be, 8);
 			}
 		}
@@ -2326,8 +2311,11 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 	if (BGP_LS_TLV_CHECK(attr->present_tlvs, BGP_LS_ATTR_PREFIX_METRIC_BIT)) {
 		uint32_t metric_be = htonl(attr->prefix_metric);
 
-		if (stream_put_tlv(s, BGP_LS_ATTR_PREFIX_METRIC, 4, &metric_be) < 0)
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 			return -1;
+		stream_putw(s, BGP_LS_ATTR_PREFIX_METRIC);
+		stream_putw(s, 4);
+		stream_put(s, &metric_be, 4);
 	}
 
 	/* OSPF Forwarding Address (TLV 1156) - IPv4 or IPv6 */
@@ -2335,14 +2323,18 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		/* Check which address family is present */
 		if (attr->ospf_fwd_addr.s_addr != 0) {
 			/* IPv4 forwarding address */
-			if (stream_put_tlv(s, BGP_LS_ATTR_OSPF_FWD_ADDR, 4, &attr->ospf_fwd_addr) <
-			    0)
+			if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 4)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_OSPF_FWD_ADDR);
+			stream_putw(s, 4);
+			stream_put(s, &attr->ospf_fwd_addr, 4);
 		} else if (!IN6_IS_ADDR_UNSPECIFIED(&attr->ospf_fwd_addr6)) {
 			/* IPv6 forwarding address */
-			if (stream_put_tlv(s, BGP_LS_ATTR_OSPF_FWD_ADDR, 16,
-					   &attr->ospf_fwd_addr6) < 0)
+			if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + 16)
 				return -1;
+			stream_putw(s, BGP_LS_ATTR_OSPF_FWD_ADDR);
+			stream_putw(s, 16);
+			stream_put(s, &attr->ospf_fwd_addr6, 16);
 		}
 	}
 
@@ -2356,10 +2348,10 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 				  "BGP-LS: %s wrong combination of V-Flag and L-Flag for Prefix SID",
 				  __func__);
 		} else {
-			if (stream_put_tlv_hdr(s, BGP_LS_ATTR_PREFIX_SID, 4 + sid_len) < 0)
+			if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + (size_t)4 + sid_len)
 				return -1;
-			if (STREAM_WRITEABLE(s) < (size_t)4 + sid_len)
-				return -1;
+			stream_putw(s, BGP_LS_ATTR_PREFIX_SID);
+			stream_putw(s, 4 + sid_len);
 			stream_putc(s, attr->prefix_sid.sid_flag);
 			stream_putc(s, attr->prefix_sid.algo);
 			stream_putw(s, 0); /* Reserved = 0 */


### PR DESCRIPTION
Remove the TLV encoding helper functions (stream_put_tlv_hdr, stream_put_tlv, and stream_putf_tlv) and inline their logic directly into the encoder functions. This improves code clarity and consistency by:

- Consolidating stream writeable checks before encoding each TLV
- Eliminating the confusion of split writeable checks between helpers and callers

The encoder functions now directly call stream_putw/stream_putl/stream_put for TLV type, length, and value, with explicit STREAM_WRITEABLE checks before each TLV block. This makes the code more maintainable and the flow easier to understand.

No functional changes.