### PR TITLE
bgpd: fix AS display inconsistency for auto-created BGP instance

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4115,6 +4115,24 @@ int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char *as_pr
 					UNSET_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS);
 				} else {
 					bgp->as = *as;
+					/* Update as_pretty when AS changes
+					 * for auto-created VRF
+					 */
+					XFREE(MTYPE_BGP_NAME, bgp->as_pretty);
+					if (as_pretty)
+						bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, as_pretty);
+					else
+						bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME,
+									 asn_asn2asplain(*as));
+					/* Update asnotation if provided and
+					 * not already configured
+					 */
+					if (!CHECK_FLAG(bgp->config, BGP_CONFIG_ASNOTATION) &&
+					    asnotation != ASNOTATION_UNDEFINED) {
+						bgp->asnotation = asnotation;
+						SET_FLAG(bgp->config, BGP_CONFIG_ASNOTATION);
+					}
+
 					if (force_config == false)
 						UNSET_FLAG(bgp->vrf_flags, BGP_VRF_AUTO);
 				}


### PR DESCRIPTION
When a BGP VRF instance is auto-created by EVPN L3VNI configuration before the explicit "router bgp" command is processed, only bgp->as is updated but bgp->as_pretty is not updated.
This caused show running-config to display the old AS number while bgp protocol used the correct one, leading to inconsistency between frr.conf and show running-config.

Note: The issue is observed when Default and non-default BGP instance has different ASN values

1. Zebra processes the following config where tenant vrf association to L3VNI (example "vrf X vni 1")
2. Zebra receivdes the SVI is operational up event which is associated to VRF X Zebra marks the VNI ready and sends L3VNI UP notification to BGPd
3. Upon receiving L3VNI up, BGPd does not have vrf instance, so it auto-creates BGP VRF X with default VRF's ASN value (asn1)
4. Subsequently when BGPd reads  "router bgp <asn2> vrf X" updates the bgp vrf instance's only the bgp->as field and not bgp->as_pretty (a BUG)
5. bgp->as_pretty remains with default VRF instances' ASN value (<asn1>)

So the running config has stale info for BGP vrf instances, this leads to an issue when a user tries to apply any config using frr-reload, it ends up restarting FRR as ASN values do not match for the BGP VRF instances. This leads to unexpected BGP sessions flap due to restart of FRR service.

Fix: To update both fileds of tenant VRF BGP instance's bgp->as and bgp->as_pretty value when a user configured bgp vrf instance is created. (the trigger would be "router bgp vrfX asn2)