### PR TITLE
ospfd: quick neighbor feature with BFD

### DIFF
--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -324,16 +324,20 @@ OSPF BFD Configuration
 
 The following commands are available inside the interface configuration node.
 
-.. clicmd:: ip ospf bfd
+.. clicmd:: ip ospf bfd [multiplier min-rx-int min-tx-int] [quick]
 
    Listen for BFD events on peers created on the interface. Every time
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
+   If the quick option is enabled, the BFD session is kept active even after the
+   OSPF neighbor is removed. When BFD detects the peer again, OSPF can re-add the
+   neighbor immediately (before learning the router ID) and drive a faster
+   adjacency bring-up.
 
 .. clicmd:: ip ospf bfd profile BFDPROF
 
-   Same as command ``ip ospf bfd``, but applies the BFD profile to the sessions
-   it creates or that already exist.
+   Applies the BFD profile to the sessions it creates or that already exist.
+   Only takes effect if ``ip ospf bfd`` command is also present.
 
 
 .. _bfd-ospf6-peer-config:

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -31,6 +31,105 @@
 #include "ospf_vty.h"
 
 DEFINE_MTYPE_STATIC(OSPFD, BFD_CONFIG, "BFD configuration data");
+DEFINE_MTYPE_STATIC(OSPFD, OSPF_BFD_SESSION_ENTRY, "OSPF BFD session entry");
+
+static void ospf_bfd_session_change(struct bfd_session_params *bsp,
+				    const struct bfd_session_status *bss, void *arg);
+
+struct ospf_bfd_session_entry {
+	struct ospf_interface *oi;
+	struct in_addr endpoint;
+	/* Weak pointer to the current neighbor (may be NULL). */
+	struct ospf_neighbor *nbr;
+	struct bfd_session_params *bsp;
+};
+
+static void ospf_bfd_entry_key(const struct in_addr *endpoint, struct prefix *p)
+{
+	memset(p, 0, sizeof(*p));
+	p->family = AF_INET;
+	p->prefixlen = IPV4_MAX_BITLEN;
+	p->u.prefix4 = *endpoint;
+}
+
+static struct ospf_bfd_session_entry *ospf_bfd_entry_lookup(struct ospf_interface *oi,
+							    const struct in_addr *endpoint)
+{
+	struct prefix key;
+	struct route_node *rn;
+	struct ospf_bfd_session_entry *entry;
+
+	if (!oi || !oi->bfd_sessions)
+		return NULL;
+
+	ospf_bfd_entry_key(endpoint, &key);
+	rn = route_node_lookup(oi->bfd_sessions, &key);
+	if (!rn)
+		return NULL;
+
+	entry = rn->info;
+	route_unlock_node(rn);
+	return entry;
+}
+
+static struct ospf_bfd_session_entry *ospf_bfd_entry_get(struct ospf_interface *oi,
+							 const struct in_addr *endpoint)
+{
+	struct prefix key;
+	struct route_node *rn;
+	struct ospf_bfd_session_entry *entry;
+
+	if (!oi->bfd_sessions)
+		oi->bfd_sessions = route_table_init();
+
+	ospf_bfd_entry_key(endpoint, &key);
+	rn = route_node_get(oi->bfd_sessions, &key);
+
+	if (rn->info) {
+		route_unlock_node(rn);
+		entry = rn->info;
+	} else {
+		entry = XCALLOC(MTYPE_OSPF_BFD_SESSION_ENTRY, sizeof(*entry));
+		entry->oi = oi;
+		entry->endpoint = *endpoint;
+		rn->info = entry;
+	}
+
+	if (!entry->bsp)
+		entry->bsp = bfd_sess_new(ospf_bfd_session_change, entry);
+
+	return entry;
+}
+
+static void ospf_bfd_entry_del(struct ospf_interface *oi, const struct in_addr *endpoint)
+{
+	struct prefix key;
+	struct route_node *rn;
+	struct ospf_bfd_session_entry *entry;
+
+	if (!oi || !oi->bfd_sessions)
+		return;
+
+	ospf_bfd_entry_key(endpoint, &key);
+	rn = route_node_lookup(oi->bfd_sessions, &key);
+	if (!rn)
+		return;
+
+	entry = rn->info;
+	if (entry) {
+		rn->info = NULL;
+		if (entry->nbr)
+			entry->nbr->bfd_session = NULL;
+		bfd_sess_free(&entry->bsp);
+		entry->nbr = NULL;
+		XFREE(MTYPE_OSPF_BFD_SESSION_ENTRY, entry);
+		/* Drop the persistent node lock held while info was set. */
+		route_unlock_node(rn);
+	}
+
+	/* Drop the lookup lock. */
+	route_unlock_node(rn);
+}
 
 /*
  * ospf_bfd_trigger_event - Neighbor is registered/deregistered with BFD when
@@ -48,7 +147,9 @@ static void ospf_bfd_session_change(struct bfd_session_params *bsp,
 				    const struct bfd_session_status *bss,
 				    void *arg)
 {
-	struct ospf_neighbor *nbr = arg;
+	struct ospf_bfd_session_entry *entry = arg;
+	struct ospf_neighbor *nbr = entry ? entry->nbr : NULL;
+	struct ospf_interface *oi = entry ? entry->oi : NULL;
 
 	/*
 	 * Handle Admin Down from peer separately.
@@ -57,63 +158,136 @@ static void ospf_bfd_session_change(struct bfd_session_params *bsp,
 	 * but the OSPF adjacency should remain up.
 	 */
 	if (bss->state == BSS_ADMIN_DOWN && bss->previous_state == BSS_UP) {
-		if (IS_DEBUG_OSPF(bfd, BFD_LIB))
-			zlog_debug("%s: NSM[%s:%pI4]: BFD received Admin Down from peer - OSPF adjacency maintained",
-				   __func__, IF_NAME(nbr->oi), &nbr->address.u.prefix4);
+		if (IS_DEBUG_OSPF(bfd, BFD_LIB)) {
+			if (nbr)
+				zlog_debug("%s: NSM[%s:%pI4]: BFD received Admin Down from peer - OSPF adjacency maintained",
+					   __func__, IF_NAME(nbr->oi), &nbr->address.u.prefix4);
+			else if (oi && entry)
+				zlog_debug("%s: NSM[%s:%pI4]: BFD received Admin Down (no neighbor) - OSPF adjacency maintained",
+					   __func__, IF_NAME(oi), &entry->endpoint);
+		}
 		/* Don't tear down OSPF neighbor, just log the event */
 		return;
+	}
+
+	/* If we don't have a current neighbor pointer, try to find it by endpoint. */
+	if (!nbr && oi && entry) {
+		nbr = ospf_nbr_lookup_by_addr(oi->nbrs, &entry->endpoint);
+		entry->nbr = nbr;
 	}
 
 	/* BFD peer went down. */
 	if (bss->state == BFD_STATUS_DOWN
 	    && bss->previous_state == BFD_STATUS_UP) {
-		if (IS_DEBUG_OSPF(bfd, BFD_LIB))
-			zlog_debug("%s: NSM[%s:%pI4]: BFD Down", __func__,
-				   IF_NAME(nbr->oi), &nbr->address.u.prefix4);
-
-		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
+		if (nbr) {
+			if (IS_DEBUG_OSPF(bfd, BFD_LIB))
+				zlog_debug("%s: NSM[%s:%pI4]: BFD Down", __func__,
+					   IF_NAME(nbr->oi), &nbr->address.u.prefix4);
+			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
+		} else if (IS_DEBUG_OSPF(bfd, BFD_LIB) && oi && entry) {
+			zlog_debug("%s: NSM[%s:%pI4]: BFD Down (no neighbor)", __func__,
+				   IF_NAME(oi), &entry->endpoint);
+		}
 	}
 
 	/* BFD peer went up. */
 	if (bss->state == BSS_UP && bss->previous_state == BSS_DOWN)
-		if (IS_DEBUG_OSPF(bfd, BFD_LIB))
-			zlog_debug("%s: NSM[%s:%pI4]: BFD Up", __func__,
-				   IF_NAME(nbr->oi), &nbr->address.u.prefix4);
+		if (IS_DEBUG_OSPF(bfd, BFD_LIB)) {
+			if (nbr)
+				zlog_debug("%s: NSM[%s:%pI4]: BFD Up", __func__, IF_NAME(nbr->oi),
+					   &nbr->address.u.prefix4);
+			else if (oi && entry)
+				zlog_debug("%s: NSM[%s:%pI4]: BFD Up (no neighbor)", __func__,
+					   IF_NAME(oi), &entry->endpoint);
+		}
 }
 
 void ospf_neighbor_bfd_apply(struct ospf_neighbor *nbr)
 {
 	struct ospf_interface *oi = nbr->oi;
 	struct ospf_if_params *oip = IF_DEF_PARAMS(oi->ifp);
+	struct ospf_bfd_session_entry *entry;
 
 	/* BFD configuration was removed. */
 	if (oip->bfd_config == NULL) {
-		bfd_sess_free(&nbr->bfd_session);
+		ospf_neighbor_bfd_clear(nbr);
 		return;
 	}
 
-	/* New BFD session. */
-	if (nbr->bfd_session == NULL) {
-		nbr->bfd_session = bfd_sess_new(ospf_bfd_session_change, nbr);
-		/* Pass local interface address as source (like BGP does with su_local) */
-		bfd_sess_set_ipv4_addrs(nbr->bfd_session,
-					oi->address ? &oi->address->u.prefix4 : NULL,  /* local source */
-					&nbr->src);                /* remote dest */
-		bfd_sess_set_interface(nbr->bfd_session, oi->ifp->name);
-		bfd_sess_set_vrf(nbr->bfd_session, oi->ospf->vrf_id);
-	}
+	entry = ospf_bfd_entry_get(oi, &nbr->src);
+	entry->nbr = nbr;
+	nbr->bfd_session = entry->bsp;
+
+	/* Pass local interface address as source (like BGP does with su_local) */
+	bfd_sess_set_ipv4_addrs(entry->bsp, oi->address ? &oi->address->u.prefix4 : NULL,
+				&nbr->src);
+	bfd_sess_set_interface(entry->bsp, oi->ifp->name);
+	bfd_sess_set_vrf(entry->bsp, oi->ospf->vrf_id);
 
 	/* Set new configuration. */
-	bfd_sess_set_timers(nbr->bfd_session,
-			    oip->bfd_config->detection_multiplier,
+	bfd_sess_set_timers(entry->bsp, oip->bfd_config->detection_multiplier,
 			    oip->bfd_config->min_rx, oip->bfd_config->min_tx);
-	bfd_sess_set_profile(nbr->bfd_session, oip->bfd_config->profile);
+	bfd_sess_set_profile(entry->bsp, oip->bfd_config->profile);
 
 	/* Don't start sessions on down OSPF sessions. */
 	if (nbr->state < NSM_TwoWay)
 		return;
 
-	bfd_sess_install(nbr->bfd_session);
+	bfd_sess_install(entry->bsp);
+}
+
+void ospf_neighbor_bfd_clear(struct ospf_neighbor *nbr)
+{
+	struct ospf_interface *oi;
+	struct ospf_bfd_session_entry *entry;
+	struct bfd_session_params *legacy_bsp;
+
+	if (!nbr)
+		return;
+
+	oi = nbr->oi;
+	legacy_bsp = nbr->bfd_session;
+	nbr->bfd_session = NULL;
+
+	/*
+	 * Preferred path: session is interface-owned. If an entry exists, delete it
+	 * and do NOT free legacy_bsp (it aliases entry->bsp).
+	 */
+	entry = (oi ? ospf_bfd_entry_lookup(oi, &nbr->src) : NULL);
+	if (entry) {
+		ospf_bfd_entry_del(oi, &nbr->src);
+		return;
+	}
+
+	/* Legacy/partial-init fallback: free whatever the neighbor owns. */
+	bfd_sess_free(&legacy_bsp);
+}
+
+void ospf_bfd_if_flush(struct ospf_interface *oi)
+{
+	struct route_node *rn, *next;
+
+	if (!oi || !oi->bfd_sessions)
+		return;
+
+	for (rn = route_top(oi->bfd_sessions); rn; rn = next) {
+		struct ospf_bfd_session_entry *entry;
+
+		entry = rn->info;
+		next = route_next(rn);
+
+		if (!entry)
+			continue;
+
+		rn->info = NULL;
+		if (entry->nbr)
+			entry->nbr->bfd_session = NULL;
+		bfd_sess_free(&entry->bsp);
+		entry->nbr = NULL;
+		XFREE(MTYPE_OSPF_BFD_SESSION_ENTRY, entry);
+		/* Drop the persistent node lock held while info was set. */
+		route_unlock_node(rn);
+	}
 }
 
 static void ospf_interface_bfd_apply(struct interface *ifp)
@@ -158,6 +332,18 @@ void ospf_interface_disable_bfd(struct interface *ifp,
 {
 	XFREE(MTYPE_BFD_CONFIG, oip->bfd_config);
 	ospf_interface_bfd_apply(ifp);
+	/* Ensure any interface-owned entries are removed too. */
+	{
+		struct route_node *rn;
+
+		for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+			struct ospf_interface *oi = rn->info;
+
+			if (!oi)
+				continue;
+			ospf_bfd_if_flush(oi);
+		}
+	}
 }
 
 /*

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -29,6 +29,7 @@
 #include "ospf_bfd.h"
 #include "ospf_dump.h"
 #include "ospf_vty.h"
+#include "ospf_quicknbr.h"
 
 DEFINE_MTYPE_STATIC(OSPFD, BFD_CONFIG, "BFD configuration data");
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_BFD_SESSION_ENTRY, "OSPF BFD session entry");
@@ -137,6 +138,15 @@ static void ospf_bfd_entry_del(struct ospf_interface *oi, const struct in_addr *
  */
 void ospf_bfd_trigger_event(struct ospf_neighbor *nbr, int old_state, int state)
 {
+	struct ospf_interface *oi = nbr->oi;
+	struct ospf_if_params *oip = IF_DEF_PARAMS(oi->ifp);
+
+	/* In quick neighbor mode, ignore the neighbor state changes. Just keep the session
+	 * installed to allow quick neighbor re-add
+	 */
+	if (!oip->bfd_config || oip->bfd_config->quick)
+		return;
+
 	if ((old_state < NSM_TwoWay) && (state >= NSM_TwoWay))
 		bfd_sess_install(nbr->bfd_session);
 	else if ((old_state >= NSM_TwoWay) && (state < NSM_TwoWay))
@@ -150,6 +160,7 @@ static void ospf_bfd_session_change(struct bfd_session_params *bsp,
 	struct ospf_bfd_session_entry *entry = arg;
 	struct ospf_neighbor *nbr = entry ? entry->nbr : NULL;
 	struct ospf_interface *oi = entry ? entry->oi : NULL;
+	struct ospf_if_params *oip = oi ? IF_DEF_PARAMS(oi->ifp) : NULL;
 
 	/*
 	 * Handle Admin Down from peer separately.
@@ -177,13 +188,12 @@ static void ospf_bfd_session_change(struct bfd_session_params *bsp,
 	}
 
 	/* BFD peer went down. */
-	if (bss->state == BFD_STATUS_DOWN
-	    && bss->previous_state == BFD_STATUS_UP) {
+	if (bss->state == BFD_STATUS_DOWN && bss->previous_state == BFD_STATUS_UP) {
 		if (nbr) {
 			if (IS_DEBUG_OSPF(bfd, BFD_LIB))
 				zlog_debug("%s: NSM[%s:%pI4]: BFD Down", __func__,
 					   IF_NAME(nbr->oi), &nbr->address.u.prefix4);
-			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
+			ospf_nbr_bring_down(nbr);
 		} else if (IS_DEBUG_OSPF(bfd, BFD_LIB) && oi && entry) {
 			zlog_debug("%s: NSM[%s:%pI4]: BFD Down (no neighbor)", __func__,
 				   IF_NAME(oi), &entry->endpoint);
@@ -191,7 +201,7 @@ static void ospf_bfd_session_change(struct bfd_session_params *bsp,
 	}
 
 	/* BFD peer went up. */
-	if (bss->state == BSS_UP && bss->previous_state == BSS_DOWN)
+	if (bss->state == BSS_UP && bss->previous_state == BSS_DOWN) {
 		if (IS_DEBUG_OSPF(bfd, BFD_LIB)) {
 			if (nbr)
 				zlog_debug("%s: NSM[%s:%pI4]: BFD Up", __func__, IF_NAME(nbr->oi),
@@ -200,6 +210,10 @@ static void ospf_bfd_session_change(struct bfd_session_params *bsp,
 				zlog_debug("%s: NSM[%s:%pI4]: BFD Up (no neighbor)", __func__,
 					   IF_NAME(oi), &entry->endpoint);
 		}
+
+		if (oi && entry && oip && oip->bfd_config && oip->bfd_config->quick)
+			ospf_qn_add(oi, &entry->endpoint);
+	}
 }
 
 void ospf_neighbor_bfd_apply(struct ospf_neighbor *nbr)
@@ -229,8 +243,10 @@ void ospf_neighbor_bfd_apply(struct ospf_neighbor *nbr)
 			    oip->bfd_config->min_rx, oip->bfd_config->min_tx);
 	bfd_sess_set_profile(entry->bsp, oip->bfd_config->profile);
 
-	/* Don't start sessions on down OSPF sessions. */
-	if (nbr->state < NSM_TwoWay)
+	/* Don't start sessions on down OSPF sessions.
+	 * Quick neighbors can still be added in a down state though
+	 */
+	if (!oip->bfd_config->quick && nbr->state < NSM_TwoWay)
 		return;
 
 	bfd_sess_install(entry->bsp);
@@ -241,11 +257,13 @@ void ospf_neighbor_bfd_clear(struct ospf_neighbor *nbr)
 	struct ospf_interface *oi;
 	struct ospf_bfd_session_entry *entry;
 	struct bfd_session_params *legacy_bsp;
+	struct ospf_if_params *oip;
 
 	if (!nbr)
 		return;
 
 	oi = nbr->oi;
+	oip = (oi && oi->ifp) ? IF_DEF_PARAMS(oi->ifp) : NULL;
 	legacy_bsp = nbr->bfd_session;
 	nbr->bfd_session = NULL;
 
@@ -255,6 +273,24 @@ void ospf_neighbor_bfd_clear(struct ospf_neighbor *nbr)
 	 */
 	entry = (oi ? ospf_bfd_entry_lookup(oi, &nbr->src) : NULL);
 	if (entry) {
+		/* legacy_bsp aliases entry->bsp; avoid using a stale local pointer. */
+		legacy_bsp = NULL;
+
+		/*
+		 * Quick-neighbor mode: keep the BFD session installed even if the
+		 * neighbor goes away, so BFD can quickly detect it again and we can
+		 * re-add via quick neighbor add.
+		 *
+		 * IMPORTANT: the neighbor object is being freed, so we must drop
+		 * the weak pointer.
+		 */
+		if (oip && oip->bfd_config && oip->bfd_config->quick) {
+			entry->nbr = NULL;
+			if (entry->bsp)
+				bfd_sess_install(entry->bsp);
+			return;
+		}
+
 		ospf_bfd_entry_del(oi, &nbr->src);
 		return;
 	}
@@ -290,6 +326,43 @@ void ospf_bfd_if_flush(struct ospf_interface *oi)
 	}
 }
 
+static void ospf_bfd_if_prune_nonquick(struct ospf_interface *oi)
+{
+	struct route_node *rn, *next;
+
+	if (!oi || !oi->bfd_sessions)
+		return;
+
+	for (rn = route_top(oi->bfd_sessions); rn; rn = next) {
+		struct ospf_bfd_session_entry *entry;
+
+		entry = rn->info;
+		next = route_next(rn);
+
+		if (!entry)
+			continue;
+
+		/*
+		 * Non-quick mode: only keep BFD sessions for neighbors that are
+		 * currently up enough for normal OSPF BFD handling (TwoWay+).
+		 *
+		 * In quick mode we may keep sessions without a neighbor to allow
+		 * rapid detection and re-add; once quick is disabled these "orphan"
+		 * sessions must be removed.
+		 */
+		if (!entry->nbr || entry->nbr->state < NSM_TwoWay) {
+			rn->info = NULL;
+			if (entry->nbr)
+				entry->nbr->bfd_session = NULL;
+			bfd_sess_free(&entry->bsp);
+			entry->nbr = NULL;
+			XFREE(MTYPE_OSPF_BFD_SESSION_ENTRY, entry);
+			/* Drop the persistent node lock held while info was set. */
+			route_unlock_node(rn);
+		}
+	}
+}
+
 static void ospf_interface_bfd_apply(struct interface *ifp)
 {
 	struct ospf_interface *oi;
@@ -313,18 +386,39 @@ static void ospf_interface_bfd_apply(struct interface *ifp)
 	}
 }
 
-static void ospf_interface_enable_bfd(struct interface *ifp)
+static void ospf_interface_enable_bfd(struct interface *ifp, bool quick)
 {
 	struct ospf_if_params *oip = IF_DEF_PARAMS(ifp);
+	bool old_quick = false;
 
-	if (oip->bfd_config)
-		return;
+	if (!oip->bfd_config) {
+		/* Allocate memory for configurations and set defaults. */
+		oip->bfd_config = XCALLOC(MTYPE_BFD_CONFIG, sizeof(*oip->bfd_config));
+		oip->bfd_config->detection_multiplier = BFD_DEF_DETECT_MULT;
+		oip->bfd_config->min_rx = BFD_DEF_MIN_RX;
+		oip->bfd_config->min_tx = BFD_DEF_MIN_TX;
+	} else
+		old_quick = oip->bfd_config->quick;
 
-	/* Allocate memory for configurations and set defaults. */
-	oip->bfd_config = XCALLOC(MTYPE_BFD_CONFIG, sizeof(*oip->bfd_config));
-	oip->bfd_config->detection_multiplier = BFD_DEF_DETECT_MULT;
-	oip->bfd_config->min_rx = BFD_DEF_MIN_RX;
-	oip->bfd_config->min_tx = BFD_DEF_MIN_TX;
+	oip->bfd_config->quick = quick;
+
+	/* Remove any down sessions kept alive for quick mode if quick
+	 * mode is being disabled.
+	 */
+	if (old_quick && !quick) {
+		struct route_node *rn;
+
+		for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+			struct ospf_interface *oi = rn->info;
+
+			if (!oi)
+				continue;
+			ospf_bfd_if_prune_nonquick(oi);
+		}
+
+		/* Re-apply BFD configuration so non-quick gating takes effect immediately. */
+		ospf_interface_bfd_apply(ifp);
+	}
 }
 
 void ospf_interface_disable_bfd(struct interface *ifp,
@@ -356,12 +450,12 @@ void ospf_bfd_write_config(struct vty *vty, const struct ospf_if_params *params
 	if (params->bfd_config->detection_multiplier != BFD_DEF_DETECT_MULT
 	    || params->bfd_config->min_rx != BFD_DEF_MIN_RX
 	    || params->bfd_config->min_tx != BFD_DEF_MIN_TX)
-		vty_out(vty, " ip ospf bfd %d %d %d\n",
-			params->bfd_config->detection_multiplier,
-			params->bfd_config->min_rx, params->bfd_config->min_tx);
+		vty_out(vty, " ip ospf bfd %d %d %d%s\n", params->bfd_config->detection_multiplier,
+			params->bfd_config->min_rx, params->bfd_config->min_tx,
+			(params->bfd_config->quick ? " quick" : ""));
 	else
 #endif /* ! HAVE_BFDD */
-		vty_out(vty, " ip ospf bfd\n");
+		vty_out(vty, " ip ospf bfd%s\n", (params->bfd_config->quick ? " quick" : ""));
 
 	if (params->bfd_config->profile[0])
 		vty_out(vty, " ip ospf bfd profile %s\n",
@@ -396,13 +490,14 @@ void ospf_interface_bfd_show(struct vty *vty, const struct interface *ifp,
 
 DEFUN (ip_ospf_bfd,
        ip_ospf_bfd_cmd,
-       "ip ospf bfd",
+       "ip ospf bfd [quick]",
        "IP Information\n"
        "OSPF interface commands\n"
-       "Enables BFD support\n")
+       "Enables BFD support\n"
+       "Quick neighbor establishment mode\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
-	ospf_interface_enable_bfd(ifp);
+	ospf_interface_enable_bfd(ifp, argc >= 4);
 	ospf_interface_bfd_apply(ifp);
 	return CMD_SUCCESS;
 }
@@ -414,13 +509,14 @@ DEFUN(
 #endif /* HAVE_BFDD */
        ip_ospf_bfd_param,
        ip_ospf_bfd_param_cmd,
-       "ip ospf bfd (2-255) (50-60000) (50-60000)",
+       "ip ospf bfd (2-255) (50-60000) (50-60000) [quick]",
        "IP Information\n"
        "OSPF interface commands\n"
        "Enables BFD support\n"
        "Detect Multiplier\n"
        "Required min receive interval\n"
-       "Desired min transmit interval\n")
+       "Desired min transmit interval\n"
+       "Quick neighbor establishment mode\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct ospf_if_params *params;
@@ -428,7 +524,7 @@ DEFUN(
 	int idx_number_2 = 4;
 	int idx_number_3 = 5;
 
-	ospf_interface_enable_bfd(ifp);
+	ospf_interface_enable_bfd(ifp, argc >= 7);
 
 	params = IF_DEF_PARAMS(ifp);
 	params->bfd_config->detection_multiplier =
@@ -493,9 +589,9 @@ DEFUN (no_ip_ospf_bfd_prof,
 DEFUN (no_ip_ospf_bfd,
        no_ip_ospf_bfd_cmd,
 #if HAVE_BFDD > 0
-       "no ip ospf bfd",
+       "no ip ospf bfd [quick]",
 #else
-       "no ip ospf bfd [(2-255) (50-60000) (50-60000)]",
+       "no ip ospf bfd [(2-255) (50-60000) (50-60000)] [quick]",
 #endif /* HAVE_BFDD */
        NO_STR
        "IP Information\n"
@@ -506,6 +602,7 @@ DEFUN (no_ip_ospf_bfd,
        "Required min receive interval\n"
        "Desired min transmit interval\n"
 #endif /* !HAVE_BFDD */
+       "Quick neighbor establishment mode\n"
 )
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);

--- a/ospfd/ospf_bfd.h
+++ b/ospfd/ospf_bfd.h
@@ -38,4 +38,10 @@ extern void ospf_interface_disable_bfd(struct interface *ifp,
  */
 extern void ospf_neighbor_bfd_apply(struct ospf_neighbor *nbr);
 
+/* Remove BFD session associated with a neighbor (interface-owned). */
+extern void ospf_neighbor_bfd_clear(struct ospf_neighbor *nbr);
+
+/* Flush all per-interface BFD session entries. */
+extern void ospf_bfd_if_flush(struct ospf_interface *oi);
+
 #endif /* _ZEBRA_OSPF_BFD_H */

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -47,6 +47,7 @@ unsigned long conf_debug_ospf_gr;
 unsigned long conf_debug_ospf_bfd;
 unsigned long conf_debug_ospf_client_api;
 unsigned long conf_debug_ospf_opaque_lsa;
+unsigned long conf_debug_ospf_qnbr;
 
 /* Enable debug option variables -- valid only session. */
 unsigned long term_debug_ospf_packet[5] = {0, 0, 0, 0, 0};
@@ -66,6 +67,7 @@ unsigned long term_debug_ospf_gr;
 unsigned long term_debug_ospf_bfd;
 unsigned long term_debug_ospf_client_api;
 unsigned long term_debug_ospf_opaque_lsa;
+unsigned long term_debug_ospf_qnbr;
 
 const char *ospf_redist_string(unsigned int route_type)
 {
@@ -1410,6 +1412,33 @@ DEFPY (debug_ospf_opaque_lsa,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_ospf_qnbr,
+       debug_ospf_qnbr_cmd,
+       "[no$no] debug ospf [(1-65535)$instance] quick-neighbor",
+       NO_STR
+       DEBUG_STR
+       OSPF_STR
+       "Instance ID\n"
+       "Quick Neighbor operations\n")
+{
+	if (instance && instance != ospf_instance)
+		return CMD_NOT_MY_INSTANCE;
+
+	if (vty->node == CONFIG_NODE) {
+		if (no)
+			DEBUG_OFF(qnbr, QNBR);
+		else
+			DEBUG_ON(qnbr, QNBR);
+	} else {
+		if (no)
+			TERM_DEBUG_OFF(qnbr, QNBR);
+		else
+			TERM_DEBUG_ON(qnbr, QNBR);
+	}
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (no_debug_ospf,
        no_debug_ospf_cmd,
        "no debug ospf",
@@ -1447,6 +1476,7 @@ DEFUN (no_debug_ospf,
 		DEBUG_OFF(ti_lfa, TI_LFA);
 		DEBUG_OFF(client_api, CLIENT_API);
 		DEBUG_OFF(opaque_lsa, OPAQUE_LSA);
+		DEBUG_OFF(qnbr, QNBR);
 
 		/* BFD debugging is two parts: OSPF and library. */
 		DEBUG_OFF(bfd, BFD_LIB);
@@ -1486,6 +1516,7 @@ DEFUN (no_debug_ospf,
 	TERM_DEBUG_OFF(bfd, BFD_LIB);
 	TERM_DEBUG_OFF(client_api, CLIENT_API);
 	TERM_DEBUG_OFF(opaque_lsa, OPAQUE_LSA);
+	TERM_DEBUG_OFF(qnbr, QNBR);
 
 	return CMD_SUCCESS;
 }
@@ -1620,6 +1651,10 @@ static int show_debugging_ospf_common(struct vty *vty)
 	/* Show debug status for OPAQUE-LSA. */
 	if (IS_DEBUG_OSPF(opaque_lsa, OPAQUE_LSA) == OSPF_DEBUG_OPAQUE_LSA)
 		vty_out(vty, "  OSPF opaque-lsa debugging is on\n");
+
+	/* Show debug status for quick neighbor. */
+	if (IS_DEBUG_OSPF(qnbr, QNBR) == OSPF_DEBUG_QNBR)
+		vty_out(vty, "  OSPF Quick Neighbor debugging is on\n");
 
 	return CMD_SUCCESS;
 }
@@ -1835,6 +1870,12 @@ static int config_write_debug(struct vty *vty)
 		write = 1;
 	}
 
+	/* debug ospf quick-neighbor */
+	if (IS_CONF_DEBUG_OSPF(qnbr, QNBR) == OSPF_DEBUG_QNBR) {
+		vty_out(vty, "debug ospf%s quick-neighbor\n", str);
+		write = 1;
+	}
+
 	/* debug ospf default-information */
 	if (IS_CONF_DEBUG_OSPF(defaultinfo, DEFAULTINFO) ==
 	    OSPF_DEBUG_DEFAULTINFO) {
@@ -1864,6 +1905,7 @@ void ospf_debug_init(void)
 	install_element(ENABLE_NODE, &debug_ospf_ldp_sync_cmd);
 	install_element(ENABLE_NODE, &debug_ospf_client_api_cmd);
 	install_element(ENABLE_NODE, &debug_ospf_opaque_lsa_cmd);
+	install_element(ENABLE_NODE, &debug_ospf_qnbr_cmd);
 	install_element(ENABLE_NODE, &debug_ospf_gr_cmd);
 	install_element(ENABLE_NODE, &debug_ospf_bfd_cmd);
 
@@ -1887,6 +1929,7 @@ void ospf_debug_init(void)
 	install_element(CONFIG_NODE, &debug_ospf_ldp_sync_cmd);
 	install_element(CONFIG_NODE, &debug_ospf_client_api_cmd);
 	install_element(CONFIG_NODE, &debug_ospf_opaque_lsa_cmd);
+	install_element(CONFIG_NODE, &debug_ospf_qnbr_cmd);
 	install_element(CONFIG_NODE, &debug_ospf_gr_cmd);
 	install_element(CONFIG_NODE, &debug_ospf_bfd_cmd);
 

--- a/ospfd/ospf_dump.h
+++ b/ospfd/ospf_dump.h
@@ -57,6 +57,8 @@
 
 #define OSPF_DEBUG_OPAQUE_LSA 0x01
 
+#define OSPF_DEBUG_QNBR 0x01
+
 /* Macro for setting debug option. */
 #define CONF_DEBUG_PACKET_ON(a, b)	    conf_debug_ospf_packet[a] |= (b)
 #define CONF_DEBUG_PACKET_OFF(a, b)	    conf_debug_ospf_packet[a] &= ~(b)
@@ -109,6 +111,7 @@
 #define IS_DEBUG_OSPF_GR IS_DEBUG_OSPF(gr, GR)
 #define IS_DEBUG_OSPF_CLIENT_API IS_DEBUG_OSPF(client_api, CLIENT_API)
 #define IS_DEBUG_OSPF_OPAQUE_LSA IS_DEBUG_OSPF(opaque_lsa, OPAQUE_LSA)
+#define IS_DEBUG_OSPF_QNBR	 IS_DEBUG_OSPF(qnbr, QNBR)
 
 #define IS_CONF_DEBUG_OSPF_PACKET(a, b)                                        \
 	(conf_debug_ospf_packet[a] & OSPF_DEBUG_##b)
@@ -135,6 +138,7 @@ extern unsigned long term_debug_ospf_gr;
 extern unsigned long term_debug_ospf_bfd;
 extern unsigned long term_debug_ospf_client_api;
 extern unsigned long term_debug_ospf_opaque_lsa;
+extern unsigned long term_debug_ospf_qnbr;
 
 /* Message Strings. */
 extern char *ospf_lsa_type_str[];

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -270,6 +270,7 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 
 	/* Initialize neighbor list. */
 	oi->nbrs = route_table_init();
+	oi->bfd_sessions = route_table_init();
 
 	/* Initialize static neighbor list. */
 	oi->nbr_nbma = list_new();
@@ -387,6 +388,8 @@ void ospf_if_free(struct ospf_interface *oi)
 	/* Free Pseudo Neighbour */
 	ospf_nbr_delete(oi->nbr_self);
 
+	ospf_bfd_if_flush(oi);
+	route_table_finish(oi->bfd_sessions);
 	route_table_finish(oi->nbrs);
 	route_table_finish(oi->ls_upd_queue);
 

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -111,6 +111,8 @@ struct ospf_if_params {
 		uint32_t min_tx;
 		/** BFD profile. */
 		char profile[BFD_PROFILE_NAME_LEN];
+		/** Allow quick re-adding of BFD neighbors */
+		bool quick;
 	} *bfd_config;
 
 	/* MPLS LDP-IGP Sync configuration */
@@ -236,6 +238,7 @@ struct ospf_interface {
 
 	uint32_t crypt_seqnum; /* Cryptographic Sequence Number */
 	uint32_t output_cost;  /* Actual Interface Output Cost */
+	uint32_t num_q_nbrs;   /* Number of quick neighbors still active */
 
 	/* Neighbor information. */
 	struct route_table *nbrs;       /* OSPF Neighbor List */
@@ -280,6 +283,7 @@ struct ospf_interface {
 	/* Threads. */
 	struct event *t_hello;		 /* timer */
 	struct event *t_wait;		 /* timer */
+	struct event *t_qn_wait;	 /* timer */
 	struct event *t_ls_ack_delayed;	 /* timer */
 	struct event *t_ls_ack_direct;	 /* event */
 	struct event *t_ls_upd_event;	 /* event */

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -240,6 +240,8 @@ struct ospf_interface {
 	/* Neighbor information. */
 	struct route_table *nbrs;       /* OSPF Neighbor List */
 	struct ospf_neighbor *nbr_self; /* Neighbor Self */
+	/* BFD session entries for this interface (keyed by neighbor endpoint). */
+	struct route_table *bfd_sessions;
 #define DR(I)			((I)->nbr_self->d_router)
 #define BDR(I)			((I)->nbr_self->bd_router)
 #define OPTIONS(I)		((I)->nbr_self->options)

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -230,8 +230,16 @@ int ospf_dr_election(struct ospf_interface *oi)
 
 	/* if DR or BDR changes, cause AdjOK? neighbor event. */
 	if (!IPV4_ADDR_SAME(&old_dr, &DR(oi)) || !IPV4_ADDR_SAME(&old_bdr, &BDR(oi)) ||
-	    oi->ospf->gr_info.restart_in_progress)
+	    oi->ospf->gr_info.restart_in_progress) {
+		struct ospf_if_params *oip = IF_DEF_PARAMS(oi->ifp);
+
 		ospf_dr_change(oi->ospf, oi->nbrs);
+		/* Trigger an extra hello on DR/BDR changes when using quick neighbors to speed up
+		 * correct DR/BDR election.
+		 */
+		if (oip->bfd_config && oip->bfd_config->quick)
+			ospf_hello_send(oi);
+	}
 
 	return new_state;
 }
@@ -285,6 +293,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   reset also. */
 		event_cancel(&oi->t_hello);
 		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_qn_wait);
 		event_cancel(&oi->t_ls_ack_delayed);
 		event_cancel(&oi->gr.hello_delay.t_grace_send);
 		break;
@@ -293,6 +302,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   unavailable for regular data traffic. */
 		event_cancel(&oi->t_hello);
 		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_qn_wait);
 		event_cancel(&oi->t_ls_ack_delayed);
 		event_cancel(&oi->gr.hello_delay.t_grace_send);
 		break;
@@ -314,6 +324,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		/* send first hello immediately */
 		OSPF_ISM_TIMER_MSEC_ON(oi->t_hello, ospf_hello_timer, 1);
 		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_qn_wait);
 		break;
 	case ISM_DROther:
 		/* The network type of the interface is broadcast or NBMA
@@ -322,6 +333,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   Backup Designated Router. */
 		OSPF_HELLO_TIMER_ON(oi);
 		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_qn_wait);
 		break;
 	case ISM_Backup:
 		/* The network type of the interface is broadcast os NBMA
@@ -329,6 +341,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   and the router is Backup Designated Router. */
 		OSPF_HELLO_TIMER_ON(oi);
 		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_qn_wait);
 		break;
 	case ISM_DR:
 		/* The network type of the interface is broadcast or NBMA
@@ -336,6 +349,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   and the router is Designated Router. */
 		OSPF_HELLO_TIMER_ON(oi);
 		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_qn_wait);
 		break;
 	}
 }

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -30,6 +30,7 @@
 #include "ospfd/ospf_dump.h"
 #include "ospfd/ospf_bfd.h"
 #include "ospfd/ospf_gr.h"
+#include "ospfd/ospf_quicknbr.h"
 
 /* Fill in the the 'key' as appropriate to retrieve the entry for nbr
  * from the ospf_interface's nbrs table. Indexed by interface address
@@ -203,8 +204,19 @@ void ospf_nbr_delete(struct ospf_neighbor *nbr)
 		}
 	}
 
+	/* Make sure we keep the quick neighbor count accurate in case a neighbor was added, then
+	 * deleted before a hello packet was received to learn the router-id
+	 */
+	if (IS_QUICKNBR(nbr) && oi->num_q_nbrs > 0)
+		oi->num_q_nbrs--;
+
 	/* Free ospf_neighbor structure. */
 	ospf_nbr_free(nbr);
+}
+
+void ospf_nbr_bring_down(struct ospf_neighbor *nbr)
+{
+	OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
 }
 
 /* Check myself is in the neighbor list. */
@@ -496,6 +508,60 @@ struct ospf_neighbor *ospf_nbr_get(struct ospf_interface *oi,
 	}
 
 	nbr->router_id = ospfh->router_id;
+
+	return nbr;
+}
+
+struct ospf_neighbor *ospf_qnbr_get(struct ospf_interface *oi, struct in_addr *src)
+{
+	struct route_node *rn;
+	struct prefix p;
+	struct ospf_neighbor *nbr;
+	struct ospf_header ospfh = {};
+
+	p.family = AF_INET;
+	p.u.prefix4 = *src;
+	p.prefixlen = IPV4_MAX_BITLEN;
+	rn = route_node_get(oi->nbrs, &p);
+
+	if (rn->info) {
+		if (IS_DEBUG_OSPF_QNBR)
+			zlog_debug("%s: Neighbor %pI4 already existed in the neighbor table!!",
+				   __func__, src);
+		route_unlock_node(rn);
+		nbr = rn->info;
+		return nbr;
+	}
+
+	/* Quick neighbor creation requires a configured interface address. */
+	if (!oi->address) {
+		if (IS_DEBUG_OSPF_QNBR)
+			zlog_debug("%s: cannot create quick neighbor for %pI4 on %s: no interface address",
+				   __func__, src, IF_NAME(oi));
+		route_unlock_node(rn);
+		return NULL;
+	}
+
+	/* Prefix length from the neighbor should match our own interface */
+	p.prefixlen = oi->address->prefixlen;
+
+	/* If auth type is cryptographic, then the crypto seq number would be saved. This also
+	 * happens when validating the OSPF header. So we are fine just setting it to NULL here so
+	 * we can create the neighbor and auth still works.
+	 */
+	ospfh.auth_type = htons(OSPF_AUTH_NULL);
+	nbr = ospf_nbr_add(oi, &ospfh, &p);
+
+	/* Copy the priority from our own configuration. As well as the DR/BDR elections and
+	 * supported options
+	 */
+	nbr->priority = PRIORITY(oi);
+	nbr->d_router = DR(oi);
+	nbr->bd_router = BDR(oi);
+	nbr->options = OPTIONS(oi);
+
+	rn->info = nbr;
+	oi->num_q_nbrs++;
 
 	return nbr;
 }

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -135,7 +135,7 @@ void ospf_nbr_free(struct ospf_neighbor *nbr)
 	/* Cancel all events. */ /* Thread lookup cost would be negligible. */
 	event_cancel_event(master, nbr);
 
-	bfd_sess_free(&nbr->bfd_session);
+	ospf_neighbor_bfd_clear(nbr);
 
 	event_cancel(&nbr->gr_helper_info.t_grace_timer);
 

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -90,6 +90,7 @@ struct ospf_neighbor {
 extern struct ospf_neighbor *ospf_nbr_new(struct ospf_interface *oi);
 extern void ospf_nbr_free(struct ospf_neighbor *nbr);
 extern void ospf_nbr_delete(struct ospf_neighbor *nbr);
+extern void ospf_nbr_bring_down(struct ospf_neighbor *nbr);
 extern int ospf_nbr_bidirectional(struct in_addr *router_id, struct in_addr *dr, int idx);
 extern void ospf_nbr_self_reset(struct ospf_interface *oi, struct in_addr router_id);
 extern void ospf_nbr_add_self(struct ospf_interface *oi, struct in_addr router_id);
@@ -97,6 +98,7 @@ extern int ospf_nbr_count(struct ospf_interface *oi, int state);
 extern int ospf_nbr_count_opaque_capable(struct ospf_interface *oi);
 extern struct ospf_neighbor *ospf_nbr_get(struct ospf_interface *oi, struct ospf_header *ospfh,
 					  struct ip *iph, struct prefix *p);
+extern struct ospf_neighbor *ospf_qnbr_get(struct ospf_interface *oi, struct in_addr *src);
 extern struct ospf_neighbor *ospf_nbr_lookup(struct ospf_interface *oi, struct ip *iph,
 					     struct ospf_header *ospfh);
 extern struct ospf_neighbor *ospf_nbr_lookup_by_addr(struct route_table *nbrs,

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -36,6 +36,7 @@
 #include "ospfd/ospf_bfd.h"
 #include "ospfd/ospf_gr.h"
 #include "ospfd/ospf_errors.h"
+#include "ospfd/ospf_quicknbr.h"
 
 DEFINE_HOOK(ospf_nsm_change,
 	    (struct ospf_neighbor * on, int state, int oldstate),
@@ -337,6 +338,12 @@ static int nsm_adj_ok(struct ospf_neighbor *nbr)
 		ospf_proactively_arp(nbr);
 	} else if (nbr->state >= NSM_ExStart && adj == 0)
 		next_state = NSM_TwoWay;
+	else if (nbr->state == NSM_TwoWay && IS_QUICKNBR(nbr) && adj == 1)
+		/*
+		 * Quick neighbor placeholder; only form adjacency when appropriate
+		 * per RFC2328 10.4.
+		 */
+		next_state = NSM_ExStart;
 
 	return next_state;
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2634,6 +2634,72 @@ static unsigned ospf_packet_examin(struct ospf_header *oh,
 	return ret;
 }
 
+/*
+ * On PtP/VLinks, neighbor structures are indexed by router-ID. Quick neighbors
+ * are created under the source address until the router ID is known.
+ */
+static void ospf_qnbr_rekey_ptp_vlink(struct ospf_interface *oi, const struct in_addr *src,
+				      struct ospf_neighbor *qnbr)
+{
+	struct prefix oldk, newk;
+	struct route_node *oldrn, *newrn;
+	struct ospf_neighbor *existing;
+
+	memset(&oldk, 0, sizeof(oldk));
+	oldk.family = AF_INET;
+	oldk.prefixlen = IPV4_MAX_BITLEN;
+	oldk.u.prefix4 = *src;
+
+	memset(&newk, 0, sizeof(newk));
+	newk.family = AF_INET;
+	newk.prefixlen = IPV4_MAX_BITLEN;
+	newk.u.prefix4 = qnbr->router_id;
+
+	/* First check if the router-id slot is already occupied. */
+	existing = NULL;
+	newrn = route_node_lookup(oi->nbrs, &newk);
+	if (newrn) {
+		existing = newrn->info;
+		route_unlock_node(newrn);
+	}
+
+	/*
+	 * If another neighbor already exists under the router-id key, prefer it
+	 * and delete the quick placeholder to avoid orphaning it.
+	 */
+	if (existing && existing != qnbr) {
+		if (IS_DEBUG_OSPF_QNBR)
+			zlog_debug("%s: router-id keyed neighbor already exists for %pI4 on %s",
+				   __func__, &qnbr->router_id, IF_NAME(oi));
+
+		oldrn = route_node_lookup(oi->nbrs, &oldk);
+		if (oldrn) {
+			if (oldrn->info == qnbr) {
+				oldrn->info = NULL;
+				route_unlock_node(oldrn);
+			}
+			route_unlock_node(oldrn);
+		}
+
+		ospf_nbr_free(qnbr);
+	} else {
+		newrn = route_node_get(oi->nbrs, &newk);
+		if (!newrn->info)
+			newrn->info = qnbr;
+		else
+			route_unlock_node(newrn);
+
+		oldrn = route_node_lookup(oi->nbrs, &oldk);
+		if (oldrn) {
+			if (oldrn->info == qnbr) {
+				oldrn->info = NULL;
+				route_unlock_node(oldrn);
+			}
+			route_unlock_node(oldrn);
+		}
+	}
+}
+
 /* OSPF Header verification. */
 static int ospf_verify_header(struct stream *ibuf, struct ospf_interface *oi,
 			      struct ip *iph, struct ospf_header *ospfh)
@@ -2660,6 +2726,38 @@ static int ospf_verify_header(struct stream *ibuf, struct ospf_interface *oi,
 	 * required. */
 	if (!ospf_auth_check(oi, iph, ospfh))
 		return -1;
+
+	/* Check for quick neighbors. Update router-id and send immediate hellos if needed */
+	if (oi->num_q_nbrs) {
+		struct ospf_neighbor *qnbr;
+		struct in_addr src;
+
+		src.s_addr = iph->ip_src.s_addr;
+		qnbr = ospf_nbr_lookup_by_addr(oi->nbrs, &src);
+		if (qnbr && qnbr->router_id.s_addr == 0) {
+			if (IS_DEBUG_OSPF_QNBR)
+				zlog_debug("%s: Quick neighbor learned router-id, qnbr=%pI4, router-id=%pI4",
+					   __func__, &src, &ospfh->router_id);
+			/* Fix the router-id and trigger a new hello to be sent */
+			qnbr->router_id = ospfh->router_id;
+			/* This is no longer a "quick" neighbor now that we know the router-id */
+			if (oi->num_q_nbrs)
+				oi->num_q_nbrs--;
+
+			/*
+			 * On Point-to-Point and Virtual-Link interfaces, the neighbor
+			 * table is indexed by router-id. Quick neighbors are created
+			 * (temporarily) under their source address; once the router-id
+			 * is known, re-key the entry to avoid duplicate neighbors.
+			 */
+			if (oi->type == OSPF_IFTYPE_VIRTUALLINK ||
+			    oi->type == OSPF_IFTYPE_POINTOPOINT)
+				ospf_qnbr_rekey_ptp_vlink(oi, &src, qnbr);
+
+			OSPF_ISM_EVENT_EXECUTE(oi, ISM_NeighborChange);
+			ospf_hello_send(oi);
+		}
+	}
 
 	return 0;
 }

--- a/ospfd/ospf_quicknbr.c
+++ b/ospfd/ospf_quicknbr.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026	ATCorp
+ *			Nathan Bahr
+ */
+
+#include <zebra.h>
+#include "lib/if.h"
+#include "ospfd/ospfd.h"
+#include "ospfd/ospf_interface.h"
+#include "ospfd/ospf_ism.h"
+#include "ospfd/ospf_lsa.h"
+#include "ospfd/ospf_lsdb.h"
+#include "ospfd/ospf_neighbor.h"
+#include "ospfd/ospf_nsm.h"
+#include "ospfd/ospf_dump.h"
+#include "ospfd/ospf_quicknbr.h"
+
+static void ospf_qn_wait(struct event *evt)
+{
+	struct ospf_interface *oi;
+
+	oi = evt->arg;
+	/* Only meaningful while the interface is in ISM_Waiting. */
+	if (oi->state != ISM_Waiting) {
+		if (IS_DEBUG_OSPF_QNBR)
+			zlog_debug("%s: stopping qnbr wait: if=%s state=%s", __func__,
+				   oi->ifp->name, lookup_msg(ospf_ism_state_msg, oi->state, NULL));
+		oi->t_qn_wait = NULL;
+		return;
+	}
+	if (oi->num_q_nbrs) {
+		event_add_timer_msec(master, ospf_qn_wait, oi, 100, &oi->t_qn_wait);
+		return;
+	}
+	/* no more quick neighbors, so go ahead and drop the interface out of waiting */
+	if (IS_DEBUG_OSPF_QNBR)
+		zlog_debug("%s: all qnbr router-ids learned, firing ISM_WaitTimer: if=%s",
+			   __func__, oi->ifp->name);
+	oi->t_qn_wait = NULL;
+	OSPF_ISM_EVENT_EXECUTE(oi, ISM_WaitTimer);
+}
+
+/*
+ * Add the neighbor immediately if not already found on the supplied interface.
+ * This may add a new neighbor to the neighbor list without a router-id and other
+ * assumed information, such as priority.
+ * The new neighbor will be artificially pushed through the NSM states until
+ * ExStart is reached.
+ * This handles the case of the interface being in the waiting state and will take over
+ * the waiting timer and allow the interface to go to the next state once all quick neighbors
+ * have been officially seen and router-ids learned.
+ */
+void ospf_qn_add(struct ospf_interface *oi, struct in_addr *endpoint)
+{
+	struct ospf_neighbor *nbr;
+
+	if (!oi || !endpoint)
+		return;
+
+	/* Don't try to force neighbor/ISM/NSM transitions on a down interface. */
+	if (!ospf_if_is_up(oi) || oi->state == ISM_Down || oi->state == ISM_Loopback)
+		return;
+
+	nbr = ospf_nbr_lookup_by_addr(oi->nbrs, endpoint);
+	if (!nbr || nbr->state <= NSM_TwoWay) {
+		if (IS_DEBUG_OSPF_QNBR)
+			zlog_debug("%s: Reachable endpoint%s, link=%s, endpoint=%pI4", __func__,
+				   (nbr ? "" : " (new)"), oi->ifp->name, endpoint);
+
+		if (!nbr)
+			nbr = ospf_qnbr_get(oi, endpoint);
+		if (!nbr)
+			return;
+
+		/* We want the neighbor to be in the two-way state */
+		/*
+		 * Must fake a hello if not yet at Init. If we're already at Init (e.g.
+		 * rapid BFD bounce mid-transition), re-firing HelloReceived is harmless:
+		 * NSM handles Init+HelloReceived as a no-op, but it may re-arm t_qn_wait.
+		 */
+		if (nbr->state <= NSM_Init)
+			OSPF_NSM_EVENT_EXECUTE(nbr, NSM_HelloReceived);
+		/* Now in init state, move to two-way */
+		OSPF_NSM_EVENT_EXECUTE(nbr, NSM_TwoWayReceived);
+
+		/* If the interface is still waiting, we need to push it out of waiting state
+		 * in order for the new neighbor to go to ExStart.
+		 * We want to wait until we have learned the router-ids of all of the quick
+		 * neighbors though first, so start a timer to check.
+		 */
+		if (oi->state == ISM_Waiting) {
+			if (!oi->t_qn_wait) {
+				if (IS_DEBUG_OSPF_QNBR)
+					zlog_debug("%s: starting qnbr wait (keeping t_wait backstop): if=%s",
+						   __func__, oi->ifp->name);
+				event_add_timer_msec(master, ospf_qn_wait, oi, 100, &oi->t_qn_wait);
+			}
+		}
+
+		/* Since DR election won't work without router-ids, push the neighbor to ExStart
+		 * artificially by saying that forming an adjacency is ok.
+		 */
+		OSPF_NSM_EVENT_EXECUTE(nbr, NSM_AdjOK);
+	} else if (IS_DEBUG_OSPF_QNBR)
+		zlog_debug("%s: Reachable endpoint already has full adjacency, link=%s, endpoint=%pI4",
+			   __func__, oi->ifp->name, endpoint);
+}

--- a/ospfd/ospf_quicknbr.h
+++ b/ospfd/ospf_quicknbr.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026	ATCorp
+ *			Nathan Bahr
+ */
+
+
+#ifndef OSPFD_OSPF_QUICKNBR_H
+#define OSPFD_OSPF_QUICKNBR_H
+
+#include <netinet/in.h>
+
+struct ospf_interface;
+
+#define IS_QUICKNBR(_nbr) ((_nbr)->router_id.s_addr == INADDR_ANY)
+
+void ospf_qn_add(struct ospf_interface *oi, struct in_addr *endpoint);
+
+#endif /* OSPFD_OSPF_QUICKNBR_H */

--- a/ospfd/subdir.am
+++ b/ospfd/subdir.am
@@ -43,6 +43,7 @@ ospfd_libfrrospf_a_SOURCES = \
 	ospfd/ospf_nsm.c \
 	ospfd/ospf_opaque.c \
 	ospfd/ospf_packet.c \
+	ospfd/ospf_quicknbr.c \
 	ospfd/ospf_ri.c \
 	ospfd/ospf_route.c \
 	ospfd/ospf_routemap.c \
@@ -97,6 +98,7 @@ noinst_HEADERS += \
 	ospfd/ospf_neighbor.h \
 	ospfd/ospf_network.h \
 	ospfd/ospf_packet.h \
+	ospfd/ospf_quicknbr.h \
 	ospfd/ospf_ri.h \
 	ospfd/ospf_gr.h \
 	ospfd/ospf_route.h \

--- a/tests/topotests/bfd_ospf_quicknbr_topo1/__init__.py
+++ b/tests/topotests/bfd_ospf_quicknbr_topo1/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: ISC

--- a/tests/topotests/bfd_ospf_quicknbr_topo1/rt1/frr.conf
+++ b/tests/topotests/bfd_ospf_quicknbr_topo1/rt1/frr.conf
@@ -1,0 +1,26 @@
+log file zebra.log
+log timestamp precision 3
+!
+hostname rt1
+!
+interface lo
+ ip address 1.1.1.1/32
+ ip ospf area 0.0.0.0
+!
+interface eth-rt2
+ ip address 10.0.1.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+ ip ospf bfd quick
+!
+ip forwarding
+!
+bfd
+!
+router ospf
+ ospf router-id 1.1.1.1
+!
+line vty
+!

--- a/tests/topotests/bfd_ospf_quicknbr_topo1/rt2/frr.conf
+++ b/tests/topotests/bfd_ospf_quicknbr_topo1/rt2/frr.conf
@@ -1,0 +1,26 @@
+log file zebra.log
+log timestamp precision 3
+!
+hostname rt2
+!
+interface lo
+ ip address 2.2.2.2/32
+ ip ospf area 0.0.0.0
+!
+interface eth-rt1
+ ip address 10.0.1.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+ ip ospf bfd quick
+!
+ip forwarding
+!
+bfd
+!
+router ospf
+ ospf router-id 2.2.2.2
+!
+line vty
+!

--- a/tests/topotests/bfd_ospf_quicknbr_topo1/test_bfd_ospf_quicknbr_topo1.py
+++ b/tests/topotests/bfd_ospf_quicknbr_topo1/test_bfd_ospf_quicknbr_topo1.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+Exercise OSPF quick-neighbor behavior with BFD.
+
+This test validates two key properties:
+- With `ip ospf bfd quick`, the BFD session remains present even when the
+  neighbor is down, so that BFD can detect it again quickly.
+- If quick mode is disabled while the neighbor is down, any orphan/down BFD
+  sessions kept alive by quick mode are pruned.
+
+This test traffic-blackholes the L2 switch with ``tc netem`` (kernel ``sch_netem``).
+If that qdisc is unavailable, the whole module is skipped (see ``setup_module``).
+"""
+
+import json
+import os
+import sys
+from functools import partial
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bfdd, pytest.mark.ospfd]
+
+SWITCH_NAME = "s1"
+
+LONG_HELLO = 60
+LONG_DEAD = 180
+
+def tc_netem_supported(sw_gear):
+    """
+    Require `sch_netem` to already be loaded. We don't try to load it and we
+    don't probe by configuring qdiscs.
+    """
+    sw_net = sw_gear.net
+    check_cmd = "lsmod 2>/dev/null | grep -q sch_netem"
+    status, out, err = sw_net.cmd_status(check_cmd, warn=False)
+    return status == 0
+
+
+def set_switch_blackhole(enable):
+    """
+    Enable/disable traffic blackholing on the middle switch without bringing
+    router links down. This avoids link-up/down events and simulates a silent
+    L2 forwarding failure (no traffic passes). Requires tc qdisc ``netem``;
+    callers run only after ``setup_module`` has called ``tc_netem_supported``.
+    """
+    tgen = get_topogen()
+    sw = tgen.gears[SWITCH_NAME]
+    sw_net = sw.net
+    switch_ports = sorted(sw.links.keys())
+
+    if enable:
+        for ifname in switch_ports:
+            sw.cmd_raises("tc qdisc replace dev {} root netem loss 100%".format(ifname))
+    else:
+        for ifname in switch_ports:
+            sw.cmd_raises("tc qdisc del dev {} root".format(ifname))
+
+
+def get_bfd_peers(router):
+    out = router.vtysh_cmd("show bfd peers json", isjson=False)
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        logger.error("Failed to decode JSON from 'show bfd peers json':\n%s", out)
+        raise
+
+
+def summarize_bfd_peer_status_by_interface(peers, ifname):
+    """
+    Return (present, all_statuses) for a given interface name.
+    Multiple entries may exist depending on address-family/etc.
+    """
+    statuses = [p.get("status") for p in peers if p.get("interface") == ifname]
+    return (len(statuses) > 0, statuses)
+
+
+def assert_bfd_interface_session_state(
+    rname, ifname, want_present, want_status=None, count=30, wait=1
+):
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+
+    def check():
+        peers = get_bfd_peers(router)
+        present, statuses = summarize_bfd_peer_status_by_interface(peers, ifname)
+        if present != want_present:
+            return {"present": present, "statuses": statuses, "peers": peers}
+        if want_present and want_status is not None and want_status not in statuses:
+            return {"present": present, "statuses": statuses, "peers": peers}
+        return None
+
+    test_func = partial(check)
+    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    assert diff is None, f"{rname}: BFD peers on {ifname} did not reach expected state"
+
+
+def assert_ospf_neighbor_full(rname, neighbor_rid, count=40, wait=1):
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+
+    def check():
+        output = router.vtysh_cmd("show ip ospf neighbor json", isjson=True)
+        neighbors = output.get("neighbors", {})
+        nbr_list = neighbors.get(neighbor_rid)
+        if not nbr_list:
+            return {"missing": neighbor_rid, "neighbors": neighbors}
+
+        # The JSON schema varies a bit across versions/tests; accept either.
+        nbr = nbr_list[0] if isinstance(nbr_list, list) and nbr_list else {}
+        if nbr.get("converged") == "Full":
+            return None
+
+        nbr_state = nbr.get("nbrState", "")
+        if isinstance(nbr_state, str) and nbr_state.split("/")[0] == "Full":
+            return None
+
+        return {"routerId": neighbor_rid, "nbr": nbr}
+
+    test_func = partial(check)
+    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    assert diff is None, f"{rname}: OSPF neighbor {neighbor_rid} did not reach Full"
+
+
+def assert_ospf_neighbor_below_twoway(rname, neighbor_rid, count=90, wait=1):
+    """
+    Wait until the neighbor is either absent or below TwoWay.
+    This aligns with non-quick behavior which only keeps BFD sessions for
+    neighbors that are TwoWay+.
+    """
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+
+    def check():
+        output = router.vtysh_cmd("show ip ospf neighbor json", isjson=True)
+        neighbors = output.get("neighbors", {})
+        nbr_list = neighbors.get(neighbor_rid)
+        if not nbr_list:
+            return None
+
+        nbr = nbr_list[0] if isinstance(nbr_list, list) and nbr_list else {}
+        # Prefer nbrState when available (e.g. "Full/DR", "2-Way/DROther", "Down", etc.)
+        nbr_state = nbr.get("nbrState", "")
+        if isinstance(nbr_state, str) and nbr_state:
+            base = nbr_state.split("/")[0]
+            if base not in ("Full", "2-Way"):
+                return None
+            return {"routerId": neighbor_rid, "nbrState": nbr_state, "nbr": nbr}
+
+        # Fallback: if only "converged" exists, treat non-Full as "below TwoWay enough" for this wait.
+        if nbr.get("converged") != "Full":
+            return None
+
+        return {"routerId": neighbor_rid, "nbr": nbr}
+
+    test_func = partial(check)
+    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    assert diff is None, f"{rname}: OSPF neighbor {neighbor_rid} did not drop below TwoWay"
+
+
+def set_ospf_bfd_quick_mode(rname, ifname, enable):
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+    if enable:
+        cmd = f"configure terminal\ninterface {ifname}\nip ospf bfd quick\nend\n"
+    else:
+        # Keep BFD enabled, but disable quick mode.
+        cmd = f"configure terminal\ninterface {ifname}\nip ospf bfd\nend\n"
+    router.vtysh_cmd(cmd, isjson=False)
+
+def assert_ospf_bfd_quick_config(rname, ifname, enabled, count=20, wait=1):
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+
+    def check():
+        out = router.vtysh_cmd("show running-config", isjson=False)
+        # Extract the interface stanza in a simple, robust way.
+        # This avoids relying on 'show running-config interface ...' which isn't always available.
+        stanza = ""
+        marker = f"interface {ifname}\n"
+        idx = out.find(marker)
+        if idx >= 0:
+            rest = out[idx:]
+            # Stanza ends at next 'interface ' line or end of config.
+            next_idx = rest.find("\ninterface ", 1)
+            stanza = rest if next_idx < 0 else rest[: next_idx + 1]
+
+        has_quick = "ip ospf bfd quick" in stanza
+        has_bfd = "ip ospf bfd" in stanza
+        if enabled:
+            if has_quick:
+                return None
+            return {"want": "quick", "has_quick": has_quick, "has_bfd": has_bfd, "stanza": stanza}
+        # disabled: accept "ip ospf bfd" without "quick"
+        if has_bfd and not has_quick:
+            return None
+        return {"want": "non-quick", "has_quick": has_quick, "has_bfd": has_bfd, "stanza": stanza}
+
+    test_func = partial(check)
+    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    assert diff is None, f"{rname}: interface {ifname} did not reach expected quick config state"
+
+
+def set_ospf_timers(rname, ifname, hello, dead):
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+    cmd = (
+        "configure terminal\n"
+        f"interface {ifname}\n"
+        f"ip ospf hello-interval {hello}\n"
+        f"ip ospf dead-interval {dead}\n"
+        "end\n"
+    )
+    router.vtysh_cmd(cmd, isjson=False)
+
+
+def assert_ospf_timers_config(rname, ifname, hello, dead, count=20, wait=1):
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+
+    def check():
+        out = router.vtysh_cmd("show running-config", isjson=False)
+        marker = f"interface {ifname}\n"
+        idx = out.find(marker)
+        if idx < 0:
+            return {"missing": ifname}
+        rest = out[idx:]
+        next_idx = rest.find("\ninterface ", 1)
+        stanza = rest if next_idx < 0 else rest[: next_idx + 1]
+
+        want_hello = f"ip ospf hello-interval {hello}" in stanza
+        want_dead = f"ip ospf dead-interval {dead}" in stanza
+        if want_hello and want_dead:
+            return None
+        return {"stanza": stanza, "want_hello": want_hello, "want_dead": want_dead}
+
+    test_func = partial(check)
+    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    assert diff is None, f"{rname}: interface {ifname} did not reach expected OSPF timer config"
+
+def setup_module(mod):
+    topodef = {"s1": ("rt1:eth-rt2", "rt2:eth-rt1")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    if not tc_netem_supported(tgen.gears[SWITCH_NAME]):
+        pytest.skip(
+            "tc qdisc netem (Linux sch_netem) is required for this topotest; "
+            "load the module / use a fuller kernel image"
+        )
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_quicknbr_bfd_session_established_on_startup():
+    """
+    Step 1: Verify OSPF adjacency and BFD session are established.
+
+    This is the baseline expectation: quick-neighbor mode must not prevent
+    normal OSPF+BFD bringup.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Startup uses short hello/dead timers for fast convergence.
+    assert_ospf_neighbor_full("rt1", "2.2.2.2", count=60, wait=1)
+    assert_ospf_neighbor_full("rt2", "1.1.1.1", count=60, wait=1)
+
+    assert_bfd_interface_session_state("rt1", "eth-rt2", want_present=True, want_status="up")
+    assert_bfd_interface_session_state("rt2", "eth-rt1", want_present=True, want_status="up")
+
+    # Switch to long hello/dead timers before exercising quick-neighbor behavior.
+    set_ospf_timers("rt1", "eth-rt2", LONG_HELLO, LONG_DEAD)
+    set_ospf_timers("rt2", "eth-rt1", LONG_HELLO, LONG_DEAD)
+
+    assert_ospf_timers_config("rt1", "eth-rt2", LONG_HELLO, LONG_DEAD)
+    assert_ospf_timers_config("rt2", "eth-rt1", LONG_HELLO, LONG_DEAD)
+
+
+def test_quicknbr_bfd_session_stays_active_when_neighbor_goes_away():
+    """
+    Step 2: Bring the peer link down (rt2 side) and confirm rt1 keeps the BFD
+    session present (now down) due to quick mode.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Blackhole traffic on the middle switch. Interfaces remain up, but traffic stops.
+    set_switch_blackhole(True)
+    topotest.sleep(4, "Wait for BFD down notification (traffic blackholed)")
+
+    # With quick enabled on rt1, the BFD peer should still be present and down on rt1.
+    assert_bfd_interface_session_state("rt1", "eth-rt2", want_present=True, want_status="down")
+
+    # Ensure OSPF has reacted (neighbor below TwoWay) before toggling quick off.
+    assert_ospf_neighbor_below_twoway("rt1", "2.2.2.2")
+
+
+def test_quicknbr_comes_back_while_bfd_session_still_present():
+    """
+    Step 3: Restore the link while quick mode is still enabled and the BFD
+    session is still present. This validates the "down/up" cycle without
+    pruning in between.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Restore traffic. With long OSPF hello, recovery should still happen promptly via BFD+quick.
+    set_switch_blackhole(False)
+
+    # First ensure BFD comes back (this is what triggers the quick-neighbor add path).
+    assert_bfd_interface_session_state("rt1", "eth-rt2", want_present=True, want_status="up", count=30, wait=1)
+
+    # Then ensure OSPF returns to Full. This window should still be far less than
+    # the configured hello interval (60s), demonstrating we didn't just wait for a periodic hello.
+    assert_ospf_neighbor_full("rt1", "2.2.2.2", count=40, wait=1)
+    assert_ospf_neighbor_full("rt2", "1.1.1.1", count=40, wait=1)
+
+    assert_bfd_interface_session_state("rt1", "eth-rt2", want_present=True, want_status="up")
+    assert_bfd_interface_session_state("rt2", "eth-rt1", want_present=True, want_status="up")
+
+
+def test_quicknbr_bfd_session_pruned_when_quick_disabled_while_down():
+    """
+    Step 4: Bring the peer link down again, then disable quick mode while
+    down and confirm the orphan/down BFD session is pruned (removed) on rt1.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Blackhole traffic again.
+    set_switch_blackhole(True)
+    topotest.sleep(4, "Wait for BFD down notification (traffic blackholed)")
+
+    # Confirm session is present and down before pruning.
+    assert_bfd_interface_session_state("rt1", "eth-rt2", want_present=True, want_status="down")
+    assert_ospf_neighbor_below_twoway("rt1", "2.2.2.2")
+
+    # Disable quick mode while the neighbor is down, this should prune orphan sessions.
+    set_ospf_bfd_quick_mode("rt1", "eth-rt2", enable=False)
+
+    assert_ospf_bfd_quick_config("rt1", "eth-rt2", enabled=False)
+
+    assert_bfd_interface_session_state("rt1", "eth-rt2", want_present=False, count=60, wait=1)
+
+
+def test_memory_leak():
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))
+


### PR DESCRIPTION
This PR adds a quick neighbor feature with a simple interface to add neighbors without a hello packet being received.
This PR integrates it with BFD but it could be used in other ways to trigger neighbors via external signals.
The existing BFD implementation only uses the Down state to delete inactive neighbors and does not make use of BFD to quickly re-add neighbors when connectivity is re-established.
This PR adds the ability to enable quick neighbors for the BFD session such that the session will stay active after the neighbor goes down, and when the neighbor comes back up, it is quickly re-added and Hellos are exchanged to form an adjacency.

This feature is only used when BFD is enabled with the "quick" option, otherwise it has no effect.

Update 4/28/26:
I needed to refactor BFD sessions in ospf to be stored per-interface instead of per-neighbor so that the BFD session can remain active after a neighbor is removed. This is now the first commit in the series.