### PR TITLE
zebra: update L2VNI SVI state on access VLAN changes

### DIFF
--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -686,6 +686,118 @@ def test_tvd_vxlan_interface_vty():
         )
 
 
+def _evpn_l2vni_svi_setup(router, vni, vtep, addr):
+    router.run(
+        "ip link add name br{} type bridge stp_state 0 vlan_filtering 1".format(vni)
+    )
+    router.run("ip link set dev br{} up".format(vni))
+    router.run("bridge vlan add vid {} dev br{} self".format(vni, vni))
+    router.run(
+        "ip link add vxlan{} type vxlan id {} dstport 4789 local {} nolearning".format(
+            vni, vni, vtep
+        )
+    )
+    router.run("ip link set dev vxlan{} master br{}".format(vni, vni))
+    router.run("bridge vlan del vid 1 dev vxlan{}".format(vni))
+    router.run("bridge vlan add vid {} dev vxlan{} pvid untagged".format(vni, vni))
+    router.run("ip link set up dev vxlan{}".format(vni))
+    router.run(
+        "ip link add link br{} name vlan{} type vlan id {} protocol 802.1q".format(
+            vni, vni, vni
+        )
+    )
+    router.run("ip addr add {} dev vlan{}".format(addr, vni))
+    router.run("ip link set dev vlan{} up".format(vni))
+
+
+def _wait_for_existing_l2vni(router, vni, vxlan_if, svi_if):
+    expected = {
+        "vni": vni,
+        "type": "L2",
+        "vxlanInterface": vxlan_if,
+        "sviInterface": svi_if,
+    }
+
+    test_func = partial(evpn_show_vni_json_elide_ifindex, router, vni, expected)
+    _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
+    assertmsg = '"{}" VNI {} did not converge before repro: {}'.format(
+        router.name, vni, result
+    )
+    assert result is None, assertmsg
+
+
+def _evpn_l2vni_svi_cleanup(router, vni):
+    router.run("ip link del vlan{} 2>/dev/null || true".format(vni))
+    router.run("ip link del vxlan{} 2>/dev/null || true".format(vni))
+    router.run("ip link del br{} 2>/dev/null || true".format(vni))
+
+
+def _check_vni_svi(router, vni, svi_name):
+    output = router.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
+    if not output:
+        return "VNI {} missing".format(vni)
+
+    if output.get("sviInterface") != svi_name:
+        return "VNI {} SVI mismatch: {}".format(vni, json.dumps(output, indent=4))
+
+    return None
+
+
+def _evpn_l2vni_vlan_flip(router, vni, vlan):
+    other_vlan = 202 if vlan == vni else vni
+    router.run(
+        "bridge vlan del vid {} dev vxlan{} 2>/dev/null || true".format(
+            other_vlan, vni
+        )
+    )
+    router.run("bridge vlan add vid {} dev vxlan{} pvid untagged".format(vlan, vni))
+
+
+def _evpn_l2vni_remap_away_then_delete_svi(router, vni):
+    _evpn_l2vni_vlan_flip(router, vni, 202)
+    router.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
+    router.run("ip link del vlan{} 2>/dev/null || true".format(vni))
+    _evpn_l2vni_vlan_flip(router, vni, vni)
+    router.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
+
+
+def test_evpn_l2vni_svi_delete_after_vlan_remap_issue_21794():
+    """
+    Delete an L2 VNI SVI after remapping the VXLAN away from its VLAN.
+
+    This targets stale zevpn->svi_if references. The SVI-down lookup no longer
+    maps back to the VNI once the VXLAN access VLAN is changed, so a later VNI
+    update can expose a stale zevpn->svi_if pointer.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["PE1"]
+    vni = 201
+    svi_name = "vlan{}".format(vni)
+
+    _wait_for_existing_l2vni(pe1, 101, "vxlan101", "br101")
+    _evpn_l2vni_svi_cleanup(pe1, vni)
+    try:
+        _evpn_l2vni_svi_setup(pe1, vni, "10.10.10.10", "10.201.0.1/24")
+
+        test_func = partial(_check_vni_svi, pe1, vni, svi_name)
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assertmsg = '"{}" VNI {} did not bind to {}'.format(pe1.name, vni, svi_name)
+        assert result is None, assertmsg
+
+        _evpn_l2vni_remap_away_then_delete_svi(pe1, vni)
+
+        status = pe1.check_router_running()
+        assertmsg = "Router {} has issues after SVI delete: {}".format(
+            pe1.name, status
+        )
+        assert not status, assertmsg
+    finally:
+        _evpn_l2vni_svi_cleanup(pe1, vni)
+
+
 def test_imet():
     """
     Verify PMSI tunnel attribute info

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -210,6 +210,34 @@ static int zebra_vxlan_if_del_vni(struct interface *ifp,
 	return 0;
 }
 
+static void zebra_evpn_l2vni_svi_update(struct zebra_evpn *zevpn,
+					struct interface *svi_if)
+{
+	struct zebra_l3vni *zl3vni;
+	vrf_id_t vrf_id = VRF_DEFAULT;
+
+	if (svi_if && svi_if->vrf)
+		vrf_id = svi_if->vrf->vrf_id;
+
+	if (zevpn->svi_if != svi_if || zevpn->vrf_id != vrf_id) {
+		/* Remove this L2VNI from the old L3VNI's associated L2VNI list. */
+		zl3vni = zl3vni_from_vrf(zevpn->vrf_id);
+		if (zl3vni)
+			listnode_delete(zl3vni->l2vnis, zevpn);
+
+		zevpn->svi_if = svi_if;
+		zevpn->vrf_id = vrf_id;
+	}
+
+	if (!svi_if)
+		return;
+
+	/* Add this L2VNI to the new L3VNI's associated L2VNI list. */
+	zl3vni = zl3vni_from_vrf(vrf_id);
+	if (zl3vni)
+		listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
+}
+
 static int zebra_vxlan_if_update_vni(struct interface *ifp,
 				     struct zebra_vxlan_vni *vnip,
 				     struct zebra_vxlan_if_update_ctx *ctx)
@@ -362,8 +390,7 @@ static int zebra_vxlan_if_update_vni(struct interface *ifp,
 		zevpn_bridge_if_set(zevpn, br_if, true /* set */);
 
 		vlan_if = zvni_map_to_svi(vnip->access_vlan, br_if);
-		if (vlan_if)
-			zevpn->svi_if = vlan_if;
+		zebra_evpn_l2vni_svi_update(zevpn, vlan_if);
 
 		/* Take further actions needed.
 		 * Note that if we are here, there is a change of interest.

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -350,7 +350,7 @@ static int zebra_vxlan_if_update_vni(struct interface *ifp,
 		    (zif->brslave_info.bridge_ifindex == IFINDEX_INTERNAL)) {
 			/* Delete from client, remove all remote VTEPs */
 			/* Also, free up all MACs and neighbors. */
-			zevpn->svi_if = NULL;
+			zebra_evpn_l2vni_svi_update(zevpn, NULL);
 			zebra_evpn_send_del_to_client(zevpn);
 			zebra_evpn_neigh_del_all(zevpn, 1, 0, DEL_ALL_NEIGH, NULL);
 			zebra_evpn_mac_del_all(zevpn, 1, 0, DEL_ALL_MAC, NULL);
@@ -501,11 +501,7 @@ static int zebra_vxlan_if_add_vni(struct interface *ifp,
 		vlan_if = zvni_map_to_svi(vnip->access_vlan, br_if);
 		if (vlan_if) {
 			zevpn->vid = vnip->access_vlan;
-			zevpn->svi_if = vlan_if;
-			zevpn->vrf_id = vlan_if->vrf->vrf_id;
-			zl3vni = zl3vni_from_vrf(vlan_if->vrf->vrf_id);
-			if (zl3vni)
-				listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
+			zebra_evpn_l2vni_svi_update(zevpn, vlan_if);
 		}
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
@@ -1067,13 +1063,8 @@ int zebra_vxlan_if_vni_up(struct interface *ifp, struct zebra_vxlan_vni *vnip)
 		zebra_evpn_vl_vxl_ref(vnip->access_vlan, vnip->vni, zif);
 		vlan_if = zvni_map_to_svi(vnip->access_vlan,
 					  zif->brslave_info.br_if);
-		if (vlan_if) {
-			zevpn->svi_if = vlan_if;
-			zevpn->vrf_id = vlan_if->vrf->vrf_id;
-			zl3vni = zl3vni_from_vrf(vlan_if->vrf->vrf_id);
-			if (zl3vni)
-				listnode_add_sort_nodup(zl3vni->l2vnis, zevpn);
-		}
+		if (vlan_if)
+			zebra_evpn_l2vni_svi_update(zevpn, vlan_if);
 
 		/* If part of a bridge, inform BGP about this VNI. */
 		/* Also, read and populate local MACs and neighbors. */


### PR DESCRIPTION
OVN-Kubernetes CI, running FRR 10.6.0, collected a zebra coredump after interface/VXLAN churn. The crash mapped to `zebra_evpn_send_add_to_client()` while reading the L2VNI SVI interface:

```
  ZEBRA: Received signal 11
  ZEBRA: in thread rib_process_dplane_results scheduled from
         zebra/zebra_rib.c:5118 rib_dplane_results()
```

The local ASAN reproducer shows the same path as a heap-use-after-free:

```
  READ of size 4 in zebra_evpn_send_add_to_client()
    zebra/zebra_evpn.c:1111
  called from zebra_vxlan_if_update_vni()
    zebra/zebra_vxlan_if.c:380
```

The stale interface is freed by `if_delete()` in the dataplane interface delete result path.

The trigger is a VXLAN access VLAN remap away from an L2VNI SVI followed by deletion of that SVI. The SVI-down lookup no longer maps back to the same VNI, so the EVPN object can retain the old SVI association until a later VNI update dereferences it.

When the VNI update path observes a changed SVI, refresh the L2VNI SVI association as a unit, using the same relationship maintenance expected by SVI up/down handling. This avoids fixing only the immediate stale pointer while leaving related association state out of sync.

Add a topotest for the remap/delete/remap-back sequence. Under ASAN it reliably caught the stale pointer before this fix.

Closes #21794