### PR TITLE
zebra: Copy the NHG ID in copy_state for NHT events

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -51,6 +51,14 @@ struct rnh {
 	uint32_t seqno;
 
 	struct route_entry *state;
+
+	/* The NHG ID of the resolved route entry. Used by NHT consumers
+	 * (e.g. fpmsyncd) to identify the nexthop-group when building FIB
+	 * entries from NHT notifications. We cache this ID in rnh instead
+	 * of the cached NHG entry due to some misuse concern on the cached
+	 * NHG entry after it gets a valid NHG ID.
+	 */
+	uint32_t resolved_nhg_id;
 	struct prefix resolved_route;
 
 	/* Single client that owns this rnh */

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1025,6 +1025,7 @@ static void copy_state(struct rnh *rnh, const struct route_entry *re,
 		free_state(rnh->vrf_id, rnh->state, rn);
 		rnh->state = NULL;
 	}
+	rnh->resolved_nhg_id = 0;
 
 	if (!re)
 		return;
@@ -1037,6 +1038,7 @@ static void copy_state(struct rnh *rnh, const struct route_entry *re,
 	state->status = re->status;
 
 	state->nhe = zebra_nhe_copy(re->nhe, 0);
+	rnh->resolved_nhg_id = re->nhe->id;
 
 	rnh->state = state;
 }


### PR DESCRIPTION
The copy_state function creates a temporary copy of the route entry's nexthop group for use in nexthop tracking (NHT) notifications to protocol clients. When zebra forwards an NHT event to fpmsyncd, the nexthop group ID stored in the copied nhe should be preserved so that fpmsyncd can identify the NHG and build the FIB entry correctly.

Change the ID argument of zebra_nhe_copy from 0 to re->nhe->id so that the copied NHE carries the correct identifier.