### PR TITLE
tests: Catch core dumps *after* teardown has completed

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -444,6 +444,7 @@ static void rpki_delete_all_cache_nodes(struct rpki_vrf *rpki_vrf)
 			rtr_mgr_remove_group(rpki_vrf->rtr_config,
 					     cache->preference);
 		listnode_delete(rpki_vrf->cache_list, cache);
+		free_cache(cache);
 	}
 }
 

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -976,9 +976,16 @@ static int start(struct rpki_vrf *rpki_vrf)
 
 static void stop(struct rpki_vrf *rpki_vrf)
 {
+	struct listnode *cache_node;
+	struct cache *cache;
+
 	rpki_vrf->rtr_is_stopping = true;
 	if (is_running(rpki_vrf)) {
 		event_cancel(&rpki_vrf->t_rpki_sync);
+
+		for (ALL_LIST_ELEMENTS_RO(rpki_vrf->cache_list, cache_node, cache))
+			frr_pthread_non_controlled_shutdown(cache->rtr_socket->thread_id);
+
 		rtr_mgr_stop(rpki_vrf->rtr_config);
 		rtr_mgr_free(rpki_vrf->rtr_config);
 		rpki_vrf->rtr_is_running = false;
@@ -1726,8 +1733,8 @@ DEFPY (no_rpki,
 	if (!rpki_vrf)
 		return CMD_WARNING;
 
-	rpki_delete_all_cache_nodes(rpki_vrf);
 	stop(rpki_vrf);
+	rpki_delete_all_cache_nodes(rpki_vrf);
 	rpki_vrf->polling_period = POLLING_PERIOD_DEFAULT;
 	rpki_vrf->expire_interval = EXPIRE_INTERVAL_DEFAULT;
 	rpki_vrf->retry_interval = RETRY_INTERVAL_DEFAULT;

--- a/doc/developer/rcu.rst
+++ b/doc/developer/rcu.rst
@@ -263,6 +263,13 @@ Internals
    important if the pthread created ends up calling back into FRR and
    one of the various zlog_XXX functions is called.
 
+.. c:function:: void frr_pthread_non_controlled_shutdown(pthread_t thread)
+
+   If a pthread on shutdown needs to be cleaned up in a manner that is
+   not controlled via the FRR pthread mechanisms, then this should be
+   called to remove the pthread from tracking.  Again if zlog_XXX functions
+   are called on shutdown after this is called we might experience some fun.
+
 .. c:function:: void rcu_shutdown(void)
 
    Stop the RCU sweeper thread and make sure all cleanup has finished.

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -290,6 +290,23 @@ int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
 	return 0;
 }
 
+void frr_pthread_non_controlled_shutdown(pthread_t thread)
+{
+	frr_with_mutex (&frr_pthread_list_mtx) {
+		struct listnode *n;
+		struct frr_pthread *fpt;
+
+		for (ALL_LIST_ELEMENTS_RO(frr_pthread_list, n, fpt)) {
+			if (!pthread_equal(fpt->thread, thread))
+				continue;
+
+			listnode_delete(frr_pthread_list, fpt);
+			frr_pthread_destroy_nolock(fpt);
+			break;
+		}
+	}
+}
+
 /*
  * ----------------------------------------------------------------------------
  * Default Event Loop

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -212,6 +212,8 @@ void frr_pthread_stop_all(void);
 int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
 				       const char *os_name);
 
+void frr_pthread_non_controlled_shutdown(pthread_t thread);
+
 /* mutex auto-lock/unlock */
 
 /* variant 1:

--- a/tests/topotests/bgp_rpki_topo1/test_bgp_rpki_topo1.py
+++ b/tests/topotests/bgp_rpki_topo1/test_bgp_rpki_topo1.py
@@ -283,6 +283,70 @@ exit
         assert result is None, "Unexpected prefixes RPKI state on {}".format(rname)
 
 
+def test_no_rpki_command():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ["r1", "r3"]:
+        logger.info("{}: checking if rtrd is running".format(rname))
+        if rtrd_process[rname].poll() is not None:
+            pytest.skip(tgen.errors)
+
+    rname = "r2"
+
+    def _show_rpki_no_connection():
+        output = json.loads(
+            tgen.gears[rname].vtysh_cmd("show rpki cache-connection json")
+        )
+        return output == {"error": "No connection to RPKI cache server."}
+
+    def _show_rpki_connected():
+        output = json.loads(
+            tgen.gears[rname].vtysh_cmd("show rpki cache-connection json")
+        )
+        return "connectedGroup" in output and "connections" in output
+
+    step("Remove full RPKI configuration using no rpki")
+    tgen.gears[rname].vtysh_cmd(
+        """
+configure
+no rpki
+"""
+    )
+
+    step("Verify RPKI cache disconnects after no rpki")
+    _, result = topotest.run_and_expect(
+        _show_rpki_no_connection, True, count=60, wait=0.5
+    )
+    assert result, "RPKI is still connected on {} after no rpki".format(rname)
+
+    step("Restore RPKI configuration")
+    tgen.gears[rname].vtysh_cmd(
+        """
+configure
+rpki
+ rpki retry_interval 5
+ rpki cache tcp 192.0.2.1 15432 preference 1
+exit
+"""
+    )
+
+    step("Verify RPKI reconnects after restoring configuration")
+    _, result = topotest.run_and_expect(_show_rpki_connected, True, count=60, wait=0.5)
+    assert result, "RPKI cache connection did not establish after restoring no rpki"
+
+    step("Verify RPKI prefix table is repopulated")
+    expected = open(os.path.join(CWD, "{}/rpki_prefix_table.json".format(rname))).read()
+    expected_json = json.loads(expected)
+    test_func = functools.partial(show_rpki_prefixes, rname, expected_json)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), "Failed to see RPKI prefixes on {} after no rpki restore".format(rname)
+
+
 def test_show_bgp_rpki_route_map():
     tgen = get_topogen()
 

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -392,9 +392,13 @@ def check_for_core_dumps(item: pytest.Item | None = None) -> None:
         existing |= latest
         tgen.existing_core_files = existing
 
-        # Call gdb_core for each new core dump to show backtrace
+        # Call gdb_core for each new core dump to show backtrace.
+        # NOTE: this can run at module teardown (after stop_topology), at
+        # which point the router netns is already gone and topo_router.net
+        # raises KeyError. We must never let those secondary failures hide
+        # the primary "core file found" message, so any error here is just
+        # logged and we proceed to the pytest.fail() below.
         for core_file in latest:
-            # Extract router name and daemon from core file path
             # Core files are typically named like: /path/to/logdir/router_name/daemon_core_*.dmp
             core_path = Path(core_file)
             router_name = core_path.parent.name
@@ -402,20 +406,24 @@ def check_for_core_dumps(item: pytest.Item | None = None) -> None:
                 0
             ]  # Remove '_core_*.dmp' suffix
 
-            # Get the actual router object from tgen
-            topo_router = tgen.gears.get(router_name)
-            if topo_router:
-                # Access the actual router instance through the net property
-                router = topo_router.net
-                try:
-                    backtrace = gdb_core(router, daemon_name, [core_file])
+            try:
+                topo_router = tgen.gears.get(router_name)
+                if topo_router is None:
                     logger.error(
-                        f"Core dump analysis for {router_name}:{daemon_name}:\n{backtrace}"
+                        f"Core dump found at {core_file} (router {router_name} no longer in topology, skipping backtrace)"
                     )
-                except Exception as e:
-                    logger.error(f"Failed to analyze core dump {core_file}: {e}")
-            else:
-                logger.error(f"Could not find router {router_name} in topology")
+                    continue
+                # topo_router.net dereferences the live netns and will raise
+                # KeyError once the topology has been stopped.
+                router = topo_router.net
+                backtrace = gdb_core(router, daemon_name, [core_file])
+                logger.error(
+                    f"Core dump analysis for {router_name}:{daemon_name}:\n{backtrace}"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Core dump found at {core_file} but backtrace analysis failed: {e!r}"
+                )
 
         emsg = "New core[s] found: " + ", ".join(latest)
         logger.error(emsg)
@@ -481,6 +489,25 @@ def module_check_memtest(request):
     if request.config.option.memleaks:
         if get_topogen() is not None:
             check_for_memleaks()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def module_check_cores(request):
+    """
+    Daemons can crash during topology shutdown (e.g. while handling SIGTERM
+    from teardown_module). Per-test hooks like check_for_core_dumps() in
+    pytest_runtest_call only fire while tests are running, so a teardown-
+    time crash would otherwise be silently ignored. This module-scoped
+    fixture re-runs the core/backtrace checks once after the topology has
+    been stopped so that any cores or backtraces produced during shutdown
+    cause the module to fail.
+    """
+    yield
+    if get_topogen() is None:
+        return
+    if not request.config.option.ignore_backtraces:
+        check_for_backtraces()
+    check_for_core_dumps()
 
 
 #

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -414,9 +414,7 @@ def check_for_core_dumps(item: pytest.Item | None = None) -> None:
                     )
                     continue
                 # topo_router.net dereferences the live netns and will raise
-                # KeyError once the topology has been stopped.
-                router = topo_router.net
-                backtrace = gdb_core(router, daemon_name, [core_file])
+                backtrace = gdb_core(topo_router, daemon_name, [core_file])
                 logger.error(
                     f"Core dump analysis for {router_name}:{daemon_name}:\n{backtrace}"
                 )

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -832,6 +832,7 @@ class TopoRouter(TopoGear):
         logfile = self._setup_tmpdir()
         params["logdir"] = self.logdir
 
+        self.daemondir = params.get("frrdir")
         self.logger = topolog.get_logger(name, log_level="debug", target=logfile)
         params["logger"] = self.logger
         tgen.net.add_host(self.name, cls=cls, **params)


### PR DESCRIPTION
If a test dumps core after it has been told to teardown, the topotests do not catch this problem.  Modify the code to catch this situation.