### PR TITLE
debian: add pkg.frr.tcmalloc build profile for tcmalloc support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Build-Depends: bison,
 	       libgrpc++-dev (>=1.16.1) <pkg.frr.grpc>,
 	       protobuf-compiler (>=3.6.1) <pkg.frr.grpc>,
 	       protobuf-compiler-grpc (>=1.16.1) <pkg.frr.grpc>,
-               libprotobuf-dev (>=3.6.1) <pkg.frr.grpc>
+               libprotobuf-dev (>=3.6.1) <pkg.frr.grpc>,
+               libgoogle-perftools-dev <pkg.frr.tcmalloc>
 Standards-Version: 4.5.0.3
 Homepage: https://www.frrouting.org/
 Vcs-Browser: https://github.com/FRRouting/frr/tree/debian/master

--- a/debian/rules
+++ b/debian/rules
@@ -45,6 +45,12 @@ else
   CONF_ASAN=--enable-address-sanitizer
 endif
 
+ifeq ($(filter pkg.frr.tcmalloc,$(DEB_BUILD_PROFILES)),)
+  CONF_TCMALLOC=--disable-gperf-tcmalloc
+else
+  CONF_TCMALLOC=--enable-gperf-tcmalloc
+endif
+
 export PYTHON=python3
 
 %:
@@ -65,6 +71,7 @@ override_dh_auto_configure:
 		$(CONF_PIM6) \
 		$(CONF_GRPC) \
 		$(CONF_ASAN) \
+		$(CONF_TCMALLOC) \
 		--with-libpam \
 		--enable-doc \
 		--enable-doc-html \


### PR DESCRIPTION
Add a pkg.frr.tcmalloc build profile that passes --enable-gperf-tcmalloc to configure when active. Also add libgoogle-perftools-dev as a profile-gated build dependency.

This allows building FRR Debian packages with tcmalloc support by specifying the pkg.frr.tcmalloc build profile, similar to how pkg.frr.grpc and pkg.frr.asan profiles work.