### PR TITLE
pimd: reject truncated IP datagrams before IGMP/mtrace handling

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -663,6 +663,7 @@ bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, size_t *hlen)
 	int igmp_msg_len;
 	int msg_type;
 	size_t ip_hlen; /* ip header length in bytes */
+	uint16_t ip_total;
 
 	if (len < sizeof(*ip_hdr)) {
 		zlog_warn("IGMP packet size=%zu shorter than minimum=%zu", len,
@@ -680,8 +681,34 @@ bool pim_igmp_verify_header(struct ip *ip_hdr, size_t len, size_t *hlen)
 		return false;
 	}
 
+	/*
+	 * Reject if the IPv4 total length is larger than what we received
+	 * (e.g. recvmsg truncated a jumbo/reassembled datagram into buf[]).
+	 * Otherwise downstream code must not trust ip_len for sendto() length.
+	 */
+	ip_total = ntohs(ip_hdr->ip_len);
+
+	if (ip_total < sizeof(struct ip)) {
+		zlog_warn("IGMP packet ip_len=%u shorter than minimum IPv4 header", ip_total);
+		return false;
+	}
+	if (ip_total < ip_hlen) {
+		zlog_warn("IGMP packet ip_len=%u shorter than header length %zu", ip_total,
+			  ip_hlen);
+		return false;
+	}
+	if (ip_total > len) {
+		zlog_warn("IGMP packet ip_len=%u exceeds received length %zu (truncated or corrupt)",
+			  ip_total, len);
+		return false;
+	}
+
 	igmp_msg = (char *)ip_hdr + ip_hlen;
-	igmp_msg_len = len - ip_hlen;
+	/*
+	 * Use datagram length from ip_hdr, not recv buffer length (len may
+	 * include link-layer padding past ip_total).
+	 */
+	igmp_msg_len = ip_total - ip_hlen;
 
 	if (igmp_msg_len < PIM_IGMP_MIN_LEN) {
 		zlog_warn("IGMP message size=%d shorter than minimum=%d",
@@ -728,6 +755,7 @@ int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len)
 	const struct pim_interface *pim_interface = igmp->interface->info;
 	struct ip *ip_hdr = (struct ip *)buf;
 	size_t ip_hlen; /* ip header length in bytes */
+	uint16_t ip_total;
 	char *igmp_msg;
 	int igmp_msg_len;
 	int msg_type;
@@ -735,6 +763,8 @@ int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len)
 
 	if (!pim_igmp_verify_header(ip_hdr, len, &ip_hlen))
 		return -1;
+
+	ip_total = ntohs(ip_hdr->ip_len);
 
 	if (ip_hlen > sizeof(struct ip)) {
 		const uint8_t *ip_options = (const uint8_t *)(ip_hdr + 1);
@@ -755,7 +785,8 @@ int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len)
 	}
 
 	igmp_msg = buf + ip_hlen;
-	igmp_msg_len = len - ip_hlen;
+	/* Same as pim_igmp_verify_header(): use ip_total, not recv len (padding). */
+	igmp_msg_len = (int)(ip_total - ip_hlen);
 	msg_type = *igmp_msg;
 
 	if (PIM_DEBUG_GM_PACKETS) {

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -444,6 +444,16 @@ int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 	if (err < 0)
 		return err;
 
+	/*
+	 * Datagram was larger than the supplied buffer; ip_hdr->ip_len can
+	 * still describe the full wire size. Drop so callers never trust
+	 * length fields against a truncated buffer.
+	 */
+	if (msgh.msg_flags & MSG_TRUNC) {
+		errno = EMSGSIZE;
+		return -1;
+	}
+
 	if (fromlen)
 		*fromlen = msgh.msg_namelen;
 


### PR DESCRIPTION
- Validate IPv4 total length against recv buffer in pim_igmp_verify_header() so downstream code cannot trust ip_hdr->ip_len past the bytes we hold (e.g. mtrace sendto length).
- Drop recvmsg results with MSG_TRUNC in pim_socket_recvfromto() so callers never process a truncated buffer as a full datagram.