### PR TITLE
bgpd: EVPN rd all or specific rd options based route table 

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2919,6 +2919,62 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 }
 
 /*
+ * Display BGP EVPN routing table -- for specific RD and prefix
+ * (vty handler). By definition, only matching type-5 route will be
+ * displayed.
+ */
+static void evpn_show_route_rd_prefix(struct vty *vty, struct bgp *bgp, struct prefix_rd *prd,
+				      struct prefix *ip_prefix, json_object *json)
+{
+	struct prefix_evpn p;
+	struct bgp_dest *rn;
+	struct bgp_path_info *pi;
+	afi_t afi;
+	safi_t safi;
+	uint32_t path_cnt = 0;
+	json_object *json_paths = NULL;
+	char prefix_str[BUFSIZ];
+
+	afi = AFI_L2VPN;
+	safi = SAFI_EVPN;
+
+	/* Build type-5 prefix. */
+	build_type5_prefix_from_ip_prefix(&p, ip_prefix);
+
+	/* See if route exists. */
+	rn = bgp_safi_node_lookup(bgp->rib[afi][safi], safi, (struct prefix *)&p, prd);
+	if (!rn || !bgp_dest_has_bgp_path_info_data(rn)) {
+		if (!json)
+			vty_out(vty, "%% Network not in table\n");
+		return;
+	}
+
+	prefix2str((struct prefix_evpn *)&p, prefix_str, sizeof(prefix_str));
+
+	/* Prefix and num paths displayed once per prefix. */
+	route_vty_out_detail_header(vty, bgp, rn, bgp_dest_get_prefix(rn), prd, afi, safi, json,
+				    false);
+
+	if (json)
+		json_paths = json_object_new_array();
+
+	/* Display each path for this prefix. */
+	for (pi = bgp_dest_get_bgp_path_info(rn); pi; pi = pi->next) {
+		route_vty_out_detail(vty, bgp, rn, bgp_dest_get_prefix(rn), pi, afi, safi,
+				     RPKI_NOT_BEING_USED, json_paths);
+		path_cnt++;
+	}
+
+	if (json && path_cnt) {
+		if (path_cnt)
+			json_object_object_add(json, "paths", json_paths);
+		json_object_int_add(json, "numPaths", path_cnt);
+	} else {
+		vty_out(vty, "\nDisplayed %u paths for requested prefix\n", path_cnt);
+	}
+}
+
+/*
  * Display BGP EVPN routing table -- for specific RD (vty handler)
  * If 'type' is non-zero, only routes matching that type are shown.
  */
@@ -5187,6 +5243,70 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_macip,
 	return CMD_SUCCESS;
 }
 
+/*
+ * Display global EVPN routing table for specific RD and prefix (type-5).
+ */
+DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
+      show_bgp_l2vpn_evpn_route_rd_prefix_cmd,
+      "show bgp l2vpn evpn route rd ASN:NN_OR_IP-ADDRESS:NN prefix <A.B.C.D/M|X:X::X:X/M> [json]",
+      SHOW_STR
+      BGP_STR
+      L2VPN_HELP_STR
+      EVPN_HELP_STR
+      "EVPN route information\n"
+      "Route Distinguisher\n"
+      "ASN:XX or A.B.C.D:XX\n"
+      "prefix\n"
+      "IP prefix\n"
+      "IPv6 prefix\n"
+      JSON_STR)
+{
+	struct bgp *bgp;
+	int ret;
+	int idx = 0;
+	struct prefix_rd prd;
+	struct prefix ip_prefix;
+	bool uj = false;
+	json_object *json = NULL;
+
+	bgp = bgp_get_evpn();
+	if (!bgp)
+		return CMD_WARNING;
+
+	/* check if we need json output */
+	uj = use_json(argc, argv);
+	if (uj)
+		json = json_object_new_object();
+
+	/* get the prd */
+	if (argv_find(argv, argc, "rd", &idx)) {
+		ret = str2prefix_rd(argv[idx + 1]->arg, &prd);
+		if (!ret) {
+			vty_out(vty, "%% Malformed Route Distinguisher\n");
+			return CMD_WARNING;
+		}
+	}
+
+	/* get the prefix */
+	if (argv_find(argv, argc, "prefix", &idx)) {
+		ret = str2prefix(argv[idx + 1]->arg, &ip_prefix);
+		if (!ret) {
+			vty_out(vty, "prefix is malformed\n");
+			return CMD_WARNING;
+		}
+	} else
+		return CMD_WARNING;
+
+	evpn_show_route_rd_prefix(vty, bgp, &prd, &ip_prefix, json);
+
+	if (uj) {
+		vty_out(vty, "%s\n", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
+		json_object_free(json);
+	}
+
+	return CMD_SUCCESS;
+}
+
 /* Display per ESI routing table */
 DEFUN(show_bgp_l2vpn_evpn_route_esi,
       show_bgp_l2vpn_evpn_route_esi_cmd,
@@ -6197,6 +6317,20 @@ ALIAS_HIDDEN(
 	"MAC address (e.g., 00:e0:ec:20:12:62)\n"
 	"IP\n"
 	"IP address (IPv4 or IPv6)\n")
+
+ALIAS_HIDDEN(
+	show_bgp_l2vpn_evpn_route_rd_prefix, show_bgp_evpn_route_rd_prefix_cmd,
+	"show bgp evpn route rd ASN:NN_OR_IP-ADDRESS:NN prefix <A.B.C.D/M|X:X::X:X/M> [json]",
+	SHOW_STR
+	BGP_STR
+	EVPN_HELP_STR
+	"EVPN route information\n"
+	"Route Distinguisher\n"
+	"ASN:XX or A.B.C.D:XX\n"
+	"prefix\n"
+	"IP prefix\n"
+	"IPv6 prefix\n"
+	JSON_STR)
 
 ALIAS_HIDDEN(
 	show_bgp_l2vpn_evpn_route_vni, show_bgp_evpn_route_vni_cmd,
@@ -7670,6 +7804,7 @@ void bgp_ethernetvpn_init(void)
 	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_route_cmd);
 	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_route_rd_cmd);
 	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_route_rd_macip_cmd);
+	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_route_rd_prefix_cmd);
 	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_route_esi_cmd);
 	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_route_vni_cmd);
 	install_element(VIEW_NODE,
@@ -7703,6 +7838,7 @@ void bgp_ethernetvpn_init(void)
 	install_element(VIEW_NODE, &show_bgp_evpn_route_cmd);
 	install_element(VIEW_NODE, &show_bgp_evpn_route_rd_cmd);
 	install_element(VIEW_NODE, &show_bgp_evpn_route_rd_macip_cmd);
+	install_element(VIEW_NODE, &show_bgp_evpn_route_rd_prefix_cmd);
 	install_element(VIEW_NODE, &show_bgp_evpn_route_vni_cmd);
 	install_element(VIEW_NODE, &show_bgp_evpn_route_vni_multicast_cmd);
 	install_element(VIEW_NODE, &show_bgp_evpn_route_vni_macip_cmd);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2851,9 +2851,7 @@ static void evpn_show_routes_vni(struct vty *vty, struct bgp *bgp, vni_t vni,
 
 /*
  * Display BGP EVPN routing table -- across all RDs for a given IP
- * prefix (vty handler). Walks both the main rib and evpn_unreach_rib
- * so type-5 (IP Prefix) and EVPN unreach (IP Prefix Unreachability)
- * routes are both reported.
+ * prefix (vty handler).
  */
 static void evpn_show_route_rd_all_prefix(struct vty *vty, struct bgp *bgp,
 					  struct prefix *ip_prefix, json_object *json)
@@ -2865,88 +2863,80 @@ static void evpn_show_route_rd_all_prefix(struct vty *vty, struct bgp *bgp,
 	afi_t afi = AFI_L2VPN;
 	safi_t safi = SAFI_EVPN;
 	uint32_t prefix_cnt = 0, path_cnt = 0;
-	struct bgp_table *ribs[2];
-	int n_ribs = 0;
-	int rib_idx;
+	struct bgp_table *rib = bgp->rib[afi][safi];
 
-	ribs[n_ribs++] = bgp->rib[afi][safi];
-	if (bgp->evpn_unreach_rib)
-		ribs[n_ribs++] = bgp->evpn_unreach_rib;
+	build_type5_prefix_from_ip_prefix(&p, ip_prefix);
 
-	for (rib_idx = 0; rib_idx < n_ribs; rib_idx++) {
-		struct bgp_table *rib = ribs[rib_idx];
-		bool is_unreach_rib = (rib == bgp->evpn_unreach_rib);
+	for (rd_dest = bgp_table_top(rib); rd_dest; rd_dest = bgp_route_next(rd_dest)) {
+		json_object *json_paths = NULL;
+		json_object *json_rd = NULL;
+		char rd_str[RD_ADDRSTRLEN];
+		const struct prefix *rd_destp = bgp_dest_get_prefix(rd_dest);
+		struct bgp_table *table;
+		uint32_t local_path_cnt = 0;
 
-		if (!rib)
+		table = bgp_dest_get_bgp_table_info(rd_dest);
+		if (table == NULL)
 			continue;
 
-		for (rd_dest = bgp_table_top(rib); rd_dest; rd_dest = bgp_route_next(rd_dest)) {
-			json_object *json_paths = NULL;
-			json_object *json_rd = NULL;
-			char rd_str[RD_ADDRSTRLEN];
-			const struct prefix *rd_destp = bgp_dest_get_prefix(rd_dest);
-			struct bgp_table *table;
-			uint32_t local_path_cnt = 0;
-
-			table = bgp_dest_get_bgp_table_info(rd_dest);
-			if (table == NULL)
-				continue;
-
-			/* Build the appropriate EVPN prefix for this rib. */
-			build_type5_prefix_from_ip_prefix(&p, ip_prefix);
-			if (is_unreach_rib)
-				p.prefix.route_type = BGP_EVPN_IP_PREFIX_UNREACH_ROUTE;
-
-			rn = bgp_safi_node_lookup(rib, safi, (struct prefix *)&p,
-						  (struct prefix_rd *)rd_destp);
-			if (!rn)
-				continue;
-			if (!bgp_dest_has_bgp_path_info_data(rn)) {
-				bgp_dest_unlock_node(rn);
-				continue;
-			}
-
-			prefix_rd2str((struct prefix_rd *)rd_destp, rd_str, sizeof(rd_str),
-				      bgp->asnotation);
-
-			if (json) {
-				json_rd = json_object_new_object();
-				json_paths = json_object_new_array();
-			}
-
-			bgp_evpn_show_route_rd_header(vty, rd_dest, json_rd, rd_str, RD_ADDRSTRLEN);
-
-			route_vty_out_detail_header(vty, bgp, rn, bgp_dest_get_prefix(rn),
-						    (struct prefix_rd *)rd_destp, afi, safi,
-						    json_rd, false);
-
-			for (pi = bgp_dest_get_bgp_path_info(rn); pi; pi = pi->next) {
-				route_vty_out_detail(vty, bgp, rn, bgp_dest_get_prefix(rn), pi,
-						     afi, safi, RPKI_NOT_BEING_USED, json_paths);
-				local_path_cnt++;
-			}
-
-			path_cnt += local_path_cnt;
-
-			if (json) {
-				if (local_path_cnt) {
-					json_object_object_add(json_rd, "paths", json_paths);
-					json_object_object_add(json, rd_str, json_rd);
-				} else {
-					/* Defensive: parent-add was skipped, so
-					 * release the per-iteration objects to
-					 * avoid leaking them with the parent.
-					 */
-					json_object_free(json_paths);
-					json_object_free(json_rd);
-				}
-			}
-
-			if (local_path_cnt)
-				prefix_cnt++;
-
+		rn = bgp_safi_node_lookup(rib, safi, (struct prefix *)&p,
+					  (struct prefix_rd *)rd_destp);
+		if (!rn)
+			continue;
+		if (!bgp_dest_has_bgp_path_info_data(rn)) {
 			bgp_dest_unlock_node(rn);
+			continue;
 		}
+
+		prefix_rd2str((struct prefix_rd *)rd_destp, rd_str, sizeof(rd_str),
+			      bgp->asnotation);
+
+		if (json) {
+			json_rd = json_object_new_object();
+			json_paths = json_object_new_array();
+		}
+
+		bgp_evpn_show_route_rd_header(vty, rd_dest, json_rd, rd_str, RD_ADDRSTRLEN);
+
+		route_vty_out_detail_header(vty, bgp, rn, bgp_dest_get_prefix(rn),
+					    (struct prefix_rd *)rd_destp, afi, safi, json_rd,
+					    false, false);
+
+		for (pi = bgp_dest_get_bgp_path_info(rn); pi; pi = pi->next) {
+			json_object *json_path = NULL;
+
+			if (json)
+				json_path = json_object_new_array();
+
+			route_vty_out_detail(vty, bgp, rn, bgp_dest_get_prefix(rn), pi, afi, safi,
+					     RPKI_NOT_BEING_USED, json_path, NULL, 0);
+
+			if (json)
+				json_object_array_add(json_paths, json_path);
+
+			local_path_cnt++;
+		}
+
+		path_cnt += local_path_cnt;
+
+		if (json) {
+			if (local_path_cnt) {
+				json_object_object_add(json_rd, "paths", json_paths);
+				json_object_object_add(json, rd_str, json_rd);
+			} else {
+				/* Defensive: parent-add was skipped, so
+				 * release the per-iteration objects to
+				 * avoid leaking them with the parent.
+				 */
+				json_object_free(json_paths);
+				json_object_free(json_rd);
+			}
+		}
+
+		if (local_path_cnt)
+			prefix_cnt++;
+
+		bgp_dest_unlock_node(rn);
 	}
 
 	if (json) {
@@ -3045,7 +3035,6 @@ static void evpn_show_route_rd_prefix(struct vty *vty, struct bgp *bgp, struct p
 	safi_t safi;
 	uint32_t path_cnt = 0;
 	json_object *json_paths = NULL;
-	char prefix_str[BUFSIZ];
 
 	afi = AFI_L2VPN;
 	safi = SAFI_EVPN;
@@ -3058,32 +3047,43 @@ static void evpn_show_route_rd_prefix(struct vty *vty, struct bgp *bgp, struct p
 	if (!rn || !bgp_dest_has_bgp_path_info_data(rn)) {
 		if (!json)
 			vty_out(vty, "%% Network not in table\n");
+		if (rn)
+			bgp_dest_unlock_node(rn);
 		return;
 	}
 
-	prefix2str((struct prefix_evpn *)&p, prefix_str, sizeof(prefix_str));
-
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, rn, bgp_dest_get_prefix(rn), prd, afi, safi, json,
-				    false);
+				    false, false);
 
 	if (json)
 		json_paths = json_object_new_array();
 
 	/* Display each path for this prefix. */
 	for (pi = bgp_dest_get_bgp_path_info(rn); pi; pi = pi->next) {
+		json_object *json_path = NULL;
+
+		if (json)
+			json_path = json_object_new_array();
+
 		route_vty_out_detail(vty, bgp, rn, bgp_dest_get_prefix(rn), pi, afi, safi,
-				     RPKI_NOT_BEING_USED, json_paths);
+				     RPKI_NOT_BEING_USED, json_path, NULL, 0);
+
+		if (json)
+			json_object_array_add(json_paths, json_path);
+
 		path_cnt++;
 	}
 
-	if (json && path_cnt) {
+	if (json) {
 		if (path_cnt)
 			json_object_object_add(json, "paths", json_paths);
 		json_object_int_add(json, "numPaths", path_cnt);
 	} else {
 		vty_out(vty, "\nDisplayed %u paths for requested prefix\n", path_cnt);
 	}
+
+	bgp_dest_unlock_node(rn);
 }
 
 /*
@@ -5358,9 +5358,10 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_macip,
 /*
  * Display global EVPN routing table for specific RD and prefix (type-5).
  */
-DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
+DEFPY(show_bgp_l2vpn_evpn_route_rd_prefix,
       show_bgp_l2vpn_evpn_route_rd_prefix_cmd,
-      "show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN|all> prefix <A.B.C.D/M|X:X::X:X/M> [json]",
+      "show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN$rd_str|all$rd_all> prefix "
+      "<A.B.C.D/M|X:X::X:X/M>$prefix [json$uj]",
       SHOW_STR
       BGP_STR
       L2VPN_HELP_STR
@@ -5369,67 +5370,34 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
       "Route Distinguisher\n"
       "ASN:XX or A.B.C.D:XX\n"
       "All VPN Route Distinguishers\n"
-      "prefix\n"
+      "Prefix\n"
       "IP prefix\n"
       "IPv6 prefix\n"
       JSON_STR)
 {
 	struct bgp *bgp;
 	int ret;
-	int idx = 0;
-	int idx_ext_community = 0;
 	struct prefix_rd prd = {};
-	struct prefix ip_prefix = {};
-	bool uj = false;
+	struct prefix ip_prefix = *prefix;
 	json_object *json = NULL;
-	bool rd_all = false;
-	int rd_all_idx = 0;
 
 	bgp = bgp_get_evpn();
 	if (!bgp)
 		return CMD_WARNING;
 
 	/* check if we need json output */
-	uj = use_json(argc, argv);
 	if (uj)
 		json = json_object_new_object();
 
-	/* The token after "rd" may be either the literal "all" or the
-	 * ASN:NN_OR_IP-ADDRESS:NN RD value. Check "all" first so we do not
-	 * pass it to str2prefix_rd(); otherwise fetch the RD by its CLI
-	 * placeholder token.
-	 */
-	rd_all = argv_find(argv, argc, "all", &rd_all_idx);
 	if (!rd_all) {
-		if (argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community)) {
-			ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
-			if (!ret) {
-				vty_out(vty, "%% Malformed Route Distinguisher\n");
-				if (uj)
-					json_object_free(json);
-				return CMD_WARNING;
-			}
-		} else {
-			vty_out(vty, "%% Route Distinguisher is required\n");
-			if (uj)
-				json_object_free(json);
-			return CMD_WARNING;
-		}
-	}
-
-	/* get the prefix */
-	if (argv_find(argv, argc, "prefix", &idx)) {
-		ret = str2prefix(argv[idx + 1]->arg, &ip_prefix);
+		ret = str2prefix_rd(rd_str, &prd);
 		if (!ret) {
-			vty_out(vty, "prefix is malformed\n");
 			if (uj)
-				json_object_free(json);
+				vty_json_empty(vty, json);
+			else
+				vty_out(vty, "%% Malformed Route Distinguisher\n");
 			return CMD_WARNING;
 		}
-	} else {
-		if (uj)
-			json_object_free(json);
-		return CMD_WARNING;
 	}
 
 	if (rd_all)
@@ -5437,10 +5405,8 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
 	else
 		evpn_show_route_rd_prefix(vty, bgp, &prd, &ip_prefix, json);
 
-	if (uj) {
-		vty_out(vty, "%s\n", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -6458,14 +6424,16 @@ ALIAS_HIDDEN(
 
 ALIAS_HIDDEN(
 	show_bgp_l2vpn_evpn_route_rd_prefix, show_bgp_evpn_route_rd_prefix_cmd,
-	"show bgp evpn route rd ASN:NN_OR_IP-ADDRESS:NN prefix <A.B.C.D/M|X:X::X:X/M> [json]",
+	"show bgp evpn route rd <ASN:NN_OR_IP-ADDRESS:NN$rd_str|all$rd_all> prefix "
+	"<A.B.C.D/M|X:X::X:X/M>$prefix [json$uj]",
 	SHOW_STR
 	BGP_STR
 	EVPN_HELP_STR
 	"EVPN route information\n"
 	"Route Distinguisher\n"
 	"ASN:XX or A.B.C.D:XX\n"
-	"prefix\n"
+	"All VPN Route Distinguishers\n"
+	"Prefix\n"
 	"IP prefix\n"
 	"IPv6 prefix\n"
 	JSON_STR)

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2850,6 +2850,118 @@ static void evpn_show_routes_vni(struct vty *vty, struct bgp *bgp, vni_t vni,
 }
 
 /*
+ * Display BGP EVPN routing table -- across all RDs for a given IP
+ * prefix (vty handler). Walks both the main rib and evpn_unreach_rib
+ * so type-5 (IP Prefix) and EVPN unreach (IP Prefix Unreachability)
+ * routes are both reported.
+ */
+static void evpn_show_route_rd_all_prefix(struct vty *vty, struct bgp *bgp,
+					  struct prefix *ip_prefix, json_object *json)
+{
+	struct prefix_evpn p;
+	struct bgp_dest *rd_dest;
+	struct bgp_dest *rn;
+	struct bgp_path_info *pi;
+	afi_t afi = AFI_L2VPN;
+	safi_t safi = SAFI_EVPN;
+	uint32_t prefix_cnt = 0, path_cnt = 0;
+	struct bgp_table *ribs[2];
+	int n_ribs = 0;
+	int rib_idx;
+
+	ribs[n_ribs++] = bgp->rib[afi][safi];
+	if (bgp->evpn_unreach_rib)
+		ribs[n_ribs++] = bgp->evpn_unreach_rib;
+
+	for (rib_idx = 0; rib_idx < n_ribs; rib_idx++) {
+		struct bgp_table *rib = ribs[rib_idx];
+		bool is_unreach_rib = (rib == bgp->evpn_unreach_rib);
+
+		if (!rib)
+			continue;
+
+		for (rd_dest = bgp_table_top(rib); rd_dest; rd_dest = bgp_route_next(rd_dest)) {
+			json_object *json_paths = NULL;
+			json_object *json_rd = NULL;
+			char rd_str[RD_ADDRSTRLEN];
+			const struct prefix *rd_destp = bgp_dest_get_prefix(rd_dest);
+			struct bgp_table *table;
+			uint32_t local_path_cnt = 0;
+
+			table = bgp_dest_get_bgp_table_info(rd_dest);
+			if (table == NULL)
+				continue;
+
+			/* Build the appropriate EVPN prefix for this rib. */
+			build_type5_prefix_from_ip_prefix(&p, ip_prefix);
+			if (is_unreach_rib)
+				p.prefix.route_type = BGP_EVPN_IP_PREFIX_UNREACH_ROUTE;
+
+			rn = bgp_safi_node_lookup(rib, safi, (struct prefix *)&p,
+						  (struct prefix_rd *)rd_destp);
+			if (!rn)
+				continue;
+			if (!bgp_dest_has_bgp_path_info_data(rn)) {
+				bgp_dest_unlock_node(rn);
+				continue;
+			}
+
+			prefix_rd2str((struct prefix_rd *)rd_destp, rd_str, sizeof(rd_str),
+				      bgp->asnotation);
+
+			if (json) {
+				json_rd = json_object_new_object();
+				json_paths = json_object_new_array();
+			}
+
+			bgp_evpn_show_route_rd_header(vty, rd_dest, json_rd, rd_str, RD_ADDRSTRLEN);
+
+			route_vty_out_detail_header(vty, bgp, rn, bgp_dest_get_prefix(rn),
+						    (struct prefix_rd *)rd_destp, afi, safi,
+						    json_rd, false);
+
+			for (pi = bgp_dest_get_bgp_path_info(rn); pi; pi = pi->next) {
+				route_vty_out_detail(vty, bgp, rn, bgp_dest_get_prefix(rn), pi,
+						     afi, safi, RPKI_NOT_BEING_USED, json_paths);
+				local_path_cnt++;
+			}
+
+			path_cnt += local_path_cnt;
+
+			if (json) {
+				if (local_path_cnt) {
+					json_object_object_add(json_rd, "paths", json_paths);
+					json_object_object_add(json, rd_str, json_rd);
+				} else {
+					/* Defensive: parent-add was skipped, so
+					 * release the per-iteration objects to
+					 * avoid leaking them with the parent.
+					 */
+					json_object_free(json_paths);
+					json_object_free(json_rd);
+				}
+			}
+
+			if (local_path_cnt)
+				prefix_cnt++;
+
+			bgp_dest_unlock_node(rn);
+		}
+	}
+
+	if (json) {
+		json_object_int_add(json, "numPrefix", prefix_cnt);
+		json_object_int_add(json, "numPaths", path_cnt);
+	} else {
+		if (prefix_cnt == 0)
+			vty_out(vty, "%% Network not in table\n");
+		else
+			vty_out(vty, "\nDisplayed %u prefixes (%u paths)\n", prefix_cnt, path_cnt);
+	}
+}
+
+
+/*
  * Display BGP EVPN routing table -- for specific RD and MAC and/or
  * IP (vty handler). By definition, only matching type-2 route will be
  * displayed.
@@ -5248,7 +5360,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_macip,
  */
 DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
       show_bgp_l2vpn_evpn_route_rd_prefix_cmd,
-      "show bgp l2vpn evpn route rd ASN:NN_OR_IP-ADDRESS:NN prefix <A.B.C.D/M|X:X::X:X/M> [json]",
+      "show bgp l2vpn evpn route rd <ASN:NN_OR_IP-ADDRESS:NN|all> prefix <A.B.C.D/M|X:X::X:X/M> [json]",
       SHOW_STR
       BGP_STR
       L2VPN_HELP_STR
@@ -5256,6 +5368,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
       "EVPN route information\n"
       "Route Distinguisher\n"
       "ASN:XX or A.B.C.D:XX\n"
+      "All VPN Route Distinguishers\n"
       "prefix\n"
       "IP prefix\n"
       "IPv6 prefix\n"
@@ -5264,10 +5377,13 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
 	struct bgp *bgp;
 	int ret;
 	int idx = 0;
-	struct prefix_rd prd;
-	struct prefix ip_prefix;
+	int idx_ext_community = 0;
+	struct prefix_rd prd = {};
+	struct prefix ip_prefix = {};
 	bool uj = false;
 	json_object *json = NULL;
+	bool rd_all = false;
+	int rd_all_idx = 0;
 
 	bgp = bgp_get_evpn();
 	if (!bgp)
@@ -5278,11 +5394,25 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
 	if (uj)
 		json = json_object_new_object();
 
-	/* get the prd */
-	if (argv_find(argv, argc, "rd", &idx)) {
-		ret = str2prefix_rd(argv[idx + 1]->arg, &prd);
-		if (!ret) {
-			vty_out(vty, "%% Malformed Route Distinguisher\n");
+	/* The token after "rd" may be either the literal "all" or the
+	 * ASN:NN_OR_IP-ADDRESS:NN RD value. Check "all" first so we do not
+	 * pass it to str2prefix_rd(); otherwise fetch the RD by its CLI
+	 * placeholder token.
+	 */
+	rd_all = argv_find(argv, argc, "all", &rd_all_idx);
+	if (!rd_all) {
+		if (argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community)) {
+			ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
+			if (!ret) {
+				vty_out(vty, "%% Malformed Route Distinguisher\n");
+				if (uj)
+					json_object_free(json);
+				return CMD_WARNING;
+			}
+		} else {
+			vty_out(vty, "%% Route Distinguisher is required\n");
+			if (uj)
+				json_object_free(json);
 			return CMD_WARNING;
 		}
 	}
@@ -5292,12 +5422,20 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_prefix,
 		ret = str2prefix(argv[idx + 1]->arg, &ip_prefix);
 		if (!ret) {
 			vty_out(vty, "prefix is malformed\n");
+			if (uj)
+				json_object_free(json);
 			return CMD_WARNING;
 		}
-	} else
+	} else {
+		if (uj)
+			json_object_free(json);
 		return CMD_WARNING;
+	}
 
-	evpn_show_route_rd_prefix(vty, bgp, &prd, &ip_prefix, json);
+	if (rd_all)
+		evpn_show_route_rd_all_prefix(vty, bgp, &ip_prefix, json);
+	else
+		evpn_show_route_rd_prefix(vty, bgp, &prd, &ip_prefix, json);
 
 	if (uj) {
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5466,6 +5466,44 @@ Displaying Routes by Route Distinguisher
    can be supplied to the command to only display matching prefixes in the
    specified RD.
 
+.. clicmd:: show bgp l2vpn evpn route rd <all|RD> prefix <A.B.C.D/M|X:X::X:X/M> [json]
+
+.. clicmd:: show bgp evpn route rd <all|RD> prefix <A.B.C.D/M|X:X::X:X/M> [json]
+
+   For EVPN Type 5 (prefix) routes, an IPv4 or IPv6 prefix can be supplied to
+   only display matching prefixes in the specified RD, or across all RDs with
+   ``all``.
+
+   Example output:
+
+   .. code-block:: frr
+
+      bordertor-11# show bgp l2vpn evpn route rd all prefix 2001:db8:1:1::/64
+      Route Distinguisher: 192.0.2.2:8
+      BGP routing table entry for 192.0.2.2:8:[5]:[0]:[64]:[2001:db8:1:1::]
+      Paths: (1 available, best #1)
+        Advertised to peers:
+        leaf-11(swp1) leaf-12(swp2)
+        Route [5]:[0]:[64]:[2001:db8:1:1::] VNI 104001
+        655000
+          192.0.2.1 (bordertor-11) from 0.0.0.0 (192.0.2.1)
+            Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
+            Extended Community: ET:8 RT:60176:104001 Rmac:00:01:00:00:01:08
+            Last update: Thu Apr 30 17:46:31 2026
+      Route Distinguisher: 192.0.2.6:9
+      BGP routing table entry for 192.0.2.6:9:[5]:[0]:[64]:[2001:db8:1:1::]
+      Paths: (1 available, best #1)
+        Advertised to peers:
+        leaf-11(swp1) leaf-12(swp2)
+        Route [5]:[0]:[64]:[2001:db8:1:1::] VNI 104002
+        655000
+          192.0.2.1 (bordertor-11) from 0.0.0.0 (192.0.2.1)
+            Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
+            Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
+            Last update: Thu Apr 30 17:46:31 2026
+
+      Displayed 2 prefixes (2 paths)
+
 Displaying Update Group Information
 -----------------------------------
 

--- a/tests/topotests/bgp_evpn_three_tier_clos_topo1/README.md
+++ b/tests/topotests/bgp_evpn_three_tier_clos_topo1/README.md
@@ -22,6 +22,8 @@ This test validates BGP EVPN functionality using:
 - **External router connectivity** via BorderToR L3VNI BGP peering
 - **Dynamic BGP neighbor** testing via ext-21 with `bgp listen range` in VRF RED
 - **Static blackhole routes** on ToRs for EVPN Type-5 route testing
+- **EVPN Type-5 RD prefix lookup** testing on bordertor-11 for `rd all` and
+  specific-RD commands
 - VXLAN aging: 18000 centiseconds (180 seconds = 3 minutes), TTL: 64
 
 ## Topology
@@ -343,21 +345,25 @@ All underlay links use IPv6 /126 subnets from fd00:10:254::/32
    - Validates route 198.51.100.0/24 in vrf1 on tor-21
    - Checks ECMP next-hops, nexthop groups, and 'onlink' flag
    - Tests RFC 5549: IPv4 routes with IPv6 next-hops (IPv6 underlay)
-10. **test_host_to_host_ping()** - Verify end-to-end connectivity (host-211 → host-111)
+10. **test_evpn_rd_prefix_route_lookup()** - Verify EVPN Type-5 RD prefix lookup commands on bordertor-11
+    - Checks `show bgp l2vpn evpn route rd all prefix <prefix>` for existing and missing prefixes
+    - Checks `show bgp l2vpn evpn route rd <RD> prefix <prefix>` for existing and missing prefixes
+    - Runs under both IPv4 and IPv6 VTEP underlay modes
+11. **test_host_to_host_ping()** - Verify end-to-end connectivity (host-211 → host-111)
     - Uses `evpn_verify_ping_connectivity()` from `lib/evpn.py`
     - IPv4 test when using IPv4 underlay, IPv6 test when using IPv6 underlay
 
 ### Dynamic Neighbor Tests
-11. **test_ext21_dynamic_neighbor()** - Verify ext-21 dynamic BGP neighbor in VRF RED (IPv4 only)
+12. **test_ext21_dynamic_neighbor()** - Verify ext-21 dynamic BGP neighbor in VRF RED (IPv4 only)
     - ext-21 uses `bgp listen range 10.1.10.0/24` to discover leaf-21 dynamically
     - Validates Established state and correct remote AS on both sides
-12. **test_ext21_dynamic_neighbor_password()** - Verify password add/remove on peer-group with dynamic neighbor (IPv4 only)
+13. **test_ext21_dynamic_neighbor_password()** - Verify password add/remove on peer-group with dynamic neighbor (IPv4 only)
     - Sets `neighbor test password test4` and confirms the dynamic neighbor is torn down
     - Removes the password and confirms the dynamic neighbor re-establishes
     - Validates the fix for stale per-peer TCP MD5 entry on the listen socket
 
 ### Memory and Cleanup
-13. **test_memory_leak()** - Memory leak detection
+14. **test_memory_leak()** - Memory leak detection
 
 ## Generic EVPN Library Functions
 
@@ -440,6 +446,8 @@ This test utilizes generic, reusable EVPN helper functions located in `tests/top
 - **L2 Connectivity:** EVPN Type-2 MAC/IP routes for intra-VLAN communication
 - **L3 Connectivity:** EVPN Type-5 IP prefix routes for inter-subnet routing via L3VNIs
 - **External Connectivity:** Per-VRF BGP peering with external router for Type-5 routes
+- **RD Prefix Lookup:** `show bgp l2vpn evpn route rd <all|RD> prefix <prefix>`
+  coverage on bordertor-11 for present and absent Type-5 prefixes
 - **Dynamic BGP Neighbor:** ext-21 tests `bgp listen range` in VRF RED (IPv4 only)
 - **Symmetric IRB:** Inter-subnet routing with L3VNI encapsulation
 - **Multi-tenancy:** Separate VRFs (vrf1, vrf2) with independent routing tables

--- a/tests/topotests/bgp_evpn_three_tier_clos_topo1/test_bgp_evpn_v4_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_three_tier_clos_topo1/test_bgp_evpn_v4_v6_vtep.py
@@ -26,14 +26,15 @@ VTYSH Commands:
 7. show ip route vrf {vrf}
 8. show ip route vrf {vrf} {route} json
 9. show ipv6 route vrf {vrf} {route} json
+10. show bgp l2vpn evpn route rd <all|RD> prefix <prefix>
 
 Linux Commands:
 ---------------
-10. bridge -j fdb show
-11. ip -d -j link show {vxlan_device}
-12. ip -j route show vrf {vrf} {route}
-13. ip -j nexthop get id {nhid}
-14. ping / ping6
+11. bridge -j fdb show
+12. ip -d -j link show {vxlan_device}
+13. ip -j route show vrf {vrf} {route}
+14. ip -j nexthop get id {nhid}
+15. ping / ping6
 
 Test Execution Order:
 =====================
@@ -47,15 +48,17 @@ Test Execution Order:
 8. test_vrf_routes                      - Display VRF routes (informational)
 9. test_evpn_vtep_nexthops              - Verify L3VNI next-hops
 10. test_evpn_check_overlay_route       - Verify EVPN Type-5 overlay route in VRF RIB
-11. test_evpn_vtep_on_uplink_flap       - No stale VTEP when uplinks down; VTEPs back when up
-12. test_host_to_host_ping              - Verify end-to-end connectivity
-13. test_memory_leak                    - Memory leak detection
+11. test_evpn_rd_prefix_route_lookup    - Verify EVPN Type-5 RD prefix lookups
+12. test_evpn_vtep_on_uplink_flap       - No stale VTEP when uplinks down; VTEPs back when up
+13. test_host_to_host_ping              - Verify end-to-end connectivity
+14. test_memory_leak                    - Memory leak detection
 """
 
 import os
 import sys
 import json
 import re
+import ipaddress
 from functools import partial
 import pytest
 
@@ -772,6 +775,75 @@ def _check_route_in_vrf(router, vrf, route, ip_version):
         return f"Route {route} not found in {vrf}"
     if "imported from" not in output.lower():
         return f"Route {route} not imported in {vrf}"
+    return None
+
+
+def _evpn_prefix_route_marker(prefix):
+    """Return the EVPN type-5 route-key suffix for an IP prefix."""
+    network = ipaddress.ip_network(prefix, strict=False)
+    return f"]:[{network.prefixlen}]:[{network.network_address.compressed.lower()}]"
+
+
+def _find_evpn_type5_rd_for_prefix(router, prefix):
+    """Find the RD that contains a specific EVPN type-5 prefix."""
+    output = router.vtysh_cmd("show bgp l2vpn evpn route json", isjson=True)
+    if not output:
+        return None, "No EVPN route JSON output"
+
+    route_marker = _evpn_prefix_route_marker(prefix)
+    for rd, rd_data in output.items():
+        if not isinstance(rd_data, dict):
+            continue
+
+        for route_key in rd_data:
+            route_key = route_key.lower()
+            if route_key.startswith("[5]:") and route_marker in route_key:
+                return rd, None
+
+    return None, f"EVPN type-5 prefix {prefix} not found"
+
+
+def _check_evpn_rd_prefix_route_lookup(router, prefix, missing_prefix):
+    """Verify rd-all and specific-RD prefix lookups for hit and miss cases."""
+    rd, error = _find_evpn_type5_rd_for_prefix(router, prefix)
+    if error:
+        return error
+
+    route_marker = _evpn_prefix_route_marker(prefix)
+    checks = [
+        (
+            f"show bgp l2vpn evpn route rd all prefix {prefix}",
+            ["Route Distinguisher:", "Displayed", route_marker],
+            "% Network not in table",
+        ),
+        (
+            f"show bgp l2vpn evpn route rd {rd} prefix {prefix}",
+            ["Displayed", route_marker],
+            "% Network not in table",
+        ),
+        (
+            f"show bgp l2vpn evpn route rd all prefix {missing_prefix}",
+            ["% Network not in table"],
+            None,
+        ),
+        (
+            f"show bgp l2vpn evpn route rd {rd} prefix {missing_prefix}",
+            ["% Network not in table"],
+            None,
+        ),
+    ]
+
+    for cmd, expected_tokens, unexpected_token in checks:
+        output = router.vtysh_cmd(cmd, isjson=False)
+        output_lower = output.lower()
+
+        for token in expected_tokens:
+            if token.lower() not in output_lower:
+                return f"{cmd}: missing expected token '{token}' in output:\n{output}"
+
+        if unexpected_token and unexpected_token.lower() in output_lower:
+            return f"{cmd}: unexpected token '{unexpected_token}' in output:\n{output}"
+
     return None
 
 
@@ -2228,6 +2300,43 @@ def test_evpn_check_overlay_route(tgen_and_ip_version):
     )
 
 
+# Exercise the new EVPN Type-5 prefix lookup CLI on a border ToR.  The command
+# is checked for both RD-wide and specific-RD lookups, and for present/missing
+# prefixes, while the surrounding fixture repeats the coverage for IPv4 and
+# IPv6 VTEP underlays.
+def test_evpn_rd_prefix_route_lookup(tgen_and_ip_version):
+    """
+    Verify EVPN Type-5 RD prefix lookup commands on bordertor-11.
+
+    The parametrized fixture runs this for both IPv4 and IPv6 VTEPs. For each
+    underlay mode, verify both rd-all and specific-RD prefix lookups for an
+    existing Type-5 prefix and for a prefix that is not present.
+    """
+    tgen, ip_version = tgen_and_ip_version
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["bordertor-11"]
+
+    if ip_version == "ipv4":
+        prefix = "203.0.113.0/24"
+        missing_prefix = "198.51.100.128/25"
+    else:
+        prefix = "2001:db8:72:21::/64"
+        missing_prefix = "2001:db8:ffff::/64"
+
+    logger.info(
+        "Verifying EVPN RD prefix lookup commands on bordertor-11: "
+        f"prefix={prefix}, missing_prefix={missing_prefix}, {ip_version} underlay"
+    )
+
+    test_func = partial(
+        _check_evpn_rd_prefix_route_lookup, router, prefix, missing_prefix
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, f"EVPN RD prefix lookup verification failed: {result}"
+
+
 def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
     """
     Verify EVPN remote VTEP lifecycle across uplink flap.
@@ -2261,9 +2370,9 @@ def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
         expected_remote_vteps,
     )
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
-    assert result is None, (
-        "tor-21: remote VTEPs not present before uplink flap: {}".format(result)
-    )
+    assert (
+        result is None
+    ), "tor-21: remote VTEPs not present before uplink flap: {}".format(result)
 
     try:
         logger.info(
@@ -2278,9 +2387,9 @@ def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
             l3vni_list,
         )
         _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
-        assert result is None, (
-            "tor-21: stale VTEP entries after uplink down: {}".format(result)
-        )
+        assert (
+            result is None
+        ), "tor-21: stale VTEP entries after uplink down: {}".format(result)
         logger.info("tor-21: no stale VTEP entries after uplinks down")
 
         logger.info("tor-21: bringing uplinks swp1 and swp2 up")
@@ -2294,9 +2403,9 @@ def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
             expected_remote_vteps,
         )
         _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
-        assert result is None, (
-            "tor-21: remote VTEPs not restored after uplink up: {}".format(result)
-        )
+        assert (
+            result is None
+        ), "tor-21: remote VTEPs not restored after uplink up: {}".format(result)
         logger.info("tor-21: remote VTEPs restored after uplinks up")
     finally:
         router.run("ip link set dev swp1 up 2>/dev/null || true")

--- a/tests/topotests/bgp_evpn_three_tier_clos_topo1/test_bgp_evpn_v4_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_three_tier_clos_topo1/test_bgp_evpn_v4_v6_vtep.py
@@ -2372,7 +2372,7 @@ def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assert (
         result is None
-    ), "tor-21: remote VTEPs not present before uplink flap: {}".format(result)
+    ), f"tor-21: remote VTEPs not present before uplink flap: {result}"
 
     try:
         logger.info(
@@ -2387,9 +2387,7 @@ def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
             l3vni_list,
         )
         _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
-        assert (
-            result is None
-        ), "tor-21: stale VTEP entries after uplink down: {}".format(result)
+        assert result is None, f"tor-21: stale VTEP entries after uplink down: {result}"
         logger.info("tor-21: no stale VTEP entries after uplinks down")
 
         logger.info("tor-21: bringing uplinks swp1 and swp2 up")
@@ -2405,7 +2403,7 @@ def test_evpn_vtep_on_uplink_flap(tgen_and_ip_version):
         _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
         assert (
             result is None
-        ), "tor-21: remote VTEPs not restored after uplink up: {}".format(result)
+        ), f"tor-21: remote VTEPs not restored after uplink up: {result}"
         logger.info("tor-21: remote VTEPs restored after uplinks up")
     finally:
         router.run("ip link set dev swp1 up 2>/dev/null || true")


### PR DESCRIPTION
```
btor-11# show bgp l2vpn evpn route rd all prefix 2060:1:1:110::/64
Route Distinguisher: 144.1.1.6:9
BGP routing table entry for 144.1.1.6:9:[5]:[0]:[64]:[2060:1:1:110::]
Paths: (1 available, best https://github.com/FRRouting/frr/pull/1)
  Not advertised to any peer
  Route [5]:[0]:[64]:[2060:1:1:110::] VNI 104002
  Local
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, weight 32768, valid,
      sourced, local, bestpath-from-AS Local, best (First path received)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Sun Apr 26 00:12:25 2026

Displayed 1 prefixes (1 paths)
```

Json:

```
btor-11# show bgp l2vpn evpn route rd all prefix 2060:1:1:110::/64 json
{
  "144.1.1.6:9":{
    "rd":"144.1.1.6:9",
    "prefix":"[5]:[0]:[64]:[2060:1:1:110::]",
    "prefixLen":352,
    "routeType":5,
  ....
  },
  "numPrefix":1,
  "numPaths":1
}
```

specific rd routes:

```
btor-11# show bgp l2vpn evpn route rd 144.1.1.6:9                                                      
EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]
EVPN unreachable prefix: [254]:[EthTag]:[IPlen]:[IP]

BGP routing table entry for 144.1.1.6:9:[5]:[0]:[24]:[60.1.110.0]
Paths: (1 available, best #1)
  Advertised to peers:
  leaf-11(swp1) leaf-12(swp2)
  Route [5]:[0]:[24]:[60.1.110.0] VNI 104002
  Local
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, weight 32768, valid, sourced, local, bestpath-from-AS Local, best (First path recei
ved)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Thu Apr 30 17:46:29 2026
BGP routing table entry for 144.1.1.6:9:[5]:[0]:[24]:[81.1.1.0]
Paths: (1 available, best #1)
  Advertised to peers:
  leaf-11(swp1) leaf-12(swp2)
  Route [5]:[0]:[24]:[81.1.1.0] VNI 104002
  655000
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Thu Apr 30 17:46:31 2026
BGP routing table entry for 144.1.1.6:9:[5]:[0]:[24]:[81.1.2.0]
Paths: (1 available, best #1)
  Advertised to peers:
  leaf-11(swp1) leaf-12(swp2)
  Route [5]:[0]:[24]:[81.1.2.0] VNI 104002
  655000
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Thu Apr 30 17:46:31 2026
BGP routing table entry for 144.1.1.6:9:[5]:[0]:[24]:[81.1.3.0]
Paths: (1 available, best #1)
  Advertised to peers:
  leaf-11(swp1) leaf-12(swp2)
  Route [5]:[0]:[24]:[81.1.3.0] VNI 104002
  655000
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Thu Apr 30 17:46:31 2026
BGP routing table entry for 144.1.1.6:9:[5]:[0]:[24]:[81.1.2.0]
Paths: (1 available, best #1)
  Advertised to peers:
  leaf-11(swp1) leaf-12(swp2)
  Route [5]:[0]:[24]:[81.1.2.0] VNI 104002
  655000
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Thu Apr 30 17:46:31 2026
BGP routing table entry for 144.1.1.6:9:[5]:[0]:[24]:[81.1.3.0]
Paths: (1 available, best #1)
  Advertised to peers:
  leaf-11(swp1) leaf-12(swp2)
  Route [5]:[0]:[24]:[81.1.3.0] VNI 104002
  655000
    6.0.0.1 (bordertor-11) from 0.0.0.0 (6.0.0.1)
      Origin incomplete, metric 0, valid, sourced, local, bestpath-from-AS 655000, best (First path received)
      Extended Community: ET:8 RT:60176:104002 Rmac:00:01:00:00:01:08
      Last update: Thu Apr 30 17:46:31 2026
 ...
Displayed 12 prefixes (12 paths) with this RD

```

Signed-off-by: Vivek Venkatraman <vivek@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>
