### PR TITLE
bgpd: bmp: don't prepend local-AS to AS_PATH in BMP updates

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -5450,8 +5450,17 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
 	struct aspath *aspath;
 	int send_as4_path = 0;
 	int send_as4_aggregator = 0;
-	bool use32bit = CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV) &&
-			CHECK_FLAG(peer->cap, PEER_CAP_AS4_ADV);
+	/*
+	 * For BMP Route Monitoring always encode ASNs as 32-bit. BMP is an
+	 * observability channel, not a BGP session; the peer's AS4 capability
+	 * state is irrelevant and may be stale across peer/VRF flaps, which
+	 * would produce 16-bit AS_PATH segments that modern BMP collectors
+	 * (always 32-bit) can't parse. As a side effect this also suppresses
+	 * the AS4_PATH backward-compat attribute (send_as4_path is only set
+	 * when use32bit is false), which BMP collectors don't need anyway.
+	 */
+	bool use32bit = for_bmp || (CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV) &&
+				    CHECK_FLAG(peer->cap, PEER_CAP_AS4_ADV));
 
 	if (!bgp)
 		bgp = peer->bgp;

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -5443,7 +5443,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
 				struct prefix_rd *prd, mpls_label_t *label, uint8_t num_labels,
 				struct bgp_attr_srv6_l3service *srv6_unicast, bool addpath_capable,
 				uint32_t addpath_tx_id, struct bgp_path_info *bpi,
-				struct bgp_ls_nlri *ls_nlri)
+				struct bgp_ls_nlri *ls_nlri, bool for_bmp)
 {
 	size_t cp;
 	size_t aspath_sizep;
@@ -5481,13 +5481,29 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
 
 	/* AS path attribute. */
 
+	/*
+	 * The for_bmp path is taken from bmp_update(), which only ever feeds
+	 * in attributes that come from receive-side storage in the three BMP
+	 * modes FRR currently emits:
+	 *
+	 *   - pre-policy Adj-RIB-In:   adjin->attr (raw on-wire from peer)
+	 *   - post-policy Adj-RIB-In:  bpi->attr   (path-info in local RIB)
+	 *   - Loc-RIB:                 bpi->attr   (selected best path)
+	 *
+	 * None of these have been through the outbound peer-specific AS_PATH
+	 * transformations below (local-AS prepend for eBGP, confed-seq,
+	 * change-local-as), so they're skipped when for_bmp is set.
+	 *
+	 * If RFC 8671 Adj-RIB-Out monitoring is added, post-policy
+	 * Adj-RIB-Out MUST be encoded "as actually transmitted to the peer"
+	 * (RFC 8671 §5.1) — that future caller must invoke this function
+	 * with for_bmp=false so the transformations below run.
+	 */
 	/* If remote-peer is EBGP */
-	if (peer->sort == BGP_PEER_EBGP
-	    && (!CHECK_FLAG(peer->af_flags[afi][safi],
-			    PEER_FLAG_AS_PATH_UNCHANGED)
-		|| attr->aspath->segments == NULL)
-	    && (!CHECK_FLAG(peer->af_flags[afi][safi],
-			    PEER_FLAG_RSERVER_CLIENT))) {
+	if (!for_bmp && peer->sort == BGP_PEER_EBGP &&
+	    (!CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_AS_PATH_UNCHANGED) ||
+	     attr->aspath->segments == NULL) &&
+	    (!CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_RSERVER_CLIENT))) {
 		aspath = aspath_dup(attr->aspath);
 
 		/* Even though we may not be configured for confederations we
@@ -5528,12 +5544,18 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
 				aspath = aspath_add_seq(aspath, peer->local_as);
 			}
 		}
-	} else if (peer->sort == BGP_PEER_CONFED) {
+	} else if (!for_bmp && peer->sort == BGP_PEER_CONFED) {
 		/* A confed member, so we need to do the AS_CONFED_SEQUENCE
 		 * thing */
 		aspath = aspath_dup(attr->aspath);
 		aspath = aspath_add_confed_seq(aspath, peer->local_as);
 	} else
+		/*
+		 * NOTE: with for_bmp=true we always reach here, including for
+		 * confed peers — the confed-seq above is intentionally
+		 * skipped. See the for_bmp commentary above the EBGP block for
+		 * the rationale and the RFC 8671 Adj-RIB-Out caveat.
+		 */
 		aspath = attr->aspath;
 
 	/* If peer is not AS4 capable, then:

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -431,14 +431,13 @@ extern struct attr *bgp_attr_aggregate_intern(
 	struct community *community, struct ecommunity *ecommunity,
 	struct lcommunity *lcommunity, struct bgp_aggregate *aggregate,
 	uint8_t atomic_aggregate, const struct prefix *p);
-extern bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct stream *s,
-				       struct attr *attr, struct bpacket_attr_vec_arr *vecarr,
-				       struct prefix *p, afi_t afi, safi_t safi, struct peer *from,
-				       struct prefix_rd *prd, mpls_label_t *label,
-				       uint8_t num_labels,
-				       struct bgp_attr_srv6_l3service *srv6_unicast,
-				       bool addpath_capable, uint32_t addpath_tx_id,
-				       struct bgp_path_info *bpi, struct bgp_ls_nlri *ls_nlri);
+extern bgp_size_t
+bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct stream *s, struct attr *attr,
+		     struct bpacket_attr_vec_arr *vecarr, struct prefix *p, afi_t afi, safi_t safi,
+		     struct peer *from, struct prefix_rd *prd, mpls_label_t *label,
+		     uint8_t num_labels, struct bgp_attr_srv6_l3service *srv6_unicast,
+		     bool addpath_capable, uint32_t addpath_tx_id, struct bgp_path_info *bpi,
+		     struct bgp_ls_nlri *ls_nlri, bool for_bmp);
 extern void bgp_dump_routes_attr(struct stream *s, struct bgp_path_info *bpi,
 				 const struct prefix *p);
 extern bool attrhash_cmp(const void *arg1, const void *arg2);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1124,9 +1124,13 @@ static struct stream *bmp_update(const struct prefix *p, struct prefix_rd *prd,
 	attrlen_pos = stream_get_endp(s);
 	stream_putw(s, 0);
 
-	/* 5: Encode all the attributes, except MP_REACH_NLRI attr. */
+	/* 5: Encode all the attributes, except MP_REACH_NLRI attr.
+	 * Pass for_bmp=true to bgp_packet_attribute() so it skips outbound
+	 * peer-specific AS_PATH transformations and emits attr->aspath as
+	 * stored — BMP is a reporting channel, not a BGP peer session.
+	 */
 	total_attr_len = bgp_packet_attribute(NULL, peer, s, attr, &vecarr, NULL, afi, safi, peer,
-					      NULL, NULL, 0, 0, 0, 0, NULL, NULL);
+					      NULL, NULL, 0, 0, 0, 0, NULL, NULL, true);
 
 	/* peer_cap_enhe & add-path removed */
 	if (afi == AFI_IP && safi == SAFI_UNICAST)

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -762,7 +762,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 			total_attr_len = bgp_packet_attribute(NULL, peer, s, adv->baa->attr,
 							      &vecarr, NULL, afi, safi, from, NULL,
 							      NULL, 0, dest->srv6_unicast, 0, 0,
-							      path, NULL);
+							      path, NULL, false);
 			space_remaining =
 				STREAM_CONCAT_REMAIN(s, snlri, STREAM_SIZE(s))
 				- BGP_MAX_PACKET_SIZE_OVERFLOW;
@@ -1273,7 +1273,8 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 	stream_putw(s, 0);
 	total_attr_len = bgp_packet_attribute(NULL, peer, s, attr, &vecarr, &p, afi, safi, from,
 					      NULL, &label, num_labels, 0, addpath_capable,
-					      BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, NULL, NULL);
+					      BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, NULL, NULL,
+					      false);
 
 	/* Set Total Path Attribute Length. */
 	stream_putw_at(s, pos, total_attr_len);

--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step1.json
@@ -2,7 +2,7 @@
     "loc-rib": {
         "update": {
             "172.31.0.15/32": {
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bgp_nexthop": "192.168.0.2",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
@@ -16,7 +16,7 @@
             },
             "2001::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2001::1111/128",
                 "is_filtered": false,

--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step2.json
+++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step2.json
@@ -3,7 +3,7 @@
         "update": {
             "2001::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2001::1111/128",
                 "is_filtered": false,
@@ -22,7 +22,7 @@
             },
             "172.31.0.15/32": {
                 "afi": 1,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
                 "is_filtered": false,

--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step1.json
@@ -2,7 +2,7 @@
     "post-policy": {
         "update": {
             "172.31.0.15/32": {
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bgp_nexthop": "192.168.0.2",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
@@ -17,7 +17,7 @@
             },
             "2001::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2001::1111/128",
                 "ipv6": true,

--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step2.json
+++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step2.json
@@ -3,7 +3,7 @@
         "update": {
             "172.31.0.15/32": {
                 "afi": 1,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
                 "ipv6": false,
@@ -22,7 +22,7 @@
             },
             "2001::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2001::1111/128",
                 "ipv6": true,

--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step1.json
@@ -2,7 +2,7 @@
     "pre-policy": {
         "update": {
             "172.31.0.15/32": {
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bgp_nexthop": "192.168.0.2",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
@@ -17,7 +17,7 @@
             },
             "2001::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2001::1111/128",
                 "ipv6": true,

--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step2.json
+++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step2.json
@@ -3,7 +3,7 @@
         "update": {
             "172.31.0.15/32": {
                 "afi": 1,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
                 "ipv6": false,
@@ -22,7 +22,7 @@
             },
             "2001::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2001::1111/128",
                 "ipv6": true,

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
@@ -2,7 +2,7 @@
     "loc-rib": {
         "update": {
             "172.31.0.15/32": {
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bgp_nexthop": "192.168.0.2",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
@@ -16,7 +16,7 @@
             },
             "2111::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2111::1111/128",
                 "is_filtered": false,

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
@@ -2,7 +2,7 @@
     "post-policy": {
         "update": {
             "172.31.0.15/32": {
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bgp_nexthop": "192.168.0.2",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
@@ -17,7 +17,7 @@
             },
             "2111::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2111::1111/128",
                 "ipv6": true,

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
@@ -2,7 +2,7 @@
     "pre-policy": {
         "update": {
             "172.31.0.15/32": {
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bgp_nexthop": "192.168.0.2",
                 "bmp_log_type": "update",
                 "ip_prefix": "172.31.0.15/32",
@@ -17,7 +17,7 @@
             },
             "2111::1111/128": {
                 "afi": 2,
-                "as_path": "65501 65502",
+                "as_path": "65502",
                 "bmp_log_type": "update",
                 "ip_prefix": "2111::1111/128",
                 "ipv6": true,


### PR DESCRIPTION
bgpd: bmp: don't prepend local-AS to AS_PATH in BMP updates

BMP Route Monitoring messages for monitored routes carried an AS_PATH
with the local AS prepended, as if the route were being re-advertised
outbound. Observed with a peer in AS 40001 advertising 100.100.100.1/32
to a router in AS 40002:

```
"as_path":[40002,40001], "as_path_count":2, "peer_asn":40001
```

The collector expected `AS_PATH=[40001]` -- the value as received from
the peer -- but saw `[40002,40001]` because the local AS was prepended
on its way out to the collector.

Root cause: `bmp_update()` in `bgp_bmp.c` reuses `bgp_packet_attribute()`,
the outbound attribute serializer, which performs peer-specific outbound
transformations on AS_PATH (prepend `peer->local_as` for eBGP, confed-seq
handling, change-local-as). These are correct for sending an UPDATE to
a peer, but BMP is a reporting channel -- pre-policy, post-policy, and
loc-rib must all emit the AS_PATH as stored (received / selected),
never with the outbound local-AS prepended.

Fix: add a `bool for_bmp` parameter to `bgp_packet_attribute()`. When
true:

- Skip the peer-sort-based AS_PATH transformations and emit
  `attr->aspath` as-is (no local-AS prepend, no confed-seq
  manipulation).

- Force 32-bit ASN encoding regardless of the peer's AS4 capability
  state. This is needed for loc-rib re-dumps after a VRF/peer flap:
  `peer->cap` can be momentarily cleared while the session
  renegotiates, which would otherwise cause `aspath_put()` to emit
  16-bit AS_PATH segments. Modern BMP collectors always parse ASNs as
  32-bit, so a 16-bit segment produces a byte-level parse error and
  the collector disconnects, losing all subsequent peer-up / peer-down
  / route-monitor messages.

`bmp_update()` passes `for_bmp=true` (covers pre-policy, post-policy,
and loc-rib). The outbound callers in `bgp_updgrp_packet.c` pass false
to keep their current behaviour.

Also update the `bgp_bmp` topotest expected JSON files for all three
modes: previously they encoded the prepended local-AS (`"65501 65502"`
where 65501 is the local AS); now they expect the raw AS_PATH
`"65502"` as received from the peer in AS 65502.