### PR TITLE
pimd: cap PIM Hello secondary address list parsing

### DIFF
--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -90,6 +90,23 @@ static void tlv_trace_list(const char *label, const char *tlv_name,
 		return (code);                                                 \
 	}
 
+/*
+ * Bound how many encoded unicast addresses we accept from one Hello
+ * address-list TLV. option_len is constrained by the received Hello buffer,
+ * so tlv_pastend already limits how large this TLV can be; a separate
+ * MTU-based bound cannot be tighter than option_len/min_encoding in normal
+ * reception paths. Apply PIM_HELLO_SECONDARY_ADDR_MAX last.
+ */
+static unsigned int pim_hello_secondary_addr_cap(uint16_t option_len)
+{
+	unsigned int min_sz = PIM_ENCODED_UCAST_MIN_SIZE;
+	unsigned int cap = option_len / min_sz;
+
+	if (cap > PIM_HELLO_SECONDARY_ADDR_MAX)
+		cap = PIM_HELLO_SECONDARY_ADDR_MAX;
+	return cap;
+}
+
 int pim_hello_recv(struct interface *ifp, pim_addr src_addr, uint8_t *tlv_buf,
 		   int tlv_buf_size)
 {
@@ -197,14 +214,16 @@ int pim_hello_recv(struct interface *ifp, pim_addr src_addr, uint8_t *tlv_buf,
 				FREE_ADDR_LIST_THEN_RETURN(-6);
 			}
 			break;
-		case PIM_MSG_OPTION_TYPE_ADDRESS_LIST:
-			if (pim_tlv_parse_addr_list(ifp->name, src_addr,
-						    &hello_options,
-						    &hello_option_addr_list,
-						    option_len, tlv_curr)) {
-				return -7;
+		case PIM_MSG_OPTION_TYPE_ADDRESS_LIST: {
+			unsigned int addr_cap = pim_hello_secondary_addr_cap(option_len);
+
+			if (pim_tlv_parse_addr_list(ifp->name, src_addr, &hello_options,
+						    &hello_option_addr_list, option_len, tlv_curr,
+						    addr_cap)) {
+				FREE_ADDR_LIST_THEN_RETURN(-7);
 			}
 			break;
+		}
 		case PIM_MSG_OPTION_TYPE_DM_STATE_REFRESH:
 			if (PIM_DEBUG_PIM_HELLO)
 				zlog_debug(

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -656,12 +656,12 @@ int pim_parse_addr_source(pim_sgaddr *sg, uint8_t *flags, const uint8_t *buf,
 	}
 
 int pim_tlv_parse_addr_list(const char *ifname, pim_addr src_addr,
-			    pim_hello_options *hello_options,
-			    struct list **hello_option_addr_list,
-			    uint16_t option_len, const uint8_t *tlv_curr)
+			    pim_hello_options *hello_options, struct list **hello_option_addr_list,
+			    uint16_t option_len, const uint8_t *tlv_curr, unsigned int max_addrs)
 {
 	const uint8_t *addr;
 	const uint8_t *pastend;
+	unsigned int stored_count = 0;
 
 	assert(hello_option_addr_list);
 
@@ -726,6 +726,16 @@ int pim_tlv_parse_addr_list(const char *ifname, pim_addr src_addr,
 				__func__, &src_addr, ifname);
 			continue;
 		}
+
+		if (stored_count >= max_addrs) {
+			if (PIM_DEBUG_PIM_HELLO)
+				zlog_debug("%s: secondary address list exceeds max=%u (option_len=%u): from %pPAs on %s",
+					   __func__, max_addrs, option_len, &src_addr, ifname);
+			FREE_ADDR_LIST(*hello_option_addr_list);
+			return -2;
+		}
+
+		stored_count++;
 
 		/*
 		  Allocate list if needed

--- a/pimd/pim_tlv.h
+++ b/pimd/pim_tlv.h
@@ -89,9 +89,8 @@ int pim_tlv_parse_generation_id(const char *ifname, pim_addr src_addr,
 				uint32_t *hello_option_generation_id,
 				uint16_t option_len, const uint8_t *tlv_curr);
 int pim_tlv_parse_addr_list(const char *ifname, pim_addr src_addr,
-			    pim_hello_options *hello_options,
-			    struct list **hello_option_addr_list,
-			    uint16_t option_len, const uint8_t *tlv_curr);
+			    pim_hello_options *hello_options, struct list **hello_option_addr_list,
+			    uint16_t option_len, const uint8_t *tlv_curr, unsigned int max_addrs);
 
 int pim_encode_addr_ucast(uint8_t *buf, pim_addr addr);
 int pim_encode_addr_ucast_prefix(uint8_t *buf, struct prefix *p);

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -37,8 +37,21 @@
 #define PIM_PIM_MIN_LEN               PIM_MSG_HEADER_LEN
 
 #define PIM_ENCODED_IPV4_UCAST_SIZE    (6)
+#define PIM_ENCODED_IPV6_UCAST_SIZE    (18) /* RFC 7761 encoded unicast, native IPv6 */
 #define PIM_ENCODED_IPV4_GROUP_SIZE    (8)
 #define PIM_ENCODED_IPV4_SOURCE_SIZE   (8)
+
+#if PIM_IPV == 4
+#define PIM_ENCODED_UCAST_MIN_SIZE PIM_ENCODED_IPV4_UCAST_SIZE
+#else
+#define PIM_ENCODED_UCAST_MIN_SIZE PIM_ENCODED_IPV6_UCAST_SIZE
+#endif
+
+/*
+ * Secondary address list on PIM Hellos is attacker-controlled length; bound
+ * stored entries (see pim_tlv_parse_addr_list).
+ */
+#define PIM_HELLO_SECONDARY_ADDR_MAX (512)
 
 /*
  * J/P Message Format, Group Header


### PR DESCRIPTION
Bound how many encoded unicast addresses we accept from a single PIM_MSG_OPTION_TYPE_ADDRESS_LIST TLV. The cap is the minimum of limits derived from interface MTU, TLV length, and PIM_HELLO_SECONDARY_ADDR_MAX.

Reject with cleanup when exceeded to avoid unbounded allocation from link-local Hellos. Free the temporary address list on parse failure in pim_hello_recv.