### PR TITLE
zebra: align ctx nh cursor with RIB when skipping DUPLICATE nexthops

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -806,14 +806,17 @@ struct nexthop *nexthop_next_resolution(const struct nexthop *nexthop,
 	return nexthop->next;
 }
 
-/* Return the next nexthop in the tree that is resolved and active */
+/* Return the next nexthop in the tree that is resolved, active, and not a
+ * duplicate-expanded copy (NEXTHOP_FLAG_DUPLICATE). The latter keeps sequential
+ * walks aligned with RIB iterations that skip duplicate nh.
+ */
 struct nexthop *nexthop_next_active_resolved(const struct nexthop *nexthop)
 {
 	struct nexthop *next = nexthop_next(nexthop);
 
-	while (next
-	       && (CHECK_FLAG(next->flags, NEXTHOP_FLAG_RECURSIVE)
-		   || !CHECK_FLAG(next->flags, NEXTHOP_FLAG_ACTIVE)))
+	while (next && (CHECK_FLAG(next->flags, NEXTHOP_FLAG_RECURSIVE) ||
+			!CHECK_FLAG(next->flags, NEXTHOP_FLAG_ACTIVE) ||
+			CHECK_FLAG(next->flags, NEXTHOP_FLAG_DUPLICATE)))
 		next = nexthop_next(next);
 
 	return next;

--- a/tests/topotests/bgp_evpn_three_tier_clos_topo1/ipv4/tor-21/type5_prefix1.json
+++ b/tests/topotests/bgp_evpn_three_tier_clos_topo1/ipv4/tor-21/type5_prefix1.json
@@ -14,7 +14,7 @@
       "internalFlags": 8,
       "internalNextHopNum": 4,
       "internalNextHopActiveNum": 4,
-      "internalNextHopFibInstalledNum": 1,
+      "internalNextHopFibInstalledNum": 2,
       "nexthops": [
         {
           "flags": 267,
@@ -37,7 +37,8 @@
           "weight": 1
         },
         {
-          "flags": 265,
+          "flags": 267,
+          "fib": true,
           "ip": "10.0.0.2",
           "afi": "ipv4",
           "interfaceName": "vlan4001",

--- a/tests/topotests/bgp_evpn_three_tier_clos_topo1/ipv6/tor-21/type5_prefix1.json
+++ b/tests/topotests/bgp_evpn_three_tier_clos_topo1/ipv6/tor-21/type5_prefix1.json
@@ -14,6 +14,7 @@
       "internalFlags":8,
       "internalNextHopNum":4,
       "internalNextHopActiveNum":4,
+      "internalNextHopFibInstalledNum":2,
       "nexthops": [
         {
           "flags": 267,
@@ -36,7 +37,8 @@
           "weight": 1
         },
         {
-          "flags": 265,
+          "flags": 267,
+          "fib": true,
           "ip": "fd00:0:20::2",
           "afi": "ipv6",
           "interfaceName": "vlan4001",

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1710,14 +1710,13 @@ static bool rib_update_nhg_from_ctx(struct nexthop_group *re_nhg,
 	bool matched_p = true;
 	struct nexthop *nexthop, *ctx_nexthop;
 
-	/* Get the first `installed` one to check against.
-	 * If the dataplane doesn't set these to be what was actually installed,
-	 * it will just be whatever was in re->nhe->nhg?
+	/* First ctx nh must match the RIB walk: active, non-recursive,
+	 * non-duplicate (nexthop_next_active_resolved skips duplicate nh).
 	 */
 	ctx_nexthop = ctx_nhg->nexthop;
-
-	if (CHECK_FLAG(ctx_nexthop->flags, NEXTHOP_FLAG_RECURSIVE)
-	    || !CHECK_FLAG(ctx_nexthop->flags, NEXTHOP_FLAG_ACTIVE))
+	if (ctx_nexthop && (CHECK_FLAG(ctx_nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ||
+			    !CHECK_FLAG(ctx_nexthop->flags, NEXTHOP_FLAG_ACTIVE) ||
+			    CHECK_FLAG(ctx_nexthop->flags, NEXTHOP_FLAG_DUPLICATE)))
 		ctx_nexthop = nexthop_next_active_resolved(ctx_nexthop);
 
 	for (ALL_NEXTHOPS_PTR(re_nhg, nexthop)) {


### PR DESCRIPTION
After a successful dataplane install, rib_update_nhg_from_ctx() mirrors NEXTHOP_FLAG_FIB from the dplane ctx nexthop list onto RIB nexthops using nexthop_same(). The RIB walk skips NEXTHOP_FLAG_DUPLICATE nh, but the ctx cursor advanced only with nexthop_next_active_resolved(), which did not skip duplicates. The cursor could then desync from the RIB iteration under ECMP with duplicate-expanded nh, clearing FIB on the wrong RIB nh and skewing per-nh fib / internalNextHopFibInstalledNum in JSON.

Skip DUPLICATE in nexthop_next_active_resolved() so sequential ctx advances match the non-duplicate RIB walk, and seed the initial ctx nh with a loop until the first nh is active, non-recursive, and non-duplicate (the iterator starts from nexthop_next(current), so the head of the list must be handled explicitly).

As you see below output , it is not proper according to kernel nh, fib 'true' is set only for one nh instead of two nh's and internalNextHopFibInstalledNum is wrong
With fix, we can see fib 'true' is properly set for expected two nh and also internalNextHopFibInstalledNum count is proper.

Without changes:
show ipv6 route vrf vrf1 2081:1:1:1::/64 json
{
  "2081:1:1:1::/64":[
    {
      "prefix":"2081:1:1:1::/64",
      "prefixLen":64,
      "protocol":"bgp",
      "vrfId":12,
      "vrfName":"vrf1",
      "selected":true,
      "destSelected":true,
      "distance":20,
      "metric":0,
      "installed":true,
      "table":1001,
      "internalStatus":16,
      "internalFlags":8,
      "internalNextHopNum":4,
      "internalNextHopActiveNum":4,
      "internalNextHopFibInstalledNum":1,
      "nexthopGroupId":185,
      "installedNexthopGroupId":185,
      "receivedNexthopGroupId":185,
      "uptime":"00:01:26",
      "nexthops":[
        {
          "flags":267,
          "fib":true,
          "ip":"::ffff:6.0.0.1",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        },
        {
          "flags":281,
          "duplicate":true,
          "ip":"::ffff:6.0.0.1",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        },
        {
          "flags":265,
          "ip":"::ffff:6.0.0.2",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        },
        {
          "flags":281,
          "duplicate":true,
          "ip":"::ffff:6.0.0.2",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        }
      ],
      "flags":8,
      "status":16
    }
  ]
}
root@tor-22:mgmt:~# ip -6 route show table 1001 2081:1:1:1::/64 2081:1:1:1::/64 nhid 185 proto bgp metric 20 pref medium root@tor-22:mgmt:~# ip -6 route show vrf vrf1 2081:1:1:1::/64 2081:1:1:1::/64 nhid 185 proto bgp metric 20 pref medium root@tor-22:mgmt:~#  ip -d -6 route show table 1001 2081:1:1:1::/64 unicast 2081:1:1:1::/64 nhid 185 proto bgp scope global metric 20 pref medium
	nh_info id 185 group 101/139 scope global proto zebra
root@tor-22:mgmt:~#

root@tor-22:mgmt:~# vtysh -c 'show ipv6 route vrf vrf1 2081:1:1:1::/64' Routing entry for 2081:1:1:1::/64
  Known via "bgp", distance 20, metric 0, vrf vrf1, best
  Last update 00:07:47 ago
  Flags: Selected
  Status: Installed
  * ::ffff:6.0.0.1, via vlan4001 onlink, weight 1 ::ffff:6.0.0.1, via vlan4001 (duplicate nexthop removed) onlink, weight 1
  * ::ffff:6.0.0.2, via vlan4001 onlink, weight 1 ::ffff:6.0.0.2, via vlan4001 (duplicate nexthop removed) onlink, weight 1

With changes:
 {
      "prefix":"2081:1:1:1::/64",
      "prefixLen":64,
      "protocol":"bgp",
      "vrfId":12,
      "vrfName":"vrf1",
      "selected":true,
      "destSelected":true,
      "distance":20,
      "metric":0,
      "installed":true,
      "table":1001,
      "internalStatus":16,
      "internalFlags":8,
      "internalNextHopNum":4,
      "internalNextHopActiveNum":4,
      "internalNextHopFibInstalledNum":2,
      "nexthopGroupId":168,
      "installedNexthopGroupId":168,
      "receivedNexthopGroupId":168,
      "uptime":"00:02:40",
      "nexthops":[
        {
          "flags":267,
          "fib":true,
          "ip":"::ffff:6.0.0.1",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        },
        {
          "flags":281,
          "duplicate":true,
          "ip":"::ffff:6.0.0.1",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        },
        {
          "flags":267,
          "fib":true,
          "ip":"::ffff:6.0.0.2",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        },
        {
          "flags":281,
          "duplicate":true,
          "ip":"::ffff:6.0.0.2",
          "afi":"ipv6",
          "interfaceIndex":18,
          "interfaceName":"vlan4001",
          "active":true,
          "onLink":true,
          "weight":1
        }
      ],
      "flags":8,
      "status":16
    } ] }