### PR TITLE
zebra: Add helper functions to display route redistribution info

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -506,7 +506,7 @@ void vrf_bitmap_unset(vrf_bitmap_t *pbmap, vrf_id_t vrf_id)
 	bit->set = false;
 }
 
-int vrf_bitmap_check(vrf_bitmap_t *pbmap, vrf_id_t vrf_id)
+int vrf_bitmap_check(const vrf_bitmap_t *pbmap, vrf_id_t vrf_id)
 {
 	struct vrf_bit_set lookup = { .vrf_id = vrf_id };
 	struct hash *vrf_hash;

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -177,7 +177,7 @@ extern void vrf_bitmap_init(vrf_bitmap_t *pbmap);
 extern void vrf_bitmap_free(vrf_bitmap_t *pbmap);
 extern void vrf_bitmap_set(vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
 extern void vrf_bitmap_unset(vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
-extern int vrf_bitmap_check(vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
+extern int vrf_bitmap_check(const vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
 
 /*
  * VRF initializer/destructor

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -110,8 +110,7 @@ static void redist_free_instance(void *data)
 	XFREE(MTYPE_REDIST_INST, data);
 }
 
-unsigned short *redist_check_instance(struct redist_proto *red,
-				      unsigned short instance)
+unsigned short *redist_check_instance(const struct redist_proto *red, unsigned short instance)
 {
 	struct listnode *node;
 	unsigned short *id;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -953,7 +953,8 @@ extern void zclient_free(struct zclient *zclient);
 
 extern int zclient_socket_connect(struct zclient *zclient);
 
-extern unsigned short *redist_check_instance(struct redist_proto *red, unsigned short instance);
+extern unsigned short *redist_check_instance(const struct redist_proto *red,
+					     unsigned short instance);
 extern void redist_add_instance(struct redist_proto *red, unsigned short instance);
 extern void redist_del_instance(struct redist_proto *red, unsigned short instance);
 extern void redist_del_all_instances(struct redist_proto *red);

--- a/tests/topotests/show_ip_route_redistribute/r1/frr.conf
+++ b/tests/topotests/show_ip_route_redistribute/r1/frr.conf
@@ -1,0 +1,7 @@
+hostname r1
+!
+ip route 192.168.100.0/24 Null0
+!
+router ospf
+ redistribute static
+!

--- a/tests/topotests/show_ip_route_redistribute/test_show_ip_route_redistribute.py
+++ b/tests/topotests/show_ip_route_redistribute/test_show_ip_route_redistribute.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Mehran Hashemi <mehranstock1383@gmail.com>
+#
+
+import os
+import sys
+import json
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.ospfd]
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_show_ip_route_redistribute_json():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check_route_json():
+        output = r1.vtysh_cmd("show ip route 192.168.100.0 json")
+        try:
+            data = json.loads(output)
+            prefix_data = data.get("192.168.100.0/24", [])
+            if not prefix_data:
+                return "Prefix not found in JSON"
+
+            if "redistributingVia" in prefix_data[0]:
+                if "ospf" in prefix_data[0]["redistributingVia"]:
+                    return None
+
+            return "redistributingVia key missing or does not contain ospf"
+        except json.JSONDecodeError:
+            return "Invalid JSON output"
+
+    success, result = topotest.run_and_expect(_check_route_json, None, count=20, wait=1)
+    assert success, "JSON test failed: {}".format(result)
+
+def test_show_ip_route_redistribute_cli():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check_route_cli():
+        output = r1.vtysh_cmd("show ip route 192.168.100.0")
+        if "Redistributing via ospf" in output:
+            return None
+        return "CLI output did not contain 'Redistributing via ospf'"
+
+    success, result = topotest.run_and_expect(_check_route_cli, None, count=20, wait=1)
+    assert success, "CLI test failed: {}".format(result)
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -183,9 +183,8 @@ static bool zebra_redistribute_is_table_direct(const struct route_entry *re)
  * Function to check if prefix is candidate for
  * redistribute.
  */
-static bool zebra_redistribute_check(const struct route_node *rn,
-				     const struct route_entry *re,
-				     struct zserv *client)
+bool zebra_redistribute_check(const struct route_node *rn, const struct route_entry *re,
+			      const struct zserv *client)
 {
 	struct zebra_vrf *zvrf;
 	afi_t afi;

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -70,6 +70,9 @@ extern int zebra_import_table_config(struct vty *vty, vrf_id_t vrf_id);
 
 extern void zebra_import_table_rm_update(const char *rmap);
 
+extern bool zebra_redistribute_check(const struct route_node *rn, const struct route_entry *re,
+				     const struct zserv *client);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -411,6 +411,46 @@ static void uptime2str(time_t uptime, char *buf, size_t bufsize)
 	frrtime_to_interval(cur, buf, bufsize);
 }
 
+static void zebra_dump_redistribution_info(const struct route_node *rn,
+					   const struct route_entry *re, struct vty *vty,
+					   struct json_object *json)
+{
+	const struct zserv *client;
+	const char *redist_proto;
+	struct json_object *json_redist = NULL;
+	bool redist_found = false;
+
+	if (!vty && !json)
+		return;
+
+	frr_each (zserv_client_list_const, &zrouter.client_list, client) {
+		if (zebra_redistribute_check(rn, re, client)) {
+			redist_proto = zebra_route_string(client->proto);
+
+			if (vty) {
+				if (redist_found)
+					vty_out(vty, ",");
+				else
+					vty_out(vty, "  Redistributing via");
+				vty_out(vty, " %s", redist_proto);
+			} else {
+				if (!json_redist)
+					json_redist = json_object_new_array();
+				json_array_string_add(json_redist, redist_proto);
+			}
+
+			redist_found = true;
+		}
+	}
+
+	if (redist_found) {
+		if (vty)
+			vty_out(vty, "\n");
+		else
+			json_object_object_add(json, "redistributingVia", json_redist);
+	}
+}
+
 /* New RIB.  Detailed information for IPv4 route. */
 static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				     int mcast, bool use_fib, bool show_ng)
@@ -466,6 +506,8 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED))
 			vty_out(vty, ", best");
 		vty_out(vty, "\n");
+
+		zebra_dump_redistribution_info(rn, re, vty, NULL);
 
 		uptime2str(re->uptime, buf, sizeof(buf));
 
@@ -811,6 +853,8 @@ static void vty_show_ip_route_detail_json(struct vty *vty,
 		json_object *json_route =
 			json_object_array_get_idx(json_prefix,
 						  json_object_array_length(json_prefix) - 1);
+
+		zebra_dump_redistribution_info(rn, re, NULL, json_route);
 
 		json_object_int_add(json_route, "flags", re->flags);
 		json_object_int_add(json_route, "status", re->status);


### PR DESCRIPTION
Add new helper functions to show which protocols are currently redistributing a specific route.

Also make function signatures const-correct to match the recent change to `zebra_redistribute_check()`. Several function pointers in the redistribution path were discarding const qualifiers, triggering compiler `-Wdiscarded-qualifiers` warnings.