### PR TITLE
ripd: add full RTE bounds check to response/request processing loops

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1692,8 +1692,8 @@ static void rip_request_process(struct rip_packet *packet, int size,
 	rte = packet->rte;
 
 	/* The Request is processed entry by entry.  If there are no
-	   entries, no response is given. */
-	if (lim == (caddr_t)rte)
+	   entries (or only a partial RTE), no response is given. */
+	if ((caddr_t)(rte + 1) > lim)
 		return;
 
 	/* There is one special case.  If there is exactly one entry in the

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -737,7 +737,7 @@ static void rip_packet_dump(struct rip_packet *packet, int size,
 	/* Dump each routing table entry. */
 	rte = packet->rte;
 
-	for (lim = (caddr_t)packet + size; (caddr_t)rte < lim; rte++) {
+	for (lim = (caddr_t)packet + size; (caddr_t)(rte + 1) <= lim; rte++) {
 		if (packet->version == RIPv2) {
 			netmask = ip_masklen(rte->mask);
 
@@ -1185,7 +1185,7 @@ static void rip_response_process(struct rip_packet *packet, int size,
 	/* Set RTE pointer. */
 	rte = packet->rte;
 
-	for (lim = (caddr_t)packet + size; (caddr_t)rte < lim; rte++) {
+	for (lim = (caddr_t)packet + size; (caddr_t)(rte + 1) <= lim; rte++) {
 		/* RIPv2 authentication check. */
 		/* If the Address Family Identifier of the first (and only the
 		   first) entry in the message is 0xFFFF, then the remainder of
@@ -1718,7 +1718,7 @@ static void rip_request_process(struct rip_packet *packet, int size,
 		   to the requestor. */
 		p.family = AF_INET;
 
-		for (; ((caddr_t)rte) < lim; rte++) {
+		for (; ((caddr_t)(rte + 1)) <= lim; rte++) {
 			p.prefix = rte->prefix;
 			p.prefixlen = ip_masklen(rte->mask);
 			apply_mask_ipv4(&p);


### PR DESCRIPTION
## Summary

Adds a full RTE bounds check to the RIP response/request processing loops in `ripd/ripd.c`.

The RTE iteration loops in `rip_response_process()`, `rip_request_process()`, and `rip_packet_dump()` check only that the start of each `struct rte` (20 bytes) is within bounds, not that the full struct fits. While currently protected by an upstream alignment check in `rip_read()`, adding an explicit bounds check provides defense-in-depth and guards against future refactoring that might remove or alter the caller's validation.

## Changes

- `rip_response_process()` (line 1188): `(caddr_t)rte < lim` → `(caddr_t)(rte + 1) <= lim`
- `rip_request_process()` (line 1721): `((caddr_t)rte) < lim` → `((caddr_t)(rte + 1)) <= lim`  
- `rip_packet_dump()` (line 740): `(caddr_t)rte < lim` → `(caddr_t)(rte + 1) <= lim`

## Testing

- Compiled successfully with `--enable-ripd` on Ubuntu 24.04 / gcc 13.3.0

## Related

No existing issues or CVEs for this specific pattern. This is a proactive hardening change.