### PR TITLE
bgpd: fix NHT for link-local nexthops from global-address peers

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -358,6 +358,29 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop, afi_
 				   &p.u.prefix6))
 			ifindex = pi->peer->connection->su.sin6.sin6_scope_id;
 
+		/*
+		 * A route may carry a link-local nexthop that differs from
+		 * the peer address (e.g. set by route-map, or from a
+		 * global-address peer advertising an LL nexthop).  Without
+		 * an ifindex the BNC is registered with zebra NHT, which
+		 * resolves the ambiguous fe80::/64 against an arbitrary
+		 * interface.  If that interface goes down, zebra marks the
+		 * nexthop unreachable and BGP withdraws routes even though
+		 * the real peer interface is still up.
+		 *
+		 * Derive ifindex from the peer's connected interface so
+		 * the BNC is tracked locally via interface events instead.
+		 * Skip when the nexthop equals the peer address to avoid
+		 * conflicting with the peer-tracking BNC (ifindex 0) that
+		 * is created before the TCP handshake for explicit LL
+		 * peers.
+		 */
+		if (afi == AFI_IP6 && !ifindex && IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6) &&
+		    pi->peer->connection->su.sa.sa_family == AF_INET6 &&
+		    !IPV6_ADDR_SAME(&pi->peer->connection->su.sin6.sin6_addr, &p.u.prefix6) &&
+		    pi->peer->nexthop.ifp)
+			ifindex = pi->peer->nexthop.ifp->ifindex;
+
 		if (!is_bgp_static_route && orig_prefix && prefix_same(&p, orig_prefix) &&
 		    CHECK_FLAG(bgp_route->flags, BGP_FLAG_IMPORT_CHECK)) {
 			if (BGP_DEBUG(nht, NHT)) {
@@ -832,13 +855,28 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
 		 */
 		bnc->metric = 0;
 		if (up) {
+			struct nexthop *nh;
+
+			/* Clear PEER_NOTIFIED so evaluate_paths() always
+			 * re-notifies the FSM on an UP transition.
+			 */
+			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
 			SET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
 			SET_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED);
+
+			bnc_nexthop_free(bnc);
+			nh = nexthop_new();
+			nh->type = NEXTHOP_TYPE_IFINDEX;
+			nh->ifindex = ifp->ifindex;
+			nh->vrf_id = ifp->vrf->vrf_id;
+			bnc->nexthop = nh;
 			bnc->nexthop_num = 1;
 		} else {
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
 			SET_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED);
+			bnc_nexthop_free(bnc);
+			bnc->nexthop = NULL;
 			bnc->nexthop_num = 0;
 		}
 
@@ -1252,6 +1290,14 @@ static void register_zebra_rnh(struct bgp_nexthop_cache *bnc)
 
 	if (bnc->ifindex_ipv6_ll) {
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED);
+		/*
+		 * Explicit LL peers (conf_if set) already get validated
+		 * via bgp_nht_interface_events(), so this is a no-op
+		 * for them.  Global-address peers with LL nexthops do
+		 * not go through that path, so they need this.
+		 */
+		event_add_event(bm->master, bgp_nht_ifp_initial, bnc->bgp, bnc->ifindex_ipv6_ll,
+				NULL);
 		return;
 	}
 

--- a/tests/topotests/bgp_ipv6_ll_peering/test_bgp_ipv6_ll_peering.py
+++ b/tests/topotests/bgp_ipv6_ll_peering/test_bgp_ipv6_ll_peering.py
@@ -572,6 +572,137 @@ def test_bgp_explicit_ll_nht_no_orphan_on_peer_delete():
     )
 
 
+def test_bgp_global_peer_ll_nexthop_nht_wrong_interface():
+    """
+    Bug: When a BGP peer is configured with a global IPv6 address
+    (e.g. IXIA/traffic-generator) and advertises routes with a
+    link-local nexthop, bgp_find_or_add_nexthop() registers the
+    NHT with ifindex=0 (no interface scope) because conf_if is NULL.
+    Zebra resolves the LL nexthop against fe80::/64 on an arbitrary
+    interface. If that interface goes down, the nexthop is falsely
+    marked unreachable and all routes using it are withdrawn.
+
+    Topology (reuses existing r1, r2, r3):
+      r2 (spine) ---[r1-eth0]--- r1 (leaf) ---[r1-eth1]--- r3 (ixia)
+                     LL peer                   global peer
+                                               (LL nexthop via route-map)
+
+    Both r1-eth0 and r1-eth1 have fe80:1::/64, so NHT for r3's LL
+    nexthop can resolve through either interface.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r3 = tgen.gears["r3"]
+
+    # --- Setup ---
+
+    step("Configure global addresses for r1-eth1 and r3-eth0")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         interface r1-eth1
+          ipv6 address 2001:db8:2::1/64
+         exit
+        end
+    """
+    )
+
+    r3.vtysh_cmd(
+        """
+        configure terminal
+         interface r3-eth0
+          ipv6 address 2001:db8:2::3/64
+         exit
+         interface lo
+          ip address 10.0.0.3/32
+          ipv6 address 2001:db8:3::1/128
+         exit
+        end
+    """
+    )
+
+    step("Configure r3: add router-id, route-map to set LL nexthop, global peer to r1")
+    r3.vtysh_cmd(
+        """
+        configure terminal
+         route-map SET_LL_NH permit 10
+          set ipv6 next-hop local fe80:1::4
+         exit
+         router bgp 65003
+          bgp router-id 10.0.0.3
+          neighbor 2001:db8:2::1 remote-as external
+          neighbor 2001:db8:2::1 timers 3 10
+          address-family ipv6 unicast
+           neighbor 2001:db8:2::1 activate
+           neighbor 2001:db8:2::1 route-map SET_LL_NH out
+           network 2001:db8:3::1/128
+          exit-address-family
+         exit
+        end
+    """
+    )
+
+    step("Configure r1: add global-address peer to r3")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 65001
+          neighbor 2001:db8:2::3 remote-as external
+          neighbor 2001:db8:2::3 timers 3 10
+          address-family ipv6 unicast
+           neighbor 2001:db8:2::3 activate
+          exit-address-family
+         exit
+        end
+    """
+    )
+
+    # --- Verify session and route ---
+
+    step("Wait for BGP session r1 <-> r3 (global address peer) to establish")
+
+    def _bgp_r3_up():
+        output = json.loads(r1.vtysh_cmd("show bgp ipv6 unicast summary json"))
+        peers = output.get("peers", {})
+        for peer, data in peers.items():
+            if "2001:db8:2::3" in peer and data.get("state") == "Established":
+                return None
+        return "BGP session to 2001:db8:2::3 not established"
+
+    test_func = functools.partial(_bgp_r3_up)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, "BGP session r1<->r3 did not establish"
+
+    step("Wait for r1 to receive 2001:db8:3::1/128 from r3")
+
+    def _route_from_r3():
+        output = json.loads(
+            r1.vtysh_cmd("show bgp ipv6 unicast 2001:db8:3::1/128 json")
+        )
+        paths = output.get("paths", [])
+        if not paths:
+            return "No paths for 2001:db8:3::1/128"
+        return None
+
+    test_func = functools.partial(_route_from_r3)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "r1 did not receive 2001:db8:3::1/128 from r3"
+
+    step("Check zebra NHT for fe80:1::4 — should NOT be registered with zebra")
+    zebra_nht = json.loads(r1.vtysh_cmd("show ipv6 nht json"))
+
+    ipv6_nht = zebra_nht.get("default", {}).get("ipv6", {})
+    assert "fe80:1::4" not in ipv6_nht, (
+        "Link-local nexthop fe80:1::4 (from global-address peer "
+        "2001:db8:2::3) was registered with zebra NHT (ifindex_ipv6_ll=0). "
+        "Zebra NHT output:\n" + json.dumps(zebra_nht, indent=2)
+    )
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
    bgpd: fix NHT for link-local nexthops from global-address peers
    
    When a global-address peer advertises a route with a link-local
    nexthop (e.g. set via route-map), bgp_find_or_add_nexthop() created
    a BNC keyed with ifindex_ipv6_ll=0 because the existing conf_if
    guard did not cover this case.  With ifindex 0 the BNC was registered
    with zebra NHT, which resolved the ambiguous fe80::/64 prefix against
    an arbitrary interface.  If that interface went down, zebra declared
    the nexthop unreachable and BGP withdrew all routes using it — even
    though the real peer interface was still up.
    
    Topology:  IXIA -----(swp63s0)---- leaf12 ----(swp1s0..swp32s3)---- spine12
    
    - IXIA peers with leaf12 using global address 2101:fee1:baad::1
    - IXIA advertises n routes to leaf12
      with link-local nexthop fe80::216:1ff:fe00:1
    - All interfaces (swp63s0 towards IXIA, swp1s0..swp32s3 towards
      spine12) have link-local addresses in fe80::/64
    
    Step 1 - BGP receives route with LL nexthop:
      Route say 4001:fee1:bab1:1f00::/56, nexthop = fe80::216:1ff:fe00:1
      This LL nexthop belongs to IXIA, reachable via swp63s0.
    
    Step 2 - BGP registers nexthop for NHT (the bug):
      bgp_find_or_add_nexthop() builds BNC key:
        prefix = fe80::216:1ff:fe00:1/128, ifindex = 0
      ifindex stays 0 because peer address (2101:fee1:baad::1) is
      global, so the conf_if guard at bgp_nht.c is skipped.
      BNC is registered with zebra NHT (not tracked locally).
    
    Step 3 - Zebra resolves against wrong interface:
      Zebra receives NHT request for fe80::216:1ff:fe00:1 with no
      ifindex.  fe80::/64 is a connected prefix on every interface.
      Zebra picks an arbitrary match:
        Resolved: fe80::/64 via swp17s1  <-- spine interface (WRONG)
        Should be: fe80::/64 via swp63s0  <-- IXIA interface (CORRECT)
      BGP marks the nexthop VALID, routes are installed.  Traffic
      works because the actual forwarding uses peer->nexthop.ifp
      (swp63s0), not the NHT resolution interface.
    
    Step 4 - 32 spine links are shut down (including swp17s1):
      swp17s1 goes down.  Zebra re-evaluates fe80::/64 on swp17s1,
      finds it unreachable, sends NHT update to BGP:
        fe80::216:1ff:fe00:1 -> UNREACHABLE
    
    Step 5 - BGP withdraws all n IXIA routes:
      BGP marks BNC invalid, withdraws every route attached to it.
      Routes are deleted from zebra/kernel, causing traffic loss on
      4-5 flows (~250-611 ms).  Routes are re-added shortly after
      when zebra re-resolves fe80::/64 via another spine interface
      that is still up.
    
    Fix: derive ifindex from peer->nexthop.ifp->ifindex so the BNC
    is keyed with the correct interface and tracked locally via
    interface events, bypassing zebra NHT entirely.
    
    Also schedule bgp_nht_ifp_initial() from register_zebra_rnh() when
    ifindex_ipv6_ll is set, so the BNC gets validated via interface events
    even when no LL peer exists to trigger bgp_nht_interface_events().
    
    Signed-off-by: Soumya Roy <soumyar@nvidia.com>