### PR TITLE
bgpd: Fix srv6 type parsing and EVPN type-5 NLRI prefix length parsing for IPv4 (backport #21345)

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3276,16 +3276,12 @@ bgp_attr_srv6_service(struct bgp_attr_parser_args *args)
 	}
 
 	if (type == BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO) {
-		if (STREAM_READABLE(peer->curr) <
-		    BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO_LENGTH) {
-			flog_err(
-				EC_BGP_ATTR_LEN,
-				"Malformed SRv6 Service Sub-TLV attribute - insufficent data (need %d for attribute data, have %zu remaining in UPDATE)",
-				BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO_LENGTH,
-				STREAM_READABLE(peer->curr));
-			return bgp_attr_malformed(
-				args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-				args->total);
+		if (length < BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO_LENGTH) {
+			flog_err(EC_BGP_ATTR_LEN,
+				 "Malformed SRv6 Service Sub-TLV attribute - declared length %u is less than minimum %d",
+				 length, BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO_LENGTH);
+			return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
+						  args->total);
 		}
 		stream_getc(peer->curr);
 		stream_get(&ipv6_sid, peer->curr, sizeof(ipv6_sid));

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5121,6 +5121,13 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 	 * a simple check on the total size.
 	 */
 	if (psize == 34) {
+		if (ippfx_len > IPV4_MAX_BITLEN) {
+			flog_err(EC_BGP_EVPN_ROUTE_INVALID,
+				 "%u:%s - Rx EVPN Type-5 NLRI with IPv4 psize but IP Prefix length %d (max %d)",
+				 peer->bgp->vrf_id, peer->host, ippfx_len, IPV4_MAX_BITLEN);
+			evpn_overlay_free(evpn);
+			return -1;
+		}
 		SET_IPADDR_V4(&p.prefix.prefix_addr.ip);
 		memcpy(&p.prefix.prefix_addr.ip.ipaddr_v4, pfx, 4);
 		pfx += 4;


### PR DESCRIPTION
Backport of #21345  to stable/10.5 (mergify version didn't patch cleanly)

