### PR TITLE
Fix local ipv4 routes add/del when dealing with secondary addresses on the same prefix.

### DIFF
--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -512,6 +512,135 @@ def test_zebra_kernel_last_ipv6_address_deleted():
     )
 
 
+def test_zebra_secondary_address_local_route():
+    """
+    Test that secondary IPv4 addresses appear as local routes in zebra RIB.
+    """
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+    ifname = "dummy_sec"
+
+    router.run("ip link del {} 2>/dev/null".format(ifname))
+    router.run("ip link add {} type dummy".format(ifname))
+    router.run("ip link set {} up".format(ifname))
+    router.run(
+        "sysctl -w net.ipv4.conf.{}.promote_secondaries=1".format(ifname)
+    )
+
+    # Phase A: primary + secondary, both /32 local routes must be present.
+    addresses = ["10.100.0.1", "10.100.0.2", "10.100.0.3", "10.100.0.4"]
+    for address in addresses:
+        router.run("ip addr add {}/24 dev {}".format(address, ifname))
+
+    expected_before = {
+        "{}/32".format(address): [
+            {
+                "protocol": "local",
+                "selected": True,
+                "nexthops": [
+                    {"interfaceName": ifname, "directlyConnected": True}
+                ],
+            }
+        ]
+        for address in addresses
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, router, "show ip route json", expected_before
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Secondary local /32 routes are missing\n{}".format(result)
+
+    # Phase B: delete the primary while a secondary on the same /24 still exists.
+    # With promote_secondaries=1 the kernel keeps 10.100.0.2.
+    # The deleted primary's /32 must be removed; the secondary's /32 must remain.
+    router.run("ip addr del 10.100.0.1/24 dev {}".format(ifname))
+
+    expected_after= {
+        "{}/32".format(address): [
+            {
+                "protocol": "local",
+                "selected": True,
+                "nexthops": [
+                    {"interfaceName": ifname, "directlyConnected": True}
+                ],
+            }
+        ]
+        for address in addresses[1:]
+    }
+    expected_after["10.100.0.1/32"] = None
+
+    test_func = partial(
+        topotest.router_json_cmp, router, "show ip route json", expected_after
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Stale local primary /32 route after deletion\n{}".format(
+        result
+    )
+
+    router.run("ip link del {}".format(ifname))
+
+
+def test_zebra_secondary_address_no_promote():
+    """
+    Test that deleting a primary address on a interface removes the local /32
+    route in zebra RIB for that address and any secondary addresses.
+    """
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+    ifname = "dummy_nopro"
+
+    router.run("sysctl -w net.ipv4.conf.all.promote_secondaries=0")
+    router.run("ip link del {} 2>/dev/null".format(ifname))
+    router.run("ip link add {} type dummy".format(ifname))
+    router.run("ip link set {} up".format(ifname))
+
+    addresses = ["10.100.0.1", "10.100.0.2", "10.100.0.3", "10.100.0.4"]
+    for address in addresses:
+        router.run("ip addr add {}/24 dev {}".format(address, ifname))
+
+    expected_before = {
+        "{}/32".format(address): [
+            {
+                "protocol": "local",
+                "selected": True,
+                "nexthops": [
+                    {"interfaceName": ifname, "directlyConnected": True}
+                ],
+            }
+        ]
+        for address in addresses
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, router, "show ip route json", expected_before
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Secondary local /32 routes are missing\n{}".format(result)
+
+    # Deleting the primary triggers kernel to also delete the secondary.
+    router.run("ip addr del 10.100.0.1/24 dev {}".format(ifname))
+
+    expected_gone = {"{}/32".format(address): None for address in addresses}
+    test_func = partial(
+        topotest.router_json_cmp, router, "show ip route json", expected_gone
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Stale local /32(s) after primary deletion (promote_secondaries=0)\n{}".format(
+        result
+    )
+
+    router.run("ip link del {}".format(ifname))
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -305,6 +305,13 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 	if (zrouter.zav.asic_offloaded)
 		flags |= ZEBRA_FLAG_OFFLOADED;
 
+	if (install_local) {
+		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags, &plocal,
+			NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
+		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags,
+			&plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
+	}
+
 	/*
 	 * It's possible to add the same network and mask
 	 * to an interface over and over.  This would
@@ -336,13 +343,6 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		connected_remove_kernel_for_connected(afi, SAFI_MULTICAST, zvrf, &p, &nh);
 		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0, flags, &p,
 			NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0, false, true);
-	}
-
-	if (install_local) {
-		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags, &plocal,
-			NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
-		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags,
-			&plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
 	}
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -504,6 +504,16 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 	/* Mark the address as 'down' */
 	SET_FLAG(ifc->conf, ZEBRA_IFC_DOWN);
 
+	if (remove_local) {
+		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
+			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
+			   zvrf->table_id, 0, 0, false);
+
+		rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
+			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
+			   zvrf->table_id, 0, 0, false);
+	}
+
 	/*
 	 * It's possible to have X number of addresses
 	 * on a interface that all resolve to the same
@@ -536,16 +546,6 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 
 		rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
 			   ZEBRA_ROUTE_CONNECT, 0, 0, &p, NULL, &nh, 0,
-			   zvrf->table_id, 0, 0, false);
-	}
-
-	if (remove_local) {
-		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
-			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
-			   zvrf->table_id, 0, 0, false);
-
-		rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
-			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
 			   zvrf->table_id, 0, 0, false);
 	}
 


### PR DESCRIPTION
Hello

I've found two 'bugs' in zebra NEW_ADDR messages processing, idk if they could result as serious bugs in some real word cases, but anyway, here they are:

1) When adding a secondary ipv4 address, the related local route isn't installed in FRR RIB:
``` shell
sudo sysctl -w net.ipv4.conf.all.promote_secondaries=0
ip link add dev myiface type dummy
ip link set myiface up
ip a a 10.100.0.1/24 dev myiface
ip a a 10.100.0.2/24 dev myiface
echo "-- FRR:" ; vtysh -c "show ip route" | grep 'L>' ; echo "-- Kernel:" ; ip r s table 255 | grep 10.100.0
```
> -- FRR:
> L>* 10.100.0.1/32 is directly connected, myiface, weight 1, 00:00:42
>        ^^^^^^^^^^^ missing the 10.100.0.2/32 route
> L>* 192.168.0.102/32 is directly connected, mgmt0, weight 1, 00:02:37
> -- Kernel:
> local 10.100.0.1 dev myiface proto kernel scope host src 10.100.0.1
> local 10.100.0.2 dev myiface proto kernel scope host src 10.100.0.1
> broadcast 10.100.0.255 dev myiface proto kernel scope link src 10.100.0.1

1.1) Deleting the primary address behavior is as expected:
``` shell
ip a d 10.100.0.1/24 dev myiface
echo "-- FRR:" ; vtysh -c "show ip route" | grep 'L>' ; echo "-- Kernel:" ; ip r s table 255 | grep 10.100.0
```
> -- FRR:
> L>* 192.168.0.102/32 is directly connected, mgmt0, weight 1, 00:04:53
> -- Kernel:

2) When promote_secondary is set to true on the interface, deleting the primary address don't remove the related route in zebra:
``` shell
sudo sysctl -w net.ipv4.conf.myiface.promote_secondaries=1
```
> net.ipv4.conf.myiface.promote_secondaries = 1
``` shell
echo "-- FRR:" ; vtysh -c "show ip route" | grep 'L>' ; echo "-- Kernel:" ; ip r s table 255 | grep 10.100.0
```
> -- FRR:
> L>* 10.100.0.1/32 is directly connected, myiface, weight 1, 00:00:30
> L>* 192.168.0.102/32 is directly connected, mgmt0, weight 1, 00:10:23
> -- Kernel:
> local 10.100.0.1 dev myiface proto kernel scope host src 10.100.0.1
> local 10.100.0.2 dev myiface proto kernel scope host src 10.100.0.1
> broadcast 10.100.0.255 dev myiface proto kernel scope link src 10.100.0.1

``` shell
ip a d 10.100.0.1/24 dev myiface
echo "-- FRR:" ; vtysh -c "show ip route" | grep 'L>' ; echo "-- Kernel:" ; ip r s table 255 | grep 10.100.0
```
> -- FRR:
> L>* 10.100.0.1/32 is directly connected, myiface, weight 1, 00:00:45
>       ^^^^^^^^^^^^^ This route is wrong! (Also missing 10.100.0.2/32 route as mentioned in (1))
> L>* 192.168.0.102/32 is directly connected, mgmt0, weight 1, 00:10:38
> -- Kernel:
> local 10.100.0.2 dev myiface proto kernel scope host src 10.100.0.2
>         ^^^^^^^^^^ The kernel correctly promotes the secondary address, and its local route is maintained
> broadcast 10.100.0.255 dev myiface proto kernel scope link src 10.100.0.2
