### PR TITLE
pimd: fix crash in JP agg list due to stale upstream entry

### DIFF
--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -195,6 +195,15 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up)
 {
 	if (up->rpf.source_nexthop.interface) {
+		struct pim_neighbor *nbr;
+
+		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
+					up->rpf.rpf_addr, true);
+		if (nbr) {
+			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
+			pim_jp_agg_upstream_verification(up, false);
+		}
+
 		pim_upstream_switch(pim, up, PIM_UPSTREAM_NOTJOINED);
 		up->rpf.source_nexthop.interface = NULL;
 		up->rpf.source_nexthop.mrib_nexthop_addr = PIMADDR_ANY;


### PR DESCRIPTION
When pim_upstream_rpf_clear() nulls the RPF interface, it does not remove the upstream from the old RPF neighbor's JP aggregation list. This leaves a stale entry that becomes a dangling pointer after the upstream is eventually freed. When the neighbor's JP timer fires and iterates the list, it dereferences the freed upstream causing a SIGSEGV.

Fix by finding the RPF neighbor and removing the upstream from its JP agg list before nulling the interface.

Signed-off-by: Soumya Roy <souroy@nvidia.com>

#0  0x00007fe9c3aa8eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007fe9c3aa8eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007fe9c3a59fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007fe9c3d006ec in core_handler (signo=11, siginfo=0x7ffcae937770, context=<optimized out>) at ../lib/sigevent.c:261
#3  <signal handler called>
#4  0x000055aaf38fde25 in pim_msg_get_jp_group_size (sources=<optimized out>) at ../pimd/pim_msg.c:199
#5  0x000055aaf38fa268 in pim_joinprune_send (rpf=rpf@entry=0x7ffcae93a2e0, groups=<optimized out>) at ../pimd/pim_join.c:515
#6  0x000055aaf39016a4 in on_neighbor_jp_timer (t=<optimized out>) at ../pimd/pim_neighbor.c:256
#7  0x00007fe9c3d13371 in event_call (thread=thread@entry=0x7ffcae93a3e0) at ../lib/event.c:2016
#8  0x00007fe9c3cbceb0 in frr_run (master=0x55ab0c0befa0) at ../lib/libfrr.c:1242
#9  0x000055aaf38e112b in main (argc=<optimized out>, argv=0x7ffcae93a638, envp=<optimized out>) at ../pimd/pim_main.c:165
(gdb) 