### PR TITLE
zebra: fix DVNI route encap type for IPv6 VTEPs

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1747,6 +1747,7 @@ static bool _netlink_route_encode_label_info(const struct nexthop *nexthop,
 	struct rtattr *nest;
 	struct mpls_label_stack *nh_label;
 	enum lsp_types_t nh_label_type;
+	enum lwtunnel_encap_types encap_type = LWTUNNEL_ENCAP_IP;
 
 	nh_label = nexthop->nh_label;
 	nh_label_type = nexthop->nh_label_type;
@@ -1763,8 +1764,12 @@ static bool _netlink_route_encode_label_info(const struct nexthop *nexthop,
 				       label_buf, label_buf_size);
 
 	if (num_labels && nh_label_type == ZEBRA_LSP_EVPN) {
+		if (nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX &&
+		    !IS_MAPPED_IPV6(&nexthop->gate.ipv6))
+			encap_type = LWTUNNEL_ENCAP_IP6;
+
 		if (!nl_attr_put16(nlmsg, buflen, RTA_ENCAP_TYPE,
-				   LWTUNNEL_ENCAP_IP))
+				   encap_type))
 			return false;
 
 		nest = nl_attr_nest(nlmsg, buflen, RTA_ENCAP);


### PR DESCRIPTION
_netlink_route_encode_label_info() hardcodes RTA_ENCAP_TYPE to LWTUNNEL_ENCAP_IP when encoding DVNI labels in route messages. For IPv6 VTEPs this causes the kernel to misinterpret the 16-byte IPv6 tunnel destination as a 4-byte IPv4 address, resulting in a corrupt nexthop dst and also programming route with incorrect encap type:

Fixed by selecting the encap type based on the nexthop address family, use LWTUNNEL_ENCAP_IP6 for pure IPv6 nexthops, LWTUNNEL_ENCAP_IP for IPv4 and IPv4-mapped-IPv6 nexthops.

```
brleaf1# show ip route vrf service_1 27.0.0.21
Routing entry for 27.0.0.21/32
  Known via "bgp", distance 20, metric 0, vrf service_1, best
  Last update 00:05:41 ago
  Flags: Selected
  Status: Installed
  * 2001:11::2, via vxlan99(vrf default) onlink, label 6000001, weight 1
```
Before Fix:
```
ip route show table all | grep 27.0.0.21
27.0.0.21  encap ip id 6000001 src 0.0.0.0 dst 32.1.0.17 ttl 0 tos 0 via inet6 2001:11::2 dev vxlan99 table service_1 proto bgp metric 20 onlink
```
After Fix:
```
ip route show table all | grep 27.0.0.21
27.0.0.21  encap ip6 id 6000001 src :: dst 2001:11::2 hoplimit 0 tc 0 via inet6 2001:11::2 dev vxlan99 table service_1 proto bgp metric 20 onlink
```