### PR TITLE
tests: Update pytestmark value in scripts

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -26,10 +26,15 @@ pytestmark = [
     pytest.mark.babeld,
     pytest.mark.bgpd,
     pytest.mark.isisd,
+    pytest.mark.ldpd,
+    pytest.mark.mgmtd,
     pytest.mark.nhrpd,
+    pytest.mark.ospf6d,
     pytest.mark.ospfd,
     pytest.mark.pbrd,
     pytest.mark.ripd,
+    pytest.mark.ripngd,
+    pytest.mark.sharpd,
 ]
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/topotests/bfd_profiles_topo1/test_bfd_profiles_topo1.py
+++ b/tests/topotests/bfd_profiles_topo1/test_bfd_profiles_topo1.py
@@ -29,7 +29,13 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.ospf6d,
+    pytest.mark.ospfd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_static_vrf/test_bfd_static_vrf.py
+++ b/tests/topotests/bfd_static_vrf/test_bfd_static_vrf.py
@@ -19,7 +19,7 @@ import platform
 import functools
 import pytest
 
-pytestmark = [pytest.mark.staticd, pytest.mark.bfdd]
+pytestmark = [pytest.mark.bfdd, pytest.mark.mgmtd, pytest.mark.staticd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -30,7 +30,12 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+    pytest.mark.ospf6d,
+    pytest.mark.ospfd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo3/test_bfd_topo3.py
+++ b/tests/topotests/bfd_topo3/test_bfd_topo3.py
@@ -29,7 +29,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.staticd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_accept_own/test_bgp_accept_own.py
+++ b/tests/topotests/bgp_accept_own/test_bgp_accept_own.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aigp/test_bgp_aigp.py
+++ b/tests/topotests/bgp_aigp/test_bgp_aigp.py
@@ -34,7 +34,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aigp_rr/test_bgp_aigp_rr.py
+++ b/tests/topotests/bgp_aigp_rr/test_bgp_aigp_rr.py
@@ -34,7 +34,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_bfd_session/test_bgp_bfd_session.py
+++ b/tests/topotests/bgp_bfd_session/test_bgp_bfd_session.py
@@ -20,7 +20,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen, TopoRouter
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.mgmtd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
+++ b/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
@@ -29,7 +29,7 @@ from lib.common_config import (
     step,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_confed1/test_bgp_confed1.py
+++ b/tests/topotests/bgp_confed1/test_bgp_confed1.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
+++ b/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
@@ -48,7 +48,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_mh_v4_v6_num/test_evpn_mh_v4_v6_num.py
+++ b/tests/topotests/bgp_evpn_mh_v4_v6_num/test_evpn_mh_v4_v6_num.py
@@ -30,7 +30,12 @@ import platform
 import time
 import re
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.pim6d, pytest.mark.evpn]
+pytestmark = [
+    pytest.mark.bgpd,
+    pytest.mark.evpn,
+    pytest.mark.mgmtd,
+    pytest.mark.pim6d,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -43,7 +43,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -41,7 +41,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospf6d, pytest.mark.ospfd]
 
 #####################################################
 #

--- a/tests/topotests/bgp_inq_limit/test_bgp_inq_limit.py
+++ b/tests/topotests/bgp_inq_limit/test_bgp_inq_limit.py
@@ -39,7 +39,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
 
 # Number of routes originated by r1 via sharpd
 ROUTE_COUNT = 1000

--- a/tests/topotests/bgp_ipv6_next_hop_self/test_bgp_ipv6_next_hop_self.py
+++ b/tests/topotests/bgp_ipv6_next_hop_self/test_bgp_ipv6_next_hop_self.py
@@ -11,7 +11,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospf6d]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_l3vpn_hidden/test_bgp_l3vpn_hidden.py
+++ b/tests/topotests/bgp_l3vpn_hidden/test_bgp_l3vpn_hidden.py
@@ -24,7 +24,13 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.bfdd, pytest.mark.isisd, pytest.mark.ldpd]
+pytestmark = [
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.ldpd,
+    pytest.mark.mgmtd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_l3vpn_label_export/test_bgp_l3vpn_label_export.py
+++ b/tests/topotests/bgp_l3vpn_label_export/test_bgp_l3vpn_label_export.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import kill_router_daemons, start_router_daemons, step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_lu_topo2/test_bgp_lu2.py
+++ b/tests/topotests/bgp_lu_topo2/test_bgp_lu2.py
@@ -32,7 +32,7 @@ from lib.checkping import check_ping
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
 #
 # Basic scenario for BGP-LU. Nodes are directly connected.

--- a/tests/topotests/bgp_path_selection/test_bgp_path_selection.py
+++ b/tests/topotests/bgp_path_selection/test_bgp_path_selection.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ldpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_route_map_match_source_protocol/test_bgp_route_map_match_source_protocol.py
+++ b/tests/topotests/bgp_route_map_match_source_protocol/test_bgp_route_map_match_source_protocol.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_rpki_topo1/test_bgp_rpki_topo1.py
+++ b/tests/topotests/bgp_rpki_topo1/test_bgp_rpki_topo1.py
@@ -19,7 +19,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_soo/test_bgp_soo.py
+++ b/tests/topotests/bgp_soo/test_bgp_soo.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_over_ipv6/test_bgp_srv6l3vpn_over_ipv6.py
+++ b/tests/topotests/bgp_srv6l3vpn_over_ipv6/test_bgp_srv6l3vpn_over_ipv6.py
@@ -21,7 +21,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
+++ b/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
@@ -25,6 +25,8 @@ import json
 import functools
 import pytest
 
+pytestmark = [pytest.mark.bgpd]
+
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 

--- a/tests/topotests/bgp_tcpv4_af6_nexthop_check/test_bgp_tcpv4_af6_nexthop_check.py
+++ b/tests/topotests/bgp_tcpv4_af6_nexthop_check/test_bgp_tcpv4_af6_nexthop_check.py
@@ -13,7 +13,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import run_frr_cmd
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.mgmtd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vpn_5549_route_map/test_bgp_vpn_5549_route_map.py
+++ b/tests/topotests/bgp_vpn_5549_route_map/test_bgp_vpn_5549_route_map.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/cspf_topo1/test_cspf_topo1.py
+++ b/tests/topotests/cspf_topo1/test_cspf_topo1.py
@@ -64,7 +64,7 @@ from lib.topolog import logger
 # and Finally pytest
 import pytest
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.isisd, pytest.mark.sharpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
+++ b/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
@@ -57,7 +57,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.bfdd, pytest.mark.isisd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
+++ b/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
@@ -51,7 +51,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.isisd, pytest.mark.pathd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_sr_flex_algo_topo2/test_isis_sr_flex_algo_topo2.py
+++ b/tests/topotests/isis_sr_flex_algo_topo2/test_isis_sr_flex_algo_topo2.py
@@ -60,7 +60,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.pathd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
+++ b/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
@@ -69,7 +69,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.bfdd, pytest.mark.isisd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/mgmt_oper/test_scale.py
+++ b/tests/topotests/mgmt_oper/test_scale.py
@@ -19,7 +19,7 @@ from lib.common_config import step
 from lib.topogen import Topogen, TopoRouter
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.mgmtd, pytest.mark.sharpd, pytest.mark.staticd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
+++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
@@ -32,7 +32,7 @@ from lib.common_config import required_linux_kernel_version, retry
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.nhrpd]
+pytestmark = [pytest.mark.nhrpd, pytest.mark.sharpd]
 TOPOLOGY = """
                                               192.168.2.0/24
                                              -----+-----

--- a/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
+++ b/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
@@ -56,7 +56,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_topo1/test_ospf_topo1.py
+++ b/tests/topotests/ospf_topo1/test_ospf_topo1.py
@@ -31,7 +31,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/pim_allow_rp/test_pim_allow_rp.py
+++ b/tests/topotests/pim_allow_rp/test_pim_allow_rp.py
@@ -30,7 +30,7 @@ import pytest
 import time
 from functools import partial
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -18,7 +18,7 @@ import pytest
 import json
 from functools import partial
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/pim_prune/test_pim_prune.py
+++ b/tests/topotests/pim_prune/test_pim_prune.py
@@ -17,7 +17,7 @@ import time
 import pytest
 from functools import partial
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.pimd, pytest.mark.ripd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
+++ b/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
@@ -23,7 +23,9 @@ from lib.topogen import Topogen, TopoRouter
 
 pytestmark = [
     pytest.mark.bfdd,
+    pytest.mark.mgmtd,
     pytest.mark.ripd,
+    pytest.mark.staticd,
 ]
 
 

--- a/tests/topotests/rip_default_route_handling/test_rip_default_route_handling.py
+++ b/tests/topotests/rip_default_route_handling/test_rip_default_route_handling.py
@@ -21,7 +21,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.ripd]
+pytestmark = [pytest.mark.ripd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/segment_routing_no_cmds/test_segment_routing_no_cmds.py
+++ b/tests/topotests/segment_routing_no_cmds/test_segment_routing_no_cmds.py
@@ -30,7 +30,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.staticd]
+pytestmark = [pytest.mark.pathd]
 
 
 def setup_module(mod):

--- a/tests/topotests/simple_snmp_test/test_simple_snmp.py
+++ b/tests/topotests/simple_snmp_test/test_simple_snmp.py
@@ -27,7 +27,14 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.snmptest import SnmpTester
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.ospf6d,
+    pytest.mark.ospfd,
+    pytest.mark.ripd,
+    pytest.mark.snmp,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/srv6_sid_manager/test_srv6_sid_manager.py
+++ b/tests/topotests/srv6_sid_manager/test_srv6_sid_manager.py
@@ -79,7 +79,7 @@ from lib.common_config import (
 )
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.isisd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.sharpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/srv6_static_route/test_srv6_route.py
+++ b/tests/topotests/srv6_static_route/test_srv6_route.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.staticd]
+pytestmark = [pytest.mark.mgmtd, pytest.mark.staticd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/static_simple/test_static_simple.py
+++ b/tests/topotests/static_simple/test_static_simple.py
@@ -20,7 +20,7 @@ from lib.topogen import TopoRouter, Topogen
 from lib.topolog import logger
 from lib.common_config import retry, step
 
-pytestmark = [pytest.mark.staticd]
+pytestmark = [pytest.mark.mgmtd, pytest.mark.staticd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/two_layer_wucmp/test_two_layer_wuecmp.py
+++ b/tests/topotests/two_layer_wucmp/test_two_layer_wuecmp.py
@@ -89,7 +89,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd, pytest.mark.staticd]
 
 # Constants
 LINKS_PER_SPINE = 32  # 32 links between each leaf and each spine

--- a/tests/topotests/v6_nexthop_group_recursive_resolution/test_v6_nexthop_group_recursive_resolution.py
+++ b/tests/topotests/v6_nexthop_group_recursive_resolution/test_v6_nexthop_group_recursive_resolution.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.staticd]
+pytestmark = [pytest.mark.mgmtd, pytest.mark.sharpd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/vtysh/test_vtysh.py
+++ b/tests/topotests/vtysh/test_vtysh.py
@@ -23,6 +23,8 @@ from lib.common_config import step
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
+pytestmark = [pytest.mark.mgmtd]
+
 
 def build_topo(tgen):
     "Build function"

--- a/tests/topotests/zebra_fec_nexthop_resolution/test_zebra_fec_nexthop_resolution.py
+++ b/tests/topotests/zebra_fec_nexthop_resolution/test_zebra_fec_nexthop_resolution.py
@@ -37,7 +37,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/zebra_neigh/test_zebra_neigh.py
+++ b/tests/topotests/zebra_neigh/test_zebra_neigh.py
@@ -28,6 +28,8 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from time import sleep
 
+pytestmark = [pytest.mark.mgmtd]
+
 
 def build_topo(tgen):
     "Build function"

--- a/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
+++ b/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
@@ -26,7 +26,14 @@ from lib.common_config import (
     start_router_daemons,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.bgpd,
+    pytest.mark.ospf6d,
+    pytest.mark.ospfd,
+    pytest.mark.pimd,
+    pytest.mark.sharpd,
+    pytest.mark.staticd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/zebra_rib/test_zebra_import.py
+++ b/tests/topotests/zebra_rib/test_zebra_import.py
@@ -39,7 +39,7 @@ TOPOLOGY = """
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.sharpd, pytest.mark.staticd]
 krel = platform.release()
 
 


### PR DESCRIPTION
Noticed while examining a test today that the pytest marks were not 100% correct.  Wrote a script that compared what was loaded via configuration -vs- what the pytestmark values where, then I adjusted all the pytestmark values to be more accurate.  There still might be a few that are `wrong` but we are much closer now.