### PR TITLE
bgpd: Fix buffer/count inconsistency in SRv6 End.X SID TLV parsers

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -5127,6 +5127,9 @@ static int parse_srv6_endx_sid(struct stream *s, uint16_t length, struct bgp_ls_
 	stream_getc(s); /* Reserved */
 	stream_get(&entry->sid, s, IPV6_MAX_BYTELEN);
 
+	attr->srv6_endx_sid_count++;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT);
+
 	/* Sub-TLVs */
 	if (length > BGP_LS_SRV6_ENDX_SID_MIN_SIZE) {
 		uint16_t sub_total = length - BGP_LS_SRV6_ENDX_SID_MIN_SIZE;
@@ -5135,8 +5138,6 @@ static int parse_srv6_endx_sid(struct stream *s, uint16_t length, struct bgp_ls_
 			return -1;
 	}
 
-	attr->srv6_endx_sid_count++;
-	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT);
 	return 0;
 }
 
@@ -5176,6 +5177,9 @@ static int parse_isis_srv6_lan_endx_sid(struct stream *s, uint16_t length, struc
 	stream_get(entry->neighbor.sysid, s, 6); /* IS-IS System-ID */
 	stream_get(&entry->sid, s, IPV6_MAX_BYTELEN);
 
+	attr->srv6_lan_endx_sid_count++;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
+
 	if (length > BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE) {
 		uint16_t sub_total = length - BGP_LS_SRV6_LAN_ENDX_SID_ISIS_MIN_SIZE;
 
@@ -5183,8 +5187,6 @@ static int parse_isis_srv6_lan_endx_sid(struct stream *s, uint16_t length, struc
 			return -1;
 	}
 
-	attr->srv6_lan_endx_sid_count++;
-	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
 	return 0;
 }
 
@@ -5224,6 +5226,9 @@ static int parse_ospf_srv6_lan_endx_sid(struct stream *s, uint16_t length, struc
 	entry->neighbor.router_id.s_addr = stream_getl(s); /* OSPFv3 Router-ID */
 	stream_get(&entry->sid, s, IPV6_MAX_BYTELEN);
 
+	attr->srv6_lan_endx_sid_count++;
+	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
+
 	if (length > BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE) {
 		uint16_t sub_total = length - BGP_LS_SRV6_LAN_ENDX_SID_OSPF_MIN_SIZE;
 
@@ -5231,8 +5236,6 @@ static int parse_ospf_srv6_lan_endx_sid(struct stream *s, uint16_t length, struc
 			return -1;
 	}
 
-	attr->srv6_lan_endx_sid_count++;
-	SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT);
 	return 0;
 }
 


### PR DESCRIPTION
When parsing SRv6 End.X SID TLVs, each new entry is added to a dynamically grown array. The array is resized first, and the new entry is filled in. The parser then processes optional sub-TLVs and increments the entry count only after sub-TLV parsing succeeds. If sub-TLV parsing fails, the function returns an error before the count is incremented, leaving the array one element larger than the count indicates.

Code that later copies the array allocates the destination based on the count, so it can allocate too little memory and miss the last entry.

Fix by incrementing the count and marking the attribute present immediately after filling in the entry, before parsing sub-TLVs. If sub-TLV parsing then fails, the count still matches the array size, and the error cleanup path frees the entire array safely.

This affects `parse_srv6_endx_sid()`, `parse_isis_srv6_lan_endx_sid()`, and `parse_ospf_srv6_lan_endx_sid()`.