### PR TITLE
add successful commit info msg

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -573,8 +573,7 @@ failed:
 /* Apply Config Message Handling */
 /* ----------------------------- */
 
-static int mgmt_be_send_apply_reply(struct mgmt_be_client *client_ctx,
-				    uint64_t txn_id, bool success,
+static int mgmt_be_send_apply_reply(struct mgmt_be_client *client_ctx, uint64_t txn_id,
 				    const char *error_if_any)
 {
 	struct mgmt_msg_cfg_apply_reply *msg;
@@ -584,6 +583,9 @@ static int mgmt_be_send_apply_reply(struct mgmt_be_client *client_ctx,
 					MTYPE_MSG_NATIVE_CFG_APPLY_REPLY);
 	msg->code = MGMT_MSG_CODE_CFG_APPLY_REPLY;
 	msg->refer_id = txn_id;
+
+	if (error_if_any && error_if_any[0])
+		mgmt_msg_native_add_str(msg, error_if_any);
 
 	debug_be_client("Sending CFG_APPLY_REPLY txn-id %" PRIu64, txn_id);
 
@@ -598,7 +600,7 @@ static bool mgmt_be_txn_proc_cfgapply(struct mgmt_be_txn_ctx *txn)
 	struct timeval apply_nb_cfg_start;
 	struct timeval apply_nb_cfg_end;
 	unsigned long apply_nb_cfg_tm;
-	char err_buf[BUFSIZ];
+	char err_buf[BUFSIZ] = {};
 	bool disconnect;
 
 	assert(txn && txn->client);
@@ -621,7 +623,8 @@ static bool mgmt_be_txn_proc_cfgapply(struct mgmt_be_txn_ctx *txn)
 	client_ctx->num_apply_nb_cfg++;
 	txn->nb_txn = NULL;
 
-	disconnect = !!mgmt_be_send_apply_reply(client_ctx, txn->txn_id, true, NULL);
+	disconnect = !!mgmt_be_send_apply_reply(client_ctx, txn->txn_id,
+						err_buf[0] ? err_buf : NULL);
 
 	debug_be_client("Nb-apply-duration %lu (avg: %Lu) uSec", apply_nb_cfg_tm,
 			client_ctx->avg_apply_nb_cfg_tm);

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -413,6 +413,7 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 	struct mgmt_msg_header *orig_msg = NULL;
 	const char *xpath = NULL;
 	const char *data = NULL;
+	const char *info = NULL;
 	uint16_t orig_code;
 	size_t dlen;
 
@@ -567,13 +568,20 @@ generic_error_handler:
 		if (!session->client->cbs.commit_config_notify)
 			break;
 		commit_msg = (typeof(commit_msg))msg;
+		if (msg_len > sizeof(*commit_msg)) {
+			if (!MGMT_MSG_VALIDATE_NUL_TERM(commit_msg, msg_len)) {
+				log_err_fe_client("Corrupt commit-reply msg recv");
+				break;
+			}
+			info = (const char *)(commit_msg + 1);
+		}
 		session->client->cbs.commit_config_notify(client, client->user_data,
 							  session->client_id, session->session_id,
 							  session->user_ctx, msg->req_id, true,
 							  commit_msg->source, commit_msg->target,
 							  commit_msg->action ==
 								  MGMT_MSG_COMMIT_VALIDATE,
-							  commit_msg->unlock, NULL);
+							  commit_msg->unlock, info);
 
 		break;
 	case MGMT_MSG_CODE_LOCK_REPLY:
@@ -611,19 +619,25 @@ generic_error_handler:
 
 		edit_msg = (typeof(edit_msg))msg;
 		if (msg_len < sizeof(*edit_msg)) {
-			log_err_fe_client("Corrupt edit-reply msg recv");
+			log_err_fe_client("Corrupt edit-reply msg recv: short len");
 			break;
 		}
 
 		xpath = mgmt_msg_native_xpath_decode(edit_msg, msg_len);
 		if (!xpath) {
-			log_err_fe_client("Corrupt edit-reply msg recv");
+			log_err_fe_client("Corrupt edit-reply msg recv: no xpath");
+			break;
+		}
+
+		info = mgmt_msg_native_data_decode(edit_msg, msg_len);
+		if (info && !MGMT_MSG_VALIDATE_NUL_TERM(edit_msg, msg_len)) {
+			log_err_fe_client("Corrupt edit-reply msg recv: bad info");
 			break;
 		}
 
 		session->client->cbs.edit_notify(client, client->user_data, session->client_id,
 						 msg->refer_id, session->user_ctx, msg->req_id,
-						 xpath, 0, NULL);
+						 xpath, 0, info);
 		break;
 	case MGMT_MSG_CODE_RPC_REPLY:
 		if (!session->client->cbs.rpc_notify)

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -71,7 +71,7 @@ struct mgmt_fe_client_cbs {
 				     uint64_t client_id, uintptr_t session_id,
 				     uintptr_t user_session_client, uint64_t req_id, bool success,
 				     enum mgmt_ds_id src_ds_id, enum mgmt_ds_id dst_ds_id,
-				     bool validate_only, bool unlock, char *errmsg_if_any);
+				     bool validate_only, bool unlock, const char *errmsg_if_any);
 
 	/* Called when get-tree result is returned */
 	int (*get_tree_notify)(struct mgmt_fe_client *client, uintptr_t user_data,

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -711,6 +711,9 @@ struct mgmt_msg_cfg_apply_req {
  * struct mgmt_msg_cfg_apply_reply - Signal the config has been applied.
  *
  * @refer_id: The transaction ID which was applied.
+ *
+ * Optional variable data after the header contains a NUL-terminated
+ * informational message string from the backend's northbound callbacks.
  */
 struct mgmt_msg_cfg_apply_reply {
 	struct mgmt_msg_header;
@@ -977,13 +980,13 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *	The secondary data or NULL if there was an error decoding (i.e., the
  *	message is corrupt).
  */
-#define mgmt_msg_native_data_decode(msg, msglen)                                                   \
-	({                                                                                         \
-		size_t _m__len = (msglen) - sizeof(*msg);                                          \
-		const char *_m__data = msg->data + msg->vsplit;                                    \
-		if (!msg->vsplit || msg->vsplit > _m__len || _m__data[-1] != 0)                    \
-			_m__data = NULL;                                                           \
-		_m__data;                                                                          \
+#define mgmt_msg_native_data_decode(msg, msglen)                                                  \
+	({                                                                                        \
+		size_t _m__len = (msglen) - sizeof(*msg);                                         \
+		const char *_m__data = msg->data + msg->vsplit;                                   \
+		if (!msg->vsplit || msg->vsplit >= _m__len || _m__data[-1] != 0)                  \
+			_m__data = NULL;                                                          \
+		_m__data;                                                                         \
 	})
 
 /**

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -546,9 +546,21 @@ static void be_adapter_process_msg(uint8_t version, uint8_t *data, size_t msg_le
 	case MGMT_MSG_CODE_CFG_REPLY:
 		mgmt_txn_handle_cfg_reply(msg->refer_id, adapter);
 		return;
-	case MGMT_MSG_CODE_CFG_APPLY_REPLY:
-		mgmt_txn_handle_cfg_apply_reply(msg->refer_id, adapter);
+	case MGMT_MSG_CODE_CFG_APPLY_REPLY: {
+		const char *errmsg = NULL;
+
+		if (msg_len > sizeof(struct mgmt_msg_cfg_apply_reply)) {
+			if (!MGMT_MSG_VALIDATE_NUL_TERM((struct mgmt_msg_cfg_apply_reply *)msg,
+							msg_len)) {
+				_log_err("Corrupt CFG_APPLY_REPLY from adapter %s", adapter->name);
+				msg_conn_disconnect(adapter->conn, false);
+				return;
+			}
+			errmsg = (const char *)(msg + 1);
+		}
+		mgmt_txn_handle_cfg_apply_reply(msg->refer_id, adapter, errmsg);
 		return;
+	}
 	case MGMT_MSG_CODE_ERROR:
 		error_msg = (typeof(error_msg))msg;
 		mgmt_txn_handle_error_reply(adapter, msg->refer_id, msg->req_id, error_msg->error,

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -623,7 +623,7 @@ int mgmt_fe_adapter_txn_error(uint64_t txn_id, uint64_t req_id, bool short_circu
 
 static void fe_session_send_commit_reply(struct mgmt_fe_session_ctx *session, uint64_t req_id,
 					 uint8_t source, uint8_t target, uint8_t action,
-					 bool unlock)
+					 bool unlock, const char *info)
 {
 	struct mgmt_msg_commit_reply *msg;
 	int ret;
@@ -637,6 +637,9 @@ static void fe_session_send_commit_reply(struct mgmt_fe_session_ctx *session, ui
 	msg->target = target;
 	msg->action = action;
 	msg->unlock = unlock;
+
+	if (info && info[0])
+		mgmt_msg_native_add_str(msg, info);
 
 	_dbg("Sending commit-reply session-id %Lu on %s req-id %Lu source-ds: %s target-ds: %s action: %u unlock: %d",
 	     session->session_id, session->adapter->name, req_id, mgmt_ds_id2name(source),
@@ -705,7 +708,8 @@ int mgmt_fe_send_commit_cfg_reply(uint64_t session_id, uint64_t txn_id, enum mgm
 	fe_session_compute_commit_timers(&session->adapter->cmt_stats);
 
 	if (result == MGMTD_SUCCESS || result == MGMTD_NO_CFG_CHANGES)
-		fe_session_send_commit_reply(session, req_id, src_ds_id, dst_ds_id, action, unlock);
+		fe_session_send_commit_reply(session, req_id, src_ds_id, dst_ds_id, action, unlock,
+					     error_if_any);
 	else {
 		ret = fe_session_send_error(
 			session, req_id, false, mgmt_result_to_error(result),

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -148,6 +148,14 @@ const struct frr_yang_module_info zebra_route_map_info = {
 	.nodes = { { .xpath = NULL } },
 };
 
+#ifdef HAVE_MGMTD_TESTC
+static const struct frr_yang_module_info frr_test_config_info = {
+	.name = "frr-test-config",
+	.ignore_cfg_cbs = true,
+	.nodes = { { .xpath = NULL } },
+};
+#endif
+
 /*
  * List of YANG modules to be loaded in the process context of
  * MGMTd.
@@ -184,6 +192,9 @@ static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 #endif
 #ifdef HAVE_STATICD
 	&frr_staticd_cli_info,
+#endif
+#ifdef HAVE_MGMTD_TESTC
+	&frr_test_config_info,
 #endif
 };
 

--- a/mgmtd/mgmt_testc.c
+++ b/mgmtd/mgmt_testc.c
@@ -21,6 +21,8 @@
 
 static void async_notification(struct nb_cb_notify_args *args);
 static int rpc_callback(struct nb_cb_rpc_args *args);
+static int test_config_modify(struct nb_cb_modify_args *args);
+static int test_config_destroy(struct nb_cb_destroy_args *args);
 
 static void sigusr1(void);
 static void sigint(void);
@@ -151,11 +153,26 @@ static const struct frr_yang_module_info frr_zebra_info = {
 	}
 };
 
+static const struct frr_yang_module_info frr_test_config_info = {
+	.name = "frr-test-config",
+	.nodes = {
+		{
+			.xpath = "/frr-test-config:frr-test-config/test-value",
+			.cbs.modify = test_config_modify,
+			.cbs.destroy = test_config_destroy,
+		},
+		{
+			.xpath = NULL,
+		}
+	}
+};
+
 static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	&frr_backend_info,
 	&frr_if_info,
 	&frr_ripd_info,
 	&frr_routing_info,
+	&frr_test_config_info,
 	&frr_vrf_info,
 	&frr_zebra_info,
 };
@@ -176,6 +193,7 @@ FRR_DAEMON_INFO(mgmtd_testc, MGMTD_TESTC,
 	);
 /* clang-format on */
 
+const char **_config_xpaths;
 const char **_notif_xpaths;
 const char **_rpc_xpaths;
 const char **_oper_xpaths;
@@ -202,7 +220,7 @@ static FRR_NORETURN void quit(int exit_code)
 	mgmt_be_client_destroy(mgmt_be_client);
 
 	event_cancel(&event_timeout);
-	darr_free(_client_cbs.config_xpaths);
+	darr_free(_config_xpaths);
 	darr_free(_client_cbs.oper_xpaths);
 	darr_free(_client_cbs.notify_xpaths);
 	darr_free(_client_cbs.rpc_xpaths);
@@ -322,6 +340,28 @@ static void async_notification(struct nb_cb_notify_args *args)
 		_notification(args);
 }
 
+static int test_config_modify(struct nb_cb_modify_args *args)
+{
+	const char *value;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	value = yang_dnode_get_string(args->dnode, NULL);
+	snprintf(args->errmsg, args->errmsg_len, "test-value set to '%s'", value);
+
+	return NB_OK;
+}
+
+static int test_config_destroy(struct nb_cb_destroy_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	snprintf(args->errmsg, args->errmsg_len, "test-value deleted");
+	return NB_OK;
+}
+
 static int rpc_callback(struct nb_cb_rpc_args *args)
 {
 	const char *vrf = NULL;
@@ -398,6 +438,10 @@ int main(int argc, char **argv)
 		_client_cbs.notify_xpaths = _notif_xpaths;
 		_client_cbs.nnotify_xpaths = darr_len(_notif_xpaths);
 	}
+
+	darr_push(_config_xpaths, "/frr-test-config:frr-test-config");
+	_client_cbs.config_xpaths = _config_xpaths;
+	_client_cbs.nconfig_xpaths = darr_len(_config_xpaths);
 
 	darr_push(_oper_xpaths, "/frr-backend:clients");
 	_client_cbs.oper_xpaths = _oper_xpaths;

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -182,8 +182,8 @@ extern int mgmt_txn_rollback_trigger_cfg_apply(struct mgmt_ds_ctx *src_ds_ctx,
 /* ---------------------------------------- */
 
 extern void mgmt_txn_handle_cfg_reply(uint64_t txn_id, struct mgmt_be_client_adapter *adapter);
-extern void mgmt_txn_handle_cfg_apply_reply(uint64_t txn_id,
-					    struct mgmt_be_client_adapter *adapter);
+extern void mgmt_txn_handle_cfg_apply_reply(uint64_t txn_id, struct mgmt_be_client_adapter *adapter,
+					    const char *errmsg);
 extern void mgmt_txn_handle_error_reply(struct mgmt_be_client_adapter *adapter, uint64_t txn_id,
 					uint64_t req_id, int error, const char *errstr);
 extern int mgmt_txn_handle_be_adapter_connect(struct mgmt_be_client_adapter *adapter, bool connect);

--- a/mgmtd/mgmt_txn_cfg.c
+++ b/mgmtd/mgmt_txn_cfg.c
@@ -62,6 +62,8 @@ struct txn_req_commit {
 	uint64_t clients;      /* interested clients */
 	uint64_t clients_wait; /* set when cfg_req sent */
 
+	char *info_msgs; /* darr: collected info messages from backends */
+
 	struct mgmt_commit_stats *cmt_stats;
 };
 #define as_commit(txn_req)                                                                        \
@@ -123,6 +125,7 @@ void txn_cfg_cleanup(struct txn_req *txn_req)
 	_dbg("Deleting COMMITCFG req-id: %Lu txn-id: %Lu", txn_req->req_id, txn_id);
 
 	XFREE(MTYPE_MGMTD_TXN_REQ, ccreq->edit);
+	darr_free(ccreq->info_msgs);
 
 	/* If we (still) had an internal nb transaction, abort it */
 	if (ccreq->mgmtd_nb_txn) {
@@ -614,7 +617,7 @@ static void txn_cfg_next_phase(struct txn_req_commit *ccreq)
 	case MGMTD_COMMIT_PHASE_FINISH:
 		if (mm->perf_stats_en)
 			gettimeofday(&ccreq->cmt_stats->txn_del_start, NULL);
-		txn_finish_commit(ccreq, MGMTD_SUCCESS, NULL);
+		txn_finish_commit(ccreq, MGMTD_SUCCESS, ccreq->info_msgs);
 		return;
 	case MGMTD_COMMIT_PHASE_SEND_CFG:
 	default:
@@ -779,14 +782,33 @@ void mgmt_txn_handle_cfg_reply(uint64_t txn_id, struct mgmt_be_client_adapter *a
 /*
  * NOTE: can disconnect (and delete) the backend.
  */
-void mgmt_txn_handle_cfg_apply_reply(uint64_t txn_id, struct mgmt_be_client_adapter *adapter)
+void mgmt_txn_handle_cfg_apply_reply(uint64_t txn_id, struct mgmt_be_client_adapter *adapter,
+				     const char *errmsg)
 {
 	struct txn_req_commit *ccreq = txn_cfg_ensure_msg(txn_id, adapter, "CFG_APPLY");
 
-	if (!ccreq)
+	if (!ccreq) {
 		msg_conn_disconnect(adapter->conn, false);
-	else
-		txn_cfg_adapter_acked(ccreq, adapter);
+		return;
+	}
+
+	if (errmsg && errmsg[0]) {
+		char buf[BUFSIZ];
+		const char *src = adapter->name;
+		size_t i;
+
+		for (i = 0; i < sizeof(buf) - 1 && src[i]; i++)
+			buf[i] = toupper((unsigned char)src[i]);
+		buf[i] = '\0';
+
+		if (darr_strlen(ccreq->info_msgs))
+			darr_in_strcat(ccreq->info_msgs, "\n");
+		darr_in_strcat(ccreq->info_msgs, buf);
+		darr_in_strcat(ccreq->info_msgs, ": ");
+		darr_in_strcat(ccreq->info_msgs, errmsg);
+	}
+
+	txn_cfg_adapter_acked(ccreq, adapter);
 }
 
 /*

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -589,6 +589,30 @@ static int mgmtd_config_write(struct vty *vty)
 	return 1;
 }
 
+#ifdef HAVE_MGMTD_TESTC
+DEFPY(mgmt_test_config_value, mgmt_test_config_value_cmd,
+      "mgmt test-config-value VALUE",
+      MGMTD_STR
+      "Set test configuration value\n"
+      "Value to set\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-test-config:frr-test-config/test-value", NB_OP_MODIFY,
+			      value);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(no_mgmt_test_config_value, no_mgmt_test_config_value_cmd,
+      "no mgmt test-config-value",
+      NO_STR
+      MGMTD_STR
+      "Remove test configuration value\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-test-config:frr-test-config/test-value", NB_OP_DESTROY,
+			      NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+#endif
+
 static struct cmd_node mgmtd_node = {
 	.name = "mgmtd",
 	.node = MGMTD_NODE,
@@ -648,6 +672,11 @@ void mgmt_vty_init(void)
 
 	install_element(VIEW_NODE, &debug_mgmt_cmd);
 	install_element(CONFIG_NODE, &debug_mgmt_cmd);
+
+#ifdef HAVE_MGMTD_TESTC
+	install_element(CONFIG_NODE, &mgmt_test_config_value_cmd);
+	install_element(CONFIG_NODE, &no_mgmt_test_config_value_cmd);
+#endif
 
 	/* Enable view */
 	install_element(ENABLE_NODE, &mgmt_performance_measurement_cmd);

--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -467,7 +467,7 @@ static void vty_mgmt_handle_commit_config_reply(struct mgmt_fe_client *client, u
 						uintptr_t session_ctx, uint64_t req_id,
 						bool success, enum mgmt_ds_id src_ds_id,
 						enum mgmt_ds_id dst_ds_id, bool validate_only,
-						bool unlock, char *errmsg_if_any)
+						bool unlock, const char *errmsg_if_any)
 {
 	struct vty *vty;
 
@@ -483,8 +483,8 @@ static void vty_mgmt_handle_commit_config_reply(struct mgmt_fe_client *client, u
 		debug_fe_client("COMMIT_CONFIG request for client 0x%" PRIx64 " req-id %" PRIu64
 				" was successfull%s%s",
 				client_id, req_id, errmsg_if_any ? ": " : "", errmsg_if_any ?: "");
-		if (!unlock && errmsg_if_any)
-			vty_out(vty, "MGMTD: %s\n", errmsg_if_any);
+		if (errmsg_if_any)
+			vty_out(vty, "%% Configuration applied with notes:\n%s\n", errmsg_if_any);
 	}
 
 	if (unlock) {
@@ -604,11 +604,13 @@ static int vty_mgmt_handle_edit_reply(struct mgmt_fe_client *client, uintptr_t u
 {
 	struct vty *vty = (struct vty *)session_ctx;
 
-	if (!error)
+	if (!error) {
 		debug_fe_client("EDIT request for client 0x%" PRIx64 " req-id %" PRIu64
 				" was successful, xpath: %s",
 				client_id, req_id, xpath);
-	else {
+		if (errstr)
+			vty_out(vty, "%% Configuration applied with notes:\n%s\n", errstr);
+	} else {
 		debug_fe_client("EDIT request for client 0x%" PRIx64 " req-id %" PRIu64
 				" failed xpath: %s: %d: %s",
 				client_id, req_id, xpath, error, errstr);

--- a/tests/topotests/mgmt_config/test_config_ok_info.py
+++ b/tests/topotests/mgmt_config/test_config_ok_info.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# April 22 2026, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2026, LabN Consulting, L.L.C.
+#
+
+"""
+Test that backend informational messages are returned to the frontend on commit.
+Tests both the edit reply path (mgmt edit) and the commit reply path (CLI command).
+"""
+import os
+
+import pytest
+from lib.common_config import retry
+from lib.topogen import Topogen
+
+pytestmark = [pytest.mark.mgmtd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+BE_CLIENT = "/usr/lib/frr/mgmtd_testc"
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    "Setup/Teardown the environment and provide tgen argument to tests"
+
+    topodef = {"s1": ("r1",)}
+
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, router in router_list.items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+@retry(retry_timeout=30)
+def check_client_connect(r1):
+    out = r1.vtysh_cmd("show mgmt backend-adapter all")
+    return None if "mgmtd-testc" in out else "missing mgmtd-testc"
+
+
+def _start_be_client(r1):
+    """Start backend test client and wait for it to connect."""
+    rc, _, _ = r1.net.cmd_status(BE_CLIENT + " --help")
+    if rc:
+        pytest.skip("No mgmtd_testc")
+
+    p = r1.net.popen(
+        [BE_CLIENT, "--timeout", "20", "--log", "file:mgmtd_testc.log"],
+    )
+
+    res = check_client_connect(r1)
+    assert res is None, "mgmtd_testc did not connect"
+    return p
+
+
+def _check_info_output(out, client_name, value):
+    """Verify the output contains info message from backend."""
+    assert "Configuration applied with notes:" in out, (
+        f"Expected 'Configuration applied with notes:' in output, got: {out!r}"
+    )
+    assert f"{client_name}:" in out, (
+        f"Expected '{client_name}:' in output, got: {out!r}"
+    )
+    assert value in out, f"Expected '{value}' in output, got: {out!r}"
+
+
+def test_edit_reply_info(tgen):
+    """Test info messages via the edit reply path (mgmt edit command)."""
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    p = _start_be_client(r1)
+
+    try:
+        xpath = "/frr-test-config:frr-test-config"
+        data = '{"frr-test-config:frr-test-config":{"test-value":"edit-test"}}'
+        out = r1.net.cmd_raises(
+            f"vtysh -c 'conf term' -c 'mgmt edit replace {xpath} lock commit {data}'"
+        )
+    finally:
+        p.kill()
+
+    _check_info_output(out, "MGMTD-TESTC", "edit-test")
+
+
+def test_commit_reply_info(tgen):
+    """Test info messages via the commit reply path (CLI config command)."""
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    p = _start_be_client(r1)
+
+    try:
+        out = r1.vtysh_cmd("conf\nmgmt test-config-value commit-test")
+    finally:
+        p.kill()
+
+    _check_info_output(out, "MGMTD-TESTC", "commit-test")

--- a/yang/frr-test-config.yang
+++ b/yang/frr-test-config.yang
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-2-Clause
+module frr-test-config {
+  yang-version 1.1;
+  namespace "urn:frr-test-config";
+  prefix frr-test-config;
+
+  organization "FRRouting";
+
+  contact "placeholder for lint";
+
+  description
+    "FRRouting test configuration module for mgmtd testing.
+
+     Copyright 2026 FRRouting
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions
+     are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+     A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+     HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
+
+  revision 2026-04-22 {
+    description
+      "Initial revision.";
+    reference "placeholder for lint";
+  }
+
+  container frr-test-config {
+    description "Test configuration container";
+    leaf test-value {
+      type string;
+      description "A test configuration value";
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -27,6 +27,7 @@ dist_yangmodels_DATA += yang/frr-logging.yang
 dist_yangmodels_DATA += yang/frr-module-translator.yang
 dist_yangmodels_DATA += yang/frr-nexthop.yang
 dist_yangmodels_DATA += yang/frr-test-module.yang
+dist_yangmodels_DATA += yang/frr-test-config.yang
 dist_yangmodels_DATA += yang/frr-if-rmap.yang
 dist_yangmodels_DATA += yang/frr-interface.yang
 dist_yangmodels_DATA += yang/frr-route-map.yang


### PR DESCRIPTION
Allow for return of informational messages from backend NB callbacks
back to the frontend on successful commits. Backend clients can now send
any errmsg set during the APPLY phase in the CFG_APPLY_REPLY variable
data. mgmtd collects messages from all backends and forwards the result
to the frontend in the COMMIT_REPLY message. The vty frontend will now
displays them as well.