### PR TITLE
bgpd: support brief json for bgp l2vpn-evpn neighbors route

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1297,9 +1297,8 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 		vty_out(vty, "\n");
 }
 
-static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
-				 enum bgp_show_type type, void *output_arg,
-				 int option, bool use_json)
+static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd, enum bgp_show_type type,
+				 void *output_arg, int option, bool use_json, bool brief)
 {
 	afi_t afi = AFI_L2VPN;
 	struct bgp *bgp;
@@ -1317,6 +1316,8 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 	json_object *json = NULL;
 	json_object *json_array = NULL;
 	json_object *json_prefix_info = NULL;
+	int prefix_path_count, multi_path_count, rd_prefix_cnt;
+	bool best_path_selected, add_rd_to_json;
 
 	memset(rd_str, 0, RD_ADDRSTRLEN);
 
@@ -1337,6 +1338,7 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 		uint64_t tbl_ver;
 		json_object *json_nroute = NULL;
 		const struct prefix *p = bgp_dest_get_prefix(dest);
+		json_object *json_flags = NULL; /* contains flags under a prefix*/
 
 		if (prd && memcmp(p->u.val, prd->val, 8) != 0)
 			continue;
@@ -1347,6 +1349,8 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 
 		rd_header = 1;
 		tbl_ver = table->version;
+		rd_prefix_cnt = 0;
+		add_rd_to_json = false;
 
 		for (rm = bgp_table_top(table); rm; rm = bgp_route_next(rm)) {
 			pi = bgp_dest_get_bgp_path_info(rm);
@@ -1354,6 +1358,9 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 				continue;
 
 			no_display = 0;
+			prefix_path_count = 0;
+			best_path_selected = false;
+			multi_path_count = 0;
 			for (; pi; pi = pi->next) {
 				struct community *picomm = NULL;
 
@@ -1361,7 +1368,7 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 
 				total_count++;
 				if (type == bgp_show_type_neighbor) {
-				        struct peer *peer = output_arg;
+					struct peer *peer = output_arg;
 
 					if (peer_cmp(peer, pi->peer) != 0)
 						continue;
@@ -1385,130 +1392,141 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 				if (type == bgp_show_type_lcommunity_exact) {
 					struct lcommunity *lcom = output_arg;
 
-					if (!bgp_attr_get_lcommunity(
-						    pi->attr) ||
-					    !lcommunity_cmp(
-						    bgp_attr_get_lcommunity(
-							    pi->attr),
-						    lcom))
+					if (!bgp_attr_get_lcommunity(pi->attr) ||
+					    !lcommunity_cmp(bgp_attr_get_lcommunity(pi->attr),
+							    lcom))
 						continue;
 				}
 				if (type == bgp_show_type_lcommunity) {
 					struct lcommunity *lcom = output_arg;
 
-					if (!bgp_attr_get_lcommunity(
-						    pi->attr) ||
-					    !lcommunity_match(
-						    bgp_attr_get_lcommunity(
-							    pi->attr),
-						    lcom))
+					if (!bgp_attr_get_lcommunity(pi->attr) ||
+					    !lcommunity_match(bgp_attr_get_lcommunity(pi->attr),
+							      lcom))
 						continue;
 				}
 				if (type == bgp_show_type_community) {
 					struct community *com = output_arg;
 
-					if (!picomm ||
-					    !community_match(picomm, com))
+					if (!picomm || !community_match(picomm, com))
 						continue;
 				}
 				if (type == bgp_show_type_community_exact) {
 					struct community *com = output_arg;
 
-					if (!picomm ||
-					    !community_cmp(picomm, com))
+					if (!picomm || !community_cmp(picomm, com))
 						continue;
 				}
-				if (header) {
+				if (!brief && header) {
 					if (use_json) {
-						json_object_int_add(
-							json, "bgpTableVersion",
-							tbl_ver);
-						json_object_string_addf(
-							json,
-							"bgpLocalRouterId",
-							"%pI4",
-							&bgp->router_id);
-						json_object_int_add(
-							json,
-							"defaultLocPrf",
-							bgp->default_local_pref);
-						asn_asn2json(json, "localAS",
-							     bgp->as,
+						json_object_int_add(json, "bgpTableVersion",
+								    tbl_ver);
+						json_object_string_addf(json, "bgpLocalRouterId",
+									"%pI4", &bgp->router_id);
+						json_object_int_add(json, "defaultLocPrf",
+								    bgp->default_local_pref);
+						asn_asn2json(json, "localAS", bgp->as,
 							     bgp->asnotation);
+					} else if (option == SHOW_DISPLAY_TAGS) {
+						vty_out(vty, V4_HEADER_TAG);
+					} else if (option == SHOW_DISPLAY_OVERLAY) {
+						vty_out(vty, V4_HEADER_OVERLAY);
 					} else {
-						if (option == SHOW_DISPLAY_TAGS)
-							vty_out(vty,
-								V4_HEADER_TAG);
-						else if (
-							option
-							== SHOW_DISPLAY_OVERLAY)
-							vty_out(vty,
-								V4_HEADER_OVERLAY);
-						else {
-							bgp_evpn_show_route_header(vty, bgp, tbl_ver, NULL);
-						}
+						bgp_evpn_show_route_header(vty, bgp, tbl_ver, NULL);
 					}
 					header = 0;
 				}
 				if (rd_header) {
 					if (use_json)
-						json_nroute =
-						       json_object_new_object();
+						json_nroute = json_object_new_object();
 					bgp_evpn_show_route_rd_header(
 						vty, dest, json_nroute, rd_str,
 						RD_ADDRSTRLEN);
 					rd_header = 0;
 				}
-				if (use_json && !json_array)
-					json_array = json_object_new_array();
+				if (!brief) {
+					if (use_json && !json_array)
+						json_array = json_object_new_array();
 
-				if (option == SHOW_DISPLAY_TAGS)
-					route_vty_out_tag(
-						vty, bgp_dest_get_prefix(rm),
-						pi, no_display, SAFI_EVPN,
-						json_array);
-				else if (option == SHOW_DISPLAY_OVERLAY)
-					route_vty_out_overlay(
-						vty, bgp_dest_get_prefix(rm),
-						pi, no_display, json_array);
-				else
-					route_vty_out(vty, bgp_dest_get_prefix(rm), pi, no_display,
-						      NULL, SAFI_EVPN, json_array, false, NULL);
+					if (option == SHOW_DISPLAY_TAGS)
+						route_vty_out_tag(vty, bgp_dest_get_prefix(rm), pi,
+								  no_display, SAFI_EVPN,
+								  json_array);
+					else if (option == SHOW_DISPLAY_OVERLAY)
+						route_vty_out_overlay(vty, bgp_dest_get_prefix(rm),
+								      pi, no_display, json_array);
+					else
+						route_vty_out(vty, bgp_dest_get_prefix(rm), pi,
+							      no_display, NULL, SAFI_EVPN,
+							      json_array, false, NULL);
+				}
+				prefix_path_count++;
 				no_display = 1;
+				add_rd_to_json = true;
+				if (CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH))
+					multi_path_count++;
+				if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+					best_path_selected = true;
 			}
 
-			if (no_display)
+			if (no_display) {
 				output_count++;
+				rd_prefix_cnt++;
+			}
 
-			if (use_json && json_array) {
+			if (use_json && no_display) {
 				const struct prefix *pfx =
 					bgp_dest_get_prefix(rm);
 
 				json_prefix_info = json_object_new_object();
 
-				json_object_string_addf(json_prefix_info,
-							"prefix", "%pFX", pfx);
+				if (!brief && json_array) {
+					json_object_string_addf(json_prefix_info, "prefix", "%pFX",
+								pfx);
 
-				json_object_int_add(json_prefix_info,
-						    "prefixLen", pfx->prefixlen);
+					json_object_int_add(json_prefix_info, "prefixLen",
+							    pfx->prefixlen);
 
-				json_object_object_add(json_prefix_info,
-					"paths", json_array);
-				json_object_object_addf(json_nroute,
-							json_prefix_info,
-							"%pFX", pfx);
+					json_object_object_add(json_prefix_info, "paths",
+							       json_array);
+				}
+				json_object_int_add(json_prefix_info, "pathCount",
+						    prefix_path_count);
+				/* add +1 to the multipath count because
+				 * it does not include the best path
+				 * itself
+				 */
+				if (best_path_selected)
+					json_object_int_add(json_prefix_info, "multiPathCount",
+							    multi_path_count + 1);
+				else
+					json_object_int_add(json_prefix_info, "multiPathCount",
+							    multi_path_count);
+				json_flags = json_object_new_object();
+				json_object_boolean_add(json_flags, "bestPathExists",
+							best_path_selected);
+				json_object_object_add(json_prefix_info, "flags", json_flags);
+				json_object_object_addf(json_nroute, json_prefix_info, "%pFX", pfx);
 				json_array = NULL;
+				json_flags = NULL;
 			}
 		}
 
-		if (use_json && json_nroute)
-			json_object_object_add(json, rd_str, json_nroute);
+		if (use_json && json_nroute) {
+			json_object_int_add(json_nroute, "numPrefixes", rd_prefix_cnt);
+			if (add_rd_to_json)
+				json_object_object_add(json, rd_str, json_nroute);
+		}
 	}
 
 	if (use_json) {
-		json_object_int_add(json, "numPrefix", output_count);
-		json_object_int_add(json, "totalPrefix", total_count);
-		vty_json(vty, json);
+		if (!brief) {
+			json_object_int_add(json, "numPrefix", output_count);
+			json_object_int_add(json, "totalPrefix", total_count);
+			vty_json(vty, json);
+		} else {
+			vty_json_no_pretty(vty, json);
+		}
 	} else {
 		if (output_count == 0)
 			vty_out(vty, "No prefixes displayed, %ld exist\n",
@@ -1526,9 +1544,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn,
       "show [ip] bgp l2vpn evpn [json]",
       SHOW_STR IP_STR BGP_STR L2VPN_HELP_STR EVPN_HELP_STR JSON_STR)
 {
-	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL,
-				     SHOW_DISPLAY_STANDARD,
-				     use_json(argc, argv));
+	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL, SHOW_DISPLAY_STANDARD,
+				     use_json(argc, argv), false);
 }
 
 DEFUN(show_ip_bgp_l2vpn_evpn_rd,
@@ -1550,9 +1567,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd,
 	int rd_all = 0;
 
 	if (argv_find(argv, argc, "all", &rd_all))
-		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal,
-					     NULL, SHOW_DISPLAY_STANDARD,
-					     use_json(argc, argv));
+		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL,
+					     SHOW_DISPLAY_STANDARD, use_json(argc, argv), false);
 
 	argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community);
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
@@ -1560,9 +1576,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd,
 		vty_out(vty, "%% Malformed Route Distinguisher\n");
 		return CMD_WARNING;
 	}
-	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL,
-				     SHOW_DISPLAY_STANDARD,
-				     use_json(argc, argv));
+	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL, SHOW_DISPLAY_STANDARD,
+				     use_json(argc, argv), false);
 }
 
 DEFUN(show_ip_bgp_l2vpn_evpn_all_tags,
@@ -1576,8 +1591,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_tags,
       "Display information about all EVPN NLRIs\n"
       "Display BGP tags for prefixes\n")
 {
-	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL,
-				     SHOW_DISPLAY_TAGS, 0);
+	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL, SHOW_DISPLAY_TAGS, 0,
+				     false);
 }
 
 DEFUN(show_ip_bgp_l2vpn_evpn_rd_tags,
@@ -1599,8 +1614,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_tags,
 	int rd_all = 0;
 
 	if (argv_find(argv, argc, "all", &rd_all))
-		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal,
-					     NULL, SHOW_DISPLAY_TAGS, 0);
+		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL,
+					     SHOW_DISPLAY_TAGS, 0, false);
 
 	argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community);
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
@@ -1608,75 +1623,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_tags,
 		vty_out(vty, "%% Malformed Route Distinguisher\n");
 		return CMD_WARNING;
 	}
-	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL,
-				     SHOW_DISPLAY_TAGS, 0);
-}
-
-DEFUN(show_ip_bgp_l2vpn_evpn_neighbor_routes,
-      show_ip_bgp_l2vpn_evpn_neighbor_routes_cmd,
-      "show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> routes [json]",
-      SHOW_STR
-      IP_STR
-      BGP_STR
-      L2VPN_HELP_STR
-      EVPN_HELP_STR
-      "Detailed information on TCP and BGP neighbor connections\n"
-      "IPv4 Neighbor to display information about\n"
-      "IPv6 Neighbor to display information about\n"
-      "Neighbor on BGP configured interface\n"
-      "Display routes learned from neighbor\n" JSON_STR)
-{
-	int idx = 0;
-	struct peer *peer;
-	char *peerstr = NULL;
-	bool uj = use_json(argc, argv);
-	afi_t afi = AFI_L2VPN;
-	safi_t safi = SAFI_EVPN;
-	struct bgp *bgp = NULL;
-
-	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi,
-					    &bgp, uj);
-	if (!idx) {
-	        vty_out(vty, "No index\n");
-		return CMD_WARNING;
-	}
-
-	/* neighbors <A.B.C.D|X:X::X:X|WORD> */
-	argv_find(argv, argc, "neighbors", &idx);
-	peerstr = argv[++idx]->arg;
-
-	peer = peer_lookup_in_view(vty, bgp, peerstr, uj);
-	if (!peer) {
-		if (uj) {
-			json_object *json_no = NULL;
-			json_no = json_object_new_object();
-			json_object_string_add(json_no, "warning",
-					       "Malformed address");
-			vty_out(vty, "%s\n",
-				json_object_to_json_string(json_no));
-			json_object_free(json_no);
-		} else
-			vty_out(vty, "Malformed address: %s\n",
-				argv[idx]->arg);
-		return CMD_WARNING;
-	}
-	if (!peer || !peer->afc[AFI_L2VPN][SAFI_EVPN]) {
-		if (uj) {
-			json_object *json_no = NULL;
-			json_no = json_object_new_object();
-			json_object_string_add(
-				json_no, "warning",
-				"No such neighbor or address family");
-			vty_out(vty, "%s\n",
-				json_object_to_json_string(json_no));
-			json_object_free(json_no);
-		} else
-			vty_out(vty, "%% No such neighbor or address family\n");
-		return CMD_WARNING;
-	}
-
-	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_neighbor, peer,
-				     SHOW_DISPLAY_STANDARD, uj);
+	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL, SHOW_DISPLAY_TAGS, 0,
+				     false);
 }
 
 DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
@@ -1708,10 +1656,10 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 	struct bgp *bgp = NULL;
 	int rd_all = 0;
 
-	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi,
-					    &bgp, uj);
+	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi, &bgp, uj);
 	if (!idx) {
-	        vty_out(vty, "No index\n");
+		if (!uj)
+			vty_out(vty, "No index\n");
 		return CMD_WARNING;
 	}
 
@@ -1755,15 +1703,13 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 				argv[idx]->arg);
 		return CMD_WARNING;
 	}
-	if (!peer || !peer->afc[AFI_L2VPN][SAFI_EVPN]) {
+	if (!peer->afc[AFI_L2VPN][SAFI_EVPN]) {
 		if (uj) {
 			json_object *json_no = NULL;
 			json_no = json_object_new_object();
-			json_object_string_add(
-				json_no, "warning",
-				"No such neighbor or address family");
-			vty_out(vty, "%s\n",
-				json_object_to_json_string(json_no));
+			json_object_string_add(json_no, "warning",
+					       "No such neighbor or address family");
+			vty_out(vty, "%s\n", json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
 			vty_out(vty, "%% No such neighbor or address family\n");
@@ -1772,11 +1718,11 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 
 
 	if (rd_all)
-		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_neighbor,
-					     peer, SHOW_DISPLAY_STANDARD, uj);
+		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_neighbor, peer,
+					     SHOW_DISPLAY_STANDARD, uj, false);
 	else
-		return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_neighbor,
-					     peer, SHOW_DISPLAY_STANDARD, uj);
+		return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_neighbor, peer,
+					     SHOW_DISPLAY_STANDARD, uj, false);
 }
 
 DEFUN(show_ip_bgp_l2vpn_evpn_neighbor_advertised_routes,
@@ -1807,7 +1753,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_neighbor_advertised_routes,
 	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi,
 					    &bgp, uj);
 	if (!idx) {
-	        vty_out(vty, "No index\n");
+		vty_out(vty, "No index\n");
 		return CMD_WARNING;
 	}
 
@@ -1830,7 +1776,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_neighbor_advertised_routes,
 				argv[idx]->arg);
 		return CMD_WARNING;
 	}
-	if (!peer || !peer->afc[AFI_L2VPN][SAFI_EVPN]) {
+	if (!peer->afc[AFI_L2VPN][SAFI_EVPN]) {
 		if (uj) {
 			json_object *json_no = NULL;
 			json_no = json_object_new_object();
@@ -1886,7 +1832,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
 	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi,
 					    &bgp, uj);
 	if (!idx) {
-	        vty_out(vty, "No index\n");
+		vty_out(vty, "No index\n");
 		return CMD_WARNING;
 	}
 
@@ -1909,7 +1855,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
 				argv[idx]->arg);
 		return CMD_WARNING;
 	}
-	if (!peer || !peer->afc[AFI_L2VPN][SAFI_EVPN]) {
+	if (!peer->afc[AFI_L2VPN][SAFI_EVPN]) {
 		if (uj) {
 			json_object *json_no = NULL;
 			json_no = json_object_new_object();
@@ -1963,9 +1909,8 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_overlay,
       "Display BGP Overlay Information for prefixes\n"
       JSON_STR)
 {
-	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL,
-				     SHOW_DISPLAY_OVERLAY,
-				     use_json(argc, argv));
+	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL, SHOW_DISPLAY_OVERLAY,
+				     use_json(argc, argv), false);
 }
 
 DEFUN(show_ip_bgp_evpn_rd_overlay,
@@ -1987,9 +1932,8 @@ DEFUN(show_ip_bgp_evpn_rd_overlay,
 	int rd_all = 0;
 
 	if (argv_find(argv, argc, "all", &rd_all))
-		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal,
-					     NULL, SHOW_DISPLAY_OVERLAY,
-					     use_json(argc, argv));
+		return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_normal, NULL,
+					     SHOW_DISPLAY_OVERLAY, use_json(argc, argv), false);
 
 	argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community);
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
@@ -1997,9 +1941,8 @@ DEFUN(show_ip_bgp_evpn_rd_overlay,
 		vty_out(vty, "%% Malformed Route Distinguisher\n");
 		return CMD_WARNING;
 	}
-	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL,
-				     SHOW_DISPLAY_OVERLAY,
-				     use_json(argc, argv));
+	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL, SHOW_DISPLAY_OVERLAY,
+				     use_json(argc, argv), false);
 }
 
 DEFUN(show_bgp_l2vpn_evpn_rt,
@@ -2033,7 +1976,7 @@ DEFUN(show_bgp_l2vpn_evpn_rt,
 	}
 
 	ret = bgp_show_ethernet_vpn(vty, NULL, show_type, ecom, SHOW_DISPLAY_STANDARD,
-				    use_json(argc, argv));
+				    use_json(argc, argv), false);
 
 	ecommunity_free(&ecom);
 	return ret;
@@ -2076,9 +2019,8 @@ DEFUN(show_bgp_l2vpn_evpn_com,
 			return CMD_WARNING;
 		}
 
-		ret = bgp_show_ethernet_vpn(vty, NULL, show_type, lcom,
-					    SHOW_DISPLAY_STANDARD,
-					    use_json(argc, argv));
+		ret = bgp_show_ethernet_vpn(vty, NULL, show_type, lcom, SHOW_DISPLAY_STANDARD,
+					    use_json(argc, argv), false);
 
 		lcommunity_free(&lcom);
 	} else if (argv_find(argv, argc, "community", &idx)) {
@@ -2096,9 +2038,8 @@ DEFUN(show_bgp_l2vpn_evpn_com,
 			return CMD_WARNING;
 		}
 
-		ret = bgp_show_ethernet_vpn(vty, NULL, show_type, com,
-					    SHOW_DISPLAY_STANDARD,
-					    use_json(argc, argv));
+		ret = bgp_show_ethernet_vpn(vty, NULL, show_type, com, SHOW_DISPLAY_STANDARD,
+					    use_json(argc, argv), false);
 		community_free(&com);
 	}
 
@@ -3903,6 +3844,56 @@ static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 }
 
 #include "bgpd/bgp_evpn_vty_clippy.c"
+
+DEFPY(show_ip_bgp_l2vpn_evpn_neighbor_routes,
+      show_ip_bgp_l2vpn_evpn_neighbor_routes_cmd,
+      "show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD>$neighbor routes [json$uj [brief$brief]]",
+      SHOW_STR
+      IP_STR
+      BGP_STR
+      L2VPN_HELP_STR
+      EVPN_HELP_STR
+      "Detailed information on TCP and BGP neighbor connections\n"
+      "IPv4 Neighbor to display information about\n"
+      "IPv6 Neighbor to display information about\n"
+      "Neighbor on BGP configured interface\n"
+      "Display routes learned from neighbor\n"
+      JSON_STR
+      "Brief information on EVPN routes\n")
+{
+	int idx = 0;
+	struct peer *peer;
+	afi_t afi = AFI_L2VPN;
+	safi_t safi = SAFI_EVPN;
+	struct bgp *bgp = NULL;
+
+	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi, &bgp, uj);
+	if (!idx) {
+		vty_out(vty, "No index\n");
+		return CMD_WARNING;
+	}
+
+	peer = peer_lookup_in_view(vty, bgp, neighbor, uj);
+	if (!peer)
+		return CMD_WARNING;
+
+	if (!peer->afc[AFI_L2VPN][SAFI_EVPN]) {
+		if (uj) {
+			json_object *json_no = NULL;
+
+			json_no = json_object_new_object();
+			json_object_string_add(json_no, "warning",
+					       "No such neighbor or address family");
+			vty_out(vty, "%s\n", json_object_to_json_string(json_no));
+			json_object_free(json_no);
+		} else
+			vty_out(vty, "%% No such neighbor or address family\n");
+		return CMD_WARNING;
+	}
+
+	return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_neighbor, peer,
+				     SHOW_DISPLAY_STANDARD, uj, brief);
+}
 
 DEFPY(bgp_evpn_flood_control,
       bgp_evpn_flood_control_cmd,

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -681,7 +681,7 @@ Terminal Mode Commands
 
       frr# find l2vpn.*neighbor
         (view)  show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> advertised-routes [json]
-        (view)  show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> routes [json]
+        (view)  show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> routes [json [brief]]
         (view)  show [ip] bgp l2vpn evpn rd ASN:NN_OR_IP-ADDRESS:NN neighbors <A.B.C.D|X:X::X:X|WORD> advertised-routes [json]
         (view)  show [ip] bgp l2vpn evpn rd ASN:NN_OR_IP-ADDRESS:NN neighbors <A.B.C.D|X:X::X:X|WORD> routes [json]
         ...

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5504,6 +5504,27 @@ Displaying Routes by Route Distinguisher
 
       Displayed 2 prefixes (2 paths)
 
+.. clicmd:: show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> routes [json [brief]]
+
+   Display EVPN routes from the BGP loc-rib that were received from the given
+   neighbor and accepted for the L2VPN EVPN address-family (same filter as the
+   non-JSON ``routes`` form).
+
+   With ``json``, output is JSON including per-prefix ``paths`` and table-level
+   counters such as ``numPrefix`` and ``totalPrefix``.
+
+   With ``json brief`` (``brief`` only after ``json``), output is compact JSON:
+   per-prefix ``pathCount``, ``multiPathCount``, and ``flags`` (for example
+   ``bestPathExists``) under each NLRI key, without a ``paths`` array and
+   without the outer ``numPrefix`` / ``totalPrefix`` fields.
+
+.. clicmd:: show [ip] bgp l2vpn evpn rd <ASN:NN_OR_IP-ADDRESS:NN|all> neighbors <A.B.C.D|X:X::X:X|WORD> routes [json]
+
+   Same intent as :clicmd:`show [ip] bgp l2vpn evpn neighbors <A.B.C.D|X:X::X:X|WORD> routes [json [brief]]`, but
+   the RIB is restricted to the given Route Distinguisher (or all RDs when
+   ``all`` is used instead of a specific RD). Only ``json`` is supported here;
+   there is no ``brief`` modifier on this variant.
+
 Displaying Update Group Information
 -----------------------------------
 

--- a/doc/user/evpn.rst
+++ b/doc/user/evpn.rst
@@ -911,6 +911,10 @@ configuration management and improves host mobility.
 Displaying EVPN information
 ---------------------------
 
+BGP EVPN NLRI (including per-neighbor ``show bgp l2vpn evpn neighbors … routes``
+with optional ``json`` and ``json brief``) is documented in the BGP chapter,
+:ref:`bgp`.
+
 .. clicmd:: show evpn mac vni (1-16777215) detail [json]
 
    Display detailed information about MAC addresses for

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -532,6 +532,111 @@ def test_bgp_evpn_route_brief_json():
     logger.info("PE1: show bgp l2vpn evpn route brief [json] tests passed")
 
 
+def test_bgp_evpn_neighbor_routes_json_brief():
+    """
+    Test 'show bgp l2vpn evpn neighbors <peer> routes [json [brief]]' on PE1.
+
+    PE1 peers with PE2 (10.30.30.30) for EVPN; we assert full JSON includes
+    table-level keys and per-prefix paths, and brief JSON omits those in favor
+    of pathCount / flags only.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+    peer = "10.30.30.30"
+
+    probe = pe1.vtysh_cmd(
+        "show bgp l2vpn evpn neighbors {} routes json brief".format(peer),
+        isjson=False,
+    )
+    if "% Unknown command" in probe or "Unknown command:" in probe:
+        pytest.skip("neighbor routes json brief not in this build")
+
+    def _full_neighbor_json_ready():
+        j = pe1.vtysh_cmd(
+            "show bgp l2vpn evpn neighbors {} routes json".format(peer), isjson=True
+        )
+        if not j or not isinstance(j, dict):
+            return False
+        if j.get("bgpLocalRouterId") != "10.10.10.10":
+            return False
+        if "numPrefix" not in j or "totalPrefix" not in j:
+            return False
+        if "localAS" not in j:
+            return False
+        meta = {
+            "numPrefix",
+            "totalPrefix",
+            "bgpTableVersion",
+            "bgpLocalRouterId",
+            "defaultLocPrf",
+            "localAS",
+        }
+        rd_objs = {k: v for k, v in j.items() if k not in meta and isinstance(v, dict)}
+        if not rd_objs:
+            return False
+        rd = next(iter(rd_objs.values()))
+        if "numPrefixes" not in rd:
+            return False
+        for k, v in rd.items():
+            if k in ("rd", "numPrefixes"):
+                continue
+            if isinstance(v, dict) and "paths" in v:
+                return True
+        return False
+
+    ok, _ = topotest.run_and_expect(_full_neighbor_json_ready, True, count=20, wait=3)
+    assert ok, "PE1: neighbor routes full JSON did not converge"
+
+    text = pe1.vtysh_cmd(
+        "show bgp l2vpn evpn neighbors {} routes".format(peer), isjson=False
+    )
+    assert "Route Distinguisher" in text
+    assert "Displayed" in text and "total prefixes" in text
+
+    full = pe1.vtysh_cmd(
+        "show bgp l2vpn evpn neighbors {} routes json".format(peer), isjson=True
+    )
+    assert isinstance(full, dict)
+    assert full.get("bgpLocalRouterId") == "10.10.10.10"
+
+    brief = pe1.vtysh_cmd(
+        "show bgp l2vpn evpn neighbors {} routes json brief".format(peer),
+        isjson=True,
+    )
+    assert isinstance(brief, dict)
+    for k in ("bgpTableVersion", "bgpLocalRouterId", "numPrefix", "totalPrefix"):
+        assert k not in brief, "PE1: brief json should omit top-level key {}".format(k)
+
+    meta = {
+        "numPrefix",
+        "totalPrefix",
+        "bgpTableVersion",
+        "bgpLocalRouterId",
+        "defaultLocPrf",
+        "localAS",
+    }
+    rd_keys = [x for x in brief if x not in meta and isinstance(brief[x], dict)]
+    assert rd_keys, "PE1: brief json should contain at least one RD object"
+    rd = brief[rd_keys[0]]
+    assert "numPrefixes" in rd
+    saw_nlri = False
+    for k, v in rd.items():
+        if k in ("rd", "numPrefixes"):
+            continue
+        if not isinstance(v, dict):
+            continue
+        saw_nlri = True
+        assert "paths" not in v, "PE1: brief must omit paths for NLRI {}".format(k)
+        assert "pathCount" in v, "PE1: brief expects pathCount for NLRI {}".format(k)
+        assert "flags" in v, "PE1: brief expects flags for NLRI {}".format(k)
+    assert saw_nlri, "PE1: brief json RD should contain at least one NLRI entry"
+
+    logger.info("PE1: neighbor routes json / json brief tests passed")
+
+
 def test_evpn_l2vni_vlan_bridge_json():
     """
     Test L2 VNI JSON output includes vlan and bridge fields


### PR DESCRIPTION
brief-json support is added for show bgp l2vpn-evpn neighbour routes

Commands supported:
 show bgp l2vpn evpn neighbors <neigh> routes brief json

Logs:
PE1# show bgp l2vpn evpn neighbors 10.30.30.30 routes 
BGP table version is 6, local router ID is 10.10.10.10
Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Origin codes:  i - IGP, e - EGP, ? - incomplete
EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.30.30.30:2
 *>i [2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[32]:[10.10.1.3]
                    10.30.30.30                   100      0 i
                    RT:65000:101 ET:8
 *>i [2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[128]:[fe80::24bb:c3ff:fe91:e6f7]
                    10.30.30.30                   100      0 i
                    RT:65000:101 ET:8
 *>i [2]:[0]:[48]:[6e:35:13:59:1d:da]
                    10.30.30.30                   100      0 i
                    RT:65000:101 ET:8
 *>i [2]:[0]:[48]:[7e:46:d3:44:06:b7]
                    10.30.30.30                   100      0 i
                    RT:65000:101 ET:8
 *>i [2]:[0]:[48]:[ae:c3:1e:3a:fc:31]
                    10.30.30.30                   100      0 i
                    RT:65000:101 ET:8
 *>i [3]:[0]:[32]:[10.30.30.30]
                    10.30.30.30                   100      0 i
                    RT:65000:101 ET:8

Displayed 6 out of 12 total prefixes
PE1# show bgp l2vpn evpn neighbors 10.30.30.30 routes json brief 
{"10.30.30.30:2":{"rd":"10.30.30.30:2","[2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[32]:[10.10.1.3]":{"pathCount":1,"multiPathCount":1,"flags":{"bestPathExists":true}},"[2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[128]:[fe80::24bb:c3ff:fe91:e6f7]":{"pathCount":1,"multiPathCount":1,"flags":{"bestPathExists":true}},"[2]:[0]:[48]:[6e:35:13:59:1d:da]":{"pathCount":1,"multiPathCount":1,"flags":{"bestPathExists":true}},"[2]:[0]:[48]:[7e:46:d3:44:06:b7]":{"pathCount":1,"multiPathCount":1,"flags":{"bestPathExists":true}},"[2]:[0]:[48]:[ae:c3:1e:3a:fc:31]":{"pathCount":1,"multiPathCount":1,"flags":{"bestPathExists":true}},"[3]:[0]:[32]:[10.30.30.30]":{"pathCount":1,"multiPathCount":1,"flags":{"bestPathExists":true}},"numPrefixes":6}}
PE1# show bgp l2vpn evpn neighbors 10.30.30.30 routes json 
{
  "bgpTableVersion":6,
  "bgpLocalRouterId":"10.10.10.10",
  "defaultLocPrf":100,
  "localAS":65000,
  "10.30.30.30:2":{
    "rd":"10.30.30.30:2",
    "[2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[32]:[10.10.1.3]":{
      "prefix":"[2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[32]:[10.10.1.3]",
      "prefixLen":352,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "selectionReason":"First path received",
          "pathFrom":"internal",
          "routeType":2,
          "ethTag":0,
          "macLen":48,
          "mac":"2a:9e:6e:39:dd:c8",
          "ipLen":32,
          "ip":"10.10.1.3",
          "locPrf":100,
          "weight":0,
          "peerId":"10.30.30.30",
          "path":"",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65000:101 ET:8"
          },
          "nexthops":[
            {
              "ip":"10.30.30.30",
              "hostname":"PE2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ],
      "pathCount":1,
      "multiPathCount":1,
      "flags":{
        "bestPathExists":true
      }
    },
"[2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[128]:[fe80::24bb:c3ff:fe91:e6f7]":{
      "prefix":"[2]:[0]:[48]:[2a:9e:6e:39:dd:c8]:[128]:[fe80::24bb:c3ff:fe91:e6f7]",
      "prefixLen":352,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "selectionReason":"First path received",
          "pathFrom":"internal",
          "routeType":2,
          "ethTag":0,
          "macLen":48,
          "mac":"2a:9e:6e:39:dd:c8",
          "ipLen":128,
          "ip":"fe80::24bb:c3ff:fe91:e6f7",
          "locPrf":100,
          "weight":0,
          "peerId":"10.30.30.30",
          "path":"",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65000:101 ET:8"
          },
          "nexthops":[
            {
              "ip":"10.30.30.30",
              "hostname":"PE2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ],
      "pathCount":1,
      "multiPathCount":1,
      "flags":{
        "bestPathExists":true
      }
    },
 "[2]:[0]:[48]:[6e:35:13:59:1d:da]":{
      "prefix":"[2]:[0]:[48]:[6e:35:13:59:1d:da]",
      "prefixLen":352,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "selectionReason":"First path received",
          "pathFrom":"internal",
          "routeType":2,
          "ethTag":0,
          "macLen":48,
          "mac":"6e:35:13:59:1d:da",
          "locPrf":100,
          "weight":0,
          "peerId":"10.30.30.30",
          "path":"",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65000:101 ET:8"
          },
          "nexthops":[
            {
              "ip":"10.30.30.30",
              "hostname":"PE2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ],
      "pathCount":1,
      "multiPathCount":1,
      "flags":{
        "bestPathExists":true
      }
    },
"[2]:[0]:[48]:[7e:46:d3:44:06:b7]":{
      "prefix":"[2]:[0]:[48]:[7e:46:d3:44:06:b7]",
      "prefixLen":352,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "selectionReason":"First path received",
          "pathFrom":"internal",
          "routeType":2,
          "ethTag":0,
          "macLen":48,
          "mac":"7e:46:d3:44:06:b7",
          "locPrf":100,
          "weight":0,
          "peerId":"10.30.30.30",
          "path":"",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65000:101 ET:8"
          },
          "nexthops":[
            {
              "ip":"10.30.30.30",
              "hostname":"PE2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ],
      "pathCount":1,
      "multiPathCount":1,
      "flags":{
        "bestPathExists":true
      }
    },
 "[2]:[0]:[48]:[ae:c3:1e:3a:fc:31]":{
      "prefix":"[2]:[0]:[48]:[ae:c3:1e:3a:fc:31]",
      "prefixLen":352,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "selectionReason":"First path received",
          "pathFrom":"internal",
          "routeType":2,
          "ethTag":0,
          "macLen":48,
          "mac":"ae:c3:1e:3a:fc:31",
          "locPrf":100,
          "weight":0,
          "peerId":"10.30.30.30",
          "path":"",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65000:101 ET:8"
          },
          "nexthops":[
            {
              "ip":"10.30.30.30",
              "hostname":"PE2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ],
      "pathCount":1,
      "multiPathCount":1,
      "flags":{
        "bestPathExists":true
      }
    },
 "[3]:[0]:[32]:[10.30.30.30]":{
      "prefix":"[3]:[0]:[32]:[10.30.30.30]",
      "prefixLen":352,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "selectionReason":"First path received",
          "pathFrom":"internal",
          "routeType":3,
          "ethTag":0,
          "ipLen":32,
          "ip":"10.30.30.30",
          "locPrf":100,
          "weight":0,
          "peerId":"10.30.30.30",
          "path":"",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65000:101 ET:8"
          },
          "nexthops":[
            {
              "ip":"10.30.30.30",
              "hostname":"PE2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ],
      "pathCount":1,
      "multiPathCount":1,
      "flags":{
        "bestPathExists":true
      }
    },
    "numPrefixes":6
  },
  "numPrefix":6,
  "totalPrefix":12
}
PE1# 