### PR TITLE
zebra: tear down old L3VNI before adding new one on VNI value change

### DIFF
--- a/tests/topotests/bgp_evpn_l3vni_modify/P1/frr.conf
+++ b/tests/topotests/bgp_evpn_l3vni_modify/P1/frr.conf
@@ -1,0 +1,33 @@
+frr defaults datacenter
+!
+interface lo
+ ip address 10.20.20.20/32
+!
+interface P1-eth0
+ ip address 10.20.1.2/24
+!
+interface P1-eth1
+ ip address 10.20.2.1/24
+!
+router ospf
+ router-id 10.20.20.20
+ network 10.20.20.20/32 area 0
+ network 10.20.1.0/24 area 0
+ network 10.20.2.0/24 area 0
+!
+router bgp 65000
+ bgp router-id 10.20.20.20
+ no bgp default ipv4-unicast
+ neighbor 10.10.10.10 remote-as 65000
+ neighbor 10.10.10.10 update-source lo
+ neighbor 10.10.10.10 timers 3 10
+ neighbor 10.30.30.30 remote-as 65000
+ neighbor 10.30.30.30 update-source lo
+ neighbor 10.30.30.30 timers 3 10
+ address-family l2vpn evpn
+  neighbor 10.10.10.10 activate
+  neighbor 10.10.10.10 route-reflector-client
+  neighbor 10.30.30.30 activate
+  neighbor 10.30.30.30 route-reflector-client
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_l3vni_modify/PE1/frr.conf
+++ b/tests/topotests/bgp_evpn_l3vni_modify/PE1/frr.conf
@@ -1,0 +1,28 @@
+frr defaults datacenter
+!
+interface lo
+ ip address 10.10.10.10/32
+!
+interface PE1-eth0
+ ip address 10.20.1.1/24
+!
+vrf vrf-blue
+ vni 3109
+exit-vrf
+!
+router ospf
+ router-id 10.10.10.10
+ network 10.10.10.10/32 area 0
+ network 10.20.1.0/24 area 0
+!
+router bgp 65000
+ bgp router-id 10.10.10.10
+ no bgp default ipv4-unicast
+ neighbor 10.30.30.30 remote-as 65000
+ neighbor 10.30.30.30 update-source lo
+ neighbor 10.30.30.30 timers 3 10
+ address-family l2vpn evpn
+  neighbor 10.30.30.30 activate
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_l3vni_modify/PE1/setup.sh
+++ b/tests/topotests/bgp_evpn_l3vni_modify/PE1/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Create Linux VRF, VXLAN, bridge, and VLAN SVI for L3VNI 3109 on PE1
+
+ip link add vrf-blue type vrf table 1000
+ip link set vrf-blue up
+
+ip link add name br3109 type bridge stp_state 0 vlan_filtering 1
+ip link set dev br3109 up
+
+ip link add vxlan3109 type vxlan id 3109 dstport 4789 local 10.10.10.10 nolearning
+ip link set dev vxlan3109 master br3109
+ip link set up dev vxlan3109
+
+bridge vlan add vid 60 dev br3109 self
+bridge vlan del vid 1 dev vxlan3109
+bridge vlan add vid 60 dev vxlan3109 pvid untagged
+
+ip link add link br3109 name vlan60 type vlan id 60
+ip link set dev vlan60 master vrf-blue
+ip addr add 10.99.99.1/24 dev vlan60
+ip link set dev vlan60 up

--- a/tests/topotests/bgp_evpn_l3vni_modify/PE2/frr.conf
+++ b/tests/topotests/bgp_evpn_l3vni_modify/PE2/frr.conf
@@ -1,0 +1,28 @@
+frr defaults datacenter
+!
+interface lo
+ ip address 10.30.30.30/32
+!
+interface PE2-eth0
+ ip address 10.20.2.2/24
+!
+vrf vrf-blue
+ vni 3109
+exit-vrf
+!
+router ospf
+ router-id 10.30.30.30
+ network 10.30.30.30/32 area 0
+ network 10.20.2.0/24 area 0
+!
+router bgp 65000
+ bgp router-id 10.30.30.30
+ no bgp default ipv4-unicast
+ neighbor 10.10.10.10 remote-as 65000
+ neighbor 10.10.10.10 update-source lo
+ neighbor 10.10.10.10 timers 3 10
+ address-family l2vpn evpn
+  neighbor 10.10.10.10 activate
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_l3vni_modify/PE2/setup.sh
+++ b/tests/topotests/bgp_evpn_l3vni_modify/PE2/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Create Linux VRF, VXLAN, bridge, and VLAN SVI for L3VNI 3109 on PE2
+
+ip link add vrf-blue type vrf table 1000
+ip link set vrf-blue up
+
+ip link add name br3109 type bridge stp_state 0 vlan_filtering 1
+ip link set dev br3109 up
+
+ip link add vxlan3109 type vxlan id 3109 dstport 4789 local 10.30.30.30 nolearning
+ip link set dev vxlan3109 master br3109
+ip link set up dev vxlan3109
+
+bridge vlan add vid 60 dev br3109 self
+bridge vlan del vid 1 dev vxlan3109
+bridge vlan add vid 60 dev vxlan3109 pvid untagged
+
+ip link add link br3109 name vlan60 type vlan id 60
+ip link set dev vlan60 master vrf-blue
+ip addr add 10.99.99.3/24 dev vlan60
+ip link set dev vlan60 up

--- a/tests/topotests/bgp_evpn_l3vni_modify/test_bgp_evpn_l3vni_modify.py
+++ b/tests/topotests/bgp_evpn_l3vni_modify/test_bgp_evpn_l3vni_modify.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# Test: L3VNI value change via NB MODIFY must tear down old VNI
+#
+# When a VRF's L3VNI value is changed with a single "vni <new>" command
+# (without first doing "no vni <old>"), the northbound system generates
+# a single NB_CB_MODIFY callback. The modify handler must tear down the
+# old L3VNI before adding the new one. If it does not, the old L3VNI is
+# orphaned in zrouter.l3vni_table and bgpd is never notified of its
+# deletion.
+#
+# Reproduction sequence (matches HBN field bug):
+#   1. Start with correct VNI 3109 (working state)
+#   2. Change to wrong VNI 60810 via vtysh
+#   3. Restart FRR (now running with VNI 60810 fully established)
+#   4. Change back to correct VNI 3109 via vtysh (BUG TRIGGER)
+#   5. Assert old VNI 60810 is gone from zebra and bgpd
+#
+# Topology:
+#   PE1 ---[s1]--- P1 ---[s2]--- PE2
+#
+#   P1:  spine / iBGP route reflector (OSPF + BGP EVPN)
+#   PE1, PE2:  VTEP leaves with VRF vrf-blue, L3VNI initially 3109
+#
+
+import os
+import sys
+import json
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+
+
+def setup_module(mod):
+    topodef = {
+        "s1": ("PE1", "P1"),
+        "s2": ("P1", "PE2"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    tgen.start_router()
+
+    for pe in ("PE1", "PE2"):
+        tgen.gears[pe].run(f"/bin/bash {CWD}/{pe}/setup.sh")
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_step1_initial_l3vni_3109():
+    """Verify L3VNI 3109 is established on PE1 and BGP EVPN peers are up."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    def _check_l3vni_3109():
+        output = pe1.vtysh_cmd("show evpn vni 3109", isjson=False)
+        if "Type: L3" not in output:
+            return "L3VNI 3109 not yet showing Type: L3"
+        if "vrf-blue" not in output:
+            return "L3VNI 3109 not associated with vrf-blue"
+        return None
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_l3vni_3109), None, count=30, wait=2
+    )
+    assert result is None, f"L3VNI 3109 not established on PE1: {result}"
+
+    def _check_bgp_evpn_peer():
+        output = pe1.vtysh_cmd("show bgp l2vpn evpn summary json", isjson=True)
+        peers = output.get("peers", {})
+        for _, pdata in peers.items():
+            if pdata.get("state") == "Established":
+                return None
+        return "No established BGP EVPN peer"
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_bgp_evpn_peer), None, count=30, wait=2
+    )
+    assert result is None, f"BGP EVPN peering not established on PE1: {result}"
+
+
+def test_step2_change_to_wrong_vni_60810():
+    """Change VNI from 3109 to 60810 via vtysh (simulates wrong nv config apply)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    pe1.vtysh_cmd(
+        """
+        configure terminal
+        vrf vrf-blue
+         vni 60810
+        end
+        """
+    )
+
+    def _check_vni_60810():
+        output = pe1.vtysh_cmd("show vrf vni json", isjson=True)
+        raw = json.dumps(output)
+        if "60810" in raw:
+            return None
+        return "VRF vrf-blue not yet showing VNI 60810"
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_vni_60810), None, count=20, wait=3
+    )
+    assert result is None, f"VNI change to 60810 not reflected: {result}"
+
+
+def test_step3_restart_frr_with_wrong_vni():
+    """Restart FRR on PE1 with VNI 60810 to fully establish it."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    wrong_conf = os.path.join(CWD, "PE1/frr.conf").replace("3109", "unused")
+    wrong_conf_path = os.path.join(tgen.logdir, "PE1", "frr_wrong_vni.conf")
+    with open(os.path.join(CWD, "PE1/frr.conf"), "r") as f:
+        conf = f.read()
+    conf = conf.replace("vni 3109", "vni 60810")
+    with open(wrong_conf_path, "w") as f:
+        f.write(conf)
+
+    pe1.stop()
+    pe1.load_frr_config(wrong_conf_path)
+    pe1.start()
+
+    def _check_l3vni_60810():
+        output = pe1.vtysh_cmd("show evpn vni 60810", isjson=False)
+        if "Type: L3" not in output:
+            return "L3VNI 60810 not yet showing Type: L3"
+        if "vrf-blue" not in output:
+            return "L3VNI 60810 not associated with vrf-blue"
+        return None
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_l3vni_60810), None, count=30, wait=2
+    )
+    assert result is None, f"L3VNI 60810 not established after restart: {result}"
+
+
+def test_step4_change_back_to_correct_vni_3109():
+    """Change VNI back to 3109 without restart (NB MODIFY bug trigger)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    pe1.vtysh_cmd(
+        """
+        configure terminal
+        vrf vrf-blue
+         vni 3109
+        end
+        """
+    )
+
+    def _check_vni_3109():
+        output = pe1.vtysh_cmd("show vrf vni json", isjson=True)
+        raw = json.dumps(output)
+        if "3109" in raw:
+            return None
+        return "VRF vrf-blue not yet showing VNI 3109"
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_vni_3109), None, count=20, wait=3
+    )
+    assert result is None, f"VNI change to 3109 not reflected: {result}"
+
+
+def test_step5_old_vni_must_not_exist():
+    """Assert old L3VNI 60810 is no longer present in zebra.
+
+    BUG: lib_vrf_zebra_l3vni_id_modify calls zebra_vxlan_process_vrf_vni_cmd
+    with add=1 for the new VNI without first calling the destroy path for
+    the old VNI. The old zl3vni entry stays orphaned in zrouter.l3vni_table.
+
+    This assertion FAILS on unfixed code.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    def _check_old_vni_gone():
+        output = pe1.vtysh_cmd("show evpn vni json", isjson=True)
+        raw = json.dumps(output)
+        if "60810" in raw:
+            return "old L3VNI 60810 still present in 'show evpn vni json' (orphaned)"
+        return None
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_old_vni_gone), None, count=20, wait=3
+    )
+    assert result is None, result
+
+
+def test_step6_bgp_old_vni_gone():
+    """Verify bgpd no longer holds the old L3VNI 60810.
+
+    BUG: Because zebra never sent ZEBRA_L3VNI_DEL for VNI 60810, bgpd
+    still has stale L3VNI state.
+
+    This assertion FAILS on unfixed code.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    def _check_bgp_old_vni():
+        output = pe1.vtysh_cmd("show bgp l2vpn evpn vni json", isjson=True)
+        raw = json.dumps(output)
+        if "60810" in raw:
+            return "old L3VNI 60810 still in bgpd 'show bgp l2vpn evpn vni json'"
+        return None
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_bgp_old_vni), None, count=20, wait=3
+    )
+    assert result is None, result
+
+
+def test_step7_new_vni_state():
+    """Verify the new L3VNI 3109 is properly associated with vrf-blue."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+
+    def _check_new_vni():
+        output = pe1.vtysh_cmd("show vrf vni json", isjson=True)
+        raw = json.dumps(output)
+        if "3109" not in raw:
+            return "VNI 3109 not found in 'show vrf vni json'"
+        return None
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_check_new_vni), None, count=20, wait=3
+    )
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -3938,6 +3938,7 @@ int lib_vrf_zebra_mpls_fec_nexthop_resolution_destroy(
 int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
+	struct zebra_vrf *zvrf;
 	vni_t vni = 0;
 	bool pfx_only = false;
 	uint32_t count;
@@ -3963,8 +3964,11 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pfx_only = yang_dnode_get_bool(args->dnode, "../prefix-only");
 
-		zebra_vxlan_process_vrf_vni_cmd(vrf->info, vni,
-						pfx_only ? 1 : 0, 1);
+		zvrf = vrf->info;
+		if (zvrf->l3vni && zvrf->l3vni != vni && zl3vni_lookup(zvrf->l3vni))
+			zebra_vxlan_process_vrf_vni_cmd(zvrf, zvrf->l3vni, 0, 0);
+
+		zebra_vxlan_process_vrf_vni_cmd(zvrf, vni, pfx_only ? 1 : 0, 1);
 		break;
 	}
 


### PR DESCRIPTION
When a VRF's L3VNI value is changed via a single "vni <new>" command (without first issuing "no vni <old>"), the northbound system generates a single NB_CB_MODIFY callback for the l3vni-id leaf. The modify handler lib_vrf_zebra_l3vni_id_modify() calls zebra_vxlan_process_vrf_vni_cmd() with add=1 for the new VNI, but never tears down the old one.

This leaves the old L3VNI entry orphaned in zrouter.l3vni_table. No ZEBRA_L3VNI_DEL is sent to bgpd, so bgpd retains stale EVPN state for the old VNI. The VRF appears to have the correct VNI in running config, but the control plane is broken until FRR is fully restarted.

This path is triggered when config management systems (e.g. NVUE) apply the full frr.conf to a running daemon, causing the NB diff to see a leaf value replace ('r') rather than the explicit destroy+create that frr-reload.py would generate.

Fix by checking zvrf->l3vni before the add. If the VRF already has a different L3VNI, call zebra_vxlan_process_vrf_vni_cmd() with add=0 for the old VNI first, which removes it from the global hash table and notifies bgpd via ZEBRA_L3VNI_DEL.