### PR TITLE
bgpd: Format IGP Router-ID in BGP-LS NLRI based on protocol

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -30,7 +30,8 @@ DEFINE_MTYPE_STATIC(BGPD, BGP_LS, "BGP-LS instance");
  */
 
 /* Convert node descriptor to JSON */
-static json_object *node_desc_to_json(struct bgp_ls_node_descriptor *node)
+static json_object *node_desc_to_json(struct bgp_ls_node_descriptor *node,
+				      enum bgp_ls_protocol_id protocol_id)
 {
 	json_object *json_node = json_object_new_object();
 
@@ -174,12 +175,15 @@ json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri)
 
 	/* Type-specific descriptors */
 	if (nlri->nlri_type == BGP_LS_NLRI_TYPE_NODE) {
-		json_object *json_local = node_desc_to_json(&nlri->nlri_data.node.local_node);
+		json_object *json_local = node_desc_to_json(&nlri->nlri_data.node.local_node,
+							    protocol_id);
 
 		json_object_object_add(json_nlri, "localNodeDescriptors", json_local);
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_LINK) {
-		json_object *json_local = node_desc_to_json(&nlri->nlri_data.link.local_node);
-		json_object *json_remote = node_desc_to_json(&nlri->nlri_data.link.remote_node);
+		json_object *json_local = node_desc_to_json(&nlri->nlri_data.link.local_node,
+							    protocol_id);
+		json_object *json_remote = node_desc_to_json(&nlri->nlri_data.link.remote_node,
+							     protocol_id);
 		json_object *json_link = link_desc_to_json(&nlri->nlri_data.link.link_desc);
 
 		json_object_object_add(json_nlri, "localNodeDescriptors", json_local);
@@ -187,14 +191,15 @@ json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri)
 		json_object_object_add(json_nlri, "linkDescriptors", json_link);
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV4_PREFIX ||
 		   nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV6_PREFIX) {
-		json_object *json_local = node_desc_to_json(&nlri->nlri_data.prefix.local_node);
+		json_object *json_local = node_desc_to_json(&nlri->nlri_data.prefix.local_node,
+							    protocol_id);
 		json_object *json_prefix = prefix_desc_to_json(&nlri->nlri_data.prefix.prefix_desc,
 							       nlri->nlri_type);
 		json_object_object_add(json_nlri, "localNodeDescriptors", json_local);
 		json_object_object_add(json_nlri, "prefixDescriptors", json_prefix);
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
 		struct bgp_ls_srv6_sid_nlri *srv6 = &nlri->nlri_data.srv6_sid;
-		json_object *json_local = node_desc_to_json(&srv6->local_node);
+		json_object *json_local = node_desc_to_json(&srv6->local_node, protocol_id);
 		json_object *json_sid = json_object_new_object();
 
 		if (CHECK_FLAG(srv6->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT)) {
@@ -215,7 +220,7 @@ json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri)
 
 /* Format node descriptor to string */
 static void format_node_desc(char **p, size_t *remain, struct bgp_ls_node_descriptor *node,
-			     const char *prefix_str)
+			     enum bgp_ls_protocol_id protocol_id, const char *prefix_str)
 {
 	int len;
 
@@ -436,14 +441,14 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 
 	/* Add NLRI type-specific descriptors */
 	if (nlri->nlri_type == BGP_LS_NLRI_TYPE_NODE) {
-		format_node_desc(&p, &remain, &nlri->nlri_data.node.local_node, "N");
+		format_node_desc(&p, &remain, &nlri->nlri_data.node.local_node, protocol_id, "N");
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_LINK) {
-		format_node_desc(&p, &remain, &nlri->nlri_data.link.local_node, "N");
-		format_node_desc(&p, &remain, &nlri->nlri_data.link.remote_node, "R");
+		format_node_desc(&p, &remain, &nlri->nlri_data.link.local_node, protocol_id, "N");
+		format_node_desc(&p, &remain, &nlri->nlri_data.link.remote_node, protocol_id, "R");
 		format_link_desc(&p, &remain, &nlri->nlri_data.link.link_desc);
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV4_PREFIX ||
 		   nlri->nlri_type == BGP_LS_NLRI_TYPE_IPV6_PREFIX) {
-		format_node_desc(&p, &remain, &nlri->nlri_data.prefix.local_node, "N");
+		format_node_desc(&p, &remain, &nlri->nlri_data.prefix.local_node, protocol_id, "N");
 
 		/* Format prefix */
 		len = snprintfrr(p, remain, "[P");
@@ -488,7 +493,8 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 		}
 	} else if (nlri->nlri_type == BGP_LS_NLRI_TYPE_SRV6_SID) {
 		/* Format local node descriptor */
-		format_node_desc(&p, &remain, &nlri->nlri_data.srv6_sid.local_node, "N");
+		format_node_desc(&p, &remain, &nlri->nlri_data.srv6_sid.local_node, protocol_id,
+				 "N");
 		format_srv6_sid_desc(&p, &remain, &nlri->nlri_data.srv6_sid.sid_desc);
 	}
 }

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -47,15 +47,37 @@ static json_object *node_desc_to_json(struct bgp_ls_node_descriptor *node,
 
 	if (CHECK_FLAG(node->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
 		char igp_router_id[256];
-		char *p = igp_router_id;
 
-		for (int i = 0; i < node->igp_router_id_len; i++) {
-			p += snprintfrr(p, sizeof(igp_router_id) - (p - igp_router_id), "%02x",
-					node->igp_router_id[i]);
-			if (i < node->igp_router_id_len - 1 && (i + 1) % 2 == 0) {
-				p += snprintfrr(p, sizeof(igp_router_id) - (p - igp_router_id),
-						".");
-			}
+		if (bgp_ls_protocol_is_isis(protocol_id) &&
+		    node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_ISIS_LEN)
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "%pSY.00",
+				   node->igp_router_id.raw);
+		else if (bgp_ls_protocol_is_isis(protocol_id) &&
+			 node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_ISIS_PSEUDO_LEN)
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "%pPN",
+				   node->igp_router_id.raw);
+		else if (bgp_ls_protocol_is_ospf(protocol_id) &&
+			 node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_OSPF_LEN)
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "%pI4",
+				   &node->igp_router_id.ospf);
+		else if (bgp_ls_protocol_is_ospf(protocol_id) &&
+			 node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_OSPF_PSEUDO_LEN)
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "%pI4:%pI4",
+				   &node->igp_router_id.pseudo_ospf.router_id,
+				   &node->igp_router_id.pseudo_ospf.ifaddr);
+		else if (bgp_ls_protocol_is_direct_static(protocol_id) &&
+			 node->igp_router_id_len == IPV4_MAX_BYTELEN)
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "%pI4",
+				   &node->igp_router_id.ipv4);
+		else if (bgp_ls_protocol_is_direct_static(protocol_id) &&
+			 node->igp_router_id_len == IPV6_MAX_BYTELEN)
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "%pI6",
+				   &node->igp_router_id.ipv6);
+		else {
+			flog_err(EC_BGP_LS_PACKET,
+				 "BGP-LS: unhandled IGP Router-ID len %u for protocol %u",
+				 node->igp_router_id_len, protocol_id);
+			snprintfrr(igp_router_id, sizeof(igp_router_id), "<unknown>");
 		}
 		json_object_string_add(json_node, "igpRouterId", igp_router_id);
 	}
@@ -246,20 +268,32 @@ static void format_node_desc(char **p, size_t *remain, struct bgp_ls_node_descri
 
 	/* IGP Router ID */
 	if (CHECK_FLAG(node->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
-		len = snprintfrr(*p, *remain, "[s");
-		*p += len;
-		*remain -= len;
-		for (int i = 0; i < node->igp_router_id_len; i++) {
-			len = snprintfrr(*p, *remain, "%02x", node->igp_router_id[i]);
-			*p += len;
-			*remain -= len;
-			if (i < node->igp_router_id_len - 1 && (i + 1) % 2 == 0) {
-				len = snprintfrr(*p, *remain, ".");
-				*p += len;
-				*remain -= len;
-			}
+		if (bgp_ls_protocol_is_isis(protocol_id) &&
+		    node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_ISIS_LEN)
+			len = snprintfrr(*p, *remain, "[s%pSY.00]", node->igp_router_id.raw);
+		else if (bgp_ls_protocol_is_isis(protocol_id) &&
+			 node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_ISIS_PSEUDO_LEN)
+			len = snprintfrr(*p, *remain, "[s%pPN]", node->igp_router_id.raw);
+		else if (bgp_ls_protocol_is_ospf(protocol_id) &&
+			 node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_OSPF_LEN)
+			len = snprintfrr(*p, *remain, "[r%pI4]", &node->igp_router_id.ospf);
+		else if (bgp_ls_protocol_is_ospf(protocol_id) &&
+			 node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_OSPF_PSEUDO_LEN)
+			len = snprintfrr(*p, *remain, "[r%pI4:%pI4]",
+					 &node->igp_router_id.pseudo_ospf.router_id,
+					 &node->igp_router_id.pseudo_ospf.ifaddr);
+		else if (bgp_ls_protocol_is_direct_static(protocol_id) &&
+			 node->igp_router_id_len == IPV4_MAX_BYTELEN)
+			len = snprintfrr(*p, *remain, "[r%pI4]", &node->igp_router_id.ipv4);
+		else if (bgp_ls_protocol_is_direct_static(protocol_id) &&
+			 node->igp_router_id_len == IPV6_MAX_BYTELEN)
+			len = snprintfrr(*p, *remain, "[r%pI6]", &node->igp_router_id.ipv6);
+		else {
+			flog_err(EC_BGP_LS_PACKET,
+				 "BGP-LS: unhandled IGP Router-ID len %u for protocol %u",
+				 node->igp_router_id_len, protocol_id);
+			len = snprintfrr(*p, *remain, "[s<unknown>]");
 		}
-		len = snprintfrr(*p, *remain, "]");
 		*p += len;
 		*remain -= len;
 	}

--- a/bgpd/bgp_ls.h
+++ b/bgpd/bgp_ls.h
@@ -121,4 +121,24 @@ extern int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer);
 extern int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi,
 				       struct bgp_dest *dest, struct bgp_path_info *path);
 
+/*
+ * ===========================================================================
+ * Protocol-ID Predicate Helpers
+ * ===========================================================================
+ */
+static inline bool bgp_ls_protocol_is_isis(enum bgp_ls_protocol_id protocol_id)
+{
+	return protocol_id == BGP_LS_PROTO_ISIS_L1 || protocol_id == BGP_LS_PROTO_ISIS_L2;
+}
+
+static inline bool bgp_ls_protocol_is_direct_static(enum bgp_ls_protocol_id protocol_id)
+{
+	return protocol_id == BGP_LS_PROTO_DIRECT || protocol_id == BGP_LS_PROTO_STATIC;
+}
+
+static inline bool bgp_ls_protocol_is_ospf(enum bgp_ls_protocol_id protocol_id)
+{
+	return protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3;
+}
+
 #endif /* _FRR_BGP_LS_H */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -56,7 +56,7 @@ int bgp_ls_node_descriptor_cmp(const struct bgp_ls_node_descriptor *d1,
 	if (CHECK_FLAG(d1->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
 		if (d1->igp_router_id_len != d2->igp_router_id_len)
 			return numcmp(d1->igp_router_id_len, d2->igp_router_id_len);
-		ret = memcmp(d1->igp_router_id, d2->igp_router_id, d1->igp_router_id_len);
+		ret = memcmp(d1->igp_router_id.raw, d2->igp_router_id.raw, d1->igp_router_id_len);
 		if (ret != 0)
 			return ret;
 	}
@@ -1234,7 +1234,7 @@ static unsigned int bgp_ls_node_descriptor_hash(const struct bgp_ls_node_descrip
 		key = jhash_1word(desc->ospf_area_id, key);
 
 	if (CHECK_FLAG(desc->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
-		key = jhash(desc->igp_router_id, desc->igp_router_id_len, key);
+		key = jhash(desc->igp_router_id.raw, desc->igp_router_id_len, key);
 
 	if (CHECK_FLAG(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 		key = jhash_1word(desc->bgp_router_id.s_addr, key);
@@ -1741,7 +1741,7 @@ int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_des
 			return -1;
 		stream_putw(s, BGP_LS_TLV_IGP_ROUTER_ID);
 		stream_putw(s, desc->igp_router_id_len);
-		stream_put(s, desc->igp_router_id, desc->igp_router_id_len);
+		stream_put(s, desc->igp_router_id.raw, desc->igp_router_id_len);
 	}
 
 	/* BGP Router ID (TLV 516) */
@@ -2972,7 +2972,7 @@ int bgp_ls_decode_node_descriptor(struct stream *s, struct bgp_ls_node_descripto
 				return -1;
 			}
 			desc->igp_router_id_len = sub_len;
-			stream_get(desc->igp_router_id, s, sub_len);
+			stream_get(desc->igp_router_id.raw, s, sub_len);
 			SET_FLAG(desc->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 			has_igp_router_id = true;
 			break;
@@ -6257,19 +6257,20 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 		if (CHECK_FLAG(local_node->present_tlvs, BGP_LS_NODE_DESC_BGP_LS_ID_BIT))
 			vty_out(vty, "\tBGP Identifier: %u\n", local_node->bgp_ls_id);
 		if (CHECK_FLAG(local_node->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
-			if (local_node->igp_router_id_len == 4) {
+			if (local_node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_OSPF_LEN)
 				vty_out(vty, "\tRouter ID IPv4: %pI4\n",
-					(struct in_addr *)local_node->igp_router_id);
-			} else if (local_node->igp_router_id_len == 6 ||
-				   local_node->igp_router_id_len == 7) {
-				vty_out(vty, "\tISO Node ID: %02x%02x.%02x%02x.%02x%02x.%02x\n",
-					local_node->igp_router_id[0], local_node->igp_router_id[1],
-					local_node->igp_router_id[2], local_node->igp_router_id[3],
-					local_node->igp_router_id[4], local_node->igp_router_id[5],
-					local_node->igp_router_id[6] >> 1);
-			} else if (local_node->igp_router_id_len == 16)
+					&local_node->igp_router_id.ospf);
+			else if (local_node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_ISIS_LEN)
+				vty_out(vty, "\tISO Node ID: %pSY.00\n",
+					local_node->igp_router_id.raw);
+			else if (local_node->igp_router_id_len ==
+				 BGP_LS_IGP_ROUTER_ID_ISIS_PSEUDO_LEN)
+				vty_out(vty, "\tISO Node ID: %pPN\n",
+					local_node->igp_router_id.raw);
+			else if (local_node->igp_router_id_len ==
+				 BGP_LS_IGP_ROUTER_ID_DIRECT_IPV6_LEN)
 				vty_out(vty, "\tRouter ID IPv6: %pI6\n",
-					(struct in6_addr *)local_node->igp_router_id);
+					&local_node->igp_router_id.ipv6);
 		}
 		if (CHECK_FLAG(local_node->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			vty_out(vty, "\tBGP Router Identifier: %pI4\n", &local_node->bgp_router_id);
@@ -6288,22 +6289,20 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 		if (CHECK_FLAG(remote_node->present_tlvs, BGP_LS_NODE_DESC_BGP_LS_ID_BIT))
 			vty_out(vty, "\tBGP Identifier: %u\n", remote_node->bgp_ls_id);
 		if (CHECK_FLAG(remote_node->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT)) {
-			if (remote_node->igp_router_id_len == 4) {
+			if (remote_node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_OSPF_LEN)
 				vty_out(vty, "\tRouter ID IPv4: %pI4\n",
-					(struct in_addr *)remote_node->igp_router_id);
-			} else if (remote_node->igp_router_id_len == 6 ||
-				   remote_node->igp_router_id_len == 7) {
-				vty_out(vty, "\tISO Node ID: %02x%02x.%02x%02x.%02x%02x.%02x\n",
-					remote_node->igp_router_id[0],
-					remote_node->igp_router_id[1],
-					remote_node->igp_router_id[2],
-					remote_node->igp_router_id[3],
-					remote_node->igp_router_id[4],
-					remote_node->igp_router_id[5],
-					remote_node->igp_router_id[6] >> 1);
-			} else if (remote_node->igp_router_id_len == 16)
+					&remote_node->igp_router_id.ospf);
+			else if (remote_node->igp_router_id_len == BGP_LS_IGP_ROUTER_ID_ISIS_LEN)
+				vty_out(vty, "\tISO Node ID: %pSY.00\n",
+					remote_node->igp_router_id.raw);
+			else if (remote_node->igp_router_id_len ==
+				 BGP_LS_IGP_ROUTER_ID_ISIS_PSEUDO_LEN)
+				vty_out(vty, "\tISO Node ID: %pPN\n",
+					remote_node->igp_router_id.raw);
+			else if (remote_node->igp_router_id_len ==
+				 BGP_LS_IGP_ROUTER_ID_DIRECT_IPV6_LEN)
 				vty_out(vty, "\tRouter ID IPv6: %pI6\n",
-					(struct in6_addr *)remote_node->igp_router_id);
+					&remote_node->igp_router_id.ipv6);
 		}
 		if (CHECK_FLAG(remote_node->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			vty_out(vty, "\tBGP Router Identifier: %pI4\n",

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -461,7 +461,21 @@ struct bgp_ls_node_descriptor {
 	uint32_t bgp_ls_id;	   /* BGP-LS Identifier (deprecated) */
 	uint32_t ospf_area_id;	   /* OSPF Area ID */
 	uint8_t igp_router_id_len; /* Length of IGP Router ID (4-16 bytes) */
-	uint8_t igp_router_id[BGP_LS_IGP_ROUTER_ID_MAX_SIZE]; /* IGP Router ID (ISIS, OSPF, Direct, or Static configuration) */
+	union {
+		uint8_t sysid[BGP_LS_IGP_ROUTER_ID_ISIS_LEN]; /* IS-IS non-pseudonode: 6-byte ISO System-ID */
+		struct {
+			uint8_t sysid[BGP_LS_IGP_ROUTER_ID_ISIS_LEN]; /* IS-IS pseudonode: ISO System-ID */
+			uint8_t psn; /* IS-IS pseudonode: Pseudonode ID (non-zero) */
+		} pseudo_isis;
+		struct in_addr ospf; /* OSPFv2 non-pseudonode: Router-ID */
+		struct {
+			struct in_addr router_id; /* OSPFv2 pseudonode: DIS Router-ID */
+			struct in_addr ifaddr;	  /* OSPFv2 pseudonode: Interface IP Address */
+		} pseudo_ospf;
+		struct in_addr ipv4;			    /* Direct/Static: IPv4 address */
+		struct in6_addr ipv6;			    /* Direct/Static: IPv6 address */
+		uint8_t raw[BGP_LS_IGP_ROUTER_ID_MAX_SIZE]; /* Raw access / encode-decode */
+	} igp_router_id;
 	struct in_addr bgp_router_id;			      /* BGP Router-ID (TLV 516) */
 };
 

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -495,7 +495,7 @@ int bgp_ls_originate_node(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_
 	}
 
 	/* Set OSPF Area ID if OSPF */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.node.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.node.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -565,7 +565,7 @@ int bgp_ls_withdraw_node(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_i
 	}
 
 	/* Set OSPF Area ID if OSPF */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.node.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.node.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -649,7 +649,7 @@ int bgp_ls_originate_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_r
 	}
 
 	/* Set OSPF Area ID if OSPF */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.link.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.link.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -793,7 +793,7 @@ int bgp_ls_withdraw_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_ro
 	}
 
 	/* Set OSPF Area ID if OSPF */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.link.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.link.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -927,7 +927,7 @@ int bgp_ls_originate_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *route
 	}
 
 	/* Set OSPF Area ID if OSPF */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.prefix.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.prefix.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -1022,7 +1022,7 @@ int bgp_ls_withdraw_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *router
 	}
 
 	/* Set OSPF Area ID if OSPF */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.prefix.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.prefix.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -1095,7 +1095,7 @@ int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rou
 	}
 
 	/* Set OSPF Area ID if OSPF (mirrors bgp_ls_originate_prefix). */
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.srv6_sid.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);
@@ -1159,7 +1159,7 @@ int bgp_ls_withdraw_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rout
 	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
-	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {
+	if (bgp_ls_protocol_is_ospf(protocol_id)) {
 		nlri.nlri_data.srv6_sid.local_node.ospf_area_id = area_id;
 		SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs,
 			 BGP_LS_NODE_DESC_OSPF_AREA_BIT);

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -485,7 +485,7 @@ int bgp_ls_originate_node(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_
 
 	/* Set Local Node Descriptor */
 	nlri.nlri_data.node.local_node.igp_router_id_len = router_id_len;
-	memcpy(nlri.nlri_data.node.local_node.igp_router_id, router_id, router_id_len);
+	memcpy(nlri.nlri_data.node.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.node.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number if available */
@@ -555,7 +555,7 @@ int bgp_ls_withdraw_node(struct bgp *bgp, uint8_t protocol_id, uint8_t *router_i
 
 	/* Set Local Node Descriptor */
 	nlri.nlri_data.node.local_node.igp_router_id_len = router_id_len;
-	memcpy(nlri.nlri_data.node.local_node.igp_router_id, router_id, router_id_len);
+	memcpy(nlri.nlri_data.node.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.node.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number if available */
@@ -624,7 +624,8 @@ int bgp_ls_originate_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_r
 
 	/* Set Local Node Descriptor */
 	nlri.nlri_data.link.local_node.igp_router_id_len = local_router_id_len;
-	memcpy(nlri.nlri_data.link.local_node.igp_router_id, local_router_id, local_router_id_len);
+	memcpy(nlri.nlri_data.link.local_node.igp_router_id.raw, local_router_id,
+	       local_router_id_len);
 	SET_FLAG(nlri.nlri_data.link.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number for Local Node if available */
@@ -636,7 +637,7 @@ int bgp_ls_originate_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_r
 
 	/* Set Remote Node Descriptor */
 	nlri.nlri_data.link.remote_node.igp_router_id_len = remote_router_id_len;
-	memcpy(nlri.nlri_data.link.remote_node.igp_router_id, remote_router_id,
+	memcpy(nlri.nlri_data.link.remote_node.igp_router_id.raw, remote_router_id,
 	       remote_router_id_len);
 	SET_FLAG(nlri.nlri_data.link.remote_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
@@ -767,7 +768,8 @@ int bgp_ls_withdraw_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_ro
 
 	/* Set Local Node Descriptor */
 	nlri.nlri_data.link.local_node.igp_router_id_len = local_router_id_len;
-	memcpy(nlri.nlri_data.link.local_node.igp_router_id, local_router_id, local_router_id_len);
+	memcpy(nlri.nlri_data.link.local_node.igp_router_id.raw, local_router_id,
+	       local_router_id_len);
 	SET_FLAG(nlri.nlri_data.link.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number for Local Node if available */
@@ -779,7 +781,7 @@ int bgp_ls_withdraw_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_ro
 
 	/* Set Remote Node Descriptor */
 	nlri.nlri_data.link.remote_node.igp_router_id_len = remote_router_id_len;
-	memcpy(nlri.nlri_data.link.remote_node.igp_router_id, remote_router_id,
+	memcpy(nlri.nlri_data.link.remote_node.igp_router_id.raw, remote_router_id,
 	       remote_router_id_len);
 	SET_FLAG(nlri.nlri_data.link.remote_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
@@ -914,7 +916,7 @@ int bgp_ls_originate_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *route
 
 	/* Set Local Node Descriptor */
 	nlri.nlri_data.prefix.local_node.igp_router_id_len = router_id_len;
-	memcpy(nlri.nlri_data.prefix.local_node.igp_router_id, router_id, router_id_len);
+	memcpy(nlri.nlri_data.prefix.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.prefix.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number if available */
@@ -1009,7 +1011,7 @@ int bgp_ls_withdraw_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *router
 
 	/* Set Local Node Descriptor */
 	nlri.nlri_data.prefix.local_node.igp_router_id_len = router_id_len;
-	memcpy(nlri.nlri_data.prefix.local_node.igp_router_id, router_id, router_id_len);
+	memcpy(nlri.nlri_data.prefix.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.prefix.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number if available */
@@ -1082,7 +1084,7 @@ int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rou
 
 	/* Local Node Descriptor */
 	nlri.nlri_data.srv6_sid.local_node.igp_router_id_len = router_id_len;
-	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id, router_id, router_id_len);
+	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	/* Set AS Number if available */
@@ -1154,7 +1156,7 @@ int bgp_ls_withdraw_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rout
 	nlri.nlri_data.srv6_sid.identifier = 0;
 
 	nlri.nlri_data.srv6_sid.local_node.igp_router_id_len = router_id_len;
-	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id, router_id, router_id_len);
+	memcpy(nlri.nlri_data.srv6_sid.local_node.igp_router_id.raw, router_id, router_id_len);
 	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT);
 
 	if (protocol_id == BGP_LS_PROTO_OSPFV2 || protocol_id == BGP_LS_PROTO_OSPFV3) {

--- a/tests/topotests/bgp_link_state/r2/bgp_ls_nlri.json
+++ b/tests/topotests/bgp_link_state/r2/bgp_ls_nlri.json
@@ -3,7 +3,7 @@
 	"vrfName": "default",
 	"routerId": "2.2.2.2",
 	"routes": {
-		"[V][L2][I0x0][N[s0000.0000.0002]]": [
+		"[V][L2][I0x0][N[s0000.0000.0002.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -26,10 +26,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -38,7 +38,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.1.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.1.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -61,16 +61,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.1.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.1.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.1.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.2.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.2.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -93,16 +93,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.2.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.2.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.2.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p2.2.2.2/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p2.2.2.2/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -125,16 +125,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "2.2.2.2/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p2.2.2.2/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p2.2.2.2/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:0:2::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -157,17 +157,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:2::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:0:2::1/128]]"
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0001]]": [
+		"[V][L2][I0x0][N[s0000.0000.0001.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -190,10 +190,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -202,7 +202,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[p1.1.1.1/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[p1.1.1.1/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -225,16 +225,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "1.1.1.1/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p1.1.1.1/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[p1.1.1.1/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.4.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.4.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -257,16 +257,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.4.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.4.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.4.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:0:1::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -289,17 +289,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:1::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:0:1::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -322,17 +322,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:1::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -355,17 +355,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:4::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.3.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.3.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -388,16 +388,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.3.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.3.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.3.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.1.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.1.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -420,16 +420,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.1.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.1.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.1.0/24]]"
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0003]]": [
+		"[V][L2][I0x0][N[s0000.0000.0003.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -452,10 +452,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -464,7 +464,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[p3.3.3.3/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[p3.3.3.3/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -487,16 +487,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "3.3.3.3/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p3.3.3.3/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[p3.3.3.3/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.5.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.5.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -519,16 +519,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.5.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.5.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:0:3::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -551,17 +551,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:3::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:0:3::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -584,17 +584,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:1::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -617,17 +617,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:2::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.2.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -650,16 +650,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.2.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.2.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -682,17 +682,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:5::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0004]]": [
+		"[V][L2][I0x0][N[s0000.0000.0004.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -715,10 +715,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -727,7 +727,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[p4.4.4.4/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -750,16 +750,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "4.4.4.4/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[p4.4.4.4/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:0:4::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -782,17 +782,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:4::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:0:4::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -815,17 +815,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:2::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.4.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.4.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -848,16 +848,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.4.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.4.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.4.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.5.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.5.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -880,16 +880,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.5.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.5.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -912,17 +912,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:5::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -945,17 +945,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:4::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[i10.0.1.1][n10.0.1.2]]": [
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[i10.0.1.1][n10.0.1.2]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -978,20 +978,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.1.1",
 						"ipv4NeighborAddress": "10.0.1.2"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[i10.0.1.1][n10.0.1.2]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[i10.0.1.1][n10.0.1.2]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[i10.0.1.2][n10.0.1.1]]": [
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[i10.0.1.2][n10.0.1.1]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1014,20 +1014,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.1.2",
 						"ipv4NeighborAddress": "10.0.1.1"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[i10.0.1.2][n10.0.1.1]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[i10.0.1.2][n10.0.1.1]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[i10.0.2.2][n10.0.2.3]]": [
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[i10.0.2.2][n10.0.2.3]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1050,20 +1050,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.2.2",
 						"ipv4NeighborAddress": "10.0.2.3"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[i10.0.2.2][n10.0.2.3]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[i10.0.2.2][n10.0.2.3]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[i10.0.2.3][n10.0.2.2]]": [
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[i10.0.2.3][n10.0.2.2]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1086,20 +1086,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.2.3",
 						"ipv4NeighborAddress": "10.0.2.2"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[i10.0.2.3][n10.0.2.2]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[i10.0.2.3][n10.0.2.2]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[i10.0.4.1][n10.0.4.4]]": [
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[i10.0.4.1][n10.0.4.4]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1122,20 +1122,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.4.1",
 						"ipv4NeighborAddress": "10.0.4.4"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[i10.0.4.1][n10.0.4.4]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[i10.0.4.1][n10.0.4.4]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[i10.0.4.4][n10.0.4.1]]": [
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[i10.0.4.4][n10.0.4.1]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1158,20 +1158,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.4.4",
 						"ipv4NeighborAddress": "10.0.4.1"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[i10.0.4.4][n10.0.4.1]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[i10.0.4.4][n10.0.4.1]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[i10.0.5.3][n10.0.5.4]]": [
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[i10.0.5.3][n10.0.5.4]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1194,20 +1194,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.5.3",
 						"ipv4NeighborAddress": "10.0.5.4"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[i10.0.5.3][n10.0.5.4]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[i10.0.5.3][n10.0.5.4]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[i10.0.5.4][n10.0.5.3]]": [
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[i10.0.5.4][n10.0.5.3]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1230,20 +1230,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.5.4",
 						"ipv4NeighborAddress": "10.0.5.3"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[i10.0.5.4][n10.0.5.3]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[i10.0.5.4][n10.0.5.3]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1267,10 +1267,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::1",
@@ -1278,10 +1278,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1305,10 +1305,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::2",
@@ -1316,10 +1316,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1343,10 +1343,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::2",
@@ -1354,10 +1354,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1381,10 +1381,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::3",
@@ -1392,10 +1392,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1419,10 +1419,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::1",
@@ -1430,10 +1430,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1457,10 +1457,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::4",
@@ -1468,10 +1468,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1495,10 +1495,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::3",
@@ -1506,10 +1506,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1533,10 +1533,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::4",
@@ -1544,7 +1544,7 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]"
 				}
 			]
 	}

--- a/tests/topotests/bgp_link_state/rr/bgp_ls_nlri.json
+++ b/tests/topotests/bgp_link_state/rr/bgp_ls_nlri.json
@@ -3,7 +3,7 @@
 	"vrfName": "default",
 	"routerId": "10.10.10.10",
 	"routes": {
-		"[V][L2][I0x0][N[s0000.0000.0002]]": [
+		"[V][L2][I0x0][N[s0000.0000.0002.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -27,10 +27,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -39,7 +39,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.1.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.1.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -63,16 +63,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.1.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.1.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.1.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.2.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.2.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -96,16 +96,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.2.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.2.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.2.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p2.2.2.2/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p2.2.2.2/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -129,16 +129,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "2.2.2.2/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p2.2.2.2/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p2.2.2.2/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:0:2::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -162,17 +162,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:2::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:0:2::1/128]]"
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0001]]": [
+		"[V][L2][I0x0][N[s0000.0000.0001.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -196,10 +196,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -208,7 +208,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[p1.1.1.1/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[p1.1.1.1/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -232,16 +232,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "1.1.1.1/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p1.1.1.1/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[p1.1.1.1/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.4.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.4.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -265,16 +265,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.4.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.4.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.4.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:0:1::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -298,17 +298,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:1::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:0:1::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -332,17 +332,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:1::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -366,17 +366,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:4::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.3.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.3.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -400,16 +400,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.3.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.3.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[p10.0.3.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.1.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.1.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -433,16 +433,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.1.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.1.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001.00]][P[p10.0.1.0/24]]"
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0003]]": [
+		"[V][L2][I0x0][N[s0000.0000.0003.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -466,10 +466,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -478,7 +478,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[p3.3.3.3/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[p3.3.3.3/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -502,16 +502,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "3.3.3.3/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p3.3.3.3/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[p3.3.3.3/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.5.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.5.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -535,16 +535,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.5.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.5.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:0:3::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -568,17 +568,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:3::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:0:3::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -602,17 +602,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:1::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -636,17 +636,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:2::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.2.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -670,16 +670,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.2.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[p10.0.2.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -703,17 +703,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:5::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0004]]": [
+		"[V][L2][I0x0][N[s0000.0000.0004.00]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -737,10 +737,10 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004]]",
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004.00]]",
 				"linkStateAttrs": {
 					"multiTopologyIds": [
 						0,
@@ -749,7 +749,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[p4.4.4.4/32]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -773,16 +773,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "4.4.4.4/32"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[p4.4.4.4/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:0:4::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -806,17 +806,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:0:4::1/128",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:0:4::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -840,17 +840,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:2::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.4.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.4.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -874,16 +874,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.4.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.4.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.4.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.5.0/24]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.5.0/24]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -907,16 +907,16 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "10.0.5.0/24"
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.5.0/24]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -940,17 +940,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:5::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -974,17 +974,17 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fc00:10:0:4::/64",
 						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[i10.0.1.1][n10.0.1.2]]": [
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[i10.0.1.1][n10.0.1.2]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1008,20 +1008,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.1.1",
 						"ipv4NeighborAddress": "10.0.1.2"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[i10.0.1.1][n10.0.1.2]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[i10.0.1.1][n10.0.1.2]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[i10.0.1.2][n10.0.1.1]]": [
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[i10.0.1.2][n10.0.1.1]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1045,20 +1045,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.1.2",
 						"ipv4NeighborAddress": "10.0.1.1"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[i10.0.1.2][n10.0.1.1]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[i10.0.1.2][n10.0.1.1]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[i10.0.2.2][n10.0.2.3]]": [
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[i10.0.2.2][n10.0.2.3]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1082,20 +1082,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.2.2",
 						"ipv4NeighborAddress": "10.0.2.3"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[i10.0.2.2][n10.0.2.3]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[i10.0.2.2][n10.0.2.3]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[i10.0.2.3][n10.0.2.2]]": [
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[i10.0.2.3][n10.0.2.2]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1119,20 +1119,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.2.3",
 						"ipv4NeighborAddress": "10.0.2.2"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[i10.0.2.3][n10.0.2.2]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[i10.0.2.3][n10.0.2.2]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[i10.0.4.1][n10.0.4.4]]": [
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[i10.0.4.1][n10.0.4.4]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1156,20 +1156,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.4.1",
 						"ipv4NeighborAddress": "10.0.4.4"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[i10.0.4.1][n10.0.4.4]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[i10.0.4.1][n10.0.4.4]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[i10.0.4.4][n10.0.4.1]]": [
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[i10.0.4.4][n10.0.4.1]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1193,20 +1193,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.4.4",
 						"ipv4NeighborAddress": "10.0.4.1"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[i10.0.4.4][n10.0.4.1]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[i10.0.4.4][n10.0.4.1]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[i10.0.5.3][n10.0.5.4]]": [
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[i10.0.5.3][n10.0.5.4]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1230,20 +1230,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.5.3",
 						"ipv4NeighborAddress": "10.0.5.4"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[i10.0.5.3][n10.0.5.4]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[i10.0.5.3][n10.0.5.4]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[i10.0.5.4][n10.0.5.3]]": [
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[i10.0.5.4][n10.0.5.3]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -1267,20 +1267,20 @@
 					"protocolId": 2,
 					"identifier": 0,
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"linkDescriptors": {
 						"ipv4InterfaceAddress": "10.0.5.4",
 						"ipv4NeighborAddress": "10.0.5.3"
 					}
 				},
-				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[i10.0.5.4][n10.0.5.3]]"
+				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[i10.0.5.4][n10.0.5.3]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1305,10 +1305,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::1",
@@ -1316,10 +1316,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1344,10 +1344,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::2",
@@ -1355,10 +1355,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1383,10 +1383,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::2",
@@ -1394,10 +1394,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1422,10 +1422,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::3",
@@ -1433,10 +1433,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0002.00]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1461,10 +1461,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::1",
@@ -1472,10 +1472,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1500,10 +1500,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::4",
@@ -1511,10 +1511,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0001.00]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1539,10 +1539,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::3",
@@ -1550,10 +1550,10 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0004.00]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1578,10 +1578,10 @@
 						"protocolId": 2,
 						"identifier": 0,
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::4",
@@ -1589,7 +1589,7 @@
 							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0003.00]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]"
 				}
 			]
 	}

--- a/tests/topotests/bgp_link_state/test_bgp_link_state.py
+++ b/tests/topotests/bgp_link_state/test_bgp_link_state.py
@@ -127,8 +127,8 @@ def check_bgp_ls_link(router, local_id, remote_id, should_exist=True):
 
     Args:
         router: Router instance
-        local_id: Local node IGP Router ID (e.g., "0000.0000.0002")
-        remote_id: Remote node IGP Router ID (e.g., "0000.0000.0001")
+        local_id: Local node IGP Router ID (e.g., "0000.0000.0002.00")
+        remote_id: Remote node IGP Router ID (e.g., "0000.0000.0001.00")
         should_exist: True to verify presence, False to verify absence
 
     Returns:
@@ -166,7 +166,7 @@ def check_bgp_ls_node(router, node_id, should_exist=True):
 
     Args:
         router: Router instance
-        node_id: Node IGP Router ID (e.g., "0000.0000.0001")
+        node_id: Node IGP Router ID (e.g., "0000.0000.0001.00")
         should_exist: True to verify presence, False to verify absence
 
     Returns:
@@ -452,7 +452,7 @@ def test_bgp_ls_attributes_consumer():
     test_func = functools.partial(
         topotest.router_json_cmp,
         router,
-        "show bgp link-state link-state [T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]] json",
+        "show bgp link-state link-state [T][L2][I0x0][N[s0000.0000.0004.00]][P[p4.4.4.4/32]] json",
         expected,
     )
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
@@ -466,7 +466,7 @@ def test_bgp_ls_attributes_consumer():
     test_func = functools.partial(
         topotest.router_json_cmp,
         router,
-        "show bgp link-state link-state [V][L2][I0x0][N[s0000.0000.0004]] json",
+        "show bgp link-state link-state [V][L2][I0x0][N[s0000.0000.0004.00]] json",
         expected,
     )
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
@@ -838,7 +838,7 @@ def test_bgp_ls_r4_link_shutdown():
     # Wait for ISIS to detect the link down and propagate to r2, then BGP-LS to withdraw link NLRI
     r2 = tgen.gears["r2"]
     test_func = functools.partial(
-        check_bgp_ls_link, r2, "0000.0000.0004", "0000.0000.0001", should_exist=False
+        check_bgp_ls_link, r2, "0000.0000.0004.00", "0000.0000.0001.00", should_exist=False
     )
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, '"r2" BGP-LS r4 link down not reflected'
@@ -846,7 +846,7 @@ def test_bgp_ls_r4_link_shutdown():
     # Verify consumer rr received the update
     consumer = tgen.gears["rr"]
     test_func = functools.partial(
-        check_bgp_ls_link, consumer, "0000.0000.0004", "0000.0000.0001", should_exist=False
+        check_bgp_ls_link, consumer, "0000.0000.0004.00", "0000.0000.0001.00", should_exist=False
     )
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, '"rr" did not receive BGP-LS r4 link down update'
@@ -869,7 +869,7 @@ def test_bgp_ls_r4_link_no_shutdown():
     # Wait for ISIS adjacency to re-establish and propagate to r2, then BGP-LS to advertise link NLRI
     r2 = tgen.gears["r2"]
     test_func = functools.partial(
-        check_bgp_ls_link, r2, "0000.0000.0004", "0000.0000.0001", should_exist=True
+        check_bgp_ls_link, r2, "0000.0000.0004.00", "0000.0000.0001.00", should_exist=True
     )
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, '"r2" BGP-LS r4 link up not reflected'
@@ -877,7 +877,7 @@ def test_bgp_ls_r4_link_no_shutdown():
     # Verify consumer rr received the update
     consumer = tgen.gears["rr"]
     test_func = functools.partial(
-        check_bgp_ls_link, consumer, "0000.0000.0004", "0000.0000.0001", should_exist=True
+        check_bgp_ls_link, consumer, "0000.0000.0004.00", "0000.0000.0001.00", should_exist=True
     )
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, '"rr" did not receive BGP-LS r4 link up update'

--- a/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
+++ b/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
@@ -1,11 +1,11 @@
 {
 	"routes": {
-		"[V][L2][I0x0][N[s0000.0000.0001]]": [
+		"[V][L2][I0x0][N[s0000.0000.0001.00]]": [
 			{
 				"nlri": {
 					"nlriType": "node",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					}
 				},
 				"linkStateAttrs": {
@@ -19,12 +19,12 @@
 				}
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0002]]": [
+		"[V][L2][I0x0][N[s0000.0000.0002.00]]": [
 			{
 				"nlri": {
 					"nlriType": "node",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					}
 				},
 				"linkStateAttrs": {
@@ -38,12 +38,12 @@
 				}
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0003]]": [
+		"[V][L2][I0x0][N[s0000.0000.0003.00]]": [
 			{
 				"nlri": {
 					"nlriType": "node",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					}
 				},
 				"linkStateAttrs": {
@@ -57,12 +57,12 @@
 				}
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0004]]": [
+		"[V][L2][I0x0][N[s0000.0000.0004.00]]": [
 			{
 				"nlri": {
 					"nlriType": "node",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					}
 				},
 				"linkStateAttrs": {
@@ -76,12 +76,12 @@
 				}
 			}
 		],
-		"[V][L2][I0x0][N[s0000.0000.0005]]": [
+		"[V][L2][I0x0][N[s0000.0000.0005.00]]": [
 			{
 				"nlri": {
 					"nlriType": "node",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
+						"igpRouterId": "0000.0000.0005.00"
 					}
 				},
 				"linkStateAttrs": {
@@ -95,12 +95,12 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfcbb:bbbb:1::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001.00]][P[t0x0002][pfcbb:bbbb:1::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fcbb:bbbb:1::/48",
@@ -116,12 +116,12 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfcbb:bbbb:2::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002.00]][P[t0x0002][pfcbb:bbbb:2::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fcbb:bbbb:2::/48",
@@ -137,12 +137,12 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfcbb:bbbb:3::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003.00]][P[t0x0002][pfcbb:bbbb:3::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fcbb:bbbb:3::/48",
@@ -158,12 +158,12 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfcbb:bbbb:4::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004.00]][P[t0x0002][pfcbb:bbbb:4::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fcbb:bbbb:4::/48",
@@ -179,12 +179,12 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0005]][P[t0x0002][pfcbb:bbbb:5::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0005.00]][P[t0x0002][pfcbb:bbbb:5::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
+						"igpRouterId": "0000.0000.0005.00"
 					},
 					"prefixDescriptors": {
 						"ipReachabilityInformation": "fcbb:bbbb:5::/48",
@@ -200,12 +200,12 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0001]][S[t0x0002][sdfcbb:bbbb:1::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0001.00]][S[t0x0002][sdfcbb:bbbb:1::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+						"igpRouterId": "0000.0000.0001.00"
 					},
 					"srv6SidDescriptors": {
 						"srv6SidValue": "fcbb:bbbb:1::",
@@ -229,12 +229,12 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0002]][S[t0x0002][sdfcbb:bbbb:2::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0002.00]][S[t0x0002][sdfcbb:bbbb:2::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+						"igpRouterId": "0000.0000.0002.00"
 					},
 					"srv6SidDescriptors": {
 						"srv6SidValue": "fcbb:bbbb:2::",
@@ -258,12 +258,12 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0003]][S[t0x0002][sdfcbb:bbbb:3::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0003.00]][S[t0x0002][sdfcbb:bbbb:3::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+						"igpRouterId": "0000.0000.0003.00"
 					},
 					"srv6SidDescriptors": {
 						"srv6SidValue": "fcbb:bbbb:3::",
@@ -287,12 +287,12 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0004]][S[t0x0002][sdfcbb:bbbb:4::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0004.00]][S[t0x0002][sdfcbb:bbbb:4::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+						"igpRouterId": "0000.0000.0004.00"
 					},
 					"srv6SidDescriptors": {
 						"srv6SidValue": "fcbb:bbbb:4::",
@@ -316,12 +316,12 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0005]][S[t0x0002][sdfcbb:bbbb:5::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0005.00]][S[t0x0002][sdfcbb:bbbb:5::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
 					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
+						"igpRouterId": "0000.0000.0005.00"
 					},
 					"srv6SidDescriptors": {
 						"srv6SidValue": "fcbb:bbbb:5::",
@@ -345,16 +345,16 @@
 				}
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:1::1][nfc00:1::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0002.00]][L[ifc00:1::1][nfc00:1::2][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -376,16 +376,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:1::2][nfc00:1::1][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0001.00]][L[ifc00:1::2][nfc00:1::1][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -407,16 +407,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:2::2][nfc00:2::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0004.00]][L[ifc00:2::2][nfc00:2::4][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -438,16 +438,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:2::4][nfc00:2::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0002.00]][L[ifc00:2::4][nfc00:2::2][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -469,16 +469,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:3::2][nfc00:3::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0002.00]][R[s0000.0000.0004.00]][L[ifc00:3::2][nfc00:3::4][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -500,16 +500,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:3::4][nfc00:3::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0002.00]][L[ifc00:3::4][nfc00:3::2][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0002"
+							"igpRouterId": "0000.0000.0002.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -531,16 +531,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:4::3][nfc00:4::5][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0005.00]][L[ifc00:4::3][nfc00:4::5][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0005"
+							"igpRouterId": "0000.0000.0005.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -562,16 +562,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:4::5][nfc00:4::3][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0005.00]][R[s0000.0000.0003.00]][L[ifc00:4::5][nfc00:4::3][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0005"
+							"igpRouterId": "0000.0000.0005.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -593,16 +593,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:5::3][nfc00:5::5][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0005.00]][L[ifc00:5::3][nfc00:5::5][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0005"
+							"igpRouterId": "0000.0000.0005.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -624,16 +624,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:5::5][nfc00:5::3][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0005.00]][R[s0000.0000.0003.00]][L[ifc00:5::5][nfc00:5::3][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0005"
+							"igpRouterId": "0000.0000.0005.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -655,16 +655,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0005]][L[ifc00:6::4][nfc00:6::5][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0004.00]][R[s0000.0000.0005.00]][L[ifc00:6::4][nfc00:6::5][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0005"
+							"igpRouterId": "0000.0000.0005.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -686,16 +686,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0004]][L[ifc00:6::5][nfc00:6::4][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0005.00]][R[s0000.0000.0004.00]][L[ifc00:6::5][nfc00:6::4][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0005"
+							"igpRouterId": "0000.0000.0005.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0004"
+							"igpRouterId": "0000.0000.0004.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -717,16 +717,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0003]][L[ifc00:7::1][nfc00:7::2][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0001.00]][R[s0000.0000.0003.00]][L[ifc00:7::1][nfc00:7::2][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						}
 					},
 					"linkStateAttrs": {
@@ -748,16 +748,16 @@
 					}
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0001]][L[ifc00:7::2][nfc00:7::1][t0x0002]]":
+		"[E][L2][I0x0][N[s0000.0000.0003.00]][R[s0000.0000.0001.00]][L[ifc00:7::2][nfc00:7::1][t0x0002]]":
 			[
 				{
 					"nlri": {
 						"nlriType": "link",
 						"localNodeDescriptors": {
-							"igpRouterId": "0000.0000.0003"
+							"igpRouterId": "0000.0000.0003.00"
 						},
 						"remoteNodeDescriptors": {
-							"igpRouterId": "0000.0000.0001"
+							"igpRouterId": "0000.0000.0001.00"
 						}
 					},
 					"linkStateAttrs": {


### PR DESCRIPTION
RFC 9552 defines the IGP Router-ID as an opaque value whose interpretation depends on the combination of Protocol-ID and field length. The IGP Router-ID is currently always emitted as a hex-dot string, ignoring both fields.

Replace the generic hex-dot loop with protocol-aware formatting:
- IS-IS (6 or 7 bytes): %pPN
- OSPF non-pseudonode (4 bytes): %pI4
- DIRECT/STATIC IPv4 (4 bytes): %pI4
- DIRECT/STATIC IPv6 (16 bytes): %pI6

Any unrecognised protocol/length combination is treated as an error and logged via flog_err(EC_BGP_LS_PACKET).

Applied to both the JSON display path (node_desc_to_json) and the string format path (format_node_desc).
