### PR TITLE
bgpd: Treat malformed BGP-LS TLV as NLRI discard per RFC 9552

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4110,7 +4110,12 @@ static enum bgp_attr_parse_ret bgp_attr_ls(struct bgp_attr_parser_args *args)
 	ret = bgp_ls_parse_attr(connection->curr, args->length, ls_attr);
 	if (ret != 0) {
 		bgp_ls_attr_free(ls_attr);
-		return BGP_ATTR_PARSE_ERROR;
+		/*
+		 * RFC 9552 §5.1 + RFC 7606 §5.4: a malformed BGP-LS TLV
+		 * requires NLRI discard (treat-as-withdraw) while the BGP
+		 * session itself continues.
+		 */
+		return BGP_ATTR_PARSE_WITHDRAW;
 	}
 
 	attr->ls_attr = bgp_ls_attr_intern(ls_attr);


### PR DESCRIPTION
RFC 9552 Section 5.1 states that when a malformed TLV is detected in a BGP-LS attribute, the router MUST handle the affected NLRI(s) as NLRI discard. The BGP session MUST NOT be reset.

bgp_attr_ls() currently returns BGP_ATTR_PARSE_ERROR on TLV parse failure, which causes the caller (bgp_packet.c) to return BGP_Stop and reset the session.

This behavior creates a remote BGP-session-reset vector for any negotiated BGP-LS peer: a malformed TLV in an UPDATE can force a session teardown.

Change the return value to BGP_ATTR_PARSE_WITHDRAW so that:
- The attribute buffer is skipped to the post-attribute position.
- All NLRIs carried by the UPDATE are treated as withdrawals.
- The BGP session is preserved and subsequent UPDATE messages continue to be processed normally.