### PR TITLE
nhrpd: improve validation in packet parsing

### DIFF
--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -80,6 +80,7 @@ struct nhrp_packet_header *nhrp_packet_pull(struct zbuf *zb,
 	struct nhrp_packet_header *hdr;
 	void *nbma_addr, *src_addr, *dst_addr;
 	size_t nbma_len, src_len, dst_len;
+	int nbma_family, proto_family;
 
 	hdr = zbuf_pull(zb, struct nhrp_packet_header);
 	if (!hdr)
@@ -89,12 +90,16 @@ struct nhrp_packet_header *nhrp_packet_pull(struct zbuf *zb,
 	src_len = hdr->src_protocol_address_len;
 	dst_len = hdr->dst_protocol_address_len;
 
-	/* Validate lens */
-	if (family2addrsize(afi2family(htons(hdr->afnum))) != nbma_len)
+	/* Validate families and lens */
+	nbma_family = afi2family(htons(hdr->afnum));
+	proto_family = proto2family(htons(hdr->protocol_type));
+	if (nbma_family == AF_UNSPEC || proto_family == AF_UNSPEC)
 		return NULL;
-	if (family2addrsize(proto2family(htons(hdr->protocol_type))) != src_len)
+	if (family2addrsize(nbma_family) != nbma_len)
 		return NULL;
-	if (family2addrsize(proto2family(htons(hdr->protocol_type))) != dst_len)
+	if (family2addrsize(proto_family) != src_len)
+		return NULL;
+	if (family2addrsize(proto_family) != dst_len)
 		return NULL;
 
 	nbma_addr = zbuf_pulln(zb, nbma_len);
@@ -195,28 +200,36 @@ struct nhrp_cie_header *nhrp_cie_pull(struct zbuf *zb,
 				      union sockunion *proto)
 {
 	struct nhrp_cie_header *cie;
+	void *addr;
 
 	cie = zbuf_pull(zb, struct nhrp_cie_header);
 	if (!cie)
 		return NULL;
 
-	if (cie->nbma_address_len + cie->nbma_subaddress_len > 0 &&
-	    cie->nbma_address_len + cie->nbma_subaddress_len <= zbuf_used(zb)) {
-		sockunion_set(nbma, afi2family(htons(hdr->afnum)),
-			      zbuf_pulln(zb,
-					 cie->nbma_address_len
-						 + cie->nbma_subaddress_len),
-			      cie->nbma_address_len + cie->nbma_subaddress_len);
-	} else {
-		sockunion_family(nbma) = AF_UNSPEC;
+	/* If the header lengths are preset but not valid, return error (NULL) */
+
+	sockunion_family(nbma) = AF_UNSPEC;
+	if (cie->nbma_address_len + cie->nbma_subaddress_len > 0) {
+		if (cie->nbma_address_len + cie->nbma_subaddress_len > zbuf_used(zb))
+			return NULL; /* Length claimed is invalid */
+		addr = zbuf_pulln(zb, cie->nbma_address_len + cie->nbma_subaddress_len);
+		if (addr)
+			sockunion_set(nbma, afi2family(htons(hdr->afnum)), addr,
+				      cie->nbma_address_len + cie->nbma_subaddress_len);
+		if (sockunion_family(nbma) == AF_UNSPEC)
+			return NULL;
 	}
 
-	if (cie->protocol_address_len && cie->protocol_address_len <= zbuf_used(zb)) {
-		sockunion_set(proto, proto2family(htons(hdr->protocol_type)),
-			      zbuf_pulln(zb, cie->protocol_address_len),
-			      cie->protocol_address_len);
-	} else {
-		sockunion_family(proto) = AF_UNSPEC;
+	sockunion_family(proto) = AF_UNSPEC;
+	if (cie->protocol_address_len > 0) {
+		if (cie->protocol_address_len > zbuf_used(zb))
+			return NULL; /* Length claimed is invalid */
+		addr = zbuf_pulln(zb, cie->protocol_address_len);
+		if (addr)
+			sockunion_set(proto, proto2family(htons(hdr->protocol_type)), addr,
+				      cie->protocol_address_len);
+		if (sockunion_family(proto) == AF_UNSPEC)
+			return NULL;
 	}
 
 	return cie;

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -89,6 +89,14 @@ struct nhrp_packet_header *nhrp_packet_pull(struct zbuf *zb,
 	src_len = hdr->src_protocol_address_len;
 	dst_len = hdr->dst_protocol_address_len;
 
+	/* Validate lens */
+	if (family2addrsize(afi2family(htons(hdr->afnum))) != nbma_len)
+		return NULL;
+	if (family2addrsize(proto2family(htons(hdr->protocol_type))) != src_len)
+		return NULL;
+	if (family2addrsize(proto2family(htons(hdr->protocol_type))) != dst_len)
+		return NULL;
+
 	nbma_addr = zbuf_pulln(zb, nbma_len);
 	src_addr = zbuf_pulln(zb, src_len);
 	dst_addr = zbuf_pulln(zb, dst_len);

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -745,46 +745,53 @@ err:
 	zbuf_free(zb);
 }
 
-static int parse_ether_packet(struct zbuf *zb, uint16_t protocol_type,
-			      union sockunion *src, union sockunion *dst)
+static bool parse_ether_packet(struct zbuf *zb, uint16_t protocol_type,
+			       union sockunion *src, union sockunion *dst)
 {
+	const struct iphdr *iph4;
+	const struct ipv6hdr *iph6;
+	bool ret = false;
+
 	switch (protocol_type) {
-	case ETH_P_IP: {
-		struct iphdr *iph = zbuf_pull(zb, struct iphdr);
-		if (iph) {
-			if (src)
-				sockunion_set(src, AF_INET,
-					      (uint8_t *)&iph->saddr,
-					      sizeof(iph->saddr));
-			if (dst)
-				sockunion_set(dst, AF_INET,
-					      (uint8_t *)&iph->daddr,
-					      sizeof(iph->daddr));
-		}
-	} break;
-	case ETH_P_IPV6: {
-		struct ipv6hdr *iph = zbuf_pull(zb, struct ipv6hdr);
-		if (iph) {
-			if (src)
-				sockunion_set(src, AF_INET6,
-					      (uint8_t *)&iph->saddr,
-					      sizeof(iph->saddr));
-			if (dst)
-				sockunion_set(dst, AF_INET6,
-					      (uint8_t *)&iph->daddr,
-					      sizeof(iph->daddr));
-		}
-	} break;
+	case ETH_P_IP:
+		iph4 = zbuf_pull(zb, struct iphdr);
+		if (iph4 == NULL)
+			break;
+
+		if (src)
+			sockunion_set(src, AF_INET, (uint8_t *)&iph4->saddr,
+				      sizeof(iph4->saddr));
+		if (dst)
+			sockunion_set(dst, AF_INET, (uint8_t *)&iph4->daddr,
+				      sizeof(iph4->daddr));
+		ret = true;
+		break;
+
+	case ETH_P_IPV6:
+		iph6 = zbuf_pull(zb, struct ipv6hdr);
+		if (iph6 == NULL)
+			break;
+
+		if (src)
+			sockunion_set(src, AF_INET6, (uint8_t *)&iph6->saddr,
+				      sizeof(iph6->saddr));
+		if (dst)
+			sockunion_set(dst, AF_INET6, (uint8_t *)&iph6->daddr,
+				      sizeof(iph6->daddr));
+		ret = true;
+		break;
+
 	default:
-		return 0;
+		break;
 	}
-	return 1;
+
+	return ret;
 }
 
 void nhrp_peer_send_indication(struct interface *ifp, uint16_t protocol_type,
 			       struct zbuf *pkt)
 {
-	union sockunion dst;
+	union sockunion dst = {};
 	struct zbuf *zb, payload;
 	struct nhrp_interface *nifp = ifp->info;
 	struct nhrp_afi_data *if_ad;
@@ -851,7 +858,7 @@ static void nhrp_handle_error_ind(struct nhrp_packet_parser *pp)
 
 static void nhrp_handle_traffic_ind(struct nhrp_packet_parser *p)
 {
-	union sockunion dst;
+	union sockunion dst = {};
 
 	if (!parse_ether_packet(&p->payload, htons(p->hdr->protocol_type), NULL,
 				&dst))

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -1257,10 +1257,20 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
 		goto drop;
 	}
 
+	/* Init before we begin parsing */
+	memset(&pp, 0, sizeof(pp));
+
 	realsize = zbuf_used(zb);
 	hdr = nhrp_packet_pull(zb, &pp.src_nbma, &pp.src_proto, &pp.dst_proto);
 	if (!hdr) {
 		info = "corrupt header";
+		goto drop;
+	}
+
+	if (sockunion_family(&pp.src_nbma) == AF_UNSPEC ||
+	    sockunion_family(&pp.src_proto) == AF_UNSPEC ||
+	    sockunion_family(&pp.dst_proto) == AF_UNSPEC) {
+		info = "invalid address family";
 		goto drop;
 	}
 


### PR DESCRIPTION
Add more careful validation in several packet-parsing paths, init more locals/arguments, return "error" or failure status in more situations. Several paths that use `struct sockunion` were not initializing input arguments, or checking returned values.
