### PR TITLE
bgpd: fix F-bit incorrectly set after port flap  

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -3283,10 +3283,15 @@ static inline void bgp_update_gr_completion(void)
 static inline bool bgp_gr_is_forwarding_preserved(struct bgp *bgp)
 {
 	/*
-	 * Is forwarding state preserved? Based either on config
-	 * or if BGP restarted gracefully.
-	 * TBD: Additional AFI/SAFI based checks etc.
+	 * F-bit should only be set when a graceful restart is actually
+	 * in progress (t_startup running or GR not yet complete).
+	 * If there is no restart (e.g. port flap), F-bit must be 0
+	 * regardless of preserve-fw-state config or -K flag.
+	 * This aligns F-bit logic with R-bit logic per RFC 4724.
 	 */
+	if (!(bgp->t_startup || bgp_in_graceful_restart()))
+		return false;
+
 	return (CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART) ||
 		CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD));
 }


### PR DESCRIPTION
The Forwarding State (F) bit in the BGP Graceful Restart capability was being set based on BM_FLAG_GRACEFUL_RESTART (from -K startup flag) or BGP_FLAG_GR_PRESERVE_FWD (from preserve-fw-state config), without gating on whether a restart was actually in progress.

Since BM_FLAG_GRACEFUL_RESTART stays set once initialized at startup and BGP_FLAG_GR_PRESERVE_FWD stays set as long as the config exists, the F-bit remained 1 even after GR completed and on subsequent port flaps where no restart occurred. This caused R=0, F=1 in the OPEN message after a port flap, violating RFC 4724.

Fix by gating the F-bit behind the same restart check used for the R-bit: bgp->t_startup (startup timer running) or
bgp_in_graceful_restart() (GR in progress). This ensures F=1 only during an actual restart window, and F=0 for port flaps or any session reset after the restart window closes.

Logs:
```
Topology:
 n1:swp1 <-----> n2:swp1

================ Before fix ====================
n1# show running-config bgpd 
Building configuration...

Current configuration:
!
frr version 10.6-dev
frr defaults datacenter
hostname n1
service integrated-vtysh-config
!
password cn321
enable password cn321
!
vrf mgmt
exit-vrf
!
router bgp 65001
 bgp router-id 10.10.0.1
 no bgp default ipv4-unicast
 bgp graceful-restart select-defer-time 45
 bgp graceful-restart
 bgp graceful-restart preserve-fw-state
 neighbor 10.0.12.2 remote-as 65002
 use-underlays-nexthop-weight
 !
 address-family ipv4 unicast
  network 10.10.0.1/32
  neighbor 10.0.12.2 activate
 exit-address-family
 !
 address-family ipv6 unicast
  network fd00:10::1/128
 exit-address-family
exit
!
line vty
 exec-timeout 0 0
exit
!
end
n1# show bgp summary 

IPv4 Unicast Summary:
BGP router identifier 10.10.0.1, local AS number 65001 VRF default vrf-id 0
BGP table version 2
RIB entries 3, using 456 bytes of memory
Peers 1, using 24 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
n2(10.0.12.2)   4      65002        66        66        2    0    0 00:03:05            1        2 FRRouting/10.6-dev

Total number of neighbors 1
n1# exit
root@n1:mgmt:~# sudo ifdown swp1
root@n1:mgmt:~# sudo ifup swp1
root@n1:mgmt:~# 


n2# show bgp summary 

IPv4 Unicast Summary:
BGP router identifier 10.10.0.2, local AS number 65002 VRF default vrf-id 0
BGP table version 2
RIB entries 3, using 456 bytes of memory
Peers 1, using 24 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
n1(10.0.12.1)   4      65001       217       221        2    0    0 00:00:04            1        2 FRRouting/10.6-dev

Total number of neighbors 1
n2# show bgp neighbors 10.0.12.1 graceful-restart json 
{
  "10.0.12.1":{
    "neighborAddr":"10.0.12.1",
    "remoteAs":65001,
    "localAs":65002,
    "localAsReplaceAsDualAs":false,
    "nbrExternalLink":true,
    "localRole":"undefined",
    "remoteRole":"undefined",
    "bgpState":"Established",
    "bgpTimerUpMsec":11000,
    "bgpTimerUpString":"00:00:11",
    "bgpTimerUpEstablishedEpoch":1777470235,
    "neighborCapabilities":{
      "gracefulRestart":"advertisedAndReceived",
      "gracefulRestartRemoteTimerSec":120,
      "nBitReceived":true,
      "addressFamiliesByPeer":{
        "ipv4Unicast":{
          "preserved":true
        }
      }
    },
    "gracefulRestartInfo":{
      "endOfRibSend":{
        "ipv4Unicast":true
      },
      "endOfRibRecv":{
        "ipv4Unicast":true
      },
      "gracefulStalepathTimerSec":347,
      "localGrMode":"Restart*",
      "remoteGrMode":"Restart",
      "rBit":false,
      "nBit":true,
      "timers":{
        "configuredRestartTimer":120,
        "configuredLlgrStaleTime":0,
        "receivedRestartTimer":120,
        "gracefulStalepathTimerSec":347
      },
      "ipv4Unicast":{
        "fBit":true,    ===============> F-bit set for port flap
        "endOfRibStatus":{
          "endOfRibSend":true,
          "endOfRibSentAfterUpdate":true,
          "endOfRibRecv":true
        },
        "timers":{
          "stalePathTimer":360,
          "llgrStaleTime":0,
          "stalePathTimerRemaining":347,
          "selectionDeferralTimer":45
        }
      }
    }
  }
}
n2# 
================ After fix =====================
n1# show running-config bgpd 
Building configuration...

Current configuration:
!
frr version 10.6-dev
frr defaults datacenter
hostname n1
service integrated-vtysh-config
!
password cn321
enable password cn321
!
vrf mgmt
exit-vrf
!
router bgp 65001
 bgp router-id 10.10.0.1
 no bgp default ipv4-unicast
 bgp graceful-restart select-defer-time 45
 bgp graceful-restart
 bgp graceful-restart preserve-fw-state
 neighbor 10.0.12.2 remote-as 65002
 use-underlays-nexthop-weight
 !
 address-family ipv4 unicast
  network 10.10.0.1/32
  neighbor 10.0.12.2 activate
 exit-address-family
 !
 address-family ipv6 unicast
  network fd00:10::1/128
 exit-address-family
exit
!
line vty
 exec-timeout 0 0
exit
!
end
n1# show bgp summary 

IPv4 Unicast Summary:
BGP router identifier 10.10.0.1, local AS number 65001 VRF default vrf-id 0
BGP table version 6
RIB entries 3, using 456 bytes of memory
Peers 1, using 24 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
n2(10.0.12.2)   4      65002      4111      4110        6    0    0 00:02:09            1        2 FRRouting/10.6-dev

Total number of neighbors 1
n1# 
n1# exit
root@n1:mgmt:~# sudo ifdown swp1
root@n1:mgmt:~# sudo ifup swp1
root@n1:mgmt:~# 


n2# show bgp summary 

IPv4 Unicast Summary:
BGP router identifier 10.10.0.2, local AS number 65002 VRF default vrf-id 0
BGP table version 20
RIB entries 3, using 456 bytes of memory
Peers 1, using 24 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
n1(10.0.12.1)   4      65001      4474      4492       20    0    0 00:00:03            1        2 FRRouting/10.6-dev

Total number of neighbors 1
n2# 
n2# show bgp neighbors 10.0.12.1 graceful-restart json 
{
  "10.0.12.1":{
    "neighborAddr":"10.0.12.1",
    "remoteAs":65001,
    "localAs":65002,
    "localAsReplaceAsDualAs":false,
    "nbrExternalLink":true,
    "localRole":"undefined",
    "remoteRole":"undefined",
    "bgpState":"Established",
    "bgpTimerUpMsec":12000,
    "bgpTimerUpString":"00:00:12",
    "bgpTimerUpEstablishedEpoch":1777468605,
    "neighborCapabilities":{
      "gracefulRestart":"advertisedAndReceived",
      "gracefulRestartRemoteTimerSec":120,
      "nBitReceived":true,
      "addressFamiliesByPeer":{
        "ipv4Unicast":{
        }
      }
    },
    "gracefulRestartInfo":{
      "endOfRibSend":{
        "ipv4Unicast":true
      },
      "endOfRibRecv":{
        "ipv4Unicast":true
      },
      "gracefulStalepathTimerSec":347,
      "localGrMode":"Restart*",
      "remoteGrMode":"Restart",
      "rBit":false,
      "nBit":true,
      "timers":{
        "configuredRestartTimer":120,
        "configuredLlgrStaleTime":0,
        "receivedRestartTimer":120,
        "gracefulStalepathTimerSec":347
      },
      "ipv4Unicast":{
        "fBit":false, =================> F-bit unset for port flap
        "endOfRibStatus":{
          "endOfRibSend":true,
          "endOfRibSentAfterUpdate":false,
          "endOfRibRecv":true
        },
        "timers":{
          "stalePathTimer":360,
          "llgrStaleTime":0,
          "stalePathTimerRemaining":347,
          "selectionDeferralTimer":45
        }
      }
    }
  }
}
n2#

```