### PR TITLE
bgpd: fix memory leaks

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -738,6 +738,7 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 	struct bgp_path_info *pi, *next;
 	struct bgp_table *table;
 	struct attr attr;
+	struct attr *old_attr;
 
 	if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN) {
 		for (dest = bgp_table_top(bgp->rib[afi][safi]); dest; dest = bgp_route_next(dest)) {
@@ -767,13 +768,14 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 						continue;
 
 					if (bgp_debug_neighbor_events(peer))
-						zlog_debug(
-							"%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
-							peer, &dest->rn->p);
+						zlog_debug("%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
+							   peer, bgp_dest_get_prefix(rm));
 
 					bgp_attr_dup_into(&attr, pi->attr);
 					bgp_attr_add_llgr_community(&attr);
+					old_attr = pi->attr;
 					pi->attr = bgp_attr_intern(&attr);
+					bgp_attr_unintern(&old_attr);
 					bgp_process(bgp, rm, pi, afi, safi);
 				}
 		}
@@ -796,13 +798,14 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 					continue;
 
 				if (bgp_debug_neighbor_events(peer))
-					zlog_debug(
-						"%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
-						peer, &dest->rn->p);
+					zlog_debug("%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
+						   peer, bgp_dest_get_prefix(dest));
 
 				bgp_attr_dup_into(&attr, pi->attr);
 				bgp_attr_add_llgr_community(&attr);
+				old_attr = pi->attr;
 				pi->attr = bgp_attr_intern(&attr);
+				bgp_attr_unintern(&old_attr);
 				bgp_process(bgp, dest, pi, afi, safi);
 			}
 	}

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -741,6 +741,7 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 	struct bgp_path_info *pi, *next;
 	struct bgp_table *table;
 	struct attr attr;
+	struct attr *old_attr;
 
 	if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN) {
 		for (dest = bgp_table_top(bgp->rib[afi][safi]); dest; dest = bgp_route_next(dest)) {
@@ -770,13 +771,14 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 						continue;
 
 					if (bgp_debug_neighbor_events(peer))
-						zlog_debug(
-							"%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
-							peer, &dest->rn->p);
+						zlog_debug("%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
+							   peer, bgp_dest_get_prefix(rm));
 
 					bgp_attr_dup_into(&attr, pi->attr);
 					bgp_attr_add_llgr_community(&attr);
+					old_attr = pi->attr;
 					pi->attr = bgp_attr_intern(&attr);
+					bgp_attr_unintern(&old_attr);
 					bgp_process(bgp, rm, pi, afi, safi);
 				}
 		}
@@ -799,13 +801,14 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 					continue;
 
 				if (bgp_debug_neighbor_events(peer))
-					zlog_debug(
-						"%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
-						peer, &dest->rn->p);
+					zlog_debug("%pBP Long-lived set stale community (LLGR_STALE) for: %pFX",
+						   peer, bgp_dest_get_prefix(dest));
 
 				bgp_attr_dup_into(&attr, pi->attr);
 				bgp_attr_add_llgr_community(&attr);
+				old_attr = pi->attr;
 				pi->attr = bgp_attr_intern(&attr);
+				bgp_attr_unintern(&old_attr);
 				bgp_process(bgp, dest, pi, afi, safi);
 			}
 	}

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -544,6 +544,7 @@ static void bgp_accept(struct event *event)
 
 				incoming->fd = -1;
 				close(bgp_sock);
+				peer_delete(dynamic_peer);
 				return;
 			}
 

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -545,6 +545,7 @@ static void bgp_accept(struct event *event)
 
 				incoming->fd = -1;
 				close(bgp_sock);
+				peer_delete(dynamic_peer);
 				return;
 			}
 

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -912,6 +912,8 @@ static int bgp_capability_hostname(struct peer_connection *connection,
 	struct peer *peer = connection->peer;
 	struct stream *s = BGP_INPUT(connection);
 	char str[BGP_MAX_HOSTNAME + 1];
+	char *new_hostname = NULL;
+	char *new_domainname = NULL;
 	size_t end = stream_get_getp(s) + hdr->length;
 	uint8_t len;
 
@@ -946,18 +948,14 @@ static int bgp_capability_hostname(struct peer_connection *connection,
 	}
 
 	str[len] = '\0';
-
-	XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
-	XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
-
-	peer->hostname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
+	new_hostname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 
 	if (stream_get_getp(s) + 1 > end) {
 		flog_warn(
 			EC_BGP_CAPABILITY_INVALID_DATA,
 			"%s: Received invalid domain name len (hostname capability) from peer %s",
 			__func__, peer->host);
-		XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
+		XFREE(MTYPE_BGP_PEER_HOST, new_hostname);
 		return -1;
 	}
 
@@ -967,7 +965,7 @@ static int bgp_capability_hostname(struct peer_connection *connection,
 			EC_BGP_CAPABILITY_INVALID_DATA,
 			"%s: Received runt domain name (hostname capability) from peer %s",
 			__func__, peer->host);
-		XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
+		XFREE(MTYPE_BGP_PEER_HOST, new_hostname);
 		return -1;
 	}
 
@@ -981,16 +979,19 @@ static int bgp_capability_hostname(struct peer_connection *connection,
 	if (len) {
 		str[len] = '\0';
 
-		XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
-
-		peer->domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
+		new_domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 	}
+
+	XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
+	XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
+	peer->hostname = new_hostname;
+	peer->domainname = new_domainname;
 
 	SET_FLAG(peer->cap, PEER_CAP_HOSTNAME_RCV);
 
 	if (bgp_debug_neighbor_events(peer)) {
-		zlog_debug("%s received hostname %s, domainname %s", peer->host,
-			   peer->hostname, peer->domainname);
+		zlog_debug("%s received hostname %s, domainname %s", peer->host, peer->hostname,
+			   peer->domainname ? peer->domainname : "n/a");
 	}
 
 	return 0;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2379,6 +2379,38 @@ static void bgp_update_receive_eor(struct peer_connection *connection, afi_t afi
 	/* NSF delete stale route */
 	if (peer->nsf[afi][safi])
 		bgp_clear_stale_route(peer, afi, safi);
+
+	if (event_is_scheduled(peer->connection->t_gr_stale)) {
+		afi_t tafi;
+		safi_t tsafi;
+		bool pending = false;
+
+		FOREACH_AFI_SAFI_NSF (tafi, tsafi) {
+			if (peer->nsf[tafi][tsafi] &&
+			    !CHECK_FLAG(peer->af_sflags[tafi][tsafi], PEER_STATUS_EOR_RECEIVED)) {
+				pending = true;
+				break;
+			}
+		}
+
+		if (!pending) {
+			/*
+			 * All EORs received - run the stalepath walk that the
+			 * t_gr_stale timer would have run (mirrors
+			 * bgp_graceful_stale_timer_expire) for every
+			 * NSF-supporting AFI/SAFI so any stale routes that
+			 * were not refreshed during graceful restart are
+			 * cleaned up now, then cancel the timer.
+			 */
+			FOREACH_AFI_SAFI_NSF (tafi, tsafi)
+				if (peer->nsf[tafi][tsafi])
+					bgp_clear_stale_route(peer, tafi, tsafi);
+			event_cancel(&peer->connection->t_gr_stale);
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug("%pBP stalepath cleared and timer stopped - all EORs received",
+					   peer);
+		}
+	}
 }
 
 /**

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2379,6 +2379,33 @@ static void bgp_update_receive_eor(struct peer_connection *connection, afi_t afi
 	/* NSF delete stale route */
 	if (peer->nsf[afi][safi])
 		bgp_clear_stale_route(peer, afi, safi);
+
+	if (event_is_scheduled(peer->connection->t_gr_stale)) {
+		afi_t tafi;
+		safi_t tsafi;
+		bool pending = false;
+
+		FOREACH_AFI_SAFI_NSF (tafi, tsafi) {
+			if (peer->nsf[tafi][tsafi] &&
+			    !CHECK_FLAG(peer->af_sflags[tafi][tsafi], PEER_STATUS_EOR_RECEIVED)) {
+				pending = true;
+				break;
+			}
+		}
+
+		if (!pending) {
+			/*
+			 * Every NSF AFI/SAFI has sent EOR; each one was
+			 * already stale-cleared above when its EOR arrived.
+			 * Cancel t_gr_stale so we do not repeat those full
+			 * table walks when the timer fires.
+			 */
+			event_cancel(&peer->connection->t_gr_stale);
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug("%pBP stalepath timer stopped - all EORs received",
+					   peer);
+		}
+	}
 }
 
 /**

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3557,6 +3557,8 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 	uint8_t *data = pnt + 3;
 	uint8_t *end = data + hdr->length;
 	char str[BGP_MAX_HOSTNAME + 1] = {};
+	char *new_hostname = NULL;
+	char *new_domainname = NULL;
 	uint8_t len;
 
 	if (action == CAPABILITY_ACTION_SET) {
@@ -3591,15 +3593,13 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 		}
 		data += len;
 
-		XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
-		XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
-
-		peer->hostname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
+		new_hostname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 
 		if (data + 1 > end) {
 			flog_err(EC_BGP_CAPABILITY_INVALID_LENGTH,
 				 "%pBP: Received invalid FQDN capability (domain name length)",
 				 peer);
+			XFREE(MTYPE_BGP_PEER_HOST, new_hostname);
 			return;
 		}
 
@@ -3609,6 +3609,7 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 			flog_err(EC_BGP_CAPABILITY_INVALID_LENGTH,
 				 "%pBP: Received invalid FQDN capability length (domain name) %d",
 				 peer, len);
+			XFREE(MTYPE_BGP_PEER_HOST, new_hostname);
 			return;
 		}
 		data++;
@@ -3622,11 +3623,13 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 		}
 		/* data += len;  In case new code is ever added */
 
-		if (len) {
-			XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
+		if (len)
+			new_domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 
-			peer->domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
-		}
+		XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
+		XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
+		peer->hostname = new_hostname;
+		peer->domainname = new_domainname;
 
 		SET_FLAG(peer->cap, PEER_CAP_HOSTNAME_RCV);
 	} else {

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3562,6 +3562,8 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 	uint8_t *data = pnt + 3;
 	uint8_t *end = data + hdr->length;
 	char str[BGP_MAX_HOSTNAME + 1] = {};
+	char *new_hostname = NULL;
+	char *new_domainname = NULL;
 	uint8_t len;
 
 	if (action == CAPABILITY_ACTION_SET) {
@@ -3596,15 +3598,13 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 		}
 		data += len;
 
-		XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
-		XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
-
-		peer->hostname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
+		new_hostname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 
 		if (data + 1 > end) {
 			flog_err(EC_BGP_CAPABILITY_INVALID_LENGTH,
 				 "%pBP: Received invalid FQDN capability (domain name length)",
 				 peer);
+			XFREE(MTYPE_BGP_PEER_HOST, new_hostname);
 			return;
 		}
 
@@ -3614,6 +3614,7 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 			flog_err(EC_BGP_CAPABILITY_INVALID_LENGTH,
 				 "%pBP: Received invalid FQDN capability length (domain name) %d",
 				 peer, len);
+			XFREE(MTYPE_BGP_PEER_HOST, new_hostname);
 			return;
 		}
 		data++;
@@ -3627,11 +3628,13 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 		}
 		/* data += len;  In case new code is ever added */
 
-		if (len) {
-			XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
+		if (len)
+			new_domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 
-			peer->domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
-		}
+		XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
+		XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
+		peer->hostname = new_hostname;
+		peer->domainname = new_domainname;
 
 		SET_FLAG(peer->cap, PEER_CAP_HOSTNAME_RCV);
 	} else {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8827,6 +8827,7 @@ static void bgp_static_free(struct bgp_static *bgp_static)
 	if (bgp_static->prd_pretty)
 		XFREE(MTYPE_BGP_NAME, bgp_static->prd_pretty);
 	XFREE(MTYPE_ATTR, bgp_static->eth_s_id);
+	XFREE(MTYPE_ATTR, bgp_static->router_mac);
 	XFREE(MTYPE_BGP_STATIC, bgp_static);
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7038,6 +7038,7 @@ filtered:
 	if (new) {
 		bgp_unlink_nexthop(new);
 		bgp_path_info_mark_for_delete(dest, new);
+		bgp_attr_unintern(&new->attr);
 		bgp_path_info_extra_free(&new->extra);
 		XFREE(MTYPE_BGP_ROUTE, new);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8851,6 +8851,7 @@ static void bgp_static_free(struct bgp_static *bgp_static)
 	if (bgp_static->prd_pretty)
 		XFREE(MTYPE_BGP_NAME, bgp_static->prd_pretty);
 	XFREE(MTYPE_ATTR, bgp_static->eth_s_id);
+	XFREE(MTYPE_ATTR, bgp_static->router_mac);
 	XFREE(MTYPE_BGP_STATIC, bgp_static);
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9382,6 +9382,21 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 				bgp_static->rmap.map = NULL;
 				bgp_static->valid = 0;
 			}
+
+			if (safi == SAFI_EVPN) {
+				if (esi) {
+					XFREE(MTYPE_ATTR, bgp_static->eth_s_id);
+					bgp_static->eth_s_id = XCALLOC(MTYPE_ATTR, sizeof(esi_t));
+					str2esi(esi, bgp_static->eth_s_id);
+				}
+				if (routermac) {
+					XFREE(MTYPE_ATTR, bgp_static->router_mac);
+					bgp_static->router_mac = XCALLOC(MTYPE_ATTR, ETH_ALEN + 1);
+					(void)prefix_str2mac(routermac, bgp_static->router_mac);
+				}
+				if (gwip)
+					prefix_copy(&bgp_static->gatewayIp, &gw_ip);
+			}
 			bgp_dest_unlock_node(dest);
 		} else {
 			/* New configuration. */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7060,6 +7060,7 @@ filtered:
 	if (new) {
 		bgp_unlink_nexthop(new);
 		bgp_path_info_mark_for_delete(dest, new);
+		bgp_attr_unintern(&new->attr);
 		bgp_path_info_extra_free(&new->extra);
 		XFREE(MTYPE_BGP_ROUTE, new);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9356,6 +9356,21 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 				bgp_static->rmap.map = NULL;
 				bgp_static->valid = 0;
 			}
+
+			if (safi == SAFI_EVPN) {
+				if (esi) {
+					XFREE(MTYPE_ATTR, bgp_static->eth_s_id);
+					bgp_static->eth_s_id = XCALLOC(MTYPE_ATTR, sizeof(esi_t));
+					str2esi(esi, bgp_static->eth_s_id);
+				}
+				if (routermac) {
+					XFREE(MTYPE_ATTR, bgp_static->router_mac);
+					bgp_static->router_mac = XCALLOC(MTYPE_ATTR, ETH_ALEN + 1);
+					(void)prefix_str2mac(routermac, bgp_static->router_mac);
+				}
+				if (gwip)
+					prefix_copy(&bgp_static->gatewayIp, &gw_ip);
+			}
 			bgp_dest_unlock_node(dest);
 		} else {
 			/* New configuration. */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2685,8 +2685,11 @@ static void peer_group2peer_config_copy_af(struct peer_group *group,
 		PEER_ATTR_INHERIT(peer, group, allowas_in[afi][safi]);
 
 	/* soo */
-	if (!CHECK_FLAG(pflags_ovrd, PEER_FLAG_SOO))
-		PEER_ATTR_INHERIT(peer, group, soo[afi][safi]);
+	if (!CHECK_FLAG(pflags_ovrd, PEER_FLAG_SOO)) {
+		ecommunity_free(&peer->soo[afi][safi]);
+		if (group->conf->soo[afi][safi])
+			peer->soo[afi][safi] = ecommunity_dup(group->conf->soo[afi][safi]);
+	}
 
 	/* weight */
 	if (!CHECK_FLAG(pflags_ovrd, PEER_FLAG_WEIGHT))

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3096,6 +3096,7 @@ void peer_nsf_stop(struct peer *peer)
 	FOREACH_AFI_SAFI_NSF (afi, safi) {
 		peer->nsf[afi][safi] = 0;
 		event_cancel(&peer->t_llgr_stale[afi][safi]);
+		UNSET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_LLGR_WAIT);
 	}
 
 	if (event_is_scheduled(peer->connection->t_gr_restart)) {

--- a/tests/topotests/bgp_gr_clear_stale_after_eor/r1/frr.conf
+++ b/tests/topotests/bgp_gr_clear_stale_after_eor/r1/frr.conf
@@ -1,0 +1,22 @@
+!
+interface lo
+ ip address 172.16.255.1/32
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!
+ip route 172.16.255.2/32 Null0
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp graceful-restart preserve-fw-state
+ bgp graceful-restart stalepath-time 600
+ neighbor 192.168.255.2 remote-as external
+ neighbor 192.168.255.2 timers 1 3
+ neighbor 192.168.255.2 timers connect 1
+ address-family ipv4 unicast
+  network 172.16.255.1/32
+  network 172.16.255.2/32
+ exit-address-family
+!

--- a/tests/topotests/bgp_gr_clear_stale_after_eor/r2/frr.conf
+++ b/tests/topotests/bgp_gr_clear_stale_after_eor/r2/frr.conf
@@ -1,0 +1,15 @@
+!
+no zebra nexthop kernel enable
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp graceful-restart preserve-fw-state
+ bgp graceful-restart stalepath-time 600
+ neighbor 192.168.255.1 remote-as external
+ neighbor 192.168.255.1 timers 1 3
+ neighbor 192.168.255.1 timers connect 1
+!

--- a/tests/topotests/bgp_gr_clear_stale_after_eor/test_bgp_gr_clear_stale_after_eor.py
+++ b/tests/topotests/bgp_gr_clear_stale_after_eor/test_bgp_gr_clear_stale_after_eor.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026 by
+# Nageswara Soma <nsoma@cisco.com>
+#
+
+"""
+Test that stale routes are cleaned up immediately once all EORs are received
+during graceful restart, instead of waiting for the stalepath timer to fire.
+
+Topology:
+
+    +----+   192.168.255.0/24   +----+
+    | r1 |----------------------| r2 |
+    +----+                      +----+
+    AS 65001                    AS 65002
+    networks:
+      172.16.255.1/32
+      172.16.255.2/32
+
+Scenario:
+  1. r1 advertises 172.16.255.1/32 and 172.16.255.2/32 to r2.
+  2. r2 confirms both prefixes are present and not stale.
+  3. r1's bgpd is killed (write memory saves the running config).
+  4. r2 marks both prefixes as stale (graceful-restart helper behavior).
+  5. The persisted r1 config is edited to remove the network statement for
+     172.16.255.2/32.
+  6. r1's bgpd is restarted.  The session re-establishes and r1 sends an EOR
+     for ipv4-unicast (the only NSF AFI/SAFI on this peer).
+  7. Once r2 sees the EOR for every NSF AFI/SAFI on this peer it walks the
+     on this peer it walks the stale routes immediately and cancels the
+     t_gr_stale timer.  We assert 172.16.255.2/32 is gone from r2's BGP
+     table well before the configured stalepath-time of 600s could fire.
+"""
+
+import os
+import sys
+import json
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.common_config import (
+    step,
+    start_router_daemons,
+)
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for _, (rname, router) in enumerate(tgen.routers().items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _bgp_converge(r2):
+    output = json.loads(
+        r2.vtysh_cmd("show bgp ipv4 neighbors 192.168.255.1 json")
+    )
+    expected = {
+        "192.168.255.1": {
+            "bgpState": "Established",
+            "addressFamilyInfo": {
+                "ipv4Unicast": {"acceptedPrefixCounter": 2}
+            },
+        }
+    }
+    return topotest.json_cmp(output, expected)
+
+
+def _bgp_prefix_present(r2, prefix):
+    output = json.loads(
+        r2.vtysh_cmd("show bgp ipv4 unicast {} json".format(prefix))
+    )
+    if not output or "paths" not in output or not output["paths"]:
+        return "{} not present".format(prefix)
+    return None
+
+
+def _bgp_prefix_stale(r2, prefix):
+    output = json.loads(
+        r2.vtysh_cmd("show bgp ipv4 unicast {} json".format(prefix))
+    )
+    expected = {"paths": [{"stale": True}]}
+    return topotest.json_cmp(output, expected)
+
+
+def _bgp_prefix_absent(r2, prefix):
+    output = json.loads(
+        r2.vtysh_cmd("show bgp ipv4 unicast {} json".format(prefix))
+    )
+    if not output or "paths" not in output or not output["paths"]:
+        return None
+    return "{} still present: {}".format(prefix, output)
+
+
+def test_bgp_gr_clear_stale_after_eor():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Initial BGP convergence (both prefixes accepted on r2)")
+    test_func = functools.partial(_bgp_converge, r2)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to see initial BGP convergence on r2"
+
+    step("Confirm both prefixes are live (not stale) on r2")
+    for prefix in ("172.16.255.1/32", "172.16.255.2/32"):
+        assert _bgp_prefix_present(r2, prefix) is None, (
+            "Prefix {} missing on r2 before restart".format(prefix)
+        )
+
+    step("Kill bgpd on r1 (write memory persists current config)")
+    # NOTE: We deliberately bypass kill_router_daemons() here because in this
+    # 2-router topology the topotest framework's wait loop never observes the
+    # killed bgpd as gone (its parent does not reap the zombie within the
+    # poll window) and the call hangs indefinitely. A direct SIGKILL plus
+    # pid-file cleanup is sufficient for our purposes; the only requirement
+    # is that bgpd is no longer accepting BGP messages from r2.
+    r1.vtysh_cmd("write memory")
+    r1.run("kill -KILL $(cat /var/run/frr/bgpd.pid 2>/dev/null) 2>/dev/null || true")
+    r1.run("rm -f /var/run/frr/bgpd.pid /var/run/frr/bgpd.vty")
+
+    step("Wait for r2 to mark 172.16.255.2/32 as stale")
+    test_func = functools.partial(_bgp_prefix_stale, r2, "172.16.255.2/32")
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    assert result is None, "r2 did not mark 172.16.255.2/32 stale: {}".format(
+        result
+    )
+
+    step(
+        "Rewrite r1 unified frr.conf to drop both the static route and the "
+        "BGP network statement for 172.16.255.2/32 so when bgpd restarts and "
+        "vtysh -b replays the config, r1 only re-advertises 172.16.255.1/32"
+    )
+    r1.run(
+        "sed -i -e '/^ip route 172.16.255.2\\/32 Null0$/d' "
+        "-e '/^  network 172.16.255.2\\/32$/d' /etc/frr/frr.conf"
+    )
+
+    step("Restart bgpd on r1")
+    start_router_daemons(tgen, "r1", ["bgpd"])
+    # In unified-config mode the per-daemon /etc/frr/bgpd.conf is empty;
+    # bgpd needs the unified config re-pushed via vtysh to learn its neighbors
+    # and networks again. start_router_daemons() does not do this.
+    r1.run("vtysh -b -f /etc/frr/frr.conf >/dev/null 2>&1 || true")
+
+    step("Wait for r2 to see the session re-established and 1 prefix accepted")
+
+    def _bgp_one_prefix(r2):
+        output = json.loads(
+            r2.vtysh_cmd("show bgp ipv4 neighbors 192.168.255.1 json")
+        )
+        expected = {
+            "192.168.255.1": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {
+                    "ipv4Unicast": {"acceptedPrefixCounter": 1}
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_one_prefix, r2)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
+    assert result is None, "r2 did not see post-restart convergence: {}".format(
+        result
+    )
+
+    step(
+        "Assert 172.16.255.2/32 is removed from r2's BGP table (stalepath "
+        "cleared promptly after EOR rather than waiting for the 600s "
+        "stalepath timer)"
+    )
+    test_func = functools.partial(
+        _bgp_prefix_absent, r2, "172.16.255.2/32"
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    assert result is None, (
+        "Stale 172.16.255.2/32 still present on r2 after r1 EOR; "
+        "stalepath cleanup did not run promptly: {}".format(result)
+    )
+
+    step("Assert 172.16.255.1/32 is still present (re-advertised after restart)")
+    assert (
+        _bgp_prefix_present(r2, "172.16.255.1/32") is None
+    ), "172.16.255.1/32 unexpectedly missing on r2 after restart"
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary

Fix multiple memory leaks and correctness issues across the BGP daemon.

By file:

- **bgp_fsm.c** — In `bgp_set_llgr_stale()`, call `bgp_attr_unintern()`
  on the old `pi->attr` before interning the LLGR-stale replacement so
  we do not leak interned attributes on every LLGR transition. Also use
  `bgp_dest_get_prefix()` for debug-log prefix display in both the L2VPN
  sub-table and main AFI/SAFI paths.

- **bgp_packet.c**
  - In `bgp_update_receive_eor()`, when all NSF-enabled AFI/SAFIs have
    received their EOR, walk stale routes and call
    `bgp_clear_stale_route()` for each peer/AFI/SAFI (mirroring
    `bgp_graceful_stale_timer_expire()`), then cancel `t_gr_stale`.
    Includes new topotest `tests/topotests/bgp_gr_clear_stale_after_eor`.
  - In `bgp_dynamic_capability_fqdn()`, decode hostname and domain-name
    into local temporaries and commit to `peer->hostname` /
    `peer->domainname` only after both halves parse cleanly. Error paths
    free the temporaries and leave existing peer values untouched.
    Wire-level acceptance is unchanged: hostname `len == 0` is still
    rejected, domain-name `len == 0` is still accepted as a no-op, and
    oversize strings are still truncated to `BGP_MAX_HOSTNAME`.

- **bgpd.c** — In `peer_nsf_stop()`, clear `PEER_STATUS_LLGR_WAIT`
  alongside LLGR stalepath timer cancellation. In
  `peer_group2peer_config_copy_af()`, deep-copy inherited `soo`
  ecommunity via `ecommunity_dup()` instead of aliasing
  `group->conf->soo[afi][safi]`.

- **bgp_route.c** — Free `router_mac` in `bgp_static_free()`. On the
  `bgp_static_set()` update path (when an existing EVPN static route is
  reconfigured), free-then-assign `eth_s_id` and `router_mac` and
  `prefix_copy` `gatewayIp` so re-issued network commands take effect
  without leaking prior allocations. Call `bgp_attr_unintern()` on the
  filtered path in `bgp_update()` when max-prefix overflow drops the
  update after `info_make()`.

- **bgp_open.c** — Make `bgp_capability_hostname()` transactional using
  the same decode-into-temporaries pattern as dynamic FQDN above. Harden
  the post-update neighbor-events debug log to print `"n/a"` when
  `peer->domainname` is NULL, matching the existing fallback in
  `bgp_vty.c`.

- **bgp_network.c** — Call `peer_delete()` on the dynamic peer if
  `bgp_set_socket_ttl()` fails in `bgp_accept()`.

Two fixes from earlier iterations of this series are no longer included
because they are already on upstream master: SRv6 `srv6_l3service`
parse-error cleanup in `bgp_attr.c`, and EVPN import-RT list cleanup in
`bgp_evpn.c` (superseded by the typed import-RT refactor).

## Commits

1. **`bgpd: fix attr leak in bgp_set_llgr_stale`**
   When marking routes LLGR-stale, bgpd interned a new attribute with the
   LLGR_STALE community but never uninterned the old `pi->attr`, leaking
   an interned attribute on every transition. This commit adds
   `bgp_attr_unintern()` on the replaced attribute and fixes debug
   logging to use `bgp_dest_get_prefix()` for correct prefix display.

2. **`bgpd: clear NSF stale routes when all EORs received`**
   After graceful restart, stale routes that the peer does not
   re-advertise should be removed once all End-of-RIB messages arrive,
   not left until the stalepath timer fires. This commit runs the same
   stalepath walk as `bgp_graceful_stale_timer_expire()` from
   `bgp_update_receive_eor()` once every NSF AFI/SAFI has reported EOR,
   then cancels `t_gr_stale`. Includes topotest
   `tests/topotests/bgp_gr_clear_stale_after_eor`.

3. **`bgpd: clear PEER_STATUS_LLGR_WAIT flag in peer_nsf_stop`**
   `peer_nsf_stop()` cancelled the LLGR stale timer but left
   `PEER_STATUS_LLGR_WAIT` set on the peer. Stale flag state from a
   prior GR cycle could then affect the next cycle; this commit clears
   the flag alongside the timer cancellation.

4. **`bgpd: deep-copy inherited soo ecommunity from peer-group`**
   Peer-group members inherited `soo` via a raw pointer assignment,
   aliasing the group's ecommunity object. Deleting a member called
   `ecommunity_free()` on the shared pointer, causing double-free when
   the group or another member was deleted later. Align `soo` with the
   rest of the peer-group copy path by deep-copying via
   `ecommunity_dup()`.

5. **`bgpd: unintern attr on filtered path in bgp_update`**
   When maximum-prefix overflow rejects an update after `info_make()`,
   the cleanup path freed the new `path_info` but skipped
   `bgp_attr_unintern()`. Each dropped update leaked the interned
   attribute and its sub-objects (aspath, communities, etc.).

6. **`bgpd: parse FQDN capability into temporaries before commit`**
   `bgp_capability_hostname()` previously freed and replaced
   `peer->hostname` before validating the domain-name half of the TLV.
   A malformed second half wiped both strings even when only the
   domain-name was bad. Decode into local temporaries and commit to the
   peer only after the full TLV parses cleanly; error paths leave
   existing values untouched.

7. **`bgpd: parse dynamic FQDN capability transactionally`**
   The runtime dynamic-capability handler `bgp_dynamic_capability_fqdn()`
   had the same destructive-on-error pattern as the OPEN-time parser.
   Apply the same transactional decode: parse both halves into
   temporaries, then swap into `peer->hostname` / `peer->domainname`
   atomically on success. Wire-level acceptance and the UNSET
   withdrawal path are unchanged.

8. **`bgpd: free router_mac in bgp_static_free`**
   EVPN static routes allocate `router_mac` but `bgp_static_free()` did
   not free it. Every EVPN static-route deletion leaked the MAC
   allocation.

9. **`bgpd: fix EVPN parameter leaks on bgp_static_set update path`**
   The initial-create path in `bgp_static_set()` correctly sets ESI,
   router-MAC, and gateway-IP, but the configuration-change branch only
   updated backdoor and route-map. Re-issuing a network command with new
   EVPN parameters silently dropped the update and would leak any
   reassigned pointer fields; mirror the create path with free-then-assign.

10. **`bgpd: delete dynamic peer on TTL setup failure in bgp_accept`**
    When `bgp_set_socket_ttl()` fails after
    `peer_lookup_dynamic_neighbor()` creates a new peer, `bgp_accept()`
    returned without calling `peer_delete()`. The half-constructed peer
    and its socket fd were left dangling on the BGP instance.

## Test plan

- [x] `tests/topotests/bgp_gr_clear_stale_after_eor` — new test for
  EOR-triggered stalepath cleanup
- [x] `tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_fqdn.py`
  — exercises the dynamic FQDN capability parser changed in this series

## Related Issue(s)

N/A — discovered during internal stress testing and code audit.

## Component(s)

bgpd