### PR TITLE
bgpd: fix aggregate->count errors in ZAPI route notifications

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9678,12 +9678,6 @@ bool bgp_aggregate_route(struct bgp *bgp, const struct prefix *p, afi_t afi,
 		if (dest_p->prefixlen <= p->prefixlen)
 			continue;
 
-		/* If suppress fib is enabled and route not installed
-		 * in FIB, skip the route
-		 */
-		if (!bgp_check_advertise(bgp, dest, safi))
-			continue;
-
 		for (pi = bgp_dest_get_bgp_path_info(dest); (pi != NULL) && (next = pi->next, 1);
 		     pi = next) {
 			if (BGP_PATH_HOLDDOWN(pi))
@@ -10235,12 +10229,14 @@ void bgp_aggregate_increment(struct bgp *bgp, const struct prefix *p,
 	if (BGP_PATH_HOLDDOWN(pi))
 		return;
 
-	/* If suppress fib is enabled and route not installed
-	 * in FIB, do not update the aggregate route
+	/* Note: do NOT guard this with bgp_check_advertise() / FIB state.
+	 * Aggregate counting tracks BGP RIB presence, not FIB installation.
+	 * bgp_aggregate_increment() is called from bgp_update() before
+	 * bgp_process() is queued, so BGP_NODE_FIB_INSTALL_PENDING is never
+	 * set yet — a bgp_check_advertise() guard here would be a no-op for
+	 * its intended purpose and could incorrectly skip the count in other
+	 * callers (e.g. NHT, dampening reuse) where the flag may be set.
 	 */
-	if (!bgp_check_advertise(bgp, pi->net, safi))
-		return;
-
 	child = bgp_node_get(table, p);
 
 	/* Aggregate address configuration check. */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3086,12 +3086,15 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
 			zlog_debug("route %pBD : INSTALLED", dest);
 		/* Find the best route */
 		for (pi = dest->info; pi; pi = pi->next) {
-			/* Process aggregate route */
-			bgp_aggregate_increment(bgp, &p, pi, afi, safi);
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
 				new_select = pi;
 		}
-		/* Advertise the route */
+		/* Advertise the route.
+		 * Note: do NOT call bgp_aggregate_increment() here.
+		 * The increment already happened in bgp_update() before
+		 * bgp_process() was queued; calling it again here would
+		 * double-count the route in aggregate->count.
+		 */
 		if (new_select)
 			group_announce_route(bgp, afi, safi, dest, new_select);
 		else {
@@ -3136,13 +3139,18 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED);
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
-			bgp_aggregate_decrement(bgp, &p, pi, afi, safi);
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
 				new_select = pi;
 		}
 		if (new_select)
 			group_announce_route(bgp, afi, safi, dest, new_select);
-		/* No action required */
+		/* Note: do NOT call bgp_aggregate_decrement() here.  The BGP
+		 * path is still present in the RIB with BGP_PATH_VALID set;
+		 * only the FIB lost to a better admin-distance route.
+		 * Aggregate counting tracks BGP RIB presence, not FIB state.
+		 * Decrementing here would underflow the count when the route is
+		 * later properly withdrawn via bgp_rib_remove().
+		 */
 		break;
 	case ZAPI_ROUTE_REMOVE_FAIL:
 		zlog_warn("%s: Route %pBD failure to remove", __func__, dest);

--- a/tests/topotests/bgp_aggregate_suppress_fib/r1/frr.conf
+++ b/tests/topotests/bgp_aggregate_suppress_fib/r1/frr.conf
@@ -1,0 +1,15 @@
+!
+interface r1-eth0
+ ip address 10.0.0.1/30
+!
+ip forwarding
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ bgp suppress-fib-pending
+ neighbor 10.0.0.2 remote-as 65002
+ address-family ipv4 unicast
+  aggregate-address 10.0.0.0/8
+  neighbor 10.0.0.2 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_aggregate_suppress_fib/r2/frr.conf
+++ b/tests/topotests/bgp_aggregate_suppress_fib/r2/frr.conf
@@ -1,0 +1,16 @@
+!
+interface r2-eth0
+ ip address 10.0.0.2/30
+!
+ip forwarding
+!
+ip route 10.0.0.0/24 blackhole
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.1 remote-as 65001
+ address-family ipv4 unicast
+  network 10.0.0.0/24
+  neighbor 10.0.0.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_aggregate_suppress_fib/test_bgp_aggregate_suppress_fib.py
+++ b/tests/topotests/bgp_aggregate_suppress_fib/test_bgp_aggregate_suppress_fib.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+test_bgp_aggregate_suppress_fib.py
+
+Verify that aggregate->count is correctly maintained when bgp
+suppress-fib-pending is enabled.
+
+Topology:  r2 (AS 65002) --- r1 (AS 65001)
+
+r2 advertises 10.0.0.0/24 to r1.  r1 has suppress-fib-pending enabled
+and aggregate-address 10.0.0.0/8 configured.
+
+The bug: ZAPI_ROUTE_INSTALLED called bgp_aggregate_increment() a second
+time (the first was in bgp_update()), doubling aggregate->count to 2.
+When r2 withdrew 10.0.0.0/24, bgp_rib_remove() decremented the count
+once (to 1), leaving the aggregate permanently installed even though no
+more-specific routes remained.
+
+The fix: bgp_aggregate_increment() is no longer called from the ZAPI
+INSTALLED handler.  This test verifies that:
+  1. The aggregate is installed with aggregateCount=1 (not 2).
+  2. The aggregate is removed when the only more-specific is withdrawn.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_aggregate_suppress_fib():
+    """
+    With suppress-fib-pending enabled, verify the aggregate route is
+    installed with aggregateCount=1 (not double-counted), and is removed
+    when the only contributing more-specific route is withdrawn.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: verify the more-specific 10.0.0.0/24 is installed on r1.
+    logger.info("Verify 10.0.0.0/24 is installed on r1 via BGP")
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        r1,
+        "show ip route 10.0.0.0/24 json",
+        {"10.0.0.0/24": [{"protocol": "bgp"}]},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "10.0.0.0/24 not installed on r1"
+
+    # Step 2: verify the aggregate is installed and aggregateCount=1.
+    # Before the fix, suppress-fib caused a double-increment so the count
+    # would be 2 here, and the aggregate would survive one withdrawal.
+    logger.info("Verify aggregate 10.0.0.0/8 is installed with aggregateCount=1")
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        r1,
+        "show bgp ipv4 unicast 10.0.0.0/8 json",
+        {"paths": [{"aggregated": True, "local": True, "aggregateCount": 1}]},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    if result is not None:
+        out = r1.vtysh_cmd("show bgp ipv4 unicast 10.0.0.0/8 json")
+        data = json.loads(out)
+        actual_count = data.get("paths", [{}])[0].get("aggregateCount", "missing")
+        assert False, (
+            "aggregate 10.0.0.0/8 not present or aggregateCount != 1"
+            " (got {})".format(actual_count)
+        )
+
+    # Step 3: withdraw 10.0.0.0/24 from r2.
+    logger.info("Withdraw 10.0.0.0/24 from r2")
+    tgen.gears["r2"].vtysh_cmd(
+        "configure terminal\n"
+        "router bgp 65002\n"
+        "address-family ipv4 unicast\n"
+        "no network 10.0.0.0/24\n"
+    )
+
+    # Step 4: verify the aggregate 10.0.0.0/8 is removed from r1.
+    # Before the fix, the double-counted aggregate would remain installed.
+    logger.info("Verify aggregate 10.0.0.0/8 is removed from r1")
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        r1,
+        "show ip route json",
+        {"10.0.0.0/8": None},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "aggregate 10.0.0.0/8 still present after more-specific withdrawn"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Aggregate counting tracks BGP RIB presence, not FIB installation state. bgp_aggregate_increment/decrement() must be called when routes enter or leave the BGP RIB — not in response to FIB events from zebra.  The ZAPI notification handlers violated this principle, causing two bugs.

1) Double-count via ZAPI_ROUTE_INSTALLED

bgp_update() calls bgp_aggregate_increment() and then queues bgp_process() as an async workqueue item.  bgp_process() later calls bgp_zebra_route_install(), which sets BGP_NODE_FIB_INSTALL_PENDING and sends the route to zebra.  When zebra confirms installation it sends ZAPI_ROUTE_INSTALLED, and the old handler called bgp_aggregate_increment() a second time — doubling the count for a route that was already counted.

  bgp_update()
    -> bgp_aggregate_increment()       /* count = 1 */
    -> bgp_process() [async workqueue]
         -> bgp_zebra_route_install()
              -> SET BGP_NODE_FIB_INSTALL_PENDING
              -> zebra installs route in FIB
                   -> ZAPI_ROUTE_INSTALLED notification
                        -> bgp_aggregate_increment()  /* count = 2, BUG */

With a double-counted route, when the peer later withdraws it bgp_rib_remove() decrements the count once (to 1), leaving the aggregate route permanently installed even though no more-specific routes remain.

A previous attempt added a bgp_check_advertise() guard inside bgp_aggregate_increment() to skip the count while
BGP_NODE_FIB_INSTALL_PENDING was set, intending to block increment #1 until FIB confirmation arrived with increment #2.  This never worked: BGP_NODE_FIB_INSTALL_PENDING is set by bgp_process() which runs *after* bgp_update() returns, so the flag is always clear at the time of increment #1.  By the time ZAPI_ROUTE_INSTALLED fires, the flag has already been cleared, so increment #2 also passed the guard.  Both increments always executed.

The guard was also harmful to other callers (NHT, dampening reuse) where BGP_NODE_FIB_INSTALL_PENDING might legitimately be set, causing their increments to be silently skipped.

Fix: remove bgp_aggregate_increment() from ZAPI_ROUTE_INSTALLED and remove the bgp_check_advertise() guard from bgp_aggregate_increment() and bgp_aggregate_route().

2) Unpaired decrement via ZAPI_ROUTE_BETTER_ADMIN_WON

When zebra selects another protocol's route over BGP due to better administrative distance, the old handler called bgp_aggregate_decrement() for every BGP path at that prefix.  But the BGP paths are still present in the BGP RIB with BGP_PATH_VALID set — the code even calls group_announce_route() immediately after, confirming they are still active from BGP's perspective.  The FIB losing to a better admin-distance route does not change the route's presence in the BGP RIB.

This decrement was designed as the counterpart to the INSTALLED increment above.  With that increment removed, the decrement becomes unpaired and causes the count to underflow when the route is eventually withdrawn through bgp_rib_remove(), which also calls bgp_aggregate_decrement().

Fix: remove bgp_aggregate_decrement() from ZAPI_ROUTE_BETTER_ADMIN_WON.