### PR TITLE
pimd: add IGMP/MLD proxy route-map filtering

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -525,6 +525,68 @@ keyword at the end.
    interfaces on this interface. Join-groups on other interfaces will
    also be proxied. The default version is v3.
 
+.. clicmd:: ip igmp proxy route-map ROUTE-MAP
+
+   Apply a route-map to filter which multicast (S,G) entries are forwarded
+   via IGMP proxy on this interface. Only groups permitted by the route-map
+   will be proxied; all others are silently dropped.
+
+   This is evaluated at proxy join time: on initial proxy setup
+   (``ip igmp proxy``) and each time a new IGMP report arrives on another
+   interface. Changing the route-map takes effect on the next proxy
+   enable/disable cycle.
+
+   The following ``match`` statements are supported:
+
+   * ``match ip multicast-group A.B.C.D``
+   * ``match ip multicast-group prefix-list PREFIX-LIST``
+   * ``match ip multicast-source A.B.C.D``
+   * ``match ip multicast-source prefix-list PREFIX-LIST``
+   * ``match multicast-interface INTERFACE-NAME``
+
+   **Indirect IGMPv2 vs IGMPv3 filtering**
+
+   There is no explicit ``match igmp-version`` condition, but IGMP version
+   can be distinguished indirectly through the source address:
+
+   * IGMPv2 joins and IGMPv3 ASM ``(*,G)`` reports both produce entries
+     with source ``0.0.0.0`` (wildcard).
+   * IGMPv3 SSM ``(S,G)`` reports carry a specific non-zero source address.
+
+   To proxy **only** IGMPv3 SSM joins (deny any-source entries)::
+
+      ip prefix-list ANY_SOURCE seq 5 permit 0.0.0.0/32
+
+      route-map PROXY_SSM_ONLY deny 10
+       match ip multicast-source prefix-list ANY_SOURCE
+      route-map PROXY_SSM_ONLY permit 20
+
+      interface eth1
+       ip igmp proxy
+       ip igmp proxy route-map PROXY_SSM_ONLY
+
+   To proxy **only** ASM / IGMPv2-style ``(*,G)`` entries (deny SSM)::
+
+      ip prefix-list ANY_SOURCE seq 5 permit 0.0.0.0/32
+
+      route-map PROXY_ASM_ONLY permit 10
+       match ip multicast-source prefix-list ANY_SOURCE
+
+      interface eth1
+       ip igmp proxy
+       ip igmp proxy route-map PROXY_ASM_ONLY
+
+   Example — proxy only groups in 239.0.0.0/8::
+
+      ip prefix-list PROXY_GROUPS seq 5 permit 239.0.0.0/8 le 32
+
+      route-map PROXY_FILTER permit 10
+       match ip multicast-group prefix-list PROXY_GROUPS
+
+      interface eth1
+       ip igmp proxy
+       ip igmp proxy route-map PROXY_FILTER
+
 .. clicmd:: ip igmp immediate-leave
 
    Immediately leaves an IGMP group when receiving a IGMPv2 Leave packet.

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -545,10 +545,15 @@ keyword at the end.
    * ``match multicast-interface INTERFACE-NAME``
    * ``match multicast-source-interface INTERFACE-NAME``
 
-   ``match multicast-source-interface`` matches against the interface where
-   the IGMP/MLD report was **received** (the upstream/listener-facing
-   interface), not the proxy output interface. This allows filtering proxy
-   joins per source interface::
+   ``match multicast-source-interface`` matches against the inbound
+   interface for the filter decision. In a proxy filter that is the
+   interface where the IGMP/MLD report was **received** (the
+   upstream/listener-facing interface), which is distinct from the proxy
+   output interface. In a regular ``ip/ipv6 igmp/mld route-map`` (or a
+   PIM ``join-filter``) it is the interface processing the report or
+   join, in which case it behaves the same as ``match multicast-interface``.
+
+   This allows filtering proxy joins per source interface::
 
       route-map PROXY_FILTER permit 10
        match multicast-source-interface eth0

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -543,6 +543,22 @@ keyword at the end.
    * ``match ip multicast-source A.B.C.D``
    * ``match ip multicast-source prefix-list PREFIX-LIST``
    * ``match multicast-interface INTERFACE-NAME``
+   * ``match multicast-source-interface INTERFACE-NAME``
+
+   ``match multicast-source-interface`` matches against the interface where
+   the IGMP/MLD report was **received** (the upstream/listener-facing
+   interface), not the proxy output interface. This allows filtering proxy
+   joins per source interface::
+
+      route-map PROXY_FILTER permit 10
+       match multicast-source-interface eth0
+
+      interface eth1
+       ip igmp proxy
+       ip igmp proxy route-map PROXY_FILTER
+
+   With this configuration, only groups reported on ``eth0`` are proxied
+   out ``eth1``.
 
    **Indirect IGMPv2 vs IGMPv3 filtering**
 

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -282,7 +282,7 @@ static bool gm_sg_filter_match(const struct gm_if *gm_if, const pim_addr source,
 		.grp.ipaddr_v6 = group,
 	};
 
-	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, gm_if->ifp, NULL)) {
+	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, gm_if->ifp, gm_if->ifp)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("%s: SG%pPSG on interface %s filtered due to route-map",
 				   __func__, &sg, gm_if->ifp->name);

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -282,7 +282,7 @@ static bool gm_sg_filter_match(const struct gm_if *gm_if, const pim_addr source,
 		.grp.ipaddr_v6 = group,
 	};
 
-	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, gm_if->ifp)) {
+	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, gm_if->ifp, NULL)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("%s: SG%pPSG on interface %s filtered due to route-map",
 				   __func__, &sg, gm_if->ifp->name);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6002,6 +6002,22 @@ DEFPY (interface_ip_igmp_proxy,
 	return pim_process_ip_gmp_proxy_cmd(vty, !no);
 }
 
+DEFPY_YANG(interface_ip_igmp_proxy_rmap, interface_ip_igmp_proxy_rmap_cmd,
+	   "[no] ip igmp proxy route-map ![RMAP_NAME]",
+	   NO_STR
+	   IP_STR
+	   IGMP_STR
+	   "Proxy IGMP join/prune operations\n"
+	   "Filter proxied groups through route-map\n"
+	   "Route-map name\n")
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "./proxy-route-map", NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, "./proxy-route-map", NB_OP_MODIFY, rmap_name);
+
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
 
 DEFPY_YANG(interface_ip_pim_neighbor_prefix_list,
            interface_ip_pim_neighbor_prefix_list_cmd,
@@ -9410,6 +9426,7 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE,
 			&interface_no_ip_igmp_last_member_query_interval_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_igmp_proxy_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_igmp_proxy_rmap_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_igmp_limits_cmd);
 	install_element(INTERFACE_NODE, &no_interface_ip_igmp_limits_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_igmp_immediate_leave_cmd);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -39,6 +39,7 @@
 #include "pim_vxlan.h"
 #include "pim_tib.h"
 #include "pim_util.h"
+#include "pim_routemap.h"
 
 #include "pim6_mld.h"
 
@@ -187,6 +188,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool gm, bool pim,
 	pim_ifp->pim->mcast_if_count++;
 
 	pim_filter_ref_init(&pim_ifp->gmp_filter);
+	pim_filter_ref_init(&pim_ifp->gm_proxy_filter);
 
 	return pim_ifp;
 }
@@ -227,6 +229,7 @@ void pim_if_delete(struct interface *ifp)
 	pim_igmp_if_fini(pim_ifp);
 
 	pim_filter_ref_fini(&pim_ifp->gmp_filter);
+	pim_filter_ref_fini(&pim_ifp->gm_proxy_filter);
 
 	list_delete(&pim_ifp->pim_neighbor_list);
 	list_delete(&pim_ifp->upstream_switch_list);
@@ -1595,6 +1598,7 @@ static void pim_if_static_group_del_all(struct interface *ifp)
 void pim_if_gm_proxy_init(struct pim_instance *pim, struct interface *oif)
 {
 	struct interface *ifp;
+	struct pim_interface *oif_pim = oif->info;
 
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp = ifp->info;
@@ -1612,6 +1616,18 @@ void pim_if_gm_proxy_init(struct pim_instance *pim, struct interface *oif)
 					  group)) {
 			for (ALL_LIST_ELEMENTS_RO(group->group_source_list,
 						  source_node, src)) {
+				pim_sgaddr sgaddr = { .src = src->source_addr,
+						      .grp = group->group_addr };
+				struct prefix_sg pfx;
+
+				pim_sg_to_prefix(&sgaddr, &pfx);
+				if (!pim_filter_match(&oif_pim->gm_proxy_filter, &pfx, oif)) {
+					if (PIM_DEBUG_GM_TRACE)
+						zlog_debug("%s: proxy join for SG%pPSG from %s to %s filtered due to route-map",
+							   __func__, &pfx, ifp->name, oif->name);
+					continue;
+				}
+
 				pim_if_gm_join_add(oif, group->group_addr,
 						   src->source_addr,
 						   GM_JOIN_PROXY);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1621,7 +1621,7 @@ void pim_if_gm_proxy_init(struct pim_instance *pim, struct interface *oif)
 				struct prefix_sg pfx;
 
 				pim_sg_to_prefix(&sgaddr, &pfx);
-				if (!pim_filter_match(&oif_pim->gm_proxy_filter, &pfx, oif)) {
+				if (!pim_filter_match(&oif_pim->gm_proxy_filter, &pfx, oif, ifp)) {
 					if (PIM_DEBUG_GM_TRACE)
 						zlog_debug("%s: proxy join for SG%pPSG from %s to %s filtered due to route-map",
 							   __func__, &pfx, ifp->name, oif->name);

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -76,6 +76,7 @@ struct pim_interface {
 
 	bool gm_enable : 1;
 	bool gm_proxy : 1; /* proxy IGMP joins/prunes */
+	struct pim_filter_ref gm_proxy_filter; /* route-map filter for proxied (S,G) */
 
 	ifindex_t mroute_vif_index;
 	struct pim_instance *pim;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1379,7 +1379,7 @@ void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 		.grp.ipaddr_v4 = group->group_addr,
 	};
 
-	if (interval_msec && !pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface)) {
+	if (interval_msec && !pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface, NULL)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Timer for %pPSG on %s not refreshed due to route-map reject",
 				   &sg, ifname);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1379,7 +1379,8 @@ void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 		.grp.ipaddr_v4 = group->group_addr,
 	};
 
-	if (interval_msec && !pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface, NULL)) {
+	if (interval_msec &&
+	    !pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface, group->interface)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Timer for %pPSG on %s not refreshed due to route-map reject",
 				   &sg, ifname);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -208,7 +208,7 @@ void igmp_source_reset_gmi(struct gm_group *group, struct gm_source *source)
 
 	group_membership_interval_msec = igmp_gmi_msec(group);
 
-	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface)) {
+	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface, NULL)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Timer for %pPSG on %s not refreshed due to route-map reject",
 				   &sg, ifp->name);
@@ -394,7 +394,7 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 	if (new)
 		*new = false;
 
-	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, group->interface))
+	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, group->interface, NULL))
 		return NULL;
 
 	src = igmp_find_source_by_addr(group, src_addr);
@@ -630,7 +630,7 @@ void igmpv3_report_isex(struct gm_sock *igmp, struct in_addr from,
 	if (pim_is_group_filtered(ifp->info, &group_addr, NULL))
 		return;
 
-	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface)) {
+	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface, NULL)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Rejected ISEX %pPSG on %s due to route-map", &sg, ifp->name);
 		return;
@@ -935,7 +935,7 @@ void igmpv3_report_toex(struct gm_sock *igmp, struct in_addr from,
 
 	on_trace(__func__, ifp, from, group_addr, num_sources, sources);
 
-	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface)) {
+	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface, NULL)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Rejected TOEX %pPSG on %s due to route-map", &sg, ifp->name);
 		return;

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -208,7 +208,7 @@ void igmp_source_reset_gmi(struct gm_group *group, struct gm_source *source)
 
 	group_membership_interval_msec = igmp_gmi_msec(group);
 
-	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface, NULL)) {
+	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, group->interface, group->interface)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Timer for %pPSG on %s not refreshed due to route-map reject",
 				   &sg, ifp->name);
@@ -394,7 +394,7 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 	if (new)
 		*new = false;
 
-	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, group->interface, NULL))
+	if (!pim_filter_match(&pim_interface->gmp_filter, &sg, group->interface, group->interface))
 		return NULL;
 
 	src = igmp_find_source_by_addr(group, src_addr);
@@ -630,7 +630,7 @@ void igmpv3_report_isex(struct gm_sock *igmp, struct in_addr from,
 	if (pim_is_group_filtered(ifp->info, &group_addr, NULL))
 		return;
 
-	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface, NULL)) {
+	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface, igmp->interface)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Rejected ISEX %pPSG on %s due to route-map", &sg, ifp->name);
 		return;
@@ -935,7 +935,7 @@ void igmpv3_report_toex(struct gm_sock *igmp, struct in_addr from,
 
 	on_trace(__func__, ifp, from, group_addr, num_sources, sources);
 
-	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface, NULL)) {
+	if (!pim_filter_match(&pim_ifp->gmp_filter, &sg, igmp->interface, igmp->interface)) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("Rejected TOEX %pPSG on %s due to route-map", &sg, ifp->name);
 		return;

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -310,7 +310,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				continue;
 
 			pim_sg_to_prefix(&sg, &psg);
-			if (!pim_filter_match(&pim_ifp->pim->join_filter, &psg, ifp)) {
+			if (!pim_filter_match(&pim_ifp->pim->join_filter, &psg, ifp, NULL)) {
 				if (PIM_DEBUG_PIM_TRACE)
 					zlog_debug("%s: SG%pPSG on interface %s filtered due to route-map",
 						   __func__, &psg, ifp->name);

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -310,7 +310,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				continue;
 
 			pim_sg_to_prefix(&sg, &psg);
-			if (!pim_filter_match(&pim_ifp->pim->join_filter, &psg, ifp, NULL)) {
+			if (!pim_filter_match(&pim_ifp->pim->join_filter, &psg, ifp, ifp)) {
 				if (PIM_DEBUG_PIM_TRACE)
 					zlog_debug("%s: SG%pPSG on interface %s filtered due to route-map",
 						   __func__, &psg, ifp->name);

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -527,6 +527,13 @@ const struct frr_yang_module_info frr_pim_route_map_info = {
 			}
 		},
 		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/frr-pim-route-map:multicast-source-interface",
+			.cbs = {
+				.modify = pim_route_map_match_source_interface_modify,
+				.destroy = lib_route_map_entry_match_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/frr-pim-route-map:list-name",
 			.cbs = {
 				.modify = pim_route_map_match_list_name_modify,

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -885,6 +885,13 @@ const struct frr_yang_module_info frr_gmp_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/proxy-route-map",
+			.cbs = {
+				.modify  = lib_interface_gm_proxy_rmap_modify,
+				.destroy = lib_interface_gm_proxy_rmap_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/immediate-leave",
 			.cbs = {
 				.modify = lib_interface_gmp_immediate_leave_modify,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -323,6 +323,8 @@ int lib_interface_gmp_immediate_leave_modify(struct nb_cb_modify_args *args);
 int lib_interface_gmp_require_router_alert_modify(struct nb_cb_modify_args *args);
 int lib_interface_gm_rmap_modify(struct nb_cb_modify_args *args);
 int lib_interface_gm_rmap_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_gm_proxy_rmap_modify(struct nb_cb_modify_args *args);
+int lib_interface_gm_proxy_rmap_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_gm_alist_modify(struct nb_cb_modify_args *args);
 int lib_interface_gm_alist_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_allow_rp_modify(struct nb_cb_modify_args *args);

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -186,6 +186,7 @@ int pim_route_map_match_source_v6_modify(struct nb_cb_modify_args *args);
 int pim_route_map_match_group_modify(struct nb_cb_modify_args *args);
 int pim_route_map_match_group_v6_modify(struct nb_cb_modify_args *args);
 int pim_route_map_match_interface_modify(struct nb_cb_modify_args *args);
+int pim_route_map_match_source_interface_modify(struct nb_cb_modify_args *args);
 int pim_route_map_match_list_name_modify(struct nb_cb_modify_args *args);
 
 /* frr-pim-rp prototypes*/

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -5093,6 +5093,59 @@ int lib_interface_gm_rmap_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/proxy-route-map
+ */
+int lib_interface_gm_proxy_rmap_modify(struct nb_cb_modify_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+	const char *rmap;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		if (!pim_ifp) {
+			pim_ifp = pim_if_new(ifp, true, false, false, false);
+			ifp->info = pim_ifp;
+		}
+
+		rmap = yang_dnode_get_string(args->dnode, NULL);
+		pim_filter_ref_set_rmap(&pim_ifp->gm_proxy_filter, rmap);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_gm_proxy_rmap_destroy(struct nb_cb_destroy_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		if (!pim_ifp)
+			return NB_ERR_INCONSISTENCY;
+
+		pim_filter_ref_set_rmap(&pim_ifp->gm_proxy_filter, NULL);
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/access-list
  */
 int lib_interface_gm_alist_modify(struct nb_cb_modify_args *args)

--- a/pimd/pim_routemap.c
+++ b/pimd/pim_routemap.c
@@ -29,6 +29,7 @@
 #define MULTICAST_IPV6_GROUP	   "multicast-group-v6"
 #define MULTICAST_IPV6_GROUP_LIST  "multicast-group-v6 prefix-list"
 #define MULTICAST_INTERFACE	   "multicast-interface"
+#define MULTICAST_SOURCE_INTERFACE "multicast-source-interface"
 
 DEFINE_MTYPE_STATIC(PIMD, PIM_ACL_REF, "PIM filter name");
 
@@ -103,10 +104,20 @@ void pim_sg_to_prefix(const pim_sgaddr *sg, struct prefix_sg *prefix)
 struct pim_rmap_info {
 	const struct prefix_sg *sg;
 	struct interface *interface;
+	/*
+	 * Multicast source interface for this route-map evaluation
+	 * (`match multicast-source-interface` matches this):
+	 *   - may differ from `interface` when membership or control traffic
+	 *     arrived on a different interface than the filter evaluation context
+	 *   - otherwise same as `interface`
+	 *
+	 * Always populated by callers; never NULL in current code paths.
+	 */
+	struct interface *source_interface;
 };
 
 bool pim_filter_match(const struct pim_filter_ref *ref, const struct prefix_sg *sg,
-		      struct interface *interface)
+		      struct interface *interface, struct interface *source_interface)
 {
 #if PIM_IPV == 4
 	if (sg->grp.ipaddr_v4.s_addr && !pim_is_group_224_4(sg->grp.ipaddr_v4))
@@ -147,6 +158,7 @@ bool pim_filter_match(const struct pim_filter_ref *ref, const struct prefix_sg *
 		struct pim_rmap_info info = {
 			.sg = sg,
 			.interface = interface,
+			.source_interface = source_interface,
 		};
 
 		if (!ref->rmap)
@@ -613,6 +625,60 @@ static const struct route_map_rule_cmd route_match_interface_cmd = {
 	route_map_rule_str_free,
 };
 
+static enum route_map_cmd_result_t
+route_match_source_interface(void *rule, const struct prefix *prefix, void *object)
+{
+	struct pim_rmap_info *info = object;
+	struct interface *ifp;
+
+	if (!info->source_interface)
+		return RMAP_NOMATCH;
+
+	ifp = if_lookup_by_name(rule, info->source_interface->vrf->vrf_id);
+	if (ifp == NULL || ifp != info->source_interface)
+		return RMAP_NOMATCH;
+
+	return RMAP_MATCH;
+}
+
+static const struct route_map_rule_cmd route_match_source_interface_cmd = {
+	MULTICAST_SOURCE_INTERFACE,
+	route_match_source_interface,
+	route_map_rule_str_compile,
+	route_map_rule_str_free,
+};
+
+DEFPY_YANG(route_map_match_source_interface,
+	   route_map_match_source_interface_cmd,
+	   "[no] match multicast-source-interface IFNAME",
+	   NO_STR
+	   MATCH_STR
+	   "Multicast source interface for this route-map evaluation\n"
+	   "Interface name\n")
+{
+	const char *xpath, *xpval;
+	char xpath_value[XPATH_MAXLEN];
+
+	xpath = "./match-condition[condition='frr-pim-route-map:multicast-source-interface']";
+	xpval = "/rmap-match-condition/frr-pim-route-map:multicast-source-interface";
+
+	if (no)
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	else {
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		snprintf(xpath_value, sizeof(xpath_value), "%s%s", xpath, xpval);
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, ifname);
+	}
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+ALIAS_YANG(route_map_match_source_interface,
+	   no_route_map_match_source_interface_cmd,
+	   "no match multicast-source-interface",
+	   NO_STR
+	   MATCH_STR
+	   "Multicast source interface for this route-map evaluation\n")
 
 static void pim_route_map_add(const char *rmap_name)
 {
@@ -651,6 +717,7 @@ void pim_route_map_init(void)
 	route_map_install_match(&route_match_group_prefix_list_cmd);
 	route_map_install_match(&route_match_group_v6_prefix_list_cmd);
 	route_map_install_match(&route_match_interface_cmd);
+	route_map_install_match(&route_match_source_interface_cmd);
 
 	install_element(RMAP_NODE, &route_map_match_address_cmd);
 	install_element(RMAP_NODE, &no_route_map_match_address_cmd);
@@ -662,6 +729,8 @@ void pim_route_map_init(void)
 	install_element(RMAP_NODE, &no_route_map_match_prefix_list_v6_cmd);
 	install_element(RMAP_NODE, &route_map_match_interface_cmd);
 	install_element(RMAP_NODE, &no_route_map_match_interface_cmd);
+	install_element(RMAP_NODE, &route_map_match_source_interface_cmd);
+	install_element(RMAP_NODE, &no_route_map_match_source_interface_cmd);
 }
 
 void pim_route_map_terminate(void)
@@ -724,6 +793,11 @@ int pim_route_map_match_group_v6_modify(struct nb_cb_modify_args *args)
 int pim_route_map_match_interface_modify(struct nb_cb_modify_args *args)
 {
 	return pim_route_map_match_item_modify(args, MULTICAST_INTERFACE);
+}
+
+int pim_route_map_match_source_interface_modify(struct nb_cb_modify_args *args)
+{
+	return pim_route_map_match_item_modify(args, MULTICAST_SOURCE_INTERFACE);
 }
 
 int pim_route_map_match_list_name_modify(struct nb_cb_modify_args *args)

--- a/pimd/pim_routemap.h
+++ b/pimd/pim_routemap.h
@@ -30,7 +30,7 @@ struct pim_filter_ref {
  * sg is required, interface is optional
  */
 extern bool pim_filter_match(const struct pim_filter_ref *ref, const struct prefix_sg *sg,
-			     struct interface *interface);
+			     struct interface *interface, struct interface *source_interface);
 
 extern void pim_sg_to_prefix(const pim_sgaddr *sg, struct prefix_sg *prefix);
 

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -102,7 +102,7 @@ void tib_sg_proxy_join_prune_check(struct pim_instance *pim, pim_sgaddr sg,
 			 * so tightening the filter without cycling the proxy cannot strand
 			 * proxy (*,G)/(S,G) state after the last host leaves.
 			 */
-			if (join && !pim_filter_match(&pim_ifp->gm_proxy_filter, &pfx, ifp)) {
+			if (join && !pim_filter_match(&pim_ifp->gm_proxy_filter, &pfx, ifp, oif)) {
 				if (PIM_DEBUG_GM_TRACE)
 					zlog_debug("%s: proxy join for SG%pPSG from %s to %s filtered due to route-map",
 						   __func__, &pfx, oif->name, ifp->name);

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -15,6 +15,7 @@
 #include "pim_oil.h"
 #include "pim_nht.h"
 #include "pim_dm.h"
+#include "pim_routemap.h"
 
 static struct channel_oil *
 tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
@@ -94,6 +95,20 @@ void tib_sg_proxy_join_prune_check(struct pim_instance *pim, pim_sgaddr sg,
 			continue;
 
 		if (pim_ifp->gm_enable && pim_ifp->gm_proxy) {
+			struct prefix_sg pfx;
+
+			pim_sg_to_prefix(&sg, &pfx);
+			/* Apply the proxy route-map only to joins.  Prunes must always run
+			 * so tightening the filter without cycling the proxy cannot strand
+			 * proxy (*,G)/(S,G) state after the last host leaves.
+			 */
+			if (join && !pim_filter_match(&pim_ifp->gm_proxy_filter, &pfx, ifp)) {
+				if (PIM_DEBUG_GM_TRACE)
+					zlog_debug("%s: proxy join for SG%pPSG from %s to %s filtered due to route-map",
+						   __func__, &pfx, oif->name, ifp->name);
+				continue;
+			}
+
 			if (join)
 				pim_if_gm_join_add(ifp, sg.grp, sg.src,
 						   GM_JOIN_PROXY);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -307,11 +307,6 @@ static int gm_config_write(struct vty *vty, int writes,
 		++writes;
 	}
 
-	if (pim_ifp->gm_proxy) {
-		vty_out(vty, " ip igmp proxy\n");
-		++writes;
-	}
-
 	/* ip igmp version */
 	if (pim_ifp->igmp_version != IGMP_DEFAULT_VERSION) {
 		vty_out(vty, " ip igmp version %d\n", pim_ifp->igmp_version);
@@ -507,6 +502,24 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 	if (pim_ifp->gmp_filter.alistname) {
 		vty_out(vty, " " PIM_AF_NAME " " GM_AF_DBG " access-list %s\n",
 			pim_ifp->gmp_filter.alistname);
+		++writes;
+	}
+
+	/*
+	 * IF igmp/mld proxy route-map
+	 *
+	 * Must be emitted before 'proxy' so that on config replay
+	 * pim_if_gm_proxy_init() runs with the filter already set.
+	 */
+	if (pim_ifp->gm_proxy_filter.rmapname) {
+		vty_out(vty, " " PIM_AF_NAME " " GM_AF_DBG " proxy route-map %s\n",
+			pim_ifp->gm_proxy_filter.rmapname);
+		++writes;
+	}
+
+	/* IF igmp/mld proxy */
+	if (pim_ifp->gm_proxy) {
+		vty_out(vty, " " PIM_AF_NAME " " GM_AF_DBG " proxy\n");
 		++writes;
 	}
 

--- a/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
+++ b/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
@@ -18,6 +18,7 @@ Following tests are covered to test pim igmp proxy:
 5. TC:5 Verify igmp drops/timeouts from another interface cause
         proxy join removal
 6. TC:6 Verify that 'ip igmp proxy route-map' filters proxied groups
+7. TC:7 Verify 'match multicast-source-interface' filters by source iface
 """
 
 import os
@@ -464,6 +465,112 @@ int r1-eth1
 conf
 no route-map PROXY_FILTER
 no ip prefix-list PROXY_GROUPS
+"""
+    )
+
+
+def test_pim_igmp_proxy_source_interface_filter():
+    """
+    TC:7 - Verify 'match multicast-source-interface' filters proxied groups
+           based on the interface where the IGMP report was received.
+
+    Topology relevant to this test:
+      r1-eth0 (10.0.20.1) <-> r2-eth0  (sw1)  -- groups from r2 arrive here
+      r1-eth1 (10.0.30.1) <-> rp        (sw2)  -- proxy output interface
+      r1-eth2 (10.0.40.1) <-> r3        (sw3)  -- static joins 225.3.3.3/225.4.4.4
+
+    State at entry (from test_pim_igmp_proxy_route_map):
+      Source iface r1-eth0: 225.2.2.2, 225.5.5.5, 225.7.7.7
+      Source iface r1-eth2: 225.3.3.3, 225.4.4.4
+      All five proxied on r1-eth1.
+
+    Steps:
+      1. Configure a route-map matching only source interface r1-eth2.
+      2. Apply it and cycle proxy.
+      3. Verify only 225.3.3.3 and 225.4.4.4 (from r1-eth2) are proxied.
+      4. Verify groups from r1-eth0 are absent.
+      5. Remove the route-map; cycle proxy; verify all five groups return.
+    """
+    logger.info("Verify match multicast-source-interface filtering")
+    tgen = get_topogen()
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1+2: route-map matching source interface r1-eth2 only
+    r1.vtysh_cmd(
+        """
+conf
+route-map PROXY_SRC_IFC permit 10
+ match multicast-source-interface r1-eth2
+!
+int r1-eth1
+ ip igmp proxy route-map PROXY_SRC_IFC
+ no ip igmp proxy
+ ip igmp proxy
+"""
+    )
+
+    # Step 3: only groups reported on r1-eth2 should be proxied
+    expected_eth2_only = {
+        "vrf": "default",
+        "r1-eth1": {
+            "name": "r1-eth1",
+            "groups": [
+                {"source": "*", "group": "225.3.3.3", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.4.4.4", "primaryAddr": "10.0.30.1"},
+            ],
+        },
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip igmp proxy json", expected_eth2_only
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"r1" proxy groups mismatch: expected only r1-eth2 groups'
+    assert result is None, assertmsg
+
+    # Step 4: groups from r1-eth0 must not appear
+    denied_groups = ["225.2.2.2", "225.5.5.5", "225.7.7.7"]
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [], denied_groups)
+    assert result is True, "Error: r1-eth0 group leaked into proxy: {}".format(result)
+
+    # Step 5: remove the route-map; all groups should return
+    r1.vtysh_cmd(
+        """
+conf
+int r1-eth1
+ no ip igmp proxy route-map
+ no ip igmp proxy
+ ip igmp proxy
+"""
+    )
+
+    expected_all = {
+        "vrf": "default",
+        "r1-eth1": {
+            "name": "r1-eth1",
+            "groups": [
+                {"source": "*", "group": "225.2.2.2", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.3.3.3", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.4.4.4", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.5.5.5", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.7.7.7", "primaryAddr": "10.0.30.1"},
+            ],
+        },
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip igmp proxy json", expected_all
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"r1" proxy groups mismatch after source-interface route-map removed'
+    assert result is None, assertmsg
+
+    # cleanup
+    r1.vtysh_cmd(
+        """
+conf
+no route-map PROXY_SRC_IFC
 """
     )
 

--- a/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
+++ b/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
@@ -17,13 +17,13 @@ Following tests are covered to test pim igmp proxy:
 4. TC:4 Verify that proper proxy joins are set up on run-time enable
 5. TC:5 Verify igmp drops/timeouts from another interface cause
         proxy join removal
+6. TC:6 Verify that 'ip igmp proxy route-map' filters proxied groups
 """
 
 import os
 import sys
 import pytest
 import json
-import time
 from functools import partial
 
 pytestmark = [pytest.mark.pimd]
@@ -303,6 +303,169 @@ def test_pim_igmp_proxy_leave():
 
     assert result is True, "Error: {}".format(result)
     # tgen.mininet_cli()
+
+
+def test_pim_igmp_proxy_route_map():
+    """
+    TC:6 - Verify that 'ip igmp proxy route-map' filters proxied groups.
+
+    State at entry (from test_pim_igmp_proxy_leave):
+      proxied on r1-eth1: 225.2.2.2, 225.3.3.3, 225.4.4.4, 225.5.5.5, 225.7.7.7
+
+    Steps:
+      1. Configure a route-map on r1 that permits only 225.2.2.2 and 225.3.3.3.
+      2. Apply 'ip igmp proxy route-map PROXY_FILTER' on r1-eth1.
+      3. Verify the line appears in 'show running-config' (config persistence
+         regression test for the AF-agnostic pim_config_write path).
+      4. Cycle proxy (no/re-enable) so pim_if_gm_proxy_init re-runs with the filter.
+      5. Verify only 225.2.2.2 and 225.3.3.3 appear in the proxy list.
+      6. Add a new join that the route-map denies; verify it is NOT proxied.
+      7. Remove the route-map; cycle proxy again; verify all groups return and
+         the line is no longer in running-config.
+    """
+    logger.info("Verify ip igmp proxy route-map filtering")
+    tgen = get_topogen()
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Step 1+2: configure prefix-list, route-map, and apply to proxy interface
+    r1.vtysh_cmd(
+        """
+conf
+ip prefix-list PROXY_GROUPS seq 5 permit 225.2.2.2/32
+ip prefix-list PROXY_GROUPS seq 10 permit 225.3.3.3/32
+!
+route-map PROXY_FILTER permit 10
+ match ip multicast-group prefix-list PROXY_GROUPS
+!
+int r1-eth1
+ ip igmp proxy route-map PROXY_FILTER
+"""
+    )
+
+    # Verify the proxy route-map is emitted in running-config (regression
+    # test for the AF-agnostic config-write path: the line must persist
+    # across restarts for both pimd and pim6d).
+    running = r1.vtysh_cmd("show running-config")
+    assert "ip igmp proxy route-map PROXY_FILTER" in running, (
+        "running-config missing 'ip igmp proxy route-map' line; "
+        "config would not persist across restart:\n" + running
+    )
+
+    # Step 3: cycle proxy so pim_if_gm_proxy_init is called with the filter active
+    r1.vtysh_cmd(
+        """
+conf
+int r1-eth1
+ no ip igmp proxy
+ ip igmp proxy
+"""
+    )
+
+    # Step 4: only the two permitted groups should be proxied
+    expected_filtered = {
+        "vrf": "default",
+        "r1-eth1": {
+            "name": "r1-eth1",
+            "groups": [
+                {"source": "*", "group": "225.2.2.2", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.3.3.3", "primaryAddr": "10.0.30.1"},
+            ],
+        },
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip igmp proxy json", expected_filtered
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"r1" proxy groups mismatch after route-map filter applied'
+    assert result is None, assertmsg
+
+    # Step 5: add a new join that the route-map denies (225.9.9.9) — must NOT appear
+    r2.vtysh_cmd(
+        """
+conf
+int r2-eth0
+ ip igmp join 225.9.9.9
+"""
+    )
+
+    denied_groups = ["225.4.4.4", "225.5.5.5", "225.7.7.7", "225.9.9.9"]
+
+    def step5_join_seen_proxy_omits_denied():
+        igmp = r2.vtysh_cmd("show ip igmp groups json", isjson=True)
+        try:
+            r2_groups = [g["group"] for g in igmp["r2-eth0"]["groups"]]
+        except (KeyError, TypeError):
+            return False
+        if "225.9.9.9" not in r2_groups:
+            return False
+        v = verify_local_igmp_proxy_groups(tgen, "r1", [], denied_groups)
+        if v is True:
+            return True
+        assert False, v
+
+    _, result = topotest.run_and_expect(
+        step5_join_seen_proxy_omits_denied, True, count=30, wait=1
+    )
+    assert result is True, (
+        "Timed out waiting for r2 IGMP join while r1 proxy omits denied groups"
+    )
+
+    # Step 6: remove the route-map and cycle proxy — all groups should return
+    r2.vtysh_cmd(
+        """
+conf
+int r2-eth0
+ no ip igmp join 225.9.9.9
+"""
+    )
+    r1.vtysh_cmd(
+        """
+conf
+int r1-eth1
+ no ip igmp proxy route-map
+ no ip igmp proxy
+ ip igmp proxy
+"""
+    )
+
+    expected_unfiltered = {
+        "vrf": "default",
+        "r1-eth1": {
+            "name": "r1-eth1",
+            "groups": [
+                {"source": "*", "group": "225.2.2.2", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.3.3.3", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.4.4.4", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.5.5.5", "primaryAddr": "10.0.30.1"},
+                {"source": "*", "group": "225.7.7.7", "primaryAddr": "10.0.30.1"},
+            ],
+        },
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip igmp proxy json", expected_unfiltered
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"r1" proxy groups mismatch after route-map removed'
+    assert result is None, assertmsg
+
+    # Verify the proxy route-map is no longer emitted in running-config.
+    running = r1.vtysh_cmd("show running-config")
+    assert "ip igmp proxy route-map" not in running, (
+        "running-config still has 'ip igmp proxy route-map' after removal:\n" + running
+    )
+
+    # cleanup route-map config
+    r1.vtysh_cmd(
+        """
+conf
+no route-map PROXY_FILTER
+no ip prefix-list PROXY_GROUPS
+"""
+    )
 
 
 def test_memory_leak():

--- a/yang/frr-gmp.yang
+++ b/yang/frr-gmp.yang
@@ -171,6 +171,12 @@ module frr-gmp {
         "Enable IGMP proxy on the interface.";
     }
 
+    leaf proxy-route-map {
+      type frr-route-map:route-map-ref;
+      description
+        "Filter proxied multicast (S,G) groups with referenced route-map.";
+    }
+
     leaf max-groups {
       type uint32;
       default "4294967295";

--- a/yang/frr-pim-route-map.yang
+++ b/yang/frr-pim-route-map.yang
@@ -93,6 +93,12 @@ module frr-pim-route-map {
       "Match multicast interface";
   }
 
+  identity multicast-source-interface {
+    base frr-route-map:rmap-match-type;
+    description
+      "Match the multicast source interface for the route-map evaluation context.";
+  }
+
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:rmap-match-condition/frr-route-map:match-condition" {
     description
       "Augments the route-map match-condition to support PIM-specific match types
@@ -146,6 +152,16 @@ module frr-pim-route-map {
         type frr-interface:interface-ref;
         description
           "Multicast interface to match";
+      }
+    }
+
+    case multicast-source-interface {
+      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:multicast-source-interface')";
+
+      leaf multicast-source-interface {
+        type frr-interface:interface-ref;
+        description
+          "Multicast source interface to match for the route-map evaluation context.";
       }
     }
 


### PR DESCRIPTION
This PR introduces per-interface route-map filtering for the IGMP/MLD proxy feature, allowing operators to control which (S,G) groups are forwarded via proxy. It also adds a new route-map match condition for matching on the interface where the IGMP/MLD report was received.

New CLI
```
  ip igmp proxy route-map RMAP_NAME
  no ip igmp proxy route-map
````
New route-map match condition
```
  match multicast-source-interface IFNAME
```
This matches the interface where the IGMP/MLD report was received (the upstream/listener-facing interface), and is distinct from the existing match multicast-interface, which matches the proxy output interface.