### PR TITLE
pathd: add optional params to `no` cmd versions for frr-reload

### DIFF
--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -486,15 +486,16 @@ int segment_list_has_prefix(
  */
 /* clang-format off */
 DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
-      "index (0-4294967295)$index <[mpls$has_mpls_label label (16-1048575)$label] "
+      "[no] index (0-4294967295)$index ![mpls$has_mpls_label label (16-1048575)$label"
       "|"
-      "[nai$has_nai <"
+      "nai$has_nai <"
       "prefix <A.B.C.D/M$prefix_ipv4|X:X::X:X/M$prefix_ipv6>"
       "<algorithm$has_algo (0-1)$algo| iface$has_iface_id (0-4294967295)$iface_id>"
       "| adjacency$has_adj "
       "<A.B.C.D$adj_src_ipv4 A.B.C.D$adj_dst_ipv4|X:X::X:X$adj_src_ipv6 X:X::X:X$adj_dst_ipv6>"
-      ">]"
-      ">",
+      ">"
+      "]",
+      NO_STR
       "Index\n"
       "Index Value\n"
       "MPLS or IP Label\n"
@@ -518,8 +519,13 @@ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
 	char xpath[XPATH_MAXLEN];
 	int status = CMD_SUCCESS;
 
-
 	snprintf(xpath, sizeof(xpath), "./segment[index='%s']", index_str);
+
+	if (no) {
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+		return nb_cli_apply_changes(vty, NULL);
+	}
+
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 
 	if (has_mpls_label != NULL) {
@@ -545,21 +551,6 @@ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
 		if (status != CMD_SUCCESS)
 			return status;
 	}
-
-	return nb_cli_apply_changes(vty, NULL);
-}
-
-DEFPY_YANG(srte_segment_list_no_segment,
-      srte_segment_list_no_segment_cmd,
-      "no index (0-4294967295)$index",
-      NO_STR
-      "Index\n"
-      "Index Value\n")
-{
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), "./segment[index='%s']", index_str);
-	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -1364,10 +1355,7 @@ void path_cli_init(void)
 	install_element(SEGMENT_ROUTING_NODE, &sr_no_traffic_eng_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_segment_list_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_no_segment_list_cmd);
-	install_element(SR_SEGMENT_LIST_NODE,
-			&srte_segment_list_segment_cmd);
-	install_element(SR_SEGMENT_LIST_NODE,
-			&srte_segment_list_no_segment_cmd);
+	install_element(SR_SEGMENT_LIST_NODE, &srte_segment_list_segment_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_policy_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &srte_no_policy_cmd);
 	install_element(SR_POLICY_NODE, &srte_policy_name_cmd);

--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -25,11 +25,12 @@
 static struct ls_ted *path_ted_create_ted(void);
 static void path_ted_register_vty(void);
 static void path_ted_unregister_vty(void);
-static uint32_t path_ted_start_importing_igp(const char *daemon_str);
+static uint32_t path_ted_start_importing_igp(enum igp_import daemon);
 static uint32_t path_ted_stop_importing_igp(void);
 static enum zclient_send_status path_ted_link_state_sync(void);
 static void path_ted_timer_handler_sync(struct event *event);
 static void path_ted_timer_handler_refresh(struct event *event);
+static enum igp_import str2igp_import(const char *str);
 
 extern struct zclient *pathd_zclient;
 
@@ -66,18 +67,18 @@ uint32_t path_ted_teardown(void)
  * @return		true if ok
  *
  */
-uint32_t path_ted_start_importing_igp(const char *daemon_str)
+uint32_t path_ted_start_importing_igp(enum igp_import daemon)
 {
 	uint32_t status = 0;
 
-	if (strcmp(daemon_str, "ospfv2") == 0)
-		ted_state_g.import = IMPORT_OSPFv2;
-	else if (strcmp(daemon_str, "ospfv3") == 0) {
-		ted_state_g.import = IMPORT_UNKNOWN;
-		return 1;
-	} else if (strcmp(daemon_str, "isis") == 0)
-		ted_state_g.import = IMPORT_ISIS;
-	else {
+	switch (daemon) {
+	case IMPORT_OSPFv2:
+	case IMPORT_ISIS:
+		ted_state_g.import = daemon;
+		break;
+	case IMPORT_OSPFv3:
+	case IMPORT_UNKNOWN:
+	default:
 		ted_state_g.import = IMPORT_UNKNOWN;
 		return 1;
 	}
@@ -406,7 +407,8 @@ DEFUN (no_path_ted,
 /* clang-format off */
 DEFPY(path_ted_import,
        path_ted_import_cmd,
-       "mpls-te import <ospfv2|ospfv3|isis>$import_daemon",
+       "[no] mpls-te import ![ospfv2|ospfv3|isis]$import_daemon",
+       NO_STR
        "Enable the TE database (TED) fill with remote igp data\n"
        "import\n"
        "Origin ospfv2\n"
@@ -414,34 +416,32 @@ DEFPY(path_ted_import,
        "Origin isis\n")
 /* clang-format on */
 {
+	enum igp_import daemon;
 
-	if (ted_state_g.enabled)
-		if (path_ted_start_importing_igp(import_daemon)) {
-			vty_out(vty, "Unable to start importing\n");
-			return CMD_WARNING;
-		}
-	return CMD_SUCCESS;
-}
-
-/* clang-format off */
-DEFUN (no_path_ted_import,
-       no_path_ted_import_cmd,
-       "no mpls-te import",
-       NO_STR
-       NO_STR
-       "Disable the TE Database fill with remote igp data\n")
-/* clang-format on */
-{
-
-	if (ted_state_g.import) {
-		if (path_ted_stop_importing_igp()) {
-			vty_out(vty, "Unable to stop importing\n");
-			return CMD_WARNING;
+	if (no) {
+		if (ted_state_g.import) {
+			/* If no import_daemon given - disable current, otherwise check */
+			if (import_daemon != NULL) {
+				daemon = str2igp_import(import_daemon);
+				if (daemon != ted_state_g.import) {
+					PATH_TED_DEBUG("%s: PATHD-TED: Requested to disable import for %s, but import is active for another daemon. Ignoring.",
+						       __func__, import_daemon);
+					return CMD_SUCCESS;
+				}
+			}
+			if (path_ted_stop_importing_igp()) {
+				vty_out(vty, "Unable to stop importing\n");
+				return CMD_WARNING;
+			}
 		} else {
-			PATH_TED_DEBUG(
-				"%s: PATHD-TED: Importing igp data already OFF",
-				__func__);
+			PATH_TED_DEBUG("%s: PATHD-TED: Importing igp data already OFF", __func__);
 		}
+	} else {
+		if (ted_state_g.enabled)
+			if (path_ted_start_importing_igp(str2igp_import(import_daemon))) {
+				vty_out(vty, "Unable to start importing\n");
+				return CMD_WARNING;
+			}
 	}
 	return CMD_SUCCESS;
 }
@@ -506,6 +506,22 @@ uint32_t path_ted_config_write(struct vty *vty)
 }
 
 /**
+ * Convert string to igp_import
+ */
+static enum igp_import str2igp_import(const char *str)
+{
+	if (!str)
+		return IMPORT_UNKNOWN;
+	if (strcmp(str, "isis") == 0)
+		return IMPORT_ISIS;
+	else if (strcmp(str, "ospfv2") == 0)
+		return IMPORT_OSPFv2;
+	else if (strcmp(str, "ospfv3") == 0)
+		return IMPORT_OSPFv3;
+	return IMPORT_UNKNOWN;
+}
+
+/**
  * Register the fn's for CLI and hook for config show
  *
  * @param void
@@ -517,7 +533,6 @@ static void path_ted_register_vty(void)
 	install_element(SR_TRAFFIC_ENG_NODE, &path_ted_on_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_cmd);
 	install_element(SR_TRAFFIC_ENG_NODE, &path_ted_import_cmd);
-	install_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_import_cmd);
 
 	install_element(CONFIG_NODE, &debug_path_ted_cmd);
 	install_element(ENABLE_NODE, &debug_path_ted_cmd);
@@ -537,7 +552,6 @@ static void path_ted_unregister_vty(void)
 	uninstall_element(SR_TRAFFIC_ENG_NODE, &path_ted_on_cmd);
 	uninstall_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_cmd);
 	uninstall_element(SR_TRAFFIC_ENG_NODE, &path_ted_import_cmd);
-	uninstall_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_import_cmd);
 }
 
 /**


### PR DESCRIPTION
Commands

* no index
* no mpls-te import

missed parameters of not `no` versions, this creates problems for `frr-reload.py`.

What is being fixed: trying to reload from config

```
!
segment-routing
 traffic-eng
  mpls-te on
  mpls-te import ospfv2
  segment-list sl1
   index 25 mpls label 500
  exit
 exit
exit
!
```

to config
```
!
segment-routing
 traffic-eng
  mpls-te on
  segment-list sl1
   index 25 mpls label 700
  exit
 exit
exit
!
```

Gives:

```
vyos@r1:~$ sudo /usr/lib/frr/frr-reload.py --test frr.conf
...

Lines To Delete
===============
segment-routing
 traffic-eng
  no mpls-te import ospfv2
 exit
exit
segment-routing
 traffic-eng
  segment-list sl1
   no index 25 mpls label 500
  exit
 exit
exit

Lines To Add
============
segment-routing
 traffic-eng
  segment-list sl1
   index 25 mpls label 700
  exit
 exit
exit
```

But command `no mpls-te import` doesn't have last parameter and `no index`  accepts only number.

Fix this by merging `mpls-te import` and `no mpls-te import`, merge `index` and `no index`.

For `no mpls-te import` I've checked that activated protocol is same as given and ignored command if not.
For `no index` it seemed too much work that is not needed, so I simply ignore all parameters.
This made previously required parameters optional, so I check they are given in code and return `CMD_ERR_INCOMPLETE` when they are missing.