### PR TITLE
zebra: tear down old L3VNI before adding new one on VNI value change

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3364,11 +3364,8 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type, jso
 					json_object_free(json_prefix);
 					if (json_paths)
 						json_object_free(json_paths);
-					if (json_flags)
-						json_object_free(json_flags);
 					json_prefix = NULL;
 					json_paths = NULL;
-					json_flags = NULL;
 				}
 			}
 		}

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -1544,12 +1544,12 @@ static inline int stream_putf_tlv(struct stream *s, uint16_t type, const float v
 int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_descriptor *desc,
 				  uint16_t tlv_type)
 {
-	size_t len_pos, sub_tlv_start;
-	int written = 0;
-	int ret;
+	size_t start, len_pos, sub_tlv_start;
 
 	if (!s || !desc)
 		return -1;
+
+	start = stream_get_endp(s);
 
 	if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE)
 		return -1;
@@ -1558,68 +1558,53 @@ int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_des
 	stream_putw(s, tlv_type);
 	len_pos = stream_get_endp(s);
 	stream_putw(s, 0); /* Placeholder for length */
-	written += BGP_LS_TLV_HDR_SIZE;
 
 	sub_tlv_start = stream_get_endp(s);
 
 	/* AS Number (TLV 512) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_AS_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_AS_NUMBER, BGP_LS_AS_NUMBER_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_AS_NUMBER, BGP_LS_AS_NUMBER_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_AS_NUMBER_SIZE)
 			return -1;
 		stream_putl(s, desc->asn);
-		written += BGP_LS_AS_NUMBER_SIZE;
 	}
 
 	/* BGP-LS Identifier (TLV 513) - deprecated but may be present */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_LS_ID_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_BGP_LS_ID, BGP_LS_BGP_LS_ID_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_BGP_LS_ID, BGP_LS_BGP_LS_ID_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_BGP_LS_ID_SIZE)
 			return -1;
 		stream_putl(s, desc->bgp_ls_id);
-		written += BGP_LS_BGP_LS_ID_SIZE;
 	}
 
 	/* OSPF Area ID (TLV 514) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_OSPF_AREA_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_OSPF_AREA_ID, BGP_LS_OSPF_AREA_ID_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_OSPF_AREA_ID, BGP_LS_OSPF_AREA_ID_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_OSPF_AREA_ID_SIZE)
 			return -1;
 		stream_putl(s, desc->ospf_area_id);
-		written += BGP_LS_OSPF_AREA_ID_SIZE;
 	}
 
 	/* IGP Router ID (TLV 515) - MANDATORY */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IGP_ROUTER_ID, desc->igp_router_id_len);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IGP_ROUTER_ID, desc->igp_router_id_len) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < desc->igp_router_id_len)
 			return -1;
 		stream_put(s, desc->igp_router_id, desc->igp_router_id_len);
-		written += desc->igp_router_id_len;
 	}
 
 	/* Update length field */
-	uint16_t sub_tlv_len = stream_get_endp(s) - sub_tlv_start;
+	stream_putw_at(s, len_pos, stream_get_endp(s) - sub_tlv_start);
 
-	stream_putw_at(s, len_pos, sub_tlv_len);
-
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*
@@ -1644,109 +1629,89 @@ int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_des
  */
 int bgp_ls_encode_link_descriptor(struct stream *s, const struct bgp_ls_link_descriptor *desc)
 {
-	int written = 0;
-	int ret;
+	size_t start;
 	uint16_t i;
 
 	if (!s || !desc)
 		return -1;
 
+	start = stream_get_endp(s);
+
 	/* Link Local/Remote Identifiers (TLV 258) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_LINK_ID_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_LINK_ID, BGP_LS_LINK_ID_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_LINK_ID, BGP_LS_LINK_ID_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_LINK_ID_SIZE)
 			return -1;
 		stream_putl(s, desc->link_local_id);
 		stream_putl(s, desc->link_remote_id);
-		written += BGP_LS_LINK_ID_SIZE;
 	}
 
 	/* IPv4 Interface Address (TLV 259) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV4_INTF_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IPV4_INTF_ADDR, BGP_LS_IPV4_ADDR_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV4_INTF_ADDR, BGP_LS_IPV4_ADDR_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_IPV4_ADDR_SIZE)
 			return -1;
 		stream_put_ipv4(s, desc->ipv4_intf_addr.s_addr);
-		written += BGP_LS_IPV4_ADDR_SIZE;
 	}
 
 	/* IPv4 Neighbor Address (TLV 260) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV4_NEIGH_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IPV4_NEIGH_ADDR, BGP_LS_IPV4_ADDR_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV4_NEIGH_ADDR, BGP_LS_IPV4_ADDR_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_IPV4_ADDR_SIZE)
 			return -1;
 		stream_put_ipv4(s, desc->ipv4_neigh_addr.s_addr);
-		written += BGP_LS_IPV4_ADDR_SIZE;
 	}
 
 	/* IPv6 Interface Address (TLV 261) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV6_INTF_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IPV6_INTF_ADDR, BGP_LS_IPV6_ADDR_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV6_INTF_ADDR, BGP_LS_IPV6_ADDR_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_IPV6_ADDR_SIZE)
 			return -1;
 		stream_put(s, &desc->ipv6_intf_addr, BGP_LS_IPV6_ADDR_SIZE);
-		written += BGP_LS_IPV6_ADDR_SIZE;
 	}
 
 	/* IPv6 Neighbor Address (TLV 262) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_IPV6_NEIGH_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IPV6_NEIGH_ADDR, BGP_LS_IPV6_ADDR_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IPV6_NEIGH_ADDR, BGP_LS_IPV6_ADDR_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_IPV6_ADDR_SIZE)
 			return -1;
 		stream_put(s, &desc->ipv6_neigh_addr, BGP_LS_IPV6_ADDR_SIZE);
-		written += BGP_LS_IPV6_ADDR_SIZE;
 	}
 
 	/* Multi-Topology ID (TLV 263) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT) &&
 	    desc->mt_id_count > 0) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_MT_ID,
-					 desc->mt_id_count * BGP_LS_MT_ID_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_MT_ID,
+				       desc->mt_id_count * BGP_LS_MT_ID_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
 			return -1;
 		for (i = 0; i < desc->mt_id_count; i++)
 			stream_putw(s, desc->mt_id[i]);
-		written += desc->mt_id_count * BGP_LS_MT_ID_SIZE;
 	}
 
 	/* Remote AS Number (TLV 264) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_LINK_DESC_REMOTE_AS_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_REMOTE_AS_NUMBER, 4);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_REMOTE_AS_NUMBER, 4) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < 4)
 			return -1;
 		stream_putl(s, desc->remote_asn);
-		written += 4;
 	}
 
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*
@@ -1768,74 +1733,63 @@ int bgp_ls_encode_link_descriptor(struct stream *s, const struct bgp_ls_link_des
  */
 int bgp_ls_encode_prefix_descriptor(struct stream *s, const struct bgp_ls_prefix_descriptor *desc)
 {
-	int written = 0;
-	int ret;
+	size_t start;
 	uint16_t i;
 	uint8_t prefix_len_bytes;
 
 	if (!s || !desc)
 		return -1;
 
+	start = stream_get_endp(s);
+
 	/* Multi-Topology ID (TLV 263) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT) &&
 	    desc->mt_id_count > 0) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_MT_ID,
-					 desc->mt_id_count * BGP_LS_MT_ID_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_MT_ID,
+				       desc->mt_id_count * BGP_LS_MT_ID_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
 			return -1;
 		for (i = 0; i < desc->mt_id_count; i++)
 			stream_putw(s, desc->mt_id[i]);
-		written += desc->mt_id_count * BGP_LS_MT_ID_SIZE;
 	}
 
 	/* OSPF Route Type (TLV 264) */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_PREFIX_DESC_OSPF_ROUTE_BIT)) {
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_OSPF_ROUTE_TYPE,
-					 BGP_LS_OSPF_ROUTE_TYPE_SIZE);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_OSPF_ROUTE_TYPE,
+				       BGP_LS_OSPF_ROUTE_TYPE_SIZE) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < BGP_LS_OSPF_ROUTE_TYPE_SIZE)
 			return -1;
 		stream_putc(s, desc->ospf_route_type);
-		written += BGP_LS_OSPF_ROUTE_TYPE_SIZE;
 	}
 
 	/* IP Reachability Information (TLV 265) - MANDATORY */
 	if (desc->prefix.family == AF_INET) {
 		prefix_len_bytes = (desc->prefix.prefixlen + 7) / 8;
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IP_REACH_INFO,
-					 BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IP_REACH_INFO,
+				       BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes)
 			return -1;
 		stream_putc(s, desc->prefix.prefixlen);
 		stream_put(s, &desc->prefix.u.prefix4, prefix_len_bytes);
-		written += BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes;
 	} else if (desc->prefix.family == AF_INET6) {
 		prefix_len_bytes = (desc->prefix.prefixlen + 7) / 8;
-		ret = stream_put_tlv_hdr(s, BGP_LS_TLV_IP_REACH_INFO,
-					 BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes);
-		if (ret < 0)
+		if (stream_put_tlv_hdr(s, BGP_LS_TLV_IP_REACH_INFO,
+				       BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes) < 0)
 			return -1;
-		written += ret;
 
 		if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes)
 			return -1;
 		stream_putc(s, desc->prefix.prefixlen);
 		stream_put(s, &desc->prefix.u.prefix6, prefix_len_bytes);
-		written += BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes;
 	}
 
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*
@@ -1857,31 +1811,28 @@ int bgp_ls_encode_prefix_descriptor(struct stream *s, const struct bgp_ls_prefix
  */
 int bgp_ls_encode_node_nlri(struct stream *s, const struct bgp_ls_node_nlri *nlri)
 {
-	int written = 0;
-	int ret;
+	size_t start;
 
 	if (!s || !nlri)
 		return -1;
+
+	start = stream_get_endp(s);
 
 	/* Protocol-ID (1 byte) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_PROTOCOL_ID_SIZE)
 		return -1;
 	stream_putc(s, nlri->protocol_id);
-	written += BGP_LS_PROTOCOL_ID_SIZE;
 
 	/* Identifier (8 bytes) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_IDENTIFIER_SIZE)
 		return -1;
 	stream_putq(s, nlri->identifier);
-	written += BGP_LS_IDENTIFIER_SIZE;
 
 	/* Local Node Descriptors */
-	ret = bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC);
-	if (ret < 0)
+	if (bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC) < 0)
 		return -1;
-	written += ret;
 
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*
@@ -1907,43 +1858,36 @@ int bgp_ls_encode_node_nlri(struct stream *s, const struct bgp_ls_node_nlri *nlr
  */
 int bgp_ls_encode_link_nlri(struct stream *s, const struct bgp_ls_link_nlri *nlri)
 {
-	int written = 0;
-	int ret;
+	size_t start;
 
 	if (!s || !nlri)
 		return -1;
+
+	start = stream_get_endp(s);
 
 	/* Protocol-ID (1 byte) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_PROTOCOL_ID_SIZE)
 		return -1;
 	stream_putc(s, nlri->protocol_id);
-	written += BGP_LS_PROTOCOL_ID_SIZE;
 
 	/* Identifier (8 bytes) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_IDENTIFIER_SIZE)
 		return -1;
 	stream_putq(s, nlri->identifier);
-	written += BGP_LS_IDENTIFIER_SIZE;
 
 	/* Local Node Descriptors */
-	ret = bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC);
-	if (ret < 0)
+	if (bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC) < 0)
 		return -1;
-	written += ret;
 
 	/* Remote Node Descriptors */
-	ret = bgp_ls_encode_node_descriptor(s, &nlri->remote_node, BGP_LS_TLV_REMOTE_NODE_DESC);
-	if (ret < 0)
+	if (bgp_ls_encode_node_descriptor(s, &nlri->remote_node, BGP_LS_TLV_REMOTE_NODE_DESC) < 0)
 		return -1;
-	written += ret;
 
 	/* Link Descriptors */
-	ret = bgp_ls_encode_link_descriptor(s, &nlri->link_desc);
-	if (ret < 0)
+	if (bgp_ls_encode_link_descriptor(s, &nlri->link_desc) < 0)
 		return -1;
-	written += ret;
 
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*
@@ -1972,8 +1916,7 @@ int bgp_ls_encode_link_nlri(struct stream *s, const struct bgp_ls_link_nlri *nlr
 int bgp_ls_encode_prefix_nlri(struct stream *s, const struct bgp_ls_prefix_nlri *nlri,
 			      enum bgp_ls_nlri_type nlri_type)
 {
-	int written = 0;
-	int ret;
+	size_t start;
 
 	if (!s || !nlri)
 		return -1;
@@ -1985,31 +1928,27 @@ int bgp_ls_encode_prefix_nlri(struct stream *s, const struct bgp_ls_prefix_nlri 
 	     nlri->prefix_desc.prefix.family != AF_INET6))
 		return -1;
 
+	start = stream_get_endp(s);
+
 	/* Protocol-ID (1 byte) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_PROTOCOL_ID_SIZE)
 		return -1;
 	stream_putc(s, nlri->protocol_id);
-	written += BGP_LS_PROTOCOL_ID_SIZE;
 
 	/* Identifier (8 bytes) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_IDENTIFIER_SIZE)
 		return -1;
 	stream_putq(s, nlri->identifier);
-	written += BGP_LS_IDENTIFIER_SIZE;
 
 	/* Local Node Descriptors */
-	ret = bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC);
-	if (ret < 0)
+	if (bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC) < 0)
 		return -1;
-	written += ret;
 
 	/* Prefix Descriptors */
-	ret = bgp_ls_encode_prefix_descriptor(s, &nlri->prefix_desc);
-	if (ret < 0)
+	if (bgp_ls_encode_prefix_descriptor(s, &nlri->prefix_desc) < 0)
 		return -1;
-	written += ret;
 
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*
@@ -2037,8 +1976,7 @@ int bgp_ls_encode_prefix_nlri(struct stream *s, const struct bgp_ls_prefix_nlri 
  */
 int bgp_ls_encode_nlri(struct stream *s, const struct bgp_ls_nlri *nlri)
 {
-	size_t len_pos, value_start;
-	int written = 0;
+	size_t start, len_pos, value_start;
 	int ret = 0;
 
 	if (!s || !nlri)
@@ -2048,18 +1986,18 @@ int bgp_ls_encode_nlri(struct stream *s, const struct bgp_ls_nlri *nlri)
 	if (!bgp_ls_nlri_validate(nlri))
 		return -1;
 
+	start = stream_get_endp(s);
+
 	/* NLRI Type (2 bytes) */
 	if (STREAM_WRITEABLE(s) < BGP_LS_NLRI_TYPE_SIZE)
 		return -1;
 	stream_putw(s, nlri->nlri_type);
-	written += BGP_LS_NLRI_TYPE_SIZE;
 
 	/* Reserve space for NLRI Length */
 	if (STREAM_WRITEABLE(s) < BGP_LS_NLRI_LENGTH_SIZE)
 		return -1;
 	len_pos = stream_get_endp(s);
 	stream_putw(s, 0); /* Placeholder */
-	written += BGP_LS_NLRI_LENGTH_SIZE;
 
 	value_start = stream_get_endp(s);
 
@@ -2085,14 +2023,10 @@ int bgp_ls_encode_nlri(struct stream *s, const struct bgp_ls_nlri *nlri)
 	if (ret < 0)
 		return -1;
 
-	written += ret;
-
 	/* Update NLRI Length field */
-	uint16_t nlri_len = stream_get_endp(s) - value_start;
+	stream_putw_at(s, len_pos, stream_get_endp(s) - value_start);
 
-	stream_putw_at(s, len_pos, nlri_len);
-
-	return written;
+	return stream_get_endp(s) - start;
 }
 
 /*

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1867,9 +1867,11 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 				stream_forward_getp(s, subtlv_len);
 			} else {
 				struct isis_srv6_endx_sid_subtlv *adj;
+				size_t endx_start;
 
 				adj = XCALLOC(MTYPE_ISIS_SUBTLV,
 					      sizeof(struct isis_srv6_endx_sid_subtlv));
+				endx_start = stream_get_getp(s);
 				adj->flags = stream_getc(s);
 				adj->algorithm = stream_getc(s);
 				adj->weight = stream_getc(s);
@@ -1882,9 +1884,7 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 					TLV_SIZE_MISMATCH(log, indent,
 							  "SRv6 End.X SID subsubtlvs");
 					XFREE(MTYPE_ISIS_SUBTLV, adj);
-					stream_forward_getp(
-						s,
-						subtlv_len - ISIS_SUBTLV_SRV6_ENDX_SID_SIZE);
+					stream_set_getp(s, endx_start + subtlv_len);
 					break;
 				}
 
@@ -1897,6 +1897,7 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 						&unpacked_known_tlvs)) {
 					isis_free_subsubtlvs(adj->subsubtlvs);
 					XFREE(MTYPE_ISIS_SUBTLV, adj);
+					stream_set_getp(s, endx_start + subtlv_len);
 					break;
 				}
 				if (!unpacked_known_tlvs) {
@@ -1904,6 +1905,7 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 					adj->subsubtlvs = NULL;
 				}
 
+				stream_set_getp(s, endx_start + subtlv_len);
 				append_item(&exts->srv6_endx_sid, (struct isis_item *)adj);
 				SET_SUBTLV(exts, EXT_SRV6_ENDX_SID);
 			}
@@ -1915,9 +1917,11 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 				stream_forward_getp(s, subtlv_len);
 			} else {
 				struct isis_srv6_lan_endx_sid_subtlv *lan;
+				size_t lan_endx_start;
 
 				lan = XCALLOC(MTYPE_ISIS_SUBTLV,
 					      sizeof(struct isis_srv6_lan_endx_sid_subtlv));
+				lan_endx_start = stream_get_getp(s);
 				stream_get(&(lan->neighbor_id), s, ISIS_SYS_ID_LEN);
 				lan->flags = stream_getc(s);
 				lan->algorithm = stream_getc(s);
@@ -1931,9 +1935,7 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 					TLV_SIZE_MISMATCH(log, indent,
 							  "SRv6 LAN End.X SID subsubtlvs");
 					XFREE(MTYPE_ISIS_SUBTLV, lan);
-					stream_forward_getp(
-						s,
-						subtlv_len - ISIS_SUBTLV_SRV6_LAN_ENDX_SID_SIZE);
+					stream_set_getp(s, lan_endx_start + subtlv_len);
 					break;
 				}
 
@@ -1946,6 +1948,7 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 						&unpacked_known_tlvs)) {
 					isis_free_subsubtlvs(lan->subsubtlvs);
 					XFREE(MTYPE_ISIS_SUBTLV, lan);
+					stream_set_getp(s, lan_endx_start + subtlv_len);
 					break;
 				}
 				if (!unpacked_known_tlvs) {
@@ -1953,6 +1956,7 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 					lan->subsubtlvs = NULL;
 				}
 
+				stream_set_getp(s, lan_endx_start + subtlv_len);
 				append_item(&exts->srv6_lan_endx_sid, (struct isis_item *)lan);
 				SET_SUBTLV(exts, EXT_SRV6_LAN_ENDX_SID);
 			}

--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -312,7 +312,8 @@ static int vty_mgmt_handle_error_reply(struct mgmt_fe_client *client, uintptr_t 
 	const char *cname = mgmt_fe_client_name(client);
 
 	if (!vty->mgmt_req_pending_cmd) {
-		debug_fe_client("Error with no pending command: %d returned for client %s 0x%Lx session-id %Lu req-id %Lu error-str %s",
+		debug_fe_client("Error with no pending command: %d returned for client %s 0x%" PRIx64
+				" session-id %" PRIu64 " req-id %" PRIu64 " error-str %s",
 				error, cname, client_id, session_id, req_id, errstr);
 		vty_out(vty, "%% Error %d from MGMTD for %s with no pending command: %s\n", error,
 			cname, errstr);
@@ -604,10 +605,12 @@ static int vty_mgmt_handle_edit_reply(struct mgmt_fe_client *client, uintptr_t u
 	struct vty *vty = (struct vty *)session_ctx;
 
 	if (!error)
-		debug_fe_client("EDIT request for client 0x%Lx req-id %Lu was successful, xpath: %s",
+		debug_fe_client("EDIT request for client 0x%" PRIx64 " req-id %" PRIu64
+				" was successful, xpath: %s",
 				client_id, req_id, xpath);
 	else {
-		debug_fe_client("EDIT request for client 0x%Lx req-id %Lu failed xpath: %s: %d: %s",
+		debug_fe_client("EDIT request for client 0x%" PRIx64 " req-id %" PRIu64
+				" failed xpath: %s: %d: %s",
 				client_id, req_id, xpath, error, errstr);
 		vty_out(vty, "%% %s\n", errstr);
 		vty_out(vty, "%% Failed to edit configuration.\n");

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -776,7 +776,7 @@ def test_bgp_norib():
     logger.info("Checking BGP configuration for 'bgp no-rib'")
 
     norib_cfg = (
-        tgen.net["r1"].cmd('vtysh -c "show running bgpd" | grep "^bgp no-rib"').rstrip()
+        tgen.net["r1"].cmd('vtysh -c "show running" | grep "^bgp no-rib"').rstrip()
     )
 
     assertmsg = "'bgp no-rib' configuration applied, but not visible in configuration"
@@ -847,9 +847,7 @@ def test_bgp_disable_norib():
     logger.info("Checking BGP configuration for 'bgp no-rib'")
 
     norib_cfg = (
-        tgen.net["r1"]
-        .cmd('vtysh -c "show running bgpd" | grep "^ bgp no-rib"')
-        .rstrip()
+        tgen.net["r1"].cmd('vtysh -c "show running" | grep "^ bgp no-rib"').rstrip()
     )
 
     assertmsg = (

--- a/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
+++ b/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
@@ -130,7 +130,7 @@ def test_show_running_remote_as_peer_group():
     output = (
         tgen.gears["r1"]
         .cmd(
-            'vtysh -c "show running bgpd" | grep "^ neighbor 192.168.252.2 remote-as 65004"'
+            'vtysh -c "show running" | grep "^ neighbor 192.168.252.2 remote-as 65004"'
         )
         .rstrip()
     )

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -3938,6 +3938,7 @@ int lib_vrf_zebra_mpls_fec_nexthop_resolution_destroy(
 int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
+	struct zebra_vrf *zvrf;
 	vni_t vni = 0;
 	bool pfx_only = false;
 	uint32_t count;
@@ -3963,8 +3964,11 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pfx_only = yang_dnode_get_bool(args->dnode, "../prefix-only");
 
-		zebra_vxlan_process_vrf_vni_cmd(vrf->info, vni,
-						pfx_only ? 1 : 0, 1);
+		zvrf = vrf->info;
+		if (zvrf->l3vni && zvrf->l3vni != vni)
+			zebra_vxlan_process_vrf_vni_cmd(zvrf, zvrf->l3vni, 0, 0);
+
+		zebra_vxlan_process_vrf_vni_cmd(zvrf, vni, pfx_only ? 1 : 0, 1);
 		break;
 	}
 


### PR DESCRIPTION
 zebra: tear down old L3VNI before adding new one on VNI value change

  When a VRF's L3VNI value is changed via a single "vni <new>" command
  (without first issuing "no vni <old>"), the northbound system generates
  a single NB_CB_MODIFY callback for the l3vni-id leaf. The modify handler
  lib_vrf_zebra_l3vni_id_modify() calls zebra_vxlan_process_vrf_vni_cmd()
  with add=1 for the new VNI, but never tears down the old one.

  This leaves the old L3VNI entry orphaned in zrouter.l3vni_table. No
  ZEBRA_L3VNI_DEL is sent to bgpd, so bgpd retains stale EVPN state for
  the old VNI. The VRF appears to have the correct VNI in running config,
  but the control plane is broken until FRR is fully restarted.

  This path is triggered when config management systems (e.g. NVUE) apply
  the full frr.conf to a running daemon, causing the NB diff to see a leaf
  value replace ('r') rather than the explicit destroy+create that
  frr-reload.py would generate.

  Fix by checking zvrf->l3vni before the add. If the VRF already has a
  different L3VNI, call zebra_vxlan_process_vrf_vni_cmd() with add=0 for
  the old VNI first, which removes it from the global hash table and
  notifies bgpd via ZEBRA_L3VNI_DEL.
