### PR TITLE
bfdd: avoid close(-1) in bfd_dplane_finish_late

### DIFF
--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -1021,7 +1021,7 @@ static int bfd_dplane_finish_late(void)
 
 	/* Cancel accept thread and close socket. */
 	event_cancel(&bglobal.bg_dplane_sockev);
-	close(bglobal.bg_dplane_sock);
+	socket_close(&bglobal.bg_dplane_sock);
 
 	return 0;
 }


### PR DESCRIPTION
When distributed BFD is used in client mode (or server socket init fails), bg_dplane_sock stays -1. frr_fini still ran bfd_dplane_finish_late and called close(-1), which Valgrind reports and is invalid for POSIX.

Use socket_close() so we only close a valid listen fd.

Ticket: #4989670