### PR TITLE
zebra: fix EVPN MACIP DEL flag mixup in neighbor delete path

### DIFF
--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -270,7 +270,7 @@ int zebra_evpn_neigh_send_del_to_client(vni_t vni, struct ipaddr *ip,
 	}
 
 	return zebra_evpn_macip_send_msg_to_client(
-		vni, macaddr, ip, flags, 0, state, NULL, ZEBRA_MACIP_DEL);
+		vni, macaddr, ip, 0, 0, state, NULL, ZEBRA_MACIP_DEL);
 }
 
 static void zebra_evpn_neigh_send_add_del_to_client(struct zebra_neigh *n,


### PR DESCRIPTION
On ZEBRA_MACIP_DEL, zebra_evpn_neigh_send_del_to_client() was passing ZEBRA_NEIGH_* flags into zebra_evpn_macip_send_msg_to_client(), while debug output decodes those bits as ZEBRA_MACIP_TYPE_* flags. Because bit values overlap, DEL logs could incorrectly print "Sticky MAC".

This is a flag-domain mismatch on DEL reporting, not a behavior change in BGP processing (DEL uses state).

Fix by sending no MACIP flags on neighbor DEL.
Neighbor DEL now passes flags=0, matching the existing MAC DEL behavior in zebra_evpn_mac_send_del_to_client().