### PR TITLE
tests: Fix invalid escape warning in BGP-LS test

### DIFF
--- a/tests/topotests/bgp_link_state/test_bgp_link_state.py
+++ b/tests/topotests/bgp_link_state/test_bgp_link_state.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2025 by Carmine Scarpitta
 #
-"""
+r"""
 Test BGP Link-State (RFC 9552) functionality:
 - BGP-LS capability negotiation
 - Producer mode: Export IGP topology to BGP-LS


### PR DESCRIPTION
Pytest reports a DeprecationWarning during collection of tests/topotests/bgp_link_state/test_bgp_link_state.py due to an invalid escape sequence in the module docstring.

```
test_bgp_link_state.py:6
  /home/user/frr/tests/topotests/bgp_link_state/test_bgp_link_state.py:6: DeprecationWarning: invalid escape sequence '\ '
    """
```

Fix this by converting the module docstring to a raw string literal (`r"""..."""`).