### PR TITLE
bgpd: Remove redundant BGP-LS NLRI forward declarations

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -86,10 +86,6 @@
 
 #include "bgpd/bgp_route_clippy.c"
 
-void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len);
-struct json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri);
-
-
 static bool bgp_attr_nexthop_same(const struct attr *attr1, const struct attr *attr2, afi_t afi)
 {
 	afi_t nh_afi1 = BGP_ATTR_NH_AFI(afi, attr1);


### PR DESCRIPTION
`bgp_route.c` declares two local prototypes for:

- `bgp_ls_nlri_format()`
- `bgp_ls_nlri_to_json()`

`bgp_ls.h` already declares both, and `bgp_route.c` includes that header. Remove the duplicate forward declarations and use the prototypes from `bgp_ls.h`.