### PR TITLE
yang: allow match-metric value of zero

### DIFF
--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -280,7 +280,7 @@ module frr-route-map {
           when "derived-from-or-self(../condition, 'match-metric')";
           leaf metric {
             type uint32 {
-              range "1..4294967295";
+              range "0..4294967295";
             }
             description
               "Metric value to match";


### PR DESCRIPTION
Include zero in the valid range of the match-metric - looks like zero is valid for the other metric attributes in the model.

Fixes #21882 
Fixes #21864 
