### PR TITLE
ospfd: Fix setting of type

### DIFF
--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1894,13 +1894,12 @@ static int ospf_te_parse_router_lsa(struct ls_ted *ted, struct ospf_lsa *lsa)
 	else
 		type = STANDARD;
 
-	if (vertex->status == NEW) {
-		vertex->node->type = type;
-		SET_FLAG(vertex->node->flags, LS_NODE_TYPE);
-	} else if (vertex->node->type != type) {
-		vertex->node->type = type;
+	if (vertex->status != NEW &&
+	    (vertex->node->type != type || !CHECK_FLAG(vertex->node->flags, LS_NODE_TYPE)))
 		vertex->status = UPDATE;
-	}
+
+	vertex->node->type = type;
+	SET_FLAG(vertex->node->flags, LS_NODE_TYPE);
 
 	/* Check if Vertex has been modified */
 	if (vertex->status != SYNC) {


### PR DESCRIPTION
There exists a code path where the vertex is already created but the type has not been set.  When
ospf_te_parse_router_lsa is called it was not
updating the type.  This caused the test_ospf_te_topo1.py topotest to fail, because it is looking for a type but it is not present.  Modify the code
to set the type here always.