### PR TITLE
tests: skip two topotests on 10.3

### DIFF
--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -32,7 +32,8 @@ log_file_date_format = %Y-%m-%d %H:%M:%S
 junit_logging = all
 junit_log_passing_tests = true
 
-norecursedirs = .git example_munet example_test example_topojson_test lib munet docker high_ecmp zebra_kernel_nhg
+norecursedirs = .git example_munet example_test example_topojson_test lib munet docker high_ecmp zebra_kernel_nhg bgp_multiple_link_bandwidth_communities two_layer_wucmp
+
 
 # Directory to store test results and run logs in, default shown
 # rundir = /tmp/topotests

--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -32,7 +32,7 @@ log_file_date_format = %Y-%m-%d %H:%M:%S
 junit_logging = all
 junit_log_passing_tests = true
 
-norecursedirs = .git example_munet example_test example_topojson_test lib munet docker high_ecmp
+norecursedirs = .git example_munet example_test example_topojson_test lib munet docker high_ecmp zebra_kernel_nhg
 
 # Directory to store test results and run logs in, default shown
 # rundir = /tmp/topotests


### PR DESCRIPTION
The code on 10.3 doesn't support the zebra_kernel_nhg, bgp_multiple_link_bandwidth_communities, or two_layer_wucmp topotests; don't run them. They look like they rely on code that isn't present on the branch.
