### PR TITLE
zebra: Fix docstr mismatches in show ip route

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1605,7 +1605,7 @@ zebra Terminal Mode Commands
    Display detailed information about a route. If [nexthop-group] is
    included, it will display the nexthop group ID the route is using as well.
 
-.. clicmd:: show [ip|ipv6] route [vrf NAME|all|table TABLENO] [A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M] [nexthop-group [summary [ecmp-count <gt|lt|eq> (1-256)]]] [failed] [brief] [json]
+.. clicmd:: show [ip|ipv6] route [vrf NAME|all|table TABLENO] [A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M] [nexthop-group [summary [ecmp-count <gt|lt|eq> (1-256)]]] [failed] [json [brief]]
 
    Display detailed information about routes in the routing table. This command provides comprehensive information about specific routes, including their attributes, nexthops, and other routing details.
 
@@ -1622,8 +1622,8 @@ zebra Terminal Mode Commands
      - ``lt``: Show routes with ECMP count less than N
      - ``eq``: Show routes with ECMP count equal to N
    - ``failed``: Show only routes that failed to install in the FIB (kernel). This is useful for troubleshooting route installation issues.
-   - ``brief``: When combined with ``json``, output a minimal set of fields per route (see **Brief JSON view** below). Omitted when not using ``json``.
    - ``json``: Display output in JSON format
+   - ``brief``: When combined with ``json``, output a minimal set of fields per route (see **Brief JSON view** below).
 
    The detailed output includes:
 
@@ -1658,11 +1658,11 @@ zebra Terminal Mode Commands
 
    **Brief JSON view**
 
-   With ``show [ip|ipv6] route ... brief json`` (and the same with ``vrf NAME``, ``vrf default``, or ``vrf all``), zebra outputs a minimal JSON structure per route instead of the full route object. Each route object in the brief view includes at least:
+   With ``show [ip|ipv6] route ... json brief`` (and the same with ``vrf NAME``, ``vrf default``, or ``vrf all``), zebra outputs a minimal JSON structure per route instead of the full route object. Each route object in the brief view includes at least:
 
    - ``protocol``, ``selected``, ``destSelected``, ``distance``, ``metric``, ``installed``, ``nexthopGroupId``, ``uptime``, ``offloaded``
 
-   With ``vrf all brief json``, the top-level structure is an object whose keys are VRF names (e.g. ``"default"``), each containing the same array of brief route objects.
+   With ``vrf all json brief``, the top-level structure is an object whose keys are VRF names (e.g. ``"default"``), each containing the same array of brief route objects.
 
    **Nexthop Group Summary View**
 

--- a/tests/topotests/static_route_blackhole/test_static_route_blackhole.py
+++ b/tests/topotests/static_route_blackhole/test_static_route_blackhole.py
@@ -107,7 +107,7 @@ def test_static_route_blackhole():
 
 
 def test_show_ip_route_brief_json():
-    """Check that 'show ip route brief json' returns valid JSON with expected brief fields."""
+    """Check that 'show ip route json brief' returns valid JSON with expected brief fields."""
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
@@ -133,12 +133,12 @@ def test_show_ip_route_brief_json():
     prefixes_connected_or_local = ["192.168.1.0/24", "192.168.1.1/32"]
 
     def _check_brief_json():
-        output = r1.vtysh_cmd("show ip route brief json", isjson=True)
+        output = r1.vtysh_cmd("show ip route json brief", isjson=True)
         if not isinstance(output, dict):
             return "Output is not a dict: %s" % type(output)
         for prefix in expected_prefixes:
             if prefix not in output:
-                return "Missing prefix %s in brief json" % prefix
+                return "Missing prefix %s in json brief" % prefix
             routes = output[prefix]
             if not isinstance(routes, list) or len(routes) == 0:
                 return "Prefix %s has no route list" % prefix
@@ -163,11 +163,11 @@ def test_show_ip_route_brief_json():
         return None
 
     _, result = topotest.run_and_expect(_check_brief_json, None, count=30, wait=1)
-    assert result is None, "show ip route brief json check failed: %s" % (result or "")
+    assert result is None, "show ip route json brief check failed: %s" % (result or "")
 
 
 def test_show_ip_route_brief_json_vrf_consistency():
-    """Check that brief json is consistent across no-vrf, vrf default, and vrf all."""
+    """Check that json brief is consistent across no-vrf, vrf default, and vrf all."""
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
@@ -175,24 +175,24 @@ def test_show_ip_route_brief_json_vrf_consistency():
     r1 = tgen.gears["r1"]
 
     def _check_vrf_consistency():
-        brief = r1.vtysh_cmd("show ip route brief json", isjson=True)
+        brief = r1.vtysh_cmd("show ip route json brief", isjson=True)
         default_brief = r1.vtysh_cmd(
-            "show ip route vrf default brief json", isjson=True
+            "show ip route vrf default json brief", isjson=True
         )
-        all_brief = r1.vtysh_cmd("show ip route vrf all brief json", isjson=True)
+        all_brief = r1.vtysh_cmd("show ip route vrf all json brief", isjson=True)
 
         if not isinstance(brief, dict):
-            return "show ip route brief json is not a dict"
+            return "show ip route json brief is not a dict"
         if not isinstance(default_brief, dict):
-            return "show ip route vrf default brief json is not a dict"
+            return "show ip route vrf default json brief is not a dict"
         if not isinstance(all_brief, dict):
-            return "show ip route vrf all brief json is not a dict"
+            return "show ip route vrf all json brief is not a dict"
 
         if set(brief.keys()) != set(default_brief.keys()):
             return "Prefix set differs: brief vs vrf default"
 
         if "default" not in all_brief:
-            return "vrf all brief json missing 'default' key"
+            return "vrf all json brief missing 'default' key"
 
         if set(all_brief["default"].keys()) != set(brief.keys()):
             return "Prefix set in vrf all['default'] differs from default VRF"
@@ -200,7 +200,7 @@ def test_show_ip_route_brief_json_vrf_consistency():
         return None
 
     _, result = topotest.run_and_expect(_check_vrf_consistency, None, count=30, wait=1)
-    assert result is None, "show ip route brief json VRF consistency failed: %s" % (
+    assert result is None, "show ip route json brief VRF consistency failed: %s" % (
         result or ""
     )
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1714,7 +1714,6 @@ DEFPY (show_route,
            " FRR_IP_REDIST_STR_ZEBRA "$type_str\
            |ospf$type_str (1-65535)$ospf_instance_id\
           >]\
-       [<brief$brief>] \
          |ipv6$ipv6 <fib$fib|route>\
           [{\
            table <(1-4294967295)$table|all$table_all>\
@@ -1726,9 +1725,9 @@ DEFPY (show_route,
            |X:X::X:X/M$prefix longer-prefixes\
           }]\
           [" FRR_IP6_REDIST_STR_ZEBRA "$type_str]\
-       [<brief$brief>] \
         >\
-       [nexthop-group$ng [summary$ng_summary [ecmp-count <gt$ecmp_gt|lt$ecmp_lt|eq$ecmp_eq> (1-256)$ecmp_count]]] [failed$failed] [json$json]",
+       [nexthop-group$ng [summary$ng_summary [ecmp-count <gt$ecmp_gt|lt$ecmp_lt|eq$ecmp_eq> (1-256)$ecmp_count]]]\
+       [failed$failed] [json$json [brief$brief]]",
        SHOW_STR
        IP_STR
        "IP forwarding table\n"
@@ -1746,10 +1745,9 @@ DEFPY (show_route,
        FRR_IP_REDIST_HELP_STR_ZEBRA
        "Open Shortest Path First (OSPFv2)\n"
        "Instance ID\n"
-       "Brief\n"
        IPV6_STR
-       "IP forwarding table\n"
-       "IP routing table\n"
+       "IPv6 forwarding table\n"
+       "IPv6 routing table\n"
        "Table to display\n"
        "The table number to display\n"
        "All tables\n"
@@ -1760,6 +1758,7 @@ DEFPY (show_route,
        "IPv6 prefix\n"
        "Show route matching the specified Network/Mask pair only\n"
        FRR_IP6_REDIST_HELP_STR_ZEBRA
+       "Nexthop Group Information\n"
        "Show ECMP count summary\n"
        "Filter by ECMP count\n"
        "Greater than (>)\n"
@@ -1767,9 +1766,8 @@ DEFPY (show_route,
        "Equal to (=)\n"
        "ECMP count value\n"
        "Show only failed routes\n"
-       "Brief\n"
        JSON_STR
-       "Nexthop Group Information\n")
+       "Brief JSON output\n")
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;


### PR DESCRIPTION
- Fix docstrings for `show ip route` options that didn't match.
- Restrict the `brief` option to be used only with the `json` option.
- Update related doc and tests