### PR TITLE
tests: fix test_pim_ssm_ping

### DIFF
--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -285,10 +285,12 @@ def test_pim_ssm_ping():
 
     def _check_ssmping():
         output = r1.run("ssmping -I r1-eth0 10.0.20.2 -c 5")
-        return "5 packets received" in output
+        # Check for multicast packets received, not just unicast
+        # The key is to verify "since first mc packet" appears in the output
+        return "5 packets received, 0% packet loss since first mc packet" in output
 
     _, result = topotest.run_and_expect(_check_ssmping, True, count=20, wait=1)
-    assert result is True, "SSM ping failed"
+    assert result is True, "SSM ping failed - multicast responses not received"
 
 
 def test_memory_leak():


### PR DESCRIPTION
Current test only checks for '5 packets received' and fails to detect multicast failure

 stdout: ssmping joined (S,G) = (10.0.20.2,232.43.211.234)
 pinging S from 10.0.20.1
   unicast from 10.0.20.2, seq=1 dist=0 time=0.099 ms
   unicast from 10.0.20.2, seq=2 dist=0 time=0.190 ms
   unicast from 10.0.20.2, seq=3 dist=0 time=0.250 ms
   unicast from 10.0.20.2, seq=4 dist=0 time=0.239 ms
   unicast from 10.0.20.2, seq=5 dist=0 time=0.550 ms

 --- 10.0.20.2 statistics ---
 5 packets transmitted, time 5000 ms
 unicast:
    5 packets received, 0% packet loss
    rtt min/avg/max/std-dev = 0.099/0.265/0.550/0.152 ms
 multicast:
    0 packets received, 100% packet loss

When multicast are received, the output looks like:

 ssmping joined (S,G) = (10.0.20.2,232.43.211.234)
 pinging S from 10.0.20.1
   unicast from 10.0.20.2, seq=1 dist=0 time=0.134 ms
 multicast from 10.0.20.2, seq=1 dist=0 time=0.150 ms
   unicast from 10.0.20.2, seq=2 dist=0 time=0.237 ms
 multicast from 10.0.20.2, seq=2 dist=0 time=0.258 ms
   unicast from 10.0.20.2, seq=3 dist=0 time=0.221 ms
 multicast from 10.0.20.2, seq=3 dist=0 time=0.237 ms
   unicast from 10.0.20.2, seq=4 dist=0 time=0.212 ms
 multicast from 10.0.20.2, seq=4 dist=0 time=0.234 ms
   unicast from 10.0.20.2, seq=5 dist=0 time=0.209 ms
 multicast from 10.0.20.2, seq=5 dist=0 time=0.220 ms

 --- 10.0.20.2 statistics ---
 5 packets transmitted, time 5001 ms
 unicast:
    5 packets received, 0% packet loss
    rtt min/avg/max/std-dev = 0.134/0.202/0.237/0.038 ms
 multicast:
    5 packets received, 0% packet loss since first mc packet (seq 1) recvd
    rtt min/avg/max/std-dev = 0.150/0.219/0.258/0.041 ms

 Fix it to assert multicast reception