### PR TITLE
pimd: Auto-RP hardening for discovery and announcements

### DIFF
--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -340,6 +340,12 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 			continue;
 		}
 
+		if (rp->grpcnt > PIM_AUTORP_MAX_GROUPS_PER_RP) {
+			zlog_warn("%s: too many groups (%u > %u) in announcement for RP %pPA",
+				  __func__, rp->grpcnt, PIM_AUTORP_MAX_GROUPS_PER_RP, &rp_addr);
+			return false;
+		}
+
 		if (!autorp_buf_advance(&offset, buf_size, AUTORP_GRPLEN)) {
 			zlog_warn("%s: Buffer underrun parsing groups for RP %pPA", __func__,
 				  &rp_addr);
@@ -348,24 +354,33 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 		offset -= AUTORP_GRPLEN;
 
 		/* Store all announced RP's, calculate what to send in discovery when discovery is sent. */
-		ma_rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(struct pim_autorp_rp));
-		memcpy(&(ma_rp->addr), &rp_addr, sizeof(pim_addr));
-		trp = pim_autorp_rp_add(&(autorp->mapping_rp_list), ma_rp);
-		if (trp == NULL) {
-			/* RP was brand new, finish initializing */
-			ma_rp->autorp = autorp;
-			ma_rp->grplist[0] = '\0';
-			memset(&(ma_rp->grp), 0, sizeof(ma_rp->grp));
-			pim_autorp_grppfix_init(&ma_rp->grp_pfix_list);
-			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: New candidate RP learned (%pPA)", __func__,
-					   &rp_addr);
-		} else {
-			/* Returned an existing entry, free allocated RP */
-			XFREE(MTYPE_PIM_AUTORP_RP, ma_rp);
-			ma_rp = trp;
-			/* Free the existing group prefix list, in case the advertised groups changed */
-			pim_autorp_grppfix_free(&ma_rp->grp_pfix_list);
+		{
+			struct pim_autorp_rp find = { .addr = rp_addr };
+
+			ma_rp = pim_autorp_rp_find(&(autorp->mapping_rp_list), &find);
+			if (!ma_rp) {
+				if (pim_autorp_rp_count(&autorp->mapping_rp_list) >=
+				    PIM_AUTORP_MAX_LEARNED_RPS) {
+					zlog_warn("%s: reached AutoRP learned RP limit (%u), drop RP %pPA",
+						  __func__, PIM_AUTORP_MAX_LEARNED_RPS, &rp_addr);
+					return false;
+				}
+
+				ma_rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*ma_rp));
+				memcpy(&(ma_rp->addr), &rp_addr, sizeof(pim_addr));
+				ma_rp->autorp = autorp;
+				ma_rp->grplist[0] = '\0';
+				memset(&(ma_rp->grp), 0, sizeof(ma_rp->grp));
+				pim_autorp_grppfix_init(&ma_rp->grp_pfix_list);
+				trp = pim_autorp_rp_add(&(autorp->mapping_rp_list), ma_rp);
+				assert(trp == NULL);
+				if (PIM_DEBUG_AUTORP)
+					zlog_debug("%s: New candidate RP learned (%pPA)", __func__,
+						   &rp_addr);
+			} else {
+				/* Free the existing group prefix list, in case the advertised groups changed */
+				pim_autorp_grppfix_free(&ma_rp->grp_pfix_list);
+			}
 		}
 
 		ma_rp->holdtime = holdtime;
@@ -443,6 +458,18 @@ static bool pim_autorp_add_rp(struct pim_autorp *autorp, pim_addr rpaddr, struct
 	struct pim_autorp_rp *trp = NULL;
 	int ret;
 
+	{
+		struct pim_autorp_rp find = { .addr = rpaddr };
+
+		trp = pim_autorp_rp_find(&(autorp->discovery_rp_list), &find);
+		if (!trp && pim_autorp_rp_count(&autorp->discovery_rp_list) >=
+				    PIM_AUTORP_MAX_LEARNED_RPS) {
+			zlog_warn("%s: reached AutoRP learned RP limit (%u), drop RP %pPA",
+				  __func__, PIM_AUTORP_MAX_LEARNED_RPS, &rpaddr);
+			return false;
+		}
+	}
+
 	ret = pim_rp_new(autorp->pim, rpaddr, grp, listname, RP_SRC_AUTORP);
 
 	/* There may not be a path to the RP right now, but that doesn't mean it failed to add the RP */
@@ -452,21 +479,22 @@ static bool pim_autorp_add_rp(struct pim_autorp *autorp, pim_addr rpaddr, struct
 		return false;
 	}
 
-	rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*rp));
-	rp->autorp = autorp;
-	memcpy(&(rp->addr), &rpaddr, sizeof(pim_addr));
-	trp = pim_autorp_rp_add(&(autorp->discovery_rp_list), rp);
-	if (trp == NULL) {
-		/* RP was brand new */
-		trp = pim_autorp_rp_find(&(autorp->discovery_rp_list),
-					 (const struct pim_autorp_rp *)rp);
-		/* Make sure the timer is NULL so the cancel below doesn't mess up */
-		trp->hold_timer = NULL;
-		zlog_info("%s: Added new AutoRP learned RP addr=%pI4, grp=%pFX, grplist=%s",
-			  __func__, &rpaddr, &grp, (listname ? listname : "NONE"));
-	} else {
-		/* RP already existed, free the temp one */
-		XFREE(MTYPE_PIM_AUTORP_RP, rp);
+	{
+		struct pim_autorp_rp find = { .addr = rpaddr };
+
+		trp = pim_autorp_rp_find(&(autorp->discovery_rp_list), &find);
+		if (!trp) {
+			rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*rp));
+			rp->autorp = autorp;
+			memcpy(&(rp->addr), &rpaddr, sizeof(pim_addr));
+			trp = pim_autorp_rp_add(&(autorp->discovery_rp_list), rp);
+			assert(trp == NULL);
+			trp = rp;
+			/* Make sure the timer is NULL so the cancel below doesn't mess up */
+			trp->hold_timer = NULL;
+			zlog_info("%s: Added new AutoRP learned RP addr=%pI4, grp=%pFX, grplist=%s",
+				  __func__, &rpaddr, &grp, (listname ? listname : "NONE"));
+		}
 	}
 
 	/* Cancel any existing timer before restarting it */
@@ -840,6 +868,12 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 				zlog_debug("%s: Discovery message has no groups for RP %pPA",
 					   __func__, &rp_addr);
 			continue;
+		}
+
+		if (rp->grpcnt > PIM_AUTORP_MAX_GROUPS_PER_RP) {
+			zlog_warn("%s: too many groups (%u > %u) in discovery for RP %pPA",
+				  __func__, rp->grpcnt, PIM_AUTORP_MAX_GROUPS_PER_RP, &rp_addr);
+			return false;
 		}
 
 		/* Make sure there is enough buffer to parse all the groups */

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -132,6 +132,16 @@ static bool autorp_buf_advance(size_t *offset, size_t buf_size, size_t len)
 	return true;
 }
 
+static bool pim_autorp_group_prefix_valid(const struct prefix *grp)
+{
+	/*
+	 * Auto-RP in this file is IPv4-only; grp->family still guards against a
+	 * corrupted struct prefix (mask/address built from wire fields).
+	 */
+	return grp->family == AF_INET && grp->prefixlen <= IPV4_MAX_BITLEN &&
+	       pim_addr_is_multicast(grp->u.prefix4) && grp->prefixlen >= 4;
+}
+
 static bool pim_autorp_should_enable_socket(struct pim_autorp *autorp)
 {
 	struct interface *ifp;
@@ -414,6 +424,15 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 			lgrp->grp.prefixlen = grp->masklen;
 			lgrp->grp.u.prefix4.s_addr = grp->addr;
 			lgrp->negative = grp->negprefix;
+
+			if (!pim_autorp_group_prefix_valid(&lgrp->grp)) {
+				if (PIM_DEBUG_AUTORP)
+					zlog_debug("%s: invalid group prefix %pFX for RP %pPA",
+						   __func__, &lgrp->grp, &rp_addr);
+				XFREE(MTYPE_PIM_AUTORP_GRPPFIX, lgrp);
+				pim_autorp_grppfix_free(&ma_rp->grp_pfix_list);
+				return false;
+			}
 
 			if (PIM_DEBUG_AUTORP)
 				zlog_debug("%s: %s%pFX added to candidate RP %pPA", __func__,
@@ -873,7 +892,20 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 		if (rp->grpcnt > PIM_AUTORP_MAX_GROUPS_PER_RP) {
 			zlog_warn("%s: too many groups (%u > %u) in discovery for RP %pPA",
 				  __func__, rp->grpcnt, PIM_AUTORP_MAX_GROUPS_PER_RP, &rp_addr);
-			return false;
+			/*
+			 * Skip this RP's group encodings so the rest of the message stays aligned;
+			 * do not return false (earlier RPs may already be installed).
+			 */
+			if (!autorp_buf_advance(&offset, buf_size,
+						AUTORP_GRPLEN * (size_t)rp->grpcnt)) {
+				zlog_warn("%s: discovery RP %pPA groups exceed buffer (%u < %u)",
+					  __func__, &rp_addr,
+					  (uint32_t)(offset > buf_size ? 0 : (buf_size - offset)),
+					  (uint32_t)(AUTORP_GRPLEN * rp->grpcnt));
+				return false;
+			}
+			success = false;
+			continue;
 		}
 
 		/* Make sure there is enough buffer to parse all the groups */
@@ -898,6 +930,15 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 			grppfix.prefixlen = grp->masklen;
 			grppfix.u.prefix4.s_addr = grp->addr;
 
+			if (!pim_autorp_group_prefix_valid(&grppfix)) {
+				if (PIM_DEBUG_AUTORP)
+					zlog_debug("%s: invalid discovery group prefix %pFX for RP %pPA",
+						   __func__, &grppfix, &rp_addr);
+				/* Same as multi-group path: do not abort the whole message */
+				success = false;
+				continue;
+			}
+
 			if (PIM_DEBUG_AUTORP)
 				zlog_debug("%s: Parsing group %s%pFX for RP %pI4", __func__,
 					   (grp->negprefix ? "!" : ""), &grppfix, &rp_addr);
@@ -905,6 +946,8 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 			if (!pim_autorp_add_rp(autorp, rp_addr, grppfix, NULL, holdtime))
 				success = false;
 		} else {
+			bool grp_parse_ok = true;
+
 			/* More than one grp, or the only group is a negative prefix.
 			 * Need to make a prefix list for this RP
 			 */
@@ -930,6 +973,17 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 				grp = (struct autorp_pkt_grp *)(buf + offset);
 				offset += AUTORP_GRPLEN;
 
+				grppfix.family = AF_INET;
+				grppfix.prefixlen = grp->masklen;
+				grppfix.u.prefix4.s_addr = grp->addr;
+				if (!pim_autorp_group_prefix_valid(&grppfix)) {
+					if (PIM_DEBUG_AUTORP)
+						zlog_debug("%s: invalid discovery group prefix %pFX for RP %pPA",
+							   __func__, &grppfix, &rp_addr);
+					grp_parse_ok = false;
+					break;
+				}
+
 				ple = prefix_list_entry_new();
 				ple->pl = pl;
 				ple->seq = seq;
@@ -949,6 +1003,26 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 					zlog_debug("%s: Parsing group %s%pFX for RP %pPA", __func__,
 						   (grp->negprefix ? "!" : ""), &ple->prefix,
 						   &rp_addr);
+			}
+			if (!grp_parse_ok) {
+				prefix_list_delete(pl);
+				success = false;
+				/* Inner loop stopped early; consume the rest of this RP's groups */
+				if ((size_t)j + 1 < (size_t)rp->grpcnt) {
+					size_t skip = AUTORP_GRPLEN *
+						      ((size_t)rp->grpcnt - (size_t)j - 1);
+
+					if (!autorp_buf_advance(&offset, buf_size, skip)) {
+						zlog_warn("%s: discovery RP %pPA tail groups exceed buffer (%u < %u)",
+							  __func__, &rp_addr,
+							  (uint32_t)(offset > buf_size
+									     ? 0
+									     : (buf_size - offset)),
+							  (uint32_t)skip);
+						return false;
+					}
+				}
+				continue;
 			}
 
 			if (!pim_autorp_add_rp(autorp, rp_addr, grppfix, plname, holdtime))

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -142,6 +142,41 @@ static bool pim_autorp_group_prefix_valid(const struct prefix *grp)
 	       pim_addr_is_multicast(grp->u.prefix4) && grp->prefixlen >= 4;
 }
 
+static void autorp_announce_abort_parse(struct pim_autorp *autorp, struct pim_autorp_rp *ma_rp,
+					bool ma_rp_new, struct pim_autorp_grppfix_head *new_grps)
+{
+	pim_autorp_grppfix_free(new_grps);
+	pim_autorp_grppfix_fini(new_grps);
+	if (ma_rp_new) {
+		pim_autorp_rp_del(&(autorp->mapping_rp_list), ma_rp);
+		pim_autorp_rp_free(ma_rp, false);
+	}
+}
+
+static bool pim_autorp_allowed_announce_src(struct pim_autorp *autorp, pim_addr src,
+					    pim_addr rp_addr)
+{
+	struct pim_autorp_rp *cfg_rp;
+
+	/*
+	 * Prefer strict check that candidate-RP announcements come from the
+	 * candidate-RP address itself.
+	 */
+	if (pim_addr_cmp(src, rp_addr) == 0)
+		return true;
+
+	/* If no candidate RPs are configured locally, keep behavior permissive. */
+	if (pim_autorp_rp_count(&autorp->candidate_rp_list) == 0)
+		return true;
+
+	frr_each (pim_autorp_rp, &autorp->candidate_rp_list, cfg_rp) {
+		if (pim_addr_cmp(cfg_rp->addr, src) == 0)
+			return true;
+	}
+
+	return false;
+}
+
 static bool pim_autorp_should_enable_socket(struct pim_autorp *autorp)
 {
 	struct interface *ifp;
@@ -297,20 +332,279 @@ static void autorp_ma_rp_holdtime(struct event *evt)
 	pim_autorp_rp_free(rp, false);
 }
 
-static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, uint16_t holdtime,
-				     char *buf, size_t buf_size)
+/*
+ * Return false if the buffer is malformed or the packet must be dropped in full
+ * (e.g. unauthorized source for a PIMv2 RP that carries mapping state, any
+ * invalid multicast group prefix for such an RP, or applying the packet would
+ * exceed the mapping-agent learned-RP cap).
+ */
+static bool autorp_announcement_prescan_ok(struct pim_autorp *autorp, uint8_t rpcnt, char *buf,
+					   size_t buf_size, pim_addr src)
 {
 	int i, j;
-	struct autorp_pkt_rp *rp;
+	size_t prescan_off = 0;
+	pim_addr pending_new[256];
+	size_t n_pending_new = 0;
+
+	for (i = 0; i < rpcnt; ++i) {
+		struct autorp_pkt_rp *pre_rp;
+		pim_addr pre_rp_addr;
+		size_t grp_bytes;
+
+		if (!autorp_buf_advance(&prescan_off, buf_size, AUTORP_RPLEN)) {
+			zlog_warn("%s: Failed to parse AutoRP Announcement RP (prescan), invalid buffer size (%u < %u)",
+				  __func__,
+				  (uint32_t)(prescan_off > buf_size ? 0 : (buf_size - prescan_off)),
+				  AUTORP_RPLEN);
+			return false;
+		}
+
+		pre_rp = (struct autorp_pkt_rp *)(buf + prescan_off - AUTORP_RPLEN);
+		pre_rp_addr.s_addr = pre_rp->addr;
+
+		if (pre_rp->pimver == AUTORP_PIM_V1 || pre_rp->pimver == AUTORP_PIM_VUNKNOWN) {
+			grp_bytes = AUTORP_GRPLEN * (size_t)pre_rp->grpcnt;
+			if (!autorp_buf_advance(&prescan_off, buf_size, grp_bytes)) {
+				zlog_warn("%s: Failed to skip groups (prescan) for unsupported AutoRP Announcement RP %pPA (%u < %u)",
+					  __func__, &pre_rp_addr,
+					  (uint32_t)(prescan_off > buf_size
+							     ? 0
+							     : (buf_size - prescan_off)),
+					  (uint32_t)grp_bytes);
+				return false;
+			}
+			continue;
+		}
+
+		if (!pim_autorp_allowed_announce_src(autorp, src, pre_rp_addr)) {
+			if (PIM_DEBUG_AUTORP)
+				zlog_debug("%s: dropping announcement for RP %pPA from unauthorized source %pI4 (prescan)",
+					   __func__, &pre_rp_addr, &src);
+			return false;
+		}
+
+		if (pre_rp->grpcnt == 0)
+			continue;
+
+		if (pre_rp->grpcnt > PIM_AUTORP_MAX_GROUPS_PER_RP) {
+			zlog_warn("%s: too many groups (%u > %u) in announcement for RP %pPA (prescan)",
+				  __func__, pre_rp->grpcnt, PIM_AUTORP_MAX_GROUPS_PER_RP,
+				  &pre_rp_addr);
+			return false;
+		}
+
+		for (j = 0; j < pre_rp->grpcnt; j++) {
+			struct autorp_pkt_grp *pre_grp;
+			struct prefix grp_pfx;
+
+			if (!autorp_buf_advance(&prescan_off, buf_size, AUTORP_GRPLEN)) {
+				zlog_warn("%s: Failed parsing AutoRP announcement groups (prescan), RP(%pPA), invalid buffer size (%u < %u)",
+					  __func__, &pre_rp_addr,
+					  (uint32_t)(prescan_off > buf_size
+							     ? 0
+							     : (buf_size - prescan_off)),
+					  AUTORP_GRPLEN);
+				return false;
+			}
+
+			pre_grp = (struct autorp_pkt_grp *)(buf + prescan_off - AUTORP_GRPLEN);
+			grp_pfx.family = AF_INET;
+			grp_pfx.prefixlen = pre_grp->masklen;
+			grp_pfx.u.prefix4.s_addr = pre_grp->addr;
+
+			if (!pim_autorp_group_prefix_valid(&grp_pfx)) {
+				if (PIM_DEBUG_AUTORP)
+					zlog_debug("%s: invalid group prefix %pFX for RP %pPA (prescan)",
+						   __func__, &grp_pfx, &pre_rp_addr);
+				return false;
+			}
+		}
+
+		/*
+		 * Count distinct RPs that would need a new mapping_rp_list slot so we
+		 * never apply a prefix of the packet then fail mid-loop (same RP twice
+		 * in one message only consumes one slot).
+		 */
+		{
+			struct pim_autorp_rp capfind = { .addr = pre_rp_addr };
+			size_t k;
+
+			if (!pim_autorp_rp_find(&(autorp->mapping_rp_list), &capfind)) {
+				for (k = 0; k < n_pending_new; k++) {
+					if (pim_addr_cmp(pending_new[k], pre_rp_addr) == 0)
+						break;
+				}
+				if (k == n_pending_new) {
+					if (n_pending_new >=
+					    sizeof(pending_new) / sizeof(pending_new[0])) {
+						zlog_warn("%s: too many distinct new RPs in one announcement (prescan)",
+							  __func__);
+						return false;
+					}
+					pending_new[n_pending_new++] = pre_rp_addr;
+					if (pim_autorp_rp_count(&(autorp->mapping_rp_list)) +
+						    n_pending_new >
+					    PIM_AUTORP_MAX_LEARNED_RPS) {
+						zlog_warn("%s: announcement would exceed AutoRP learned RP limit (%u) (prescan)",
+							  __func__, PIM_AUTORP_MAX_LEARNED_RPS);
+						return false;
+					}
+				}
+			}
+		}
+	}
+
+	return true;
+}
+
+/*
+ * Find mapping-agent RP state for rp_addr on autorp->mapping_rp_list, or insert
+ * a new entry when under PIM_AUTORP_MAX_LEARNED_RPS. *ma_rp_new is true iff the
+ * entry was just created (so the caller can remove it on parse failure).
+ */
+static bool autorp_mapping_rp_get_or_create(struct pim_autorp *autorp, pim_addr rp_addr,
+					    struct pim_autorp_rp **ma_rp, bool *ma_rp_new)
+{
+	struct pim_autorp_rp find = { .addr = rp_addr };
+	struct pim_autorp_rp *rp;
+
+	rp = pim_autorp_rp_find(&(autorp->mapping_rp_list), &find);
+	if (rp) {
+		*ma_rp = rp;
+		*ma_rp_new = false;
+		return true;
+	}
+
+	if (pim_autorp_rp_count(&autorp->mapping_rp_list) >= PIM_AUTORP_MAX_LEARNED_RPS) {
+		zlog_warn("%s: reached AutoRP learned RP limit (%u), drop RP %pPA", __func__,
+			  PIM_AUTORP_MAX_LEARNED_RPS, &rp_addr);
+		return false;
+	}
+
+	rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*rp));
+	memcpy(&(rp->addr), &rp_addr, sizeof(pim_addr));
+	rp->autorp = autorp;
+	rp->grplist[0] = '\0';
+	memset(&(rp->grp), 0, sizeof(rp->grp));
+	pim_autorp_grppfix_init(&rp->grp_pfix_list);
+	assert(pim_autorp_rp_add(&(autorp->mapping_rp_list), rp) == NULL);
+	if (PIM_DEBUG_AUTORP)
+		zlog_debug("%s: New candidate RP learned (%pPA)", __func__, &rp_addr);
+
+	*ma_rp = rp;
+	*ma_rp_new = true;
+	return true;
+}
+
+static void autorp_mapping_rp_restart_holdtimer(struct pim_autorp_rp *ma_rp, uint16_t holdtime)
+{
+	ma_rp->holdtime = holdtime;
+	event_cancel(&ma_rp->hold_timer);
+	if (holdtime > 0)
+		event_add_timer(router->master, autorp_ma_rp_holdtime, ma_rp, ma_rp->holdtime,
+				&(ma_rp->hold_timer));
+}
+
+static bool autorp_announcement_apply_mapping_rp(struct pim_autorp *autorp, uint16_t holdtime,
+						 struct autorp_pkt_rp *rp, pim_addr rp_addr,
+						 char *buf, size_t buf_size, size_t *offset)
+{
+	int j;
 	struct autorp_pkt_grp *grp;
+	bool ma_rp_new = false;
+	struct pim_autorp_grppfix_head new_grps;
+	struct pim_autorp_rp *ma_rp;
+
+	if (!autorp_mapping_rp_get_or_create(autorp, rp_addr, &ma_rp, &ma_rp_new))
+		return false;
+
+	pim_autorp_grppfix_init(&new_grps);
+
+	if (PIM_DEBUG_AUTORP)
+		zlog_debug("%s: Parsing %u group(s) for candidate RP %pPA", __func__, rp->grpcnt,
+			   &rp_addr);
+
+	for (j = 0; j < rp->grpcnt; ++j) {
+		struct pim_autorp_grppfix *lgrp;
+		struct pim_autorp_grppfix *tgrp;
+
+		if (!autorp_buf_advance(offset, buf_size, AUTORP_GRPLEN)) {
+			zlog_warn("%s: Failed parsing AutoRP announcement, RP(%pI4), invalid buffer size (%u < %u)",
+				  __func__, &rp_addr,
+				  (uint32_t)(*offset > buf_size ? 0 : (buf_size - *offset)),
+				  AUTORP_GRPLEN);
+			autorp_announce_abort_parse(autorp, ma_rp, ma_rp_new, &new_grps);
+			return false;
+		}
+
+		grp = (struct autorp_pkt_grp *)(buf + *offset - AUTORP_GRPLEN);
+
+		lgrp = XCALLOC(MTYPE_PIM_AUTORP_GRPPFIX, sizeof(struct pim_autorp_grppfix));
+		lgrp->grp.family = AF_INET;
+		lgrp->grp.prefixlen = grp->masklen;
+		lgrp->grp.u.prefix4.s_addr = grp->addr;
+		lgrp->negative = grp->negprefix;
+
+		if (!pim_autorp_group_prefix_valid(&lgrp->grp)) {
+			if (PIM_DEBUG_AUTORP)
+				zlog_debug("%s: invalid group prefix %pFX for RP %pPA", __func__,
+					   &lgrp->grp, &rp_addr);
+			XFREE(MTYPE_PIM_AUTORP_GRPPFIX, lgrp);
+			autorp_announce_abort_parse(autorp, ma_rp, ma_rp_new, &new_grps);
+			return false;
+		}
+
+		if (PIM_DEBUG_AUTORP)
+			zlog_debug("%s: %s%pFX added to candidate RP %pPA", __func__,
+				   (lgrp->negative ? "!" : ""), &lgrp->grp, &rp_addr);
+
+		tgrp = pim_autorp_grppfix_add(&new_grps, lgrp);
+		if (tgrp != NULL) {
+			/* This should never happen but if there was an existing entry just free the
+			 * allocated group prefix
+			 */
+			if (PIM_DEBUG_AUTORP)
+				zlog_debug("%s: %pFX was duplicated in AutoRP announcement",
+					   __func__, &lgrp->grp);
+			XFREE(MTYPE_PIM_AUTORP_GRPPFIX, lgrp);
+		}
+	}
+
+	pim_autorp_grppfix_free(&ma_rp->grp_pfix_list);
+	while (1) {
+		struct pim_autorp_grppfix *g = pim_autorp_grppfix_pop(&new_grps);
+
+		if (!g)
+			break;
+		assert(pim_autorp_grppfix_add(&ma_rp->grp_pfix_list, g) == NULL);
+	}
+	pim_autorp_grppfix_fini(&new_grps);
+
+	/* Restart hold timer only after groups parsed and committed successfully */
+	autorp_mapping_rp_restart_holdtimer(ma_rp, holdtime);
+
+	return true;
+}
+
+static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, uint16_t holdtime,
+				     char *buf, size_t buf_size, pim_addr src)
+{
+	int i;
+	struct autorp_pkt_rp *rp;
 	size_t offset = 0;
 	pim_addr rp_addr;
-	struct pim_autorp_rp *ma_rp;
-	struct pim_autorp_rp *trp;
 
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: Processing AutoRP Announcement (rpcnt=%u, holdtime=%u)", __func__,
 			   rpcnt, holdtime);
+
+	/*
+	 * Reject the whole message if any RP that would update mapping state is
+	 * announced from an unauthorized source — avoids applying a prefix of RPs
+	 * before failing mid-packet.
+	 */
+	if (!autorp_announcement_prescan_ok(autorp, rpcnt, buf, buf_size, src))
+		return false;
 
 	for (i = 0; i < rpcnt; ++i) {
 		if (!autorp_buf_advance(&offset, buf_size, AUTORP_RPLEN)) {
@@ -343,18 +637,23 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 		}
 
 		if (rp->grpcnt == 0) {
-			/* No groups?? */
+			struct pim_autorp_rp find = { .addr = rp_addr };
+			struct pim_autorp_rp *ma_rp;
+
 			if (PIM_DEBUG_AUTORP)
 				zlog_debug("%s: Announcement message has no groups for RP %pPA",
 					   __func__, &rp_addr);
+			/*
+			 * No group encodings to parse; still refresh hold time for an RP we
+			 * already track so grpcnt==0 keep-alives do not let the mapping entry expire.
+			 */
+			ma_rp = pim_autorp_rp_find(&(autorp->mapping_rp_list), &find);
+			if (ma_rp)
+				autorp_mapping_rp_restart_holdtimer(ma_rp, holdtime);
 			continue;
 		}
 
-		if (rp->grpcnt > PIM_AUTORP_MAX_GROUPS_PER_RP) {
-			zlog_warn("%s: too many groups (%u > %u) in announcement for RP %pPA",
-				  __func__, rp->grpcnt, PIM_AUTORP_MAX_GROUPS_PER_RP, &rp_addr);
-			return false;
-		}
+		/* grpcnt already capped by autorp_announcement_prescan_ok for this RP */
 
 		if (!autorp_buf_advance(&offset, buf_size, AUTORP_GRPLEN)) {
 			zlog_warn("%s: Buffer underrun parsing groups for RP %pPA", __func__,
@@ -363,92 +662,9 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 		}
 		offset -= AUTORP_GRPLEN;
 
-		/* Store all announced RP's, calculate what to send in discovery when discovery is sent. */
-		{
-			struct pim_autorp_rp find = { .addr = rp_addr };
-
-			ma_rp = pim_autorp_rp_find(&(autorp->mapping_rp_list), &find);
-			if (!ma_rp) {
-				if (pim_autorp_rp_count(&autorp->mapping_rp_list) >=
-				    PIM_AUTORP_MAX_LEARNED_RPS) {
-					zlog_warn("%s: reached AutoRP learned RP limit (%u), drop RP %pPA",
-						  __func__, PIM_AUTORP_MAX_LEARNED_RPS, &rp_addr);
-					return false;
-				}
-
-				ma_rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*ma_rp));
-				memcpy(&(ma_rp->addr), &rp_addr, sizeof(pim_addr));
-				ma_rp->autorp = autorp;
-				ma_rp->grplist[0] = '\0';
-				memset(&(ma_rp->grp), 0, sizeof(ma_rp->grp));
-				pim_autorp_grppfix_init(&ma_rp->grp_pfix_list);
-				trp = pim_autorp_rp_add(&(autorp->mapping_rp_list), ma_rp);
-				assert(trp == NULL);
-				if (PIM_DEBUG_AUTORP)
-					zlog_debug("%s: New candidate RP learned (%pPA)", __func__,
-						   &rp_addr);
-			} else {
-				/* Free the existing group prefix list, in case the advertised groups changed */
-				pim_autorp_grppfix_free(&ma_rp->grp_pfix_list);
-			}
-		}
-
-		ma_rp->holdtime = holdtime;
-		/* Cancel any existing timer and restart it */
-		event_cancel(&ma_rp->hold_timer);
-		if (holdtime > 0)
-			event_add_timer(router->master, autorp_ma_rp_holdtime, ma_rp,
-					ma_rp->holdtime, &(ma_rp->hold_timer));
-
-		if (PIM_DEBUG_AUTORP)
-			zlog_debug("%s: Parsing %u group(s) for candidate RP %pPA", __func__,
-				   rp->grpcnt, &rp_addr);
-
-		for (j = 0; j < rp->grpcnt; ++j) {
-			/* grp is already pointing at the first group in the buffer */
-			struct pim_autorp_grppfix *lgrp;
-			struct pim_autorp_grppfix *tgrp;
-
-			if (!autorp_buf_advance(&offset, buf_size, AUTORP_GRPLEN)) {
-				zlog_warn("%s: Failed parsing AutoRP announcement, RP(%pI4), invalid buffer size (%u < %u)",
-					  __func__, &rp_addr,
-					  (uint32_t)(offset > buf_size ? 0 : (buf_size - offset)),
-					  AUTORP_GRPLEN);
-				return false;
-			}
-
-			grp = (struct autorp_pkt_grp *)(buf + offset - AUTORP_GRPLEN);
-
-			lgrp = XCALLOC(MTYPE_PIM_AUTORP_GRPPFIX, sizeof(struct pim_autorp_grppfix));
-			lgrp->grp.family = AF_INET;
-			lgrp->grp.prefixlen = grp->masklen;
-			lgrp->grp.u.prefix4.s_addr = grp->addr;
-			lgrp->negative = grp->negprefix;
-
-			if (!pim_autorp_group_prefix_valid(&lgrp->grp)) {
-				if (PIM_DEBUG_AUTORP)
-					zlog_debug("%s: invalid group prefix %pFX for RP %pPA",
-						   __func__, &lgrp->grp, &rp_addr);
-				XFREE(MTYPE_PIM_AUTORP_GRPPFIX, lgrp);
-				pim_autorp_grppfix_free(&ma_rp->grp_pfix_list);
-				return false;
-			}
-
-			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: %s%pFX added to candidate RP %pPA", __func__,
-					   (lgrp->negative ? "!" : ""), &lgrp->grp, &rp_addr);
-
-			tgrp = pim_autorp_grppfix_add(&ma_rp->grp_pfix_list, lgrp);
-			if (tgrp != NULL) {
-				/* This should never happen but if there was an existing entry just free the
-				 * allocated group prefix
-				 */
-				if (PIM_DEBUG_AUTORP)
-					zlog_debug("%s: %pFX was duplicated in AutoRP announcement",
-						   __func__, &lgrp->grp);
-				XFREE(MTYPE_PIM_AUTORP_GRPPFIX, lgrp);
-			}
-		}
+		if (!autorp_announcement_apply_mapping_rp(autorp, holdtime, rp, rp_addr, buf,
+							  buf_size, &offset))
+			return false;
 	}
 
 	if (PIM_DEBUG_AUTORP)
@@ -473,20 +689,16 @@ static void autorp_cand_rp_holdtime(struct event *evt)
 static bool pim_autorp_add_rp(struct pim_autorp *autorp, pim_addr rpaddr, struct prefix grp,
 			      char *listname, uint16_t holdtime)
 {
+	struct pim_autorp_rp find = { .addr = rpaddr };
 	struct pim_autorp_rp *rp;
 	struct pim_autorp_rp *trp = NULL;
 	int ret;
 
-	{
-		struct pim_autorp_rp find = { .addr = rpaddr };
-
-		trp = pim_autorp_rp_find(&(autorp->discovery_rp_list), &find);
-		if (!trp && pim_autorp_rp_count(&autorp->discovery_rp_list) >=
-				    PIM_AUTORP_MAX_LEARNED_RPS) {
-			zlog_warn("%s: reached AutoRP learned RP limit (%u), drop RP %pPA",
-				  __func__, PIM_AUTORP_MAX_LEARNED_RPS, &rpaddr);
-			return false;
-		}
+	trp = pim_autorp_rp_find(&(autorp->discovery_rp_list), &find);
+	if (!trp && pim_autorp_rp_count(&autorp->discovery_rp_list) >= PIM_AUTORP_MAX_LEARNED_RPS) {
+		zlog_warn("%s: reached AutoRP learned RP limit (%u), drop RP %pPA", __func__,
+			  PIM_AUTORP_MAX_LEARNED_RPS, &rpaddr);
+		return false;
 	}
 
 	ret = pim_rp_new(autorp->pim, rpaddr, grp, listname, RP_SRC_AUTORP);
@@ -498,26 +710,35 @@ static bool pim_autorp_add_rp(struct pim_autorp *autorp, pim_addr rpaddr, struct
 		return false;
 	}
 
-	{
-		struct pim_autorp_rp find = { .addr = rpaddr };
-
-		trp = pim_autorp_rp_find(&(autorp->discovery_rp_list), &find);
-		if (!trp) {
-			rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*rp));
-			rp->autorp = autorp;
-			memcpy(&(rp->addr), &rpaddr, sizeof(pim_addr));
-			trp = pim_autorp_rp_add(&(autorp->discovery_rp_list), rp);
-			assert(trp == NULL);
-			trp = rp;
-			/* Make sure the timer is NULL so the cancel below doesn't mess up */
-			trp->hold_timer = NULL;
-			zlog_info("%s: Added new AutoRP learned RP addr=%pI4, grp=%pFX, grplist=%s",
-				  __func__, &rpaddr, &grp, (listname ? listname : "NONE"));
-		}
+	trp = pim_autorp_rp_find(&(autorp->discovery_rp_list), &find);
+	if (!trp) {
+		rp = XCALLOC(MTYPE_PIM_AUTORP_RP, sizeof(*rp));
+		rp->autorp = autorp;
+		memcpy(&(rp->addr), &rpaddr, sizeof(pim_addr));
+		trp = pim_autorp_rp_add(&(autorp->discovery_rp_list), rp);
+		assert(trp == NULL);
+		trp = rp;
+		/* Make sure the timer is NULL so the cancel below doesn't mess up */
+		trp->hold_timer = NULL;
+		zlog_info("%s: Added new AutoRP learned RP addr=%pI4, grp=%pFX, grplist=%s",
+			  __func__, &rpaddr, &grp, (listname ? listname : "NONE"));
 	}
 
 	/* Cancel any existing timer before restarting it */
 	event_cancel(&trp->hold_timer);
+	/*
+	 * Drop a superseded __AUTORP_*__ prefix-list when the group-list name changes.
+	 * Must run only after pim_rp_new above: that call detaches this RP's rp_info
+	 * from the old plist name (for listname NULL or a different non-NULL name)
+	 * before we free the prefix_list object, so PIM never holds a dangling name.
+	 */
+	if (strlen(trp->grplist) && (!listname || !strmatch(trp->grplist, listname))) {
+		struct prefix_list *old_pl = prefix_list_lookup(AFI_IP, trp->grplist);
+
+		if (old_pl)
+			prefix_list_delete(old_pl);
+	}
+
 	trp->holdtime = holdtime;
 	prefix_copy(&(trp->grp), &grp);
 	if (listname)
@@ -1025,8 +1246,10 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 				continue;
 			}
 
-			if (!pim_autorp_add_rp(autorp, rp_addr, grppfix, plname, holdtime))
+			if (!pim_autorp_add_rp(autorp, rp_addr, grppfix, plname, holdtime)) {
+				prefix_list_delete(pl);
 				success = false;
+			}
 		}
 	}
 
@@ -1056,7 +1279,7 @@ static bool autorp_recv_msg(struct pim_autorp *autorp, char *buf, size_t buf_siz
 
 	if (h->type == AUTORP_ANNOUNCEMENT_TYPE)
 		return autorp_recv_announcement(autorp, h->rpcnt, htons(h->holdtime),
-						buf + AUTORP_HDRLEN, buf_size - AUTORP_HDRLEN);
+						buf + AUTORP_HDRLEN, buf_size - AUTORP_HDRLEN, src);
 
 	if (h->type == AUTORP_DISCOVERY_TYPE)
 		return autorp_recv_discovery(autorp, h->rpcnt, htons(h->holdtime),

--- a/pimd/pim_autorp.h
+++ b/pimd/pim_autorp.h
@@ -26,6 +26,12 @@
 #define DEFAULT_AUTORP_DISCOVERY_INTERVAL 60
 #define DEFAULT_AUTORP_DISCOVERY_SCOPE	  31
 #define DEFAULT_AUTORP_DISCOVERY_HOLDTIME 180
+/*
+ * Upper bounds for learned Auto-RP state to limit memory growth from malformed
+ * or malicious announcement/discovery traffic.
+ */
+#define PIM_AUTORP_MAX_LEARNED_RPS   1024
+#define PIM_AUTORP_MAX_GROUPS_PER_RP 128
 
 PREDECL_SORTLIST_UNIQ(pim_autorp_rp);
 PREDECL_SORTLIST_UNIQ(pim_autorp_grppfix);


### PR DESCRIPTION
- Cap learned Auto-RP RPs and groups per RP per message (fixed upper bounds).
- Validate Auto-RP multicast group prefixes; drop bad data and avoid leaking half-built prefix-lists on parse failure.
- When candidate RPs are configured, accept announcements only from the RP address or a matching configured candidate; otherwise drop.
- Delete superseded __AUTORP_*__ prefix-lists when an RP refresh uses a new group-list name.