### PR TITLE
tests: Remove invalid link-params command from BGP-LS topotest configs

### DIFF
--- a/tests/topotests/bgp_link_state/r1/frr.conf
+++ b/tests/topotests/bgp_link_state/r1/frr.conf
@@ -14,7 +14,7 @@ interface r1-eth0
  ip address 10.0.1.1/24
  ipv6 address fc00:10:0:1::1/64
  link-params
-  neighbor 10.0.255.2
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2
@@ -26,7 +26,7 @@ interface r1-eth1
  ip address 10.0.4.1/24
  ipv6 address fc00:10:0:4::1/64
  link-params
-  neighbor 10.0.255.4
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2

--- a/tests/topotests/bgp_link_state/r2/frr.conf
+++ b/tests/topotests/bgp_link_state/r2/frr.conf
@@ -18,7 +18,7 @@ interface r2-eth0
  ip address 10.0.1.2/24
  ipv6 address fc00:10:0:1::2/64
  link-params
-  neighbor 10.0.255.1
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2
@@ -30,7 +30,7 @@ interface r2-eth1
  ip address 10.0.2.2/24
  ipv6 address fc00:10:0:2::2/64
  link-params
-  neighbor 10.0.255.3
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2

--- a/tests/topotests/bgp_link_state/r3/frr.conf
+++ b/tests/topotests/bgp_link_state/r3/frr.conf
@@ -13,7 +13,7 @@ interface r3-eth0
  ip address 10.0.2.3/24
  ipv6 address fc00:10:0:2::3/64
  link-params
-  neighbor 10.0.255.2
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2
@@ -25,7 +25,7 @@ interface r3-eth1
  ip address 10.0.5.3/24
  ipv6 address fc00:10:0:5::3/64
  link-params
-  neighbor 10.0.255.4
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2

--- a/tests/topotests/bgp_link_state/r4/frr.conf
+++ b/tests/topotests/bgp_link_state/r4/frr.conf
@@ -12,7 +12,7 @@ interface r4-eth0
  ip address 10.0.4.4/24
  ipv6 address fc00:10:0:4::4/64
  link-params
-  neighbor 10.0.255.1
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2
@@ -24,7 +24,7 @@ interface r4-eth1
  ip address 10.0.5.4/24
  ipv6 address fc00:10:0:5::4/64
  link-params
-  neighbor 10.0.255.3
+ exit-link-params
  ip router isis 1
  ipv6 router isis 1
  isis circuit-type level-2


### PR DESCRIPTION
The `frr.conf` files for `r1–r4` contain a `neighbor` command inside link-params blocks:

```
  link-params
   neighbor 10.0.255.X
```

The command is incomplete and invalid. When loading the config, FRR reports:

```
  % Command incomplete: neighbor 10.0.255.X
```

and silently ignores it. Remove the command.