### PR TITLE
bgpd: send dynamic ENHE capability to peer-group members

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6501,6 +6501,33 @@ DEFPY (neighbor_capability_fqdn,
 	return ret;
 }
 
+/*
+ * Send dynamic capability on the peer(s) that own the TCP BGP session.
+ * The peer-group template (PEER_STATUS_GROUP) stays Idle; members in
+ * peer->group->peer are Established.
+ */
+static void bgp_vty_capability_send_dynamic_peer_group(struct peer *peer, afi_t afi, safi_t safi,
+						       int capability_code, int action)
+{
+	struct listnode *node;
+	struct peer *member;
+	struct peer_group *pg;
+
+	if (!peer)
+		return;
+
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
+		pg = peer->group;
+		if (!pg)
+			return;
+		for (ALL_LIST_ELEMENTS_RO(pg->peer, node, member))
+			bgp_capability_send(member->connection, afi, safi, capability_code,
+					    action);
+	} else {
+		bgp_capability_send(peer->connection, afi, safi, capability_code, action);
+	}
+}
+
 /* neighbor capability extended next hop encoding */
 DEFUN (neighbor_capability_enhe,
        neighbor_capability_enhe_cmd,
@@ -6523,8 +6550,8 @@ DEFUN (neighbor_capability_enhe,
 
 	ret = peer_flag_set_vty(vty, argv[idx_peer]->arg, PEER_FLAG_CAPABILITY_ENHE);
 
-	bgp_capability_send(peer->connection, AFI_IP, SAFI_UNICAST, CAPABILITY_CODE_ENHE,
-			    CAPABILITY_ACTION_SET);
+	bgp_vty_capability_send_dynamic_peer_group(peer, AFI_IP, SAFI_UNICAST,
+						   CAPABILITY_CODE_ENHE, CAPABILITY_ACTION_SET);
 
 	return ret;
 }
@@ -6553,10 +6580,15 @@ DEFUN (no_neighbor_capability_enhe,
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	ret = peer_flag_unset_vty(vty, argv[idx_peer]->arg, PEER_FLAG_CAPABILITY_ENHE);
+	/*
+	 * Send dynamic UNSET while PEER_FLAG_CAPABILITY_ENHE is still set.
+	 * bgp_capability_send() only encodes ENHE TLVs when that flag is set;
+	 * peer_flag_unset_vty clears it on members first.
+	 */
+	bgp_vty_capability_send_dynamic_peer_group(peer, AFI_IP, SAFI_UNICAST,
+						   CAPABILITY_CODE_ENHE, CAPABILITY_ACTION_UNSET);
 
-	bgp_capability_send(peer->connection, AFI_IP, SAFI_UNICAST, CAPABILITY_CODE_ENHE,
-			    CAPABILITY_ACTION_UNSET);
+	ret = peer_flag_unset_vty(vty, argv[idx_peer]->arg, PEER_FLAG_CAPABILITY_ENHE);
 
 	return ret;
 }


### PR DESCRIPTION
Problem:
ENHE may never take effect on live sessions when the session was brought up with ENHE absent from OPEN (e.g. enhe_cfg=0), and the operator later runs on peergroup:

  neighbor <WORD> capability extended-nexthop

If <WORD> is a peer-group name, peer_and_group_lookup_vty() returns the peer-group template. That struct peer does not own the BGP TCP session to each remote neighbor, it typically stays Idle while member peers are Established.

The VTY handlers called bgp_capability_send(peer, …, CAPABILITY_CODE_ENHE) only on that lookup result. bgp_capability_send() correctly requires an Established connection on the peer that was passed — but `peer` was the template, not each member, so the dynamic ENHE capability was never sent on the real adjacencies.

Fix:
Add bgp_vty_capability_enhe_send_dynamic(peer, action): if PEER_STATUS_GROUP, iterate peer->group->peer and call bgp_capability_send for each member; otherwise call bgp_capability_send once for the neighbor peer. Use this from both the set and no neighbor capability extended-nexthop commands so SET/UNSET apply to the peers that actually have the session.