### PR TITLE
tests: Add `evpn` pytestmark to tests that are missing

### DIFF
--- a/tests/topotests/bgp_evpn_ead_evi_routes/test_bgp_evpn_ead_evi_routes.py
+++ b/tests/topotests/bgp_evpn_ead_evi_routes/test_bgp_evpn_ead_evi_routes.py
@@ -21,7 +21,7 @@ from functools import partial
 
 import pytest
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_evpn_ead_evi_routes/test_bgp_evpn_ead_evi_routes.py
+++ b/tests/topotests/bgp_evpn_ead_evi_routes/test_bgp_evpn_ead_evi_routes.py
@@ -37,16 +37,16 @@ def build_topo(tgen):
     - Each TOR has 3 VNIs (1001, 1002, 1003)
     - This generates EAD-EVI routes that can be tested
     """
-    
+
     tgen.add_router("tor1")
     tgen.add_router("tor2")
     tgen.add_router("spine")
-    
+
     # Connect TORs to spine
     switch = tgen.add_switch("s1")
     switch.add_link(tgen.gears["tor1"])
     switch.add_link(tgen.gears["spine"])
-    
+
     switch = tgen.add_switch("s2")
     switch.add_link(tgen.gears["tor2"])
     switch.add_link(tgen.gears["spine"])
@@ -55,12 +55,12 @@ def build_topo(tgen):
 def setup_module(module):
     tgen = Topogen(build_topo, module.__name__)
     tgen.start_topology()
-    
+
     # Configure VxLAN and ES on TORs
     for tor_name in ["tor1", "tor2"]:
         tor = tgen.gears[tor_name]
         tor_ip = "1.1.1.1" if tor_name == "tor1" else "2.2.2.2"
-        
+
         # Create VLAN-aware bridge
         tor.run("ip link add dev bridge type bridge stp_state 0")
         tor.run("ip link set dev bridge type bridge vlan_filtering 1")
@@ -69,22 +69,24 @@ def setup_module(module):
         tor.run("/sbin/bridge vlan add vid 1001 dev bridge self")
         tor.run("/sbin/bridge vlan add vid 1002 dev bridge self")
         tor.run("/sbin/bridge vlan add vid 1003 dev bridge self")
-        
+
         # Create bond interface for ES
         tor.run("ip link add dev hostbond1 type bond mode 802.3ad")
         tor.run("ip link set dev hostbond1 type bond ad_actor_system 44:38:39:ff:ff:01")
         tor.run("ip link set dev hostbond1 up")
-        
+
         # Add bond to bridge with VLANs
         tor.run("ip link set dev hostbond1 master bridge")
         tor.run("/sbin/bridge vlan del vid 1 dev hostbond1")
         tor.run("/sbin/bridge vlan add vid 1001 dev hostbond1")
         tor.run("/sbin/bridge vlan add vid 1002 dev hostbond1")
         tor.run("/sbin/bridge vlan add vid 1003 dev hostbond1")
-        
+
         # Create VxLAN interfaces for 3 VNIs
         for vni in [1001, 1002, 1003]:
-            tor.run(f"ip link add dev vx-{vni} type vxlan id {vni} dstport 4789 local {tor_ip} nolearning")
+            tor.run(
+                f"ip link add dev vx-{vni} type vxlan id {vni} dstport 4789 local {tor_ip} nolearning"
+            )
             tor.run(f"ip link set dev vx-{vni} up")
             tor.run(f"ip link set dev vx-{vni} master bridge")
             tor.run(f"/sbin/bridge link set dev vx-{vni} neigh_suppress on")
@@ -92,11 +94,11 @@ def setup_module(module):
             tor.run(f"/sbin/bridge vlan del vid 1 dev vx-{vni}")
             tor.run(f"/sbin/bridge vlan add vid {vni} dev vx-{vni}")
             tor.run(f"/sbin/bridge vlan add vid {vni} untagged pvid dev vx-{vni}")
-    
+
     router_list = tgen.routers()
     for rname, router in router_list.items():
         router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
-    
+
     tgen.start_router()
 
 
@@ -110,33 +112,33 @@ def count_ead_routes_by_type(router):
     Count EAD-ES and EAD-EVI routes
     EAD-ES: [1]:[4294967295]:... (eth-tag = MAX_ET)
     EAD-EVI: [1]:[0]:... or other non-MAX eth-tags
-    
+
     Note: In the output we're looking at lines like:
     *>  [1]:[0]:[ESI]:[128]:[IP]:[Frag] - EAD-EVI
     *>  [1]:[4294967295]:[ESI]:[128]:[IP]:[Frag] - EAD-ES
     """
     output = router.vtysh_cmd("show bgp l2vpn evpn route type ead")
-    
+
     ead_es_count = 0
     ead_evi_count = 0
-    
+
     for line in output.splitlines():
         if "*>" in line and "[1]:[" in line:
             # Extract the eth-tag which is the second field after [1]:
             try:
                 idx = line.find("[1]:[")
                 if idx >= 0:
-                    rest = line[idx+5:]
+                    rest = line[idx + 5 :]
                     eth_tag_str = rest.split("]")[0]
                     eth_tag = int(eth_tag_str)
-                    
+
                     if eth_tag == 4294967295:
                         ead_es_count += 1
                     else:
                         ead_evi_count += 1
             except:
                 pass
-    
+
     return ead_es_count, ead_evi_count
 
 
@@ -145,12 +147,12 @@ def test_evpn_ead_evi_routes_initial():
     Verify EAD routes are generated with multiple VNIs
     """
     tgen = get_topogen()
-    
+
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     router = tgen.gears["tor1"]
-    
+
     def check_bgp_summary():
         output = router.vtysh_cmd("show bgp summary json")
         try:
@@ -164,59 +166,71 @@ def test_evpn_ead_evi_routes_initial():
         except:
             return False
         return False
-    
+
     test_fn = partial(check_bgp_summary)
-    _, result = topotest.run_and_expect(lambda: check_bgp_summary(), True, count=20, wait=3)
-    
+    _, result = topotest.run_and_expect(
+        lambda: check_bgp_summary(), True, count=20, wait=3
+    )
+
     ead_es, ead_evi = count_ead_routes_by_type(router)
     assertmsg = "No EAD-EVI routes found, VNI/ES-EVI may not be configured properly. ES: {}, EVI: {}".format(
-        ead_es, ead_evi)
+        ead_es, ead_evi
+    )
     assert ead_evi > 0, assertmsg
 
 
 def test_evpn_disable_ead_evi_tx():
     """
     Test disable-ead-evi-tx knob
-    
+
     Expected behavior:
     - Initial: EAD-EVI routes present (3 routes for 3 VNIs)
     - After disable-ead-evi-tx: EAD-EVI routes withdrawn (count = 0)
     - After no disable-ead-evi-tx: EAD-EVI routes restored
-    
+
     Note: EAD-ES routes may not be present since bond has no members
     """
     tgen = get_topogen()
-    
+
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     router = tgen.gears["tor1"]
-    
+
     initial_es, initial_evi = count_ead_routes_by_type(router)
     if initial_evi == 0:
         pytest.skip("No EAD-EVI routes, cannot test disable-ead-evi-tx")
-    
-    router.vtysh_cmd("conf\nrouter bgp 65000\naddress-family l2vpn evpn\ndisable-ead-evi-tx")
-    
+
+    router.vtysh_cmd(
+        "conf\nrouter bgp 65000\naddress-family l2vpn evpn\ndisable-ead-evi-tx"
+    )
+
     def check_ead_evi_withdrawn():
         _, ead_evi = count_ead_routes_by_type(router)
         return ead_evi == 0
-    
+
     test_fn = partial(check_ead_evi_withdrawn)
     _, result = topotest.run_and_expect(test_fn, True, count=20, wait=3)
     disabled_es, disabled_evi = count_ead_routes_by_type(router)
-    assertmsg = "EAD-EVI routes not withdrawn: had {}, still have {}".format(initial_evi, disabled_evi)
+    assertmsg = "EAD-EVI routes not withdrawn: had {}, still have {}".format(
+        initial_evi, disabled_evi
+    )
     assert disabled_evi == 0, assertmsg
-    
-    router.vtysh_cmd("conf\nrouter bgp 65000\naddress-family l2vpn evpn\nno disable-ead-evi-tx")
+
+    router.vtysh_cmd(
+        "conf\nrouter bgp 65000\naddress-family l2vpn evpn\nno disable-ead-evi-tx"
+    )
+
     def check_ead_evi_restored():
         _, ead_evi = count_ead_routes_by_type(router)
         return ead_evi == initial_evi
-    
+
     test_fn = partial(check_ead_evi_restored)
     _, result = topotest.run_and_expect(test_fn, True, count=20, wait=3)
     final_es, final_evi = count_ead_routes_by_type(router)
-    assertmsg = "EAD-EVI routes not restored: expected {}, got {}".format(initial_evi, final_evi)
+    assertmsg = "EAD-EVI routes not restored: expected {}, got {}".format(
+        initial_evi, final_evi
+    )
     assert final_evi == initial_evi, assertmsg
 
 

--- a/tests/topotests/bgp_evpn_flooding_per_vni/test_bgp_evpn_flooding_per_vni.py
+++ b/tests/topotests/bgp_evpn_flooding_per_vni/test_bgp_evpn_flooding_per_vni.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_evpn_gr/test_bgp_evpn_gr.py
+++ b/tests/topotests/bgp_evpn_gr/test_bgp_evpn_gr.py
@@ -23,7 +23,7 @@ import time
 import functools
 import pytest
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_evpn_gr/test_bgp_evpn_gr.py
+++ b/tests/topotests/bgp_evpn_gr/test_bgp_evpn_gr.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: ISC
 #
 # Reference topology from bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py:
-# 
+#
 #          +--------+ BGP     +--------+ BGP  +--------+      +--------+
 #     SN1  |        | IPv4/v6 |        | EVPN |        |      |        |
 #   =======+ Host1  +---------+   PE1  +------+   PE2  +------+  Host2 +
 #          |        |         |        |      |        |      |        |
 #          +--------+         +--------+      +--------+      +--------+
-# 
+#
 # Host1 is connected to PE1 and Host2 is connected to PE2.
 # Host1 and PE1 have IPv4/v6 BGP sessions.
 # PE1 and PE2 have an EVPN session.
@@ -38,6 +38,7 @@ from lib.common_config import (
     start_router_daemons,
 )
 
+
 def build_topo(tgen):
     # Create PE and host routers
     for name in ["PE1", "PE2", "host1", "host2"]:
@@ -46,6 +47,7 @@ def build_topo(tgen):
     tgen.add_link(tgen.gears["PE1"], tgen.gears["PE2"], "PE1-eth0", "PE2-eth0")
     tgen.add_link(tgen.gears["PE1"], tgen.gears["host1"], "PE1-eth1", "host1-eth0")
     tgen.add_link(tgen.gears["PE2"], tgen.gears["host2"], "PE2-eth1", "host2-eth0")
+
 
 def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
@@ -68,7 +70,9 @@ def setup_module(mod):
         bridge_ipv6 = f"fd00:50:1::{suf}/48"
         pe.cmd_raises("ip link add vrf-blue type vrf table 10")
         pe.cmd_raises("ip link set dev vrf-blue up")
-        pe.cmd_raises(f"ip link add vxlan100 type vxlan id 100 dstport 4789 local {vtep_ip}")
+        pe.cmd_raises(
+            f"ip link add vxlan100 type vxlan id 100 dstport 4789 local {vtep_ip}"
+        )
         pe.cmd_raises("ip link add name br100 type bridge stp_state 0")
         pe.cmd_raises("ip link set dev vxlan100 master br100")
         pe.cmd_raises(f"ip link set dev {name}-eth1 master br100")
@@ -78,7 +82,9 @@ def setup_module(mod):
         pe.cmd_raises(f"ip link set up dev {name}-eth1")
         pe.cmd_raises("ip link set dev br100 master vrf-blue")
         pe.cmd_raises(f"ip -6 addr add {bridge_ipv6} dev br100")
-        pe.cmd_raises(f"ip link add vxlan1000 type vxlan id 1000 dstport 4789 local {vtep_ip}")
+        pe.cmd_raises(
+            f"ip link add vxlan1000 type vxlan id 1000 dstport 4789 local {vtep_ip}"
+        )
         pe.cmd_raises("ip link add name br1000 type bridge stp_state 0")
         pe.cmd_raises("ip link set dev vxlan1000 master br1000")
         pe.cmd_raises("ip link set up dev br1000")
@@ -111,7 +117,9 @@ def _evpn_peer_established(router: TopoRouter, neighbor_ip: str) -> bool:
     if neighbor_ip not in peers:
         logger.info(f"Neighbor {neighbor_ip} not found in BGP summary")
         return False
-    logger.info(f"Neighbor {neighbor_ip} found in BGP summary with state: {peers[neighbor_ip].get('state')}")
+    logger.info(
+        f"Neighbor {neighbor_ip} found in BGP summary with state: {peers[neighbor_ip].get('state')}"
+    )
     return peers[neighbor_ip].get("state") == "Established"
 
 
@@ -215,7 +223,9 @@ def _evpn_remote_type_paths_stale(router: TopoRouter, route_type: int) -> bool:
     return found_remote and found_stale
 
 
-def _evpn_routes_with_stale_only_for_rd(router: TopoRouter, rd: str, route_type: int) -> bool:
+def _evpn_routes_with_stale_only_for_rd(
+    router: TopoRouter, rd: str, route_type: int
+) -> bool:
     """
     Verify that all paths whose RD matches the input RD and route_type are marked as stale.
     Succeeds only if at least one matching path is found and all such paths are stale.
@@ -247,12 +257,15 @@ def _evpn_routes_with_stale_only_for_rd(router: TopoRouter, rd: str, route_type:
                     found_matching_path = True
                     logger.info(f"Checking prefix: {prefix} path: {p}")
                     if not bool(p.get("stale")):
-                        logger.info(f"Checking prefix: {prefix} path: {p} is not stale, returning False")
+                        logger.info(
+                            f"Checking prefix: {prefix} path: {p} is not stale, returning False"
+                        )
                         return False
     if not found_matching_path:
         logger.info(f"No matching path found for RD: {rd} and route type: {route_type}")
         return False
     return True
+
 
 def _vrf_has_kernel_routes(router: TopoRouter, vrf_name: str, prefixes):
     if isinstance(prefixes, str):
@@ -314,7 +327,7 @@ def fetch_vni_rd_from_pe2(pe2: TopoRouter, vni: int):
             output = json.loads(output)
         if "rd" in output:
             logger.info(f"RD for VNI {vni} found: {output.get('rd')}")
-            return output.get("rd") 
+            return output.get("rd")
     except Exception as e:
         logger.info(f"Failed to fetch RD from PE2 VNI {vni}: {e}")
     return None
@@ -449,13 +462,23 @@ def test_bgp_evpn_gr_stale_and_recovery():
     assert result, "No remote EVPN type-5 routes seen on PE2"
 
     # Kernel VRF routes imported (type-5): verify PE2 has host1, PE1 has host2
-    logger.info("STEP 5: Verify type-5 routes are installed into kernel VRF on both PEs")
-    test_func = functools.partial(_vrf_has_kernel_routes, pe2, "vrf-blue", ["172.31.0.21"])
+    logger.info(
+        "STEP 5: Verify type-5 routes are installed into kernel VRF on both PEs"
+    )
+    test_func = functools.partial(
+        _vrf_has_kernel_routes, pe2, "vrf-blue", ["172.31.0.21"]
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
-    assert result, "Type-5 prefix 172.31.0.21/32 not installed in PE2 kernel VRF vrf-blue"
-    test_func = functools.partial(_vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"])
+    assert (
+        result
+    ), "Type-5 prefix 172.31.0.21/32 not installed in PE2 kernel VRF vrf-blue"
+    test_func = functools.partial(
+        _vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"]
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
-    assert result, "Type-5 prefix 172.31.0.22/32 not installed in PE1 kernel VRF vrf-blue"
+    assert (
+        result
+    ), "Type-5 prefix 172.31.0.22/32 not installed in PE1 kernel VRF vrf-blue"
 
     # Ensure type-2 routes exist on both PEs
     logger.info("STEP 6: Verify remote EVPN type-2 routes exist on both PEs")
@@ -468,15 +491,21 @@ def test_bgp_evpn_gr_stale_and_recovery():
 
     # Ensure type-2 are installed as extern_learn in FDB (remote MACs)
     logger.info("STEP 7: Verify remote MACs are extern_learn in FDB (type-2)")
-    test_func = functools.partial(_bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62")
+    test_func = functools.partial(
+        _bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62"
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "Remote MAC (host2) not extern_learn in PE1 FDB for vxlan100"
-    test_func = functools.partial(_bridge_has_extern_learn, pe2, "vxlan100", "1a:2b:3c:4d:5e:61")
+    test_func = functools.partial(
+        _bridge_has_extern_learn, pe2, "vxlan100", "1a:2b:3c:4d:5e:61"
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "Remote MAC (host1) not extern_learn in PE2 FDB for vxlan100"
 
     # Verify that remote MACs on PE1 are installed as extern_learn in kernel's ip_neigh table
-    logger.info("STEP 7b: Verify remote MACs are extern_learn in PE1 kernel's ip_neigh table")
+    logger.info(
+        "STEP 7b: Verify remote MACs are extern_learn in PE1 kernel's ip_neigh table"
+    )
 
     # For PE1, check host2's MAC (remote side)
     test_func = functools.partial(_ip_neigh_has_extern_learn, pe1, "1a:2b:3c:4d:5e:62")
@@ -500,43 +529,55 @@ def test_bgp_evpn_gr_stale_and_recovery():
     # PE1 should retain only PE2-originated EVPN routes as stale during GR (type-2 and type-5), not local
     # Verify only type-5 routes from PE2's RD are stale
     logger.info("STEP 9: Check PE1 retains ONLY PE2-originated type-5 routes as stale")
-    test_func = functools.partial(_evpn_routes_with_stale_only_for_rd, pe1, rd=pe2_rd_vni_1000, route_type=5)
-    result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
-    assert result, (
-        "PE1 did not retain ONLY PE2-originated EVPN type-5 routes as stale during PE2 restart"
+    test_func = functools.partial(
+        _evpn_routes_with_stale_only_for_rd, pe1, rd=pe2_rd_vni_1000, route_type=5
     )
-    
+    result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
+    assert (
+        result
+    ), "PE1 did not retain ONLY PE2-originated EVPN type-5 routes as stale during PE2 restart"
+
     logger.info(f"PE2 RD for VNI 100: {pe2_rd_vni_100}")
     # Verify only type-2 routes from PE2's RD are stale
     logger.info("STEP 10: Check PE1 retains ONLY PE2-originated type-2 routes as stale")
-    test_func = functools.partial(_evpn_routes_with_stale_only_for_rd, pe1, rd=pe2_rd_vni_100, route_type=2)
-    result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
-    assert result, (
-        "PE1 did not retain ONLY PE2-originated EVPN type-2 routes as stale during PE2 restart"
+    test_func = functools.partial(
+        _evpn_routes_with_stale_only_for_rd, pe1, rd=pe2_rd_vni_100, route_type=2
     )
+    result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
+    assert (
+        result
+    ), "PE1 did not retain ONLY PE2-originated EVPN type-2 routes as stale during PE2 restart"
 
     # Also generic check for any stale presence
-    logger.info("STEP 11: Confirm PE1 shows some EVPN routes as stale during PE2 restart")
+    logger.info(
+        "STEP 11: Confirm PE1 shows some EVPN routes as stale during PE2 restart"
+    )
     test_func = functools.partial(_evpn_has_any_stale, pe1)
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "PE1 did not retain EVPN routes as stale during PE2 restart"
 
     # Verify PE1 kernel still has routes learned from PE2 in vrf-blue (type-5 retained)
     logger.info("STEP 12: Verify PE1 kernel retains type-5 routes from PE2 during GR")
-    test_func = functools.partial(_vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"])
+    test_func = functools.partial(
+        _vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"]
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "PE1 kernel VRF routes learned from PE2 disappeared during GR"
 
     # Verify PE1 FDB retains extern learned MAC from PE2 (type-2 retained)
     logger.info("STEP 13: Verify PE1 FDB retains extern_learn MAC from PE2 during GR")
-    test_func = functools.partial(_bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62")
+    test_func = functools.partial(
+        _bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62"
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "PE1 FDB extern_learn entry from PE2 disappeared during GR"
 
     # Verify PE1 kernel still has routes learned from PE2 in vrf-blue (type-5 retained)
     test_func = functools.partial(_ip_neigh_has_extern_learn, pe1, "1a:2b:3c:4d:5e:62")
     result, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
-    assert result, "PE1 kernel ip_neigh table extern_learn entry from PE2 disappeared during GR"
+    assert (
+        result
+    ), "PE1 kernel ip_neigh table extern_learn entry from PE2 disappeared during GR"
 
     # Bring bgpd back on PE2
     logger.info("STEP 14: Restart bgpd on PE2 to recover session")
@@ -573,13 +614,15 @@ def test_bgp_evpn_gr_stale_and_recovery():
     test_func = functools.partial(_gr_r_bit_set, pe1, "10.0.1.2")
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "EVPN GR R-bit not set on PE1 neighbor view after PE2 restart"
-    
+
     test_func = functools.partial(_evpn_f_bit_set, pe1, "10.0.1.2")
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "EVPN AF F-bit not set on PE1 neighbor view during PE2 restart"
 
     # After session recovery, stale flags should be cleared for type-2 and type-5 on PE1
-    logger.info("STEP 17: Ensure remote EVPN type-5 and type-2 remain active after recovery")
+    logger.info(
+        "STEP 17: Ensure remote EVPN type-5 and type-2 remain active after recovery"
+    )
     test_func = functools.partial(_evpn_has_remote_route_type, pe1, 5)
     result, _ = topotest.run_and_expect(test_func, True, count=120, wait=2)
     assert result, "Remote EVPN type-5 routes disappeared on PE1 after PE2 recovered"
@@ -589,13 +632,17 @@ def test_bgp_evpn_gr_stale_and_recovery():
 
     # After bgpd recovery on PE2, verify PE1 kernel still has routes learned from PE2
     logger.info("STEP 18: Verify PE1 kernel still has routes from PE2 after recovery")
-    test_func = functools.partial(_vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"])
+    test_func = functools.partial(
+        _vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"]
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=120, wait=2)
     assert result, "PE1 kernel VRF routes learned from PE2 disappeared after recovery"
 
     # And verify PE1 FDB still has extern_learn entry from PE2
     logger.info("STEP 19: Verify PE1 FDB retains extern_learn MAC after recovery")
-    test_func = functools.partial(_bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62")
+    test_func = functools.partial(
+        _bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62"
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=120, wait=2)
     assert result, "PE1 FDB extern_learn entry from PE2 disappeared after recovery"
 
@@ -652,12 +699,16 @@ def test_bgp_evpn_gr_stale_cleanup_on_timeout():
     assert result, "No remote EVPN type-5 routes on PE1"
 
     logger.info("STEP 4: Verify kernel VRF has type-5 route on PE1 prior to GR")
-    test_func = functools.partial(_vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"])
+    test_func = functools.partial(
+        _vrf_has_kernel_routes, pe1, "vrf-blue", ["172.31.0.22"]
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "Missing kernel VRF routes on PE1 prior to GR"
 
     logger.info("STEP 5: Verify extern_learn MAC is present on PE1 prior to GR")
-    test_func = functools.partial(_bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62")
+    test_func = functools.partial(
+        _bridge_has_extern_learn, pe1, "vxlan100", "1a:2b:3c:4d:5e:62"
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=60, wait=2)
     assert result, "Missing extern_learn MAC on PE1 prior to GR"
 
@@ -675,10 +726,16 @@ def test_bgp_evpn_gr_stale_cleanup_on_timeout():
     result, _ = topotest.run_and_expect(test_func, True, count=160, wait=1)
     assert result, "VRF kernel routes on PE1 not cleaned after GR stalepath-time expiry"
 
-    logger.info("STEP 9: Verify FDB extern_learn MAC learned from PE2 is cleaned on PE1")
-    test_func = functools.partial(_bridge_extern_absent, pe1, "vxlan100", "1a:2b:3c:4d:5e:62")
+    logger.info(
+        "STEP 9: Verify FDB extern_learn MAC learned from PE2 is cleaned on PE1"
+    )
+    test_func = functools.partial(
+        _bridge_extern_absent, pe1, "vxlan100", "1a:2b:3c:4d:5e:62"
+    )
     result, _ = topotest.run_and_expect(test_func, True, count=160, wait=1)
-    assert result, "FDB extern_learn MAC on PE1 not cleaned after GR stalepath-time expiry"
+    assert (
+        result
+    ), "FDB extern_learn MAC on PE1 not cleaned after GR stalepath-time expiry"
 
     # Restore bgpd on PE2 for subsequent tests
     logger.info("STEP 10: Restart bgpd on PE2 for subsequent tests")

--- a/tests/topotests/bgp_evpn_maximum_prefix/test_bgp_evpn_maximum_prefix.py
+++ b/tests/topotests/bgp_evpn_maximum_prefix/test_bgp_evpn_maximum_prefix.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -24,7 +24,7 @@ import json
 import platform
 from functools import partial
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.pimd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -860,7 +860,9 @@ def test_evpn_vtep_change():
     # 4. Verify new VTEP appears and old VTEP is removed
     test_fn = partial(check_remote_es_vtep_present, dut, esi, secondary_vtep)
     _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
-    assertmsg = f"torm11: secondary VTEP {secondary_vtep} not found in ES {esi} after switch"
+    assertmsg = (
+        f"torm11: secondary VTEP {secondary_vtep} not found in ES {esi} after switch"
+    )
     assert result is None, assertmsg
 
     test_fn = partial(check_remote_es_vtep_absent, dut, esi, primary_vtep)

--- a/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
+++ b/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
@@ -62,7 +62,7 @@ from lib.common_config import (
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 # Global variables

--- a/tests/topotests/bgp_evpn_route_map_match/test_bgp_evpn_route_map_match.py
+++ b/tests/topotests/bgp_evpn_route_map_match/test_bgp_evpn_route_map_match.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_evpn_route_map_set/test_bgp_evpn_route_map_set.py
+++ b/tests/topotests/bgp_evpn_route_map_set/test_bgp_evpn_route_map_set.py
@@ -23,6 +23,7 @@ from lib import topotest
 from lib.topogen import TopoRouter, Topogen, get_topogen
 from lib.topolog import logger
 
+
 def setup_module(mod):
     topodef = {"s1": ("c1", "r1"), "s2": ("r1", "r2")}
     tgen = Topogen(topodef, mod.__name__)
@@ -58,6 +59,7 @@ def test_bgp_evpn_route_map_set_gateway_ip():
         pytest.skip(tgen.errors)
 
     r2: TopoRouter = tgen.gears["r2"]
+
     def _bgp_converge():
         output = json.loads(r2.vtysh_cmd("show bgp l2vpn evpn all overlay json"))
         expected = {

--- a/tests/topotests/bgp_evpn_route_map_set/test_bgp_evpn_route_map_set.py
+++ b/tests/topotests/bgp_evpn_route_map_set/test_bgp_evpn_route_map_set.py
@@ -13,7 +13,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -35,7 +35,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
@@ -35,7 +35,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
+++ b/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
@@ -46,7 +46,7 @@ import sys
 import pytest
 from typing import Optional
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
+++ b/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
@@ -64,15 +64,18 @@ def setup_module(mod):
     tgen.start_topology()
 
     # L3 SVI only
-    tgen.net["r1"].cmd("""
+    tgen.net["r1"].cmd(
+        """
         ip link add vrf100 up type vrf table 100
         ip link add br100 up master vrf100 type bridge
         ip link add vxlan100 up master br100 type vxlan id 100 dstport 4789 local 10.0.0.10 nolearning
         ip link set r1-eth0 master vrf100
         ip link set r1-eth1 master vrf100
-    """)
+    """
+    )
     # L3 + L2 SVIs
-    tgen.net["r2"].cmd("""
+    tgen.net["r2"].cmd(
+        """
         ip link add vrf100 up type vrf table 100
         ip link add br100 up master vrf100 type bridge
         ip link add vxlan100 up master br100 type vxlan id 100 dstport 4789 local 10.0.0.11 nolearning
@@ -80,9 +83,11 @@ def setup_module(mod):
         ip link add vxlan10 up master br10 type vxlan id 10 dstport 4789 local 10.0.0.11 nolearning
         ip addr add 10.0.0.1/31 dev br10
         ip addr add 10.0.0.3/31 dev br10
-    """)
+    """
+    )
     # L2 SVI only
-    tgen.net["r3"].cmd("""
+    tgen.net["r3"].cmd(
+        """
         ip link add vrf100 up type vrf table 100
         ip link add br10 up master vrf100 type bridge
         ip link add vxlan10 up master br10 type vxlan id 10 dstport 4789 local 10.0.0.12 nolearning
@@ -94,9 +99,10 @@ def setup_module(mod):
         bridge fdb add 00:00:00:00:00:c2 dev dummy-c2 master static
         ip neigh add 10.0.0.0 dev br10 lladdr 00:00:00:00:00:c1
         ip neigh add 10.0.0.2 dev br10 lladdr 00:00:00:00:00:c2
-    """)
-        # ip link add br100 up master vrf100 type bridge
-        # ip link add vxlan100 up master br100 type vxlan id 100 dstport 4789 local 10.0.0.12 nolearning
+    """
+    )
+    # ip link add br100 up master vrf100 type bridge
+    # ip link add vxlan100 up master br100 type vxlan id 100 dstport 4789 local 10.0.0.12 nolearning
 
     for name, router in tgen.routers().items():
         router.load_frr_config(os.path.join(CWD, f"{name}/frr.conf"))
@@ -107,12 +113,17 @@ def teardown_module(mod):
     get_topogen().stop_topology()
 
 
-def _converge_fn(router: TopoRouter, command: str, expected: dict, not_vtep: bool = False):
+def _converge_fn(
+    router: TopoRouter, command: str, expected: dict, not_vtep: bool = False
+):
     def _converge() -> Optional[json_cmp_result]:
         output: str = router.vtysh_cmd(command)
         if not_vtep:
-            assert output is not "", "Could not access the EVPN RIB on non-VTEP speaker."
+            assert (
+                output is not ""
+            ), "Could not access the EVPN RIB on non-VTEP speaker."
         return topotest.json_cmp(json.loads(output), expected)
+
     return functools.partial(_converge)
 
 
@@ -162,7 +173,9 @@ EXPECTED_R2_IPV4_BASELINE = {
 def _ensure_baseline(tgen: Topogen):
     logger.info("Check IPv4 routes on R2")
     expected = EXPECTED_R2_IPV4_BASELINE
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Multipath routes should be in overlay VRF"
 
@@ -178,7 +191,9 @@ def test_bgp_evpn_rt5_addpath_basic():
 
     logger.info("Check IPv4 routes on R1")
     expected = EXPECTED_R1_IPV4_BASELINE
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Multipath routes should be in overlay VRF"
 
@@ -215,7 +230,9 @@ def test_bgp_evpn_rt5_addpath_basic():
         "numPrefix": 1,
         "numPaths": 2,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Multipath routes should be exported to EVPN"
 
@@ -250,7 +267,12 @@ def test_bgp_evpn_rt5_addpath_basic():
         "numPrefix": 1,
         "numPaths": 2,
     }
-    f = _converge_fn(tgen.gears["rr"], "show bgp l2vpn evpn route detail type prefix json", expected, not_vtep=True)
+    f = _converge_fn(
+        tgen.gears["rr"],
+        "show bgp l2vpn evpn route detail type prefix json",
+        expected,
+        not_vtep=True,
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "All EVPN paths should be present in RR"
 
@@ -285,7 +307,9 @@ def test_bgp_evpn_rt5_addpath_basic():
         "numPrefix": 1,
         "numPaths": 2,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "All EVPN paths should be present in R2"
 
@@ -311,24 +335,38 @@ def test_bgp_evpn_rt5_addpath_basic():
         "totalRoutes": 1,
         "totalPaths": 2,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Multipath routes should be imported in overlay VRF"
 
     logger.info("Check FIB on R2")
     expected = {
-        "10.0.0.0/24":[
+        "10.0.0.0/24": [
             {
                 "selected": True,
                 "installed": True,
-                "nexthops":[
-                    {"fib": True, "ip": "10.0.0.0", "interfaceName": "br10", "active":True},
-                    {"fib": True, "ip": "10.0.0.2", "interfaceName": "br10", "active":True},
+                "nexthops": [
+                    {
+                        "fib": True,
+                        "ip": "10.0.0.0",
+                        "interfaceName": "br10",
+                        "active": True,
+                    },
+                    {
+                        "fib": True,
+                        "ip": "10.0.0.2",
+                        "interfaceName": "br10",
+                        "active": True,
+                    },
                 ],
             },
         ],
     }
-    f = _converge_fn(tgen.gears["r2"], "show ip route vrf vrf100 10.0.0.0/24 json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show ip route vrf vrf100 10.0.0.0/24 json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Multipath routes should be installed in FIB"
 
@@ -347,12 +385,14 @@ def test_bgp_evpn_rt5_addpath_withdraw():
 
     logger.info("Withdrawing path through C1")
     c1: TopoRouter = tgen.gears["c1"]
-    c1.vtysh_cmd("""
+    c1.vtysh_cmd(
+        """
         conf
         router bgp 64000
          address-family ipv4 unicast
           no network 10.0.0.0/24
-    """)
+    """
+    )
 
     expected = {
         "routes": {
@@ -367,7 +407,9 @@ def test_bgp_evpn_rt5_addpath_withdraw():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Route through C1 should be absent from overlay VRF"
 
@@ -392,7 +434,9 @@ def test_bgp_evpn_rt5_addpath_withdraw():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be withdrawn from EVPN"
 
@@ -416,7 +460,12 @@ def test_bgp_evpn_rt5_addpath_withdraw():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["rr"], "show bgp l2vpn evpn route detail type prefix json", expected, not_vtep=True)
+    f = _converge_fn(
+        tgen.gears["rr"],
+        "show bgp l2vpn evpn route detail type prefix json",
+        expected,
+        not_vtep=True,
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be absent from EVPN on the RR"
 
@@ -440,7 +489,9 @@ def test_bgp_evpn_rt5_addpath_withdraw():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be absent from R2"
 
@@ -458,17 +509,21 @@ def test_bgp_evpn_rt5_addpath_withdraw():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be un-imported in R2"
 
     logger.info("Adding back path through C1")
-    c1.vtysh_cmd("""
+    c1.vtysh_cmd(
+        """
         conf
         router bgp 64000
          address-family ipv4 unicast
           network 10.0.0.0/24
-    """)
+    """
+    )
 
     # ensure it is propagated back
     test_bgp_evpn_rt5_addpath_basic()
@@ -489,16 +544,20 @@ def test_bgp_evpn_rt5_addpath_transitions():
 
     logger.info("Switching to bestpath advertisement")
     r1: TopoRouter = tgen.gears["r1"]
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         router bgp 64001 vrf vrf100
          address-family l2vpn evpn
           advertise ipv4 unicast
-    """)
+    """
+    )
 
     logger.info("Check IPv4 routes on R1")
     expected = EXPECTED_R1_IPV4_BASELINE
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Multipath routes should be in overlay VRF"
 
@@ -522,7 +581,9 @@ def test_bgp_evpn_rt5_addpath_transitions():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Only the best path should be kept in R1"
 
@@ -545,7 +606,9 @@ def test_bgp_evpn_rt5_addpath_transitions():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Only the best path should be kept in R2"
 
@@ -563,17 +626,21 @@ def test_bgp_evpn_rt5_addpath_transitions():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Route should go through R1 now"
 
     logger.info("Switching back to gateway-ip")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         router bg 64001 vrf vrf100
          address-family l2vpn evpn
           advertise ipv4 unicast gateway-ip
-    """)
+    """
+    )
 
     # ensure we go back to the original state
     test_bgp_evpn_rt5_addpath_basic()
@@ -592,7 +659,8 @@ def test_bgp_evpn_rt5_addpath_route_map():
 
     logger.info("Adding drop route-map")
     r1: TopoRouter = tgen.gears["r1"]
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         route-map drop-c2 deny 10
          match ip next-hop address 10.0.0.2
@@ -600,11 +668,14 @@ def test_bgp_evpn_rt5_addpath_route_map():
         router bgp 64001 vrf vrf100
          address-family l2vpn evpn
           advertise ipv4 unicast gateway-ip route-map drop-c2
-    """)
+    """
+    )
 
     logger.info("Check IPv4 routes on R1")
     expected = EXPECTED_R1_IPV4_BASELINE
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "R1 overlay shoud still have both paths"
 
@@ -629,7 +700,9 @@ def test_bgp_evpn_rt5_addpath_route_map():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C2 should be withdrawn from EVPN"
 
@@ -647,12 +720,15 @@ def test_bgp_evpn_rt5_addpath_route_map():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C2 should be un-imported in R2"
 
     logger.info("Changing for a preference update route-map")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         no route-map drop-c2
         route-map set-pref permit 10
@@ -662,11 +738,14 @@ def test_bgp_evpn_rt5_addpath_route_map():
         router bgp 64001 vrf vrf100
          address-family l2vpn evpn
           advertise ipv4 unicast gateway-ip route-map set-pref
-    """)
+    """
+    )
 
     logger.info("Check IPv4 routes on R1")
     expected = EXPECTED_R1_IPV4_BASELINE
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "R1 overlay shoud still have both paths"
 
@@ -681,7 +760,10 @@ def test_bgp_evpn_rt5_addpath_route_map():
                             "valid": True,
                             "local": True,
                             "nexthops": [{"ip": "10.0.0.10"}],
-                            "bestpath": {"overall": True, "selectionReason": "Local Pref"},
+                            "bestpath": {
+                                "overall": True,
+                                "selectionReason": "Local Pref",
+                            },
                         },
                     ],
                     [
@@ -698,7 +780,9 @@ def test_bgp_evpn_rt5_addpath_route_map():
         "numPrefix": 1,
         "numPaths": 2,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "All paths, including non-best should be in EVPN"
 
@@ -712,7 +796,10 @@ def test_bgp_evpn_rt5_addpath_route_map():
                             "gatewayIP": "10.0.0.2",
                             "valid": True,
                             "nexthops": [{"ip": "10.0.0.10"}],
-                            "bestpath": {"overall": True, "selectionReason": "Local Pref"},
+                            "bestpath": {
+                                "overall": True,
+                                "selectionReason": "Local Pref",
+                            },
                         },
                     ],
                     [
@@ -728,7 +815,12 @@ def test_bgp_evpn_rt5_addpath_route_map():
         "numPrefix": 1,
         "numPaths": 2,
     }
-    f = _converge_fn(tgen.gears["rr"], "show bgp l2vpn evpn route detail type prefix json", expected, not_vtep=True)
+    f = _converge_fn(
+        tgen.gears["rr"],
+        "show bgp l2vpn evpn route detail type prefix json",
+        expected,
+        not_vtep=True,
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "All paths, including non-best should be transmitted in EVPN"
 
@@ -742,7 +834,10 @@ def test_bgp_evpn_rt5_addpath_route_map():
                             "gatewayIP": "10.0.0.2",
                             "valid": True,
                             "nexthops": [{"ip": "10.0.0.10"}],
-                            "bestpath": {"overall": True, "selectionReason": "Local Pref"},
+                            "bestpath": {
+                                "overall": True,
+                                "selectionReason": "Local Pref",
+                            },
                         },
                     ],
                     [
@@ -758,7 +853,9 @@ def test_bgp_evpn_rt5_addpath_route_map():
         "numPrefix": 1,
         "numPaths": 2,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "All paths, including non-best should be transmitted in EVPN"
 
@@ -783,18 +880,24 @@ def test_bgp_evpn_rt5_addpath_route_map():
         "totalRoutes": 1,
         "totalPaths": 2,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
-    assert result is None, "All paths, including non-best, should be imported in overlay VRF"
+    assert (
+        result is None
+    ), "All paths, including non-best, should be imported in overlay VRF"
 
     logger.info("Cleaning up")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         no route-map set-pref
         router bgp 64001 vrf vrf100
          address-family l2vpn evpn
           advertise ipv4 unicast gateway-ip
-    """)
+    """
+    )
     _ensure_baseline(tgen)
 
 
@@ -810,11 +913,13 @@ def test_bgp_evpn_rt5_addpath_session_down():
 
     logger.info("Admin shutdown of the session with C1")
     r1: TopoRouter = tgen.gears["r1"]
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         router bgp 64001 vrf vrf100
          neighbor 10.0.0.0 shutdown
-    """)
+    """
+    )
 
     expected = {
         "routes": {
@@ -829,7 +934,9 @@ def test_bgp_evpn_rt5_addpath_session_down():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Route through C1 should be absent from overlay VRF"
 
@@ -854,7 +961,9 @@ def test_bgp_evpn_rt5_addpath_session_down():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be withdrawn from EVPN"
 
@@ -872,25 +981,31 @@ def test_bgp_evpn_rt5_addpath_session_down():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be un-imported in R2"
 
     logger.info("Restore session to C1")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         router bgp 64001 vrf vrf100
          no neighbor 10.0.0.0 shutdown
-    """)
+    """
+    )
     _ensure_baseline(tgen)
 
     logger.info("Break session with C1")
     c1: TopoRouter = tgen.gears["c1"]
-    c1.vtysh_cmd("""
+    c1.vtysh_cmd(
+        """
         conf
         router bgp 64000
          neighbor 10.0.0.1 shutdown
-    """)
+    """
+    )
 
     expected = {
         "routes": {
@@ -905,7 +1020,9 @@ def test_bgp_evpn_rt5_addpath_session_down():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Route through C1 should be absent from overlay VRF"
 
@@ -930,7 +1047,9 @@ def test_bgp_evpn_rt5_addpath_session_down():
         "numPrefix": 1,
         "numPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected)
+    f = _converge_fn(
+        tgen.gears["r1"], "show bgp l2vpn evpn route detail type prefix json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be withdrawn from EVPN"
 
@@ -948,16 +1067,20 @@ def test_bgp_evpn_rt5_addpath_session_down():
         "totalRoutes": 1,
         "totalPaths": 1,
     }
-    f = _converge_fn(tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected)
+    f = _converge_fn(
+        tgen.gears["r2"], "show bgp vrf vrf100 ipv4 unicast detail json", expected
+    )
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
     assert result is None, "Path through C1 should be un-imported in R2"
 
     logger.info("Restore session with C1")
-    c1.vtysh_cmd("""
+    c1.vtysh_cmd(
+        """
         conf
         router bgp 64000
          no neighbor 10.0.0.1 shutdown
-    """)
+    """
+    )
     _ensure_baseline(tgen)
 
 
@@ -973,12 +1096,14 @@ def test_bgp_evpn_rt5_addpath_disable_addpath_rx():
 
     logger.info("Disable RX AddPath on R2")
     r2: TopoRouter = tgen.gears["r2"]
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
         conf
         router bgp 64001
          address-family l2vpn evpn
           neighbor 10.0.0.9 disable-addpath-rx
-    """)
+    """
+    )
 
     # 1. ensure that path through C1 wins due to a lower IP
     logger.info("Check EVPN routes on R2")
@@ -1022,14 +1147,16 @@ def test_bgp_evpn_rt5_addpath_disable_addpath_rx():
     # 2. ensure an actually bestpath wins
     logger.info("Make path through C2 the preferred one")
     r1: TopoRouter = tgen.gears["r1"]
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         route-map set-pref permit 10
          set local-pref 200
         router bgp 64001 vrf vrf100
          address-family ipv4 unicast
           neighbor 10.0.0.2 route-map set-pref in
-    """)
+    """
+    )
 
     logger.info("Check IPv4 routes on R1")
     expected = {
@@ -1056,7 +1183,12 @@ def test_bgp_evpn_rt5_addpath_disable_addpath_rx():
 
     logger.info("Check EVPN routes on RR")
     expected = {"numPrefix": 1, "numPaths": 2}
-    f = _converge_fn(tgen.gears["rr"], "show bgp l2vpn evpn route detail type prefix json", expected, not_vtep=True)
+    f = _converge_fn(
+        tgen.gears["rr"],
+        "show bgp l2vpn evpn route detail type prefix json",
+        expected,
+        not_vtep=True,
+    )
     assert result is None, "All should still be sent by R1"
 
     logger.info("Check EVPN routes on R2")
@@ -1084,19 +1216,23 @@ def test_bgp_evpn_rt5_addpath_disable_addpath_rx():
     assert result is None, "Path through C2 should be the only one left"
 
     logger.info("Cleaning up...")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         no route-map set-pref
         router bgp 64001 vrf vrf100
          address-family ipv4 unicast
           no neighbor 10.0.0.2 route-map set-pref in
-    """)
-    r2.vtysh_cmd("""
+    """
+    )
+    r2.vtysh_cmd(
+        """
         conf
         router bgp 64001
          address-family l2vpn evpn
           no neighbor 10.0.0.9 disable-addpath-rx
-    """)
+    """
+    )
     _ensure_baseline(tgen)
 
 
@@ -1112,12 +1248,14 @@ def test_bgp_evpn_rt5_addpath_tx_bestpath():
 
     logger.info("Limiting paths sent by R1")
     r1: TopoRouter = tgen.gears["r1"]
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         router bgp 64001
          address-family l2vpn evpn
           neighbor 10.0.0.9 addpath-tx-bestpath-per-AS
-    """)
+    """
+    )
 
     logger.info("Checking EVPN routes on R2")
     r2: TopoRouter = tgen.gears["r2"]
@@ -1143,7 +1281,8 @@ def test_bgp_evpn_rt5_addpath_tx_bestpath():
     assert result is None, "Only one path should be transmitted"
 
     logger.info("Prepending fake AS, and skewing paths")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         route-map prepend-as-65001 permit 10
          set as-path prepend 65001
@@ -1158,7 +1297,8 @@ def test_bgp_evpn_rt5_addpath_tx_bestpath():
          address-family ipv4 unicast
           neighbor 10.0.0.0 route-map prepend-as-65001 in
           neighbor 10.0.0.2 route-map prepend-as-65002 in
-    """)
+    """
+    )
 
     logger.info("Check IPv4 routes on R1")
     expected = {
@@ -1211,10 +1351,13 @@ def test_bgp_evpn_rt5_addpath_tx_bestpath():
     }
     f = _converge_fn(r2, "show bgp l2vpn evpn route detail type prefix json", expected)
     _, result = topotest.run_and_expect(f, None, count=60, wait=1)
-    assert result is None, "Both paths have different neighboring AS, both should be sent"
+    assert (
+        result is None
+    ), "Both paths have different neighboring AS, both should be sent"
 
     logger.info("Cleaning up")
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
         conf
         router bgp 64001 vrf vrf100
          address-family ipv4 unicast
@@ -1225,5 +1368,6 @@ def test_bgp_evpn_rt5_addpath_tx_bestpath():
         router bgp 64001
          address-family l2vpn evpn
           neighbor 10.0.0.9 addpath-tx-all-paths
-    """)
+    """
+    )
     _ensure_baseline(tgen)

--- a/tests/topotests/bgp_evpn_rt5_implied/test_bgp_evpn_implied.py
+++ b/tests/topotests/bgp_evpn_rt5_implied/test_bgp_evpn_implied.py
@@ -43,7 +43,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_rt5_implied/test_bgp_evpn_implied.py
+++ b/tests/topotests/bgp_evpn_rt5_implied/test_bgp_evpn_implied.py
@@ -141,6 +141,7 @@ def teardown_module(_mod):
     tgen.net["r1"].delete_netns("vrf-102")
     tgen.stop_topology()
 
+
 def _create_rmac(router, vrf):
     """
     Creates RMAC for a given router and vrf
@@ -192,32 +193,36 @@ def test_protocols_check_implied_is_working():
         "defaultLocPrf": 100,
         "localAS": 65000,
         "routes": {
-            "10.0.101.1/32": [{
-                "valid": True,
-                "bestpath": True,
-                "pathFrom": "internal",
-                "prefix": "10.0.101.1",
-                "prefixLen": 32,
-                "network": "10.0.101.1/32",
-                "metric": 0,
-                "locPrf": 100,
-                "weight": 0,
-                "peerId": "192.168.2.101",
-                "path": "",
-                "origin": "IGP",
-                "announceNexthopSelf": True,
-                "nexthops": [{
-                    "ip": "192.168.1.1",
-                    "hostname": "rr",
-                    "afi": "ipv4",
-                    "used": True
-                }]
-            }]
+            "10.0.101.1/32": [
+                {
+                    "valid": True,
+                    "bestpath": True,
+                    "pathFrom": "internal",
+                    "prefix": "10.0.101.1",
+                    "prefixLen": 32,
+                    "network": "10.0.101.1/32",
+                    "metric": 0,
+                    "locPrf": 100,
+                    "weight": 0,
+                    "peerId": "192.168.2.101",
+                    "path": "",
+                    "origin": "IGP",
+                    "announceNexthopSelf": True,
+                    "nexthops": [
+                        {
+                            "ip": "192.168.1.1",
+                            "hostname": "rr",
+                            "afi": "ipv4",
+                            "used": True,
+                        }
+                    ],
+                }
+            ]
         },
         "totalRoutes": 1,
-        "totalPaths": 1
+        "totalPaths": 1,
     }
-    
+
     test_func = partial(
         topotest.router_json_cmp,
         r2,
@@ -235,32 +240,36 @@ def test_protocols_check_implied_is_working():
         "defaultLocPrf": 100,
         "localAS": 65000,
         "routes": {
-            "10.0.102.1/32": [{
-                "valid": True,
-                "bestpath": True,
-                "pathFrom": "internal",
-                "prefix": "10.0.102.1",
-                "prefixLen": 32,
-                "network": "10.0.102.1/32",
-                "metric": 0,
-                "locPrf": 100,
-                "weight": 0,
-                "peerId": "192.168.2.101",
-                "path": "",
-                "origin": "IGP",
-                "announceNexthopSelf": True,
-                "nexthops": [{
-                    "ip": "192.168.1.1",
-                    "hostname": "rr",
-                    "afi": "ipv4",
-                    "used": True
-                }]
-            }]
+            "10.0.102.1/32": [
+                {
+                    "valid": True,
+                    "bestpath": True,
+                    "pathFrom": "internal",
+                    "prefix": "10.0.102.1",
+                    "prefixLen": 32,
+                    "network": "10.0.102.1/32",
+                    "metric": 0,
+                    "locPrf": 100,
+                    "weight": 0,
+                    "peerId": "192.168.2.101",
+                    "path": "",
+                    "origin": "IGP",
+                    "announceNexthopSelf": True,
+                    "nexthops": [
+                        {
+                            "ip": "192.168.1.1",
+                            "hostname": "rr",
+                            "afi": "ipv4",
+                            "used": True,
+                        }
+                    ],
+                }
+            ]
         },
         "totalRoutes": 1,
-        "totalPaths": 1
+        "totalPaths": 1,
     }
-    
+
     test_func_vrf102 = partial(
         topotest.router_json_cmp,
         r2,
@@ -273,71 +282,83 @@ def test_protocols_check_implied_is_working():
 
     # Check that routes are properly added to VRF routing table
     expected_ip_route_vrf101 = {
-        "10.0.101.1/32": [{
-            "prefix": "10.0.101.1/32",
-            "prefixLen": 32,
-            "protocol": "bgp",
-            "vrfName": "vrf-101",
-            "selected": True,
-            "destSelected": True,
-            "distance": 200,
-            "metric": 0,
-            "installed": True,
-            "nexthops": [{
-                "flags": 267,
-                "fib": True,
-                "ip": "192.168.1.1",
-                "afi": "ipv4",
-                "interfaceName": "bridge-101",
-                "active": True,
-                "onLink": True,
-                "weight": 1
-            }]
-        }],
+        "10.0.101.1/32": [
+            {
+                "prefix": "10.0.101.1/32",
+                "prefixLen": 32,
+                "protocol": "bgp",
+                "vrfName": "vrf-101",
+                "selected": True,
+                "destSelected": True,
+                "distance": 200,
+                "metric": 0,
+                "installed": True,
+                "nexthops": [
+                    {
+                        "flags": 267,
+                        "fib": True,
+                        "ip": "192.168.1.1",
+                        "afi": "ipv4",
+                        "interfaceName": "bridge-101",
+                        "active": True,
+                        "onLink": True,
+                        "weight": 1,
+                    }
+                ],
+            }
+        ],
     }
-    
+
     test_func_ip_route = partial(
         topotest.router_json_cmp,
         r2,
         "show ip route vrf vrf-101 json",
         expected_ip_route_vrf101,
     )
-    _, result_ip_route = topotest.run_and_expect(test_func_ip_route, None, count=20, wait=1)
+    _, result_ip_route = topotest.run_and_expect(
+        test_func_ip_route, None, count=20, wait=1
+    )
     assertmsg_ip_route = '"r2" IP route VRF vrf-101 JSON output mismatches'
     assert result_ip_route is None, assertmsg_ip_route
 
     # Check that routes are properly added to VRF-102 routing table
     expected_ip_route_vrf102 = {
-        "10.0.102.1/32": [{
-            "prefix": "10.0.102.1/32",
-            "prefixLen": 32,
-            "protocol": "bgp",
-            "vrfName": "vrf-102",
-            "selected": True,
-            "destSelected": True,
-            "distance": 200,
-            "metric": 0,
-            "installed": True,
-            "nexthops": [{
-                "flags": 267,
-                "fib": True,
-                "ip": "192.168.1.1",
-                "afi": "ipv4",
-                "interfaceName": "bridge-102",
-                "active": True,
-                "onLink": True,
-                "weight": 1
-            }]
-        }],
+        "10.0.102.1/32": [
+            {
+                "prefix": "10.0.102.1/32",
+                "prefixLen": 32,
+                "protocol": "bgp",
+                "vrfName": "vrf-102",
+                "selected": True,
+                "destSelected": True,
+                "distance": 200,
+                "metric": 0,
+                "installed": True,
+                "nexthops": [
+                    {
+                        "flags": 267,
+                        "fib": True,
+                        "ip": "192.168.1.1",
+                        "afi": "ipv4",
+                        "interfaceName": "bridge-102",
+                        "active": True,
+                        "onLink": True,
+                        "weight": 1,
+                    }
+                ],
+            }
+        ],
     }
-    
+
     test_func_ip_route_vrf102 = partial(
         topotest.router_json_cmp,
         r2,
         "show ip route vrf vrf-102 json",
         expected_ip_route_vrf102,
     )
-    _, result_ip_route_vrf102 = topotest.run_and_expect(test_func_ip_route_vrf102, None, count=20, wait=1)
+    _, result_ip_route_vrf102 = topotest.run_and_expect(
+        test_func_ip_route_vrf102, None, count=20, wait=1
+    )
     assertmsg_ip_route_vrf102 = '"r2" IP route VRF vrf-102 JSON output mismatches'
     assert result_ip_route_vrf102 is None, assertmsg_ip_route_vrf102
 

--- a/tests/topotests/bgp_evpn_v6_pmsi_tunnel/test_bgp_evpn_v6_pmsi_tunnel.py
+++ b/tests/topotests/bgp_evpn_v6_pmsi_tunnel/test_bgp_evpn_v6_pmsi_tunnel.py
@@ -30,7 +30,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -43,7 +43,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -168,7 +168,8 @@ def setup_module(mod):
     router_list = tgen.routers()
     for rname, router in router_list.items():
         router.load_config(
-            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra_v6_vtep.conf".format(rname))
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, "{}/zebra_v6_vtep.conf".format(rname)),
         )
         router.load_config(
             TopoRouter.RD_OSPF6, os.path.join(CWD, "{}/ospfd6.conf".format(rname))

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -43,7 +43,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospf6d]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -53,7 +53,7 @@ from lib.common_config import required_linux_kernel_version
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -37,7 +37,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -41,7 +41,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospf6d]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_show_l2vpn_evpn_rt/test_bgp_show_l2vpn_evpn_rt.py
+++ b/tests/topotests/bgp_show_l2vpn_evpn_rt/test_bgp_show_l2vpn_evpn_rt.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 
 def build_topo(tgen):

--- a/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py
+++ b/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py
@@ -20,7 +20,7 @@ import pytest
 import json
 from functools import partial
 
-pytestmark = [pytest.mark.pimd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.pimd, pytest.mark.bgpd, pytest.mark.evpn]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
@@ -62,7 +62,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.staticd]
 
 # Reading the data from JSON File for topology creation
 # Global variables

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -70,7 +70,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "10.1.1.1/32", "ipv6": "10::1/128"}


### PR DESCRIPTION
There are a number of evpn tests that have been created that do not have the evpn pytestmark.  Make it so.