### PR TITLE
*: don't use static char buffer in srv6 zapi code

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3767,7 +3767,7 @@ static int bgp_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 	struct prefix_ipv6 tmp_prefix;
 	uint32_t sid_func, sid_wide_func = 0;
 	bool found = false;
-	char *loc_name;
+	char loc_name[SRV6_LOCNAME_SIZE];
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
 		if (!bgp_srv6_locator_is_configured(bgp))
@@ -3788,7 +3788,7 @@ static int bgp_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 
 	/* Decode the received notification message */
 	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr, &sid_func, &sid_wide_func,
-					 &note, &loc_name)) {
+					 &note, loc_name, sizeof(loc_name))) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1455,7 +1455,7 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 
 	/* Decode the received notification message */
 	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr,
-					 &sid_func, NULL, &note, NULL)) {
+					 &sid_func, NULL, &note, NULL, 0)) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2341,13 +2341,11 @@ stream_failure:
 
 bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
 				 struct in6_addr *sid_value, uint32_t *func,
-				 uint32_t *wide_func,
-				 enum zapi_srv6_sid_notify *note,
-				 char **p_locator_name)
+				 uint32_t *wide_func, enum zapi_srv6_sid_notify *note,
+				 char *locator_name, size_t loc_size)
 {
 	uint32_t f, wf;
 	uint16_t len = 0;
-	static char locator_name[SRV6_LOCNAME_SIZE];
 
 	STREAM_GET(note, s, sizeof(*note));
 	STREAM_GET(ctx, s, sizeof(struct srv6_sid_ctx));
@@ -2355,25 +2353,30 @@ bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
 	STREAM_GETL(s, f);
 	STREAM_GETL(s, wf);
 
+	STREAM_GETW(s, len);
+	if (len >= loc_size && locator_name != NULL)
+		return false;
+
 	if (func)
 		*func = f;
 	if (wide_func)
 		*wide_func = wf;
 
-	STREAM_GETW(s, len);
-	if (len > SRV6_LOCNAME_SIZE) {
-		*p_locator_name = NULL;
-		return false;
-	}
-	if (p_locator_name) {
-		if (len == 0)
-			*p_locator_name = NULL;
-		else {
-			memset(locator_name, 0, sizeof(locator_name));
+	if (locator_name != NULL) {
+		/* This is a cstring, and it looks like it's normally sent without
+		 * its terminal NULL...
+		 */
+		if (len == 0) {
+			locator_name[0] = 0;
+		} else {
 			STREAM_GET(locator_name, s, len);
-			*p_locator_name = locator_name;
+			locator_name[len] = 0;
 		}
+	} else if (len > 0) {
+		/* Advance the stream */
+		stream_forward_getp(s, len);
 	}
+
 	return true;
 
 stream_failure:

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1202,11 +1202,12 @@ bool zapi_rule_notify_decode(struct stream *s, uint32_t *seqno,
 bool zapi_ipset_notify_decode(struct stream *s,
 			      uint32_t *unique,
 			     enum zapi_ipset_notify_owner *note);
+
+/* Normally use SRV6_LOCNAME_SIZE for the locator name buffer */
 bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
 				 struct in6_addr *sid_value, uint32_t *func,
-				 uint32_t *wide_func,
-				 enum zapi_srv6_sid_notify *note,
-				 char **locator_name);
+				 uint32_t *wide_func, enum zapi_srv6_sid_notify *note,
+				 char *locator_name, size_t loc_size);
 
 /* Nexthop-group message apis */
 extern enum zclient_send_status

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -1392,7 +1392,6 @@ static int static_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 	struct listnode *node;
 	char buf[256];
 	struct static_srv6_sid *sid = NULL;
-	char *loc_name;
 	bool found = false;
 
 	if (!srv6_locators)
@@ -1400,7 +1399,7 @@ static int static_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 
 	/* Decode the received notification message */
 	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr, &sid_func, NULL, &note,
-					 &loc_name)) {
+					 NULL, 0)) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}


### PR DESCRIPTION
Don't use a static buffer for the "locator name" in some zapi apis - the one caller who uses this can supply a buffer.
