### PR TITLE
bgpd: Allow `no network ....` form for safi = EVPN or MPLS_VPN

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8756,7 +8756,7 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 
 	if (negate) {
 		/* Set BGP static route configuration. */
-		dest = bgp_node_lookup(bgp->static_routes[afi][safi], &p);
+		dest = bgp_node_lookup(table, &p);
 
 		if (!dest) {
 			vty_out(vty, "%% Can't find static route specified\n");
@@ -8782,8 +8782,12 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 			}
 
 			/* Update BGP RIB. */
-			if (!bgp_static->backdoor)
-				bgp_static_withdraw(bgp, &p, afi, safi, NULL);
+			if (!bgp_static->backdoor) {
+				if (safi == SAFI_MPLS_VPN || safi == SAFI_EVPN)
+					bgp_static_withdraw(bgp, &p, afi, safi, &prd);
+				else
+					bgp_static_withdraw(bgp, &p, afi, safi, NULL);
+			}
 
 			/* Clear configuration. */
 			bgp_static_free(bgp_static);

--- a/tests/topotests/bgp_vpnv4_asbr/test_bgp_vpnv4_asbr.py
+++ b/tests/topotests/bgp_vpnv4_asbr/test_bgp_vpnv4_asbr.py
@@ -784,6 +784,63 @@ router bgp 65501
     check_show_bgp_vpn_ok(r2, vpnv4_checks)
 
 
+def test_undeclare_vpn_network_with_different_label():
+    """
+    Remove the previously declared vpnv4 network on r3 via
+    'no network 33.33.33.33/32 rd 444:3 label 33' under
+    'address-family ipv4 vpn' and check that the entry is withdrawn
+    from r2's BGP VPNv4 table. Regression for the bug where negating
+    a 'network ... rd ... label ...' statement under 'address-family
+    ipv4|ipv6 vpn' returned '% Can't find static route specified'.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r3 = tgen.gears["r3"]
+    logger.info(
+        "{}, undeclare static 33.33.33.33/32 network rd 444:3 label 33".format(r3.name)
+    )
+    output = r3.vtysh_cmd(
+        """
+configure terminal
+router bgp 65501
+ address-family ipv4 vpn
+  no network 33.33.33.33/32 rd 444:3 label 33
+"""
+    )
+    assert "Can't find static route specified" not in output, (
+        "{}, 'no network ... rd ... label ...' under 'address-family ipv4 vpn' "
+        "was rejected: {}".format(r3.name, output)
+    )
+
+    r2 = tgen.gears["r2"]
+    logger.info(
+        "{}, check that prefix 33.33.33.33/32 rd 444:3 is no longer present".format(
+            r2.name
+        )
+    )
+    test_func = functools.partial(
+        check_show_bgp_vpn_prefix_not_found,
+        r2,
+        "ipv4",
+        "33.33.33.33/32",
+        "444:3",
+    )
+    success, _ = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    assert success, "{}, vpnv4 update 33.33.33.33/32 is still present".format(r2.name)
+
+    vpnv4_checks = {
+        "172.31.1.0/24": "r1",
+        "172.31.2.0/24": "r1",
+        "172.31.3.0/24": "r1",
+    }
+    logger.info(
+        "{}, check that the original VPNv4 entries are still present".format(r2.name)
+    )
+    check_show_bgp_vpn_ok(r2, vpnv4_checks)
+
+
 def test_filter_vpn_network_from_r1():
     """
     Get the list of labels in 'show mpls table'


### PR DESCRIPTION
Currently when you negate a network statement for bgp: router bgp 3295425
 address-family ipv4 vpn
   network 10.0.0.0/24 rd 1:1 label 2000

You get `no such network`.  Fix the code to allow for deletion:

eva# do show bgp ipv4 vpn
BGP table version is 1, local router ID is 192.168.122.1, vrf id 0 Default local pref 100, local AS 329395
Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

     Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 1:1
 *>  10.0.0.0/24      0.0.0.0                  0         32768 i
    UN=0.0.0.0 label=2000 type=bgp, subtype=1

Displayed 1 routes and 1 total paths
eva# conf
eva(config)# router bgp
eva(config-router)# address-family ipv4 vpn
eva(config-router-af)# no network 10.0.0.0/24 rd 1:1 label 2000 eva(config-router-af)# do show bgp ipv4 vpn
No BGP prefixes displayed, 0 exist
eva(config-router-af)#

Fixes: #21852