### PR TITLE
tests: Fix invalid ISIS max-lsp-lifetime in BGP-LS configs

### DIFF
--- a/tests/topotests/bgp_link_state/r1/frr.conf
+++ b/tests/topotests/bgp_link_state/r1/frr.conf
@@ -44,7 +44,7 @@ router isis 1
  redistribute ipv6 connected level-2
  lsp-gen-interval 1
  lsp-refresh-interval 10
- max-lsp-lifetime 20
+ max-lsp-lifetime 350
  mpls-te on
  mpls-te router-address 1.1.1.1
  mpls-te router-address ipv6 fc00:0:1::1

--- a/tests/topotests/bgp_link_state/r2/frr.conf
+++ b/tests/topotests/bgp_link_state/r2/frr.conf
@@ -58,7 +58,7 @@ router isis 1
  redistribute ipv6 connected level-2
  lsp-gen-interval 1
  lsp-refresh-interval 10
- max-lsp-lifetime 20
+ max-lsp-lifetime 350
  mpls-te on
  mpls-te export
  mpls-te router-address 2.2.2.2

--- a/tests/topotests/bgp_link_state/r3/frr.conf
+++ b/tests/topotests/bgp_link_state/r3/frr.conf
@@ -43,7 +43,7 @@ router isis 1
  redistribute ipv6 connected level-2
  lsp-gen-interval 1
  lsp-refresh-interval 10
- max-lsp-lifetime 20
+ max-lsp-lifetime 350
  mpls-te on
  mpls-te router-address 3.3.3.3
  mpls-te router-address ipv6 fc00:0:3::1

--- a/tests/topotests/bgp_link_state/r4/frr.conf
+++ b/tests/topotests/bgp_link_state/r4/frr.conf
@@ -42,7 +42,7 @@ router isis 1
  redistribute ipv6 connected level-2
  lsp-gen-interval 1
  lsp-refresh-interval 10
- max-lsp-lifetime 20
+ max-lsp-lifetime 350
  mpls-te on
  mpls-te router-address 4.4.4.4
  mpls-te router-address ipv6 fc00:0:4::1


### PR DESCRIPTION
The bgp_link_state topotest ISIS configs set:
```
  max-lsp-lifetime 20
```

FRR accepts max-lsp-lifetime only in range 350-65535, so value 20 triggers warnings while loading the configs.

Update r1/r2/r3/r4 configs to use:
```
  max-lsp-lifetime 350
```