### PR TITLE
No kernel nhg original

### DIFF
--- a/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
+++ b/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
@@ -224,6 +224,130 @@ def test_fpm_connected_and_local_routes():
     assert success, f"Failed to find {result} local routes"
 
 
+def _get_nhg_for_prefix(router, prefix):
+    """
+    Helper: return (nhg_id, nhg_data) for a given route prefix string,
+    or (None, None) if not found.
+    """
+    route_info = router.vtysh_cmd("show ip route {} json".format(prefix))
+    try:
+        route_json = json.loads(route_info)
+    except json.JSONDecodeError:
+        return None, None
+
+    for pfx, routes in route_json.items():
+        if pfx == prefix:
+            nhg_id = routes[0].get("nexthopGroupId")
+            if nhg_id is None:
+                return None, None
+            nhg_info = router.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
+            try:
+                nhg_json = json.loads(nhg_info)
+                return nhg_id, nhg_json.get(str(nhg_id))
+            except json.JSONDecodeError:
+                return None, None
+    return None, None
+
+
+def _check_nhg_fpm_and_not_kernel(router, prefix, route_type):
+    """
+    Helper: assert that the NHG for prefix has been sent to FPM
+    while skipping kernel programming.
+    """
+
+    def check_nhg_sent_to_fpm():
+        nhg_id, nhg_data = _get_nhg_for_prefix(router, prefix)
+        if nhg_id is None or nhg_data is None:
+            return False
+        return nhg_data.get("fpm", False) is True
+
+    success, result = topotest.run_and_expect(
+        check_nhg_sent_to_fpm, True, count=60, wait=1
+    )
+    assert success, (
+        "{} route NHG ({}) was not sent to FPM "
+        "(NEXTHOP_GROUP_FPM flag not set). NHG data: {}".format(
+            route_type, prefix, result
+        )
+    )
+
+    def check_nhg_not_in_kernel():
+        nhg_id, _ = _get_nhg_for_prefix(router, prefix)
+        if nhg_id is None:
+            return False
+        output = router.run("ip nexthop show")
+        return "id {} ".format(nhg_id) not in output
+
+    success, _ = topotest.run_and_expect(
+        check_nhg_not_in_kernel, True, count=30, wait=1
+    )
+    assert (
+        success
+    ), "{} route NHG ({}) was unexpectedly installed in the Linux kernel.".format(
+        route_type, prefix
+    )
+
+
+def test_fpm_system_route_nhg_sent_to_fpm_not_kernel():
+    """
+    Test that NHGs for system routes (connected, local, kernel) are forwarded
+    to FPM but NOT installed in the kernel.
+      - FPM provider receives and sends the NHG  (NEXTHOP_GROUP_FPM flag set)
+      - Kernel provider skips netlink programming (NHG absent from kernel)
+
+    Three sub-cases are verified:
+      1. Connected route  (ZEBRA_ROUTE_CONNECT) - 172.16.1.0/24
+      2. Local route      (ZEBRA_ROUTE_LOCAL)   - 172.16.1.1/32
+      3. Kernel route     (ZEBRA_ROUTE_KERNEL)  - 172.16.2.0/24
+    """
+
+    tgen = get_topogen()
+    router = tgen.gears["r1"]
+
+    # Sub-case 1 & 2: connected + local routes
+    router.vtysh_cmd(
+        """
+        configure terminal
+        interface r1-eth0
+        ip address 172.16.1.1/24
+        """
+    )
+
+    _check_nhg_fpm_and_not_kernel(router, "172.16.1.0/24", "connected")
+    _check_nhg_fpm_and_not_kernel(router, "172.16.1.1/32", "local")
+
+    # Cleanup sub-case 1 & 2
+    router.vtysh_cmd(
+        """
+        configure terminal
+        interface r1-eth0
+        no ip address 172.16.1.1/24
+        """
+    )
+
+    # Sub-case 3: kernel route
+    router.run("ip route add 172.16.2.0/24 dev r1-eth0")
+
+    def kernel_route_visible():
+        route_info = router.vtysh_cmd("show ip route 172.16.2.0/24 json")
+        try:
+            rj = json.loads(route_info)
+            for pfx, routes in rj.items():
+                if pfx == "172.16.2.0/24":
+                    return routes[0].get("protocol") == "kernel"
+        except (json.JSONDecodeError, KeyError, IndexError):
+            pass
+        return False
+
+    success, _ = topotest.run_and_expect(kernel_route_visible, True, count=30, wait=1)
+    assert success, "Kernel route 172.16.2.0/24 did not appear in zebra RIB"
+
+    _check_nhg_fpm_and_not_kernel(router, "172.16.2.0/24", "kernel")
+
+    # Cleanup sub-case 3
+    router.run("ip route del 172.16.2.0/24 dev r1-eth0")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
+++ b/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
@@ -249,42 +249,91 @@ def _get_nhg_for_prefix(router, prefix):
     return None, None
 
 
+def _fpm_dump_path(router):
+    return os.path.join(router.gearlogdir, "fpm_test.data")
+
+
+def _fpm_listener_dump(router):
+    """Send SIGUSR1 to fpm_listener so it rewrites its dump file."""
+    pid_file = os.path.join(router.gearlogdir, "fpm_listener.pid")
+    try:
+        with open(pid_file, "r") as f:
+            pid = f.read().strip()
+        router.run("kill -SIGUSR1 {}".format(pid))
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _read_fpm_dump(router):
+    try:
+        with open(_fpm_dump_path(router), "r") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def _fpm_dump_has_nhg(router, nhg_id):
+    """
+    Return True iff the fpm_listener dump file currently contains an entry
+    for ``nhg_id``. The listener writes one line per live NHG of the form
+    "  ID: <id>, Protocol: ..." (see sigusr1_handler in fpm_listener.c),
+    and removes the entry when it receives the matching RTM_DELNEXTHOP.
+    """
+    if not _fpm_listener_dump(router):
+        return False
+    return "  ID: {},".format(nhg_id) in _read_fpm_dump(router)
+
+
 def _check_nhg_fpm_and_not_kernel(router, prefix, route_type):
     """
-    Helper: assert that the NHG for prefix has been sent to FPM
-    while skipping kernel programming.
+    Assert that the NHG for ``prefix`` was received by the mock FPM
+    listener and that the Linux kernel did NOT install it.
+
+    The "received by FPM" half is verified by inspecting the fpm_listener
+    dump file directly rather than relying on the in-zebra
+    NEXTHOP_GROUP_FPM flag, which is only set by the FPM resync hash-walk
+    (fpm_nhg_send_cb) and not by the runtime fpm_nl_enqueue() path that
+    this test exercises.
     """
 
-    def check_nhg_sent_to_fpm():
-        nhg_id, nhg_data = _get_nhg_for_prefix(router, prefix)
-        if nhg_id is None or nhg_data is None:
-            return False
-        return nhg_data.get("fpm", False) is True
+    last_seen = {"nhg_id": None, "nhg_data": None}
 
-    success, result = topotest.run_and_expect(
-        check_nhg_sent_to_fpm, True, count=60, wait=1
+    def have_nhg_id():
+        nhg_id, nhg_data = _get_nhg_for_prefix(router, prefix)
+        last_seen["nhg_id"] = nhg_id
+        last_seen["nhg_data"] = nhg_data
+        return nhg_id is not None
+
+    success, _ = topotest.run_and_expect(have_nhg_id, True, count=30, wait=1)
+    nhg_id = last_seen["nhg_id"]
+    assert (
+        success and nhg_id is not None
+    ), "{} route ({}) never picked up an NHG id in zebra. NHG data: {}".format(
+        route_type, prefix, json.dumps(last_seen["nhg_data"], indent=2)
     )
+
+    def check_nhg_in_fpm_dump():
+        return _fpm_dump_has_nhg(router, nhg_id)
+
+    success, _ = topotest.run_and_expect(check_nhg_in_fpm_dump, True, count=60, wait=1)
     assert success, (
-        "{} route NHG ({}) was not sent to FPM "
-        "(NEXTHOP_GROUP_FPM flag not set). NHG data: {}".format(
-            route_type, prefix, result
+        "{} route NHG ({}, id {}) was not received by the FPM listener.\n"
+        "FPM dump tail:\n{}".format(
+            route_type, prefix, nhg_id, _read_fpm_dump(router)[-2000:]
         )
     )
 
     def check_nhg_not_in_kernel():
-        nhg_id, _ = _get_nhg_for_prefix(router, prefix)
-        if nhg_id is None:
-            return False
         output = router.run("ip nexthop show")
         return "id {} ".format(nhg_id) not in output
 
     success, _ = topotest.run_and_expect(
         check_nhg_not_in_kernel, True, count=30, wait=1
     )
-    assert (
-        success
-    ), "{} route NHG ({}) was unexpectedly installed in the Linux kernel.".format(
-        route_type, prefix
+    assert success, (
+        "{} route NHG ({}, id {}) was unexpectedly installed in the "
+        "Linux kernel.".format(route_type, prefix, nhg_id)
     )
 
 
@@ -292,8 +341,10 @@ def test_fpm_system_route_nhg_sent_to_fpm_not_kernel():
     """
     Test that NHGs for system routes (connected, local, kernel) are forwarded
     to FPM but NOT installed in the kernel.
-      - FPM provider receives and sends the NHG  (NEXTHOP_GROUP_FPM flag set)
-      - Kernel provider skips netlink programming (NHG absent from kernel)
+      - FPM listener receives the RTM_NEWNEXTHOP for the NHG (verified by
+        inspecting the fpm_listener SIGUSR1 dump for the NHG id)
+      - Kernel provider skips netlink programming (NHG absent from
+        ``ip nexthop show``)
 
     Three sub-cases are verified:
       1. Connected route  (ZEBRA_ROUTE_CONNECT) - 172.16.1.0/24

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -4988,17 +4988,8 @@ dplane_nexthop_update_internal(struct nhg_hash_entry *nhe, enum dplane_op_e op)
 
 	ret = dplane_ctx_nexthop_init(ctx, op, nhe);
 	if (ret == AOK) {
-		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
-			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED);
-			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_REINSTALL);
-			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
-
-			dplane_ctx_free(&ctx);
-			atomic_fetch_add_explicit(&zdplane_info.dg_nexthops_in,
-						  1, memory_order_relaxed);
-
-			return ZEBRA_DPLANE_REQUEST_SUCCESS;
-		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL))
+			dplane_ctx_set_skip_kernel(ctx);
 
 		ret = dplane_update_enqueue(ctx);
 	}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3449,6 +3449,7 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL);
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED);
 	}
 
 	/* Make sure all depends are installed/queued */
@@ -3480,16 +3481,9 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 				nhe);
 			break;
 		case ZEBRA_DPLANE_REQUEST_SUCCESS:
-			if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
-				/* Expected: delayed-install optimization */
-				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-					zlog_debug("%s: NHG %pNG delayed-install optimization (flags 0x%x)",
-						   __func__, nhe, nhe->flags);
-			} else {
-				flog_err(EC_ZEBRA_DP_INVALID_RC,
-					 "DPlane returned an invalid result code for attempt of installation of %pNG into the kernel",
-					 nhe);
-			}
+			flog_err(EC_ZEBRA_DP_INVALID_RC,
+				 "DPlane returned an invalid result code for attempt of installation of %pNG into the kernel",
+				 nhe);
 			break;
 		}
 	}

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -196,8 +196,9 @@ static void zebra_vrf_disable_update_vrfid(struct zebra_vrf *zvrf, afi_t afi, sa
 		 */
 		rn_delete = true;
 		RNODE_FOREACH_RE_SAFE (rn, re, nre) {
-			if (re->type == ZEBRA_ROUTE_KERNEL ||
-			    CHECK_FLAG(re->flags, ZEBRA_FLAG_TABLEID)) {
+			if (!zebra_router_in_shutdown() &&
+			    (re->type == ZEBRA_ROUTE_KERNEL ||
+			     CHECK_FLAG(re->flags, ZEBRA_FLAG_TABLEID))) {
 				nexthop_vrf_update(rn, re, VRF_DEFAULT);
 				if (CHECK_FLAG(re->flags, ZEBRA_FLAG_TABLEID))
 					/* reinstall routes */


### PR DESCRIPTION
PR #21125 attempts to modify slightly how NHG data is sent to the kernel for connected/local/kernel NHG's.  The approach taken there was too complicated and in order for me to figure out what was going on I had to reverse engineer it to a degree that my approach is just much simplier and frankly easier to understand.   Here's my alternate approach to the problem