### PR TITLE
bgpd: Reject BGP-LS node/link names containing non-printable characters

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -3531,6 +3531,23 @@ static int parse_node_name(struct stream *s, uint16_t length, struct bgp_ls_attr
 	attr->node_name = XCALLOC(MTYPE_BGP_LS_ATTR, length + 1);
 	stream_get(attr->node_name, s, length);
 	attr->node_name[length] = '\0';
+
+	/*
+	 * Reject names containing embedded NUL or non-printable characters to
+	 * prevent log spoofing and deduplication bypass (RFC 9552 Section 5.3.1.3
+	 * implies printable hostname).
+	 */
+	for (uint16_t i = 0; i < length; i++) {
+		if ((unsigned char)attr->node_name[i] < 0x20 ||
+		    (unsigned char)attr->node_name[i] > 0x7E) {
+			flog_warn(EC_BGP_UPDATE_RCV,
+				  "BGP-LS: Node Name TLV contains non-printable character at byte %u, rejecting",
+				  i);
+			XFREE(MTYPE_BGP_LS_ATTR, attr->node_name);
+			return -1;
+		}
+	}
+
 	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_NODE_NAME_BIT);
 
 	return 0;
@@ -3907,6 +3924,19 @@ static int parse_link_name(struct stream *s, uint16_t length, struct bgp_ls_attr
 	attr->link_name = XCALLOC(MTYPE_BGP_LS_ATTR, length + 1);
 	stream_get(attr->link_name, s, length);
 	attr->link_name[length] = '\0';
+
+	/* Reject names containing embedded NUL or non-printable characters. */
+	for (uint16_t i = 0; i < length; i++) {
+		if ((unsigned char)attr->link_name[i] < 0x20 ||
+		    (unsigned char)attr->link_name[i] > 0x7E) {
+			flog_warn(EC_BGP_UPDATE_RCV,
+				  "BGP-LS: Link Name TLV contains non-printable character at byte %u, rejecting",
+				  i);
+			XFREE(MTYPE_BGP_LS_ATTR, attr->link_name);
+			return -1;
+		}
+	}
+
 	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_LINK_NAME_BIT);
 
 	return 0;


### PR DESCRIPTION
`parse_node_name()` and `parse_link_name()` accept arbitrary bytes from the wire, including embedded NUL bytes and control characters. A malicious peer can inject names such as "good\0bad", which:

 - Are silently truncated by strcmp/printf (only "good" is visible), allowing two distinct TLV values to appear identical in logs and VTY output (log spoofing).
 - Can bypass NLRI deduplication: bgp_ls_attr_cmp() uses strcmp on node_name, so "good\0A" and "good\0B" compare equal while remaining distinct in memory (deduplication bypass).
 - Can carry control characters and ANSI escape sequences that corrupt terminal or syslog output.

Validate every byte of the received name after reading it from the stream. If any non-printable character is found, free the buffer and reject the TLV, causing the BGP UPDATE to be treated as malformed.