### PR TITLE
bgpd: honor 'no activate' for dynamic neighbors in peer-group

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4888,8 +4888,11 @@ struct peer *peer_create_bind_dynamic_neighbor(struct bgp *bgp,
 	 * want.
 	 */
 	FOREACH_AFI_SAFI (afi, safi) {
-		if (!group->conf->afc[afi][safi])
+		if (!group->conf->afc[afi][safi]) {
+			if (peer->afc[afi][safi])
+				peer_deactivate(peer, afi, safi);
 			continue;
+		}
 		peer->afc[afi][safi] = 1;
 
 		if (!peer_af_find(peer, afi, safi))


### PR DESCRIPTION
When a dynamic peer connects via 'bgp listen range', peer_create() activates IPv4 unicast by default. peer_create_bind_dynamic_neighbor() then applies the group's AF config but only activates AFIs the group has enabled -- it never deactivates AFIs the group has disabled. This causes 'no neighbor <group> activate' under an address-family to be ignored for dynamic peers.
Add peer_deactivate() for AFIs the group has deactivated, matching the fix in peer_group_bind() from commit 5f007459f648 ("bgpd: peer-group members 'activate' when they shouldn't").