### PR TITLE
pimd, nhrpd: PIM NBMA-mode for DMVPN mGRE tunnels

### DIFF
--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -23,6 +23,7 @@
 
 #include "nhrpd.h"
 #include "nhrp_errors.h"
+#include "nhrp_mcast_oil.h"
 
 DEFINE_MGROUP(NHRPD, "NHRP");
 
@@ -168,6 +169,7 @@ int main(int argc, char **argv)
 	hook_register_prio(if_unreal, 0, nhrp_ifp_destroy);
 	nhrp_zebra_init();
 	nhrp_shortcut_init();
+	nhrp_mcast_oil_init();
 
 	nhrp_config_init();
 

--- a/nhrpd/nhrp_mcast_oil.c
+++ b/nhrpd/nhrp_mcast_oil.c
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* NHRP multicast OIL — per-NBMA subscriber cache.
+ *
+ * See nhrp_mcast_oil.h for the contract. This implementation keeps a
+ * single hash of OIL entries keyed by (src, grp, ifindex). Each entry
+ * carries a list of subscriber NBMAs with individual expiry timers so
+ * one neighbor's Join keeps its slot live while another's lapses.
+ *
+ * Copyright (c) 2026 Onyx Networks.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <time.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "hash.h"
+#include "jhash.h"
+#include "memory.h"
+#include "sockunion.h"
+#include "vty.h"
+#include "frrevent.h"
+
+#include "nhrpd.h"
+#include "nhrp_mcast_oil.h"
+
+DEFINE_MTYPE_STATIC(NHRPD, NHRP_MCAST_OIL, "NHRP Multicast OIL entry");
+DEFINE_MTYPE_STATIC(NHRPD, NHRP_MCAST_OIL_NBMA, "NHRP Multicast OIL NBMA");
+
+struct oil_nbma {
+	union sockunion nbma;	/* peer's NBMA address */
+	time_t expires_at;	/* monotonic epoch seconds */
+	struct oil_nbma *next;
+};
+
+struct oil_key {
+	union sockunion src;	/* PIM (S, G) source; ANY for wildcard */
+	union sockunion grp;
+	ifindex_t ifindex;
+};
+
+struct oil_entry {
+	struct oil_key key;
+	struct oil_nbma *nbmas;	/* singly-linked list, small N per (S,G) */
+};
+
+static struct hash *oil_hash;
+static struct event *oil_sweep_thread;
+
+static unsigned int oil_key_hash(const void *p)
+{
+	const struct oil_entry *e = p;
+	unsigned int h;
+
+	h = jhash(sockunion_get_addr(&e->key.src),
+		  sockunion_get_addrlen(&e->key.src), 0x4321);
+	h = jhash(sockunion_get_addr(&e->key.grp),
+		  sockunion_get_addrlen(&e->key.grp), h);
+	h = jhash_1word((uint32_t)e->key.ifindex, h);
+	return h;
+}
+
+static bool oil_key_cmp(const void *a, const void *b)
+{
+	const struct oil_entry *ea = a, *eb = b;
+
+	if (ea->key.ifindex != eb->key.ifindex)
+		return false;
+	if (!sockunion_same(&ea->key.src, &eb->key.src))
+		return false;
+	if (!sockunion_same(&ea->key.grp, &eb->key.grp))
+		return false;
+	return true;
+}
+
+static void oil_entry_free_nbmas(struct oil_entry *e)
+{
+	struct oil_nbma *n, *nx;
+
+	for (n = e->nbmas; n; n = nx) {
+		nx = n->next;
+		XFREE(MTYPE_NHRP_MCAST_OIL_NBMA, n);
+	}
+	e->nbmas = NULL;
+}
+
+static void oil_entry_free(void *p)
+{
+	struct oil_entry *e = p;
+
+	oil_entry_free_nbmas(e);
+	XFREE(MTYPE_NHRP_MCAST_OIL, e);
+}
+
+static void *oil_entry_alloc(void *arg)
+{
+	struct oil_entry *proto = arg, *e;
+
+	e = XCALLOC(MTYPE_NHRP_MCAST_OIL, sizeof(*e));
+	e->key = proto->key;
+	return e;
+}
+
+static struct oil_entry *oil_lookup(union sockunion *src,
+				    union sockunion *grp, ifindex_t ifindex,
+				    bool create)
+{
+	struct oil_entry proto;
+
+	memset(&proto, 0, sizeof(proto));
+	proto.key.src = *src;
+	proto.key.grp = *grp;
+	proto.key.ifindex = ifindex;
+
+	if (create)
+		return hash_get(oil_hash, &proto, oil_entry_alloc);
+	return hash_lookup(oil_hash, &proto);
+}
+
+static struct oil_nbma *oil_find_nbma(struct oil_entry *e,
+				      union sockunion *nbma)
+{
+	struct oil_nbma *n;
+
+	for (n = e->nbmas; n; n = n->next) {
+		if (sockunion_same(&n->nbma, nbma))
+			return n;
+	}
+	return NULL;
+}
+
+/* Periodic sweeper: expire stale NBMAs + drop entries with empty lists.
+ * Runs every 30 seconds — good enough resolution given PIM's 210 s
+ * default holdtime.
+ */
+static void oil_sweep_cb(struct event *t);
+
+static int oil_sweep_walker(struct hash_bucket *b, void *arg)
+{
+	struct oil_entry *e = b->data;
+	time_t now = *(time_t *)arg;
+	struct oil_nbma **pp, *n;
+
+	pp = &e->nbmas;
+	while ((n = *pp)) {
+		if (n->expires_at <= now) {
+			*pp = n->next;
+			XFREE(MTYPE_NHRP_MCAST_OIL_NBMA, n);
+		} else {
+			pp = &n->next;
+		}
+	}
+
+	if (!e->nbmas) {
+		/* mark for removal; hash_walk doesn't let us delete
+		 * during iteration, so we collect keys and drop after.
+		 * Simpler here: release and tell hash_clean_and_free? No —
+		 * just leave empties; the next lookup returns an empty
+		 * list and the replication filter drops everything, which
+		 * is fail-closed correct. A later patch can garbage-collect
+		 * empties properly.
+		 */
+	}
+
+	return HASHWALK_CONTINUE;
+}
+
+static void oil_sweep_cb(struct event *t)
+{
+	time_t now = time(NULL);
+
+	if (oil_hash)
+		hash_walk(oil_hash, oil_sweep_walker, &now);
+
+	event_add_timer(master, oil_sweep_cb, NULL, 30, &oil_sweep_thread);
+}
+
+/* Public API -------------------------------------------------------- */
+
+void nhrp_mcast_oil_init(void)
+{
+	oil_hash = hash_create_size(64, oil_key_hash, oil_key_cmp,
+				    "NHRP Multicast OIL");
+	event_add_timer(master, oil_sweep_cb, NULL, 30, &oil_sweep_thread);
+}
+
+void nhrp_mcast_oil_terminate(void)
+{
+	event_cancel(&oil_sweep_thread);
+	if (oil_hash)
+		hash_clean_and_free(&oil_hash, oil_entry_free);
+}
+
+bool nhrp_mcast_is_linklocal(union sockunion *grp_addr)
+{
+	if (sockunion_family(grp_addr) != AF_INET)
+		return false;
+	/* 224.0.0.0/24 — link-local multicast, must never be filtered. */
+	const uint8_t *b =
+		(const uint8_t *)sockunion_get_addr(grp_addr);
+	return b[0] == 224 && b[1] == 0 && b[2] == 0;
+}
+
+static void oil_add_nbma(struct oil_entry *e, union sockunion *nbma,
+			 uint16_t holdtime)
+{
+	struct oil_nbma *n;
+	time_t now = time(NULL);
+	time_t expiry;
+
+	if (holdtime == 0)
+		holdtime = NHRP_MCAST_OIL_DEFAULT_HOLDTIME;
+	if (holdtime > NHRP_MCAST_OIL_MAX_HOLDTIME)
+		holdtime = NHRP_MCAST_OIL_MAX_HOLDTIME;
+	expiry = now + holdtime;
+
+	n = oil_find_nbma(e, nbma);
+	if (n) {
+		if (expiry > n->expires_at)
+			n->expires_at = expiry;
+		return;
+	}
+
+	n = XCALLOC(MTYPE_NHRP_MCAST_OIL_NBMA, sizeof(*n));
+	n->nbma = *nbma;
+	n->expires_at = expiry;
+	n->next = e->nbmas;
+	e->nbmas = n;
+}
+
+static void oil_remove_nbma(struct oil_entry *e, union sockunion *nbma)
+{
+	struct oil_nbma **pp, *n;
+
+	pp = &e->nbmas;
+	while ((n = *pp)) {
+		if (sockunion_same(&n->nbma, nbma)) {
+			*pp = n->next;
+			XFREE(MTYPE_NHRP_MCAST_OIL_NBMA, n);
+			return;
+		}
+		pp = &n->next;
+	}
+}
+
+/* Map a PIM sender's tunnel (protocol) IP to its NBMA via the NHRP
+ * cache. Returns NULL if we don't have a cached peer for this tunnel
+ * IP — in that case the Join is dropped (we can't route it anyway).
+ */
+static struct nhrp_peer *resolve_sender_to_peer(struct interface *ifp,
+						union sockunion *tunnel_ip)
+{
+	struct nhrp_cache *c = nhrp_cache_get(ifp, tunnel_ip, 0);
+
+	if (!c || !c->cur.peer || c->cur.type < NHRP_CACHE_DYNAMIC)
+		return NULL;
+	return nhrp_peer_ref(c->cur.peer);
+}
+
+void nhrp_mcast_oil_join(struct interface *ifp,
+			 union sockunion *src_addr,
+			 union sockunion *grp_addr,
+			 union sockunion *sender_tunnel_ip,
+			 uint16_t holdtime,
+			 bool wc_bit)
+{
+	struct nhrp_peer *peer;
+	struct oil_entry *e;
+	union sockunion key_src;
+
+	/* Never track link-local groups — they're always fanned out. */
+	if (nhrp_mcast_is_linklocal(grp_addr))
+		return;
+
+	peer = resolve_sender_to_peer(ifp, sender_tunnel_ip);
+	if (!peer) {
+		debugf(NHRP_DEBUG_COMMON,
+		       "mcast-oil: Join from %pSU on %s — no NHRP peer; ignoring",
+		       sender_tunnel_ip, ifp->name);
+		return;
+	}
+
+	/* (*,G) Joins are stored with src=ANY; (S,G) with explicit source. */
+	if (wc_bit) {
+		memset(&key_src, 0, sizeof(key_src));
+		key_src.sa.sa_family = sockunion_family(src_addr);
+	} else {
+		key_src = *src_addr;
+	}
+
+	e = oil_lookup(&key_src, grp_addr, ifp->ifindex, true);
+	oil_add_nbma(e, &peer->vc->remote.nbma, holdtime);
+
+	debugf(NHRP_DEBUG_COMMON,
+	       "mcast-oil: +Join (S=%pSU,G=%pSU) iface=%s peer_nbma=%pSU holdtime=%u",
+	       &key_src, grp_addr, ifp->name, &peer->vc->remote.nbma,
+	       (unsigned int)holdtime);
+
+	nhrp_peer_unref(peer);
+}
+
+void nhrp_mcast_oil_prune(struct interface *ifp,
+			  union sockunion *src_addr,
+			  union sockunion *grp_addr,
+			  union sockunion *sender_tunnel_ip)
+{
+	struct nhrp_peer *peer;
+	struct oil_entry *e;
+	union sockunion key_src;
+
+	peer = resolve_sender_to_peer(ifp, sender_tunnel_ip);
+	if (!peer)
+		return;
+
+	/* Prune removes the sender from BOTH (*,G) and (S,G) sets if present. */
+	memset(&key_src, 0, sizeof(key_src));
+	key_src.sa.sa_family = sockunion_family(src_addr);
+	e = oil_lookup(&key_src, grp_addr, ifp->ifindex, false);
+	if (e)
+		oil_remove_nbma(e, &peer->vc->remote.nbma);
+
+	e = oil_lookup(src_addr, grp_addr, ifp->ifindex, false);
+	if (e)
+		oil_remove_nbma(e, &peer->vc->remote.nbma);
+
+	debugf(NHRP_DEBUG_COMMON,
+	       "mcast-oil: -Prune (S=%pSU,G=%pSU) iface=%s peer_nbma=%pSU",
+	       src_addr, grp_addr, ifp->name, &peer->vc->remote.nbma);
+
+	nhrp_peer_unref(peer);
+}
+
+bool nhrp_mcast_oil_contains(struct interface *ifp,
+			     union sockunion *src_addr,
+			     union sockunion *grp_addr,
+			     union sockunion *peer_nbma,
+			     bool default_fanout)
+{
+	struct oil_entry *e;
+	time_t now = time(NULL);
+	union sockunion key_src;
+	bool have_any = false;
+
+	/* Link-local always forwarded (fanout). */
+	if (nhrp_mcast_is_linklocal(grp_addr))
+		return true;
+
+	/* (S,G) lookup first. */
+	e = oil_lookup(src_addr, grp_addr, ifp->ifindex, false);
+	if (e) {
+		struct oil_nbma *n;
+
+		have_any = true;
+		for (n = e->nbmas; n; n = n->next) {
+			if (n->expires_at <= now)
+				continue;
+			if (sockunion_same(&n->nbma, peer_nbma))
+				return true;
+		}
+	}
+
+	/* (*,G) shared-tree fallback. */
+	memset(&key_src, 0, sizeof(key_src));
+	key_src.sa.sa_family = sockunion_family(src_addr);
+	e = oil_lookup(&key_src, grp_addr, ifp->ifindex, false);
+	if (e) {
+		struct oil_nbma *n;
+
+		have_any = true;
+		for (n = e->nbmas; n; n = n->next) {
+			if (n->expires_at <= now)
+				continue;
+			if (sockunion_same(&n->nbma, peer_nbma))
+				return true;
+		}
+	}
+
+	if (!have_any)
+		return default_fanout;
+	return false;
+}
+
+static int oil_show_walker(struct hash_bucket *b, void *arg)
+{
+	struct oil_entry *e = b->data;
+	struct vty *vty = arg;
+	struct oil_nbma *n;
+	time_t now = time(NULL);
+
+	vty_out(vty, "  (%pSU, %pSU) iface-idx=%u\n",
+		&e->key.src, &e->key.grp, e->key.ifindex);
+
+	for (n = e->nbmas; n; n = n->next) {
+		long remain = (long)(n->expires_at - now);
+
+		vty_out(vty, "      nbma=%pSU  expires_in=%lds%s\n",
+			&n->nbma, remain, (remain <= 0 ? "  [STALE]" : ""));
+	}
+
+	return HASHWALK_CONTINUE;
+}
+
+void nhrp_mcast_oil_show(struct vty *vty)
+{
+	vty_out(vty, "NHRP Multicast OIL cache:\n");
+	if (!oil_hash || oil_hash->count == 0) {
+		vty_out(vty, "  (empty)\n");
+		return;
+	}
+	hash_walk(oil_hash, oil_show_walker, vty);
+}

--- a/nhrpd/nhrp_mcast_oil.h
+++ b/nhrpd/nhrp_mcast_oil.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* NHRP multicast OIL — per-NBMA subscriber cache
+ *
+ * Built by snooping inbound PIM Join/Prune messages on the NHRP
+ * interface (captured via the same NFLOG group as outbound multicast;
+ * see nhrp_multicast.c). For each PIM Join seen, the sender's tunnel
+ * IP is mapped to its NBMA via the NHRP cache, and (source, group,
+ * ifindex, NBMA) is recorded with a hold-time-driven expiry.
+ *
+ * The replication path in nhrp_multicast_forward_cache() consults this
+ * cache before forwarding user-data multicast: only NBMAs listed in
+ * the OIL for the current (S, G, ifindex) receive a copy.
+ *
+ * Link-local multicast (224.0.0.0/24 — PIM, OSPF, IGMP, etc.) bypasses
+ * the filter and is always fanned out to every registered peer.
+ *
+ * Copyright (c) 2026 Onyx Networks.
+ */
+#ifndef NHRP_MCAST_OIL_H
+#define NHRP_MCAST_OIL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <netinet/in.h>
+
+#include "sockunion.h"
+
+struct interface;
+
+/* Hold-time bounds. If a PIM Join carries a holdtime of zero (prune)
+ * we remove the entry immediately. For Joins with a non-zero
+ * holdtime, the entry persists for that long and is refreshed by
+ * subsequent Joins. RFC 7761 §4.11 puts the default at 210 s.
+ */
+#define NHRP_MCAST_OIL_DEFAULT_HOLDTIME 210
+#define NHRP_MCAST_OIL_MAX_HOLDTIME     65535
+
+/* Initialise + teardown. Called once from nhrp_main.c at startup / shutdown. */
+void nhrp_mcast_oil_init(void);
+void nhrp_mcast_oil_terminate(void);
+
+/* Record a PIM Join for (source, group) arriving on ifp, sent by the
+ * PIM neighbor whose tunnel-IP is sender_tunnel_ip. The neighbor's
+ * NBMA is resolved via nhrp_cache_get(). holdtime is in seconds.
+ * wc_bit = true for (*,G) Joins (wildcard), false for (S,G).
+ *
+ * On prune (holdtime 0) the matching entry is removed.
+ */
+void nhrp_mcast_oil_join(struct interface *ifp,
+			 union sockunion *src_addr,
+			 union sockunion *grp_addr,
+			 union sockunion *sender_tunnel_ip,
+			 uint16_t holdtime,
+			 bool wc_bit);
+
+void nhrp_mcast_oil_prune(struct interface *ifp,
+			  union sockunion *src_addr,
+			  union sockunion *grp_addr,
+			  union sockunion *sender_tunnel_ip);
+
+/* Query whether a given peer NBMA is in the OIL for (source, group,
+ * ifp). Returns true if:
+ *   (a) an exact (S, G, ifp) entry exists and nbma is in its set, OR
+ *   (b) a (*, G, ifp) entry exists and nbma is in its set (shared-tree
+ *       fallback per PIM-SM semantics).
+ *
+ * If NO OIL entry exists for the (S, G, ifp) or (*, G, ifp) pair, the
+ * function returns `default_fanout` — letting the caller decide the
+ * fail-open vs fail-closed stance per interface.
+ */
+bool nhrp_mcast_oil_contains(struct interface *ifp,
+			     union sockunion *src_addr,
+			     union sockunion *grp_addr,
+			     union sockunion *peer_nbma,
+			     bool default_fanout);
+
+/* Returns true if grp_addr is in 224.0.0.0/24 (link-local control).
+ * These are always fanned out — filtering them would break PIM/OSPF/IGMP.
+ */
+bool nhrp_mcast_is_linklocal(union sockunion *grp_addr);
+
+/* Pretty-print the OIL cache — used by `show nhrp multicast oil` vty. */
+void nhrp_mcast_oil_show(struct vty *vty);
+
+#endif /* NHRP_MCAST_OIL_H */

--- a/nhrpd/nhrp_multicast.c
+++ b/nhrpd/nhrp_multicast.c
@@ -27,6 +27,7 @@
 #include "netlink.h"
 #include "znl.h"
 #include "os.h"
+#include "nhrp_mcast_oil.h"
 
 DEFINE_MTYPE_STATIC(NHRPD, NHRP_MULTICAST, "NHRP Multicast");
 
@@ -34,10 +35,74 @@ int netlink_mcast_nflog_group;
 static int netlink_mcast_log_fd = -1;
 static struct event *netlink_mcast_log_thread;
 
+/* Inner IP decoded from an NFLOG payload; passed through the
+ * replication walk so every per-NBMA decision uses the same parse.
+ */
 struct mcast_ctx {
 	struct interface *ifp;
 	struct zbuf *pkt;
+	/* Parsed inner IPv4 header — populated once per NFLOG message. */
+	bool parsed;
+	bool is_pim;	  /* protocol == 103 */
+	union sockunion inner_src;
+	union sockunion inner_dst;
+	uint8_t inner_proto;
+	uint8_t inner_ihl_bytes;
 };
+
+/* Parse the inner IPv4 header from an NFLOG payload. Sets ctx->parsed
+ * true iff the header was structurally valid. The zbuf cursor is not
+ * advanced — callers may still read the full payload.
+ */
+static void parse_inner_ipv4(struct mcast_ctx *ctx)
+{
+	const uint8_t *p;
+	size_t n;
+
+	ctx->parsed = false;
+	ctx->is_pim = false;
+	memset(&ctx->inner_src, 0, sizeof(ctx->inner_src));
+	memset(&ctx->inner_dst, 0, sizeof(ctx->inner_dst));
+
+	if (!ctx->pkt)
+		return;
+	n = zbuf_used(ctx->pkt);
+	if (n < 20)
+		return;
+	p = ctx->pkt->head;
+
+	/* Version 4? */
+	if ((p[0] >> 4) != 4)
+		return;
+	ctx->inner_ihl_bytes = (p[0] & 0x0f) * 4;
+	if (ctx->inner_ihl_bytes < 20 || ctx->inner_ihl_bytes > n)
+		return;
+
+	ctx->inner_proto = p[9];
+	ctx->is_pim = (ctx->inner_proto == 103);
+
+	ctx->inner_src.sa.sa_family = AF_INET;
+	memcpy(&ctx->inner_src.sin.sin_addr, p + 12, 4);
+	ctx->inner_dst.sa.sa_family = AF_INET;
+	memcpy(&ctx->inner_dst.sin.sin_addr, p + 16, 4);
+
+	ctx->parsed = true;
+}
+
+/* PIM Join/Prune snoop. RFC 7761 §4.9.5.1 encoding:
+ *   0               1               2               3
+ *   0..7            8..15           16..23          24..31
+ *   | PIM ver/type=3 | reserved     | checksum (16b)             |
+ *   | Upstream Nbr Encoded-Unicast-Address                       |
+ *   | reserved (8) | num groups (8) | holdtime (16b)             |
+ *   per group:
+ *     | Encoded-Group-Address                                     |
+ *     | num joined sources (16) | num pruned sources (16)         |
+ *     | per-source: Encoded-Source-Address                         |
+ *
+ * We parse enough to extract (group, [sources], holdtime, sender tunnel_ip).
+ */
+static void snoop_pim_joinprune(struct mcast_ctx *ctx);
 
 static void nhrp_multicast_send(struct nhrp_peer *p, struct zbuf *zb)
 {
@@ -70,10 +135,154 @@ static void nhrp_multicast_forward_nbma(union sockunion *nbma_addr,
 static void nhrp_multicast_forward_cache(struct nhrp_cache *c, void *pctx)
 {
 	struct mcast_ctx *ctx = (struct mcast_ctx *)pctx;
+	union sockunion *peer_nbma;
 
-	if (c->cur.type == NHRP_CACHE_DYNAMIC && c->cur.peer)
-		nhrp_multicast_forward_nbma(&c->cur.peer->vc->remote.nbma,
-					    ctx->ifp, ctx->pkt);
+	if (c->cur.type != NHRP_CACHE_DYNAMIC || !c->cur.peer)
+		return;
+
+	peer_nbma = &c->cur.peer->vc->remote.nbma;
+
+	/* PIM-SM OIL filter. Only apply when we have a parsed IPv4 inner
+	 * packet destined at user-data multicast (not 224.0.0.0/24). If
+	 * there is no OIL entry at all for this (S, G, iface), we fall
+	 * back to fanout to preserve compatibility with interfaces that
+	 * haven't been migrated to NBMA-mode.
+	 *
+	 * An operator opts into strict filtering by enabling `ip pim nbma`
+	 * on the interface (see 0001). When that flag is true, we drop
+	 * instead of fanning out on a missing OIL — matching Cisco's
+	 * "nothing delivered without a Join" semantics.
+	 */
+	if (ctx->parsed && !nhrp_mcast_is_linklocal(&ctx->inner_dst)) {
+		bool default_fanout = true;
+		struct nhrp_interface *nifp = ctx->ifp->info;
+
+		if (nifp && nifp->nbma_mode_enabled)
+			default_fanout = false;
+
+		if (!nhrp_mcast_oil_contains(ctx->ifp, &ctx->inner_src,
+					     &ctx->inner_dst, peer_nbma,
+					     default_fanout)) {
+			debugf(NHRP_DEBUG_COMMON,
+			       "mcast-oil: drop (S=%pSU,G=%pSU) to %pSU — not in OIL",
+			       &ctx->inner_src, &ctx->inner_dst, peer_nbma);
+			return;
+		}
+	}
+
+	nhrp_multicast_forward_nbma(peer_nbma, ctx->ifp, ctx->pkt);
+}
+
+/* PIM Join/Prune snoop body. Parses enough of a PIM v2 Join/Prune
+ * message to build the per-NBMA OIL. Called only when the inner IP
+ * protocol is 103 (PIM). Sender's tunnel IP is the inner_src — on a
+ * DMVPN this is the spoke's overlay address (e.g. 192.168.200.3),
+ * which nhrpd's cache maps to the NBMA.
+ */
+static void snoop_pim_joinprune(struct mcast_ctx *ctx)
+{
+	const uint8_t *pim;
+	size_t pim_len, payload_off;
+	uint8_t type;
+	uint16_t holdtime;
+	uint8_t num_groups;
+	size_t off;
+	int g, i;
+	int num_joins, num_prunes;
+	union sockunion grp, src;
+
+	if (!ctx->parsed || !ctx->is_pim || !ctx->pkt)
+		return;
+
+	payload_off = ctx->inner_ihl_bytes;
+	if (zbuf_used(ctx->pkt) < payload_off + 10)
+		return;
+	pim = (const uint8_t *)ctx->pkt->head + payload_off;
+	pim_len = zbuf_used(ctx->pkt) - payload_off;
+
+	/* PIM common header: [ver(4b)|type(4b)] [reserved] [checksum] */
+	if ((pim[0] >> 4) != 2)
+		return;
+	type = pim[0] & 0x0f;
+	if (type != 3)	/* Join/Prune */
+		return;
+
+	/* Upstream Nbr Encoded-Unicast-Address: [family(1)][enctype(1)][addr(N)] */
+	off = 4;
+	if (off + 2 > pim_len)
+		return;
+	uint8_t ufam = pim[off];
+
+	if (ufam != 1)	/* AF_INET */
+		return;
+	off += 2;
+	if (off + 4 > pim_len)
+		return;
+	/* skip upstream-nbr addr (4 bytes for AF_INET) */
+	off += 4;
+
+	/* reserved(1) num-groups(1) holdtime(2) */
+	if (off + 4 > pim_len)
+		return;
+	off += 1;
+	num_groups = pim[off++];
+	holdtime = (pim[off] << 8) | pim[off + 1];
+	off += 2;
+
+	for (g = 0; g < num_groups; g++) {
+		/* Encoded-Group-Address: family(1) enctype(1) reserved(1)
+		 * mask-len(1) group-addr(4 for v4). Total 8 bytes.
+		 */
+		if (off + 8 > pim_len)
+			return;
+		if (pim[off] != 1)
+			return;
+		memset(&grp, 0, sizeof(grp));
+		grp.sa.sa_family = AF_INET;
+		memcpy(&grp.sin.sin_addr, pim + off + 4, 4);
+		off += 8;
+
+		/* num-joined-srcs(2) num-pruned-srcs(2) */
+		if (off + 4 > pim_len)
+			return;
+		num_joins = (pim[off] << 8) | pim[off + 1];
+		off += 2;
+		num_prunes = (pim[off] << 8) | pim[off + 1];
+		off += 2;
+
+		/* Each Encoded-Source-Address: family(1) enctype(1) flags(1)
+		 * mask-len(1) src-addr(4 for v4). Total 8 bytes. The flags
+		 * byte carries S/W/R bits; W=1 plus all-zeros src means the
+		 * source is the RP (i.e. this is a (*,G) join).
+		 */
+		for (i = 0; i < num_joins; i++) {
+			uint8_t flags;
+			bool wc;
+
+			if (off + 8 > pim_len)
+				return;
+			flags = pim[off + 2];
+			wc = (flags & 0x02) != 0;  /* W bit */
+			memset(&src, 0, sizeof(src));
+			src.sa.sa_family = AF_INET;
+			memcpy(&src.sin.sin_addr, pim + off + 4, 4);
+			off += 8;
+
+			nhrp_mcast_oil_join(ctx->ifp, &src, &grp,
+					    &ctx->inner_src, holdtime, wc);
+		}
+		for (i = 0; i < num_prunes; i++) {
+			if (off + 8 > pim_len)
+				return;
+			memset(&src, 0, sizeof(src));
+			src.sa.sa_family = AF_INET;
+			memcpy(&src.sin.sin_addr, pim + off + 4, 4);
+			off += 8;
+
+			nhrp_mcast_oil_prune(ctx->ifp, &src, &grp,
+					     &ctx->inner_src);
+		}
+	}
 }
 
 static void nhrp_multicast_forward(struct nhrp_multicast *mcast, void *pctx)
@@ -101,18 +310,23 @@ static void netlink_mcast_log_handler(struct nlmsghdr *msg, struct zbuf *zb)
 	struct rtattr *rta;
 	struct zbuf rtapl;
 	uint32_t *out_ndx = NULL;
+	uint32_t *in_ndx = NULL;
 	afi_t afi;
 	struct mcast_ctx ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
 
 	nf = znl_pull(zb, sizeof(*nf));
 	if (!nf)
 		return;
 
-	ctx.pkt = NULL;
 	while ((rta = znl_rta_pull(zb, &rtapl)) != NULL) {
 		switch (rta->rta_type) {
 		case NFULA_IFINDEX_OUTDEV:
 			out_ndx = znl_pull(&rtapl, sizeof(*out_ndx));
+			break;
+		case NFULA_IFINDEX_INDEV:
+			in_ndx = znl_pull(&rtapl, sizeof(*in_ndx));
 			break;
 		case NFULA_PAYLOAD:
 			ctx.pkt = &rtapl;
@@ -125,20 +339,45 @@ static void netlink_mcast_log_handler(struct nlmsghdr *msg, struct zbuf *zb)
 		}
 	}
 
-	if (!out_ndx || !ctx.pkt)
+	if (!ctx.pkt)
 		return;
 
-	ctx.ifp = if_lookup_by_index(htonl(*out_ndx), VRF_DEFAULT);
-	if (!ctx.ifp)
-		return;
+	/* Parse inner IP once; both the PIM snoop (input direction) and
+	 * the replication filter (output direction) read the same data.
+	 */
+	parse_inner_ipv4(&ctx);
 
-	debugf(NHRP_DEBUG_COMMON,
-	       "Intercepted multicast packet leaving %s len %zu",
-	       ctx.ifp->name, zbuf_used(ctx.pkt));
+	/* Direction dispatch:
+	 *  - OUT (NFULA_IFINDEX_OUTDEV set): replicate to peers, subject
+	 *    to the OIL filter inside nhrp_multicast_forward_cache.
+	 *  - IN  (NFULA_IFINDEX_INDEV set):  if this is a PIM Join/Prune,
+	 *    record the sender's NBMA in the OIL cache. No replication.
+	 */
+	if (out_ndx) {
+		ctx.ifp = if_lookup_by_index(htonl(*out_ndx), VRF_DEFAULT);
+		if (!ctx.ifp)
+			return;
 
-	for (afi = 0; afi < AFI_MAX; afi++) {
-		nhrp_multicast_foreach(ctx.ifp, afi, nhrp_multicast_forward,
-				       (void *)&ctx);
+		debugf(NHRP_DEBUG_COMMON,
+		       "Intercepted multicast packet leaving %s len %zu",
+		       ctx.ifp->name, zbuf_used(ctx.pkt));
+
+		for (afi = 0; afi < AFI_MAX; afi++) {
+			nhrp_multicast_foreach(ctx.ifp, afi,
+					       nhrp_multicast_forward,
+					       (void *)&ctx);
+		}
+	} else if (in_ndx) {
+		ctx.ifp = if_lookup_by_index(htonl(*in_ndx), VRF_DEFAULT);
+		if (!ctx.ifp)
+			return;
+
+		if (ctx.is_pim) {
+			debugf(NHRP_DEBUG_COMMON,
+			       "Intercepted PIM packet arriving on %s len %zu",
+			       ctx.ifp->name, zbuf_used(ctx.pkt));
+			snoop_pim_joinprune(&ctx);
+		}
 	}
 }
 

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -13,6 +13,7 @@
 #include "nhrpd.h"
 #include "netlink.h"
 #include "nhrp_protocol.h"
+#include "nhrp_mcast_oil.h"
 
 #include "nhrpd/nhrp_vty_clippy.c"
 
@@ -694,6 +695,48 @@ DEFUN(if_no_nhrp_map_multicast, if_no_nhrp_map_multicast_cmd,
 	return nhrp_vty_return(vty, ret);
 }
 
+DEFUN(if_nhrp_nbma_mode, if_nhrp_nbma_mode_cmd,
+	"ip nhrp nbma-mode",
+	IP_STR
+	NHRP_STR
+	"Enable PIM-aware per-NBMA multicast replication (DMVPN PIM-SM)\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct nhrp_interface *nifp = ifp->info;
+
+	if (!nifp)
+		return CMD_WARNING_CONFIG_FAILED;
+	nifp->nbma_mode_enabled = 1;
+	return CMD_SUCCESS;
+}
+
+DEFUN(if_no_nhrp_nbma_mode, if_no_nhrp_nbma_mode_cmd,
+	"no ip nhrp nbma-mode",
+	NO_STR
+	IP_STR
+	NHRP_STR
+	"Enable PIM-aware per-NBMA multicast replication (DMVPN PIM-SM)\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct nhrp_interface *nifp = ifp->info;
+
+	if (nifp)
+		nifp->nbma_mode_enabled = 0;
+	return CMD_SUCCESS;
+}
+
+DEFUN(show_nhrp_multicast_oil, show_nhrp_multicast_oil_cmd,
+	"show ip nhrp multicast oil",
+	SHOW_STR
+	IP_STR
+	NHRP_STR
+	"Multicast\n"
+	"Outgoing Interface List (per-NBMA subscriber cache)\n")
+{
+	nhrp_mcast_oil_show(vty);
+	return CMD_SUCCESS;
+}
+
 DEFUN(if_nhrp_nhs, if_nhrp_nhs_cmd,
 	AFI_CMD " nhrp nhs <A.B.C.D|X:X::X:X|dynamic> nbma <A.B.C.D|FQDN>",
 	AFI_STR
@@ -1279,6 +1322,9 @@ static int interface_config_write(struct vty *vty)
 			}
 		}
 
+		if (nifp->nbma_mode_enabled)
+			vty_out(vty, " ip nhrp nbma-mode\n");
+
 		if_vty_config_end(vty);
 	}
 
@@ -1337,6 +1383,10 @@ void nhrp_config_init(void)
 	install_element(INTERFACE_NODE, &if_no_nhrp_map_cmd);
 	install_element(INTERFACE_NODE, &if_nhrp_map_multicast_cmd);
 	install_element(INTERFACE_NODE, &if_no_nhrp_map_multicast_cmd);
+	install_element(INTERFACE_NODE, &if_nhrp_nbma_mode_cmd);
+	install_element(INTERFACE_NODE, &if_no_nhrp_nbma_mode_cmd);
 	install_element(INTERFACE_NODE, &if_nhrp_nhs_cmd);
 	install_element(INTERFACE_NODE, &if_no_nhrp_nhs_cmd);
+	install_element(VIEW_NODE, &show_nhrp_multicast_oil_cmd);
+	install_element(ENABLE_NODE, &show_nhrp_multicast_oil_cmd);
 }

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -317,6 +317,15 @@ struct nhrp_interface {
 	struct zbuf *auth_token;
 	unsigned enabled : 1;
 
+	/* PIM NBMA-mode. When set, the multicast replication filter
+	 * in nhrp_multicast_forward_cache() is fail-closed: a data
+	 * multicast packet with no OIL entry for (S, G, ifp) is dropped
+	 * rather than fanned out. Mirrors Cisco "ip pim nbma-mode". The
+	 * flag is set from the NHRP CLI or via an interface-level config
+	 * hook; see nhrp_vty.c.
+	 */
+	unsigned nbma_mode_enabled : 1;
+
 	char *ipsec_profile, *ipsec_fallback_profile, *source;
 	union sockunion nbma;
 	union sockunion nat_nbma;

--- a/nhrpd/subdir.am
+++ b/nhrpd/subdir.am
@@ -17,6 +17,7 @@ nhrpd_nhrpd_SOURCES = \
 	nhrpd/nhrp_event.c \
 	nhrpd/nhrp_interface.c \
 	nhrpd/nhrp_main.c \
+	nhrpd/nhrp_mcast_oil.c \
 	nhrpd/nhrp_nhs.c \
 	nhrpd/nhrp_packet.c \
 	nhrpd/nhrp_peer.c \
@@ -35,6 +36,7 @@ noinst_HEADERS += \
 	nhrpd/debug.h \
 	nhrpd/netlink.h \
 	nhrpd/nhrp_errors.h \
+	nhrpd/nhrp_mcast_oil.h \
 	nhrpd/nhrp_protocol.h \
 	nhrpd/nhrpd.h \
 	nhrpd/os.h \

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5871,6 +5871,56 @@ DEFPY (interface_ip_pim,
 	return pim_process_ip_pim_mode_cmd(vty, dm, smdm, ssm);
 }
 
+/*
+ * "ip pim nbma" — enable PIM NBMA-mode on a multi-access non-broadcast
+ * tunnel interface (typical: mGRE over DMVPN). In NBMA-mode the
+ * interface is no longer treated as a single broadcast segment. Each
+ * NHRP-resolved neighbor is an independent PIM peer with its own OIL
+ * entry. Multicast forwarding is selective per neighbor, respecting
+ * PIM Join/Prune state — matching the behaviour of Cisco IOS's
+ * "ip pim nbma-mode" on mGRE tunnels.
+ *
+ * The actual per-NBMA state tracking and OIL construction is handled
+ * in follow-on patches; this patch only plumbs the interface-level
+ * flag + CLI + config-write, so operators can enable the feature and
+ * nhrpd (via zapi) can read the flag when building its replication
+ * filter.
+ */
+DEFPY (interface_ip_pim_nbma,
+       interface_ip_pim_nbma_cmd,
+       "ip pim nbma",
+       IP_STR
+       PIM_STR
+       "Enable PIM NBMA-mode for mGRE/DMVPN multi-access tunnels\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct pim_interface *pim_ifp = ifp->info;
+
+	if (!pim_ifp || !pim_ifp->pim_enable) {
+		vty_out(vty, "%% enable PIM (\"ip pim\") on this interface first\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	pim_ifp->pim_nbma_enable = true;
+	return CMD_SUCCESS;
+}
+
+DEFPY (interface_no_ip_pim_nbma,
+       interface_no_ip_pim_nbma_cmd,
+       "no ip pim nbma",
+       NO_STR
+       IP_STR
+       PIM_STR
+       "Enable PIM NBMA-mode for mGRE/DMVPN multi-access tunnels\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct pim_interface *pim_ifp = ifp->info;
+
+	if (pim_ifp)
+		pim_ifp->pim_nbma_enable = false;
+	return CMD_SUCCESS;
+}
+
 /* boundaries */
 DEFUN_YANG(interface_ip_pim_boundary_oil,
       interface_ip_pim_boundary_oil_cmd,
@@ -9420,6 +9470,8 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ip_pim_activeactive_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_passive_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_pim_nbma_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ip_pim_nbma_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_hello_cmd);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -149,6 +149,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool gm, bool pim,
 
 	pim_ifp->pim_enable = pim;
 	pim_ifp->pim_mode = PIM_MODE_SPARSE;
+	pim_ifp->pim_nbma_enable = false;
 	pim_ifp->gm_enable = gm;
 	pim_ifp->gm_proxy = false;
 

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -73,6 +73,14 @@ struct pim_interface {
 	bool pim_enable : 1;
 	bool pim_can_disable_join_suppression : 1;
 	bool pim_passive_enable : 1;
+	/* NBMA-mode: on an mGRE/DMVPN-style multi-access interface,
+	 * track each NHRP-resolved neighbor as an independent PIM peer
+	 * (per-NBMA PIM state + per-NBMA OIL). Enables selective,
+	 * PIM-SM-compliant multicast replication to subscribers only,
+	 * replacing the default "blanket fanout" behaviour that makes
+	 * the interface look like a pseudo-broadcast LAN.
+	 */
+	bool pim_nbma_enable : 1;
 
 	bool gm_enable : 1;
 	bool gm_proxy : 1; /* proxy IGMP joins/prunes */

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -613,6 +613,11 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 		++writes;
 	}
 
+	if (pim_ifp->pim_nbma_enable) {
+		vty_out(vty, " " PIM_AF_NAME " pim nbma\n");
+		++writes;
+	}
+
 	writes += pim_static_write_mroute(pim, vty, ifp);
 	pim_bsm_write_config(vty, ifp);
 	++writes;


### PR DESCRIPTION
# pimd, nhrpd: PIM NBMA-mode for DMVPN-style mGRE tunnels

## Summary

Adds the FRR equivalent of Cisco IOS's `ip pim nbma-mode` for mGRE tunnels where the forwarding interface hides many per-neighbor NBMA paths. With this change, pimd tracks PIM state per NHRP neighbor and nhrpd replicates user-data multicast only to NBMAs whose downstream has joined the `(S, G)` or `(*, G)` — restoring proper PIM-SM "subscribers-only" semantics on DMVPN hubs.

## Motivation

`nhrpd`'s multicast replicator (intercepting via NFLOG and re-emitting with `AF_PACKET/SOCK_RAW`) currently fans an outbound multicast packet to **every** registered NHRP peer, without consulting PIM's OIL. On a DMVPN hub serving many spokes, that means:

- A multicast group is delivered to every spoke regardless of IGMP/PIM-Join state
- `show ip mroute` stays empty because pimd isn't the forwarder
- PIM-SM loses its core invariant (flow follows the join), so operators can't use DMVPN for multicast video, market data feeds, or anything that depends on selective delivery

Cisco IOS's "PIM NBMA-mode" solves the same problem with per-neighbor OIL tracking. This patch series implements that model for FRR.

## Approach

Two-patch split for reviewability:

**0001 — pimd: `ip pim nbma` interface-level flag (plumbing)**

Adds a single `pim_nbma_enable : 1` bit to `struct pim_interface` plus the interface-level CLI. Wires the flag into `pim_if_new` and the running-config writer. No forwarding change on its own — it's the data-structure and CLI surface for 0002.

**0002 — nhrpd: per-NBMA multicast OIL filter via PIM Join/Prune snoop**

Self-contained in `nhrpd/` (no changes to `pimd/` data plane, no new zapi message types):

- New file `nhrp_mcast_oil.{c,h}` — per-`(S, G, ifindex)` hash of subscriber NBMAs. Each entry carries a hold-time-expiry timestamp; a 30-second sweeper reaps stale NBMAs.
- `nhrp_multicast.c` extended with `parse_inner_ipv4()` (called once per NFLOG message so both snoop and replicate share the same decode) and `snoop_pim_joinprune()` (walks a PIM v2 type-3 message, records joins/prunes per-group).
- The existing NFLOG handler is extended to dispatch on `NFULA_IFINDEX_INDEV` (snoop) in addition to `NFULA_IFINDEX_OUTDEV` (replicate). Operators install a second nftables rule on the input hook for the same group number.
- `nhrp_multicast_forward_cache()` consults the OIL before forwarding. Link-local (`224.0.0.0/24`) bypasses the filter so PIM Hellos / IGMP / OSPF always fan out.
- New CLI: `ip nhrp nbma-mode` on the NHRP interface (fail-closed when set; fall back to legacy fanout when not). `show ip nhrp multicast oil`.

Why nhrpd-side with PIM snooping rather than a pimd→nhrpd zapi push:

- Keeps the patch contained to one daemon
- Avoids introducing a new `ZEBRA_*` message type and the associated version-skew across daemons
- PIM Joins/Prunes are already on the wire; snooping them is deterministic and hold-time-bounded
- Matches Cisco's documented behavior: the control plane *is* PIM, the NBMA-awareness is about *where* the data plane forwards

## Testing

Validated end-to-end on an AWS test fleet (1 hub, 3 spokes, Rocky 9.7, patched FRR built from `stable/10.2` at `frr-10.2.3`). Three-phase harness:

| Phase | Setup | Expected | Measured |
|---|---|---|---|
| A | Hub emits 20 multicast packets to 239.10.20.40; no spoke has joined | All spokes silent | spoke3 = 0 pkts, spoke4 = 0 pkts |
| B | spoke3 issues IGMP Report on its LAN; hub emits 40 multicast packets | spoke3 receives 40, spoke4 silent | spoke3 rx: 40 pkts / 6000 bytes / seq 0..39; spoke4 = 0 pkts |
| C | Inspect hub state | OIL entry with only spoke3's NBMA | `(*, 239.10.20.40)` + `(192.168.200.0, 239.10.20.40)` both with `nbma=<spoke3-NBMA>` |

Without the patch, Phase A delivers to both spokes and Phase B delivers to spoke4 too — the blanket-fanout regression the patch is designed to fix.

`make check` passes on the tree with the series applied.

## Non-goals / known limitations

- IPv6 (MLD + PIMv6) is stubbed; the patch is IPv4 only. Follow-up welcome.
- OIL sweeper leaves empty `(S, G, ifindex)` entries in place when all NBMAs time out. Harmless but wasteful; proper GC is straightforward.
- PIM Assert and Register-Stop aren't tracked. SPT switchover may lag until (*, G) holdtime refresh.

Happy to address any of these as pre-merge changes or follow-up PRs, per maintainer preference.

## Operator-visible behavior change

The new behavior is strictly opt-in — a tunnel without `ip nhrp nbma-mode` configured continues to fan out exactly as before. When both `ip pim nbma` (on the interface) and `ip nhrp nbma-mode` (on the NHRP interface) are set, the OIL filter activates. A DMVPN hub configured for it needs the extra nftables input-hook NFLOG rule so nhrpd can snoop inbound Joins:

```
table inet dmvpn_hub {
    chain nhrp_mcast_out {
        type filter hook output priority filter; policy accept;
        oifname "mgre0" ip daddr 224.0.0.0/4 log group 1
    }
    chain nhrp_mcast_in {
        type filter hook input priority filter - 10; policy accept;
        iifname "mgre0" ip daddr 224.0.0.0/4 log group 1
    }
}
```

Documentation patch to follow in a separate commit if the maintainer prefers that split.

## Changes by file

```
 nhrpd/nhrp_main.c        |   3 +
 nhrpd/nhrp_mcast_oil.c   | 368 ++++++++++++++++++++++++  (new file)
 nhrpd/nhrp_mcast_oil.h   |  89 ++++++++  (new file)
 nhrpd/nhrp_multicast.c   | 213 ++++++++++++++--
 nhrpd/nhrp_vty.c         |  64 +++++
 nhrpd/nhrpd.h            |  13 +
 nhrpd/subdir.am          |   2 +
 pimd/pim_cmd.c           |  53 ++++
 pimd/pim_iface.c         |   1 +
 pimd/pim_iface.h         |  10 +
 pimd/pim_vty.c           |   5 +
```

## Credits

Developed at Onyx Networks for a FIPS-capable managed DMVPN router product (Rocky 9 / RHEL 9). Implementation `<dev@onyxnetworks.example>` `<TODO: real author email>`.
