### PR TITLE
bgpd: Skip route clearing for peers that were never established

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1986,10 +1986,15 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 	    (bgp->established_peers == 0))
 		bgp_router_id_zebra_bump(bgp->vrf_id, NULL);
 
-	/* Transition into Clearing or Deleted must /always/ clear all routes..
-	 * (and must do so before actually changing into Deleted..
+	/* Transition into Clearing or Deleted must clear all routes,
+	 * and must do so before actually changing into Deleted.
+	 * Skip the clear if the peer was not in Established state,
+	 * as it cannot have any routes in the BGP table (e.g.,
+	 * doppelganger peers from collision resolution.
+	 * Walking the entire BGP table for such
+	 * peers is pure overhead.
 	 */
-	if (status >= Clearing && (peer->established || peer != bgp->peer_self)) {
+	if (status >= Clearing && peer_established(connection)) {
 		bgp_clear_route_all(peer);
 
 		/* If no route was queued for the clear-node processing,


### PR DESCRIPTION
**Issue:**
When bgp_fsm_change_status() transitions a peer to Clearing or Deleted state, it unconditionally calls bgp_clear_route_all() which walks the entire BGP table. For peers that were not in Established state (e.g., doppelganger peers from TCP collision resolution), this walk is pure overhead

Below commits attempted to fix the same issue, but the issue is still seen in scaled setup and this fix needs to be revisited.
https://github.com/FRRouting/frr/commit/e0ae285eb8beeef7b43bdadc073d8ae346eaeb6c
https://github.com/FRRouting/frr/commit/06480c0c81471d4e00aee669f78e426a083cb759

The previous fix(e0ae285) uses peer->established which is a monotonically increasing counter that is never reset — once a peer has been Established in any prior session, the counter is non-zero forever. This means doppelganger peers from collision resolution still trigger unnecessary bgp_clear_route_all() table walks if the config peer had a previous session, defeating the optimization for the most common collision scenario.

**Fix:**
The correct fix uses peer_established(connection) which checks the current connection state (connection->status == Established), accurately identifying the state. This ensures only transitions from Established state trigger the route clearing