### PR TITLE
bgpd: Allow `no network ....` form for safi = EVPN or MPLS_VPN (backport #21860)

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8074,7 +8074,7 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 
 	if (negate) {
 		/* Set BGP static route configuration. */
-		dest = bgp_node_lookup(bgp->route[afi][safi], &p);
+		dest = bgp_node_lookup(table, &p);
 
 		if (!dest) {
 			vty_out(vty, "%% Can't find static route specified\n");
@@ -8100,8 +8100,12 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 			}
 
 			/* Update BGP RIB. */
-			if (!bgp_static->backdoor)
-				bgp_static_withdraw(bgp, &p, afi, safi, NULL);
+			if (!bgp_static->backdoor) {
+				if (safi == SAFI_MPLS_VPN || safi == SAFI_EVPN)
+					bgp_static_withdraw(bgp, &p, afi, safi, &prd);
+				else
+					bgp_static_withdraw(bgp, &p, afi, safi, NULL);
+			}
 
 			/* Clear configuration. */
 			bgp_static_free(bgp_static);


### PR DESCRIPTION
Currently when you negate a network statement for bgp: router bgp 3295425
 address-family ipv4 vpn
   network 10.0.0.0/24 rd 1:1 label 2000

You get `no such network`.  Fix the code to allow for deletion:

eva# do show bgp ipv4 vpn
BGP table version is 1, local router ID is 192.168.122.1, vrf id 0 Default local pref 100, local AS 329395
Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

     Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 1:1
 *>  10.0.0.0/24      0.0.0.0                  0         32768 i
    UN=0.0.0.0 label=2000 type=bgp, subtype=1

Displayed 1 routes and 1 total paths
eva# conf
eva(config)# router bgp
eva(config-router)# address-family ipv4 vpn
eva(config-router-af)# no network 10.0.0.0/24 rd 1:1 label 2000 eva(config-router-af)# do show bgp ipv4 vpn
No BGP prefixes displayed, 0 exist
eva(config-router-af)#

Fixes: #21852