### PR TITLE
staticd: move label count check from pre_validate to  NB_EV_VALIDATE

### DIFF
--- a/doc/developer/northbound/retrofitting-configuration-commands.rst
+++ b/doc/developer/northbound/retrofitting-configuration-commands.rst
@@ -520,6 +520,34 @@ constraints whenever possible. Code-level validations should be used
 only to validate constraints that can’t be modeled using the YANG
 language.
 
+.. warning::
+
+   **Avoid using pre_validate callbacks**
+
+   The ``pre_validate`` callback walks the **entire** candidate config tree
+   on every commit. For a deployment with N instances of a node (e.g., N
+   static routes), changing any single node triggers N ``pre_validate``
+   calls -- O(N) work for an O(1) change. This causes severe performance
+   degradation at scale (e.g., 10,000+ static routes where modifying one
+   route’s tag takes minutes instead of milliseconds).
+
+   **Prefer NB_EV_VALIDATE instead:**
+
+   * ``NB_EV_VALIDATE`` fires only for nodes actually changed in the
+     current transaction -- O(changed) instead of O(total).
+   * At ``NB_EV_VALIDATE`` time, ``args->dnode`` reflects the candidate
+     config including all changes in the transaction, so you can walk
+     parent or sibling nodes (via ``lyd_parent()``, ``lyd_child()``, etc.)
+     to perform cross-node validation.
+
+   For example, to validate that a list doesn’t exceed a maximum count,
+   use ``NB_EV_VALIDATE`` in the list entry’s ``create`` callback and count
+   siblings via ``yang_get_list_elements_count(lyd_child(lyd_parent(args->dnode)))``.
+
+   Only use ``pre_validate`` when you truly need to validate relationships
+   across **unrelated** subtrees that cannot be expressed via YANG
+   constraints or ``NB_EV_VALIDATE``.
+
 Most callbacks don’t need to perform any validations nor perform any
 error-prone operations, so in these cases we can use the following
 pattern to return early if ``event`` is different than ``NB_EV_APPLY``:

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -222,6 +222,12 @@ struct nb_cb_move_args {
 	size_t errmsg_len;
 };
 
+/*
+ * WARNING: pre_validate is called for EVERY instance of a node type on EVERY
+ * commit, causing O(N) overhead where N is the total count of that node type.
+ * Prefer NB_EV_VALIDATE in create/modify/delete callbacks instead.
+ * See the pre_validate callback documentation below for details.
+ */
 struct nb_cb_pre_validate_args {
 	/* Context of the configuration transaction. */
 	struct nb_context *context;
@@ -415,6 +421,23 @@ struct nb_callbacks {
 	 * configuration being committed before validating the configuration
 	 * changes themselves. It's useful to perform more complex validations
 	 * that depend on the relationship between multiple nodes.
+	 *
+	 * WARNING: pre_validate walks the ENTIRE candidate config tree on every
+	 * commit.  For a deployment with N instances of this node, changing any
+	 * single node triggers N pre_validate calls -- O(N) work for an O(1)
+	 * change.  This causes severe performance degradation at scale (e.g.,
+	 * 10,000+ static routes).
+	 *
+	 * PREFER NB_EV_VALIDATE in create/modify/delete callbacks instead:
+	 *   - NB_EV_VALIDATE fires only for nodes actually changed in the
+	 *     current transaction -- O(changed) instead of O(total).
+	 *   - At NB_EV_VALIDATE time, args->dnode reflects the candidate config
+	 *     including all changes in the transaction, so you can walk parent
+	 *     or sibling nodes to perform cross-node validation.
+	 *
+	 * Only use pre_validate when you truly need to validate relationships
+	 * across unrelated subtrees that cannot be expressed via YANG
+	 * constraints or NB_EV_VALIDATE.
 	 *
 	 * args
 	 *    Refer to the documentation comments of nb_cb_pre_validate_args for

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -28,7 +28,6 @@ const struct frr_yang_module_info frr_staticd_info = {
 				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_apply_finish,
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_destroy,
-				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_pre_validate,
 			}
 		},
 		{

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -128,10 +128,6 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_p
 void routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_apply_finish(
 	struct nb_cb_apply_finish_args *args);
 
-/* Optional 'pre_validate' callbacks. */
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_pre_validate(
-	struct nb_cb_pre_validate_args *args);
-
 /*
  * Callback registered with routing_nb lib to validate only
  * one instance of staticd is allowed

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -509,7 +509,9 @@ static int static_nexthop_srv6_encap_behavior_destroy(struct nb_cb_destroy_args 
 
 static int nexthop_mpls_label_stack_entry_create(struct nb_cb_create_args *args)
 {
+	const struct lyd_node *mls_dnode;
 	struct static_nexthop *nh;
+	uint32_t count;
 	uint32_t pos;
 	uint8_t index;
 
@@ -519,6 +521,25 @@ static int nexthop_mpls_label_stack_entry_create(struct nb_cb_create_args *args)
 			snprintf(
 				args->errmsg, args->errmsg_len,
 				"%% MPLS not turned on in kernel ignoring static route");
+			return NB_ERR_VALIDATION;
+		}
+
+		/*
+		 * Validate label count here rather than in pre_validate.
+		 * pre_validate walks the entire candidate config on every
+		 * commit — O(total routes) — even when only one route
+		 * changed.  Moving the check to NB_EV_VALIDATE fires only
+		 * for changed label-stack entries: O(labels being added).
+		 *
+		 * args->dnode is the entry node; its parent is mpls-label-stack.
+		 * At validate time the dnode reflects the candidate config
+		 * including all entries being added in this transaction.
+		 */
+		mls_dnode = lyd_parent(args->dnode);
+		count = yang_get_list_elements_count(lyd_child(mls_dnode));
+		if (count > MPLS_MAX_LABELS) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Too many labels, Enter %d or fewer", MPLS_MAX_LABELS);
 			return NB_ERR_VALIDATION;
 		}
 		break;
@@ -748,23 +769,6 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_p
 	static_install_nexthop(nh);
 }
 
-int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_pre_validate(
-	struct nb_cb_pre_validate_args *args)
-{
-	const struct lyd_node *mls_dnode;
-	uint32_t count;
-
-	mls_dnode = yang_dnode_get(args->dnode, "mpls-label-stack");
-	count = yang_get_list_elements_count(lyd_child(mls_dnode));
-
-	if (count > MPLS_MAX_LABELS) {
-		snprintf(args->errmsg, args->errmsg_len,
-			"Too many labels, Enter %d or fewer",
-			MPLS_MAX_LABELS);
-		return NB_ERR_VALIDATION;
-	}
-	return NB_OK;
-}
 
 int routing_control_plane_protocols_name_validate(
 	struct nb_cb_create_args *args)

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -211,6 +211,27 @@ class NorthboundClient
 		return reply.candidate_id();
 	}
 
+	/* Commit a candidate that is expected to fail validation.
+	 * Asserts that the error message contains 'expected_err'. */
+	void CommitExpectFailure(uint32_t candidate_id, const std::string &expected_err)
+	{
+		frr::CommitRequest request;
+		frr::CommitResponse reply;
+		ClientContext context;
+
+		request.set_candidate_id(candidate_id);
+		request.set_phase(frr::CommitRequest::ALL);
+
+		auto st = stub_->Commit(&context, request, &reply);
+		if (st.ok())
+			throw std::runtime_error(
+				"CommitExpectFailure: commit succeeded unexpectedly");
+		if (st.error_message().find(expected_err) == std::string::npos)
+			throw std::runtime_error(
+				"CommitExpectFailure: wrong error: " + st.error_message() +
+				" (expected to contain: " + expected_err + ")");
+	}
+
 	void DeleteCandidate(uint32_t candidate_id)
 	{
 		frr::DeleteCandidateRequest request;
@@ -474,6 +495,41 @@ void grpc_client_run_test(void)
 
 	std::string ltxreply = client.ListTransactions();
 	// std::cout << "client: pthread received: " << ltxreply << std::endl;
+
+	/*
+	 * Verify that adding more than MPLS_MAX_LABELS (16) label-stack
+	 * entries to a nexthop is rejected at NB_EV_VALIDATE time.
+	 * EditCandidate goes directly to the northbound framework, bypassing
+	 * the VTY change-count limit, so NB_EV_VALIDATE is the active guard.
+	 */
+	std::cout << "Testing MPLS label count validation (NB_EV_VALIDATE)...";
+	cid = client.CreateCandidate();
+
+	/* Base xpath for a gateway nexthop on a new prefix. */
+	const char *nh_xpath_base = "/frr-routing:routing/control-plane-protocols/"
+				    "control-plane-protocol[type='frr-staticd:staticd']"
+				    "[name='staticd'][vrf='default']/frr-staticd:staticd/"
+				    "route-list[prefix='12.0.0.0/24']"
+				    "[afi-safi='frr-routing:ipv4-unicast']/"
+				    "path-list[table-id='0'][nh-type='ip4']"
+				    "[vrf='default'][gateway='192.0.2.1'][interface='(null)']/"
+				    "mpls-label-stack/entry";
+
+	/* Enqueue 17 label-stack entries — one beyond MPLS_MAX_LABELS. */
+	for (int i = 0; i < 17; i++) {
+		char entry_xpath[2048];
+		snprintf(entry_xpath, sizeof(entry_xpath), "%s[id='%d']/label", nh_xpath_base, i);
+		client.EditCandidate(cid, entry_xpath, std::to_string(100 + i));
+	}
+
+	try {
+		client.CommitExpectFailure(cid, "Too many labels");
+	} catch (...) {
+		client.DeleteCandidate(cid);
+		throw;
+	}
+	client.DeleteCandidate(cid);
+	std::cout << "ok" << std::endl;
 }
 
 void *grpc_client_test_start(void *arg)

--- a/tests/topotests/static_route_distance/test_static_mpls_label_stack.py
+++ b/tests/topotests/static_route_distance/test_static_mpls_label_stack.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test MPLS label stack configuration for static routes via CLI.
+
+MPLS_MAX_LABELS is 16.  This test verifies that an 8-label stack (well
+within the limit) is accepted via the CLI and appears correctly in both
+running-config and the RIB.
+
+The gRPC test in tests/lib/test_grpc.cpp exercises the NB_EV_VALIDATE
+guard against >16 labels; this topotest complements it by confirming
+that valid label stacks work end-to-end through the CLI path.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+PREFIX = "10.88.0.0/24"
+NH = "192.0.2.2"
+
+# 8 labels — well within MPLS_MAX_LABELS (16)
+LABELS_8 = "/".join(str(100 + i) for i in range(8))
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _running_has_labels(router, prefix, label_str):
+    """Return True if running-config for prefix contains label_str."""
+    output = router.vtysh_cmd("show running-config")
+    for line in output.splitlines():
+        if f"ip route {prefix}" in line and f"label {label_str}" in line:
+            return True
+    return False
+
+
+def _route_installed(router, prefix):
+    """Return True if prefix appears in the RIB."""
+    output = router.vtysh_cmd(f"show ip route {prefix} json")
+    data = json.loads(output)
+    return bool(data.get(prefix))
+
+
+def _route_has_labels(router, prefix, expected_labels):
+    """Return True if the RIB entry for prefix has the expected label stack."""
+    output = router.vtysh_cmd(f"show ip route {prefix} json")
+    data = json.loads(output)
+    entries = data.get(prefix, [])
+    for entry in entries:
+        for nh in entry.get("nexthops", []):
+            labels = nh.get("labels", [])
+            if labels == expected_labels:
+                return True
+    return False
+
+
+def _check_route_with_labels(router, prefix, expected_labels):
+    """Return None if route has expected labels, else error string."""
+    if not _route_installed(router, prefix):
+        return "route not installed"
+    if not _route_has_labels(router, prefix, expected_labels):
+        return "labels mismatch"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Test: 8-label stack accepted via CLI
+# ---------------------------------------------------------------------------
+
+
+def test_label_stack_8_labels():
+    """An 8-label stack must be installed correctly via CLI."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Configure route with 8 labels
+    output = r1.vtysh_cmd(
+        f"configure terminal\nip route {PREFIX} {NH} label {LABELS_8}\n"
+    )
+
+    # Should not be rejected
+    assert "% Configuration failed" not in output, (
+        f"8-label stack unexpectedly rejected: {output!r}"
+    )
+    assert "% Exceeded" not in output, (
+        f"8-label stack hit change limit: {output!r}"
+    )
+
+    # Expected labels as integers for RIB comparison
+    expected_labels = [100 + i for i in range(8)]
+
+    # Wait for route to be installed with correct labels
+    test_func = functools.partial(
+        _check_route_with_labels, r1, PREFIX, expected_labels
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    assert result is None, f"Route not installed with 8-label stack: {result}"
+
+    # Verify labels appear in running-config
+    assert _running_has_labels(r1, PREFIX, LABELS_8), (
+        "8-label stack not found in running-config"
+    )
+
+    # Clean up
+    r1.vtysh_cmd(f"configure terminal\nno ip route {PREFIX} {NH}\n")
+
+    # Verify cleanup
+    test_func = functools.partial(_route_installed, r1, PREFIX)
+    _, result = topotest.run_and_expect(
+        lambda: None if not _route_installed(r1, PREFIX) else "still installed",
+        None,
+        count=15,
+        wait=1,
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
pre_validate walks the ENTIRE candidate config tree on every commit.
For a deployment with N static routes, changing a single route's tag
triggers N pre_validate calls — O(N) work for an O(1) change.

The only check in the path-list pre_validate was an MPLS label count
limit (> MPLS_MAX_LABELS).  Move it to NB_EV_VALIDATE in
nexthop_mpls_label_stack_entry_create, which fires only for label-stack
entries being created or modified in the current transaction — O(labels
changed) instead of O(total routes).

At NB_EV_VALIDATE time args->dnode is the entry node in the candidate
config, which already contains all entries being added in the current
transaction.  lyd_parent(args->dnode) is the mpls-label-stack node;
yang_get_list_elements_count on its children gives the correct total
(including the entry being added) without walking unrelated routes.

Remove the now-empty pre_validate function, its declaration from
static_nb.h, and its registration from static_nb.c.