### PR TITLE
bgpd: Use ST token for BGP-LS STATIC protocol in NLRI output

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -403,7 +403,7 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 		proto_str = "D";
 		break;
 	case BGP_LS_PROTO_STATIC:
-		proto_str = "S";
+		proto_str = "ST";
 		break;
 	case BGP_LS_PROTO_BGP:
 		proto_str = "B";


### PR DESCRIPTION
The protocol tag in BGP-LS NLRI output currently renders STATIC as "S". This is ambiguous because "S" is already used for SID in the same output and legend.

Render `BGP_LS_PROTO_STATIC` as "ST" instead, matching the documented legend and avoiding confusion between STATIC and SID.

```
r1# show bgp link-state link-state
Prefix codes: E link, V node, T IP reachable route, S SRv6 SID, SP SRTE Policy, u/U unknown
              I Identifier, N local node, R remote node, L link, P prefix, S SID, C candidate path
              L1/L2 ISIS level-1/level-2, O OSPF, O3 OSPFv3, D direct, ST static/peer-node, SR Segment Routing
              a area-ID, l link-ID, t topology-ID, s ISO-ID,
              c confed-ID/ASN, b bgp-identifier, r router-ID, te te-router-ID, sd SID
              i if-address, n nbr-address, o OSPF Route-type, p IP-prefix
              d designated router address, po protocol-origin, f flag
              e endpoint-ip, cl color, as originator-asn oa originator-address
              di discriminator, q bgp-router-ID

Before:
[T][S][I0x0][N[s0000.0000.0001.00]][P[p10.0.1.0/24]]

After:
[T][ST][I0x0][N[s0000.0000.0001.00]][P[p10.0.1.0/24]]
```