### PR TITLE
mgmtd: vty_mgmt_handle_error_reply need extra unlock by fe

### DIFF
--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -326,6 +326,17 @@ static int vty_mgmt_handle_error_reply(struct mgmt_fe_client *client, uintptr_t 
 
 	vty_out(vty, "%% %s (for %s, client %s)\n", errstr, vty->mgmt_req_pending_cmd, cname);
 
+	//"MESSAGE_COMMCFG_REQ" need extra unlock when validate failed by mgmtd:
+	//avoid assert(!vty->mgmt_locked_candidate_ds) at next vty_mgmt_send_config_data.
+	//TODO: if a command(with vty->node chg) failed, vty->node rollback also required (seems difficult).
+	//      o/w vtysh and mgmtd will be inconsistent. need an "end" command aligns them.
+	if ((!vty->pending_allowed) && strmatch(vty->mgmt_req_pending_cmd, "MESSAGE_COMMCFG_REQ")) {
+		if (vty->mgmt_locked_running_ds)
+			vty_mgmt_unlock_running_inline(vty);
+		if (vty->mgmt_locked_candidate_ds)
+			vty_mgmt_unlock_candidate_inline(vty);
+	}
+
 	vty_mgmt_resume_response(vty, error ? CMD_WARNING : CMD_SUCCESS);
 
 	return 0;


### PR DESCRIPTION
Q1:
after vty_mgmt_send_config_data,  mgmtd may validate failed (For example, one Yang level constraint failed).
In this case, code will run to  vty_mgmt_handle_error_reply, and response error to vtysh.

when next vty_mgmt_send_config_data comes, mgmtd will assert at :
vty_mgmt_lock_candidate_inline => 	assert(!vty->mgmt_locked_candidate_ds);

The optional solution is to unlock inside vty_mgmt_ handled_error_reply.  :)


Q2:
>	//TODO: if a command(with vty->node chg) failed, vty->node rollback also required (seems difficult).
	//      o/w vtysh and mgmtd will be inconsistent. An "end" command aligns them again.

I have no solution to fix this problem.  Just add  a NOTE there