### PR TITLE
bgpd: add suppressed flag to JSON detail view for aggregate-suppressed routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12552,6 +12552,11 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 			vty_out(vty, ", (suppressed due to dampening)");
 	}
 
+	if (bgp_path_suppressed(path)) {
+		if (json_paths)
+			json_object_boolean_true_add(json_path, "suppressed");
+	}
+
 	if (!json_paths)
 		vty_out(vty, "\n");
 


### PR DESCRIPTION
The "show bgp <afi> <safi> <prefix> json" detail view was missing the "suppressed" flag for routes suppressed by an aggregate-address. The non-JSON detail output already showed "Advertisements suppressed by an aggregate." in the header, and the summary table view (route_vty_short_status_out) already included "suppressed":true in JSON, but route_vty_out_detail() never called bgp_path_suppressed() to add it.

Add the bgp_path_suppressed() check in route_vty_out_detail() to emit "suppressed":true in the per-path JSON output, consistent with the summary view.

Testing:

```
  r1# show bgp ipv6 unicast
   s> 2001:1:2:1::/127 ::(r1)        0    32768 ?
   s> 2001:1:2:2::/127 ::(r1)        0    32768 ?
```

Before this change, "show bgp ipv6 unicast 2001:1:2:1::/127 json" did
not include "suppressed" in the per-path object. 

After:

```
  r1# show bgp ipv6 unicast 2001:1:2:1::/127 json
  {
    "prefix":"2001:1:2:1::/127",
    "paths":[
      {
        "suppressed":true,
        "valid":true,
        "bestpath":{ ... },
        ...
      }
    ]
  }
```
  