### PR TITLE
bgpd: delete GR stale routes when nexthop becomes unreachable

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1486,6 +1486,49 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 						 path);
 		else if (old_path_valid != bnc_is_valid_nexthop) {
 			if (old_path_valid) {
+				/*
+				 * RFC 4724 section 4.2: "A BGP speaker
+				 * could have some way of determining
+				 * whether its peer's forwarding state
+				 * is still viable, for example through
+				 * Bidirectional Forwarding Detection
+				 * [BFD] or through monitoring layer
+				 * two information. ... In the event
+				 * that it determines that its peer's
+				 * forwarding state is not viable prior
+				 * to the re-establishment of the
+				 * session, the speaker MAY delete all
+				 * the stale routes from the peer that
+				 * it is retaining."
+				 *
+				 * Nexthop becoming unreachable means
+				 * the link went down, so forwarding
+				 * state was not preserved. Delete the
+				 * stale path immediately so traffic
+				 * is not blackholed. If the peer comes
+				 * back before the restart timer and the
+				 * link is up again, NHT will mark the
+				 * nexthop reachable and we no longer
+				 * have this path to revive; the peer
+				 * will re-advertise on session up.
+				 */
+				if (CHECK_FLAG(path->flags, BGP_PATH_STALE)) {
+					if (bgp_debug_neighbor_events(path->peer))
+						zlog_debug("%pBP NH %pFX unreachable and path stale, deleting %pFX",
+							   path->peer, &bnc->prefix, p);
+					if (safi == SAFI_EVPN && bgp_evpn_is_prefix_nht_supported(
+									 bgp_dest_get_prefix(dest)))
+						bgp_evpn_unimport_route(bgp_path, (afi_t)afi, safi,
+									bgp_dest_get_prefix(dest),
+									path);
+					if (safi == SAFI_UNICAST &&
+					    (bgp_path->inst_type != BGP_INSTANCE_TYPE_VIEW))
+						vpn_leak_from_vrf_withdraw(bgp_get_default(),
+									   bgp_path, path);
+					bgp_rib_remove(dest, path, path->peer, (afi_t)afi, safi);
+					continue;
+				}
+
 				/* No longer valid, clear flag; also for EVPN
 				 * routes, unimport from VRFs if needed.
 				 */


### PR DESCRIPTION
During a cold reboot of a spine, BGP peers on the leaf that do not receive a NOTIFICATION enter GR helper mode and mark paths as stale. Peers that receive a NOTIFICATION follow the normal teardown path and delete routes cleanly.

For the peers in GR helper mode, when the link to the spine goes down, NHT detects the nexthop as unreachable.  Previously, NHT would only invalidate these stale paths (clear BGP_PATH_VALID) but retain them. When the spine comes back up and links are restored, NHT would re-resolve the nexthop as reachable and revalidate the stale paths, reviving them into the FIB before the spine has converged.  This causes traffic to be forwarded to a peer that has no routes in hardware yet, resulting in blackholing.

Fix this by checking for BGP_PATH_STALE in evaluate_paths() when a nexthop becomes unreachable.  If the path is stale, delete it via bgp_rib_remove() instead of merely invalidating it.  The nexthop becoming unreachable means the link went down, so forwarding state was not preserved.

Per RFC 4724 section 4.2: "A BGP speaker could have some way of determining whether its peer's forwarding state is still viable, for example through Bidirectional Forwarding Detection [BFD] or through monitoring layer two information.  In the event that it determines that its peer's forwarding state is not viable prior to the re-establishment of the session, the speaker MAY delete all the stale routes from the peer that it is retaining."

This does not affect real Graceful Restart (warm boot) scenarios where links remain up throughout and NHT never observes a nexthop becoming unreachable.

