### PR TITLE
zebra: tear down old L3VNI before adding new one on VNI value change

### DIFF
--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -3938,6 +3938,7 @@ int lib_vrf_zebra_mpls_fec_nexthop_resolution_destroy(
 int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 {
 	struct vrf *vrf;
+	struct zebra_vrf *zvrf;
 	vni_t vni = 0;
 	bool pfx_only = false;
 	uint32_t count;
@@ -3963,8 +3964,11 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pfx_only = yang_dnode_get_bool(args->dnode, "../prefix-only");
 
-		zebra_vxlan_process_vrf_vni_cmd(vrf->info, vni,
-						pfx_only ? 1 : 0, 1);
+		zvrf = vrf->info;
+		if (zvrf->l3vni && zvrf->l3vni != vni)
+			zebra_vxlan_process_vrf_vni_cmd(zvrf, zvrf->l3vni, 0, 0);
+
+		zebra_vxlan_process_vrf_vni_cmd(zvrf, vni, pfx_only ? 1 : 0, 1);
 		break;
 	}
 


### PR DESCRIPTION
When a VRF's L3VNI value is changed via a single "vni <new>" command (without first issuing "no vni <old>"), the northbound system generates a single NB_CB_MODIFY callback for the l3vni-id leaf. The modify handler lib_vrf_zebra_l3vni_id_modify() calls zebra_vxlan_process_vrf_vni_cmd() with add=1 for the new VNI, but never tears down the old one.

This leaves the old L3VNI entry orphaned in zrouter.l3vni_table. No ZEBRA_L3VNI_DEL is sent to bgpd, so bgpd retains stale EVPN state for the old VNI. The VRF appears to have the correct VNI in running config, but the control plane is broken until FRR is fully restarted.

This path is triggered when config management systems (e.g. NVUE) apply the full frr.conf to a running daemon, causing the NB diff to see a leaf value replace ('r') rather than the explicit destroy+create that frr-reload.py would generate.

Fix by checking zvrf->l3vni before the add. If the VRF already has a different L3VNI, call zebra_vxlan_process_vrf_vni_cmd() with add=0 for the old VNI first, which removes it from the global hash table and notifies bgpd via ZEBRA_L3VNI_DEL.