### PR TITLE
greptile: Add Greptile configuration for automated code review on PRs.

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,50 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "ignorePatterns": ["**/*.generated.*", "**/*.pb.cc", "**/*.pb.h", "**/*.grpc.pb.cc", "**/*.grpc.pb.h", ".git/**"],
+  "excludeAuthors": ["dependabot[bot]"],
+  "summarySection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": true
+  },
+  "confidenceScoreSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
+  "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback.",
+  "rules": [
+    {
+      "id": "memory-allocation",
+      "rule": "NEVER allow standard malloc(), calloc(), realloc(), or free(). Enforce FRR's XCALLOC, XMALLOC, XREALLOC, XSTRDUP, and XFREE macros (requires MTYPE). Every allocation must use the MTYPE tracking system declared via DECLARE_MTYPE/DEFINE_MTYPE. Prefer DEFINE_MTYPE_STATIC for module-private types.",
+      "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
+      "severity": "critical"
+    },
+    {
+      "id": "logging-api",
+      "rule": "Reject printf() or stdio logging. Enforce FRR's zlog_* API (zlog_debug, zlog_err, zlog_warn, zlog_info, zlog_notice) and structured error macros flog_err(), flog_warn(), flog_err_sys() (which require an EC_* error-code argument). All debug statements MUST be guarded with CLI-controllable debug flags — unguarded debug prints are unacceptable at scale.",
+      "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
+      "severity": "high"
+    },
+    {
+      "id": "string-safety",
+      "rule": "strcpy(), strcat(), and sprintf() are strictly FORBIDDEN — no exceptions, even if the buffer cannot currently overflow (a future change may introduce one). Enforce strlcpy(), strlcat(), and snprintf(). Buffer size arguments MUST use sizeof() wherever possible — never hardcoded size constants.",
+      "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
+      "severity": "critical"
+    }
+  ],
+  "disabledRules": []
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,16 @@
+{
+  "files": [
+    {
+      "path": "doc/developer/workflow.rst",
+      "description": "FRR core coding standards, PR requirements, commit message format, review process, release cycle, defensive coding, formatting rules, and architectural guidelines."
+    },
+    {
+      "path": "doc/developer/memtypes.rst",
+      "description": "MTYPE memory tracking system — XMALLOC/XCALLOC/XFREE usage, DECLARE_MTYPE/DEFINE_MTYPE patterns, XFREE NULL-safety, DEFINE_MTYPE_STATIC preference."
+    },
+    {
+      "path": "doc/developer/logging.rst",
+      "description": "zlog API usage, printfrr format extensions (%pFX, %pI4, %pSU, etc.), debug flag conventions, assert usage policy (no asserts for input validation), log level guidelines (ERROR/WARNING/INFO/DEBUG semantics)."
+    }
+  ]
+}


### PR DESCRIPTION
Settings:
- Strictness 2, status check enabled, re-reviews on every push
- Comment types: logic, syntax, style

Rule structure:
Each rule has an id, description, scope, and severity.
- Scope: glob patterns that limit which files the rule applies to (all three rules scope to **/*.c, **/*.h, **/*.cpp)
- Severity: critical (P0 — must fix), high (P1 — should fix), medium (P2 — consider fix)

Rules cover:
- Memory safety: XMALLOC/XCALLOC/XREALLOC/XSTRDUP/XFREE enforcement, no raw malloc/calloc/realloc/free, MTYPE tracking via DECLARE_MTYPE/DEFINE_MTYPE, prefer DEFINE_MTYPE_STATIC for module-private types
- String safety: no strcpy/strcat/sprintf, enforce strlcpy/strlcat/snprintf, buffer size arguments must use sizeof()
- Logging: zlog_* (zlog_debug, zlog_err, zlog_warn, zlog_info, zlog_notice) and flog_*/flog_err_sys (structured error logging with EC_* codes), no printf/stdio, all debug statements guarded by CLI-controllable debug flags

Doc context loaded by Greptile (.greptile/files.json):
- doc/developer/workflow.rst — coding standards, string-safety policy, debug-guard requirement
- doc/developer/memtypes.rst — XMALLOC/MTYPE system reference
- doc/developer/logging.rst — zlog/flog API, debug message conventions
