### PR TITLE
 pimd: fix stale pointer during shutdown after VRF move

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1799,6 +1799,7 @@ int pim_if_ifchannel_count(struct pim_interface *pim_ifp)
 static int pim_ifp_create(struct interface *ifp)
 {
 	struct pim_instance *pim;
+	struct pim_interface *pim_ifp;
 
 	pim = ifp->vrf->info;
 	if (PIM_DEBUG_ZEBRA) {
@@ -1809,17 +1810,20 @@ static int pim_ifp_create(struct interface *ifp)
 			ifp->mtu, if_is_operative(ifp));
 	}
 
-	if (if_is_operative(ifp)) {
-		struct pim_interface *pim_ifp;
+	/*
+	 * If we have a pim_ifp already and this is an if_add
+	 * that means that we probably have a vrf move event
+	 * If that is the case, set the proper vrfness.
+	 * This should be done irrespective of the interface's
+	 * operational state, otherwise a VRF move while the
+	 * interface is DOWN would leave pim_ifp->pim stale,
+	 * causing a use-after-free at shutdown.
+	 */
+	pim_ifp = ifp->info;
+	if (pim_ifp)
+		pim_ifp->pim = pim;
 
-		pim_ifp = ifp->info;
-		/*
-		 * If we have a pim_ifp already and this is an if_add
-		 * that means that we probably have a vrf move event
-		 * If that is the case, set the proper vrfness.
-		 */
-		if (pim_ifp)
-			pim_ifp->pim = pim;
+	if (if_is_operative(ifp)) {
 		pim_if_addr_add_all(ifp);
 
 		/*
@@ -1841,8 +1845,6 @@ static int pim_ifp_create(struct interface *ifp)
 	 * for pim or not.
 	 */
 	if (pim_if_is_vrf_device(ifp)) {
-		struct pim_interface *pim_ifp;
-
 		if (!ifp->info) {
 			pim_ifp = pim_if_new(ifp, false, false, false,
 					     false /*vxlan_term*/);

--- a/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
+++ b/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
@@ -608,6 +608,103 @@ def test_pim6_interface_removal():
     )
 
 
+def test_pim_vrf_uaf_on_shutdown():
+    """
+    Regression test for use-after-free in pimd shutdown after a VRF move.
+
+    Steps:
+      a) Enable PIM on one interface per VRF.
+      b) Flush addresses and bring interfaces DOWN before VRF deletion,
+         so the back-pointer resync is not triggered on re-parent.
+      c) Delete both non-default VRFs from the kernel.
+      d) Teardown sends SIGINT to pimd; Valgrind should report no errors
+         with the fix applied.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # (a) Re-enable PIM on one interface per VRF.
+    logger.info("UAF step-a: enabling PIM on r1-eth1 (blue) and r1-eth3 (red)")
+    r1.vtysh_cmd(
+        """
+        conf
+        interface r1-eth1
+          ip pim
+        interface r1-eth3
+          ip pim
+        """
+    )
+    topotest.sleep(1, "let pimd register PIM-enabled interfaces")
+
+    blue_ifaces = r1.vtysh_cmd("show ip pim vrf blue interface json", isjson=True)
+    red_ifaces = r1.vtysh_cmd("show ip pim vrf red interface json", isjson=True)
+    assert (
+        "r1-eth1" in blue_ifaces
+    ), "r1-eth1 not visible to pimd in VRF blue after ip pim re-enable"
+    assert (
+        "r1-eth3" in red_ifaces
+    ), "r1-eth3 not visible to pimd in VRF red after ip pim re-enable"
+
+    # (b) Flush addresses and bring interfaces DOWN before deleting VRFs.
+    # Flushing addresses prevents pim_if_addr_update from resyncing the
+    # back-pointer when the interface is re-parented to the default VRF.
+    # Bringing the interface DOWN prevents pim_ifp_create from resyncing
+    # since it only does so when if_is_operative() is true.
+    logger.info("UAF step-b: flushing addresses and bringing interfaces DOWN")
+    for cmd in (
+        "ip addr flush dev r1-eth1",
+        "ip addr flush dev r1-eth3",
+    ):
+        tgen.net["r1"].cmd(cmd)
+    topotest.sleep(1, "let pimd process address-delete events")
+
+    blue_ifaces2 = r1.vtysh_cmd("show ip pim vrf blue interface json", isjson=True)
+    red_ifaces2 = r1.vtysh_cmd("show ip pim vrf red interface json", isjson=True)
+    assert "r1-eth1" in blue_ifaces2, "r1-eth1 disappeared from pimd after addr flush"
+    assert "r1-eth3" in red_ifaces2, "r1-eth3 disappeared from pimd after addr flush"
+
+    for cmd in (
+        "ip link set dev r1-eth1 down",
+        "ip link set dev r1-eth3 down",
+    ):
+        tgen.net["r1"].cmd(cmd)
+    topotest.sleep(1, "let pimd process interface-down events")
+
+    eth1_state = tgen.net["r1"].cmd("ip -o link show dev r1-eth1")
+    eth3_state = tgen.net["r1"].cmd("ip -o link show dev r1-eth3")
+    assert "state DOWN" in eth1_state or "NO-CARRIER" in eth1_state, (
+        "r1-eth1 did not go DOWN as expected: " + eth1_state
+    )
+    assert "state DOWN" in eth3_state or "NO-CARRIER" in eth3_state, (
+        "r1-eth3 did not go DOWN as expected: " + eth3_state
+    )
+
+    # (c) Delete both non-default VRFs from the kernel.
+    # The kernel re-parents the interfaces to the default VRF; since they
+    # are DOWN and have no addresses, the back-pointer resync is skipped,
+    # leaving pim_ifp->pim pointing at the freed pim_instance.
+    logger.info("UAF step-c: deleting VRFs blue and red from kernel")
+    for cmd in (
+        "ip link del blue",
+        "ip link del red",
+    ):
+        tgen.net["r1"].cmd(cmd)
+    topotest.sleep(3, "let pimd process VRF delete and interface re-parent events")
+
+    vrf_list = tgen.net["r1"].cmd("ip -o link show type vrf")
+    assert "blue" not in vrf_list, "VRF blue still present in kernel after ip link del"
+    assert "red" not in vrf_list, "VRF red still present in kernel after ip link del"
+
+    # (d) Teardown will send SIGINT to pimd triggering shutdown.
+    # Without the fix a use-after-free occurs here; with the fix
+    # Valgrind should report zero errors.
+    logger.info("UAF step-d: setup complete, teardown will trigger pimd shutdown")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
 pimd: fix stale pointer during shutdown after VRF move
    
     When an interface is moved to a new VRF while operationally DOWN,
     the back-pointer to the owning PIM instance is not updated, leaving
     it stale.
    
     Fix by always resyncing the back-pointer on interface creation,
     regardless of the interface's operational state.
    
     Signed-off-by: Soumya Roy <souroy@nvidia.com>

valgrind call stack>>
==688542==    This could cause spurious value errors to appear.
==688542==    See README_MISSING_SYSCALL_OR_IOCTL for guidance on writing a proper wrapper.
==688542== Invalid read of size 4
==688542==    at 0x172B4E: pim_if_delete (in /usr/lib/frr/pimd)
==688542==    by 0x172CE1: pim_if_terminate (in /usr/lib/frr/pimd)
==688542==    by 0x17722C: ??? (in /usr/lib/frr/pimd)
==688542==    by 0x17764B: pim_vrf_terminate (in /usr/lib/frr/pimd)
==688542==    by 0x1965E4: pim_terminate (in /usr/lib/frr/pimd)
==688542==    by 0x1B792D: ??? (in /usr/lib/frr/pimd)
==688542==    by 0x4952862: frr_sigevent_process (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x4964FF4: event_fetch (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x490EEBA: frr_run (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x15F12A: main (in /usr/lib/frr/pimd)
==688542==  Address 0x5eab4d8 is 1,192 bytes inside a block of size 1,768 free'd
==688542==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==688542==    by 0x17764B: pim_vrf_terminate (in /usr/lib/frr/pimd)
==688542==    by 0x1965E4: pim_terminate (in /usr/lib/frr/pimd)
==688542==    by 0x1B792D: ??? (in /usr/lib/frr/pimd)
==688542==    by 0x4952862: frr_sigevent_process (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x4964FF4: event_fetch (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x490EEBA: frr_run (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x15F12A: main (in /usr/lib/frr/pimd)
==688542==  Block was alloc'd at
==688542==    at 0x48465EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==688542==    by 0x491B6CF: qcalloc (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x1773DA: ??? (in /usr/lib/frr/pimd)
==688542==    by 0x4968020: vrf_get (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x4979C13: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x497B14B: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x4965370: event_call (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x490EEAF: frr_run (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==688542==    by 0x15F12A: main (in /usr/lib/frr/pimd)