### PR TITLE
bgpd: fix shutdown crash by restricting evpn cleanup to owner instance

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -5194,6 +5194,17 @@ void bgp_evpn_mh_init(void)
 	memset(&zero_esi_buf, 0, sizeof(esi_t));
 }
 
+void bgp_evpn_es_cleanup_routes(struct bgp *bgp)
+{
+	struct bgp_evpn_es *es;
+
+	if (!bgp_mh_info)
+		return;
+
+	RB_FOREACH (es, bgp_es_rb_head, &bgp_mh_info->es_rb_tree)
+		bgp_evpn_es_route_del_all(bgp, es);
+}
+
 void bgp_evpn_mh_finish(void)
 {
 	struct bgp_evpn_es *es;

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -429,6 +429,7 @@ bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgpevpn *vpn,
 			   struct bgp_path_info *pi);
 extern void bgp_evpn_mh_init(void);
 extern void bgp_evpn_mh_finish(void);
+extern void bgp_evpn_es_cleanup_routes(struct bgp *bgp);
 void bgp_evpn_vni_es_init(struct bgpevpn *vpn);
 void bgp_evpn_vni_es_cleanup(struct bgpevpn *vpn);
 void bgp_evpn_es_show_esi(struct vty *vty, esi_t *esi, bool uj);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4606,13 +4606,16 @@ int bgp_delete(struct bgp *bgp)
 
 	bgp_cleanup_routes(bgp);
 
-	if (bm->terminating)
+	if (bm->terminating && bm->bgp_evpn == bgp) {
 		/*
-		 * Release EVPN VNI bgp_lock references so the
+		 * Clean ES route tables while bgp is still alive,
+		 * then release EVPN VNI bgp_lock references so the
 		 * subsequent bgp_unlock() can drive refcount to
 		 * zero and trigger bgp_free().
 		 */
+		bgp_evpn_es_cleanup_routes(bgp);
 		bgp_evpn_cleanup(bgp);
+	}
 
 	for (afi = 0; afi < AFI_MAX; ++afi) {
 		if (!bgp->vpn_policy[afi].import_redirect_rtlist)


### PR DESCRIPTION
Restrict early bgp_evpn_cleanup() call during termination to only the EVPN owner instance to avoid destroying tenant VRF state that is still referenced by VNI entries on the default instance.

Signed-off-by: Soumya Roy <souroy@nvidia.com>

Fixes >>

find /tmp/topotests -name '*.dmp'
/tmp/topotests/bgp_evpn_mh.test_evpn_mh/torm22/bgpd_core-sig_6-pid_695692.dmp
/tmp/topotests/bgp_evpn_mh.test_evpn_mh/torm12/bgpd_core-sig_6-pid_695536.dmp
/tmp/topotests/bgp_evpn_mh.test_evpn_mh/torm21/bgpd_core-sig_6-pid_695614.dmp
/tmp/topotests/bgp_evpn_mh.test_evpn_mh/torm11/bgpd_core-sig_6-pid_695458.dmp
/tmp/topotests/bgp_evpn_rt5_addpath.test_bgp_evpn_rt5_addpath/r2/bgpd_core-sig_6-pid_666971.dmp
[Current thread is 1 (Thread 0x77297f4cf9c0 (LWP 2844434))]
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x000077297ee4527e in __GI_raise (sig=6) at ../sysdeps/posix/raise.c:26
#4  0x000077297f354194 in core_handler (signo=6, siginfo=0x7ffd1a4f62b0, context=0x7ffd1a4f6180) at lib/sigevent.c:268
#5  <signal handler called>
#6  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#7  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#8  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#9  0x000077297ee4527e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#10 0x000077297ee288ff in __GI_abort () at ./stdlib/abort.c:79
#11 0x000077297f39d567 in _zlog_assert_failed (xref=0x5d1e7d6d3c60 <_xref.6>, extra=0x0) at lib/zlog.c:801
#12 0x00005d1e7d490f8e in bgp_pi_hash_fini (h=0x5d1eb3188898) at ./bgpd/bgp_route.h:761
#13 0x00005d1e7d4911b9 in bgp_table_unlock (rt=0x5d1eb3188880) at bgpd/bgp_table.c:38
#14 0x00005d1e7d3ba297 in bgp_evpn_es_free (es=0x5d1eb3188740, caller=0x5d1e7d5dc200 <__func__.189> "bgp_evpn_es_local_info_clear") at bgpd/bgp_evpn_mh.c:2112
#15 0x00005d1e7d3ba4e2 in bgp_evpn_es_local_info_clear (es=0x5d1eb3188740, finish=true) at bgpd/bgp_evpn_mh.c:2179
#16 0x00005d1e7d3c2791 in bgp_evpn_mh_finish () at bgpd/bgp_evpn_mh.c:5230
#17 0x00005d1e7d3763ee in bgp_exit (status=0) at bgpd/bgp_main.c:193
#18 0x00005d1e7d3762ce in sigint () at bgpd/bgp_main.c:141
#19 0x000077297f353f00 in frr_sigevent_process () at lib/sigevent.c:117
#20 0x000077297f3708f5 in event_fetch_inner_loop (m=0x5d1eb291cf10, event=0x0, fetch=0x7ffd1a4f7200, broken=0x7ffd1a4f71be, continued=0x7ffd1a4f71bf) at lib/event.c:2437
#21 0x000077297f370c2b in event_fetch (m=0x5d1eb291cf10, fetch=0x7ffd1a4f7200) at lib/event.c:2569
#22 0x000077297f2dd06f in frr_run (loop=0x5d1eb291cf10) at lib/libfrr.c:1257
#23 0x00005d1e7d37705f in main (argc=7, argv=0x7ffd1a4f7498) at bgpd/bgp_main.c:550
(gdb)[2:20 PM](gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007e1f00e4527e in __GI_raise (sig=6) at ../sysdeps/posix/raise.c:26
#4  0x00007e1f01354194 in core_handler (signo=6, siginfo=0x7ffcc9c68870, context=0x7ffcc9c68740) at lib/sigevent.c:268
#5  <signal handler called>
#6  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#7  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#8  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#9  0x00007e1f00e4527e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#10 0x00007e1f00e288ff in __GI_abort () at ./stdlib/abort.c:79
#11 0x00007e1f0139d567 in _zlog_assert_failed (xref=0x7e1f01460c80 <_xref.1>, extra=0x0) at lib/zlog.c:801
#12 0x00007e1f012de4c4 in listnode_lookup (list=0x0, data=0x579a9be6fd10) at lib/linklist.c:352
#13 0x00007e1f012de2e2 in listnode_delete (list=0x0, val=0x579a9be6fd10) at lib/linklist.c:306
#14 0x0000579a666b78cc in bgpevpn_unlink_from_l3vni (vpn=0x579a9be6fd10) at ./bgpd/bgp_evpn_private.h:266
#15 0x0000579a666c7ac2 in bgp_evpn_free (bgp=0x579a9be7c340, vpn=0x579a9be6fd10) at bgpd/bgp_evpn.c:6779
#16 0x0000579a666c49ca in free_vni_entry (bucket=0x579a9be70120, bgp=0x579a9be7c340) at bgpd/bgp_evpn.c:5449
#17 0x00007e1f012c5536 in hash_iterate (hash=0x579a9beaf9c0, func=0x579a666c4984 <free_vni_entry>, arg=0x579a9be7c340) at lib/hash.c:252
#18 0x0000579a666c9da7 in bgp_evpn_cleanup (bgp=0x579a9be7c340) at bgpd/bgp_evpn.c:7778
#19 0x0000579a6682f996 in bgp_delete (bgp=0x579a9be7c340) at bgpd/bgpd.c:4599
#20 0x0000579a6668e3e9 in bgp_exit (status=0) at bgpd/bgp_main.c:191
#21 0x0000579a6668e2ce in sigint () at bgpd/bgp_main.c:141
#22 0x00007e1f01353f00 in frr_sigevent_process () at lib/sigevent.c:117
#23 0x00007e1f013708f5 in event_fetch_inner_loop (m=0x579a9b605f90, event=0x0, fetch=0x7ffcc9c698f0, broken=0x7ffcc9c698ae, continued=0x7ffcc9c698af) at lib/event.c:2437
#24 0x00007e1f01370c2b in event_fetch (m=0x579a9b605f90, fetch=0x7ffcc9c698f0) at lib/event.c:2569
#25 0x00007e1f012dd06f in frr_run (loop=0x579a9b605f90) at lib/libfrr.c:1257
#26 0x0000579a6668f05f in main (argc=7, argv=0x7ffcc9c69b88) at bgpd/bgp_main.c:550
(gdb)