### PR TITLE
bgpd: Reject malformed SRv6 End.X sub-TLV payloads with leftover bytes

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -5090,6 +5090,13 @@ static int parse_endx_sub_tlvs(struct stream *s, uint16_t sub_total, bool *has_s
 		sub_total -= len;
 	}
 
+	if (sub_total != 0) {
+		flog_warn(EC_BGP_UPDATE_RCV,
+			  "BGP-LS: malformed SRv6 End.X sub-TLV list (%u byte(s) remain after sub-TLV parsing)",
+			  sub_total);
+		return -1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
BGP-LS SRv6 End.X sub-TLV parsing currently accepts payloads that leave unparsed bytes at the end (for example, fewer than a full TLV header).

Treat this as malformed input by adding a post-parse check in `parse_endx_sub_tlvs()`: if bytes remain after parsing complete TLV header/value pairs, return -1.