### PR TITLE
bgpd: Fix missing Multi-Topology ID in BGP-LS NLRIs

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -91,9 +91,8 @@ static json_object *link_desc_to_json(struct bgp_ls_link_descriptor *link_desc)
 		json_object_string_addf(json_link, "ipv6NeighborAddress", "%pI6",
 					&link_desc->ipv6_neigh_addr);
 
-	if (CHECK_FLAG(link_desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT) &&
-	    link_desc->mt_id_count > 0)
-		json_object_int_add(json_link, "mtId", link_desc->mt_id[0]);
+	if (CHECK_FLAG(link_desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT))
+		json_object_int_add(json_link, "multiTopologyId", link_desc->mt_id);
 
 	return json_link;
 }
@@ -194,12 +193,10 @@ json_object *bgp_ls_nlri_to_json(struct bgp_ls_nlri *nlri)
 		json_object *json_local = node_desc_to_json(&srv6->local_node);
 		json_object *json_sid = json_object_new_object();
 
-		if (srv6->sid_desc.mt_id_count > 0) {
+		if (CHECK_FLAG(srv6->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT)) {
 			json_object *json_mt = json_object_new_array();
 
-			for (uint8_t i = 0; i < srv6->sid_desc.mt_id_count; i++)
-				json_object_array_add(json_mt,
-						      json_object_new_int(srv6->sid_desc.mt_id[i]));
+			json_object_array_add(json_mt, json_object_new_int(srv6->sid_desc.mt_id));
 			json_object_object_add(json_sid, "multiTopologyId", json_mt);
 		}
 

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -118,6 +118,10 @@ static json_object *prefix_desc_to_json(struct bgp_ls_prefix_descriptor *prefix_
 		json_object_string_addf(json_prefix, "bgpRouteType", "%s",
 					bgp_ls_bgp_route_type_str_json(prefix_desc->bgp_route_type));
 
+	/* Multi-Topology ID */
+	if (CHECK_FLAG(prefix_desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT))
+		json_object_int_add(json_prefix, "multiTopologyId", prefix_desc->mt_id);
+
 	return json_prefix;
 }
 
@@ -323,6 +327,13 @@ static void format_link_desc(char **p, size_t *remain, struct bgp_ls_link_descri
 		*remain -= len;
 	}
 
+	/* Multi-Topology ID (TLV 263) */
+	if (CHECK_FLAG(link_desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT)) {
+		len = snprintfrr(*p, *remain, "[t0x%04x]", link_desc->mt_id);
+		*p += len;
+		*remain -= len;
+	}
+
 	len = snprintfrr(*p, *remain, "]");
 	*p += len;
 	*remain -= len;
@@ -425,7 +436,19 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 		format_node_desc(&p, &remain, &nlri->nlri_data.prefix.local_node, "N");
 
 		/* Format prefix */
-		len = snprintfrr(p, remain, "[P[p");
+		len = snprintfrr(p, remain, "[P");
+		p += len;
+		remain -= len;
+
+		if (CHECK_FLAG(nlri->nlri_data.prefix.prefix_desc.present_tlvs,
+			       BGP_LS_PREFIX_DESC_MT_ID_BIT)) {
+			len = snprintfrr(p, remain, "[t0x%04x]",
+					 nlri->nlri_data.prefix.prefix_desc.mt_id);
+			p += len;
+			remain -= len;
+		}
+
+		len = snprintfrr(p, remain, "[p");
 		p += len;
 		remain -= len;
 

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -277,7 +277,17 @@ static void format_srv6_sid_desc(char **p, size_t *remain,
 {
 	int len;
 
-	len = snprintfrr(*p, *remain, "[S[sd%pI6]]", &sid_desc->sid);
+	len = snprintfrr(*p, *remain, "[S");
+	*p += len;
+	*remain -= len;
+
+	if (CHECK_FLAG(sid_desc->present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT)) {
+		len = snprintfrr(*p, *remain, "[t0x%04x]", sid_desc->mt_id);
+		*p += len;
+		*remain -= len;
+	}
+
+	len = snprintfrr(*p, *remain, "[sd%pI6]]", &sid_desc->sid);
 	*p += len;
 	*remain -= len;
 }

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -128,12 +128,8 @@ int bgp_ls_link_descriptor_cmp(const struct bgp_ls_link_descriptor *d1,
 
 	/* Compare Multi-Topology IDs if present */
 	if (CHECK_FLAG(d1->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT)) {
-		if (d1->mt_id_count != d2->mt_id_count)
-			return numcmp(d1->mt_id_count, d2->mt_id_count);
-		for (int i = 0; i < d1->mt_id_count; i++) {
-			if (d1->mt_id[i] != d2->mt_id[i])
-				return numcmp(d1->mt_id[i], d2->mt_id[i]);
-		}
+		if (d1->mt_id != d2->mt_id)
+			return numcmp(d1->mt_id, d2->mt_id);
 	}
 
 	return 0;
@@ -171,12 +167,8 @@ int bgp_ls_prefix_descriptor_cmp(const struct bgp_ls_prefix_descriptor *d1,
 
 	/* Compare Multi-Topology IDs if present */
 	if (CHECK_FLAG(d1->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT)) {
-		if (d1->mt_id_count != d2->mt_id_count)
-			return numcmp(d1->mt_id_count, d2->mt_id_count);
-		for (int i = 0; i < d1->mt_id_count; i++) {
-			if (d1->mt_id[i] != d2->mt_id[i])
-				return numcmp(d1->mt_id[i], d2->mt_id[i]);
-		}
+		if (d1->mt_id != d2->mt_id)
+			return numcmp(d1->mt_id, d2->mt_id);
 	}
 
 	/* Compare BGP Route Type if present */
@@ -598,30 +590,6 @@ struct bgp_ls_nlri *bgp_ls_nlri_alloc(void)
 
 void bgp_ls_nlri_free(struct bgp_ls_nlri *nlri)
 {
-	if (!nlri)
-		return;
-
-	switch (nlri->nlri_type) {
-	case BGP_LS_NLRI_TYPE_NODE:
-		break;
-
-	case BGP_LS_NLRI_TYPE_LINK:
-		XFREE(MTYPE_BGP_LS_NLRI, nlri->nlri_data.link.link_desc.mt_id);
-		break;
-
-	case BGP_LS_NLRI_TYPE_IPV4_PREFIX:
-	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
-		XFREE(MTYPE_BGP_LS_NLRI, nlri->nlri_data.prefix.prefix_desc.mt_id);
-		break;
-
-	case BGP_LS_NLRI_TYPE_SRV6_SID:
-		XFREE(MTYPE_BGP_LS_NLRI, nlri->nlri_data.srv6_sid.sid_desc.mt_id);
-		break;
-
-	case BGP_LS_NLRI_TYPE_RESERVED:
-		break;
-	}
-
 	XFREE(MTYPE_BGP_LS_NLRI, nlri);
 }
 
@@ -667,52 +635,6 @@ struct bgp_ls_nlri *bgp_ls_nlri_copy(const struct bgp_ls_nlri *nlri)
 	nlri_copy = XCALLOC(MTYPE_BGP_LS_NLRI, sizeof(*nlri_copy));
 	memcpy(nlri_copy, nlri, sizeof(*nlri_copy));
 	nlri_copy->refcnt = 0;
-
-	/* Copy type-specific dynamically allocated fields */
-	switch (nlri->nlri_type) {
-	case BGP_LS_NLRI_TYPE_NODE:
-		break;
-
-	case BGP_LS_NLRI_TYPE_LINK:
-		/* Copy link descriptor mt_id */
-		if (nlri->nlri_data.link.link_desc.mt_id) {
-			size_t mt_size = nlri->nlri_data.link.link_desc.mt_id_count *
-					 sizeof(uint16_t);
-			nlri_copy->nlri_data.link.link_desc.mt_id = XCALLOC(MTYPE_BGP_LS_NLRI,
-									    mt_size);
-			memcpy(nlri_copy->nlri_data.link.link_desc.mt_id,
-			       nlri->nlri_data.link.link_desc.mt_id, mt_size);
-		}
-		break;
-
-	case BGP_LS_NLRI_TYPE_IPV4_PREFIX:
-	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
-		/* Copy prefix descriptor mt_id */
-		if (nlri->nlri_data.prefix.prefix_desc.mt_id) {
-			size_t mt_size = nlri->nlri_data.prefix.prefix_desc.mt_id_count *
-					 sizeof(uint16_t);
-			nlri_copy->nlri_data.prefix.prefix_desc.mt_id = XCALLOC(MTYPE_BGP_LS_NLRI,
-										mt_size);
-			memcpy(nlri_copy->nlri_data.prefix.prefix_desc.mt_id,
-			       nlri->nlri_data.prefix.prefix_desc.mt_id, mt_size);
-		}
-		break;
-
-	case BGP_LS_NLRI_TYPE_SRV6_SID:
-		/* Copy SRv6 SID descriptor mt_id */
-		if (nlri->nlri_data.srv6_sid.sid_desc.mt_id) {
-			size_t mt_size = nlri->nlri_data.srv6_sid.sid_desc.mt_id_count *
-					 sizeof(uint16_t);
-			nlri_copy->nlri_data.srv6_sid.sid_desc.mt_id = XCALLOC(MTYPE_BGP_LS_NLRI,
-									       mt_size);
-			memcpy(nlri_copy->nlri_data.srv6_sid.sid_desc.mt_id,
-			       nlri->nlri_data.srv6_sid.sid_desc.mt_id, mt_size);
-		}
-		break;
-
-	case BGP_LS_NLRI_TYPE_RESERVED:
-		break;
-	}
 
 	return nlri_copy;
 }
@@ -1046,8 +968,7 @@ size_t bgp_ls_nlri_size(const struct bgp_ls_nlri *nlri)
 		if (CHECK_FLAG(l->link_desc.present_tlvs, BGP_LS_LINK_DESC_IPV6_NEIGH_BIT))
 			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_IPV6_ADDR_SIZE;
 		if (CHECK_FLAG(l->link_desc.present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT))
-			size += BGP_LS_TLV_HDR_SIZE +
-				(l->link_desc.mt_id_count * BGP_LS_MT_ID_SIZE);
+			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_MT_ID_SIZE;
 
 		break;
 	}
@@ -1061,8 +982,7 @@ size_t bgp_ls_nlri_size(const struct bgp_ls_nlri *nlri)
 
 		/* Prefix Descriptor */
 		if (CHECK_FLAG(p->prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT))
-			size += BGP_LS_TLV_HDR_SIZE +
-				(p->prefix_desc.mt_id_count * BGP_LS_MT_ID_SIZE);
+			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_MT_ID_SIZE;
 		if (CHECK_FLAG(p->prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_OSPF_ROUTE_BIT))
 			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_OSPF_ROUTE_TYPE_SIZE;
 
@@ -1091,8 +1011,8 @@ size_t bgp_ls_nlri_size(const struct bgp_ls_nlri *nlri)
 		size += BGP_LS_TLV_HDR_SIZE + BGP_LS_SRV6_SID_INFO_SIZE;
 
 		/* Optional MT-ID TLV in SID descriptor */
-		if (s->sid_desc.mt_id_count > 0)
-			size += BGP_LS_TLV_HDR_SIZE + (s->sid_desc.mt_id_count * BGP_LS_MT_ID_SIZE);
+		if (CHECK_FLAG(s->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT))
+			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_MT_ID_SIZE;
 
 		break;
 	}
@@ -1851,7 +1771,6 @@ int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_des
 int bgp_ls_encode_link_descriptor(struct stream *s, const struct bgp_ls_link_descriptor *desc)
 {
 	size_t start;
-	uint16_t i;
 
 	if (!s || !desc)
 		return -1;
@@ -1905,14 +1824,12 @@ int bgp_ls_encode_link_descriptor(struct stream *s, const struct bgp_ls_link_des
 	}
 
 	/* Multi-Topology ID (TLV 263) */
-	if (CHECK_FLAG(desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT) && desc->mt_id_count > 0) {
-		if (STREAM_WRITEABLE(s) <
-		    BGP_LS_TLV_HDR_SIZE + (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
+	if (CHECK_FLAG(desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_MT_ID_SIZE)
 			return -1;
 		stream_putw(s, BGP_LS_TLV_MT_ID);
-		stream_putw(s, desc->mt_id_count * BGP_LS_MT_ID_SIZE);
-		for (i = 0; i < desc->mt_id_count; i++)
-			stream_putw(s, desc->mt_id[i]);
+		stream_putw(s, BGP_LS_MT_ID_SIZE);
+		stream_putw(s, desc->mt_id);
 	}
 
 	/* Remote AS Number (TLV 264) */
@@ -1947,7 +1864,6 @@ int bgp_ls_encode_link_descriptor(struct stream *s, const struct bgp_ls_link_des
 int bgp_ls_encode_prefix_descriptor(struct stream *s, const struct bgp_ls_prefix_descriptor *desc)
 {
 	size_t start;
-	uint16_t i;
 	uint8_t prefix_len_bytes;
 
 	if (!s || !desc)
@@ -1956,14 +1872,12 @@ int bgp_ls_encode_prefix_descriptor(struct stream *s, const struct bgp_ls_prefix
 	start = stream_get_endp(s);
 
 	/* Multi-Topology ID (TLV 263) */
-	if (CHECK_FLAG(desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT) && desc->mt_id_count > 0) {
-		if (STREAM_WRITEABLE(s) <
-		    BGP_LS_TLV_HDR_SIZE + (size_t)desc->mt_id_count * BGP_LS_MT_ID_SIZE)
+	if (CHECK_FLAG(desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_MT_ID_SIZE)
 			return -1;
 		stream_putw(s, BGP_LS_TLV_MT_ID);
-		stream_putw(s, desc->mt_id_count * BGP_LS_MT_ID_SIZE);
-		for (i = 0; i < desc->mt_id_count; i++)
-			stream_putw(s, desc->mt_id[i]);
+		stream_putw(s, BGP_LS_MT_ID_SIZE);
+		stream_putw(s, desc->mt_id);
 	}
 
 	/* OSPF Route Type (TLV 264) */
@@ -2209,14 +2123,12 @@ int bgp_ls_encode_srv6_sid_nlri(struct stream *s, const struct bgp_ls_srv6_sid_n
 	stream_put(s, &nlri->sid_desc.sid, BGP_LS_SRV6_SID_INFO_SIZE);
 
 	/* Optional MT-ID TLV in SID descriptor */
-	if (nlri->sid_desc.mt_id_count > 0) {
-		if (STREAM_WRITEABLE(s) <
-		    BGP_LS_TLV_HDR_SIZE + (size_t)nlri->sid_desc.mt_id_count * BGP_LS_MT_ID_SIZE)
+	if (CHECK_FLAG(nlri->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_MT_ID_SIZE)
 			return -1;
 		stream_putw(s, BGP_LS_TLV_MT_ID);
-		stream_putw(s, nlri->sid_desc.mt_id_count * BGP_LS_MT_ID_SIZE);
-		for (uint8_t i = 0; i < nlri->sid_desc.mt_id_count; i++)
-			stream_putw(s, nlri->sid_desc.mt_id[i]);
+		stream_putw(s, BGP_LS_MT_ID_SIZE);
+		stream_putw(s, nlri->sid_desc.mt_id);
 	}
 
 	return stream_get_endp(s) - start;
@@ -3213,16 +3125,14 @@ int bgp_ls_decode_link_descriptor(struct stream *s, struct bgp_ls_link_descripto
 					  "BGP-LS: duplicate MT-ID TLV in link descriptor");
 				goto error;
 			}
-			/* Variable length: 2*n bytes where n is number of MT-IDs */
-			if (tlv_len == 0 || tlv_len % 2 != 0 || tlv_len > BGP_LS_MAX_MT_ID * 2) {
-				flog_warn(EC_BGP_LS_PACKET, "BGP-LS: Invalid MT-ID TLV length %u",
-					  tlv_len);
+			/* RFC 9552 Section 5.2.2.1: exactly one MT-ID in Link Descriptor */
+			if (tlv_len != BGP_LS_MT_ID_SIZE) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: Invalid MT-ID TLV length %u in link descriptor (expected %u)",
+					  tlv_len, BGP_LS_MT_ID_SIZE);
 				goto error;
 			}
-			desc->mt_id_count = tlv_len / 2;
-			desc->mt_id = XCALLOC(MTYPE_BGP_LS_NLRI, tlv_len);
-			for (uint16_t i = 0; i < desc->mt_id_count; i++)
-				desc->mt_id[i] = stream_getw(s);
+			desc->mt_id = stream_getw(s);
 			SET_FLAG(desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT);
 			break;
 
@@ -3261,9 +3171,7 @@ int bgp_ls_decode_link_descriptor(struct stream *s, struct bgp_ls_link_descripto
 	return 0;
 
 error:
-	XFREE(MTYPE_BGP_LS_NLRI, desc->mt_id);
-	desc->mt_id = NULL;
-	desc->mt_id_count = 0;
+	desc->mt_id = 0;
 	return -1;
 }
 
@@ -3312,16 +3220,14 @@ int bgp_ls_decode_prefix_descriptor(struct stream *s, struct bgp_ls_prefix_descr
 					  "BGP-LS: duplicate MT-ID TLV in prefix descriptor");
 				goto error;
 			}
-			/* Variable length: 2*n bytes where n is number of MT-IDs */
-			if (tlv_len == 0 || tlv_len % 2 != 0 || tlv_len > BGP_LS_MAX_MT_ID * 2) {
-				flog_warn(EC_BGP_LS_PACKET, "BGP-LS: Invalid MT-ID TLV length %u",
-					  tlv_len);
+			/* RFC 9552 Section 5.2.2.1: exactly one MT-ID in Prefix Descriptor */
+			if (tlv_len != BGP_LS_MT_ID_SIZE) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: Invalid MT-ID TLV length %u in prefix descriptor (expected %u)",
+					  tlv_len, BGP_LS_MT_ID_SIZE);
 				goto error;
 			}
-			desc->mt_id_count = tlv_len / 2;
-			desc->mt_id = XCALLOC(MTYPE_BGP_LS_NLRI, tlv_len);
-			for (uint16_t i = 0; i < desc->mt_id_count; i++)
-				desc->mt_id[i] = stream_getw(s);
+			desc->mt_id = stream_getw(s);
 			SET_FLAG(desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT);
 			break;
 
@@ -3446,9 +3352,7 @@ int bgp_ls_decode_prefix_descriptor(struct stream *s, struct bgp_ls_prefix_descr
 	return 0;
 
 error:
-	XFREE(MTYPE_BGP_LS_NLRI, desc->mt_id);
-	desc->mt_id = NULL;
-	desc->mt_id_count = 0;
+	desc->mt_id = 0;
 	return -1;
 }
 
@@ -3888,22 +3792,21 @@ int bgp_ls_decode_srv6_sid_nlri(struct stream *s, struct bgp_ls_nlri *nlri, uint
 			break;
 
 		case BGP_LS_TLV_MT_ID:
-			if (srv6->sid_desc.mt_id_count != 0) {
+			if (CHECK_FLAG(srv6->sid_desc.present_tlvs,
+				       BGP_LS_SRV6_SID_DESC_MT_ID_BIT)) {
 				flog_warn(EC_BGP_LS_PACKET,
 					  "BGP-LS: duplicate MT-ID TLV in SRv6 SID descriptor");
 				return -1;
 			}
-			/* Variable length: 2*n bytes where n is number of MT-IDs */
-			if (length == 0 || length % 2 != 0 || length > BGP_LS_MAX_MT_ID * 2) {
+			/* SRv6 SID NLRI carries a single MT-ID when present. */
+			if (length != BGP_LS_MT_ID_SIZE) {
 				flog_warn(EC_BGP_LS_PACKET,
-					  "BGP-LS: Invalid MT-ID TLV length %u in SRv6 SID descriptor",
-					  length);
+					  "BGP-LS: Invalid MT-ID TLV length %u in SRv6 SID descriptor (expected %u)",
+					  length, BGP_LS_MT_ID_SIZE);
 				return -1;
 			}
-			srv6->sid_desc.mt_id_count = length / 2;
-			srv6->sid_desc.mt_id = XCALLOC(MTYPE_BGP_LS_NLRI, length);
-			for (uint16_t i = 0; i < srv6->sid_desc.mt_id_count; i++)
-				srv6->sid_desc.mt_id[i] = stream_getw(s);
+			srv6->sid_desc.mt_id = stream_getw(s);
+			SET_FLAG(srv6->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT);
 			break;
 
 		default:
@@ -6368,11 +6271,8 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 				&link_desc->ipv6_neigh_addr);
 
 		/* Display Link Descriptor Multi-Topology info */
-		if (CHECK_FLAG(link_desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT)) {
-			vty_out(vty, "Multi-Topology:\n");
-			for (uint8_t i = 0; i < link_desc->mt_id_count; i++)
-				vty_out(vty, "\tMT-ID: %u\n", link_desc->mt_id[i]);
-		}
+		if (CHECK_FLAG(link_desc->present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT))
+			vty_out(vty, "\tMulti-Topology: 0x%04x\n", link_desc->mt_id);
 	}
 
 	/* Display Prefix Descriptor for Prefix NLRI */
@@ -6424,11 +6324,8 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 		}
 
 		/* Multi-Topology */
-		if (CHECK_FLAG(prefix_desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT)) {
-			vty_out(vty, "Multi-Topology:\n");
-			for (uint8_t i = 0; i < prefix_desc->mt_id_count; i++)
-				vty_out(vty, "\tMT-ID: %u\n", prefix_desc->mt_id[i]);
-		}
+		if (CHECK_FLAG(prefix_desc->present_tlvs, BGP_LS_PREFIX_DESC_MT_ID_BIT))
+			vty_out(vty, "\tMulti-Topology: 0x%04x\n", prefix_desc->mt_id);
 	}
 
 	/* Display SRv6 SID Descriptor for SRv6 SID NLRI (RFC 9514) */
@@ -6436,8 +6333,10 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 		const struct bgp_ls_srv6_sid_nlri *s = &nlri->nlri_data.srv6_sid;
 
 		vty_out(vty, "SRv6 SID Descriptor:\n");
-		for (uint8_t i = 0; i < s->sid_desc.mt_id_count; i++)
-			vty_out(vty, "\tMulti-Topology: 0x%04x\n", s->sid_desc.mt_id[i]);
+
+		if (CHECK_FLAG(s->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT))
+			vty_out(vty, "\tMulti-Topology: 0x%04x\n", s->sid_desc.mt_id);
+
 		vty_out(vty, "\tSID: %pI6\n", &s->sid_desc.sid);
 	}
 }

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -3881,6 +3881,7 @@ int bgp_ls_decode_srv6_sid_nlri(struct stream *s, struct bgp_ls_nlri *nlri, uint
 				return -1;
 			}
 			stream_get(&srv6->sid_desc.sid, s, IPV6_MAX_BYTELEN);
+			SET_FLAG(srv6->sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_INFO_BIT);
 			if (length > BGP_LS_SRV6_SID_INFO_SIZE)
 				stream_forward_getp(s, length - BGP_LS_SRV6_SID_INFO_SIZE);
 			got_sid = true;

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -1333,8 +1333,13 @@ unsigned int bgp_ls_nlri_hash_key(const struct bgp_ls_nlri *nlri)
 	case BGP_LS_NLRI_TYPE_IPV6_PREFIX:
 		return key ^ bgp_ls_prefix_hash_key_internal(nlri);
 	case BGP_LS_NLRI_TYPE_SRV6_SID:
-		return key ^ jhash(&nlri->nlri_data.srv6_sid.sid_desc.sid,
-				   sizeof(nlri->nlri_data.srv6_sid.sid_desc.sid), 0);
+		key = jhash(&nlri->nlri_data.srv6_sid.sid_desc.sid,
+			    sizeof(nlri->nlri_data.srv6_sid.sid_desc.sid), key);
+		key = jhash_1word(nlri->nlri_data.srv6_sid.sid_desc.present_tlvs, key);
+		if (CHECK_FLAG(nlri->nlri_data.srv6_sid.sid_desc.present_tlvs,
+			       BGP_LS_SRV6_SID_DESC_MT_ID_BIT))
+			key = jhash_1word(nlri->nlri_data.srv6_sid.sid_desc.mt_id, key);
+		return key;
 	case BGP_LS_NLRI_TYPE_RESERVED:
 		return key;
 	}

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -505,11 +505,13 @@ int bgp_ls_attr_cmp(const struct bgp_ls_attr *attr1, const struct bgp_ls_attr *a
 			return ret;
 	}
 
-	if (attr1->mt_id_count != attr2->mt_id_count)
-		return numcmp(attr1->mt_id_count, attr2->mt_id_count);
-	for (int i = 0; i < attr1->mt_id_count; i++) {
-		if (attr1->mt_id[i] != attr2->mt_id[i])
-			return numcmp(attr1->mt_id[i], attr2->mt_id[i]);
+	if (CHECK_FLAG(attr1->present_tlvs, BGP_LS_ATTR_MT_ID_BIT)) {
+		if (attr1->mt_id_count != attr2->mt_id_count)
+			return numcmp(attr1->mt_id_count, attr2->mt_id_count);
+		for (int i = 0; i < attr1->mt_id_count; i++) {
+			if (attr1->mt_id[i] != attr2->mt_id[i])
+				return numcmp(attr1->mt_id[i], attr2->mt_id[i]);
+		}
 	}
 
 	/* SRv6 comparisons (RFC 9514) */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -189,6 +189,27 @@ int bgp_ls_prefix_descriptor_cmp(const struct bgp_ls_prefix_descriptor *d1,
 }
 
 /*
+ * Compare two SRv6 SID descriptors for equality
+ * Returns 0 if equal, non-zero otherwise
+ */
+static int bgp_ls_srv6_sid_descriptor_cmp(const struct bgp_ls_srv6_sid_descriptor *d1,
+					  const struct bgp_ls_srv6_sid_descriptor *d2)
+{
+	int ret;
+
+	/* Must have same SID descriptor TLVs present */
+	if (d1->present_tlvs != d2->present_tlvs)
+		return numcmp(d1->present_tlvs, d2->present_tlvs);
+
+	/* Compare SRv6 SID value */
+	ret = IPV6_ADDR_CMP(&d1->sid, &d2->sid);
+	if (ret != 0)
+		return ret;
+
+	return 0;
+}
+
+/*
  * ===========================================================================
  * NLRI Comparison Functions
  * ===========================================================================
@@ -285,8 +306,8 @@ int bgp_ls_nlri_cmp(const struct bgp_ls_nlri *nlri1, const struct bgp_ls_nlri *n
 		if (ret != 0)
 			return ret;
 
-		/* Compare SRv6 SID (the 128-bit SID identifies the NLRI) */
-		return memcmp(&s1->sid_desc.sid, &s2->sid_desc.sid, sizeof(s1->sid_desc.sid));
+		/* Compare SRv6 SID descriptor */
+		return bgp_ls_srv6_sid_descriptor_cmp(&s1->sid_desc, &s2->sid_desc);
 	}
 
 	case BGP_LS_NLRI_TYPE_RESERVED:

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -2649,6 +2649,19 @@ int bgp_ls_encode_attr(struct stream *s, const struct bgp_ls_attr *attr)
 		}
 	}
 
+	/* Multi-Topology ID (TLV 263) - RFC 9552 §5.2.1.4 / §5.3 */
+	if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_MT_ID_BIT) && attr->mt_id &&
+	    attr->mt_id_count > 0) {
+		uint16_t mt_len = attr->mt_id_count * BGP_LS_MT_ID_SIZE;
+
+		if (STREAM_WRITEABLE(s) < (size_t)BGP_LS_TLV_HDR_SIZE + (size_t)mt_len)
+			return -1;
+		stream_putw(s, BGP_LS_TLV_MT_ID);
+		stream_putw(s, mt_len);
+		for (int i = 0; i < attr->mt_id_count; i++)
+			stream_putw(s, attr->mt_id[i]);
+	}
+
 	/*
 	 * RFC 9514 SRv6 Attribute TLVs
 	 */
@@ -5413,6 +5426,27 @@ int bgp_ls_parse_attr(struct stream *s, uint16_t total_length, struct bgp_ls_att
 				return -1;
 			break;
 
+
+		case BGP_LS_TLV_MT_ID:
+			/* Multi-Topology ID - RFC 9552 §5.2.1.4 */
+			if (CHECK_FLAG(attr->present_tlvs, BGP_LS_ATTR_MT_ID_BIT)) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: duplicate MT-ID TLV in attribute, ignoring");
+				stream_skip_tlv(s, length);
+				break;
+			}
+			if (length == 0 || length % 2 != 0 || length > BGP_LS_MAX_MT_ID * 2) {
+				flog_warn(EC_BGP_LS_PACKET, "BGP-LS: invalid MT-ID TLV length %u",
+					  length);
+				return -1;
+			}
+			attr->mt_id_count = length / 2;
+			attr->mt_id = XCALLOC(MTYPE_BGP_LS_ATTR, length);
+			for (uint16_t i = 0; i < attr->mt_id_count; i++)
+				attr->mt_id[i] = stream_getw(s);
+			SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_MT_ID_BIT);
+			break;
+
 		/* SRv6 TLVs (RFC 9514) */
 		case BGP_LS_ATTR_SRV6_CAPABILITIES:
 			if (parse_srv6_capabilities(s, length, attr) < 0)
@@ -5649,6 +5683,15 @@ struct json_object *bgp_ls_attr_to_json(struct bgp_ls_attr *ls_attr)
 		else if (!IN6_IS_ADDR_UNSPECIFIED(&ls_attr->ospf_fwd_addr6))
 			json_object_string_addf(json_ls_attr, "forwardingAddrV6", "%pI6",
 						&ls_attr->ospf_fwd_addr6);
+	}
+
+	/* Multi-Topology IDs */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_MT_ID_BIT) && ls_attr->mt_id) {
+		json_object *jmt = json_object_new_array();
+
+		json_object_object_add(json_ls_attr, "multiTopologyIds", jmt);
+		for (int i = 0; i < ls_attr->mt_id_count; i++)
+			json_object_array_add(jmt, json_object_new_int(ls_attr->mt_id[i]));
 	}
 
 	/* Prefix SID */
@@ -5984,6 +6027,14 @@ void bgp_ls_attr_display(struct vty *vty, struct bgp_ls_attr *ls_attr)
 			CHECK_WRAP();
 			col += vty_out(vty, "Forwarding addr: %pI6", &ls_attr->ospf_fwd_addr6);
 		}
+	}
+
+	/* Multi-Topology IDs */
+	if (CHECK_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_MT_ID_BIT) && ls_attr->mt_id) {
+		CHECK_WRAP();
+		col += vty_out(vty, "MT-ID:");
+		for (int i = 0; i < ls_attr->mt_id_count; i++)
+			col += vty_out(vty, " %u", ls_attr->mt_id[i]);
 	}
 
 	/* Prefix SID */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -198,6 +198,12 @@ static int bgp_ls_srv6_sid_descriptor_cmp(const struct bgp_ls_srv6_sid_descripto
 	if (ret != 0)
 		return ret;
 
+	/* Compare Multi-Topology ID */
+	if (CHECK_FLAG(d1->present_tlvs, BGP_LS_SRV6_SID_DESC_MT_ID_BIT)) {
+		if (d1->mt_id != d2->mt_id)
+			return numcmp(d1->mt_id, d2->mt_id);
+	}
+
 	return 0;
 }
 

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -495,6 +495,7 @@ struct bgp_ls_prefix_descriptor {
  * MUST contain exactly one SRv6 SID Information TLV (518).
  */
 struct bgp_ls_srv6_sid_descriptor {
+	uint16_t present_tlvs;		      /* Bitmask of present SID descriptor TLVs */
 	struct in6_addr sid;		      /* 128-bit SRv6 SID (from TLV 518) */
 	uint8_t mt_id_count;		      /* Number of Multi-Topology IDs */
 	uint16_t *mt_id;			      /* Multi-Topology IDs (from TLV 263) */

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -407,6 +407,8 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_ATTR_SRV6_LAN_ENDX_SID_BIT      (1ULL << 42)
 #define BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT (1ULL << 43)
 #define BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT     (1ULL << 44)
+/* Multi-Topology IDs - RFC 9552 §5.2.1.4 */
+#define BGP_LS_ATTR_MT_ID_BIT                  (1ULL << 45)
 
 /*
  * Node Flag Bits (TLV 1024)

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -478,8 +478,7 @@ struct bgp_ls_link_descriptor {
 	struct in6_addr ipv6_intf_addr;	 /* IPv6 Interface Address */
 	struct in6_addr ipv6_neigh_addr; /* IPv6 Neighbor Address */
 	as_t remote_asn;		 /* Remote AS Number */
-	uint8_t mt_id_count;		 /* Number of Multi-Topology IDs */
-	uint16_t *mt_id;		 /* Multi-Topology IDs */
+	uint16_t mt_id;			 /* Multi-Topology ID (TLV 263) */
 };
 
 /*
@@ -488,8 +487,7 @@ struct bgp_ls_link_descriptor {
  */
 struct bgp_ls_prefix_descriptor {
 	uint16_t present_tlvs;			     /* Bitmask of present TLVs */
-	uint8_t mt_id_count;			     /* Number of Multi-Topology IDs */
-	uint16_t *mt_id;			     /* Multi-Topology IDs */
+	uint16_t mt_id;				     /* Multi-Topology ID (TLV 263) */
 	enum bgp_ls_ospf_route_type ospf_route_type; /* OSPF Route Type */
 	enum bgp_ls_bgp_route_type bgp_route_type;   /* BGP Route Type */
 	struct prefix prefix;			     /* IP prefix (IPv4 or IPv6) */
@@ -503,8 +501,7 @@ struct bgp_ls_prefix_descriptor {
 struct bgp_ls_srv6_sid_descriptor {
 	uint16_t present_tlvs;		      /* Bitmask of present SID descriptor TLVs */
 	struct in6_addr sid;		      /* 128-bit SRv6 SID (from TLV 518) */
-	uint8_t mt_id_count;		      /* Number of Multi-Topology IDs */
-	uint16_t *mt_id;			      /* Multi-Topology IDs (from TLV 263) */
+	uint16_t mt_id;			      /* Multi-Topology ID (from TLV 263) */
 };
 
 /*

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -283,6 +283,10 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_PREFIX_DESC_IP_REACH_BIT        (1ULL << 2)
 #define BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT  (1ULL << 3)
 
+/* Bit positions for SRv6 SID Descriptor TLVs */
+#define BGP_LS_SRV6_SID_DESC_INFO_BIT          (1ULL << 0)
+#define BGP_LS_SRV6_SID_DESC_MT_ID_BIT         (1ULL << 1)
+
 /* Maximum number of MT-IDs per descriptor */
 #define BGP_LS_MAX_MT_ID 16
 

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -1064,6 +1064,7 @@ int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rou
 
 	/* SRv6 SID Descriptor: SID Information (TLV 518) */
 	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
+	SET_FLAG(nlri.nlri_data.srv6_sid.sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_INFO_BIT);
 
 	/* Populate SRv6 SID attributes (endpoint behavior, SID structure) */
 	ls_attr = bgp_ls_attr_alloc();
@@ -1119,6 +1120,7 @@ int bgp_ls_withdraw_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rout
 	}
 
 	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
+	SET_FLAG(nlri.nlri_data.srv6_sid.sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_INFO_BIT);
 
 	ret = bgp_ls_withdraw(bgp, &nlri);
 	if (ret < 0) {

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -677,6 +677,12 @@ int bgp_ls_originate_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_r
 	}
 
 	/* IPv4 Neighbor Address (TLV 260) */
+
+	/* Advertise MT-ID only for non-default topologies (RFC 9552 §5.2.2.1). */
+	if (CHECK_FLAG(edge->attributes->flags, LS_ATTR_MT_ID) && edge->attributes->mt_id != 0) {
+		nlri.nlri_data.link.link_desc.mt_id = edge->attributes->mt_id;
+		SET_FLAG(nlri.nlri_data.link.link_desc.present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT);
+	}
 	if (CHECK_FLAG(edge->attributes->flags, LS_ATTR_NEIGH_ADDR)) {
 		nlri.nlri_data.link.link_desc.ipv4_neigh_addr = edge->attributes->standard.remote;
 		SET_FLAG(nlri.nlri_data.link.link_desc.present_tlvs,
@@ -801,6 +807,12 @@ int bgp_ls_withdraw_link(struct bgp *bgp, uint8_t protocol_id, uint8_t *local_ro
 		SET_FLAG(nlri.nlri_data.link.link_desc.present_tlvs, BGP_LS_LINK_DESC_LINK_ID_BIT);
 	}
 
+	/* Advertise MT-ID only for non-default topologies (RFC 9552 §5.2.2.1). */
+	if (CHECK_FLAG(edge->attributes->flags, LS_ATTR_MT_ID) && edge->attributes->mt_id != 0) {
+		nlri.nlri_data.link.link_desc.mt_id = edge->attributes->mt_id;
+		SET_FLAG(nlri.nlri_data.link.link_desc.present_tlvs, BGP_LS_LINK_DESC_MT_ID_BIT);
+	}
+
 	if (CHECK_FLAG(edge->attributes->flags, LS_ATTR_NEIGH_ID)) {
 		nlri.nlri_data.link.link_desc.link_remote_id = edge->attributes->standard.remote_id;
 		SET_FLAG(nlri.nlri_data.link.link_desc.present_tlvs, BGP_LS_LINK_DESC_LINK_ID_BIT);
@@ -895,6 +907,7 @@ int bgp_ls_originate_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *route
 		return -1;
 	}
 
+
 	/* Build Prefix NLRI */
 	nlri.nlri_data.prefix.protocol_id = protocol_id;
 	nlri.nlri_data.prefix.identifier = 0; /* Instance ID, use 0 for default */
@@ -922,6 +935,13 @@ int bgp_ls_originate_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *route
 	nlri.nlri_data.prefix.prefix_desc.prefix = *prefix;
 	apply_mask(&nlri.nlri_data.prefix.prefix_desc.prefix);
 	SET_FLAG(nlri.nlri_data.prefix.prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_IP_REACH_BIT);
+
+	/* Advertise MT-ID only for non-default topologies (RFC 9552 §5.2.3). */
+	if (CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_MT_ID) && subnet->ls_pref->mt_id != 0) {
+		nlri.nlri_data.prefix.prefix_desc.mt_id = subnet->ls_pref->mt_id;
+		SET_FLAG(nlri.nlri_data.prefix.prefix_desc.present_tlvs,
+			 BGP_LS_PREFIX_DESC_MT_ID_BIT);
+	}
 
 	/* Populate BGP-LS attributes from Link State subnet */
 	ls_attr = bgp_ls_attr_alloc();
@@ -973,6 +993,7 @@ int bgp_ls_withdraw_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *router
 	memset(&nlri, 0, sizeof(nlri));
 
 	/* Determine NLRI type based on prefix family */
+
 	if (prefix->family == AF_INET)
 		nlri.nlri_type = BGP_LS_NLRI_TYPE_IPV4_PREFIX;
 	else if (prefix->family == AF_INET6)
@@ -1008,6 +1029,13 @@ int bgp_ls_withdraw_prefix(struct bgp *bgp, uint8_t protocol_id, uint8_t *router
 	/* Set Prefix Descriptor */
 	nlri.nlri_data.prefix.prefix_desc.prefix = *prefix;
 	SET_FLAG(nlri.nlri_data.prefix.prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_IP_REACH_BIT);
+
+	/* Advertise MT-ID only for non-default topologies (RFC 9552 §5.2.3). */
+	if (CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_MT_ID) && subnet->ls_pref->mt_id != 0) {
+		nlri.nlri_data.prefix.prefix_desc.mt_id = subnet->ls_pref->mt_id;
+		SET_FLAG(nlri.nlri_data.prefix.prefix_desc.present_tlvs,
+			 BGP_LS_PREFIX_DESC_MT_ID_BIT);
+	}
 
 	/* Withdraw from RIB */
 	ret = bgp_ls_withdraw(bgp, &nlri);
@@ -1075,6 +1103,13 @@ int bgp_ls_originate_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rou
 	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
 	SET_FLAG(nlri.nlri_data.srv6_sid.sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_INFO_BIT);
 
+	/* Advertise MT-ID only for non-default topologies. */
+	if (CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_MT_ID) && subnet->ls_pref->mt_id != 0) {
+		nlri.nlri_data.srv6_sid.sid_desc.mt_id = subnet->ls_pref->mt_id;
+		SET_FLAG(nlri.nlri_data.srv6_sid.sid_desc.present_tlvs,
+			 BGP_LS_SRV6_SID_DESC_MT_ID_BIT);
+	}
+
 	/* Populate SRv6 SID attributes (endpoint behavior, SID structure) */
 	ls_attr = bgp_ls_attr_alloc();
 	if (bgp_ls_populate_srv6_sid_attr(subnet->ls_pref, ls_attr) < 0) {
@@ -1130,6 +1165,13 @@ int bgp_ls_withdraw_srv6_sid(struct bgp *bgp, uint8_t protocol_id, uint8_t *rout
 
 	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, &subnet->ls_pref->srv6.sid);
 	SET_FLAG(nlri.nlri_data.srv6_sid.sid_desc.present_tlvs, BGP_LS_SRV6_SID_DESC_INFO_BIT);
+
+	/* Advertise MT-ID only for non-default topologies. */
+	if (CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_MT_ID) && subnet->ls_pref->mt_id != 0) {
+		nlri.nlri_data.srv6_sid.sid_desc.mt_id = subnet->ls_pref->mt_id;
+		SET_FLAG(nlri.nlri_data.srv6_sid.sid_desc.present_tlvs,
+			 BGP_LS_SRV6_SID_DESC_MT_ID_BIT);
+	}
 
 	ret = bgp_ls_withdraw(bgp, &nlri);
 	if (ret < 0) {

--- a/bgpd/bgp_ls_ted.c
+++ b/bgpd/bgp_ls_ted.c
@@ -85,6 +85,15 @@ int bgp_ls_populate_node_attr(struct ls_node *ls_node, struct bgp_ls_attr *attr)
 		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_IPV6_ROUTER_ID_LOCAL_BIT);
 	}
 
+	/* Multi-Topology IDs (TLV 263) - RFC 9552 §5.2.1.4 */
+	if (CHECK_FLAG(ls_node->flags, LS_NODE_MT_IDS) && ls_node->mt_id_count > 0 &&
+	    !(ls_node->mt_id_count == 1 && ls_node->mt_ids[0] == 0)) {
+		attr->mt_id = XCALLOC(MTYPE_BGP_LS_ATTR, ls_node->mt_id_count * sizeof(uint16_t));
+		memcpy(attr->mt_id, ls_node->mt_ids, ls_node->mt_id_count * sizeof(uint16_t));
+		attr->mt_id_count = ls_node->mt_id_count;
+		SET_FLAG(attr->present_tlvs, BGP_LS_ATTR_MT_ID_BIT);
+	}
+
 	/* SRv6 Capabilities (TLV 1038, RFC 9514 Section 3.1) */
 	if (CHECK_FLAG(ls_node->flags, LS_NODE_SRV6)) {
 		attr->srv6_cap_flags = ls_node->srv6_cap_flags;

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -794,6 +794,24 @@ static struct ls_vertex *lsp_to_vertex(struct ls_ted *ted, struct isis_lsp *lsp)
 				       sizeof(struct isis_srv6_msd));
 			}
 		}
+
+		/*
+		 * MT-IDs (RFC 9552 §5.2.1.4): MT-0 (standard) is always
+		 * present; additional topologies come from the MT Router
+		 * Info TLV (TLV 229).
+		 */
+		lnode.mt_id_count = 0;
+		lnode.mt_ids[lnode.mt_id_count++] = ISIS_MT_IPV4_UNICAST;
+		if (!tlvs->mt_router_info_empty) {
+			struct isis_mt_router_info *info;
+
+			for (info = (struct isis_mt_router_info *)tlvs->mt_router_info.head;
+			     info && lnode.mt_id_count < LS_NODE_MT_IDS_MAX; info = info->next) {
+				if (info->mtid != ISIS_MT_IPV4_UNICAST)
+					lnode.mt_ids[lnode.mt_id_count++] = info->mtid;
+			}
+		}
+		SET_FLAG(lnode.flags, LS_NODE_MT_IDS);
 	}
 
 	/* Update Link State Node information */
@@ -1143,6 +1161,9 @@ static int lsp_to_edge_cb(const uint8_t *id, uint32_t metric, bool old_metric,
 	attr->metric = metric;
 	SET_FLAG(attr->flags, LS_ATTR_METRIC);
 
+	attr->mt_id = args->mt_id;
+	SET_FLAG(attr->flags, LS_ATTR_MT_ID);
+
 	/* Get corresponding Edge from Link State Data Base */
 	edge = get_edge(args->ted, attr);
 	/*
@@ -1331,6 +1352,14 @@ static int lsp_to_subnet_cb(const struct prefix *prefix, uint32_t metric, bool e
 			subnet->status = SYNC;
 	}
 
+	/* Update MT-ID */
+	if (!CHECK_FLAG(ls_pref->flags, LS_PREF_MT_ID) || ls_pref->mt_id != args->mt_id) {
+		ls_pref->mt_id = args->mt_id;
+		SET_FLAG(ls_pref->flags, LS_PREF_MT_ID);
+		if (subnet->status != NEW)
+			subnet->status = UPDATE;
+	}
+
 	/* Update Prefix SID if any */
 	if (subtlvs && subtlvs->prefix_sids.count != 0) {
 		struct isis_prefix_sid *psid;
@@ -1466,17 +1495,24 @@ static void isis_te_parse_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 	args.ted = ted;
 	args.vertex = vertex;
 	args.export = mta->export || IS_DISTRIBUTE_LS(lsp->area);
+	args.mt_id = ISIS_MT_IPV4_UNICAST;
 	isis_lsp_iterate_is_reach(lsp, ISIS_MT_IPV4_UNICAST, lsp_to_edge_cb, &args);
 
+	args.mt_id = ISIS_MT_IPV6_UNICAST;
 	isis_lsp_iterate_is_reach(lsp, ISIS_MT_IPV6_UNICAST, lsp_to_edge_cb, &args);
 
 	/* Process all Extended IP (v4 & v6) in LSP (all fragments) */
 	args.srv6_locator = false;
+	args.mt_id = ISIS_MT_IPV4_UNICAST;
 	isis_lsp_iterate_ip_reach(lsp, AF_INET, ISIS_MT_IPV4_UNICAST, lsp_to_subnet_cb, &args);
+	args.mt_id = ISIS_MT_IPV6_UNICAST;
 	isis_lsp_iterate_ip_reach(lsp, AF_INET6, ISIS_MT_IPV6_UNICAST, lsp_to_subnet_cb, &args);
+	args.mt_id = ISIS_MT_IPV4_UNICAST;
 	isis_lsp_iterate_ip_reach(lsp, AF_INET6, ISIS_MT_IPV4_UNICAST, lsp_to_subnet_cb, &args);
 	args.srv6_locator = true;
+	args.mt_id = ISIS_MT_STANDARD;
 	isis_lsp_iterate_srv6_locator(lsp, ISIS_MT_STANDARD, lsp_to_subnet_cb, &args);
+	args.mt_id = ISIS_MT_IPV6_UNICAST;
 	isis_lsp_iterate_srv6_locator(lsp, ISIS_MT_IPV6_UNICAST, lsp_to_subnet_cb, &args);
 
 	/* Clean remaining Orphan Edges or Subnets */

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -105,6 +105,7 @@ struct isis_te_args {
 	struct ls_vertex *vertex;
 	bool export;
 	bool srv6_locator;
+	uint16_t mt_id; /* IS-IS MT-ID of the current iteration context */
 };
 
 enum lsp_event { LSP_UNKNOWN, LSP_ADD, LSP_UPD, LSP_DEL, LSP_INC, LSP_TICK };

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -152,6 +152,12 @@ int ls_node_same(struct ls_node *n1, struct ls_node *n2)
 		if (memcmp(n1->isis_area_id, n2->isis_area_id, n1->isis_area_id_len))
 			return 0;
 	}
+	if (CHECK_FLAG(n1->flags, LS_NODE_MT_IDS)) {
+		if (n1->mt_id_count != n2->mt_id_count)
+			return 0;
+		if (memcmp(n1->mt_ids, n2->mt_ids, n1->mt_id_count * sizeof(uint16_t)))
+			return 0;
+	}
 
 	/* OK, n1 & n2 are equal */
 	return 1;
@@ -361,6 +367,8 @@ int ls_attributes_same(struct ls_attributes *l1, struct ls_attributes *l2)
 			  l1->srlg_len * sizeof(uint32_t))
 			   != 0))
 		return 0;
+	if (CHECK_FLAG(l1->flags, LS_ATTR_MT_ID) && (l1->mt_id != l2->mt_id))
+		return 0;
 
 	/* OK, l1 & l2 are equal */
 	return 1;
@@ -436,6 +444,8 @@ int ls_prefix_same(struct ls_prefix *p1, struct ls_prefix *p2)
 		      p1->srv6.fn_len != p2->srv6.fn_len || p1->srv6.arg_len != p2->srv6.arg_len)))
 			return 0;
 	}
+	if (CHECK_FLAG(p1->flags, LS_PREF_MT_ID) && (p1->mt_id != p2->mt_id))
+		return 0;
 
 	/* OK, p1 & p2 are equal */
 	return 1;
@@ -1242,6 +1252,16 @@ static struct ls_node *ls_parse_node(struct stream *s)
 		}
 		STREAM_GET(node->isis_area_id, s, node->isis_area_id_len);
 	}
+	if (CHECK_FLAG(node->flags, LS_NODE_MT_IDS)) {
+		STREAM_GETC(s, node->mt_id_count);
+		if (node->mt_id_count > LS_NODE_MT_IDS_MAX) {
+			zlog_err("LS(%s): MT-ID count %u exceeds maximum (%d)", __func__,
+				 node->mt_id_count, LS_NODE_MT_IDS_MAX);
+			goto stream_failure;
+		}
+		for (len = 0; len < node->mt_id_count; len++)
+			STREAM_GETW(s, node->mt_ids[len]);
+	}
 
 	return node;
 
@@ -1403,6 +1423,8 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 		for (len = 0; len < attr->srlg_len; len++)
 			STREAM_GETL(s, attr->srlgs[len]);
 	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_MT_ID))
+		STREAM_GETW(s, attr->mt_id);
 
 	return attr;
 
@@ -1458,6 +1480,8 @@ static struct ls_prefix *ls_parse_prefix(struct stream *s)
 			STREAM_GETC(s, ls_pref->srv6.arg_len);
 		}
 	}
+	if (CHECK_FLAG(ls_pref->flags, LS_PREF_MT_ID))
+		STREAM_GETW(s, ls_pref->mt_id);
 
 	return ls_pref;
 
@@ -1546,6 +1570,11 @@ static int ls_format_node(struct stream *s, struct ls_node *node)
 	if (CHECK_FLAG(node->flags, LS_NODE_ISIS_AREA_ID)) {
 		stream_putc(s, node->isis_area_id_len);
 		stream_put(s, node->isis_area_id, node->isis_area_id_len);
+	}
+	if (CHECK_FLAG(node->flags, LS_NODE_MT_IDS)) {
+		stream_putc(s, node->mt_id_count);
+		for (len = 0; len < node->mt_id_count; len++)
+			stream_putw(s, node->mt_ids[len]);
 	}
 
 	return 0;
@@ -1690,6 +1719,8 @@ static int ls_format_attributes(struct stream *s, struct ls_attributes *attr)
 		for (len = 0; len < attr->srlg_len; len++)
 			stream_putl(s, attr->srlgs[len]);
 	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_MT_ID))
+		stream_putw(s, attr->mt_id);
 
 	return 0;
 }
@@ -1732,6 +1763,8 @@ static int ls_format_prefix(struct stream *s, struct ls_prefix *ls_pref)
 			stream_putc(s, ls_pref->srv6.arg_len);
 		}
 	}
+	if (CHECK_FLAG(ls_pref->flags, LS_PREF_MT_ID))
+		stream_putw(s, ls_pref->mt_id);
 
 	return 0;
 }

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -112,6 +112,10 @@ extern int ls_node_id_same(struct ls_node_id i1, struct ls_node_id i2);
 #define LS_NODE_MSD		0x0100
 #define LS_NODE_SRV6		0x0200
 #define LS_NODE_ISIS_AREA_ID	0x0400
+#define LS_NODE_MT_IDS		0x0800
+
+/* Maximum number of MT-IDs per node (matches BGP_LS_MAX_MT_ID) */
+#define LS_NODE_MT_IDS_MAX 16
 
 /* Link State Node structure */
 struct ls_node {
@@ -144,6 +148,8 @@ struct ls_node {
 		uint8_t max_h_encaps_msd;
 		uint8_t max_end_d_msd;
 	} srv6_msd;
+	uint8_t mt_id_count;		     /* Number of MT-IDs */
+	uint16_t mt_ids[LS_NODE_MT_IDS_MAX]; /* Multi-Topology IDs (RFC 9552 §5.2.1.4) */
 };
 
 /* Link State flags to indicate which Attribute parameters are valid */
@@ -171,6 +177,7 @@ struct ls_node {
 #define LS_ATTR_AVA_BW		0x00100000U
 #define LS_ATTR_RSV_BW		0x00200000U
 #define LS_ATTR_USE_BW		0x00400000U
+#define LS_ATTR_MT_ID		0x00800000U
 #define LS_ATTR_ADJ_SID		0x01000000U
 #define LS_ATTR_BCK_ADJ_SID	0x02000000U
 #define LS_ATTR_ADJ_SID6	0x04000000U
@@ -247,6 +254,7 @@ struct ls_attributes {
 	} adj_srv6_sid[2];
 	uint32_t *srlgs;	/* List of Shared Risk Link Group */
 	uint8_t srlg_len;	/* number of SRLG in the list */
+	uint16_t mt_id;		/* IS-IS Multi-Topology ID of this link */
 };
 
 /* Link State flags to indicate which Prefix parameters are valid */
@@ -257,6 +265,7 @@ struct ls_attributes {
 #define LS_PREF_METRIC		0x08
 #define LS_PREF_SR		0x10
 #define LS_PREF_SRV6		0x20
+#define LS_PREF_MT_ID		0x40
 
 /* Link State Prefix */
 struct ls_prefix {
@@ -283,6 +292,7 @@ struct ls_prefix {
 		uint8_t fn_len;		/* Function length in bits */
 		uint8_t arg_len;	/* Argument length in bits */
 	} srv6;
+	uint16_t mt_id; /* IS-IS Multi-Topology ID of this prefix */
 };
 
 /**

--- a/tests/topotests/bgp_link_state/r2/bgp_ls_nlri.json
+++ b/tests/topotests/bgp_link_state/r2/bgp_ls_nlri.json
@@ -29,7 +29,13 @@
 						"igpRouterId": "0000.0000.0002"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.1.0/24]]": [
@@ -128,7 +134,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p2.2.2.2/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:0:2::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -154,10 +160,11 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:2::1/128"
+						"ipReachabilityInformation": "fc00:0:2::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:0:2::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]"
 			}
 		],
 		"[V][L2][I0x0][N[s0000.0000.0001]]": [
@@ -186,7 +193,13 @@
 						"igpRouterId": "0000.0000.0001"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0001]][P[p1.1.1.1/32]]": [
@@ -253,7 +266,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.4.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:0:1::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -279,13 +292,14 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:1::1/128"
+						"ipReachabilityInformation": "fc00:0:1::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:0:1::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -311,13 +325,14 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:1::/64"
+						"ipReachabilityInformation": "fc00:10:0:1::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -343,10 +358,11 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:4::/64"
+						"ipReachabilityInformation": "fc00:10:0:4::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.3.0/24]]": [
@@ -439,7 +455,13 @@
 						"igpRouterId": "0000.0000.0003"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0003]][P[p3.3.3.3/32]]": [
@@ -506,7 +528,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:0:3::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -532,13 +554,14 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:3::1/128"
+						"ipReachabilityInformation": "fc00:0:3::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:0:3::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -564,13 +587,14 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:1::/64"
+						"ipReachabilityInformation": "fc00:10:0:1::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -596,10 +620,11 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:2::/64"
+						"ipReachabilityInformation": "fc00:10:0:2::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]": [
@@ -634,7 +659,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -660,10 +685,11 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:5::/64"
+						"ipReachabilityInformation": "fc00:10:0:5::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
 		"[V][L2][I0x0][N[s0000.0000.0004]]": [
@@ -692,7 +718,13 @@
 						"igpRouterId": "0000.0000.0004"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]": [
@@ -727,7 +759,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:0:4::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -753,13 +785,14 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:4::1/128"
+						"ipReachabilityInformation": "fc00:0:4::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:0:4::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -785,10 +818,11 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:2::/64"
+						"ipReachabilityInformation": "fc00:10:0:2::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.4.0/24]]": [
@@ -855,7 +889,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -881,13 +915,14 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:5::/64"
+						"ipReachabilityInformation": "fc00:10:0:5::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -913,10 +948,11 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:4::/64"
+						"ipReachabilityInformation": "fc00:10:0:4::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
 		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[i10.0.1.1][n10.0.1.2]]": [
@@ -1207,7 +1243,7 @@
 				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[i10.0.5.4][n10.0.5.3]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2]]":
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1238,13 +1274,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::1",
-							"ipv6NeighborAddress": "fc00:10:0:1::2"
+							"ipv6NeighborAddress": "fc00:10:0:1::2",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1]]":
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1275,13 +1312,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::2",
-							"ipv6NeighborAddress": "fc00:10:0:1::1"
+							"ipv6NeighborAddress": "fc00:10:0:1::1",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3]]":
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1312,13 +1350,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::2",
-							"ipv6NeighborAddress": "fc00:10:0:2::3"
+							"ipv6NeighborAddress": "fc00:10:0:2::3",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2]]":
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1349,13 +1388,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::3",
-							"ipv6NeighborAddress": "fc00:10:0:2::2"
+							"ipv6NeighborAddress": "fc00:10:0:2::2",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4]]":
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1386,13 +1426,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::1",
-							"ipv6NeighborAddress": "fc00:10:0:4::4"
+							"ipv6NeighborAddress": "fc00:10:0:4::4",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1]]":
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1423,13 +1464,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::4",
-							"ipv6NeighborAddress": "fc00:10:0:4::1"
+							"ipv6NeighborAddress": "fc00:10:0:4::1",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4]]":
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1460,13 +1502,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::3",
-							"ipv6NeighborAddress": "fc00:10:0:5::4"
+							"ipv6NeighborAddress": "fc00:10:0:5::4",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3]]":
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1497,10 +1540,11 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::4",
-							"ipv6NeighborAddress": "fc00:10:0:5::3"
+							"ipv6NeighborAddress": "fc00:10:0:5::3",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]"
 				}
 			]
 	}

--- a/tests/topotests/bgp_link_state/rr/bgp_ls_nlri.json
+++ b/tests/topotests/bgp_link_state/rr/bgp_ls_nlri.json
@@ -30,7 +30,13 @@
 						"igpRouterId": "0000.0000.0002"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0002]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.1.0/24]]": [
@@ -132,7 +138,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[p2.2.2.2/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:0:2::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -159,10 +165,11 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:2::1/128"
+						"ipReachabilityInformation": "fc00:0:2::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:0:2::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:0:2::1/128]]"
 			}
 		],
 		"[V][L2][I0x0][N[s0000.0000.0001]]": [
@@ -192,7 +199,13 @@
 						"igpRouterId": "0000.0000.0001"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0001]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0001]][P[p1.1.1.1/32]]": [
@@ -261,7 +274,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[p10.0.4.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:0:1::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -288,13 +301,14 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:1::1/128"
+						"ipReachabilityInformation": "fc00:0:1::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:0:1::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:0:1::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -321,13 +335,14 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:1::/64"
+						"ipReachabilityInformation": "fc00:10:0:1::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -354,10 +369,11 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:4::/64"
+						"ipReachabilityInformation": "fc00:10:0:4::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0002]][P[p10.0.3.0/24]]": [
@@ -453,7 +469,13 @@
 						"igpRouterId": "0000.0000.0003"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0003]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0003]][P[p3.3.3.3/32]]": [
@@ -522,7 +544,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:0:3::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -549,13 +571,14 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:3::1/128"
+						"ipReachabilityInformation": "fc00:0:3::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:0:3::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:0:3::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:1::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -582,13 +605,14 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:1::/64"
+						"ipReachabilityInformation": "fc00:10:0:1::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:1::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:1::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -615,10 +639,11 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:2::/64"
+						"ipReachabilityInformation": "fc00:10:0:2::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]": [
@@ -654,7 +679,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[p10.0.2.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -681,10 +706,11 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:5::/64"
+						"ipReachabilityInformation": "fc00:10:0:5::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
 		"[V][L2][I0x0][N[s0000.0000.0004]]": [
@@ -714,7 +740,13 @@
 						"igpRouterId": "0000.0000.0004"
 					}
 				},
-				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004]]"
+				"nlriStr": "[V][L2][I0x0][N[s0000.0000.0004]]",
+				"linkStateAttrs": {
+					"multiTopologyIds": [
+						0,
+						2
+					]
+				}
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]": [
@@ -750,7 +782,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p4.4.4.4/32]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:0:4::1/128]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -777,13 +809,14 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:0:4::1/128"
+						"ipReachabilityInformation": "fc00:0:4::1/128",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:0:4::1/128]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:0:4::1/128]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:2::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -810,10 +843,11 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:2::/64"
+						"ipReachabilityInformation": "fc00:10:0:2::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[pfc00:10:0:2::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfc00:10:0:2::/64]]"
 			}
 		],
 		"[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.4.0/24]]": [
@@ -882,7 +916,7 @@
 				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[p10.0.5.0/24]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:5::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -909,13 +943,14 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:5::/64"
+						"ipReachabilityInformation": "fc00:10:0:5::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:5::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:5::/64]]"
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:4::/64]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]": [
 			{
 				"valid": true,
 				"bestpath": true,
@@ -942,10 +977,11 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fc00:10:0:4::/64"
+						"ipReachabilityInformation": "fc00:10:0:4::/64",
+						"multiTopologyId": 2
 					}
 				},
-				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[pfc00:10:0:4::/64]]"
+				"nlriStr": "[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfc00:10:0:4::/64]]"
 			}
 		],
 		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[i10.0.1.1][n10.0.1.2]]": [
@@ -1244,7 +1280,7 @@
 				"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[i10.0.5.4][n10.0.5.3]]"
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2]]":
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1276,13 +1312,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::1",
-							"ipv6NeighborAddress": "fc00:10:0:1::2"
+							"ipv6NeighborAddress": "fc00:10:0:1::2",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:10:0:1::1][nfc00:10:0:1::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1]]":
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1314,13 +1351,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:1::2",
-							"ipv6NeighborAddress": "fc00:10:0:1::1"
+							"ipv6NeighborAddress": "fc00:10:0:1::1",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:10:0:1::2][nfc00:10:0:1::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3]]":
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1352,13 +1390,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::2",
-							"ipv6NeighborAddress": "fc00:10:0:2::3"
+							"ipv6NeighborAddress": "fc00:10:0:2::3",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0003]][L[ifc00:10:0:2::2][nfc00:10:0:2::3][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2]]":
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1390,13 +1429,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:2::3",
-							"ipv6NeighborAddress": "fc00:10:0:2::2"
+							"ipv6NeighborAddress": "fc00:10:0:2::2",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0002]][L[ifc00:10:0:2::3][nfc00:10:0:2::2][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4]]":
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1428,13 +1468,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::1",
-							"ipv6NeighborAddress": "fc00:10:0:4::4"
+							"ipv6NeighborAddress": "fc00:10:0:4::4",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0004]][L[ifc00:10:0:4::1][nfc00:10:0:4::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1]]":
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1466,13 +1507,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:4::4",
-							"ipv6NeighborAddress": "fc00:10:0:4::1"
+							"ipv6NeighborAddress": "fc00:10:0:4::1",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0001]][L[ifc00:10:0:4::4][nfc00:10:0:4::1][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4]]":
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1504,13 +1546,14 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::3",
-							"ipv6NeighborAddress": "fc00:10:0:5::4"
+							"ipv6NeighborAddress": "fc00:10:0:5::4",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0004]][L[ifc00:10:0:5::3][nfc00:10:0:5::4][t0x0002]]"
 				}
 			],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3]]":
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]":
 			[
 				{
 					"valid": true,
@@ -1542,10 +1585,11 @@
 						},
 						"linkDescriptors": {
 							"ipv6InterfaceAddress": "fc00:10:0:5::4",
-							"ipv6NeighborAddress": "fc00:10:0:5::3"
+							"ipv6NeighborAddress": "fc00:10:0:5::3",
+							"multiTopologyId": 2
 						}
 					},
-					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3]]"
+					"nlriStr": "[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0003]][L[ifc00:10:0:5::4][nfc00:10:0:5::3][t0x0002]]"
 				}
 			]
 	}

--- a/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
+++ b/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
@@ -11,7 +11,11 @@
 				"linkStateAttrs": {
 					"srv6Capabilities": {
 						"flags": "0x0"
-					}
+					},
+					"multiTopologyIds": [
+						0,
+						2
+					]
 				}
 			}
 		],
@@ -26,7 +30,11 @@
 				"linkStateAttrs": {
 					"srv6Capabilities": {
 						"flags": "0x0"
-					}
+					},
+					"multiTopologyIds": [
+						0,
+						2
+					]
 				}
 			}
 		],
@@ -41,7 +49,11 @@
 				"linkStateAttrs": {
 					"srv6Capabilities": {
 						"flags": "0x0"
-					}
+					},
+					"multiTopologyIds": [
+						0,
+						2
+					]
 				}
 			}
 		],
@@ -56,7 +68,11 @@
 				"linkStateAttrs": {
 					"srv6Capabilities": {
 						"flags": "0x0"
-					}
+					},
+					"multiTopologyIds": [
+						0,
+						2
+					]
 				}
 			}
 		],
@@ -71,11 +87,15 @@
 				"linkStateAttrs": {
 					"srv6Capabilities": {
 						"flags": "0x0"
-					}
+					},
+					"multiTopologyIds": [
+						0,
+						2
+					]
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0001]][P[pfcbb:bbbb:1::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0001]][P[t0x0002][pfcbb:bbbb:1::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
@@ -83,7 +103,8 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fcbb:bbbb:1::/48"
+						"ipReachabilityInformation": "fcbb:bbbb:1::/48",
+						"multiTopologyId": 2
 					}
 				},
 				"linkStateAttrs": {
@@ -95,7 +116,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0002]][P[pfcbb:bbbb:2::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0002]][P[t0x0002][pfcbb:bbbb:2::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
@@ -103,7 +124,8 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fcbb:bbbb:2::/48"
+						"ipReachabilityInformation": "fcbb:bbbb:2::/48",
+						"multiTopologyId": 2
 					}
 				},
 				"linkStateAttrs": {
@@ -115,7 +137,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0003]][P[pfcbb:bbbb:3::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0003]][P[t0x0002][pfcbb:bbbb:3::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
@@ -123,7 +145,8 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fcbb:bbbb:3::/48"
+						"ipReachabilityInformation": "fcbb:bbbb:3::/48",
+						"multiTopologyId": 2
 					}
 				},
 				"linkStateAttrs": {
@@ -135,7 +158,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0004]][P[pfcbb:bbbb:4::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0004]][P[t0x0002][pfcbb:bbbb:4::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
@@ -143,7 +166,8 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fcbb:bbbb:4::/48"
+						"ipReachabilityInformation": "fcbb:bbbb:4::/48",
+						"multiTopologyId": 2
 					}
 				},
 				"linkStateAttrs": {
@@ -155,7 +179,7 @@
 				}
 			}
 		],
-		"[T][L2][I0x0][N[s0000.0000.0005]][P[pfcbb:bbbb:5::/48]]": [
+		"[T][L2][I0x0][N[s0000.0000.0005]][P[t0x0002][pfcbb:bbbb:5::/48]]": [
 			{
 				"nlri": {
 					"nlriType": "ipv6Prefix",
@@ -163,7 +187,8 @@
 						"igpRouterId": "0000.0000.0005"
 					},
 					"prefixDescriptors": {
-						"ipReachabilityInformation": "fcbb:bbbb:5::/48"
+						"ipReachabilityInformation": "fcbb:bbbb:5::/48",
+						"multiTopologyId": 2
 					}
 				},
 				"linkStateAttrs": {
@@ -175,7 +200,7 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0001]][S[sdfcbb:bbbb:1::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0001]][S[t0x0002][sdfcbb:bbbb:1::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
@@ -183,7 +208,10 @@
 						"igpRouterId": "0000.0000.0001"
 					},
 					"srv6SidDescriptors": {
-						"srv6SidValue": "fcbb:bbbb:1::"
+						"srv6SidValue": "fcbb:bbbb:1::",
+						"multiTopologyId": [
+							2
+						]
 					}
 				},
 				"linkStateAttrs": {
@@ -201,7 +229,7 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0002]][S[sdfcbb:bbbb:2::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0002]][S[t0x0002][sdfcbb:bbbb:2::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
@@ -209,7 +237,10 @@
 						"igpRouterId": "0000.0000.0002"
 					},
 					"srv6SidDescriptors": {
-						"srv6SidValue": "fcbb:bbbb:2::"
+						"srv6SidValue": "fcbb:bbbb:2::",
+						"multiTopologyId": [
+							2
+						]
 					}
 				},
 				"linkStateAttrs": {
@@ -227,7 +258,7 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0003]][S[sdfcbb:bbbb:3::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0003]][S[t0x0002][sdfcbb:bbbb:3::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
@@ -235,7 +266,10 @@
 						"igpRouterId": "0000.0000.0003"
 					},
 					"srv6SidDescriptors": {
-						"srv6SidValue": "fcbb:bbbb:3::"
+						"srv6SidValue": "fcbb:bbbb:3::",
+						"multiTopologyId": [
+							2
+						]
 					}
 				},
 				"linkStateAttrs": {
@@ -253,7 +287,7 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0004]][S[sdfcbb:bbbb:4::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0004]][S[t0x0002][sdfcbb:bbbb:4::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
@@ -261,7 +295,10 @@
 						"igpRouterId": "0000.0000.0004"
 					},
 					"srv6SidDescriptors": {
-						"srv6SidValue": "fcbb:bbbb:4::"
+						"srv6SidValue": "fcbb:bbbb:4::",
+						"multiTopologyId": [
+							2
+						]
 					}
 				},
 				"linkStateAttrs": {
@@ -279,7 +316,7 @@
 				}
 			}
 		],
-		"[S][L2][I0x0][N[s0000.0000.0005]][S[sdfcbb:bbbb:5::]]": [
+		"[S][L2][I0x0][N[s0000.0000.0005]][S[t0x0002][sdfcbb:bbbb:5::]]": [
 			{
 				"nlri": {
 					"nlriType": "srv6Sid",
@@ -287,7 +324,10 @@
 						"igpRouterId": "0000.0000.0005"
 					},
 					"srv6SidDescriptors": {
-						"srv6SidValue": "fcbb:bbbb:5::"
+						"srv6SidValue": "fcbb:bbbb:5::",
+						"multiTopologyId": [
+							2
+						]
 					}
 				},
 				"linkStateAttrs": {
@@ -305,425 +345,439 @@
 				}
 			}
 		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:1::1][nfc00:1::2]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
-					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:1:e001::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
-							}
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0002]][L[ifc00:1::1][nfc00:1::2][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0001"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0002"
 						}
-					]
-				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:1::2][nfc00:1::1]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:2:e001::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:1:e001::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:2::2][nfc00:2::4]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0001]][L[ifc00:1::2][nfc00:1::1][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0002"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0001"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:2:e002::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:2:e001::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:2::4][nfc00:2::2]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:2::2][nfc00:2::4][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0002"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0004"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:4:e001::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:2:e002::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:3::2][nfc00:3::4]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:2::4][nfc00:2::2][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0004"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0002"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:2:e003::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:4:e001::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:3::4][nfc00:3::2]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0002]][R[s0000.0000.0004]][L[ifc00:3::2][nfc00:3::4][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0002"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0004"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0002"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:4:e000::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:2:e003::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:4::3][nfc00:4::5]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0002]][L[ifc00:3::4][nfc00:3::2][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0004"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0002"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:3:e002::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:4:e000::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:4::5][nfc00:4::3]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:4::3][nfc00:4::5][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0003"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0005"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:5:e000::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:3:e002::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:5::3][nfc00:5::5]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:4::5][nfc00:4::3][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0005"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0003"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:3:e003::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:5:e000::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:5::5][nfc00:5::3]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0005]][L[ifc00:5::3][nfc00:5::5][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0003"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0005"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:5:e001::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:3:e003::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0005]][L[ifc00:6::4][nfc00:6::5]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0003]][L[ifc00:5::5][nfc00:5::3][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0005"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0003"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:4:e002::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:5:e001::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0004]][L[ifc00:6::5][nfc00:6::4]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0005"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0004]][R[s0000.0000.0005]][L[ifc00:6::4][nfc00:6::5][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0004"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0005"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0004"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:5:e002::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:4:e002::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0003]][L[ifc00:7::1][nfc00:7::2]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0005]][R[s0000.0000.0004]][L[ifc00:6::5][nfc00:6::4][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0005"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0004"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:1:e001::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:5:e002::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		],
-		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0001]][L[ifc00:7::2][nfc00:7::1]]": [
-			{
-				"nlri": {
-					"nlriType": "link",
-					"localNodeDescriptors": {
-						"igpRouterId": "0000.0000.0003"
+			],
+		"[E][L2][I0x0][N[s0000.0000.0001]][R[s0000.0000.0003]][L[ifc00:7::1][nfc00:7::2][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0001"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0003"
+						}
 					},
-					"remoteNodeDescriptors": {
-						"igpRouterId": "0000.0000.0001"
-					}
-				},
-				"linkStateAttrs": {
-					"srv6EndxSids": [
-						{
-							"sid": "fcbb:bbbb:3:e001::",
-							"behavior": "0x34",
-							"flags": "0x0",
-							"algo": 0,
-							"weight": 0,
-							"srv6SidStructure": {
-								"lbLen": 32,
-								"lnLen": 16,
-								"funLen": 16,
-								"argLen": 0
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:1:e001::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
 							}
-						}
-					]
+						]
+					}
 				}
-			}
-		]
+			],
+		"[E][L2][I0x0][N[s0000.0000.0003]][R[s0000.0000.0001]][L[ifc00:7::2][nfc00:7::1][t0x0002]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"localNodeDescriptors": {
+							"igpRouterId": "0000.0000.0003"
+						},
+						"remoteNodeDescriptors": {
+							"igpRouterId": "0000.0000.0001"
+						}
+					},
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:3:e001::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
+							}
+						]
+					}
+				}
+			]
 	}
 }


### PR DESCRIPTION
RFC 9552 defines how Multi-Topology ID (MT-ID) is carried in BGP-LS:

- For Node NLRI, MT-ID is carried in the BGP-LS Attribute.
- For Link and Prefix NLRIs, MT-ID is carried in descriptors and is **MANDATORY** when the link or prefix belongs to a non-default topology.
 
Today, IS-IS can learn multi-topology information, but MT-ID is not propagated end-to-end through the BGP-LS pipeline. Link and Prefix NLRIs for non-default topologies are advertised without MT-ID in their descriptors, **violating RFC 9552 §5.2.2.1 and §5.2.3**. Additionally, Node NLRI attributes do not carry MT-ID information. As a result, BGP-LS consumers cannot identify which topology each link or prefix belongs to.

This PR implements RFC 9552-compliant Multi-Topology ID propagation throughout the BGP-LS pipeline, ensuring that Node, Link, Prefix, and SRv6 SID NLRIs correctly advertise MT-ID when applicable.