### PR TITLE
isisd: validate ASLA sub-sub-TLV length ... (10.6 backport of 21542)

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1393,6 +1393,8 @@ static int unpack_item_ext_subtlv_asla(uint16_t mtid, uint8_t subtlv_len, struct
 	while (readable > 0) {
 		if (readable < ISIS_SUBSUBTLV_HDR_SIZE) {
 			TLV_SIZE_MISMATCH(log, indent, "ASLA Sub TLV");
+			stream_forward_getp(s, readable);
+			XFREE(MTYPE_ISIS_SUBTLV, asla);
 			return -1;
 		}
 
@@ -1400,6 +1402,12 @@ static int unpack_item_ext_subtlv_asla(uint16_t mtid, uint8_t subtlv_len, struct
 		subsubtlv_len = stream_getc(s);
 		readable -= ISIS_SUBSUBTLV_HDR_SIZE;
 
+		if (subsubtlv_len > readable) {
+			TLV_SIZE_MISMATCH(log, indent, "ASLA Sub TLV");
+			stream_forward_getp(s, readable);
+			XFREE(MTYPE_ISIS_SUBTLV, asla);
+			return -1;
+		}
 
 		switch (subsubtlv_type) {
 		case ISIS_SUBTLV_ADMIN_GRP:


### PR DESCRIPTION
Move the subsubtlv_len > readable bounds check to before the switch statement so that oversized sub-sub-TLVs are caught before any branch reads past the buffer. Add stream_forward_getp() on all error paths so the caller's stream position stays consistent after a parse failure.

10.6 backport of #21542 
