### PR TITLE
bgpd: fix aggregate->count not decremented when route is dampened

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -375,14 +375,12 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, struct reuselist *list,
 	struct bgp_path_info *bpi = bdi->path;
 	struct bgp_dest *dest = bdi->dest;
 	struct bgp *bgp = bpi->peer->bgp;
-	const struct prefix *p = bgp_dest_get_prefix(bdi->dest);
 
 	bgp_damp_info_unclaim(bdi, list);
 
 	bpi->extra->damp_info = NULL;
 	bgp_path_info_unset_flag(dest, bpi, BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw) {
-		bgp_aggregate_decrement(bgp, p, bpi, afi, SAFI_UNICAST);
 		bgp_path_info_mark_for_delete(dest, bpi);
 		bgp_process(bgp, dest, bpi, afi, safi);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5346,10 +5346,12 @@ void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,
 	struct bgp *bgp = NULL;
 	bool delete_route = false;
 
-	bgp_aggregate_decrement(peer->bgp, bgp_dest_get_prefix(dest), pi, afi,
-				safi);
-
+	/* Skip for HISTORY routes: bgp_rib_withdraw already decremented before
+	 * bgp_damp_withdraw set BGP_PATH_HISTORY; bgp_damp_info_free handles
+	 * the eventual RIB cleanup.
+	 */
 	if (!CHECK_FLAG(pi->flags, BGP_PATH_HISTORY)) {
+		bgp_aggregate_decrement(peer->bgp, bgp_dest_get_prefix(dest), pi, afi, safi);
 		bgp_path_info_mark_for_delete(dest, pi); /* keep historical info */
 
 		/* If the selected path is removed, reset BGP_NODE_SELECT_DEFER
@@ -5380,12 +5382,14 @@ static void bgp_rib_withdraw(const struct prefix *p, struct bgp_dest *dest, stru
 	 */
 	if (peer->sort == BGP_PEER_EBGP) {
 		if (get_active_bdc_from_pi(pi, afi, safi)) {
-			if (bgp_damp_withdraw(pi, dest, afi, safi, 0) ==
-			    BGP_DAMP_SUPPRESSED) {
-				bgp_aggregate_decrement(peer->bgp, p, pi, afi,
-							safi);
+			/* Decrement BEFORE bgp_damp_withdraw sets
+			 * BGP_PATH_HISTORY, which is part of BGP_PATH_UNUSEABLE
+			 * and would cause bgp_remove_route_from_aggregate to
+			 * skip the decrement via the BGP_PATH_HOLDDOWN check.
+			 */
+			bgp_aggregate_decrement(peer->bgp, p, pi, afi, safi);
+			if (bgp_damp_withdraw(pi, dest, afi, safi, 0) == BGP_DAMP_SUPPRESSED)
 				return;
-			}
 		}
 	}
 


### PR DESCRIPTION
When bgp_rib_withdraw() applies dampening, bgp_damp_withdraw() sets BGP_PATH_HISTORY (part of BGP_PATH_UNUSEABLE) unconditionally before bgp_aggregate_decrement() is called. This causes
bgp_remove_route_from_aggregate() to skip the decrement via the BGP_PATH_HOLDDOWN check, even though the route was previously counted. The aggregate->count stays high, keeping the aggregate route installed incorrectly.

Fix by calling bgp_aggregate_decrement() before bgp_damp_withdraw() in bgp_rib_withdraw(), and guard the decrement in bgp_rib_remove() to skip it for BGP_PATH_HISTORY routes (which were already decremented before dampening set the flag), preventing a double-decrement when bgp_rib_remove() is called on a previously-suppressed route.