### PR TITLE
bgpd: set mp_nexthop_len consistently in  subgroup_default_originate()

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -989,6 +989,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 			attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
 	} else {
 		bgp_attr_set(&attr, BGP_ATTR_NEXT_HOP);
+		attr.mp_nexthop_len = IPV4_MAX_BYTELEN;
 	}
 
 	if (peer->default_rmap[afi][safi].name) {


### PR DESCRIPTION
d33a1dd19f added bgp_attr_set(&attr, BGP_ATTR_NEXT_HOP) to the IPv4
else branch of subgroup_default_originate(), but bgp_attr_default_set()
still initializes mp_nexthop_len to IPV6_MAX_BYTELEN. For the IPv4
default-originate path, mp_nexthop_len should be IPV4_MAX_BYTELEN.

This has no behavioral effect: every code path that consults mp_nexthop_len
(BGP_ATTR_NEXTHOP_AFI_IP6, BGP_NEXTHOP_AFI_FROM_NHLEN) first guards on
BGP_ATTR_NEXT_HOP being absent, which it is not for IPv4. The change
restores internal consistency so the field accurately reflects the nexthop
type.