### PR TITLE
bgpd: fix aggregate->count undercount when dampening is cleared

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -493,6 +493,8 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 		list = &bdc->reuse_list[i];
 		while ((bdi = SLIST_FIRST(list)) != NULL) {
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
+				bgp_path_info_unset_flag(bdi->dest, bdi->path,
+							 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 				bgp_aggregate_increment(bgp,
 							bgp_dest_get_prefix(
 								bdi->dest),


### PR DESCRIPTION
bgp_damp_info_clean() calls bgp_aggregate_increment() while the path still carries BGP_PATH_DAMPED (and BGP_PATH_HISTORY), so the increment is skipped because BGP_PATH_HOLDDOWN() is true.  bgp_damp_info_free() then clears those flags, leaving the route active in the RIB with no HOLDDOWN.  When the route is later deleted, bgp_aggregate_decrement() proceeds normally, driving count one below where it should be and potentially uninstalling the aggregate prematurely.

The parallel code path bgp_damp_reuse() does this correctly: it clears BGP_PATH_DAMPED and BGP_PATH_HISTORY *before* calling bgp_aggregate_increment().  Apply the same ordering in bgp_damp_info_clean() for the BGP_RECORD_UPDATE case.