### PR TITLE
zebra: Allow quick flaps of interfaces to be handled properly in next…

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -152,6 +152,13 @@ struct route_entry {
  * used for nexthops
  */
 #define ROUTE_ENTRY_ROUTE_REPLACING 0x80
+/*
+ * If the route entry experiences a quick flap
+ * of the route entry due to interface flapping
+ * we need to note that we should send a nht removal
+ * then addition.
+ */
+#define ROUTE_ENTRY_SEND_NHT_REMOVAL 0x100
 
 	/* Sequence value incremented for each dataplane operation */
 	uint32_t dplane_sequence;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1493,6 +1493,24 @@ static void rib_process(struct route_node *rn)
 
 		if (old_selected) {
 			/*
+			 * We need to check to see if the old_selected was
+			 * something that was removed from the kernel.  At
+			 * this point in time we do not have any code that
+			 * let's us track nhgs to re's so when we have an
+			 * interface down event, we cannot just mark the
+			 * route entries as no longer installed.  We can
+			 * make do for the moment with Kernel/Connected/Local
+			 * routes because we know if we have a removal/addition
+			 * of one of those route types, we had a very very
+			 * quick interface flap and zebra was unable to
+			 * finish up processing the down event before
+			 * new up events have come in.
+			 */
+			if (new_selected && CHECK_FLAG(old_selected->status, ROUTE_ENTRY_REMOVED) &&
+			    RSYSTEM_ROUTE(old_selected->type))
+				SET_FLAG(new_selected->status, ROUTE_ENTRY_SEND_NHT_REMOVAL);
+
+			/*
 			 * If we're removing the old entry, we should tell
 			 * redist subscribers about that *if* they aren't
 			 * going to see a redist for the new entry.
@@ -2214,6 +2232,9 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 	}
 
 	zebra_rib_evaluate_rn_nexthops(rn, seq, rt_delete);
+	if (re)
+		UNSET_FLAG(re->status, ROUTE_ENTRY_SEND_NHT_REMOVAL);
+
 	zebra_rib_evaluate_mpls(rn);
 done:
 

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -817,7 +817,14 @@ static void zebra_rnh_eval_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 	}
 	zebra_rnh_store_in_routing_table(rnh);
 
-	if (state_changed || force) {
+	if (state_changed || force ||
+	    (re && CHECK_FLAG(re->status, ROUTE_ENTRY_SEND_NHT_REMOVAL))) {
+		if (re && CHECK_FLAG(re->status, ROUTE_ENTRY_SEND_NHT_REMOVAL)) {
+			struct rnh rnh_empty = *rnh;
+
+			rnh_empty.state = NULL;
+			zebra_rnh_notify_protocol_clients(zvrf, afi, nrn, &rnh_empty, prn, NULL);
+		}
 		/* NOTE: Use the "copy" of resolving route stored in 'rnh' i.e.,
 		 * rnh->state.
 		 */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -569,6 +569,9 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn, struct rou
 			json_object_boolean_false_add(json_route, "offloaded");
 		if (CHECK_FLAG(re->status, ROUTE_ENTRY_FAILED))
 			json_object_boolean_true_add(json_route, "failed");
+		if (CHECK_FLAG(re->status, ROUTE_ENTRY_SEND_NHT_REMOVAL))
+			json_object_boolean_true_add(json_route, "kernelRemoved");
+
 		json_object_int_add(json_route, "nexthopGroupId", re->nhe_id);
 		json_object_int_add(json_route, "vrfId", re->vrf_id);
 		json_object_string_add(json_route, "vrfName", vrf_id_to_name(re->vrf_id));


### PR DESCRIPTION
…hop tracking

Currently if you have a quick series of events:

interface down
interface up

This can end up resolving to no changes in the nexthop tracking if zebra is extremely busy.

Modify zebra to notice that the connected/local/kernel routes have been removed and re-added and allow nexthop trackign to send a nexthop withdraw then a add to make things keep working.