### PR TITLE
pimd: validate PIM LAN sources and cap neighbors

### DIFF
--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -474,15 +474,25 @@ pim_neighbor_add(struct interface *ifp, pim_addr source_addr,
 	struct pim_interface *pim_ifp;
 	struct pim_neighbor *neigh;
 
-	neigh = pim_neighbor_new(ifp, source_addr, hello_options, holdtime,
-				 propagation_delay, override_interval,
-				 dr_priority, generation_id, addr_list);
+	if (!ifp)
+		return NULL;
+	pim_ifp = ifp->info;
+	if (!pim_ifp)
+		return NULL;
+
+	if (!pim_neighbor_find(ifp, source_addr, false) &&
+	    listcount(pim_ifp->pim_neighbor_list) >= PIM_NEIGHBOR_LIST_MAX) {
+		if (PIM_DEBUG_PIM_EVENTS)
+			zlog_debug("%s: neighbor list limit (%u) reached on %s, ignoring new neighbor %pPA",
+				   __func__, PIM_NEIGHBOR_LIST_MAX, ifp->name, &source_addr);
+		return NULL;
+	}
+
+	neigh = pim_neighbor_new(ifp, source_addr, hello_options, holdtime, propagation_delay,
+				 override_interval, dr_priority, generation_id, addr_list);
 	if (!neigh) {
 		return 0;
 	}
-
-	pim_ifp = ifp->info;
-	assert(pim_ifp);
 
 	listnode_add(pim_ifp->pim_neighbor_list, neigh);
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -223,7 +223,15 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len,
 	case PIM_MSG_TYPE_HELLO:
 	case PIM_MSG_TYPE_JOIN_PRUNE:
 	case PIM_MSG_TYPE_ASSERT:
-		if (pim_ifp == NULL || pim_ifp->nbr_plist == NULL)
+		if (!pim_ifp) {
+			if (PIM_DEBUG_PIM_PACKETS)
+				zlog_debug("%s: reject PIM %s from %pPA on %s: PIM not enabled on interface",
+					   __func__, pim_pim_msgtype2str(header->type), &sg.src,
+					   ifp->name);
+			return -1;
+		}
+
+		if (pim_ifp->nbr_plist == NULL)
 			break;
 
 		nbr_plist = prefix_list_lookup(PIM_AFI, pim_ifp->nbr_plist);

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -54,6 +54,12 @@
 #define PIM_HELLO_SECONDARY_ADDR_MAX (512)
 
 /*
+ * Upper bound on PIM neighbors per interface (limits memory use and DR election
+ * work if bogus Hellos inject many source addresses).
+ */
+#define PIM_NEIGHBOR_LIST_MAX (4096)
+
+/*
  * J/P Message Format, Group Header
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |        Upstream Neighbor Address (Encoded-Unicast format)     |

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -589,7 +589,11 @@ module frr-pim {
     leaf neighbor-filter-prefix-list {
       type plist-ref;
       description
-        "Prefix-List to filter allowed PIM neighbors.";
+        "Optional prefix list restricting which IP source addresses may act as PIM
+         neighbors on this interface (evaluated for Hello, Join/Prune, and Assert
+         processing alongside other PIM interface checks). This is an additional
+         operator filter only; it does not independently enforce IPv6 link-local or
+         IPv4 connected-subnet requirements on the packet source.";
     }
 
     leaf join-prune-interval {


### PR DESCRIPTION
Require multicast PIM Hello / Join–Prune / Assert sources per RFC 7761 Section 4.9: IPv6 link-local only; IPv4 source must match a connected prefix on the interface (aligned with IGMP verification). Apply the optional neighbor prefix-list after those checks.

Cap the neighbor list size per interface (PIM_NEIGHBOR_LIST_MAX) to bound memory and DR election cost under spoofed Hellos.

Document neighbor-filter-prefix-list as an additional filter in YANG.