### PR TITLE
bgpd: Add BGP-LS Extensions for SRv6 (RFC 9514)

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -152,6 +152,11 @@ json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri)
 		protocol_id = nlri->nlri_data.prefix.protocol_id;
 		identifier = nlri->nlri_data.prefix.identifier;
 		break;
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		nlri_type_str = "srv6Sid";
+		protocol_id = nlri->nlri_data.srv6_sid.protocol_id;
+		identifier = nlri->nlri_data.srv6_sid.identifier;
+		break;
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		nlri_type_str = "unknown";
 		break;
@@ -184,6 +189,24 @@ json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri)
 							       nlri->nlri_type);
 		json_object_object_add(json_nlri, "localNodeDescriptors", json_local);
 		json_object_object_add(json_nlri, "prefixDescriptors", json_prefix);
+	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
+		struct bgp_ls_srv6_sid_nlri *srv6 = &nlri->nlri_data.srv6_sid;
+		json_object *json_local = node_desc_to_json(&srv6->local_node);
+		json_object *json_sid = json_object_new_object();
+
+		if (srv6->sid_desc.mt_id_count > 0) {
+			json_object *json_mt = json_object_new_array();
+
+			for (uint8_t i = 0; i < srv6->sid_desc.mt_id_count; i++)
+				json_object_array_add(json_mt,
+						      json_object_new_int(srv6->sid_desc.mt_id[i]));
+			json_object_object_add(json_sid, "multiTopologyId", json_mt);
+		}
+
+		json_object_string_addf(json_sid, "srv6SidValue", "%pI6", &srv6->sid_desc.sid);
+
+		json_object_object_add(json_nlri, "localNodeDescriptors", json_local);
+		json_object_object_add(json_nlri, "srv6SidDescriptors", json_sid);
 	}
 
 	return json_nlri;
@@ -243,6 +266,17 @@ static void format_node_desc(char **p, size_t *remain, struct bgp_ls_node_descri
 	}
 
 	len = snprintfrr(*p, *remain, "]");
+	*p += len;
+	*remain -= len;
+}
+
+/* Format SRv6 SID descriptor to string */
+static void format_srv6_sid_desc(char **p, size_t *remain,
+				 struct bgp_ls_srv6_sid_descriptor *sid_desc)
+{
+	int len;
+
+	len = snprintfrr(*p, *remain, "[S[sd%pI6]]", &sid_desc->sid);
 	*p += len;
 	*remain -= len;
 }
@@ -322,6 +356,9 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		len = snprintfrr(p, remain, "[T]");
 		break;
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		len = snprintfrr(p, remain, "[S]");
+		break;
 	default:
 		len = snprintfrr(p, remain, "[U]");
 		break;
@@ -344,6 +381,9 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 		   nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV6_PREFIX) {
 		protocol_id = nlri->nlri_data.prefix.protocol_id;
 		instance_id = nlri->nlri_data.prefix.identifier;
+	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
+		protocol_id = nlri->nlri_data.srv6_sid.protocol_id;
+		instance_id = nlri->nlri_data.srv6_sid.identifier;
 	}
 
 	switch (protocol_id) {
@@ -416,6 +456,10 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 			p += len;
 			remain -= len;
 		}
+	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
+		/* Format local node descriptor */
+		format_node_desc(&p, &remain, &nlri->nlri_data.srv6_sid.local_node, "N");
+		format_srv6_sid_desc(&p, &remain, &nlri->nlri_data.srv6_sid.sid_desc);
 	}
 }
 

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -272,6 +272,23 @@ int bgp_ls_nlri_cmp(const struct bgp_ls_nlri *nlri1, const struct bgp_ls_nlri *n
 		return bgp_ls_prefix_descriptor_cmp(&p1->prefix_desc, &p2->prefix_desc);
 	}
 
+	case BGP_LS_NLRI_TYPE_SRV6_SID: {
+		const struct bgp_ls_srv6_sid_nlri *s1 = &nlri1->nlri_data.srv6_sid;
+		const struct bgp_ls_srv6_sid_nlri *s2 = &nlri2->nlri_data.srv6_sid;
+
+		if (s1->protocol_id != s2->protocol_id)
+			return numcmp(s1->protocol_id, s2->protocol_id);
+		if (s1->identifier != s2->identifier)
+			return numcmp(s1->identifier, s2->identifier);
+
+		ret = bgp_ls_node_descriptor_cmp(&s1->local_node, &s2->local_node);
+		if (ret != 0)
+			return ret;
+
+		/* Compare SRv6 SID (the 128-bit SID identifies the NLRI) */
+		return memcmp(&s1->sid_desc.sid, &s2->sid_desc.sid, sizeof(s1->sid_desc.sid));
+	}
+
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		/* Reserved type should never be compared */
 		return 0;
@@ -565,6 +582,10 @@ void bgp_ls_nlri_free(struct bgp_ls_nlri *nlri)
 		XFREE(MTYPE_BGP_LS_NLRI, nlri->nlri_data.prefix.prefix_desc.mt_id);
 		break;
 
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		XFREE(MTYPE_BGP_LS_NLRI, nlri->nlri_data.srv6_sid.sid_desc.mt_id);
+		break;
+
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		break;
 	}
@@ -642,6 +663,18 @@ struct bgp_ls_nlri *bgp_ls_nlri_copy(const struct bgp_ls_nlri *nlri)
 										mt_size);
 			memcpy(nlri_copy->nlri_data.prefix.prefix_desc.mt_id,
 			       nlri->nlri_data.prefix.prefix_desc.mt_id, mt_size);
+		}
+		break;
+
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		/* Copy SRv6 SID descriptor mt_id */
+		if (nlri->nlri_data.srv6_sid.sid_desc.mt_id) {
+			size_t mt_size = nlri->nlri_data.srv6_sid.sid_desc.mt_id_count *
+					 sizeof(uint16_t);
+			nlri_copy->nlri_data.srv6_sid.sid_desc.mt_id = XCALLOC(MTYPE_BGP_LS_NLRI,
+									       mt_size);
+			memcpy(nlri_copy->nlri_data.srv6_sid.sid_desc.mt_id,
+			       nlri->nlri_data.srv6_sid.sid_desc.mt_id, mt_size);
 		}
 		break;
 
@@ -781,6 +814,25 @@ static bool bgp_ls_igp_router_id_len_valid(enum bgp_ls_protocol_id proto_id, uin
 	return false;
 }
 
+/*
+ * Validate an SRv6 SID NLRI: must have a valid protocol-ID and a non-zero SID
+ * (RFC 9514, Section 6)
+ */
+static bool bgp_ls_nlri_validate_srv6_sid(const struct bgp_ls_nlri *nlri)
+{
+	const struct bgp_ls_srv6_sid_nlri *s = &nlri->nlri_data.srv6_sid;
+	const struct in6_addr zero = {};
+
+	if (s->protocol_id == BGP_LS_PROTO_RESERVED)
+		return false;
+
+	/* The SID MUST be non-zero */
+	if (memcmp(&s->sid_desc.sid, &zero, sizeof(zero)) == 0)
+		return false;
+
+	return true;
+}
+
 bool bgp_ls_nlri_validate(const struct bgp_ls_nlri *nlri)
 {
 	if (!nlri)
@@ -878,6 +930,9 @@ bool bgp_ls_nlri_validate(const struct bgp_ls_nlri *nlri)
 
 		return true;
 	}
+
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		return bgp_ls_nlri_validate_srv6_sid(nlri);
 
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		/* Reserved type is invalid */
@@ -994,6 +1049,22 @@ size_t bgp_ls_nlri_size(const struct bgp_ls_nlri *nlri)
 		break;
 	}
 
+	case BGP_LS_NLRI_TYPE_SRV6_SID: {
+		const struct bgp_ls_srv6_sid_nlri *s = &nlri->nlri_data.srv6_sid;
+
+		/* Local Node Descriptor */
+		size += bgp_ls_node_descriptor_size(&s->local_node);
+
+		/* SRv6 SID Information TLV (mandatory) */
+		size += BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_SID_INFO_SIZE;
+
+		/* Optional MT-ID TLV in SID descriptor */
+		if (s->sid_desc.mt_id_count > 0)
+			size += BGP_LS_TLV_HDR_SIZE + (s->sid_desc.mt_id_count * BGP_LS_MT_ID_SIZE);
+
+		break;
+	}
+
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		return 0;
 	}
@@ -1044,6 +1115,8 @@ const char *bgp_ls_nlri_type_str(enum bgp_ls_nlri_type nlri_type)
 		return "IPv4 Prefix";
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		return "IPv6 Prefix";
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		return "SRv6 SID";
 	}
 
 	return "Unknown";
@@ -1307,6 +1380,9 @@ unsigned int bgp_ls_nlri_hash_key(const struct bgp_ls_nlri *nlri)
 	case BGP_LS_NLRI_TYPE_IPV4_PREFIX:
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		return key ^ bgp_ls_prefix_hash_key_internal(nlri);
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		return key ^ jhash(&nlri->nlri_data.srv6_sid.sid_desc.sid,
+				   sizeof(nlri->nlri_data.srv6_sid.sid_desc.sid), 0);
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		return key;
 	}
@@ -2060,6 +2136,61 @@ int bgp_ls_encode_prefix_nlri(struct stream *s, const struct bgp_ls_prefix_nlri 
 }
 
 /*
+ * Encode SRv6 SID NLRI to wire format (RFC 9514, Section 6)
+ *
+ *  Protocol-ID (1) + Identifier (8) + Local Node Descriptors + SID Descriptors
+ *
+ * SID Descriptors field:
+ *   - SRv6 SID Information TLV (518): 16-byte SID [mandatory]
+ *   - Multi-Topology Identifier TLV (263): optional
+ *
+ * Returns number of bytes written, or -1 on error
+ */
+int bgp_ls_encode_srv6_sid_nlri(struct stream *s, const struct bgp_ls_srv6_sid_nlri *nlri)
+{
+	size_t start;
+
+	if (!s || !nlri)
+		return -1;
+
+	start = stream_get_endp(s);
+
+	/* Protocol-ID (1 byte) */
+	if (STREAM_WRITEABLE(s) < BGP_LS_PROTOCOL_ID_SIZE)
+		return -1;
+	stream_putc(s, nlri->protocol_id);
+
+	/* Identifier (8 bytes) */
+	if (STREAM_WRITEABLE(s) < BGP_LS_IDENTIFIER_SIZE)
+		return -1;
+	stream_putq(s, nlri->identifier);
+
+	/* Local Node Descriptors */
+	if (bgp_ls_encode_node_descriptor(s, &nlri->local_node, BGP_LS_TLV_LOCAL_NODE_DESC) < 0)
+		return -1;
+
+	/* SRv6 SID Descriptors - SRv6 SID Information TLV (518) is mandatory */
+	if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_SID_INFO_SIZE)
+		return -1;
+	stream_putw(s, BGP_LS_TLV_SRV6_SID_INFO);
+	stream_putw(s, BGP_LS_SRV6_SID_INFO_SIZE);
+	stream_put(s, &nlri->sid_desc.sid, BGP_LS_SRV6_SID_INFO_SIZE);
+
+	/* Optional MT-ID TLV in SID descriptor */
+	if (nlri->sid_desc.mt_id_count > 0) {
+		if (STREAM_WRITEABLE(s) <
+		    BGP_LS_TLV_HDR_SIZE + (size_t)nlri->sid_desc.mt_id_count * BGP_LS_MT_ID_SIZE)
+			return -1;
+		stream_putw(s, BGP_LS_TLV_MT_ID);
+		stream_putw(s, nlri->sid_desc.mt_id_count * BGP_LS_MT_ID_SIZE);
+		for (uint8_t i = 0; i < nlri->sid_desc.mt_id_count; i++)
+			stream_putw(s, nlri->sid_desc.mt_id[i]);
+	}
+
+	return stream_get_endp(s) - start;
+}
+
+/*
  * Encode complete NLRI with Type-Length-Value header
  *
  * Wire format (RFC 9552 Section 5.2):
@@ -2074,7 +2205,7 @@ int bgp_ls_encode_prefix_nlri(struct stream *s, const struct bgp_ls_prefix_nlri 
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  *
  * Where:
- *   Type   = NLRI Type (1=Node, 2=Link, 3=IPv4 Prefix, 4=IPv6 Prefix)
+ *   Type   = NLRI Type (1=Node, 2=Link, 3=IPv4 Prefix, 4=IPv6 Prefix, 6=SRv6 SID)
  *   Length = Length of NLRI Value in octets
  *   Value  = Type-specific NLRI data (Protocol-ID + Identifier + Descriptors)
  *
@@ -2122,6 +2253,10 @@ int bgp_ls_encode_nlri(struct stream *s, const struct bgp_ls_nlri *nlri)
 	case BGP_LS_NLRI_TYPE_IPV4_PREFIX:
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		ret = bgp_ls_encode_prefix_nlri(s, &nlri->nlri_data.prefix, nlri->nlri_type);
+		break;
+
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		ret = bgp_ls_encode_srv6_sid_nlri(s, &nlri->nlri_data.srv6_sid);
 		break;
 
 	case BGP_LS_NLRI_TYPE_RESERVED:
@@ -3603,6 +3738,156 @@ int bgp_ls_decode_prefix_nlri(struct stream *s, struct bgp_ls_nlri *nlri, uint16
 }
 
 /*
+ * Decode SRv6 SID NLRI from wire format (RFC 9514, Section 6)
+ *
+ * SRv6 SID NLRI format:
+ *   Protocol-ID (1) + Identifier (8) + Local Node Descriptors + SID Descriptors
+ *
+ * SID Descriptors field:
+ *   - SRv6 SID Information TLV (518): 16-byte SID [mandatory]
+ *   - Multi-Topology Identifier TLV (263): optional
+ *
+ * Returns 0 on success, -1 on error
+ */
+int bgp_ls_decode_srv6_sid_nlri(struct stream *s, struct bgp_ls_nlri *nlri, uint16_t nlri_length)
+{
+	struct bgp_ls_srv6_sid_nlri *srv6;
+	uint16_t type, length;
+	size_t start_pos, consumed, sid_desc_len;
+	bool got_sid = false;
+
+	if (!s || !nlri)
+		return -1;
+
+	/* Save start position for length validation */
+	start_pos = stream_get_getp(s);
+
+	/* Check minimum length */
+	if (nlri_length < BGP_LS_NLRI_MIN_LENGTH) {
+		flog_warn(EC_BGP_LS_PACKET,
+			  "BGP-LS: SRv6 SID NLRI length %u too short (minimum %u)", nlri_length,
+			  BGP_LS_NLRI_MIN_LENGTH);
+		return -1;
+	}
+
+	nlri->nlri_type = BGP_LS_NLRI_TYPE_SRV6_SID;
+	srv6 = &nlri->nlri_data.srv6_sid;
+
+	/* Protocol-ID (1 byte) */
+	srv6->protocol_id = stream_getc(s);
+
+	/* Validate Protocol-ID */
+	if (srv6->protocol_id == BGP_LS_PROTO_RESERVED || srv6->protocol_id > BGP_LS_PROTO_BGP) {
+		flog_warn(EC_BGP_LS_PACKET, "BGP-LS: Invalid Protocol-ID %u", srv6->protocol_id);
+		return -1;
+	}
+
+	/* Identifier (8 bytes) */
+	srv6->identifier = stream_getq(s);
+
+	/* Local Node Descriptor TLV */
+	if (stream_get_tlv_hdr(s, &type, &length) < 0)
+		return -1;
+
+	if (type != BGP_LS_TLV_LOCAL_NODE_DESC) {
+		flog_warn(EC_BGP_LS_PACKET, "BGP-LS: Expected Local Node Descriptor TLV %u, got %u",
+			  BGP_LS_TLV_LOCAL_NODE_DESC, type);
+		return -1;
+	}
+
+	consumed = stream_get_getp(s) - start_pos;
+	if (consumed > nlri_length || length > nlri_length - consumed) {
+		flog_warn(EC_BGP_LS_PACKET,
+			  "BGP-LS: Local Node Descriptor TLV length %u exceeds NLRI boundary",
+			  length);
+		return -1;
+	}
+
+	if (bgp_ls_decode_node_descriptor(s, &srv6->local_node, length) < 0)
+		return -1;
+
+	/* SRv6 SID Descriptors - remaining bytes after node descriptor */
+	consumed = stream_get_getp(s) - start_pos;
+	sid_desc_len = nlri_length - consumed;
+
+	while (sid_desc_len >= BGP_LS_TLV_HDR_SIZE) {
+		if (stream_get_tlv_hdr(s, &type, &length) < 0)
+			return -1;
+		sid_desc_len -= BGP_LS_TLV_HDR_SIZE;
+
+		if (length > sid_desc_len) {
+			flog_warn(EC_BGP_LS_PACKET,
+				  "BGP-LS: SRv6 SID descriptor TLV %u length %u exceeds remaining %zu",
+				  type, length, sid_desc_len);
+			return -1;
+		}
+
+		switch (type) {
+		case BGP_LS_TLV_SRV6_SID_INFO:
+			/* SRv6 SID Information TLV: 16-byte IPv6 SID */
+			if (got_sid) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: duplicate SRv6 SID Information TLV in SRv6 SID descriptor");
+				return -1;
+			}
+			if (length < BGP_LS_SRV6_SID_INFO_SIZE) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: SRv6 SID Info TLV too short (%u bytes)", length);
+				return -1;
+			}
+			stream_get(&srv6->sid_desc.sid, s, IPV6_MAX_BYTELEN);
+			if (length > BGP_LS_SRV6_SID_INFO_SIZE)
+				stream_forward_getp(s, length - BGP_LS_SRV6_SID_INFO_SIZE);
+			got_sid = true;
+			break;
+
+		case BGP_LS_TLV_MT_ID:
+			if (srv6->sid_desc.mt_id_count != 0) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: duplicate MT-ID TLV in SRv6 SID descriptor");
+				return -1;
+			}
+			/* Variable length: 2*n bytes where n is number of MT-IDs */
+			if (length == 0 || length % 2 != 0 || length > BGP_LS_MAX_MT_ID * 2) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: Invalid MT-ID TLV length %u in SRv6 SID descriptor",
+					  length);
+				return -1;
+			}
+			srv6->sid_desc.mt_id_count = length / 2;
+			srv6->sid_desc.mt_id = XCALLOC(MTYPE_BGP_LS_NLRI, length);
+			for (uint16_t i = 0; i < srv6->sid_desc.mt_id_count; i++)
+				srv6->sid_desc.mt_id[i] = stream_getw(s);
+			break;
+
+		default:
+			if (BGP_DEBUG(update, UPDATE_IN))
+				zlog_debug("BGP-LS: SRv6 SID NLRI: unknown descriptor TLV %u",
+					   type);
+			stream_forward_getp(s, length);
+			break;
+		}
+		sid_desc_len -= length;
+	}
+
+	if (!got_sid) {
+		flog_warn(EC_BGP_LS_PACKET,
+			  "BGP-LS: SRv6 SID NLRI missing mandatory SID Information TLV");
+		return -1;
+	}
+
+	/* Verify we consumed exactly nlri_length bytes */
+	if (stream_get_getp(s) - start_pos != nlri_length) {
+		flog_warn(EC_BGP_LS_PACKET,
+			  "BGP-LS: SRv6 SID NLRI length mismatch (consumed %zu, expected %u)",
+			  stream_get_getp(s) - start_pos, nlri_length);
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
  * Decode complete BGP-LS NLRI from UPDATE message (RFC 9552 Section 5.2)
  *
  * This is the main entry point for decoding NLRIs from MP_REACH_NLRI
@@ -3643,6 +3928,9 @@ int bgp_ls_decode_nlri(struct stream *s, struct bgp_ls_nlri *nlri)
 	case BGP_LS_NLRI_TYPE_IPV4_PREFIX:
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		return bgp_ls_decode_prefix_nlri(s, nlri, nlri_type, nlri_length);
+
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		return bgp_ls_decode_srv6_sid_nlri(s, nlri, nlri_length);
 
 	default:
 		/* Unknown NLRI type - preserve and propagate (RFC 9552 Section 5.2) */
@@ -5817,6 +6105,10 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 		protocol_id = nlri->nlri_data.prefix.protocol_id;
 		identifier = nlri->nlri_data.prefix.identifier;
 		break;
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		protocol_id = nlri->nlri_data.srv6_sid.protocol_id;
+		identifier = nlri->nlri_data.srv6_sid.identifier;
+		break;
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		break;
 	}
@@ -5834,6 +6126,9 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 		break;
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		nlri_type_str = "Prefix";
+		break;
+	case BGP_LS_NLRI_TYPE_SRV6_SID:
+		nlri_type_str = "SRv6 SID";
 		break;
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		nlri_type_str = "Unknown";
@@ -5883,6 +6178,8 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV4_PREFIX ||
 		   nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV6_PREFIX) {
 		local_node = &nlri->nlri_data.prefix.local_node;
+	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
+		local_node = &nlri->nlri_data.srv6_sid.local_node;
 	}
 
 	if (local_node) {
@@ -6030,5 +6327,15 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 			for (uint8_t i = 0; i < prefix_desc->mt_id_count; i++)
 				vty_out(vty, "\tMT-ID: %u\n", prefix_desc->mt_id[i]);
 		}
+	}
+
+	/* Display SRv6 SID Descriptor for SRv6 SID NLRI (RFC 9514) */
+	if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
+		const struct bgp_ls_srv6_sid_nlri *s = &nlri->nlri_data.srv6_sid;
+
+		vty_out(vty, "SRv6 SID Descriptor:\n");
+		for (uint8_t i = 0; i < s->sid_desc.mt_id_count; i++)
+			vty_out(vty, "\tMulti-Topology: 0x%04x\n", s->sid_desc.mt_id[i]);
+		vty_out(vty, "\tSID: %pI6\n", &s->sid_desc.sid);
 	}
 }

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -480,6 +480,13 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 			return numcmp(attr1->srv6_cap_flags, attr2->srv6_cap_flags);
 	}
 
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
+		ret = memcmp(&attr1->srv6_sid_structure, &attr2->srv6_sid_structure,
+			     sizeof(attr1->srv6_sid_structure));
+		if (ret != 0)
+			return ret;
+	}
+
 	return 0;
 }
 
@@ -2524,6 +2531,18 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		stream_putw(s, 0); /* Reserved */
 	}
 
+	/* SRv6 SID Structure (TLV 1252) - top-level in SRv6 SID NLRI attributes */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_SID_STRUCTURE_SIZE)
+			return -1;
+		stream_putw(s, BGP_LS_ATTR_SRV6_SID_STRUCTURE);
+		stream_putw(s, BGP_LS_SRV6_SID_STRUCTURE_SIZE);
+		stream_putc(s, attr->srv6_sid_structure.lb_len);
+		stream_putc(s, attr->srv6_sid_structure.ln_len);
+		stream_putc(s, attr->srv6_sid_structure.fun_len);
+		stream_putc(s, attr->srv6_sid_structure.arg_len);
+	}
+
 	return stream_get_endp(s) - start_pos;
 }
 
@@ -4538,6 +4557,56 @@ static int parse_srv6_capabilities(struct stream *s, uint16_t length, struct bgp
 	return 0;
 }
 
+/*
+ * Parse SRv6 SID Structure sub-TLV (Type 1252, RFC 9514 Section 8)
+ * Format: LB Length (1) + LN Length (1) + Function Length (1) + Argument Length (1)
+ * The sum of all four length fields MUST be <= 128 (RFC 9514 Section 8).
+ * On success, populates *ss and returns 0; returns -1 on error.
+ */
+static int parse_srv6_sid_structure_subtlv(struct stream *s, uint16_t length,
+					   struct bgp_ls_srv6_sid_structure *ss)
+{
+	if (length != BGP_LS_SRV6_SID_STRUCTURE_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 SID Structure sub-TLV bad length (%u bytes, expected %u)",
+			  length, BGP_LS_SRV6_SID_STRUCTURE_SIZE);
+		return -1;
+	}
+
+	ss->lb_len = stream_getc(s);
+	ss->ln_len = stream_getc(s);
+	ss->fun_len = stream_getc(s);
+	ss->arg_len = stream_getc(s);
+
+	if ((uint32_t)ss->lb_len + ss->ln_len + ss->fun_len + ss->arg_len > 128) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 SID Structure sub-TLV length sum exceeds 128 (%u+%u+%u+%u)",
+			  ss->lb_len, ss->ln_len, ss->fun_len, ss->arg_len);
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Parse SRv6 SID Structure TLV (Type 1252, RFC 9514 Section 8)
+ * Used as a top-level TLV in the BGP-LS Attribute of an SRv6 SID NLRI.
+ * Format: LB Length (1) + LN Length (1) + Function Length (1) + Argument Length (1)
+ */
+static int parse_srv6_sid_structure(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
+		flog_warn(EC_BGP_UPDATE_RCV, "BGP-LS: duplicate SRv6 SID Structure TLV");
+		return -1;
+	}
+
+	if (parse_srv6_sid_structure_subtlv(s, length, &attr->srv6_sid_structure) < 0)
+		return -1;
+
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT);
+	return 0;
+}
+
 int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_attr *attr)
 {
 	uint16_t type, length;
@@ -4722,6 +4791,11 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 		/* SRv6 TLVs (RFC 9514) */
 		case BGP_LS_ATTR_SRV6_CAPABILITIES:
 			if (parse_srv6_capabilities(s, length, attr) < 0)
+				return -1;
+			break;
+
+		case BGP_LS_ATTR_SRV6_SID_STRUCTURE:
+			if (parse_srv6_sid_structure(s, length, attr) < 0)
 				return -1;
 			break;
 
@@ -4943,6 +5017,17 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 
 		json_object_string_addf(jcap, "flags", "0x%x", ls_attr->srv6_cap_flags);
 		json_object_object_add(json_ls_attr, "srv6Capabilities", jcap);
+	}
+
+	/* SRv6 SID Structure (TLV 1252) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
+		json_object *jss = json_object_new_object();
+
+		json_object_int_add(jss, "lbLen", ls_attr->srv6_sid_structure.lb_len);
+		json_object_int_add(jss, "lnLen", ls_attr->srv6_sid_structure.ln_len);
+		json_object_int_add(jss, "funLen", ls_attr->srv6_sid_structure.fun_len);
+		json_object_int_add(jss, "argLen", ls_attr->srv6_sid_structure.arg_len);
+		json_object_object_add(json_ls_attr, "srv6SidStructure", jss);
 	}
 
 	return json_ls_attr;
@@ -5178,6 +5263,16 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
 		CHECK_WRAP();
 		col += vty_out(vty, "SRv6 Capabilities: 0x%x", ls_attr->srv6_cap_flags);
+	}
+
+	/* SRv6 SID Structure (TLV 1252) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
+		CHECK_WRAP();
+		col += vty_out(vty, "SRv6 SID Structure: LBL: %u LNL: %u FL: %u AL: %u",
+			       ls_attr->srv6_sid_structure.lb_len,
+			       ls_attr->srv6_sid_structure.ln_len,
+			       ls_attr->srv6_sid_structure.fun_len,
+			       ls_attr->srv6_sid_structure.arg_len);
 	}
 
 	(void)col; /* Don't complain about last 'col +=' */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -503,6 +503,15 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 		}
 	}
 
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT)) {
+		if (attr1->srv6_locator_flags != attr2->srv6_locator_flags)
+			return numcmp(attr1->srv6_locator_flags, attr2->srv6_locator_flags);
+		if (attr1->srv6_locator_algo != attr2->srv6_locator_algo)
+			return numcmp(attr1->srv6_locator_algo, attr2->srv6_locator_algo);
+		if (attr1->srv6_locator_metric != attr2->srv6_locator_metric)
+			return numcmp(attr1->srv6_locator_metric, attr2->srv6_locator_metric);
+	}
+
 	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
 		ret = memcmp(&attr1->srv6_sid_structure, &attr2->srv6_sid_structure,
 			     sizeof(attr1->srv6_sid_structure));
@@ -2642,6 +2651,19 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 				stream_putc(s, lan_endx->structure.arg_len);
 			}
 		}
+	}
+
+	/* SRv6 Locator (TLV 1162) */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_LOCATOR_MIN_SIZE)
+			return -1;
+
+		stream_putw(s, BGP_LS_ATTR_SRV6_LOCATOR);
+		stream_putw(s, BGP_LS_SRV6_LOCATOR_MIN_SIZE);
+		stream_putc(s, attr->srv6_locator_flags);
+		stream_putc(s, attr->srv6_locator_algo);
+		stream_putw(s, 0); /* Reserved */
+		stream_putl(s, attr->srv6_locator_metric);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) - top-level in SRv6 SID NLRI attributes */
@@ -4904,6 +4926,37 @@ static int parse_ospf_srv6_lan_endx_sid(struct stream *s, uint16_t length, struc
 	return 0;
 }
 
+/*
+ * Parse SRv6 Locator TLV (Type 1162, RFC 9514 Section 5.1)
+ * Format: Flags (1) + Algorithm (1) + Reserved (2) + Metric (4) + Sub-TLVs (variable)
+ */
+static int parse_srv6_locator(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT)) {
+		flog_warn(EC_BGP_UPDATE_RCV, "BGP-LS: duplicate SRv6 Locator TLV");
+		return -1;
+	}
+
+	if (length < BGP_LS_SRV6_LOCATOR_MIN_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 Locator TLV too short (%u bytes, need %u)", length,
+			  BGP_LS_SRV6_LOCATOR_MIN_SIZE);
+		return -1;
+	}
+
+	attr->srv6_locator_flags = stream_getc(s);
+	attr->srv6_locator_algo = stream_getc(s);
+	stream_getw(s); /* Reserved */
+	attr->srv6_locator_metric = stream_getl(s);
+
+	/* Sub-TLVs (none currently defined; skip them) */
+	if (length > BGP_LS_SRV6_LOCATOR_MIN_SIZE)
+		stream_forward_getp(s, length - BGP_LS_SRV6_LOCATOR_MIN_SIZE);
+
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT);
+	return 0;
+}
+
 int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_attr *attr)
 {
 	uint16_t type, length;
@@ -5108,6 +5161,11 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 
 		case BGP_LS_ATTR_SRV6_LAN_ENDX_SID_OSPF:
 			if (parse_ospf_srv6_lan_endx_sid(s, length, attr) < 0)
+				return -1;
+			break;
+
+		case BGP_LS_ATTR_SRV6_LOCATOR:
+			if (parse_srv6_locator(s, length, attr) < 0)
 				return -1;
 			break;
 
@@ -5393,6 +5451,16 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 			json_object_array_add(jlan_arr, jlan);
 		}
 		json_object_object_add(json_ls_attr, "srv6LanEndxSids", jlan_arr);
+	}
+
+	/* SRv6 Locator (TLV 1162) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT)) {
+		json_object *jloc = json_object_new_object();
+
+		json_object_string_addf(jloc, "flags", "0x%x", ls_attr->srv6_locator_flags);
+		json_object_int_add(jloc, "algo", ls_attr->srv6_locator_algo);
+		json_object_int_add(jloc, "metric", ls_attr->srv6_locator_metric);
+		json_object_object_add(json_ls_attr, "srv6Locator", jloc);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */
@@ -5690,6 +5758,14 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 					       e->structure.fun_len, e->structure.arg_len);
 			}
 		}
+	}
+
+	/* SRv6 Locator (TLV 1162) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT)) {
+		CHECK_WRAP();
+		col += vty_out(vty, "SRv6 Locator Metric: %u Flags: 0x%x Algo: %u",
+			       ls_attr->srv6_locator_metric, ls_attr->srv6_locator_flags,
+			       ls_attr->srv6_locator_algo);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -474,6 +474,12 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 			return numcmp(attr1->mt_id[i], attr2->mt_id[i]);
 	}
 
+	/* SRv6 comparisons (RFC 9514) */
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
+		if (attr1->srv6_cap_flags != attr2->srv6_cap_flags)
+			return numcmp(attr1->srv6_cap_flags, attr2->srv6_cap_flags);
+	}
+
 	return 0;
 }
 
@@ -2504,6 +2510,20 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		}
 	}
 
+	/*
+	 * RFC 9514 SRv6 Attribute TLVs
+	 */
+
+	/* SRv6 Capabilities (TLV 1038) */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_CAPABILITIES_SIZE)
+			return -1;
+		stream_putw(s, BGP_LS_ATTR_SRV6_CAPABILITIES);
+		stream_putw(s, BGP_LS_SRV6_CAPABILITIES_SIZE);
+		stream_putw(s, attr->srv6_cap_flags);
+		stream_putw(s, 0); /* Reserved */
+	}
+
 	return stream_get_endp(s) - start_pos;
 }
 
@@ -4490,7 +4510,34 @@ static int parse_prefix_sid(struct stream *s, uint16_t length, struct bgp_ls_att
 /*
  * Parse BGP-LS Attribute TLVs
  * RFC 9552 Section 5.3.1
+ * RFC 9514 SRv6 extensions
  */
+
+/*
+ * Parse SRv6 Capabilities TLV (Type 1038, RFC 9514 Section 3.1)
+ * Format: Flags (2) + Reserved (2)
+ */
+static int parse_srv6_capabilities(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	if (length != BGP_LS_SRV6_CAPABILITIES_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 Capabilities TLV wrong length (%u bytes, expected %u)",
+			  length, BGP_LS_SRV6_CAPABILITIES_SIZE);
+		return -1;
+	}
+
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
+		flog_warn(EC_BGP_UPDATE_RCV, "BGP-LS: duplicate SRv6 Capabilities TLV");
+		return -1;
+	}
+
+	attr->srv6_cap_flags = stream_getw(s);
+	stream_getw(s); /* Reserved */
+
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT);
+	return 0;
+}
+
 int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_attr *attr)
 {
 	uint16_t type, length;
@@ -4669,6 +4716,12 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 
 		case BGP_LS_ATTR_PREFIX_SID:
 			if (parse_prefix_sid(s, length, attr) < 0)
+				return -1;
+			break;
+
+		/* SRv6 TLVs (RFC 9514) */
+		case BGP_LS_ATTR_SRV6_CAPABILITIES:
+			if (parse_srv6_capabilities(s, length, attr) < 0)
 				return -1;
 			break;
 
@@ -4882,6 +4935,14 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 		json_object_int_add(jpref, "sid", ls_attr->prefix_sid.sid);
 		json_object_string_addf(jpref, "flags", "0x%x", ls_attr->prefix_sid.sid_flag);
 		json_object_int_add(jpref, "algo", ls_attr->prefix_sid.algo);
+	}
+
+	/* SRv6 Capabilities (TLV 1038) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
+		json_object *jcap = json_object_new_object();
+
+		json_object_string_addf(jcap, "flags", "0x%x", ls_attr->srv6_cap_flags);
+		json_object_object_add(json_ls_attr, "srv6Capabilities", jcap);
 	}
 
 	return json_ls_attr;
@@ -5113,7 +5174,14 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 			       ls_attr->prefix_sid.sid_flag, ls_attr->prefix_sid.algo);
 	}
 
+	/* SRv6 Capabilities (TLV 1038) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
+		CHECK_WRAP();
+		col += vty_out(vty, "SRv6 Capabilities: 0x%x", ls_attr->srv6_cap_flags);
+	}
+
 	(void)col; /* Don't complain about last 'col +=' */
+
 #undef CHECK_WRAP
 #undef COL_WIDTH
 #undef INIT_INDENT

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -491,6 +491,18 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 		}
 	}
 
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT)) {
+		if (attr1->srv6_lan_endx_sid_count != attr2->srv6_lan_endx_sid_count)
+			return numcmp(attr1->srv6_lan_endx_sid_count,
+				      attr2->srv6_lan_endx_sid_count);
+		for (uint16_t i = 0; i < attr1->srv6_lan_endx_sid_count; i++) {
+			ret = memcmp(&attr1->srv6_lan_endx_sid[i], &attr2->srv6_lan_endx_sid[i],
+				     sizeof(attr1->srv6_lan_endx_sid[i]));
+			if (ret != 0)
+				return ret;
+		}
+	}
+
 	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
 		ret = memcmp(&attr1->srv6_sid_structure, &attr2->srv6_sid_structure,
 			     sizeof(attr1->srv6_sid_structure));
@@ -576,6 +588,7 @@ void bgp_ls_attr_free(struct bgp_ls_attr *attr)
 	XFREE(MTYPE_BGP_LS_ATTR, attr->extended_tags);
 	XFREE(MTYPE_BGP_LS_ATTR, attr->opaque_data);
 	XFREE(MTYPE_BGP_LS_ATTR, attr->srv6_endx_sid);
+	XFREE(MTYPE_BGP_LS_ATTR, attr->srv6_lan_endx_sid);
 
 	XFREE(MTYPE_BGP_LS_ATTR, attr);
 }
@@ -694,6 +707,13 @@ struct bgp_ls_attr *bgp_ls_attr_copy(const struct bgp_ls_attr *src)
 
 		dst->srv6_endx_sid = XCALLOC(MTYPE_BGP_LS_ATTR, endx_sid_size);
 		memcpy(dst->srv6_endx_sid, src->srv6_endx_sid, endx_sid_size);
+	}
+
+	if (src->srv6_lan_endx_sid) {
+		size_t sz = src->srv6_lan_endx_sid_count * sizeof(*src->srv6_lan_endx_sid);
+
+		dst->srv6_lan_endx_sid = XCALLOC(MTYPE_BGP_LS_ATTR, sz);
+		memcpy(dst->srv6_lan_endx_sid, src->srv6_lan_endx_sid, sz);
 	}
 
 	return dst;
@@ -2579,6 +2599,47 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 				stream_putc(s, endx->structure.ln_len);
 				stream_putc(s, endx->structure.fun_len);
 				stream_putc(s, endx->structure.arg_len);
+			}
+		}
+	}
+
+	/* SRv6 LAN End.X SID (TLV 1107 IS-IS / TLV 1108 OSPFv3) */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT)) {
+		for (uint16_t i = 0; i < attr->srv6_lan_endx_sid_count; i++) {
+			const struct bgp_ls_srv6_lan_endx_sid *lan_endx =
+				&attr->srv6_lan_endx_sid[i];
+			uint16_t sub_len = lan_endx->has_structure
+						   ? BGP_LS_TLV_HDR_SIZE +
+							     BGP_LS_SRV6_SID_STRUCTURE_SIZE
+						   : 0;
+			uint16_t min_size = lan_endx->is_isis
+						    ? BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE
+						    : BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE;
+			uint16_t tlv_len = min_size + sub_len;
+
+			if (STREAM_WRITEABLE(s) < (size_t)(BGP_LS_TLV_HDR_SIZE + tlv_len))
+				return -1;
+
+			stream_putw(s, lan_endx->is_isis ? BGP_LS_ATTR_SRV6_LAN_ENDX_SID_ISIS
+							 : BGP_LS_ATTR_SRV6_LAN_ENDX_SID_OSPF);
+			stream_putw(s, tlv_len);
+			stream_putw(s, lan_endx->endpoint_behavior);
+			stream_putc(s, lan_endx->flags);
+			stream_putc(s, lan_endx->algo);
+			stream_putc(s, lan_endx->weight);
+			stream_putc(s, 0); /* Reserved */
+			if (lan_endx->is_isis)
+				stream_put(s, lan_endx->neighbor.sysid, 6);
+			else
+				stream_putl(s, lan_endx->neighbor.router_id.s_addr);
+			stream_put(s, &lan_endx->sid, IPV6_MAX_BYTELEN);
+			if (lan_endx->has_structure) {
+				stream_putw(s, BGP_LS_ATTR_SRV6_SID_STRUCTURE);
+				stream_putw(s, BGP_LS_SRV6_SID_STRUCTURE_SIZE);
+				stream_putc(s, lan_endx->structure.lb_len);
+				stream_putc(s, lan_endx->structure.ln_len);
+				stream_putc(s, lan_endx->structure.fun_len);
+				stream_putc(s, lan_endx->structure.arg_len);
 			}
 		}
 	}
@@ -4747,6 +4808,102 @@ static int parse_srv6_endx_sid(struct stream *s, uint16_t length, struct bgp_ls_
 	return 0;
 }
 
+/*
+ * Parse IS-IS SRv6 LAN End.X SID TLV (Type 1107, RFC 9514 Section 4.2)
+ * Format: Endpoint Behavior (2) + Flags (1) + Algorithm (1) + Weight (1)
+ *         + Reserved (1) + IS-IS Neighbor System-ID (6) + SID (16) + Sub-TLVs
+ */
+static int parse_isis_srv6_lan_endx_sid(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	struct bgp_ls_srv6_lan_endx_sid *entry;
+
+	if (length < BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: IS-IS SRv6 LAN End.X SID TLV too short (%u, need %u)", length,
+			  BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE);
+		return -1;
+	}
+	if (attr->srv6_lan_endx_sid_count >= BGP_LS_MAX_SRV6_SIDS) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: IS-IS SRv6 LAN End.X SID count exceeds max (%u), ignoring TLV",
+			  BGP_LS_MAX_SRV6_SIDS);
+		stream_forward_getp(s, length);
+		return 0;
+	}
+	attr->srv6_lan_endx_sid =
+		XREALLOC(MTYPE_BGP_LS_ATTR, attr->srv6_lan_endx_sid,
+			 (attr->srv6_lan_endx_sid_count + 1) * sizeof(*attr->srv6_lan_endx_sid));
+	entry = &attr->srv6_lan_endx_sid[attr->srv6_lan_endx_sid_count];
+	memset(entry, 0, sizeof(*entry));
+	entry->is_isis = true;
+	entry->endpoint_behavior = stream_getw(s);
+	entry->flags = stream_getc(s);
+	entry->algo = stream_getc(s);
+	entry->weight = stream_getc(s);
+	stream_getc(s);				 /* Reserved */
+	stream_get(entry->neighbor.sysid, s, 6); /* IS-IS System-ID */
+	stream_get(&entry->sid, s, IPV6_MAX_BYTELEN);
+
+	if (length > BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE) {
+		uint16_t sub_total = length - BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE;
+
+		if (parse_endx_sub_tlvs(s, sub_total, &entry->has_structure, &entry->structure) < 0)
+			return -1;
+	}
+
+	attr->srv6_lan_endx_sid_count++;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
+	return 0;
+}
+
+/*
+ * Parse OSPFv3 SRv6 LAN End.X SID TLV (Type 1108, RFC 9514 Section 4.2)
+ * Format: Endpoint Behavior (2) + Flags (1) + Algorithm (1) + Weight (1)
+ *         + Reserved (1) + OSPFv3 Router-ID (4) + SID (16) + Sub-TLVs
+ */
+static int parse_ospf_srv6_lan_endx_sid(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	struct bgp_ls_srv6_lan_endx_sid *entry;
+
+	if (length < BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: OSPFv3 SRv6 LAN End.X SID TLV too short (%u, need %u)", length,
+			  BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE);
+		return -1;
+	}
+	if (attr->srv6_lan_endx_sid_count >= BGP_LS_MAX_SRV6_SIDS) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: OSPFv3 SRv6 LAN End.X SID count exceeds max (%u), ignoring TLV",
+			  BGP_LS_MAX_SRV6_SIDS);
+		stream_forward_getp(s, length);
+		return 0;
+	}
+	attr->srv6_lan_endx_sid =
+		XREALLOC(MTYPE_BGP_LS_ATTR, attr->srv6_lan_endx_sid,
+			 (attr->srv6_lan_endx_sid_count + 1) * sizeof(*attr->srv6_lan_endx_sid));
+	entry = &attr->srv6_lan_endx_sid[attr->srv6_lan_endx_sid_count];
+	memset(entry, 0, sizeof(*entry));
+	entry->is_isis = false;
+	entry->endpoint_behavior = stream_getw(s);
+	entry->flags = stream_getc(s);
+	entry->algo = stream_getc(s);
+	entry->weight = stream_getc(s);
+	stream_getc(s);					   /* Reserved */
+	entry->neighbor.router_id.s_addr = stream_getl(s); /* OSPFv3 Router-ID */
+	stream_get(&entry->sid, s, IPV6_MAX_BYTELEN);
+
+	if (length > BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE) {
+		uint16_t sub_total = length - BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE;
+
+		if (parse_endx_sub_tlvs(s, sub_total, &entry->has_structure, &entry->structure) < 0)
+			return -1;
+	}
+
+	attr->srv6_lan_endx_sid_count++;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
+	return 0;
+}
+
 int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_attr *attr)
 {
 	uint16_t type, length;
@@ -4941,6 +5098,16 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 
 		case BGP_LS_ATTR_SRV6_ENDX_SID:
 			if (parse_srv6_endx_sid(s, length, attr) < 0)
+				return -1;
+			break;
+
+		case BGP_LS_ATTR_SRV6_LAN_ENDX_SID_ISIS:
+			if (parse_isis_srv6_lan_endx_sid(s, length, attr) < 0)
+				return -1;
+			break;
+
+		case BGP_LS_ATTR_SRV6_LAN_ENDX_SID_OSPF:
+			if (parse_ospf_srv6_lan_endx_sid(s, length, attr) < 0)
 				return -1;
 			break;
 
@@ -5189,6 +5356,43 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 			json_object_array_add(jendx_arr, jendx);
 		}
 		json_object_object_add(json_ls_attr, "srv6EndxSids", jendx_arr);
+	}
+
+	/* SRv6 LAN End.X SID (TLV 1107 IS-IS / TLV 1108 OSPFv3) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT)) {
+		json_object *jlan_arr = json_object_new_array();
+
+		for (uint16_t i = 0; i < ls_attr->srv6_lan_endx_sid_count; i++) {
+			const struct bgp_ls_srv6_lan_endx_sid *e = &ls_attr->srv6_lan_endx_sid[i];
+			json_object *jlan = json_object_new_object();
+
+			json_object_string_addf(jlan, "sid", "%pI6", &e->sid);
+			json_object_string_addf(jlan, "behavior", "0x%x", e->endpoint_behavior);
+			json_object_string_addf(jlan, "flags", "0x%x", e->flags);
+			json_object_int_add(jlan, "algo", e->algo);
+			json_object_int_add(jlan, "weight", e->weight);
+			if (e->is_isis)
+				json_object_string_addf(jlan, "neighborSysId",
+							"%02x%02x.%02x%02x.%02x%02x",
+							e->neighbor.sysid[0], e->neighbor.sysid[1],
+							e->neighbor.sysid[2], e->neighbor.sysid[3],
+							e->neighbor.sysid[4], e->neighbor.sysid[5]);
+			else
+				json_object_string_addf(jlan, "neighborRouterId", "%pI4",
+							&e->neighbor.router_id);
+
+			if (e->has_structure) {
+				json_object *jss = json_object_new_object();
+
+				json_object_int_add(jss, "lbLen", e->structure.lb_len);
+				json_object_int_add(jss, "lnLen", e->structure.ln_len);
+				json_object_int_add(jss, "funLen", e->structure.fun_len);
+				json_object_int_add(jss, "argLen", e->structure.arg_len);
+				json_object_object_add(jlan, "srv6SidStructure", jss);
+			}
+			json_object_array_add(jlan_arr, jlan);
+		}
+		json_object_object_add(json_ls_attr, "srv6LanEndxSids", jlan_arr);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */
@@ -5454,6 +5658,36 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 					       "SRv6 SID Structure: LBL: %u LNL: %u FL: %u AL: %u",
 					       endx->structure.lb_len, endx->structure.ln_len,
 					       endx->structure.fun_len, endx->structure.arg_len);
+			}
+		}
+	}
+
+	/* SRv6 LAN End.X SID (TLV 1107 IS-IS / TLV 1108 OSPFv3) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT)) {
+		for (uint16_t i = 0; i < ls_attr->srv6_lan_endx_sid_count; i++) {
+			const struct bgp_ls_srv6_lan_endx_sid *e = &ls_attr->srv6_lan_endx_sid[i];
+
+			CHECK_WRAP();
+			if (e->is_isis)
+				col += vty_out(vty,
+					       "SRv6 LAN End.X SID: %pI6 Behavior 0x%x Nbr %02x%02x.%02x%02x.%02x%02x Flags: 0x%x Algo: %u Weight: %u",
+					       &e->sid, e->endpoint_behavior, e->neighbor.sysid[0],
+					       e->neighbor.sysid[1], e->neighbor.sysid[2],
+					       e->neighbor.sysid[3], e->neighbor.sysid[4],
+					       e->neighbor.sysid[5], e->flags, e->algo, e->weight);
+			else
+				col += vty_out(vty,
+					       "SRv6 LAN End.X SID: %pI6 Behavior 0x%x Nbr %pI4 Flags: 0x%x Algo: %u Weight: %u",
+					       &e->sid, e->endpoint_behavior,
+					       &e->neighbor.router_id, e->flags, e->algo,
+					       e->weight);
+
+			if (e->has_structure) {
+				CHECK_WRAP();
+				col += vty_out(vty,
+					       "SRv6 SID Structure: LBL: %u LNL: %u FL: %u AL: %u",
+					       e->structure.lb_len, e->structure.ln_len,
+					       e->structure.fun_len, e->structure.arg_len);
 			}
 		}
 	}

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -529,6 +529,15 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 			return numcmp(attr1->srv6_locator_metric, attr2->srv6_locator_metric);
 	}
 
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT)) {
+		if (attr1->srv6_endpoint_behavior != attr2->srv6_endpoint_behavior)
+			return numcmp(attr1->srv6_endpoint_behavior, attr2->srv6_endpoint_behavior);
+		if (attr1->srv6_endpoint_flags != attr2->srv6_endpoint_flags)
+			return numcmp(attr1->srv6_endpoint_flags, attr2->srv6_endpoint_flags);
+		if (attr1->srv6_endpoint_algo != attr2->srv6_endpoint_algo)
+			return numcmp(attr1->srv6_endpoint_algo, attr2->srv6_endpoint_algo);
+	}
+
 	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
 		ret = memcmp(&attr1->srv6_sid_structure, &attr2->srv6_sid_structure,
 			     sizeof(attr1->srv6_sid_structure));
@@ -2799,6 +2808,19 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		stream_putc(s, attr->srv6_locator_algo);
 		stream_putw(s, 0); /* Reserved */
 		stream_putl(s, attr->srv6_locator_metric);
+	}
+
+	/* SRv6 Endpoint Behavior (TLV 1250) */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT)) {
+		if (STREAM_WRITEABLE(s) <
+		    (size_t)(BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_ENDPOINT_BEHAVIOR_SIZE))
+			return -1;
+
+		stream_putw(s, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR);
+		stream_putw(s, BGP_LS_SRV6_ENDPOINT_BEHAVIOR_SIZE);
+		stream_putw(s, attr->srv6_endpoint_behavior);
+		stream_putc(s, attr->srv6_endpoint_flags);
+		stream_putc(s, attr->srv6_endpoint_algo);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) - top-level in SRv6 SID NLRI attributes */
@@ -5245,6 +5267,32 @@ static int parse_srv6_locator(struct stream *s, uint16_t length, struct bgp_ls_a
 	return 0;
 }
 
+/*
+ * Parse SRv6 Endpoint Behavior TLV (Type 1250, RFC 9514 Section 7.1)
+ * Format: Endpoint Behavior (2) + Flags (1) + Algorithm (1)
+ */
+static int parse_srv6_endpoint_behavior(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT)) {
+		flog_warn(EC_BGP_UPDATE_RCV, "BGP-LS: duplicate SRv6 Endpoint Behavior TLV");
+		return -1;
+	}
+
+	if (length != BGP_LS_SRV6_ENDPOINT_BEHAVIOR_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 Endpoint Behavior TLV bad length (%u bytes, expected %u)",
+			  length, BGP_LS_SRV6_ENDPOINT_BEHAVIOR_SIZE);
+		return -1;
+	}
+
+	attr->srv6_endpoint_behavior = stream_getw(s);
+	attr->srv6_endpoint_flags = stream_getc(s);
+	attr->srv6_endpoint_algo = stream_getc(s);
+
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT);
+	return 0;
+}
+
 int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_attr *attr)
 {
 	uint16_t type, length;
@@ -5454,6 +5502,11 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 
 		case BGP_LS_ATTR_SRV6_LOCATOR:
 			if (parse_srv6_locator(s, length, attr) < 0)
+				return -1;
+			break;
+
+		case BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR:
+			if (parse_srv6_endpoint_behavior(s, length, attr) < 0)
 				return -1;
 			break;
 
@@ -5749,6 +5802,16 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 		json_object_int_add(jloc, "algo", ls_attr->srv6_locator_algo);
 		json_object_int_add(jloc, "metric", ls_attr->srv6_locator_metric);
 		json_object_object_add(json_ls_attr, "srv6Locator", jloc);
+	}
+
+	/* SRv6 Endpoint Behavior (TLV 1250) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT)) {
+		json_object *jep = json_object_new_object();
+
+		json_object_string_addf(jep, "behavior", "0x%x", ls_attr->srv6_endpoint_behavior);
+		json_object_string_addf(jep, "flags", "0x%x", ls_attr->srv6_endpoint_flags);
+		json_object_int_add(jep, "algo", ls_attr->srv6_endpoint_algo);
+		json_object_object_add(json_ls_attr, "srv6EndpointBehavior", jep);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */
@@ -6054,6 +6117,14 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 		col += vty_out(vty, "SRv6 Locator Metric: %u Flags: 0x%x Algo: %u",
 			       ls_attr->srv6_locator_metric, ls_attr->srv6_locator_flags,
 			       ls_attr->srv6_locator_algo);
+	}
+
+	/* SRv6 Endpoint Behavior (TLV 1250) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT)) {
+		CHECK_WRAP();
+		col += vty_out(vty, "SRv6 Endpoint Behavior: 0x%x Flags: 0x%x Algo: %u",
+			       ls_attr->srv6_endpoint_behavior, ls_attr->srv6_endpoint_flags,
+			       ls_attr->srv6_endpoint_algo);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -480,6 +480,17 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 			return numcmp(attr1->srv6_cap_flags, attr2->srv6_cap_flags);
 	}
 
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT)) {
+		if (attr1->srv6_endx_sid_count != attr2->srv6_endx_sid_count)
+			return numcmp(attr1->srv6_endx_sid_count, attr2->srv6_endx_sid_count);
+		for (uint16_t i = 0; i < attr1->srv6_endx_sid_count; i++) {
+			ret = memcmp(&attr1->srv6_endx_sid[i], &attr2->srv6_endx_sid[i],
+				     sizeof(attr1->srv6_endx_sid[i]));
+			if (ret != 0)
+				return ret;
+		}
+	}
+
 	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT)) {
 		ret = memcmp(&attr1->srv6_sid_structure, &attr2->srv6_sid_structure,
 			     sizeof(attr1->srv6_sid_structure));
@@ -564,6 +575,7 @@ void bgp_ls_attr_free(struct bgp_ls_attr *attr)
 	XFREE(MTYPE_BGP_LS_ATTR, attr->route_tags);
 	XFREE(MTYPE_BGP_LS_ATTR, attr->extended_tags);
 	XFREE(MTYPE_BGP_LS_ATTR, attr->opaque_data);
+	XFREE(MTYPE_BGP_LS_ATTR, attr->srv6_endx_sid);
 
 	XFREE(MTYPE_BGP_LS_ATTR, attr);
 }
@@ -675,6 +687,13 @@ struct bgp_ls_attr *bgp_ls_attr_copy(const struct bgp_ls_attr *src)
 	if (src->opaque_data) {
 		dst->opaque_data = XCALLOC(MTYPE_BGP_LS_ATTR, src->opaque_len);
 		memcpy(dst->opaque_data, src->opaque_data, src->opaque_len);
+	}
+
+	if (src->srv6_endx_sid) {
+		size_t endx_sid_size = src->srv6_endx_sid_count * sizeof(*src->srv6_endx_sid);
+
+		dst->srv6_endx_sid = XCALLOC(MTYPE_BGP_LS_ATTR, endx_sid_size);
+		memcpy(dst->srv6_endx_sid, src->srv6_endx_sid, endx_sid_size);
 	}
 
 	return dst;
@@ -2529,6 +2548,39 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		stream_putw(s, BGP_LS_SRV6_CAPABILITIES_SIZE);
 		stream_putw(s, attr->srv6_cap_flags);
 		stream_putw(s, 0); /* Reserved */
+	}
+
+	/* SRv6 End.X SID (TLV 1106) */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT)) {
+		for (uint16_t i = 0; i < attr->srv6_endx_sid_count; i++) {
+			const struct bgp_ls_srv6_endx_sid *endx = &attr->srv6_endx_sid[i];
+			uint16_t sub_len = endx->has_structure
+						   ? BGP_LS_TLV_HDR_SIZE +
+							     BGP_LS_SRV6_SID_STRUCTURE_SIZE
+						   : 0;
+			uint16_t tlv_len = BGP_LS_SRV6_ENDX_SID_MIN_SIZE + sub_len;
+
+			if (STREAM_WRITEABLE(s) < (size_t)(BGP_LS_TLV_HDR_SIZE + tlv_len))
+				return -1;
+
+			stream_putw(s, BGP_LS_ATTR_SRV6_ENDX_SID);
+			stream_putw(s, tlv_len);
+			stream_putw(s, endx->endpoint_behavior);
+			stream_putc(s, endx->flags);
+			stream_putc(s, endx->algo);
+			stream_putc(s, endx->weight);
+			stream_putc(s, 0); /* Reserved */
+			stream_put(s, &endx->sid, IPV6_MAX_BYTELEN);
+
+			if (endx->has_structure) {
+				stream_putw(s, BGP_LS_ATTR_SRV6_SID_STRUCTURE);
+				stream_putw(s, BGP_LS_SRV6_SID_STRUCTURE_SIZE);
+				stream_putc(s, endx->structure.lb_len);
+				stream_putc(s, endx->structure.ln_len);
+				stream_putc(s, endx->structure.fun_len);
+				stream_putc(s, endx->structure.arg_len);
+			}
+		}
 	}
 
 	/* SRv6 SID Structure (TLV 1252) - top-level in SRv6 SID NLRI attributes */
@@ -4607,6 +4659,94 @@ static int parse_srv6_sid_structure(struct stream *s, uint16_t length, struct bg
 	return 0;
 }
 
+/*
+ * Parse sub-TLVs inside an SRv6 End.X SID / LAN End.X SID TLV.
+ * Currently only SRv6 SID Structure sub-TLV (1252) is defined.
+ * Updates *has_structure and *ss on success.
+ */
+static int parse_endx_sub_tlvs(struct stream *s, uint16_t sub_total, bool *has_structure,
+			       struct bgp_ls_srv6_sid_structure *ss)
+{
+	uint16_t type, len;
+
+	while (sub_total >= BGP_LS_TLV_HDR_SIZE) {
+		if (stream_get_tlv_hdr(s, &type, &len) < 0)
+			return -1;
+		sub_total -= BGP_LS_TLV_HDR_SIZE;
+
+		if (len > sub_total) {
+			flog_warn(EC_BGP_UPDATE_RCV,
+				  "BGP-LS: SRv6 End.X sub-TLV %u length %u exceeds remaining",
+				  type, len);
+			return -1;
+		}
+
+		if (type == BGP_LS_ATTR_SRV6_SID_STRUCTURE) {
+			if (*has_structure) {
+				flog_warn(EC_BGP_UPDATE_RCV,
+					  "BGP-LS: duplicate SRv6 SID Structure sub-TLV in End.X SID");
+				return -1;
+			}
+			if (parse_srv6_sid_structure_subtlv(s, len, ss) < 0)
+				return -1;
+			*has_structure = true;
+		} else {
+			/* Unknown sub-TLV — skip and continue (RFC 9514 Section 3) */
+			stream_forward_getp(s, len);
+		}
+		sub_total -= len;
+	}
+
+	return 0;
+}
+
+/*
+ * Parse SRv6 End.X SID TLV (Type 1106, RFC 9514 Section 4.1)
+ * Format: Endpoint Behavior (2) + Flags (1) + Algorithm (1) + Weight (1)
+ *         + Reserved (1) + SID (16) + Sub-TLVs (variable)
+ */
+static int parse_srv6_endx_sid(struct stream *s, uint16_t length, struct bgp_ls_attr *attr)
+{
+	struct bgp_ls_srv6_endx_sid *entry;
+
+	if (length < BGP_LS_SRV6_ENDX_SID_MIN_SIZE) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 End.X SID TLV too short (%u bytes, need %u)", length,
+			  BGP_LS_SRV6_ENDX_SID_MIN_SIZE);
+		return -1;
+	}
+	if (attr->srv6_endx_sid_count >= BGP_LS_MAX_SRV6_SIDS) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: SRv6 End.X SID count exceeds max (%u), ignoring TLV",
+			  BGP_LS_MAX_SRV6_SIDS);
+		stream_forward_getp(s, length);
+		return 0;
+	}
+	attr->srv6_endx_sid =
+		XREALLOC(MTYPE_BGP_LS_ATTR, attr->srv6_endx_sid,
+			 (attr->srv6_endx_sid_count + 1) * sizeof(*attr->srv6_endx_sid));
+	entry = &attr->srv6_endx_sid[attr->srv6_endx_sid_count];
+	memset(entry, 0, sizeof(*entry));
+	entry->endpoint_behavior = stream_getw(s);
+	entry->flags = stream_getc(s);
+	entry->algo = stream_getc(s);
+	entry->weight = stream_getc(s);
+	stream_getc(s); /* Reserved */
+	stream_get(&entry->sid, s, IPV6_MAX_BYTELEN);
+
+	/* Sub-TLVs */
+	if (length > BGP_LS_SRV6_ENDX_SID_MIN_SIZE) {
+		uint16_t sub_total = length - BGP_LS_SRV6_ENDX_SID_MIN_SIZE;
+
+		if (parse_endx_sub_tlvs(s, sub_total, &entry->has_structure, &entry->structure) < 0)
+			return -1;
+	}
+
+	attr->srv6_endx_sid_count++;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT);
+	return 0;
+}
+
 int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_attr *attr)
 {
 	uint16_t type, length;
@@ -4796,6 +4936,11 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 
 		case BGP_LS_ATTR_SRV6_SID_STRUCTURE:
 			if (parse_srv6_sid_structure(s, length, attr) < 0)
+				return -1;
+			break;
+
+		case BGP_LS_ATTR_SRV6_ENDX_SID:
+			if (parse_srv6_endx_sid(s, length, attr) < 0)
 				return -1;
 			break;
 
@@ -5017,6 +5162,33 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 
 		json_object_string_addf(jcap, "flags", "0x%x", ls_attr->srv6_cap_flags);
 		json_object_object_add(json_ls_attr, "srv6Capabilities", jcap);
+	}
+
+	/* SRv6 End.X SID (TLV 1106) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT)) {
+		json_object *jendx_arr = json_object_new_array();
+
+		for (uint16_t i = 0; i < ls_attr->srv6_endx_sid_count; i++) {
+			const struct bgp_ls_srv6_endx_sid *endx = &ls_attr->srv6_endx_sid[i];
+			json_object *jendx = json_object_new_object();
+
+			json_object_string_addf(jendx, "sid", "%pI6", &endx->sid);
+			json_object_string_addf(jendx, "behavior", "0x%x", endx->endpoint_behavior);
+			json_object_string_addf(jendx, "flags", "0x%x", endx->flags);
+			json_object_int_add(jendx, "algo", endx->algo);
+			json_object_int_add(jendx, "weight", endx->weight);
+			if (endx->has_structure) {
+				json_object *jss = json_object_new_object();
+
+				json_object_int_add(jss, "lbLen", endx->structure.lb_len);
+				json_object_int_add(jss, "lnLen", endx->structure.ln_len);
+				json_object_int_add(jss, "funLen", endx->structure.fun_len);
+				json_object_int_add(jss, "argLen", endx->structure.arg_len);
+				json_object_object_add(jendx, "srv6SidStructure", jss);
+			}
+			json_object_array_add(jendx_arr, jendx);
+		}
+		json_object_object_add(json_ls_attr, "srv6EndxSids", jendx_arr);
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */
@@ -5263,6 +5435,27 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT)) {
 		CHECK_WRAP();
 		col += vty_out(vty, "SRv6 Capabilities: 0x%x", ls_attr->srv6_cap_flags);
+	}
+
+	/* SRv6 End.X SID (TLV 1106) */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT)) {
+		for (uint16_t i = 0; i < ls_attr->srv6_endx_sid_count; i++) {
+			const struct bgp_ls_srv6_endx_sid *endx = &ls_attr->srv6_endx_sid[i];
+
+			CHECK_WRAP();
+			col += vty_out(vty,
+				       "SRv6 End.X SID: %pI6 Behavior: 0x%x Flags: 0x%x Algo: %u Weight: %u",
+				       &endx->sid, endx->endpoint_behavior, endx->flags,
+				       endx->algo, endx->weight);
+
+			if (endx->has_structure) {
+				CHECK_WRAP();
+				col += vty_out(vty,
+					       "SRv6 SID Structure: LBL: %u LNL: %u FL: %u AL: %u",
+					       endx->structure.lb_len, endx->structure.ln_len,
+					       endx->structure.fun_len, endx->structure.arg_len);
+			}
+		}
 	}
 
 	/* SRv6 SID Structure (TLV 1252) */

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -135,6 +135,21 @@ struct bgp_ls_srv6_sid_structure {
 };
 
 /*
+ * SRv6 End.X SID entry (RFC 9514, Section 4.1, Type 1106)
+ * Multiple instances may appear in the BGP-LS Attribute of a Link NLRI.
+ */
+/* SRv6 End.X SID (TLV 1106, RFC 9514 Section 4.1) - point-to-point adjacency */
+struct bgp_ls_srv6_endx_sid {
+	uint16_t endpoint_behavior; /* Endpoint Behavior code point (RFC 8986) */
+	uint8_t flags;		    /* Flags (B/S/P for BGP EPE, or from IS-IS/OSPFv3) */
+	uint8_t algo;		    /* Algorithm */
+	uint8_t weight;		    /* Weight for load balancing */
+	struct in6_addr sid;	    /* 128-bit SRv6 SID */
+	bool has_structure;	    /* SID Structure sub-TLV present */
+	struct bgp_ls_srv6_sid_structure structure; /* SID Structure sub-TLV */
+};
+
+/*
  * BGP-LS Attribute TLV Types
  * IANA: https://www.iana.org/assignments/bgp-ls-parameters/bgp-ls-parameters.xhtml#node-descriptor-link-descriptor-prefix-descriptor-attribute-tlv
  */
@@ -179,6 +194,10 @@ enum bgp_ls_attr_tlv {
 	BGP_LS_ATTR_PEER_ADJ_SID = 1102,	      /* PeerAdj SID */
 	BGP_LS_ATTR_PEER_SET_SID = 1103,	      /* PeerSet SID */
 	BGP_LS_ATTR_LINK_MSD = 1104,		      /* Link MSD */
+
+	/* Link Attribute TLVs (RFC 9514 Section 4) */
+	BGP_LS_ATTR_SRV6_ENDX_SID = 1106,	      /* SRv6 End.X SID */
+
 	BGP_LS_ATTR_UNIDIRECTIONAL_LINK_DELAY = 1114, /* Unidirectional Link Delay */
 	BGP_LS_ATTR_MIN_MAX_UNIDIRECTIONAL_LINK_DELAY = 1115, /* Min/Max Unidirectional Link Delay */
 	BGP_LS_ATTR_UNIDIRECTIONAL_DELAY_VARIATION = 1116,    /* Unidirectional Delay Variation */
@@ -290,6 +309,7 @@ enum bgp_ls_attr_tlv {
  */
 #define BGP_LS_SRV6_CAPABILITIES_SIZE 4 /* Flags (2) + Reserved (2) */
 #define BGP_LS_SRV6_SID_STRUCTURE_SIZE		4  /* LB Length (1) + LN Length (1) + Fun Length (1) + Arg Length (1) */
+#define BGP_LS_SRV6_ENDX_SID_MIN_SIZE		  22 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) */
 
 /*
  * Maximum values for arrays
@@ -300,6 +320,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_MAX_EXT_ADMIN_GROUPS 256 /* Maximum number of admin groups in Extended Admin Group TLV */
 #define BGP_LS_MAX_NODE_NAME_LEN 255	/* Maximum node name length */
 #define BGP_LS_MAX_LINK_NAME_LEN 255	/* Maximum link name length */
+#define BGP_LS_MAX_SRV6_SIDS	 256	/* Maximum SRv6 SIDs per TLV type */
 
 /*
  * Bit positions for attribute presence bitmasks
@@ -346,6 +367,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_ATTR_SRV6_LOCATOR_BIT           (1ULL << 39)
 /* SRv6 attribute bits (RFC 9514) */
 #define BGP_LS_ATTR_SRV6_CAPABILITIES_BIT      (1ULL << 40)
+#define BGP_LS_ATTR_SRV6_ENDX_SID_BIT	       (1ULL << 41)
 #define BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT     (1ULL << 44)
 
 /*
@@ -684,6 +706,10 @@ struct bgp_ls_attr {
 
 	/* SRv6 SID Structure (TLV 1252, RFC 9514 Section 8) */
 	struct bgp_ls_srv6_sid_structure srv6_sid_structure;
+
+	/* SRv6 End.X SID (TLV 1106, RFC 9514 Section 4.1) */
+	uint16_t srv6_endx_sid_count;
+	struct bgp_ls_srv6_endx_sid *srv6_endx_sid;
 
 	unsigned long refcnt; /* Reference count */
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -251,6 +251,7 @@ enum bgp_ls_attr_tlv {
 	BGP_LS_ATTR_SRV6_LOCATOR = 1162,       /* SRv6 Locator - RFC 9514, Section 5.1 */
 
 	/* SRv6 SID Attribute TLVs (RFC 9514 Section 7.1) */
+	BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR = 1250,  /* SRv6 Endpoint Behavior */
 	BGP_LS_ATTR_SRV6_SID_STRUCTURE = 1252,	     /* SRv6 SID Structure */
 };
 
@@ -343,6 +344,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE	  28 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Sys-ID (6) */
 #define BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE	  26 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Router-ID (4) */
 #define BGP_LS_SRV6_LOCATOR_MIN_SIZE		8  /* Flags (1) + Algo (1) + Reserved (2) + Metric (4) */
+#define BGP_LS_SRV6_ENDPOINT_BEHAVIOR_SIZE	4  /* Behavior (2) + Flags (1) + Algo (1) */
 #define BGP_LS_SRV6_SID_INFO_SIZE		16 /* 128-bit SRv6 SID */
 
 /*
@@ -403,6 +405,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_ATTR_SRV6_CAPABILITIES_BIT      (1ULL << 40)
 #define BGP_LS_ATTR_SRV6_ENDX_SID_BIT	       (1ULL << 41)
 #define BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT      (1ULL << 42)
+#define BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT (1ULL << 43)
 #define BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT     (1ULL << 44)
 
 /*
@@ -789,6 +792,11 @@ struct bgp_ls_attr {
 	uint8_t srv6_locator_flags;
 	uint8_t srv6_locator_algo;
 	uint32_t srv6_locator_metric;
+
+	/* SRv6 Endpoint Behavior (TLV 1250, RFC 9514 Section 7.1) */
+	uint16_t srv6_endpoint_behavior;
+	uint8_t srv6_endpoint_flags;
+	uint8_t srv6_endpoint_algo;
 
 	unsigned long refcnt; /* Reference count */
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -132,6 +132,9 @@ enum bgp_ls_attr_tlv {
 	BGP_LS_ATTR_SR_LOCAL_BLOCK = 1036,  /* SR Local Block */
 	BGP_LS_ATTR_SRMS_PREFERENCE = 1037, /* SRMS Preference */
 
+	/* Node Attribute TLVs (RFC 9514 Section 3.1) */
+	BGP_LS_ATTR_SRV6_CAPABILITIES = 1038, /* SRv6 Capabilities */
+
 	/* Node Attribute TLVs (RFC 8814) */
 	BGP_LS_ATTR_NODE_MSD = 266,         /* Node MSD */
 
@@ -261,6 +264,11 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_IGP_MSD_TYPE_BASE_MPLS 1
 
 /*
+ * SRv6 TLV fixed payload sizes (RFC 9514)
+ */
+#define BGP_LS_SRV6_CAPABILITIES_SIZE 4 /* Flags (2) + Reserved (2) */
+
+/*
  * Maximum values for arrays
  */
 #define BGP_LS_MAX_SRLG	      64 /* Maximum SRLGs per link */
@@ -313,6 +321,8 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_ATTR_RANGE_BIT                  (1ULL << 37)
 #define BGP_LS_ATTR_SID_LABEL_BIT              (1ULL << 38)
 #define BGP_LS_ATTR_SRV6_LOCATOR_BIT           (1ULL << 39)
+/* SRv6 attribute bits (RFC 9514) */
+#define BGP_LS_ATTR_SRV6_CAPABILITIES_BIT      (1ULL << 40)
 
 /*
  * Node Flag Bits (TLV 1024)
@@ -644,6 +654,9 @@ struct bgp_ls_attr {
 	/* Opaque Node Attribute (TLV 1025/1097/1157) */
 	uint16_t opaque_len;
 	uint8_t *opaque_data;
+
+	/* SRv6 Capabilities (TLV 1038, RFC 9514 Section 3.1) */
+	uint16_t srv6_cap_flags; /* SRv6 capability flags */
 
 	unsigned long refcnt; /* Reference count */
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -7,6 +7,9 @@
 #ifndef _FRR_BGP_LS_NLRI_H
 #define _FRR_BGP_LS_NLRI_H
 
+#define UNKNOWN LS_UNKNOWN
+#include "link_state.h"
+#undef UNKNOWN
 #include "prefix.h"
 #include "bgpd/bgpd.h"
 
@@ -149,6 +152,22 @@ struct bgp_ls_srv6_endx_sid {
 	struct bgp_ls_srv6_sid_structure structure; /* SID Structure sub-TLV */
 };
 
+/* SRv6 LAN End.X SID (TLV 1107 IS-IS / TLV 1108 OSPFv3, RFC 9514 Section 4.2) - LAN adjacency */
+struct bgp_ls_srv6_lan_endx_sid {
+	uint16_t endpoint_behavior; /* Endpoint Behavior code point (RFC 8986) */
+	uint8_t flags;		    /* Flags */
+	uint8_t algo;		    /* Algorithm */
+	uint8_t weight;		    /* Weight for load balancing */
+	bool is_isis;		    /* true = IS-IS (TLV 1107), false = OSPFv3 (TLV 1108) */
+	struct in6_addr sid;	    /* 128-bit SRv6 SID */
+	union {
+		uint8_t sysid[ISO_SYS_ID_LEN]; /* IS-IS Neighbor System ID (TLV 1107) */
+		struct in_addr router_id;      /* OSPFv3 Neighbor Router-ID (TLV 1108) */
+	} neighbor;
+	bool has_structure;	    /* SID Structure sub-TLV present */
+	struct bgp_ls_srv6_sid_structure structure; /* SID Structure sub-TLV */
+};
+
 /*
  * BGP-LS Attribute TLV Types
  * IANA: https://www.iana.org/assignments/bgp-ls-parameters/bgp-ls-parameters.xhtml#node-descriptor-link-descriptor-prefix-descriptor-attribute-tlv
@@ -197,6 +216,8 @@ enum bgp_ls_attr_tlv {
 
 	/* Link Attribute TLVs (RFC 9514 Section 4) */
 	BGP_LS_ATTR_SRV6_ENDX_SID = 1106,	      /* SRv6 End.X SID */
+	BGP_LS_ATTR_SRV6_LAN_ENDX_SID_ISIS = 1107,   /* SRv6 LAN End.X SID (IS-IS) */
+	BGP_LS_ATTR_SRV6_LAN_ENDX_SID_OSPF = 1108,   /* SRv6 LAN End.X SID (OSPFv3) */
 
 	BGP_LS_ATTR_UNIDIRECTIONAL_LINK_DELAY = 1114, /* Unidirectional Link Delay */
 	BGP_LS_ATTR_MIN_MAX_UNIDIRECTIONAL_LINK_DELAY = 1115, /* Min/Max Unidirectional Link Delay */
@@ -310,6 +331,8 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_SRV6_CAPABILITIES_SIZE 4 /* Flags (2) + Reserved (2) */
 #define BGP_LS_SRV6_SID_STRUCTURE_SIZE		4  /* LB Length (1) + LN Length (1) + Fun Length (1) + Arg Length (1) */
 #define BGP_LS_SRV6_ENDX_SID_MIN_SIZE		  22 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) */
+#define BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE	  28 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Sys-ID (6) */
+#define BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE	  26 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Router-ID (4) */
 
 /*
  * Maximum values for arrays
@@ -368,6 +391,7 @@ enum bgp_ls_attr_tlv {
 /* SRv6 attribute bits (RFC 9514) */
 #define BGP_LS_ATTR_SRV6_CAPABILITIES_BIT      (1ULL << 40)
 #define BGP_LS_ATTR_SRV6_ENDX_SID_BIT	       (1ULL << 41)
+#define BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT      (1ULL << 42)
 #define BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT     (1ULL << 44)
 
 /*
@@ -710,6 +734,10 @@ struct bgp_ls_attr {
 	/* SRv6 End.X SID (TLV 1106, RFC 9514 Section 4.1) */
 	uint16_t srv6_endx_sid_count;
 	struct bgp_ls_srv6_endx_sid *srv6_endx_sid;
+
+	/* SRv6 LAN End.X SID (TLV 1107/1108, RFC 9514 Section 4.2) */
+	uint16_t srv6_lan_endx_sid_count;
+	struct bgp_ls_srv6_lan_endx_sid *srv6_lan_endx_sid;
 
 	unsigned long refcnt; /* Reference count */
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -115,6 +115,25 @@ enum bgp_ls_bgp_route_type {
 	BGP_LS_BGP_RT_REDISTRIBUTED = 5, /* Prefix redistributed into BGP */
 };
 
+
+/*
+ * ===========================================================================
+ * SRv6 Structures (RFC 9514)
+ * ===========================================================================
+ */
+
+
+/*
+ * SRv6 SID Structure TLV (RFC 9514, Section 8, Type 1252)
+ * Also used as sub-TLV of SRv6 End.X SID and LAN End.X SID TLVs
+ */
+struct bgp_ls_srv6_sid_structure {
+	uint8_t lb_len;  /* Locator Block length in bits */
+	uint8_t ln_len;  /* Locator Node length in bits */
+	uint8_t fun_len; /* Function length in bits */
+	uint8_t arg_len; /* Argument length in bits */
+};
+
 /*
  * BGP-LS Attribute TLV Types
  * IANA: https://www.iana.org/assignments/bgp-ls-parameters/bgp-ls-parameters.xhtml#node-descriptor-link-descriptor-prefix-descriptor-attribute-tlv
@@ -181,6 +200,9 @@ enum bgp_ls_attr_tlv {
 	BGP_LS_ATTR_SID_LABEL = 1161,	       /* SID/Label */
 	BGP_LS_ATTR_PREFIX_ATTR_FLAGS = 1170,  /* Prefix Attribute Flags */
 	BGP_LS_ATTR_SRV6_LOCATOR = 1162,       /* SRv6 Locator */
+
+	/* SRv6 SID Attribute TLVs (RFC 9514 Section 7.1) */
+	BGP_LS_ATTR_SRV6_SID_STRUCTURE = 1252,	     /* SRv6 SID Structure */
 };
 
 /*
@@ -267,6 +289,7 @@ enum bgp_ls_attr_tlv {
  * SRv6 TLV fixed payload sizes (RFC 9514)
  */
 #define BGP_LS_SRV6_CAPABILITIES_SIZE 4 /* Flags (2) + Reserved (2) */
+#define BGP_LS_SRV6_SID_STRUCTURE_SIZE		4  /* LB Length (1) + LN Length (1) + Fun Length (1) + Arg Length (1) */
 
 /*
  * Maximum values for arrays
@@ -323,6 +346,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_ATTR_SRV6_LOCATOR_BIT           (1ULL << 39)
 /* SRv6 attribute bits (RFC 9514) */
 #define BGP_LS_ATTR_SRV6_CAPABILITIES_BIT      (1ULL << 40)
+#define BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT     (1ULL << 44)
 
 /*
  * Node Flag Bits (TLV 1024)
@@ -657,6 +681,9 @@ struct bgp_ls_attr {
 
 	/* SRv6 Capabilities (TLV 1038, RFC 9514 Section 3.1) */
 	uint16_t srv6_cap_flags; /* SRv6 capability flags */
+
+	/* SRv6 SID Structure (TLV 1252, RFC 9514 Section 8) */
+	struct bgp_ls_srv6_sid_structure srv6_sid_structure;
 
 	unsigned long refcnt; /* Reference count */
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -239,7 +239,7 @@ enum bgp_ls_attr_tlv {
 	BGP_LS_ATTR_RANGE = 1159,	       /* Range */
 	BGP_LS_ATTR_SID_LABEL = 1161,	       /* SID/Label */
 	BGP_LS_ATTR_PREFIX_ATTR_FLAGS = 1170,  /* Prefix Attribute Flags */
-	BGP_LS_ATTR_SRV6_LOCATOR = 1162,       /* SRv6 Locator */
+	BGP_LS_ATTR_SRV6_LOCATOR = 1162,       /* SRv6 Locator - RFC 9514, Section 5.1 */
 
 	/* SRv6 SID Attribute TLVs (RFC 9514 Section 7.1) */
 	BGP_LS_ATTR_SRV6_SID_STRUCTURE = 1252,	     /* SRv6 SID Structure */
@@ -333,6 +333,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_SRV6_ENDX_SID_MIN_SIZE		  22 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) */
 #define BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE	  28 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Sys-ID (6) */
 #define BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE	  26 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Router-ID (4) */
+#define BGP_LS_SRV6_LOCATOR_MIN_SIZE		8  /* Flags (1) + Algo (1) + Reserved (2) + Metric (4) */
 
 /*
  * Maximum values for arrays
@@ -738,6 +739,11 @@ struct bgp_ls_attr {
 	/* SRv6 LAN End.X SID (TLV 1107/1108, RFC 9514 Section 4.2) */
 	uint16_t srv6_lan_endx_sid_count;
 	struct bgp_ls_srv6_lan_endx_sid *srv6_lan_endx_sid;
+
+	/* SRv6 Locator attributes (TLV 1162, RFC 9514 Section 5.1) */
+	uint8_t srv6_locator_flags;
+	uint8_t srv6_locator_algo;
+	uint32_t srv6_locator_metric;
 
 	unsigned long refcnt; /* Reference count */
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -47,6 +47,7 @@ enum bgp_ls_nlri_type {
 	BGP_LS_NLRI_TYPE_LINK = 2,	  /* Link NLRI - RFC 9552 */
 	BGP_LS_NLRI_TYPE_IPV4_PREFIX = 3, /* IPv4 Topology Prefix NLRI - RFC 9552 */
 	BGP_LS_NLRI_TYPE_IPV6_PREFIX = 4, /* IPv6 Topology Prefix NLRI - RFC 9552 */
+	BGP_LS_NLRI_TYPE_SRV6_SID = 6,	  /* SRv6 SID NLRI - RFC 9514 */
 };
 
 /*
@@ -81,6 +82,14 @@ enum bgp_ls_link_descriptor_tlv {
 	BGP_LS_TLV_IPV6_NEIGH_ADDR = 262, /* IPv6 neighbor address - RFC 9552, Section 5.2.2 */
 	BGP_LS_TLV_MT_ID = 263, /* Multi-Topology Identifier - RFC 9552, Section 5.2.2.1 */
 	BGP_LS_TLV_REMOTE_AS_NUMBER = 270, /* Remote AS Number - draft-ietf-idr-bgpls-inter-as-topology-ext */
+};
+
+/*
+ * SRv6 SID Descriptor TLV Types (RFC 9514, Section 6)
+ * Used in the SRv6 SID NLRI SID Descriptors field
+ */
+enum bgp_ls_srv6_sid_descriptor_tlv {
+	BGP_LS_TLV_SRV6_SID_INFO = 518, /* SRv6 SID Information - RFC 9514, Section 6.1 */
 };
 
 /*
@@ -334,6 +343,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE	  28 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Sys-ID (6) */
 #define BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE	  26 /* Behavior (2) + Flags (1) + Algo (1) + Weight (1) + Rsvd (1) + SID (16) + Neighbor Router-ID (4) */
 #define BGP_LS_SRV6_LOCATOR_MIN_SIZE		8  /* Flags (1) + Algo (1) + Reserved (2) + Metric (4) */
+#define BGP_LS_SRV6_SID_INFO_SIZE		16 /* 128-bit SRv6 SID */
 
 /*
  * Maximum values for arrays
@@ -477,6 +487,17 @@ struct bgp_ls_prefix_descriptor {
 };
 
 /*
+ * SRv6 SID Descriptor (RFC 9514, Section 6)
+ * Identifies a specific SRv6 SID within an SRv6 SID NLRI.
+ * MUST contain exactly one SRv6 SID Information TLV (518).
+ */
+struct bgp_ls_srv6_sid_descriptor {
+	struct in6_addr sid;		      /* 128-bit SRv6 SID (from TLV 518) */
+	uint8_t mt_id_count;		      /* Number of Multi-Topology IDs */
+	uint16_t *mt_id;			      /* Multi-Topology IDs (from TLV 263) */
+};
+
+/*
  * ===========================================================================
  * BGP-LS NLRI Structures (RFC 9552 Section 5.2)
  * ===========================================================================
@@ -563,6 +584,29 @@ struct bgp_ls_prefix_nlri {
 	struct bgp_ls_prefix_descriptor prefix_desc; /* Prefix identity */
 };
 
+/*
+ * SRv6 SID NLRI (Type 6) - RFC 9514, Section 6
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+
+ * |  Protocol-ID  |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                         Identifier                            |
+ * |                          (8 octets)                           |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * //              Local Node Descriptors (variable)              //
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * //              SRv6 SID Descriptors (variable)                //
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+struct bgp_ls_srv6_sid_nlri {
+	enum bgp_ls_protocol_id protocol_id;	    /* IGP/BGP protocol */
+	uint64_t identifier;					    /* Instance identifier */
+	struct bgp_ls_node_descriptor local_node;   /* Local node descriptors */
+	struct bgp_ls_srv6_sid_descriptor sid_desc; /* SRv6 SID descriptors */
+};
+
 /* Forward declare the hash table */
 PREDECL_HASH(bgp_ls_nlri_hash);
 
@@ -594,6 +638,7 @@ struct bgp_ls_nlri {
 		struct bgp_ls_node_nlri node;	  /* Node NLRI (Type 1) */
 		struct bgp_ls_link_nlri link;	  /* Link NLRI (Type 2) */
 		struct bgp_ls_prefix_nlri prefix; /* Prefix NLRI (Type 3/4) */
+		struct bgp_ls_srv6_sid_nlri srv6_sid; /* SRv6 SID NLRI (Type 6, RFC 9514) */
 	} nlri_data;
 
 	unsigned long refcnt; /* Reference count */
@@ -915,6 +960,13 @@ extern int bgp_ls_decode_link_nlri(struct stream *s, struct bgp_ls_nlri *nlri,
 /* Decode Prefix NLRI from wire format */
 extern int bgp_ls_decode_prefix_nlri(struct stream *s, struct bgp_ls_nlri *nlri,
 				     uint16_t nlri_type, uint16_t nlri_length);
+
+/* Encode SRv6 SID NLRI to wire format (RFC 9514) */
+extern int bgp_ls_encode_srv6_sid_nlri(struct stream *s, const struct bgp_ls_srv6_sid_nlri *nlri);
+
+/* Decode SRv6 SID NLRI from wire format (RFC 9514) */
+extern int bgp_ls_decode_srv6_sid_nlri(struct stream *s, struct bgp_ls_nlri *nlri,
+				       uint16_t nlri_length);
 
 /* Decode complete NLRI */
 extern int bgp_ls_decode_nlri(struct stream *s, struct bgp_ls_nlri *nlri);

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -101,6 +101,46 @@ int bgp_ls_populate_node_attr(struct ls_node *ls_node, struct bgp_ls_attr *attr)
  */
 
 /*
+ * Fill a pre-allocated SRv6 End.X SID entry (TLV 1106) from a Link State adjacency SID
+ */
+static void bgp_ls_fill_srv6_endx_sid(struct bgp_ls_srv6_endx_sid *endx,
+				      const struct ls_srv6_adjacency *adj)
+{
+	memset(endx, 0, sizeof(*endx));
+	endx->endpoint_behavior = adj->endpoint_behavior;
+	endx->flags = adj->flags;
+	endx->weight = adj->weight;
+	IPV6_ADDR_COPY(&endx->sid, &adj->sid);
+	if (adj->has_structure) {
+		endx->has_structure = true;
+		endx->structure.lb_len = adj->lb_len;
+		endx->structure.ln_len = adj->ln_len;
+		endx->structure.fun_len = adj->fn_len;
+		endx->structure.arg_len = adj->arg_len;
+	}
+}
+
+/*
+ * Append a single SRv6 adjacency SID to the appropriate BGP-LS attribute array.
+ * A non-zero neighbor sysid identifies a LAN adjacency (TLV 1107/1108);
+ * an all-zero sysid identifies a point-to-point adjacency (TLV 1106).
+ */
+static void bgp_ls_populate_srv6_adj_sid(struct bgp_ls_attr *attr,
+					 const struct ls_srv6_adjacency *adj)
+{
+	static const uint8_t zero_sysid[ISO_SYS_ID_LEN];
+
+	if (memcmp(adj->neighbor.sysid, zero_sysid, ISO_SYS_ID_LEN) == 0) {
+		/* Point-to-point adjacency: End.X SID (TLV 1106) */
+		attr->srv6_endx_sid =
+			XREALLOC(MTYPE_BGP_LS_ATTR, attr->srv6_endx_sid,
+				 (attr->srv6_endx_sid_count + 1) * sizeof(*attr->srv6_endx_sid));
+		bgp_ls_fill_srv6_endx_sid(&attr->srv6_endx_sid[attr->srv6_endx_sid_count++], adj);
+		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT);
+	}
+}
+
+/*
  * Populate BGP-LS Attributes from Link State Attributes
  */
 int bgp_ls_populate_link_attr(struct ls_attributes *ls_attr, struct bgp_ls_attr *attr)
@@ -235,6 +275,12 @@ int bgp_ls_populate_link_attr(struct ls_attributes *ls_attr, struct bgp_ls_attr 
 		attr->utilized_bw = ls_attr->extended.used_bw;
 		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_UTILIZED_BW_BIT);
 	}
+
+	/* SRv6 End.X SID (TLV 1106) / LAN End.X SID (TLV 1107/1108, RFC 9514 Section 4) */
+	if (CHECK_FLAG(ls_attr->flags, LS_ATTR_ADJ_SRV6SID))
+		bgp_ls_populate_srv6_adj_sid(attr, &ls_attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6]);
+	if (CHECK_FLAG(ls_attr->flags, LS_ATTR_BCK_ADJ_SRV6SID))
+		bgp_ls_populate_srv6_adj_sid(attr, &ls_attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6]);
 
 	return 0;
 }

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -980,6 +980,115 @@ int bgp_ls_withdraw_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *router
 	return 0;
 }
 
+
+/*
+ * Originate SRv6 SID NLRI (Type 6, RFC 9514 Section 6) from IGP SRv6 SID data
+ *
+ * Called when an IGP prefix carrying an SRv6 SID is learned from the TED.
+ * Builds the SRv6 SID NLRI (local node + SID descriptor) and installs it
+ * in the RIB for advertisement to BGP-LS peers.
+ */
+int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_id,
+			      uint16_t router_id_len, uint32_t area_id, struct ls_subnet *subnet)
+{
+	struct bgp_ls_nlri nlri;
+	struct bgp_ls_attr *ls_attr = NULL;
+	int ret;
+
+	if (!bgp || !router_id || !subnet || !subnet->ls_pref)
+		return -1;
+
+	if (!CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_SRV6))
+		return 0;
+
+	/* Clear NLRI structure */
+	memset(&nlri, 0, sizeof(nlri));
+
+	/* Build SRv6 SID NLRI (Type 6) */
+	nlri.nlri_type = BGP_LS_NLRI_TYPE_SRV6_SID;
+	nlri.nlri_data.srv6_sid.protocol_id = protocol_id;
+	nlri.nlri_data.srv6_sid.identifier = 0;
+
+	/* Local Node Descriptor */
+	nlri.nlri_data.srv6_sid.local_node.igp_router_id_len = router_id_len;
+	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id, router_id, router_id_len);
+	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
+
+	/* Set AS Number if available */
+	if (subnet->vertex && subnet->vertex->node &&
+	    CHECK_FLAG(subnet->vertex->node->flags, LS_NODE_AS_NUMBER)) {
+		nlri.nlri_data.srv6_sid.local_node.asn = subnet->vertex->node->as_number;
+		SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
+	}
+
+	/* Set OSPF Area ID if OSPF (mirrors bgp_ls_originate_prefix). */
+	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+		nlri.nlri_data.srv6_sid.local_node.ospf_area_id = area_id;
+		SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs,
+			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
+	}
+
+	/* SRv6 SID Descriptor: SID Information (TLV 518) */
+	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
+
+	/* Install in RIB */
+	ret = bgp_ls_update(bgp, &nlri, ls_attr);
+	if (ret < 0) {
+		flog_err(EC_BGP_LS_PACKET, "BGP-LS: Failed to originate SRv6 SID NLRI");
+		bgp_ls_attr_free(ls_attr);
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Originated SRv6 SID NLRI %pI6 behavior 0x%04x",
+			   &subnet->ls_pref->srv6.sid, subnet->ls_pref->srv6.behavior);
+
+	return 0;
+}
+
+
+int bgp_ls_withdraw_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_id,
+			     uint16_t router_id_len, uint32_t area_id, struct ls_subnet *subnet)
+{
+	struct bgp_ls_nlri nlri;
+	int ret;
+
+	if (!bgp || !router_id || !subnet || !subnet->ls_pref)
+		return -1;
+
+	if (!CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_SRV6))
+		return 0;
+
+	memset(&nlri, 0, sizeof(nlri));
+
+	nlri.nlri_type = BGP_LS_NLRI_TYPE_SRV6_SID;
+	nlri.nlri_data.srv6_sid.protocol_id = protocol_id;
+	nlri.nlri_data.srv6_sid.identifier = 0;
+
+	nlri.nlri_data.srv6_sid.local_node.igp_router_id_len = router_id_len;
+	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id, router_id, router_id_len);
+	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
+
+	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+		nlri.nlri_data.srv6_sid.local_node.ospf_area_id = area_id;
+		SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs,
+			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
+	}
+
+	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
+
+	ret = bgp_ls_withdraw(bgp, &nlri);
+	if (ret < 0) {
+		flog_err(EC_BGP_LS_PACKET, "BGP-LS: Failed to withdraw SRv6 SID NLRI");
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Withdrawn SRv6 SID NLRI %pI6", &subnet->ls_pref->srv6.sid);
+
+	return 0;
+}
+
 /*
  * ===========================================================================
  * Link State Message Processing
@@ -1141,6 +1250,7 @@ int bgp_ls_process_edge(struct bgp *bgp, struct ls_edge *edge, uint8_t event)
 
 /*
  * Process Link State subnet and originate/withdraw BGP-LS Prefix NLRI
+ * and, when the prefix carries an SRv6 SID, also the SRv6 SID NLRI (Type 6).
  */
 int bgp_ls_process_subnet(struct bgp *bgp, struct ls_subnet *subnet, uint8_t event)
 {
@@ -1187,14 +1297,29 @@ int bgp_ls_process_subnet(struct bgp *bgp, struct ls_subnet *subnet, uint8_t eve
 	switch (event) {
 	case LS_MSG_EVENT_SYNC:
 	case LS_MSG_EVENT_ADD:
-	case LS_MSG_EVENT_UPDATE:
-		return bgp_ls_originate_prefix(bgp, protocol_id, router_id, router_id_len,
-					       &subnet->key, area_id, subnet);
-
-	case LS_MSG_EVENT_DELETE:
-		return bgp_ls_withdraw_prefix(bgp, protocol_id, router_id, router_id_len,
-					      &subnet->key, area_id, subnet);
-
+	case LS_MSG_EVENT_UPDATE: {
+		int ret = bgp_ls_originate_prefix(bgp, protocol_id, router_id, router_id_len,
+						  &subnet->key, area_id, subnet);
+		if (ret < 0)
+			return ret;
+		/* Also originate SRv6 SID NLRI for prefixes carrying an SRv6 SID */
+		if (CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_SRV6))
+			ret = bgp_ls_originate_srv6_sid(bgp, protocol_id, router_id, router_id_len,
+							area_id, subnet);
+		return ret;
+	}
+	case LS_MSG_EVENT_DELETE: {
+		int ret = bgp_ls_withdraw_prefix(bgp, protocol_id, router_id, router_id_len,
+						 &subnet->key, area_id, subnet);
+		/* Also withdraw SRv6 SID NLRI when present */
+		if (CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_SRV6)) {
+			int srv6_ret = bgp_ls_withdraw_srv6_sid(bgp, protocol_id, router_id,
+								router_id_len, area_id, subnet);
+			if (!ret)
+				ret = srv6_ret;
+		}
+		return ret;
+	}
 	default:
 		zlog_warn("BGP-LS: Unknown event type %u for subnet", event);
 		return -1;

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -370,6 +370,14 @@ int bgp_ls_populate_prefix_attr(struct ls_prefix *ls_prefix, struct bgp_ls_attr 
 		}
 	}
 
+	/* SRv6 Locator (TLV 1162, RFC 9514 Section 5.1) — for SRv6 Locator prefixes */
+	if (CHECK_FLAG(ls_prefix->flags, LS_PREF_SRV6)) {
+		attr->srv6_locator_flags = 0;
+		attr->srv6_locator_algo = 0;
+		attr->srv6_locator_metric = ls_prefix->metric;
+		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT);
+	}
+
 	return 0;
 }
 

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -85,6 +85,12 @@ int bgp_ls_populate_node_attr(struct ls_node *ls_node, struct bgp_ls_attr *attr)
 		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_IPV6_ROUTER_ID_LOCAL_BIT);
 	}
 
+	/* SRv6 Capabilities (TLV 1038, RFC 9514 Section 3.1) */
+	if (CHECK_FLAG(ls_node->flags, LS_NODE_SRV6)) {
+		attr->srv6_cap_flags = ls_node->srv6_cap_flags;
+		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT);
+	}
+
 	return 0;
 }
 

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -382,6 +382,40 @@ int bgp_ls_populate_prefix_attr(struct ls_prefix *ls_prefix, struct bgp_ls_attr 
 }
 
 /*
+ * Populate BGP-LS Attributes for an SRv6 SID NLRI (Type 6)
+ *
+ * Fills in the SRv6 SID-specific attribute TLVs:
+ *   TLV 1250 - SRv6 Endpoint Behavior (RFC 9514 Section 7.1)
+ *   TLV 1252 - SRv6 SID Structure (RFC 9514 Section 7.3)
+ *              (populated only when structure info is available in ls_prefix)
+ */
+static int bgp_ls_populate_srv6_sid_attr(struct ls_prefix *ls_prefix, struct bgp_ls_attr *attr)
+{
+	if (!ls_prefix || !attr)
+		return -1;
+
+	if (!CHECK_FLAG(ls_prefix->flags, LS_PREF_SRV6))
+		return 0;
+
+	/* SRv6 Endpoint Behavior (TLV 1250) - identifies the SID function */
+	attr->srv6_endpoint_behavior = ls_prefix->srv6.behavior;
+	attr->srv6_endpoint_flags = ls_prefix->srv6.flags;
+	attr->srv6_endpoint_algo = 0;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT);
+
+	/* SRv6 SID Structure (TLV 1252, RFC 9514 Section 7.3) */
+	if (ls_prefix->srv6.has_structure) {
+		attr->srv6_sid_structure.lb_len = ls_prefix->srv6.lb_len;
+		attr->srv6_sid_structure.ln_len = ls_prefix->srv6.ln_len;
+		attr->srv6_sid_structure.fun_len = ls_prefix->srv6.fn_len;
+		attr->srv6_sid_structure.arg_len = ls_prefix->srv6.arg_len;
+		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT);
+	}
+
+	return 0;
+}
+
+/*
  * ===========================================================================
  * IGP Origination Functions
  * ===========================================================================
@@ -1031,6 +1065,14 @@ int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rou
 	/* SRv6 SID Descriptor: SID Information (TLV 518) */
 	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
 
+	/* Populate SRv6 SID attributes (endpoint behavior, SID structure) */
+	ls_attr = bgp_ls_attr_alloc();
+	if (bgp_ls_populate_srv6_sid_attr(subnet->ls_pref, ls_attr) < 0) {
+		zlog_warn("BGP-LS: Failed to populate SRv6 SID attributes");
+		bgp_ls_attr_free(ls_attr);
+		return -1;
+	}
+
 	/* Install in RIB */
 	ret = bgp_ls_update(bgp, &nlri, ls_attr);
 	if (ret < 0) {
@@ -1043,6 +1085,7 @@ int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rou
 		zlog_debug("BGP-LS: Originated SRv6 SID NLRI %pI6 behavior 0x%04x",
 			   &subnet->ls_pref->srv6.sid, subnet->ls_pref->srv6.behavior);
 
+	bgp_ls_attr_free(ls_attr);
 	return 0;
 }
 

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -121,6 +121,28 @@ static void bgp_ls_fill_srv6_endx_sid(struct bgp_ls_srv6_endx_sid *endx,
 }
 
 /*
+ * Fill a pre-allocated SRv6 LAN End.X SID entry (TLV 1107/1108) from a Link State adjacency SID
+ */
+static void bgp_ls_fill_srv6_lan_endx_sid(struct bgp_ls_srv6_lan_endx_sid *endx,
+					  const struct ls_srv6_adjacency *adj)
+{
+	memset(endx, 0, sizeof(*endx));
+	endx->endpoint_behavior = adj->endpoint_behavior;
+	endx->flags = adj->flags;
+	endx->weight = adj->weight;
+	endx->is_isis = true; /* Only IS-IS LAN End.X SID (TLV 1107) is currently supported */
+	IPV6_ADDR_COPY(&endx->sid, &adj->sid);
+	memcpy(endx->neighbor.sysid, adj->neighbor.sysid, ISO_SYS_ID_LEN);
+	if (adj->has_structure) {
+		endx->has_structure = true;
+		endx->structure.lb_len = adj->lb_len;
+		endx->structure.ln_len = adj->ln_len;
+		endx->structure.fun_len = adj->fn_len;
+		endx->structure.arg_len = adj->arg_len;
+	}
+}
+
+/*
  * Append a single SRv6 adjacency SID to the appropriate BGP-LS attribute array.
  * A non-zero neighbor sysid identifies a LAN adjacency (TLV 1107/1108);
  * an all-zero sysid identifies a point-to-point adjacency (TLV 1106).
@@ -137,6 +159,14 @@ static void bgp_ls_populate_srv6_adj_sid(struct bgp_ls_attr *attr,
 				 (attr->srv6_endx_sid_count + 1) * sizeof(*attr->srv6_endx_sid));
 		bgp_ls_fill_srv6_endx_sid(&attr->srv6_endx_sid[attr->srv6_endx_sid_count++], adj);
 		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT);
+	} else {
+		/* LAN adjacency: LAN End.X SID (IS-IS TLV 1107 / OSPFv3 TLV 1108) */
+		attr->srv6_lan_endx_sid = XREALLOC(MTYPE_BGP_LS_ATTR, attr->srv6_lan_endx_sid,
+						   (attr->srv6_lan_endx_sid_count + 1) *
+							   sizeof(*attr->srv6_lan_endx_sid));
+		bgp_ls_fill_srv6_lan_endx_sid(&attr->srv6_lan_endx_sid[attr->srv6_lan_endx_sid_count++],
+					      adj);
+		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
 	}
 }
 

--- a/bgpd/bgp_ls_ted.h
+++ b/bgpd/bgp_ls_ted.h
@@ -111,6 +111,26 @@ extern int bgp_ls_originate_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t
 				   struct ls_subnet *subnet);
 
 /*
+ * Originate SRv6 SID NLRI (Type 6) from an IGP prefix that carries an SRv6 SID
+ *
+ * Creates a BGP-LS SRv6 SID NLRI from the SRv6 SID fields of ls_prefix
+ * and installs it in the RIB. The prefix must have LS_PREF_SRV6 set.
+ *
+ * @param bgp - BGP instance
+ * @param protocol_id - IGP protocol (ISIS/OSPF)
+ * @param router_id - Advertising router IGP ID
+ * @param router_id_len - Length of router ID
+ * @param area_id - IGP area/level identifier
+ * @param subnet - Link State subnet carrying the SRv6 SID
+ * @return 0 on success, -1 on error
+ */
+extern int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_id,
+				     uint16_t router_id_len, uint32_t area_id,
+				     struct ls_subnet *subnet);
+extern int bgp_ls_withdraw_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_id,
+				    uint16_t router_id_len, uint32_t area_id,
+				    struct ls_subnet *subnet);
+/*
  * ===========================================================================
  * Link State Message Processing
  * ===========================================================================

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11655,6 +11655,13 @@ void route_vty_out(struct vty *vty, const struct prefix *p, struct bgp_path_info
 					       json_nexthops);
 		}
 
+		/* BGP-LS link-state attributes */
+		if (safi == SAFI_BGP_LS && attr->ls_attr) {
+			json_object *json_ls_attr = bgp_ls_attr_to_json(attr->ls_attr);
+
+			json_object_object_add(json_path, "linkStateAttrs", json_ls_attr);
+		}
+
 		json_object_array_add(json_paths, json_path);
 	} else {
 		vty_out(vty, "\n");

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -301,9 +301,9 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 		ipv4->prefix = connected->address->u.prefix4;
 		listnode_add(circuit->ip_addrs, ipv4);
 
-		/* Update Local IP address parameter if MPLS TE is enable */
-		if (circuit->ext && circuit->area
-		    && IS_MPLS_TE(circuit->area->mta)) {
+		/* Update local IP address parameter if MPLS TE or SRv6 is enabled. */
+		if (circuit->ext && circuit->area &&
+		    (IS_MPLS_TE(circuit->area->mta) || IS_SRV6_ENABLED(circuit->area))) {
 			circuit->ext->local_addr.s_addr = ipv4->prefix.s_addr;
 			SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR);
 		}
@@ -340,9 +340,9 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 			listnode_add(circuit->ipv6_link, ipv6);
 		else {
 			listnode_add(circuit->ipv6_non_link, ipv6);
-			/* Update Local IPv6 address param. if MPLS TE is on */
-			if (circuit->ext && circuit->area
-			    && IS_MPLS_TE(circuit->area->mta)) {
+			/* Update local IPv6 address parameter if MPLS TE or SRv6 is enabled. */
+			if (circuit->ext && circuit->area &&
+			    (IS_MPLS_TE(circuit->area->mta) || IS_SRV6_ENABLED(circuit->area))) {
 				IPV6_ADDR_COPY(&circuit->ext->local_addr6,
 					       &ipv6->prefix);
 				SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR6);

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1214,6 +1214,26 @@ void cli_show_isis_mpls_te_export(struct vty *vty, const struct lyd_node *dnode,
 	vty_out(vty, " mpls-te export\n");
 }
 
+DEFPY_YANG(isis_distribute_link_state, isis_distribute_link_state_cmd,
+	     "[no] distribute link-state",
+	     NO_STR
+	     "Distribute routing information to external services\n"
+	     "Distribute the link-state database to external services\n")
+{
+	nb_cli_enqueue_change(vty, "./distribute-link-state", NB_OP_MODIFY, no ? "false" : "true");
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void cli_show_isis_distribute_link_state(struct vty *vty, const struct lyd_node *dnode,
+					 bool show_defaults)
+{
+	if (!yang_dnode_get_bool(dnode, NULL))
+		return;
+
+	vty_out(vty, " distribute link-state\n");
+}
+
 /*
  * XPath: /frr-isisd:isis/instance/default-information-originate
  */
@@ -3671,6 +3691,7 @@ void isis_cli_init(void)
 	install_element(ISIS_NODE, &isis_mpls_te_inter_as_cmd);
 	install_element(ISIS_NODE, &isis_mpls_te_export_cmd);
 	install_element(ISIS_NODE, &no_isis_mpls_te_export_cmd);
+	install_element(ISIS_NODE, &isis_distribute_link_state_cmd);
 
 	install_element(ISIS_NODE, &isis_default_originate_cmd);
 	install_element(ISIS_NODE, &isis_redistribute_cmd);

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -645,6 +645,13 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
+			.xpath = "/frr-isisd:isis/instance/distribute-link-state",
+			.cbs = {
+				.cli_show = cli_show_isis_distribute_link_state,
+				.modify = isis_instance_distribute_link_state_modify,
+			},
+		},
+		{
 			.xpath = "/frr-isisd:isis/instance/segment-routing/enabled",
 			.cbs = {
 				.modify = isis_instance_segment_routing_enabled_modify,

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -146,6 +146,7 @@ int isis_instance_mpls_te_router_address_destroy(struct nb_cb_destroy_args *args
 int isis_instance_mpls_te_router_address_ipv6_modify(struct nb_cb_modify_args *args);
 int isis_instance_mpls_te_router_address_ipv6_destroy(struct nb_cb_destroy_args *args);
 int isis_instance_mpls_te_export_modify(struct nb_cb_modify_args *args);
+int isis_instance_distribute_link_state_modify(struct nb_cb_modify_args *args);
 int lib_interface_isis_create(struct nb_cb_create_args *args);
 int lib_interface_isis_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_isis_area_tag_modify(struct nb_cb_modify_args *args);
@@ -424,6 +425,8 @@ void cli_show_isis_mpls_te_router_addr_ipv6(struct vty *vty, const struct lyd_no
 					    bool show_defaults);
 void cli_show_isis_mpls_te_export(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
+void cli_show_isis_distribute_link_state(struct vty *vty, const struct lyd_node *dnode,
+					 bool show_defaults);
 void cli_show_isis_def_origin_ipv4(struct vty *vty, const struct lyd_node *dnode,
 				   bool show_defaults);
 void cli_show_isis_def_origin_ipv6(struct vty *vty, const struct lyd_node *dnode,

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2008,6 +2008,40 @@ int isis_instance_mpls_te_export_modify(struct nb_cb_modify_args *args)
 }
 
 /*
+ * XPath: /frr-isisd:isis/instance/distribute-link-state
+ */
+int isis_instance_distribute_link_state_modify(struct nb_cb_modify_args *args)
+{
+	struct isis_area *area;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	area = nb_running_get_entry(args->dnode, NULL, true);
+	area->distribute_link_state = yang_dnode_get_bool(args->dnode, NULL);
+
+	/* Keep TED active for link-state distribution even without mpls-te config. */
+	if (area->distribute_link_state && !area->mta)
+		isis_mpls_te_create(area);
+
+	if (area->distribute_link_state) {
+		if (IS_DEBUG_EVENTS)
+			zlog_debug("MPLS-TE: Enabled Link State export");
+		if (isis_zebra_ls_register(true) != 0)
+			zlog_warn("Unable to register Link State");
+	} else {
+		isis_mpls_te_disable(area);
+
+		if (IS_DEBUG_EVENTS)
+			zlog_debug("MPLS-TE: Disable Link State export");
+		if (isis_zebra_ls_register(false) != 0)
+			zlog_warn("Unable to register Link State");
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-isisd:isis/instance/segment-routing/enabled
  */
 int isis_instance_segment_routing_enabled_modify(struct nb_cb_modify_args *args)

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -18,6 +18,8 @@
 #define ISIS_DEFAULT_SRV6_MAX_H_ENCAPS_MSD 2
 #define ISIS_DEFAULT_SRV6_MAX_END_D_MSD	   5
 
+#define IS_SRV6_ENABLED(area) ((area) && (area)->srv6db.config.enabled)
+
 /* SRv6 SID structure */
 struct isis_srv6_sid_structure {
 	uint8_t loc_block_len;

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -316,8 +316,8 @@ void isis_link_params_update(struct isis_circuit *circuit, struct interface *ifp
 	struct prefix_ipv6 *addr6;
 	struct isis_ext_subtlvs *ext;
 
-	/* Check if TE is enable or not */
-	if (!circuit->area || !IS_MPLS_TE(circuit->area->mta))
+	/* Check if TE should be advertised (MPLS TE or SRv6 enabled). */
+	if (!circuit->area || (!IS_MPLS_TE(circuit->area->mta) && !IS_SRV6_ENABLED(circuit->area)))
 		return;
 
 	/* Sanity Check */
@@ -495,8 +495,8 @@ static int _isis_mpls_te_adj_ip_enabled(struct isis_adjacency *adj, int family, 
 
 	circuit = adj->circuit;
 
-	/* Check that MPLS TE is enabled */
-	if (!IS_MPLS_TE(circuit->area->mta) || !circuit->ext)
+	/* Check that MPLS TE or SRv6 is enabled */
+	if ((!IS_MPLS_TE(circuit->area->mta) && !IS_SRV6_ENABLED(circuit->area)) || !circuit->ext)
 		return 0;
 
 	ext = circuit->ext;
@@ -558,14 +558,14 @@ static int _isis_mpls_te_adj_ip_disabled(struct isis_adjacency *adj, int family,
 
 	circuit = adj->circuit;
 
-	/* Check that MPLS TE is enabled */
-	if (!IS_MPLS_TE(circuit->area->mta) || !circuit->ext)
+	/* Check that MPLS TE or SRv6 is enabled */
+	if ((!IS_MPLS_TE(circuit->area->mta) && !IS_SRV6_ENABLED(circuit->area)) || !circuit->ext)
 		return 0;
 
 	ext = circuit->ext;
 
 	/* Update MPLS TE IP address parameters if possible */
-	if (!IS_MPLS_TE(circuit->area->mta) || !IS_EXT_TE(ext))
+	if (!IS_EXT_TE(ext))
 		return 0;
 
 	/* Determine nexthop IP address */
@@ -650,11 +650,11 @@ int isis_mpls_te_update(struct interface *ifp)
 	/* Update TE TLVs ... */
 	isis_link_params_update(circuit, ifp);
 
-	if (circuit->area && IS_MPLS_TE(circuit->area->mta))
+	if (circuit->area && (IS_MPLS_TE(circuit->area->mta) || IS_SRV6_ENABLED(circuit->area)))
 		isis_mpls_te_circuit_ip_update(circuit);
 
 	/* ... and LSP */
-	if (circuit->area && (IS_MPLS_TE(circuit->area->mta)
+	if (circuit->area && (IS_MPLS_TE(circuit->area->mta) || IS_SRV6_ENABLED(circuit->area)
 #ifndef FABRICD
 			      || !list_isempty(circuit->area->flex_algos->flex_algos)
 #endif /* ifndef FABRICD */

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1450,7 +1450,7 @@ static void isis_te_parse_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	/* Check if Vertex has been modified */
 	if (vertex->status != SYNC) {
 		/* Vertex is out of sync: export it if requested */
-		if (IS_EXPORT_TE(mta))
+		if (IS_EXPORT_TE(mta) || IS_DISTRIBUTE_LS(lsp->area))
 			isis_te_export(LS_MSG_TYPE_NODE, vertex);
 		vertex->status = SYNC;
 	}
@@ -1465,7 +1465,7 @@ static void isis_te_parse_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	/* Process all Extended Reachability in LSP (all fragments) */
 	args.ted = ted;
 	args.vertex = vertex;
-	args.export = mta->export;
+	args.export = mta->export || IS_DISTRIBUTE_LS(lsp->area);
 	isis_lsp_iterate_is_reach(lsp, ISIS_MT_IPV4_UNICAST, lsp_to_edge_cb, &args);
 
 	isis_lsp_iterate_is_reach(lsp, ISIS_MT_IPV6_UNICAST, lsp_to_edge_cb, &args);
@@ -1480,7 +1480,7 @@ static void isis_te_parse_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	isis_lsp_iterate_srv6_locator(lsp, ISIS_MT_IPV6_UNICAST, lsp_to_subnet_cb, &args);
 
 	/* Clean remaining Orphan Edges or Subnets */
-	if (IS_EXPORT_TE(mta))
+	if (IS_EXPORT_TE(mta) || IS_DISTRIBUTE_LS(lsp->area))
 		ls_vertex_clean(ted, vertex, isis_zclient);
 	else
 		ls_vertex_clean(ted, vertex, NULL);
@@ -1530,7 +1530,7 @@ static void isis_te_delete_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	 */
 	/* Remove outgoing Edges */
 	for (ALL_LIST_ELEMENTS(vertex->outgoing_edges, node, nnode, edge)) {
-		if (IS_EXPORT_TE(mta)) {
+		if (IS_EXPORT_TE(mta) || IS_DISTRIBUTE_LS(lsp->area)) {
 			edge->status = DELETE;
 			isis_te_export(LS_MSG_TYPE_ATTRIBUTES, edge);
 		}
@@ -1541,7 +1541,7 @@ static void isis_te_delete_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	for (ALL_LIST_ELEMENTS(vertex->incoming_edges, node, nnode, edge)) {
 		ls_disconnect(vertex, edge, false);
 		if (edge->source == NULL) {
-			if (IS_EXPORT_TE(mta)) {
+			if (IS_EXPORT_TE(mta) || IS_DISTRIBUTE_LS(lsp->area)) {
 				edge->status = DELETE;
 				isis_te_export(LS_MSG_TYPE_ATTRIBUTES, edge);
 			}
@@ -1551,7 +1551,7 @@ static void isis_te_delete_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 
 	/* Remove subnets */
 	for (ALL_LIST_ELEMENTS(vertex->prefixes, node, nnode, subnet)) {
-		if (IS_EXPORT_TE(mta)) {
+		if (IS_EXPORT_TE(mta) || IS_DISTRIBUTE_LS(lsp->area)) {
 			subnet->status = DELETE;
 			isis_te_export(LS_MSG_TYPE_PREFIX, subnet);
 		}
@@ -1559,7 +1559,7 @@ static void isis_te_delete_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	}
 
 	/* Then remove Link State Node */
-	if (IS_EXPORT_TE(mta)) {
+	if (IS_EXPORT_TE(lsp->area->mta) || IS_DISTRIBUTE_LS(lsp->area)) {
 		vertex->status = DELETE;
 		isis_te_export(LS_MSG_TYPE_NODE, vertex);
 	}
@@ -1635,7 +1635,8 @@ int isis_te_sync_ted(struct zapi_opaque_reg_info dst)
 	frr_each (isis_instance_list, &im->isis, isis) {
 		frr_each (isis_area_list, &isis->area_list, area) {
 			mta = area->mta;
-			if (IS_MPLS_TE(mta) && IS_EXPORT_TE(mta)) {
+			if (((IS_MPLS_TE(mta) && IS_EXPORT_TE(mta)) || IS_DISTRIBUTE_LS(area)) &&
+			    mta && mta->ted) {
 				te_debug("  |- Export TED from area %s", area->area_tag);
 				rc = ls_sync_ted(mta->ted, isis_zclient, &dst);
 				if (rc != 0)

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1058,6 +1058,15 @@ static struct ls_attributes *get_attributes(struct ls_node_id adv, struct isis_e
 			attr->adj_srv6_sid[i].weight = endx->weight;
 			memcpy(&attr->adj_srv6_sid[i].sid, &endx->sid, sizeof(struct in6_addr));
 			attr->adj_srv6_sid[i].endpoint_behavior = endx->behavior;
+			if (endx->subsubtlvs && endx->subsubtlvs->srv6_sid_structure) {
+				struct isis_srv6_sid_structure_subsubtlv *ss =
+					endx->subsubtlvs->srv6_sid_structure;
+				attr->adj_srv6_sid[i].has_structure = true;
+				attr->adj_srv6_sid[i].lb_len = ss->loc_block_len;
+				attr->adj_srv6_sid[i].ln_len = ss->loc_node_len;
+				attr->adj_srv6_sid[i].fn_len = ss->func_len;
+				attr->adj_srv6_sid[i].arg_len = ss->arg_len;
+			}
 		}
 	}
 	if (CHECK_FLAG(tlvs->status, EXT_SRV6_LAN_ENDX_SID)) {
@@ -1079,6 +1088,15 @@ static struct ls_attributes *get_attributes(struct ls_node_id adv, struct isis_e
 			attr->adj_srv6_sid[i].weight = lendx->weight;
 			memcpy(&attr->adj_srv6_sid[i].sid, &lendx->sid, sizeof(struct in6_addr));
 			attr->adj_srv6_sid[i].endpoint_behavior = lendx->behavior;
+			if (lendx->subsubtlvs && lendx->subsubtlvs->srv6_sid_structure) {
+				struct isis_srv6_sid_structure_subsubtlv *ss =
+					lendx->subsubtlvs->srv6_sid_structure;
+				attr->adj_srv6_sid[i].has_structure = true;
+				attr->adj_srv6_sid[i].lb_len = ss->loc_block_len;
+				attr->adj_srv6_sid[i].ln_len = ss->loc_node_len;
+				attr->adj_srv6_sid[i].fn_len = ss->func_len;
+				attr->adj_srv6_sid[i].arg_len = ss->arg_len;
+			}
 		}
 	}
 	return attr;
@@ -1353,6 +1371,20 @@ static int lsp_to_subnet_cb(const struct prefix *prefix, uint32_t metric, bool e
 		sr.behavior = psid->behavior;
 		sr.flags = psid->flags;
 		memcpy(&sr.sid, &psid->sid, sizeof(struct in6_addr));
+
+		/*
+		 * For locator prefixes, also capture SID Structure (sub-sub-TLV)
+		 * for BGP-LS TLVs 1162 / 1252
+		 */
+		if (psid->subsubtlvs && psid->subsubtlvs->srv6_sid_structure) {
+			struct isis_srv6_sid_structure_subsubtlv *ss =
+				psid->subsubtlvs->srv6_sid_structure;
+			sr.has_structure = true;
+			sr.lb_len = ss->loc_block_len;
+			sr.ln_len = ss->loc_node_len;
+			sr.fn_len = ss->func_len;
+			sr.arg_len = ss->arg_len;
+		}
 
 		if (!CHECK_FLAG(ls_pref->flags, LS_PREF_SRV6) ||
 		    memcmp(&ls_pref->srv6, &sr, sizeof(struct ls_srv6_sid))) {

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -75,6 +75,7 @@ typedef enum _interas_mode_t { off, region, as, emulate } interas_mode_t;
 	 e->status != EXT_SRV6_LAN_ENDX_SID)
 #define IS_MPLS_TE(a)	(a && a->status == enable)
 #define IS_EXPORT_TE(a) (a->export)
+#define IS_DISTRIBUTE_LS(area) ((area) && (area)->distribute_link_state)
 
 /* Per area MPLS-TE parameters */
 struct ls_ted;

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -222,6 +222,8 @@ struct isis_area {
 	uint8_t log_pdu_drops;
 	/* multi topology settings */
 	struct list *mt_settings;
+	/* Distribute link-state information to external consumers */
+	bool distribute_link_state;
 	/* MPLS-TE settings */
 	struct mpls_te_area *mta;
 	/* Segment Routing information */

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -340,7 +340,13 @@ int ls_attributes_same(struct ls_attributes *l1, struct ls_attributes *l2)
 		    (l1->adj_srv6_sid[i].flags != l2->adj_srv6_sid[i].flags) ||
 		    (l1->adj_srv6_sid[i].weight != l2->adj_srv6_sid[i].weight) ||
 		    (l1->adj_srv6_sid[i].endpoint_behavior !=
-		     l2->adj_srv6_sid[i].endpoint_behavior))
+		     l2->adj_srv6_sid[i].endpoint_behavior) ||
+		    (l1->adj_srv6_sid[i].has_structure != l2->adj_srv6_sid[i].has_structure) ||
+		    (l1->adj_srv6_sid[i].has_structure &&
+		     (l1->adj_srv6_sid[i].lb_len != l2->adj_srv6_sid[i].lb_len ||
+		      l1->adj_srv6_sid[i].ln_len != l2->adj_srv6_sid[i].ln_len ||
+		      l1->adj_srv6_sid[i].fn_len != l2->adj_srv6_sid[i].fn_len ||
+		      l1->adj_srv6_sid[i].arg_len != l2->adj_srv6_sid[i].arg_len)))
 			return 0;
 		if (((l1->adv.origin == ISIS_L1) ||
 		     (l1->adv.origin == ISIS_L2)) &&
@@ -421,10 +427,13 @@ int ls_prefix_same(struct ls_prefix *p1, struct ls_prefix *p2)
 			return 0;
 	}
 	if (CHECK_FLAG(p1->flags, LS_PREF_SRV6)) {
-		if (memcmp(&p1->srv6.sid, &p2->srv6.sid,
-			   sizeof(struct in6_addr)) ||
+		if (memcmp(&p1->srv6.sid, &p2->srv6.sid, sizeof(struct in6_addr)) ||
 		    (p1->srv6.flags != p2->srv6.flags) ||
-		    (p1->srv6.behavior != p2->srv6.behavior))
+		    (p1->srv6.behavior != p2->srv6.behavior) ||
+		    (p1->srv6.has_structure != p2->srv6.has_structure) ||
+		    (p1->srv6.has_structure &&
+		     (p1->srv6.lb_len != p2->srv6.lb_len || p1->srv6.ln_len != p2->srv6.ln_len ||
+		      p1->srv6.fn_len != p2->srv6.fn_len || p1->srv6.arg_len != p2->srv6.arg_len)))
 			return 0;
 	}
 
@@ -1352,6 +1361,18 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 				       .endpoint_behavior);
 		STREAM_GET(attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].neighbor.sysid,
 			   s, ISO_SYS_ID_LEN);
+		{
+			uint8_t has_struct;
+
+			STREAM_GETC(s, has_struct);
+			attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].has_structure = (has_struct != 0);
+			if (attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].has_structure) {
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].lb_len);
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].ln_len);
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].fn_len);
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].arg_len);
+			}
+		}
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID)) {
 		STREAM_GET(&attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].sid, s,
@@ -1362,6 +1383,18 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 				       .endpoint_behavior);
 		STREAM_GET(attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].neighbor.sysid,
 			   s, ISO_SYS_ID_LEN);
+		{
+			uint8_t has_struct;
+
+			STREAM_GETC(s, has_struct);
+			attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].has_structure = (has_struct != 0);
+			if (attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].has_structure) {
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].lb_len);
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].ln_len);
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].fn_len);
+				STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].arg_len);
+			}
+		}
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_SRLG)) {
 		STREAM_GETC(s, len);
@@ -1411,9 +1444,19 @@ static struct ls_prefix *ls_parse_prefix(struct stream *s)
 		STREAM_GETC(s, ls_pref->sr.algo);
 	}
 	if (CHECK_FLAG(ls_pref->flags, LS_PREF_SRV6)) {
+		uint8_t has_struct;
+
 		STREAM_GET(&ls_pref->srv6.sid, s, sizeof(struct in6_addr));
 		STREAM_GETW(s, ls_pref->srv6.behavior);
 		STREAM_GETC(s, ls_pref->srv6.flags);
+		STREAM_GETC(s, has_struct);
+		ls_pref->srv6.has_structure = (has_struct != 0);
+		if (ls_pref->srv6.has_structure) {
+			STREAM_GETC(s, ls_pref->srv6.lb_len);
+			STREAM_GETC(s, ls_pref->srv6.ln_len);
+			STREAM_GETC(s, ls_pref->srv6.fn_len);
+			STREAM_GETC(s, ls_pref->srv6.arg_len);
+		}
 	}
 
 	return ls_pref;
@@ -1616,6 +1659,13 @@ static int ls_format_attributes(struct stream *s, struct ls_attributes *attr)
 		stream_put(s,
 			   attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].neighbor.sysid,
 			   ISO_SYS_ID_LEN);
+		stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].has_structure ? 1 : 0);
+		if (attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].has_structure) {
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].lb_len);
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].ln_len);
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].fn_len);
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].arg_len);
+		}
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID)) {
 		stream_put(s, &attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].sid,
@@ -1627,6 +1677,13 @@ static int ls_format_attributes(struct stream *s, struct ls_attributes *attr)
 		stream_put(s,
 			   attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].neighbor.sysid,
 			   ISO_SYS_ID_LEN);
+		stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].has_structure ? 1 : 0);
+		if (attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].has_structure) {
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].lb_len);
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].ln_len);
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].fn_len);
+			stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].arg_len);
+		}
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_SRLG)) {
 		stream_putc(s, attr->srlg_len);
@@ -1667,6 +1724,13 @@ static int ls_format_prefix(struct stream *s, struct ls_prefix *ls_pref)
 		stream_put(s, &ls_pref->srv6.sid, sizeof(struct in6_addr));
 		stream_putw(s, ls_pref->srv6.behavior);
 		stream_putc(s, ls_pref->srv6.flags);
+		stream_putc(s, ls_pref->srv6.has_structure ? 1 : 0);
+		if (ls_pref->srv6.has_structure) {
+			stream_putc(s, ls_pref->srv6.lb_len);
+			stream_putc(s, ls_pref->srv6.ln_len);
+			stream_putc(s, ls_pref->srv6.fn_len);
+			stream_putc(s, ls_pref->srv6.arg_len);
+		}
 	}
 
 	return 0;

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -238,6 +238,12 @@ struct ls_attributes {
 		union {
 			uint8_t sysid[ISO_SYS_ID_LEN]; /* Sys-ID for ISIS */
 		} neighbor;
+		/* SID Structure sub-sub-TLV (RFC 9352 section 9) */
+		bool has_structure;
+		uint8_t lb_len;	 /* Locator Block length in bits */
+		uint8_t ln_len;	 /* Locator Node length in bits */
+		uint8_t fn_len;	 /* Function length in bits */
+		uint8_t arg_len; /* Argument length in bits */
 	} adj_srv6_sid[2];
 	uint32_t *srlgs;	/* List of Shared Risk Link Group */
 	uint8_t srlg_len;	/* number of SRLG in the list */
@@ -270,6 +276,12 @@ struct ls_prefix {
 		struct in6_addr sid; /* Segment Routing ID */
 		uint16_t behavior;   /* Endpoint behavior bound to the SID */
 		uint8_t flags;	     /* Flags */
+		/* SID Structure sub-sub-TLV (valid when has_structure is true) */
+		bool has_structure;
+		uint8_t lb_len;		/* Locator Block length in bits */
+		uint8_t ln_len;		/* Locator Node length in bits */
+		uint8_t fn_len;		/* Function length in bits */
+		uint8_t arg_len;	/* Argument length in bits */
 	} srv6;
 };
 

--- a/tests/topotests/bgp_link_state_srv6/__init__.py
+++ b/tests/topotests/bgp_link_state_srv6/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: ISC

--- a/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
+++ b/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
@@ -1,0 +1,729 @@
+{
+	"routes": {
+		"[V][L2][I0x0][N[s0000.0000.0001]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][L2][I0x0][N[s0000.0000.0002]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][L2][I0x0][N[s0000.0000.0003]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][L2][I0x0][N[s0000.0000.0004]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][L2][I0x0][N[s0000.0000.0005]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfcbb:bbbb:1::/48]]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:1::/48"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfcbb:bbbb:2::/48]]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:2::/48"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfcbb:bbbb:3::/48]]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:3::/48"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfcbb:bbbb:4::/48]]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:4::/48"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][L2][I0x0][N[s0000.0000.0005]][P[pfcbb:bbbb:5::/48]]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:5::/48"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[S][L2][I0x0][N[s0000.0000.0001]][S[sdfcbb:bbbb:1::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:1::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 16,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][L2][I0x0][N[s0000.0000.0002]][S[sdfcbb:bbbb:2::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:2::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 16,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][L2][I0x0][N[s0000.0000.0003]][S[sdfcbb:bbbb:3::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:3::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 16,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][L2][I0x0][N[s0000.0000.0004]][S[sdfcbb:bbbb:4::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:4::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 16,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][L2][I0x0][N[s0000.0000.0005]][S[sdfcbb:bbbb:5::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:5::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 16,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:1::1][nfc00:1::2]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:1:e001::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:1::2][nfc00:1::1]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:2:e001::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:2::2][nfc00:2::4]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:2:e002::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:2::4][nfc00:2::2]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:4:e001::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:3::2][nfc00:3::4]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:2:e003::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:3::4][nfc00:3::2]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0002"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:4:e000::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:4::3][nfc00:4::5]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:3:e002::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:4::5][nfc00:4::3]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:5:e000::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:5::3][nfc00:5::5]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:3:e003::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:5::5][nfc00:5::3]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:5:e001::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0005]][L[ifc00:6::4][nfc00:6::5]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:4:e002::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0004]][L[ifc00:6::5][nfc00:6::4]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0005"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0004"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:5:e002::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0003]][L[ifc00:7::1][nfc00:7::2]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:1:e001::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		],
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0001]][L[ifc00:7::2][nfc00:7::1]]": [
+			{
+				"nlri": {
+					"nlriType": "link",
+					"localNodeDescriptors": {
+						"igpRouterId": "0000.0000.0003"
+					},
+					"remoteNodeDescriptors": {
+						"igpRouterId": "0000.0000.0001"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndxSids": [
+						{
+							"sid": "fcbb:bbbb:3:e001::",
+							"behavior": "0x34",
+							"flags": "0x0",
+							"algo": 0,
+							"weight": 0,
+							"srv6SidStructure": {
+								"lbLen": 32,
+								"lnLen": 16,
+								"funLen": 16,
+								"argLen": 0
+							}
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/tests/topotests/bgp_link_state_srv6/r1/bgp_capability.json
+++ b/tests/topotests/bgp_link_state_srv6/r1/bgp_capability.json
@@ -1,0 +1,11 @@
+{
+        "10.0.0.100": {
+                "neighborCapabilities": {
+                        "multiprotocolExtensions": {
+                                "linkState": {
+                                        "advertisedAndReceived": true
+                                }
+                        }
+                }
+        }
+}

--- a/tests/topotests/bgp_link_state_srv6/r1/bgp_neighbor.json
+++ b/tests/topotests/bgp_link_state_srv6/r1/bgp_neighbor.json
@@ -1,0 +1,5 @@
+{
+    "10.0.0.100": {
+        "bgpState": "Established"
+    }
+}

--- a/tests/topotests/bgp_link_state_srv6/r1/frr.conf
+++ b/tests/topotests/bgp_link_state_srv6/r1/frr.conf
@@ -1,0 +1,76 @@
+hostname r1
+!
+interface lo
+ ip address 1.1.1.1/32
+ ipv6 address fc00:0:1::1/128
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r2
+ ip address 10.0.1.1/24
+ ipv6 address fc00:1::1/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r3
+ ip address 10.0.7.1/24
+ ipv6 address fc00:7::1/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-rr
+ ip address 10.0.0.1/24
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:1::/48
+    format usid-f3216
+   !
+  !
+ !
+!
+router isis 1
+ net 49.0000.0000.0000.0001.00
+ is-type level-2-only
+ topology ipv6-unicast
+ redistribute ipv4 connected level-2
+ redistribute ipv6 connected level-2
+ lsp-gen-interval 1
+ lsp-refresh-interval 10
+ max-lsp-lifetime 350
+ distribute link-state
+ segment-routing srv6
+  locator MAIN
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+!
+router bgp 65000
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.100 remote-as 65000
+ !
+ address-family link-state
+  neighbor 10.0.0.100 activate
+ exit-address-family
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_link_state_srv6/r1/isis_adj.json
+++ b/tests/topotests/bgp_link_state_srv6/r1/isis_adj.json
@@ -1,0 +1,18 @@
+{
+        "areas": [
+                {
+                        "circuits": [
+                                {
+                                        "adj": "r2",
+                                        "interface": "eth-r2",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r3",
+                                        "interface": "eth-r3",
+                                        "state": "Up"
+                                }
+                        ]
+                }
+        ]
+}

--- a/tests/topotests/bgp_link_state_srv6/r2/frr.conf
+++ b/tests/topotests/bgp_link_state_srv6/r2/frr.conf
@@ -1,0 +1,75 @@
+hostname r2
+!
+interface lo
+ ip address 2.2.2.2/32
+ ipv6 address fc00:0:2::1/128
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r1
+ ip address 10.0.1.2/24
+ ipv6 address fc00:1::2/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r4-1
+ ip address 10.0.2.2/24
+ ipv6 address fc00:2::2/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r4-2
+ ip address 10.0.3.2/24
+ ipv6 address fc00:3::2/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:2::/48
+    format usid-f3216
+   !
+  !
+ !
+!
+router isis 1
+ net 49.0000.0000.0000.0002.00
+ is-type level-2-only
+ topology ipv6-unicast
+ redistribute ipv4 connected level-2
+ redistribute ipv6 connected level-2
+ lsp-gen-interval 1
+ lsp-refresh-interval 10
+ max-lsp-lifetime 350
+ segment-routing srv6
+  locator MAIN
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_link_state_srv6/r2/isis_adj.json
+++ b/tests/topotests/bgp_link_state_srv6/r2/isis_adj.json
@@ -1,0 +1,23 @@
+{
+        "areas": [
+                {
+                        "circuits": [
+                                {
+                                        "adj": "r1",
+                                        "interface": "eth-r1",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r4",
+                                        "interface": "eth-r4-1",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r4",
+                                        "interface": "eth-r4-2",
+                                        "state": "Up"
+                                }
+                        ]
+                }
+        ]
+}

--- a/tests/topotests/bgp_link_state_srv6/r3/frr.conf
+++ b/tests/topotests/bgp_link_state_srv6/r3/frr.conf
@@ -1,0 +1,75 @@
+hostname r3
+!
+interface lo
+ ip address 3.3.3.3/32
+ ipv6 address fc00:0:3::1/128
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r1
+ ip address 10.0.7.2/24
+ ipv6 address fc00:7::2/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r5-1
+ ip address 10.0.4.3/24
+ ipv6 address fc00:4::3/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r5-2
+ ip address 10.0.5.3/24
+ ipv6 address fc00:5::3/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:3::/48
+    format usid-f3216
+   !
+  !
+ !
+!
+router isis 1
+ net 49.0000.0000.0000.0003.00
+ is-type level-2-only
+ topology ipv6-unicast
+ redistribute ipv4 connected level-2
+ redistribute ipv6 connected level-2
+ lsp-gen-interval 1
+ lsp-refresh-interval 10
+ max-lsp-lifetime 350
+ segment-routing srv6
+  locator MAIN
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_link_state_srv6/r3/isis_adj.json
+++ b/tests/topotests/bgp_link_state_srv6/r3/isis_adj.json
@@ -1,0 +1,23 @@
+{
+        "areas": [
+                {
+                        "circuits": [
+                                {
+                                        "adj": "r1",
+                                        "interface": "eth-r1",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r5",
+                                        "interface": "eth-r5-1",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r5",
+                                        "interface": "eth-r5-2",
+                                        "state": "Up"
+                                }
+                        ]
+                }
+        ]
+}

--- a/tests/topotests/bgp_link_state_srv6/r4/frr.conf
+++ b/tests/topotests/bgp_link_state_srv6/r4/frr.conf
@@ -1,0 +1,75 @@
+hostname r4
+!
+interface lo
+ ip address 4.4.4.4/32
+ ipv6 address fc00:0:4::1/128
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r2-1
+ ip address 10.0.2.4/24
+ ipv6 address fc00:2::4/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r2-2
+ ip address 10.0.3.4/24
+ ipv6 address fc00:3::4/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r5
+ ip address 10.0.6.4/24
+ ipv6 address fc00:6::4/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:4::/48
+    format usid-f3216
+   !
+  !
+ !
+!
+router isis 1
+ net 49.0000.0000.0000.0004.00
+ is-type level-2-only
+ topology ipv6-unicast
+ redistribute ipv4 connected level-2
+ redistribute ipv6 connected level-2
+ lsp-gen-interval 1
+ lsp-refresh-interval 10
+ max-lsp-lifetime 350
+ segment-routing srv6
+  locator MAIN
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_link_state_srv6/r4/isis_adj.json
+++ b/tests/topotests/bgp_link_state_srv6/r4/isis_adj.json
@@ -1,0 +1,23 @@
+{
+        "areas": [
+                {
+                        "circuits": [
+                                {
+                                        "adj": "r2",
+                                        "interface": "eth-r2-1",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r2",
+                                        "interface": "eth-r2-2",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r5",
+                                        "interface": "eth-r5",
+                                        "state": "Up"
+                                }
+                        ]
+                }
+        ]
+}

--- a/tests/topotests/bgp_link_state_srv6/r5/frr.conf
+++ b/tests/topotests/bgp_link_state_srv6/r5/frr.conf
@@ -1,0 +1,75 @@
+hostname r5
+!
+interface lo
+ ip address 5.5.5.5/32
+ ipv6 address fc00:0:5::1/128
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r3-1
+ ip address 10.0.4.5/24
+ ipv6 address fc00:4::5/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r3-2
+ ip address 10.0.5.5/24
+ ipv6 address fc00:5::5/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r4
+ ip address 10.0.6.5/24
+ ipv6 address fc00:6::5/64
+ ip router isis 1
+ ipv6 router isis 1
+ link-params
+ exit-link-params
+ isis circuit-type level-2-only
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:5::/48
+    format usid-f3216
+   !
+  !
+ !
+!
+router isis 1
+ net 49.0000.0000.0000.0005.00
+ is-type level-2-only
+ topology ipv6-unicast
+ redistribute ipv4 connected level-2
+ redistribute ipv6 connected level-2
+ lsp-gen-interval 1
+ lsp-refresh-interval 10
+ max-lsp-lifetime 350
+ segment-routing srv6
+  locator MAIN
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_link_state_srv6/r5/isis_adj.json
+++ b/tests/topotests/bgp_link_state_srv6/r5/isis_adj.json
@@ -1,0 +1,23 @@
+{
+        "areas": [
+                {
+                        "circuits": [
+                                {
+                                        "adj": "r3",
+                                        "interface": "eth-r3-1",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r3",
+                                        "interface": "eth-r3-2",
+                                        "state": "Up"
+                                },
+                                {
+                                        "adj": "r4",
+                                        "interface": "eth-r4",
+                                        "state": "Up"
+                                }
+                        ]
+                }
+        ]
+}

--- a/tests/topotests/bgp_link_state_srv6/rr/bgp_capability.json
+++ b/tests/topotests/bgp_link_state_srv6/rr/bgp_capability.json
@@ -1,0 +1,11 @@
+{
+        "10.0.0.1": {
+                "neighborCapabilities": {
+                        "multiprotocolExtensions": {
+                                "linkState": {
+                                        "advertisedAndReceived": true
+                                }
+                        }
+                }
+        }
+}

--- a/tests/topotests/bgp_link_state_srv6/rr/bgp_neighbor.json
+++ b/tests/topotests/bgp_link_state_srv6/rr/bgp_neighbor.json
@@ -1,0 +1,5 @@
+{
+    "10.0.0.1": {
+        "bgpState": "Established"
+    }
+}

--- a/tests/topotests/bgp_link_state_srv6/rr/frr.conf
+++ b/tests/topotests/bgp_link_state_srv6/rr/frr.conf
@@ -1,0 +1,20 @@
+hostname rr
+!
+interface lo
+ ip address 100.100.100.100/32
+!
+interface eth-r1
+ ip address 10.0.0.100/24
+!
+router bgp 65000
+ bgp router-id 100.100.100.100
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.1 remote-as 65000
+ !
+ address-family link-state
+  neighbor 10.0.0.1 activate
+ exit-address-family
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/bgp_link_state_srv6/test_bgp_link_state_srv6.py
+++ b/tests/topotests/bgp_link_state_srv6/test_bgp_link_state_srv6.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026 by Carmine Scarpitta
+#
+"""
+Test BGP Link-State SRv6 Extensions (RFC 9514).
+
+The test creates a five-router IS-IS L2 domain and verifies that all BGP-LS
+NLRI types -- Node, IPv6 Prefix (SRv6 locators), SRv6 SID, and Link -- are
+correctly originated by the producer (r1) and received by the consumer (rr),
+together with their SRv6-specific BGP-LS attributes (RFC 9514).
+
+Topology
+--------
+
+                         +---------+
+                         |   rr    | (BGP-LS Consumer)
+                         +---------+
+                              |eth-r1
+                              |
+                              |eth-rr
+                         +---------+
+                         |   r1    | (BGP-LS Producer)
+                         +---------+
+                         /         \
+                    eth-r2         eth-r3
+                       /             \
+                      /               \
+                     /                 \
+                    /                   \
+                eth-r1                 eth-r1
+                  /                       \
+         +---------+                     +---------+
+         |         |                     |         |
+         |   r2    |                     |   r3    |
+         |         |                     |         |
+         +---------+                     +---------+
+     eth-r4-1|  |eth-r4-2            eth-r5-1|  |eth-r5-2
+             |  |                            |  |
+     eth-r2-1|  |eth-r2-2            eth-r3-1|  |eth-r3-2
+         +---------+                     +---------+
+         |         |                     |         |
+         |   r4    |  eth-r5     eth-r4  |   r5    |
+         |         +---------------------+         |
+         +---------+                     +---------+
+"""
+
+import os
+import sys
+import json
+import re
+import pytest
+import functools
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import create_interface_in_kernel, required_linux_kernel_version
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+
+
+_ENDX_SID_FUNC_RE = re.compile(r":e[0-9a-f]{3}::", re.IGNORECASE)
+
+
+def _normalize_dynamic_srv6_sid_fields(obj):
+    """Normalize run-to-run dynamic SRv6 End.X/LAN-End.X SID function bits."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key in ("srv6EndxSids", "srv6LanEndxSids") and isinstance(value, list):
+                for sid_obj in value:
+                    if isinstance(sid_obj, dict) and "sid" in sid_obj:
+                        sid = sid_obj["sid"]
+                        if isinstance(sid, str):
+                            sid_obj["sid"] = _ENDX_SID_FUNC_RE.sub(":e000::", sid)
+            else:
+                _normalize_dynamic_srv6_sid_fields(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            _normalize_dynamic_srv6_sid_fields(item)
+
+
+# ---------------------------------------------------------------------------
+# Topology definition
+# ---------------------------------------------------------------------------
+
+
+def build_topo(tgen):
+    """Instantiate the IS-IS topology (mirrors test_isis_srv6_topo1 without rt6/dst)."""
+    for rname in ["r1", "r2", "r3", "r4", "r5"]:
+        tgen.add_router(rname)
+    tgen.add_router("rr")
+
+    # r1/eth-r2 <-> r2/eth-r1  (10.0.1.0/24)
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"], "eth-r2", "eth-r1")
+
+    # r1/eth-r3 <-> r3/eth-r1  (10.0.7.0/24)
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r3"], "eth-r3", "eth-r1")
+
+    # r2/eth-r4-1 <-> r4/eth-r2-1  (10.0.2.0/24)
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"], nodeif="eth-r4-1")
+    switch.add_link(tgen.gears["r4"], nodeif="eth-r2-1")
+
+    # r2/eth-r4-2 <-> r4/eth-r2-2  (10.0.3.0/24)
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r2"], nodeif="eth-r4-2")
+    switch.add_link(tgen.gears["r4"], nodeif="eth-r2-2")
+
+    # r3/eth-r5-1 <-> r5/eth-r3-1  (10.0.4.0/24)
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r3"], nodeif="eth-r5-1")
+    switch.add_link(tgen.gears["r5"], nodeif="eth-r3-1")
+
+    # r3/eth-r5-2 <-> r5/eth-r3-2  (10.0.5.0/24)
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["r3"], nodeif="eth-r5-2")
+    switch.add_link(tgen.gears["r5"], nodeif="eth-r3-2")
+
+    # r4/eth-r5 <-> r5/eth-r4  (10.0.6.0/24)
+    switch = tgen.add_switch("s6")
+    switch.add_link(tgen.gears["r4"], nodeif="eth-r5")
+    switch.add_link(tgen.gears["r5"], nodeif="eth-r4")
+
+    # r1/eth-rr <-> rr/eth-r1  (BGP only, 10.0.0.0/24)
+    switch = tgen.add_switch("s7")
+    switch.add_link(tgen.gears["r1"], nodeif="eth-rr")
+    switch.add_link(tgen.gears["rr"], nodeif="eth-r1")
+
+    # Add dummy sr0 interface on each SRv6 router for uN SID installation
+    for idx, rname in enumerate(["r1", "r2", "r3", "r4", "r5"], start=1):
+        create_interface_in_kernel(
+            tgen,
+            rname,
+            "sr0",
+            "fcbb:bbbb:{}::1".format(idx),
+            netmask="128",
+            create=True,
+        )
+
+
+def setup_module(mod):
+    """Build the topology, load FRR configs, and start all routers."""
+    result = required_linux_kernel_version("4.10")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    """Stop all routers and tear down the topology."""
+    get_topogen().stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+
+
+def test_isis_convergence():
+    """All IS-IS L2 adjacencies converge on every router."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking IS-IS convergence on r1/r2/r3/r4/r5")
+
+    for rname in ["r1", "r2", "r3", "r4", "r5"]:
+        router = tgen.gears[rname]
+        expected = json.loads(
+            open(os.path.join(CWD, "{}/isis_adj.json".format(rname))).read()
+        )
+        test_func = functools.partial(
+            topotest.router_json_cmp, router, "show isis neighbor json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+        assert result is None, '"{}" IS-IS adj not established: {}'.format(
+            rname, result
+        )
+
+
+def test_bgp_convergence():
+    """The BGP Link-State session between r1 and rr reaches Established."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking BGP-LS session: r1 <-> rr")
+
+    for rname, reffile in [
+        ("r1", "r1/bgp_neighbor.json"),
+        ("rr", "rr/bgp_neighbor.json"),
+    ]:
+        router = tgen.gears[rname]
+        expected = json.loads(open(os.path.join(CWD, reffile)).read())
+        test_func = functools.partial(
+            topotest.router_json_cmp, router, "show bgp neighbor json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+        assert result is None, '"{}" BGP session not established: {}'.format(
+            rname, result
+        )
+
+
+def test_bgp_ls_capability():
+    """Both r1 and rr advertise and receive the BGP Link-State AFI/SAFI capability."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking BGP-LS capability negotiation on r1 and rr")
+
+    for rname, reffile in [
+        ("r1", "r1/bgp_capability.json"),
+        ("rr", "rr/bgp_capability.json"),
+    ]:
+        router = tgen.gears[rname]
+        expected = json.loads(open(os.path.join(CWD, reffile)).read())
+        test_func = functools.partial(
+            topotest.router_json_cmp, router, "show bgp neighbor json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, '"{}" BGP-LS capability not negotiated: {}'.format(
+            rname, result
+        )
+
+
+def _check_all_nlris(router, router_name):
+    """Assert that *router* holds the expected SRv6-related BGP-LS NLRIs."""
+    expected = json.loads(open(os.path.join(CWD, "bgp_ls_nlri_srv6.json")).read())
+    _normalize_dynamic_srv6_sid_fields(expected)
+
+    def _cmp_nlri_json():
+        output = router.vtysh_cmd("show bgp link-state link-state json", isjson=True)
+        _normalize_dynamic_srv6_sid_fields(output)
+        return topotest.json_cmp(output, expected)
+
+    test_func = _cmp_nlri_json
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=2)
+    assert result is None, "{}: BGP-LS NLRI/attribute mismatch: {}".format(
+        router_name, result
+    )
+
+
+def test_bgp_ls_producer():
+    """r1 originates the expected SRv6-related BGP-LS NLRIs and attributes."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    logger.info("Checking all BGP-LS NLRIs + SRv6 attributes on producer r1")
+    _check_all_nlris(tgen.gears["r1"], "r1")
+
+
+def test_bgp_ls_consumer():
+    """rr receives the expected SRv6-related BGP-LS NLRIs and attributes."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    logger.info("Checking all BGP-LS NLRIs + SRv6 attributes on consumer rr")
+    _check_all_nlris(tgen.gears["rr"], "rr")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -1733,6 +1733,18 @@ module frr-isisd {
           "Log any dropped PDUs in this area.";
       }
 
+      leaf distribute-link-state {
+        type boolean;
+        default "false";
+        must ". = 'false' or (not(../mpls-te) and not(../mpls-te/export = 'true'))" {
+          error-message
+            "distribute-link-state is mutually exclusive with mpls-te and mpls-te export";
+        }
+        description
+          "Enable distribution of IS-IS link-state information to external
+           consumers (for example, BGP-LS).";
+      }
+
       container mpls-te {
         presence "Present if MPLS-TE is enabled.";
         description


### PR DESCRIPTION
This PR adds BGP-LS extensions for SRv6.

It includes the following TLVs/NLRIs:

- SRv6 SID NLRI (NLRI Type 6)
- SRv6 Capabilities (TLV 1038)
- SRv6 End.X SID (TLV 1106)
- SRv6 LAN End.X SID - IS-IS (TLV 1107)
- SRv6 LAN End.X SID - OSPFv3 (TLV 1108)
- SRv6 Locator (TLV 1162)
- SRv6 Endpoint Behavior (TLV 1250)
- SRv6 SID Structure (TLV 1252)
- SRv6 SID Information (TLV 518, within SRv6 SID descriptors)