### PR TITLE
Use vrftable instead of table

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
@@ -99,6 +99,7 @@ def setup_module(mod):
         logger.info("Loading router %s" % rname)
         router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
 
+    tgen.gears["r1"].run("sysctl net.vrf.strict_mode=1")
     tgen.gears["r1"].run("ip link add vrf10 type vrf table 10")
     tgen.gears["r1"].run("ip link set vrf10 up")
     tgen.gears["r1"].run("ip link add vrf20 type vrf table 20")
@@ -107,6 +108,7 @@ def setup_module(mod):
     tgen.gears["r1"].run("ip link set eth2 master vrf10")
     tgen.gears["r1"].run("ip link set eth3 master vrf20")
 
+    tgen.gears["r2"].run("sysctl net.vrf.strict_mode=1")
     tgen.gears["r2"].run("ip link add vrf10 type vrf table 10")
     tgen.gears["r2"].run("ip link set vrf10 up")
     tgen.gears["r2"].run("ip link add vrf20 type vrf table 20")

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -316,12 +316,18 @@ def test_ping_step1():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
+    # On rt6, create a VRF to host seg6local DT6 route
+    # inner received packet will fallback to 254 routing table
+    tgen.gears["rt6"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt6"].run("ip link add vrf254fallback type vrf table 1000")
+    tgen.gears["rt6"].run("ip link set dev vrf254fallback up")
+
     # Setup encap route on rt1, decap route on rt2
     tgen.gears["rt1"].vtysh_cmd(
         "sharp install seg6-routes fc00:0:9::1 nexthop-seg6 2001:db8:1::2 encap fc00:0:2:6:f00d:: 1"
     )
     tgen.gears["rt6"].vtysh_cmd(
-        "sharp install seg6local-routes fc00:0:f00d:: nexthop-seg6local eth-dst End_DT6 254 1"
+        "sharp install seg6local-routes fc00:0:f00d:: nexthop-seg6local eth-dst End_DT6 1000 1"
     )
     tgen.gears["dst"].vtysh_cmd(
         "sharp install route 2001:db8:1::1 nexthop 2001:db8:10::1 1"

--- a/tests/topotests/srv6_sid_manager/test_srv6_sid_manager.py
+++ b/tests/topotests/srv6_sid_manager/test_srv6_sid_manager.py
@@ -224,6 +224,12 @@ def build_topo(tgen):
         netmask="128",
         create=True,
     )
+    tgen.gears["rt1"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt2"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt3"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt4"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt5"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt6"].run("sysctl net.vrf.strict_mode=1")
 
 
 def setup_module(mod):

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -482,12 +482,11 @@ parse_encap_seg6local(struct rtattr *tb,
 	if (tb_encap[SEG6_LOCAL_OIF])
 		ctx->ifindex = *(uint32_t *)RTA_DATA(tb_encap[SEG6_LOCAL_OIF]);
 
-	if (tb_encap[SEG6_LOCAL_TABLE])
-		ctx->table = *(uint32_t *)RTA_DATA(tb_encap[SEG6_LOCAL_TABLE]);
-
 	if (tb_encap[SEG6_LOCAL_VRFTABLE])
 		ctx->table =
 			*(uint32_t *)RTA_DATA(tb_encap[SEG6_LOCAL_VRFTABLE]);
+	else if (tb_encap[SEG6_LOCAL_TABLE])
+		ctx->table = *(uint32_t *)RTA_DATA(tb_encap[SEG6_LOCAL_TABLE]);
 
 	if (tb_encap[SEG6_LOCAL_FLAVORS]) {
 		parse_encap_seg6local_flavors(tb_encap[SEG6_LOCAL_FLAVORS],
@@ -1994,7 +1993,7 @@ static bool _netlink_nexthop_encode_seg6local_info(const struct nexthop *nexthop
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DT6:
 		if (!nl_attr_put32(nlmsg, buflen, SEG6_LOCAL_ACTION, SEG6_LOCAL_ACTION_END_DT6))
 			return false;
-		if (!nl_attr_put32(nlmsg, buflen, SEG6_LOCAL_TABLE, ctx->table))
+		if (!nl_attr_put32(nlmsg, buflen, SEG6_LOCAL_VRFTABLE, ctx->table))
 			return false;
 		break;
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DT4:


### PR DESCRIPTION
    zebra: use VRFTABLE attribute for SEG6LOCAL_DT6 instruction
    
    The VRFTABLE attribute is supported on kernel for DT6 instruction.
    Let us use it.
    
    Link: https://github.com/FRRouting/frr/pull/21760
