### PR TITLE
bgpd: Fix missing SRv6 advertisement with `distribute bgp-fabric-link-state`

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -1758,6 +1758,66 @@ int bgp_ls_delete_bgp_link_srv6_endx_sid(struct bgp *bgp, const struct in6_addr 
 }
 
 /*
+ * Originate BGP Prefix NLRI - Helper
+ *
+ * Internal helper for originating prefix NLRIs. Handles common prefix
+ * origination logic used by both BGP route prefixes and SRv6 locator prefixes.
+ *
+ * @param bgp - BGP instance
+ * @param afi - Address family (AFI_IP or AFI_IP6)
+ * @param prefix - Prefix to originate
+ * @param route_type - BGP-LS route type for prefix descriptor
+ * @param ls_attr - Optional BGP-LS attributes (NULL if none)
+ * @return 0 on success, -1 on failure
+ */
+static int bgp_ls_originate_prefix_internal(struct bgp *bgp, afi_t afi, const struct prefix *prefix,
+					    enum bgp_ls_bgp_route_type route_type,
+					    struct bgp_ls_attr *ls_attr)
+{
+	struct bgp_ls_nlri *nlri;
+	int ret;
+
+	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution || !prefix)
+		return -1;
+
+	nlri = bgp_ls_nlri_alloc();
+
+	/* Set NLRI type and protocol */
+	if (afi == AFI_IP)
+		nlri->nlri_type = BGP_LS_NLRI_TYPE_IPV4_PREFIX;
+	else if (afi == AFI_IP6)
+		nlri->nlri_type = BGP_LS_NLRI_TYPE_IPV6_PREFIX;
+	else {
+		bgp_ls_nlri_free(nlri);
+		return -1;
+	}
+
+	nlri->nlri_data.prefix.protocol_id = BGP_LS_PROTO_BGP;
+	nlri->nlri_data.prefix.identifier = bgp->ls_info->instance_id;
+
+	/* Local Node Descriptor */
+	nlri->nlri_data.prefix.local_node.asn = bgp->as;
+	SET_FLAG(nlri->nlri_data.prefix.local_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
+
+	nlri->nlri_data.prefix.local_node.bgp_router_id = bgp->router_id;
+	SET_FLAG(nlri->nlri_data.prefix.local_node.present_tlvs,
+		 BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	/* Prefix Descriptor */
+	nlri->nlri_data.prefix.prefix_desc.bgp_route_type = route_type;
+	SET_FLAG(nlri->nlri_data.prefix.prefix_desc.present_tlvs,
+		 BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT);
+
+	prefix_copy(&nlri->nlri_data.prefix.prefix_desc.prefix, prefix);
+	SET_FLAG(nlri->nlri_data.prefix.prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_IP_REACH_BIT);
+
+	ret = bgp_ls_update(bgp, nlri, ls_attr);
+	bgp_ls_nlri_free(nlri);
+
+	return ret;
+}
+
+/*
  * Originate BGP Prefix NLRI
  *
  * Reference: draft-ietf-idr-bgp-ls-bgp-only-fabric-04 Section 4.3
@@ -1774,9 +1834,8 @@ int bgp_ls_delete_bgp_link_srv6_endx_sid(struct bgp *bgp, const struct in6_addr 
 int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *dest,
 				struct bgp_path_info *path)
 {
-	struct bgp_ls_nlri *nlri;
 	const struct prefix *p;
-	int ret;
+	enum bgp_ls_bgp_route_type route_type;
 
 	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution)
 		return 0;
@@ -1796,63 +1855,22 @@ int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct 
 		return -1;
 	}
 
-	nlri = bgp_ls_nlri_alloc();
-
-	/* Set NLRI type and protocol */
-	if (afi == AFI_IP)
-		nlri->nlri_type = BGP_LS_NLRI_TYPE_IPV4_PREFIX;
-	else if (afi == AFI_IP6)
-		nlri->nlri_type = BGP_LS_NLRI_TYPE_IPV6_PREFIX;
-	else {
-		zlog_err("BGP-LS: Unsupported AFI %d for BGP prefix", afi);
-		bgp_ls_nlri_free(nlri);
-		return -1;
-	}
-
-	nlri->nlri_data.prefix.protocol_id = BGP_LS_PROTO_BGP;
-	nlri->nlri_data.prefix.identifier = bgp->ls_info->instance_id;
-
-	/* Local Node Descriptor */
-	/* TLV 512: Autonomous System Number */
-	nlri->nlri_data.prefix.local_node.asn = bgp->as;
-	SET_FLAG(nlri->nlri_data.prefix.local_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
-
-	/* TLV 516: BGP Router-ID */
-	nlri->nlri_data.prefix.local_node.bgp_router_id = bgp->router_id;
-	SET_FLAG(nlri->nlri_data.prefix.local_node.present_tlvs,
-		 BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
-
-	/* Prefix Descriptor */
-	/* TLV 267: BGP Route Type */
+	/* Determine BGP route type */
 	if (path->type == ZEBRA_ROUTE_LOCAL)
-		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_LOCAL;
+		route_type = BGP_LS_BGP_RT_LOCAL;
 	else if (path->type == ZEBRA_ROUTE_CONNECT)
-		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_ATTACHED;
+		route_type = BGP_LS_BGP_RT_ATTACHED;
 	else if (path->type == ZEBRA_ROUTE_BGP && path->peer && path->peer->sort == BGP_PEER_EBGP)
-		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_EXTERNAL_BGP;
+		route_type = BGP_LS_BGP_RT_EXTERNAL_BGP;
 	else if (path->type == ZEBRA_ROUTE_BGP && path->peer && path->peer->sort == BGP_PEER_IBGP)
-		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_INTERNAL_BGP;
+		route_type = BGP_LS_BGP_RT_INTERNAL_BGP;
 	else
-		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_REDISTRIBUTED;
-	SET_FLAG(nlri->nlri_data.prefix.prefix_desc.present_tlvs,
-		 BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT);
-
-	/* TLV 265: IP Reachability Information */
-	nlri->nlri_data.prefix.prefix_desc.prefix = *p;
-	SET_FLAG(nlri->nlri_data.prefix.prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_IP_REACH_BIT);
-
-	ret = bgp_ls_update(bgp, nlri, NULL);
-	if (ret != 0) {
-		zlog_err("BGP-LS: Failed to originate BGP prefix NLRI for %pFX", p);
-		bgp_ls_nlri_free(nlri);
-		return -1;
-	}
+		route_type = BGP_LS_BGP_RT_REDISTRIBUTED;
 
 	if (BGP_DEBUG(linkstate, LINKSTATE))
-		zlog_debug("BGP-LS: Originated BGP Prefix NLRI for %pFX", p);
+		zlog_debug("BGP-LS: Originating BGP Prefix NLRI for %pFX", p);
 
-	bgp_ls_nlri_free(nlri);
-	return 0;
+	return bgp_ls_originate_prefix_internal(bgp, afi, p, route_type, NULL);
 }
 
 /*

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -1068,6 +1068,14 @@ void bgp_ls_cleanup(struct bgp *bgp)
 	zlog_info("BGP-LS: Module terminated for instance %s", bgp->name_pretty);
 }
 
+static bool bgp_ls_has_srv6_capability(const struct bgp *bgp)
+{
+	if (!bgp || !bgp->ls_info)
+		return false;
+
+	return bgp->ls_info->srv6_locator_nlri_count > 0;
+}
+
 static struct bgp_ls_static_endx_sid *
 bgp_ls_static_endx_sid_lookup(struct bgp *bgp, const struct in6_addr *sid, uint8_t prefixlen)
 {
@@ -1351,6 +1359,11 @@ int bgp_ls_originate_bgp_node(struct bgp *bgp)
 	/* TLV 1026: Node Name */
 	ls_attr->node_name = XSTRDUP(MTYPE_BGP_LS_ATTR, bgp->peer_self->host);
 	SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_NODE_NAME_BIT);
+
+	if (bgp_ls_has_srv6_capability(bgp)) {
+		ls_attr->srv6_cap_flags = 0;
+		SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_CAPABILITIES_BIT);
+	}
 
 	ret = bgp_ls_update(bgp, nlri, ls_attr);
 	if (ret != 0) {

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -26,6 +26,8 @@
 DEFINE_MTYPE_STATIC(BGPD, BGP_LS, "BGP-LS instance");
 
 static int bgp_ls_refresh_bgp_link_endx_attrs(struct bgp *bgp, struct peer *peer);
+static struct bgp_ls_nlri *bgp_ls_lookup_bgp_prefix_nlri(struct bgp *bgp, const struct prefix *p,
+							 enum bgp_ls_bgp_route_type route_type);
 
 void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct prefix *p, afi_t afi,
 					uint8_t type, unsigned short instance,
@@ -1873,6 +1875,122 @@ int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct 
 	return bgp_ls_originate_prefix_internal(bgp, afi, p, route_type, NULL);
 }
 
+int bgp_ls_originate_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locator *locator)
+{
+	struct bgp_ls_attr *ls_attr;
+	struct bgp_ls_nlri *existing_nlri;
+	bool had_srv6_cap;
+	bool is_new_locator_nlri;
+	int ret;
+
+	if (!bgp || !bgp->ls_info || !locator)
+		return -1;
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS [locator]: entry instance=%s locator=%s prefix=%pFX algo=%u",
+			   bgp->name_pretty, locator->name, &locator->prefix, locator->algonum);
+
+	if (!bgp->ls_info->enable_distribution) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS [locator]: skipping locator %s because distribution is disabled",
+				   locator->name);
+		return 0;
+	}
+
+	if (locator->prefix.family != AF_INET6) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS [locator]: skipping locator %s because family=%u is not IPv6",
+				   locator->name, locator->prefix.family);
+		return 0;
+	}
+
+	had_srv6_cap = bgp_ls_has_srv6_capability(bgp);
+	existing_nlri = bgp_ls_lookup_bgp_prefix_nlri(bgp, (const struct prefix *)&locator->prefix,
+						      BGP_LS_BGP_RT_LOCAL);
+	is_new_locator_nlri = (existing_nlri == NULL);
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS [locator]: advertising locator %s prefix=%pFX algo=%u",
+			   locator->name, &locator->prefix, locator->algonum);
+
+	/* Prepare SRv6 locator attributes */
+	ls_attr = bgp_ls_attr_alloc();
+	ls_attr->srv6_locator_flags = 0;
+	ls_attr->srv6_locator_algo = locator->algonum;
+	ls_attr->srv6_locator_metric = 0;
+	SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_LOCATOR_BIT);
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS [locator]: update prefix=%pFX route_type=0x%02x algo=%u attr_present=0x%llx",
+			   &locator->prefix, BGP_LS_BGP_RT_LOCAL, locator->algonum,
+			   (unsigned long long)ls_attr->present_tlvs);
+
+	/* Originate prefix NLRI with SRv6 locator attributes */
+	ret = bgp_ls_originate_prefix_internal(bgp, AFI_IP6,
+					       (const struct prefix *)&locator->prefix,
+					       BGP_LS_BGP_RT_LOCAL, ls_attr);
+	bgp_ls_attr_free(ls_attr);
+
+	if (ret != 0) {
+		zlog_err("BGP-LS: Failed to originate SRv6 locator prefix NLRI for %pFX",
+			 &locator->prefix);
+		return -1;
+	}
+
+	if (is_new_locator_nlri)
+		bgp->ls_info->srv6_locator_nlri_count++;
+
+	if (!had_srv6_cap)
+		ret = bgp_ls_originate_bgp_node(bgp);
+
+	if (!had_srv6_cap && BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS [locator]: node re-originate for SRv6 capability ret=%d", ret);
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS [locator]: originated locator prefix NLRI for %s",
+			   locator->name);
+
+	return 0;
+}
+
+int bgp_ls_withdraw_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locator *locator)
+{
+	struct bgp_ls_nlri *nlri;
+	int ret;
+	bool had_srv6_cap;
+
+	if (!bgp || !bgp->ls_info || !locator)
+		return -1;
+
+	if (!bgp->ls_info->enable_distribution)
+		return 0;
+
+	if (locator->prefix.family != AF_INET6)
+		return 0;
+
+	nlri = bgp_ls_lookup_bgp_prefix_nlri(bgp, (const struct prefix *)&locator->prefix,
+					     BGP_LS_BGP_RT_LOCAL);
+	if (!nlri)
+		return 0;
+
+	had_srv6_cap = bgp_ls_has_srv6_capability(bgp);
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS [locator]: withdrawn locator prefix NLRI for %s", locator->name);
+
+	ret = bgp_ls_withdraw(bgp, nlri);
+	if (ret != 0)
+		return ret;
+
+	if (bgp->ls_info->srv6_locator_nlri_count > 0)
+		bgp->ls_info->srv6_locator_nlri_count--;
+
+	if (bgp->ls_info->srv6_locator_nlri_count == 0 && had_srv6_cap)
+		bgp_ls_originate_bgp_node(bgp);
+
+	return 0;
+}
+
 /*
  * Export BGP topology as BGP-LS NLRIs.
  *
@@ -1972,6 +2090,8 @@ void bgp_ls_withdraw_all(struct bgp *bgp)
 
 		bgp_ls_withdraw(bgp, nlri);
 	}
+
+	bgp->ls_info->srv6_locator_nlri_count = 0;
 }
 
 static struct bgp_ls_nlri *bgp_ls_lookup_bgp_link_nlri(struct bgp *bgp, struct peer *peer)

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -25,6 +25,70 @@
 
 DEFINE_MTYPE_STATIC(BGPD, BGP_LS, "BGP-LS instance");
 
+void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct prefix *p, afi_t afi,
+					uint8_t type, unsigned short instance,
+					uint32_t seg6local_action,
+					const struct seg6local_context *seg6local_ctx, bool is_add)
+{
+	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution)
+		return;
+
+	if (afi != AFI_IP6 || type != ZEBRA_ROUTE_STATIC)
+		return;
+
+	if (!is_add) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("%s: BGP-LS localsid delete %pFX type=%s(%u) instance=%u",
+				   __func__, p, zebra_route_string(type), type, instance);
+
+		bgp_ls_withdraw_static_srv6_sid(bgp, &p->u.prefix6, p->prefixlen);
+		return;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("%s: BGP-LS localsid add %pFX type=%s(%u) instance=%u action=%u ctx=%s",
+			   __func__, p, zebra_route_string(type), type, instance, seg6local_action,
+			   seg6local_ctx ? "set" : "unset");
+
+	if (seg6local_action == ZEBRA_SEG6_LOCAL_ACTION_UNSPEC || !seg6local_ctx)
+		return;
+
+	if (seg6local_action == ZEBRA_SEG6_LOCAL_ACTION_END)
+		bgp_ls_originate_static_srv6_sid_from_seg6local(bgp, &p->u.prefix6, p->prefixlen,
+								seg6local_action, seg6local_ctx);
+}
+
+/*
+ * BGP-LS Route Handler - Add
+ *
+ * Abstraction layer for route redistribution events. Handles BGP-LS concerns
+ * including SRv6 localsid updates from route add events.
+ */
+int bgp_ls_handle_route_add(struct bgp *bgp, const struct prefix *p, afi_t afi, uint8_t type,
+			    unsigned short instance, uint32_t seg6local_action,
+			    const struct seg6local_context *seg6local_ctx)
+{
+	/* Delegate SRv6 localsid handling to BGP-LS layer */
+	bgp_ls_handle_srv6_localsid_update(bgp, p, afi, type, instance, seg6local_action,
+					   seg6local_ctx, true);
+	return 0;
+}
+
+/*
+ * BGP-LS Route Handler - Delete
+ *
+ * Abstraction layer for route redistribution events. Handles BGP-LS concerns
+ * including SRv6 localsid updates from route delete events.
+ */
+int bgp_ls_handle_route_delete(struct bgp *bgp, const struct prefix *p, afi_t afi, uint8_t type,
+			       unsigned short instance)
+{
+	/* Delegate SRv6 localsid handling to BGP-LS layer */
+	bgp_ls_handle_srv6_localsid_update(bgp, p, afi, type, instance,
+					   ZEBRA_SEG6_LOCAL_ACTION_UNSPEC, NULL, false);
+	return 0;
+}
+
 /*
  * Helper Functions for NLRI Formatting
  */
@@ -962,6 +1026,179 @@ void bgp_ls_cleanup(struct bgp *bgp)
 	XFREE(MTYPE_BGP_LS, bgp->ls_info);
 
 	zlog_info("BGP-LS: Module terminated for instance %s", bgp->name_pretty);
+}
+
+static uint16_t bgp_ls_seg6local_to_srv6_behavior(uint32_t action,
+						  const struct seg6local_context *ctx)
+{
+	bool next_csid = (ctx && seg6local_has_next_csid(ctx));
+	bool psp = (ctx && CHECK_SRV6_FLV_OP(ctx->flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP));
+	bool usd = (ctx && CHECK_SRV6_FLV_OP(ctx->flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_USD));
+
+	switch (action) {
+	case ZEBRA_SEG6_LOCAL_ACTION_END:
+		if (next_csid) {
+			if (psp && usd)
+				return SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD;
+			if (psp)
+				return SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP;
+			return SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID;
+		}
+		if (psp && usd)
+			return SRV6_ENDPOINT_BEHAVIOR_END_PSP_USD;
+		if (psp)
+			return SRV6_ENDPOINT_BEHAVIOR_END_PSP;
+		return SRV6_ENDPOINT_BEHAVIOR_END;
+	default:
+		return SRV6_ENDPOINT_BEHAVIOR_RESERVED;
+	}
+}
+
+static bool bgp_ls_static_srv6_behavior_allowed(uint16_t behavior)
+{
+	switch (behavior) {
+	case SRV6_ENDPOINT_BEHAVIOR_END:
+	case SRV6_ENDPOINT_BEHAVIOR_END_PSP:
+	case SRV6_ENDPOINT_BEHAVIOR_END_PSP_USD:
+	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID:
+	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP:
+	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static int bgp_ls_originate_static_srv6_sid(struct bgp *bgp, const struct in6_addr *sid,
+					    uint8_t prefixlen, uint16_t behavior, uint8_t lb_len,
+					    uint8_t ln_len, uint8_t fn_len, uint8_t arg_len)
+{
+	struct bgp_ls_nlri nlri;
+	struct bgp_ls_attr *ls_attr;
+	int ret;
+
+	if (!bgp || !sid)
+		return -1;
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: originate_static_srv6_sid %pI6/%u behavior=0x%04x lb=%u ln=%u fn=%u arg=%u",
+			   sid, prefixlen, behavior, lb_len, ln_len, fn_len, arg_len);
+
+	if (!bgp_ls_static_srv6_behavior_allowed(behavior)) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS: behavior 0x%04x NOT in allowed list - skipping %pI6/%u",
+				   behavior, sid, prefixlen);
+		return 0;
+	}
+
+	memset(&nlri, 0, sizeof(nlri));
+	nlri.nlri_type = BGP_LS_NLRI_TYPE_SRV6_SID;
+	nlri.nlri_data.srv6_sid.protocol_id = BGP_LS_PROTO_STATIC;
+	nlri.nlri_data.srv6_sid.identifier = bgp->ls_info->instance_id;
+
+	nlri.nlri_data.srv6_sid.local_node.bgp_router_id = bgp->router_id;
+	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs,
+		 BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, sid);
+
+	ls_attr = bgp_ls_attr_alloc();
+	ls_attr->srv6_endpoint_behavior = behavior;
+	ls_attr->srv6_endpoint_flags = 0;
+	ls_attr->srv6_endpoint_algo = 0;
+	SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDPOINT_BEHAVIOR_BIT);
+
+	if (lb_len || ln_len || fn_len || arg_len) {
+		ls_attr->srv6_sid_structure.lb_len = lb_len;
+		ls_attr->srv6_sid_structure.ln_len = ln_len;
+		ls_attr->srv6_sid_structure.fun_len = fn_len;
+		ls_attr->srv6_sid_structure.arg_len = arg_len;
+		SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_SID_STRUCTURE_BIT);
+	}
+
+	ret = bgp_ls_update(bgp, &nlri, ls_attr);
+	bgp_ls_attr_free(ls_attr);
+	if (ret < 0) {
+		flog_err(EC_BGP_LS_PACKET, "BGP-LS: Failed to originate static SRv6 SID NLRI");
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Originated static SRv6 SID NLRI %pI6/%u behavior 0x%04x", sid,
+			   prefixlen, behavior);
+
+	return 0;
+}
+
+int bgp_ls_originate_static_srv6_sid_from_seg6local(struct bgp *bgp, const struct in6_addr *sid,
+						    uint8_t prefixlen, uint32_t action,
+						    const struct seg6local_context *ctx)
+{
+	uint16_t behavior;
+	uint8_t lb_len = 0;
+	uint8_t ln_len = 0;
+	uint8_t fn_len = 0;
+	uint8_t arg_len = 0;
+
+	if (!bgp || !sid)
+		return -1;
+
+	behavior = bgp_ls_seg6local_to_srv6_behavior(action, ctx);
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: _from_seg6local %pI6/%u action=%u -> behavior=0x%04x", sid,
+			   prefixlen, action, behavior);
+
+	if (behavior == SRV6_ENDPOINT_BEHAVIOR_RESERVED) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS: %pI6/%u action=%u mapped to RESERVED - skipping", sid,
+				   prefixlen, action);
+		return 0;
+	}
+
+	if (ctx) {
+		lb_len = ctx->block_len;
+		ln_len = ctx->node_len;
+		fn_len = ctx->function_len;
+		arg_len = ctx->argument_len;
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS: %pI6/%u SID structure lb=%u ln=%u fn=%u arg=%u", sid,
+				   prefixlen, lb_len, ln_len, fn_len, arg_len);
+	}
+
+	return bgp_ls_originate_static_srv6_sid(bgp, sid, prefixlen, behavior, lb_len, ln_len,
+						fn_len, arg_len);
+}
+
+int bgp_ls_withdraw_static_srv6_sid(struct bgp *bgp, const struct in6_addr *sid, uint8_t prefixlen)
+{
+	struct bgp_ls_nlri nlri;
+	int ret;
+
+	if (!bgp || !sid)
+		return -1;
+
+	memset(&nlri, 0, sizeof(nlri));
+	nlri.nlri_type = BGP_LS_NLRI_TYPE_SRV6_SID;
+	nlri.nlri_data.srv6_sid.protocol_id = BGP_LS_PROTO_STATIC;
+	nlri.nlri_data.srv6_sid.identifier = bgp->ls_info->instance_id;
+
+	nlri.nlri_data.srv6_sid.local_node.bgp_router_id = bgp->router_id;
+	SET_FLAG(nlri.nlri_data.srv6_sid.local_node.present_tlvs,
+		 BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	IPV6_ADDR_COPY(&nlri.nlri_data.srv6_sid.sid_desc.sid, sid);
+
+	ret = bgp_ls_withdraw(bgp, &nlri);
+	if (ret < 0) {
+		flog_err(EC_BGP_LS_PACKET, "BGP-LS: Failed to withdraw static SRv6 SID NLRI");
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Withdrawn static SRv6 SID NLRI %pI6/%u", sid, prefixlen);
+
+	return 0;
 }
 
 /*

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -25,6 +25,8 @@
 
 DEFINE_MTYPE_STATIC(BGPD, BGP_LS, "BGP-LS instance");
 
+static int bgp_ls_refresh_bgp_link_endx_attrs(struct bgp *bgp, struct peer *peer);
+
 void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct prefix *p, afi_t afi,
 					uint8_t type, unsigned short instance,
 					uint32_t seg6local_action,
@@ -42,6 +44,7 @@ void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct prefix *p,
 				   __func__, p, zebra_route_string(type), type, instance);
 
 		bgp_ls_withdraw_static_srv6_sid(bgp, &p->u.prefix6, p->prefixlen);
+		bgp_ls_delete_bgp_link_srv6_endx_sid(bgp, &p->u.prefix6, p->prefixlen);
 		return;
 	}
 
@@ -56,6 +59,9 @@ void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct prefix *p,
 	if (seg6local_action == ZEBRA_SEG6_LOCAL_ACTION_END)
 		bgp_ls_originate_static_srv6_sid_from_seg6local(bgp, &p->u.prefix6, p->prefixlen,
 								seg6local_action, seg6local_ctx);
+	else if (seg6local_action == ZEBRA_SEG6_LOCAL_ACTION_END_X)
+		bgp_ls_upsert_bgp_link_srv6_endx_sid(bgp, &p->u.prefix6, p->prefixlen,
+						     seg6local_action, seg6local_ctx);
 }
 
 /*
@@ -966,6 +972,28 @@ bool bgp_ls_is_registered(struct bgp *bgp)
 
 /*
  * ===========================================================================
+ * Static END.X SID list management
+ * ===========================================================================
+ */
+
+struct bgp_ls_static_endx_sid {
+	struct in6_addr sid;
+	uint8_t prefixlen;
+	uint16_t behavior;
+	uint8_t lb_len;
+	uint8_t ln_len;
+	uint8_t fn_len;
+	uint8_t arg_len;
+	struct in6_addr nh6;
+	ifindex_t ifindex;
+	struct peer *peer;
+	struct bgp_ls_endx_sid_list_item list_item;
+};
+
+DECLARE_DLIST(bgp_ls_endx_sid_list, struct bgp_ls_static_endx_sid, list_item);
+
+/*
+ * ===========================================================================
  * Module Initialization and Cleanup
  * ===========================================================================
  */
@@ -987,6 +1015,8 @@ void bgp_ls_init(struct bgp *bgp)
 
 	bgp->ls_info->ted = ls_ted_new(bgp->as, "BGP-LS TED", bgp->as);
 
+	bgp_ls_endx_sid_list_init(&bgp->ls_info->static_endx_sids);
+
 	zlog_info("BGP-LS: Module initialized for instance %s", bgp->name_pretty);
 }
 
@@ -998,6 +1028,7 @@ void bgp_ls_cleanup(struct bgp *bgp)
 {
 	struct bgp_ls_nlri *entry;
 	struct bgp_ls_attr *ls_attr;
+	struct bgp_ls_static_endx_sid *endx_entry;
 
 	if (bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT)
 		return;
@@ -1021,11 +1052,62 @@ void bgp_ls_cleanup(struct bgp *bgp)
 
 	ls_ted_del_all(&bgp->ls_info->ted);
 
+	frr_each_safe (bgp_ls_endx_sid_list, &bgp->ls_info->static_endx_sids, endx_entry) {
+		bgp_ls_endx_sid_list_del(&bgp->ls_info->static_endx_sids, endx_entry);
+		XFREE(MTYPE_BGP_LS, endx_entry);
+	}
+
+	bgp_ls_endx_sid_list_fini(&bgp->ls_info->static_endx_sids);
+
 	idalloc_destroy(bgp->ls_info->allocator);
 
 	XFREE(MTYPE_BGP_LS, bgp->ls_info);
 
 	zlog_info("BGP-LS: Module terminated for instance %s", bgp->name_pretty);
+}
+
+static struct bgp_ls_static_endx_sid *
+bgp_ls_static_endx_sid_lookup(struct bgp *bgp, const struct in6_addr *sid, uint8_t prefixlen)
+{
+	struct bgp_ls_static_endx_sid *entry;
+
+	if (!bgp || !bgp->ls_info || !sid)
+		return NULL;
+
+	frr_each (bgp_ls_endx_sid_list, &bgp->ls_info->static_endx_sids, entry) {
+		if (entry->prefixlen == prefixlen && memcmp(&entry->sid, sid, sizeof(*sid)) == 0)
+			return entry;
+	}
+
+	return NULL;
+}
+
+static uint16_t bgp_ls_seg6local_endx_behavior(uint32_t action, const struct seg6local_context *ctx)
+{
+	bool next_csid;
+	bool psp;
+	bool usd;
+
+	if (action != ZEBRA_SEG6_LOCAL_ACTION_END_X)
+		return SRV6_ENDPOINT_BEHAVIOR_RESERVED;
+
+	next_csid = (ctx && seg6local_has_next_csid(ctx));
+	psp = (ctx && CHECK_SRV6_FLV_OP(ctx->flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP));
+	usd = (ctx && CHECK_SRV6_FLV_OP(ctx->flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_USD));
+
+	if (next_csid) {
+		if (psp && usd)
+			return SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID_PSP_USD;
+		if (psp)
+			return SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID_PSP;
+		return SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID;
+	}
+
+	if (psp && usd)
+		return SRV6_ENDPOINT_BEHAVIOR_END_X_PSP_USD;
+	if (psp)
+		return SRV6_ENDPOINT_BEHAVIOR_END_X_PSP;
+	return SRV6_ENDPOINT_BEHAVIOR_END_X;
 }
 
 static uint16_t bgp_ls_seg6local_to_srv6_behavior(uint32_t action,
@@ -1049,6 +1131,19 @@ static uint16_t bgp_ls_seg6local_to_srv6_behavior(uint32_t action,
 		if (psp)
 			return SRV6_ENDPOINT_BEHAVIOR_END_PSP;
 		return SRV6_ENDPOINT_BEHAVIOR_END;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_X:
+		if (next_csid) {
+			if (psp && usd)
+				return SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID_PSP_USD;
+			if (psp)
+				return SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID_PSP;
+			return SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID;
+		}
+		if (psp && usd)
+			return SRV6_ENDPOINT_BEHAVIOR_END_X_PSP_USD;
+		if (psp)
+			return SRV6_ENDPOINT_BEHAVIOR_END_X_PSP;
+		return SRV6_ENDPOINT_BEHAVIOR_END_X;
 	default:
 		return SRV6_ENDPOINT_BEHAVIOR_RESERVED;
 	}
@@ -1063,6 +1158,12 @@ static bool bgp_ls_static_srv6_behavior_allowed(uint16_t behavior)
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID:
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD:
+	case SRV6_ENDPOINT_BEHAVIOR_END_X:
+	case SRV6_ENDPOINT_BEHAVIOR_END_X_PSP:
+	case SRV6_ENDPOINT_BEHAVIOR_END_X_PSP_USD:
+	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID:
+	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID_PSP:
+	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID_PSP_USD:
 		return true;
 	default:
 		return false;
@@ -1309,7 +1410,8 @@ static struct interface *bgp_ls_get_ifp_from_connection(struct peer_connection *
  * @param peer - BGP peer (remote endpoint of the session)
  * @return 0 on success, -1 on error
  */
-int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer)
+static int bgp_ls_originate_bgp_link_internal(struct bgp *bgp, struct peer *peer,
+					      struct bgp_ls_attr *ls_attr)
 {
 	struct bgp_ls_nlri *nlri;
 	struct peer_connection *connection;
@@ -1402,7 +1504,7 @@ int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer)
 			 BGP_LS_LINK_DESC_IPV6_INTF_BIT);
 	}
 
-	ret = bgp_ls_update(bgp, nlri, NULL);
+	ret = bgp_ls_update(bgp, nlri, ls_attr);
 	if (ret != 0) {
 		zlog_err("BGP-LS: Failed to originate BGP link NLRI");
 		bgp_ls_nlri_free(nlri);
@@ -1415,6 +1517,244 @@ int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer)
 
 	bgp_ls_nlri_free(nlri);
 	return 0;
+}
+
+int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer)
+{
+	return bgp_ls_refresh_bgp_link_endx_attrs(bgp, peer);
+}
+
+static bool bgp_ls_static_endx_sid_matches_peer(const struct bgp_ls_static_endx_sid *entry,
+						const struct peer *peer)
+{
+	struct interface *ifp;
+	struct in6_addr zero = IN6ADDR_ANY_INIT;
+
+	if (!entry || !peer || !peer->connection)
+		return false;
+
+	if (peer->connection->su.sa.sa_family != AF_INET6)
+		return false;
+
+	if (memcmp(&entry->nh6, &zero, sizeof(entry->nh6)) != 0 &&
+	    memcmp(&peer->connection->su.sin6.sin6_addr, &entry->nh6, sizeof(entry->nh6)) != 0)
+		return false;
+
+	if (!entry->ifindex)
+		return true;
+
+	ifp = bgp_ls_get_ifp_from_connection(peer->connection);
+	return ifp && ifp->ifindex == entry->ifindex;
+}
+
+static struct peer *bgp_ls_find_peer_by_nh6(struct bgp *bgp, const struct in6_addr *nh6,
+					    ifindex_t ifindex)
+{
+	struct listnode *node;
+	struct peer *peer;
+	struct in6_addr zero = IN6ADDR_ANY_INIT;
+	bool match_by_ifindex_only;
+
+	if (!bgp || !nh6)
+		return NULL;
+
+	match_by_ifindex_only = (memcmp(nh6, &zero, sizeof(*nh6)) == 0);
+
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+		struct interface *ifp;
+		int status;
+
+		if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+			continue;
+
+		if (!peer->connection || peer->connection->status != Established) {
+			status = peer->connection ? (int)peer->connection->status : -1;
+			if (BGP_DEBUG(linkstate, LINKSTATE))
+				zlog_debug("BGP-LS: peer %s skipped (not Established, status=%d)",
+					   peer->host, status);
+			continue;
+		}
+
+		if (peer->connection->su.sa.sa_family != AF_INET6) {
+			if (BGP_DEBUG(linkstate, LINKSTATE))
+				zlog_debug("BGP-LS: peer %s skipped (not AF_INET6, family=%d)",
+					   peer->host, peer->connection->su.sa.sa_family);
+			continue;
+		}
+
+		if (!match_by_ifindex_only &&
+		    memcmp(&peer->connection->su.sin6.sin6_addr, nh6, sizeof(*nh6)) != 0)
+			continue;
+
+		if (!ifindex)
+			return peer;
+
+		ifp = bgp_ls_get_ifp_from_connection(peer->connection);
+		if (ifp && ifp->ifindex == ifindex)
+			return peer;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: find_peer_by_nh6 %pI6 ifindex=%u - no matching peer found%s",
+			   nh6, ifindex, match_by_ifindex_only ? " (interface-only match)" : "");
+	return NULL;
+}
+
+static int bgp_ls_refresh_bgp_link_endx_attrs(struct bgp *bgp, struct peer *peer)
+{
+	struct bgp_ls_static_endx_sid *entry;
+	struct bgp_ls_attr *ls_attr;
+	struct bgp_ls_srv6_endx_sid *endx;
+	uint16_t count = 0;
+	uint16_t idx = 0;
+
+	if (!bgp || !bgp->ls_info || !peer)
+		return -1;
+
+	frr_each (bgp_ls_endx_sid_list, &bgp->ls_info->static_endx_sids, entry) {
+		if (bgp_ls_static_endx_sid_matches_peer(entry, peer))
+			entry->peer = peer;
+
+		if (entry->peer == peer)
+			count++;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: peer %s refresh with %u End.X SID(s)", peer->host, count);
+
+	if (count == 0)
+		return bgp_ls_originate_bgp_link_internal(bgp, peer, NULL);
+
+	ls_attr = bgp_ls_attr_alloc();
+	ls_attr->srv6_endx_sid_count = count;
+	ls_attr->srv6_endx_sid = XCALLOC(MTYPE_BGP_LS_ATTR,
+					 count * sizeof(*ls_attr->srv6_endx_sid));
+
+	frr_each (bgp_ls_endx_sid_list, &bgp->ls_info->static_endx_sids, entry) {
+		if (entry->peer != peer)
+			continue;
+
+		endx = &ls_attr->srv6_endx_sid[idx++];
+		memset(endx, 0, sizeof(*endx));
+		endx->endpoint_behavior = entry->behavior;
+		endx->flags = 0;
+		endx->algo = 0;
+		endx->weight = 0;
+		IPV6_ADDR_COPY(&endx->sid, &entry->sid);
+		if (entry->lb_len || entry->ln_len || entry->fn_len || entry->arg_len) {
+			endx->has_structure = true;
+			endx->structure.lb_len = entry->lb_len;
+			endx->structure.ln_len = entry->ln_len;
+			endx->structure.fun_len = entry->fn_len;
+			endx->structure.arg_len = entry->arg_len;
+		}
+	}
+
+	SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_SRV6_ENDX_SID_BIT);
+
+	if (bgp_ls_originate_bgp_link_internal(bgp, peer, ls_attr) != 0) {
+		bgp_ls_attr_free(ls_attr);
+		return -1;
+	}
+
+	bgp_ls_attr_free(ls_attr);
+	return 0;
+}
+
+int bgp_ls_upsert_bgp_link_srv6_endx_sid(struct bgp *bgp, const struct in6_addr *sid,
+					 uint8_t prefixlen, uint32_t action,
+					 const struct seg6local_context *ctx)
+{
+	struct bgp_ls_static_endx_sid *entry;
+	struct peer *peer;
+	struct peer *old_peer = NULL;
+	bool had_srv6_cap;
+	uint16_t behavior;
+
+	if (!bgp || !bgp->ls_info || !sid || !ctx)
+		return -1;
+
+	behavior = bgp_ls_seg6local_endx_behavior(action, ctx);
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: upsert_endx_sid %pI6/%u action=%u behavior=0x%04x nh6=%pI6 ifindex=%u",
+			   sid, prefixlen, action, behavior, &ctx->nh6, ctx->ifindex);
+
+	if (behavior == SRV6_ENDPOINT_BEHAVIOR_RESERVED) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS: %pI6/%u End.X behavior RESERVED - skipping", sid,
+				   prefixlen);
+		return 0;
+	}
+
+	had_srv6_cap = bgp_ls_has_srv6_capability(bgp);
+
+	entry = bgp_ls_static_endx_sid_lookup(bgp, sid, prefixlen);
+	if (!entry) {
+		entry = XCALLOC(MTYPE_BGP_LS, sizeof(*entry));
+		entry->sid = *sid;
+		entry->prefixlen = prefixlen;
+		bgp_ls_endx_sid_list_add_tail(&bgp->ls_info->static_endx_sids, entry);
+	} else {
+		old_peer = entry->peer;
+	}
+
+	entry->behavior = behavior;
+	entry->lb_len = ctx->block_len;
+	entry->ln_len = ctx->node_len;
+	entry->fn_len = ctx->function_len;
+	entry->arg_len = ctx->argument_len;
+	entry->nh6 = ctx->nh6;
+	entry->ifindex = ctx->ifindex;
+	entry->peer = NULL;
+
+	peer = bgp_ls_find_peer_by_nh6(bgp, &ctx->nh6, ctx->ifindex);
+	if (!peer) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS: %pI6/%u stored pending End.X SID for nh6=%pI6 ifindex=%u until link exists",
+				   sid, prefixlen, &ctx->nh6, ctx->ifindex);
+	} else {
+		entry->peer = peer;
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("BGP-LS: %pI6/%u matched peer %s", sid, prefixlen, peer->host);
+	}
+
+	if (!had_srv6_cap)
+		bgp_ls_originate_bgp_node(bgp);
+
+	if (old_peer && old_peer != peer)
+		bgp_ls_refresh_bgp_link_endx_attrs(bgp, old_peer);
+
+	if (!peer)
+		return 0;
+
+	return bgp_ls_refresh_bgp_link_endx_attrs(bgp, peer);
+}
+
+int bgp_ls_delete_bgp_link_srv6_endx_sid(struct bgp *bgp, const struct in6_addr *sid,
+					 uint8_t prefixlen)
+{
+	struct bgp_ls_static_endx_sid *entry;
+	struct peer *peer;
+
+	if (!bgp || !bgp->ls_info || !sid)
+		return -1;
+
+	entry = bgp_ls_static_endx_sid_lookup(bgp, sid, prefixlen);
+	if (!entry)
+		return 0;
+
+	peer = entry->peer;
+	bgp_ls_endx_sid_list_del(&bgp->ls_info->static_endx_sids, entry);
+	XFREE(MTYPE_BGP_LS, entry);
+
+	if (!bgp_ls_has_srv6_capability(bgp))
+		bgp_ls_originate_bgp_node(bgp);
+
+	if (!peer)
+		return 0;
+
+	return bgp_ls_refresh_bgp_link_endx_attrs(bgp, peer);
 }
 
 /*

--- a/bgpd/bgp_ls.h
+++ b/bgpd/bgp_ls.h
@@ -7,8 +7,11 @@
 #ifndef _FRR_BGP_LS_H
 #define _FRR_BGP_LS_H
 
+#include <typesafe.h>
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_ls_nlri.h"
+
+PREDECL_DLIST(bgp_ls_endx_sid_list);
 
 struct bgp_ls {
 	/* Back-pointer to parent BGP instance */
@@ -33,6 +36,9 @@ struct bgp_ls {
 
 	/* BGP-fabric link-state instance ID */
 	uint64_t instance_id;
+
+	/* Static End.X/uA SIDs associated to BGP links. */
+	struct bgp_ls_endx_sid_list_head static_endx_sids;
 };
 
 /* Function prototypes */
@@ -110,6 +116,11 @@ int bgp_ls_withdraw_bgp_link(struct bgp *bgp, struct peer *peer);
 int bgp_ls_withdraw_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *dest,
 			       struct bgp_path_info *path);
 
+extern int bgp_ls_upsert_bgp_link_srv6_endx_sid(struct bgp *bgp, const struct in6_addr *sid,
+						uint8_t prefixlen, uint32_t action,
+						const struct seg6local_context *ctx);
+extern int bgp_ls_delete_bgp_link_srv6_endx_sid(struct bgp *bgp, const struct in6_addr *sid,
+						uint8_t prefixlen);
 extern int bgp_ls_originate_static_srv6_sid_from_seg6local(struct bgp *bgp,
 							   const struct in6_addr *sid,
 							   uint8_t prefixlen, uint32_t action,

--- a/bgpd/bgp_ls.h
+++ b/bgpd/bgp_ls.h
@@ -110,6 +110,32 @@ int bgp_ls_withdraw_bgp_link(struct bgp *bgp, struct peer *peer);
 int bgp_ls_withdraw_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *dest,
 			       struct bgp_path_info *path);
 
+extern int bgp_ls_originate_static_srv6_sid_from_seg6local(struct bgp *bgp,
+							   const struct in6_addr *sid,
+							   uint8_t prefixlen, uint32_t action,
+							   const struct seg6local_context *ctx);
+extern int bgp_ls_withdraw_static_srv6_sid(struct bgp *bgp, const struct in6_addr *sid,
+					   uint8_t prefixlen);
+extern void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct prefix *p, afi_t afi,
+					       uint8_t type, unsigned short instance,
+					       uint32_t seg6local_action,
+					       const struct seg6local_context *seg6local_ctx,
+					       bool is_add);
+
+/*
+ * BGP-LS route handlers - abstraction layer for route redistribution
+ *
+ * These functions handle BGP-LS concerns (including SRv6 localsid) from
+ * route redistribution events. Route code calls these handlers instead of
+ * directly invoking SRv6-specific functions.
+ */
+extern int bgp_ls_handle_route_add(struct bgp *bgp, const struct prefix *p, afi_t afi,
+				   uint8_t type, unsigned short instance, uint32_t seg6local_action,
+				   const struct seg6local_context *seg6local_ctx);
+
+extern int bgp_ls_handle_route_delete(struct bgp *bgp, const struct prefix *p, afi_t afi,
+				      uint8_t type, unsigned short instance);
+
 /*
  * ===========================================================================
  * Link State Message Processing

--- a/bgpd/bgp_ls.h
+++ b/bgpd/bgp_ls.h
@@ -39,6 +39,9 @@ struct bgp_ls {
 
 	/* Static End.X/uA SIDs associated to BGP links. */
 	struct bgp_ls_endx_sid_list_head static_endx_sids;
+
+	/* Number of active SRv6 locator Prefix NLRIs originated by BGP-LS. */
+	uint32_t srv6_locator_nlri_count;
 };
 
 /* Function prototypes */
@@ -132,6 +135,9 @@ extern void bgp_ls_handle_srv6_localsid_update(struct bgp *bgp, const struct pre
 					       uint32_t seg6local_action,
 					       const struct seg6local_context *seg6local_ctx,
 					       bool is_add);
+extern int bgp_ls_originate_srv6_locator_prefix(struct bgp *bgp,
+						const struct srv6_locator *locator);
+extern int bgp_ls_withdraw_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locator *locator);
 
 /*
  * BGP-LS route handlers - abstraction layer for route redistribution

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10747,12 +10747,12 @@ DEFPY(aggregate_addressv6, aggregate_addressv6_cmd,
 }
 
 /* Redistribute route treatment. */
-void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
-			  const union g_addr *nexthop, ifindex_t ifindex,
-			  enum nexthop_types_t nhtype, uint8_t distance,
-			  enum blackhole_type bhtype, uint32_t metric,
-			  uint8_t type, unsigned short instance,
-			  route_tag_t tag)
+
+void bgp_redistribute_add(struct bgp *bgp, struct prefix *p, const union g_addr *nexthop,
+			  ifindex_t ifindex, enum nexthop_types_t nhtype, uint8_t distance,
+			  enum blackhole_type bhtype, uint32_t metric, uint8_t type,
+			  unsigned short instance, route_tag_t tag, uint32_t seg6local_action,
+			  const struct seg6local_context *seg6local_ctx)
 {
 	struct bgp_path_info *new;
 	struct bgp_path_info *bpi;
@@ -10836,6 +10836,9 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 	attr.tag = tag;
 
 	afi = family2afi(p->family);
+
+	/* Handle BGP-LS concerns including SRv6 localsid updates */
+	bgp_ls_handle_route_add(bgp, p, afi, type, instance, seg6local_action, seg6local_ctx);
 
 	red = bgp_redist_lookup(bgp, afi, type, instance);
 	if (red) {
@@ -10969,6 +10972,9 @@ void bgp_redistribute_delete(struct bgp *bgp, struct prefix *p, uint8_t type,
 
 	afi = family2afi(p->family);
 	frrtrace(4, frr_bgp, bgp_redistribute_delete_zrecv, bgp, p, type, instance);
+
+	/* Handle BGP-LS concerns including SRv6 localsid updates */
+	bgp_ls_handle_route_delete(bgp, p, afi, type, instance);
 
 	red = bgp_redist_lookup(bgp, afi, type, instance);
 	if (red) {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -842,12 +842,12 @@ extern int bgp_nlri_parse_ip(struct peer *peer, struct attr *attr, struct bgp_nl
 
 extern bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi, int always);
 
-extern void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
-				 const union g_addr *nexthop, ifindex_t ifindex,
-				 enum nexthop_types_t nhtype, uint8_t distance,
-				 enum blackhole_type bhtype, uint32_t metric,
-				 uint8_t type, unsigned short instance,
-				 route_tag_t tag);
+extern void bgp_redistribute_add(struct bgp *bgp, struct prefix *p, const union g_addr *nexthop,
+				 ifindex_t ifindex, enum nexthop_types_t nhtype, uint8_t distance,
+				 enum blackhole_type bhtype, uint32_t metric, uint8_t type,
+				 unsigned short instance, route_tag_t tag,
+				 uint32_t seg6local_action,
+				 const struct seg6local_context *seg6local_ctx);
 extern void bgp_redistribute_delete(struct bgp *bgp, struct prefix *p, uint8_t type,
 				    unsigned short instance);
 extern void bgp_redistribute_withdraw(struct bgp *bgp, afi_t afi, int type,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -20507,6 +20507,11 @@ DEFPY(bgp_ls_distribute_bgp_fabric,
 	bgp->ls_info->instance_id = instance_id;
 	bgp->ls_info->enable_distribution = true;
 
+	bgp_redist_add(bgp, AFI_IP6, ZEBRA_ROUTE_ALL, 0);
+	if (bgp_redistribute_set(bgp, AFI_IP6, ZEBRA_ROUTE_ALL, 0, false) != CMD_SUCCESS)
+		zlog_warn("%s: failed to subscribe to IPv6 ZEBRA_ROUTE_ALL redistribution",
+			  __func__);
+
 	if (bgp_ls_export_bgp_topology(bgp) != 0) {
 		vty_out(vty, "%% Failed to export BGP topology\n");
 		return CMD_WARNING;
@@ -20544,6 +20549,8 @@ DEFPY(no_bgp_ls_distribute_bgp_fabric,
 	if (bgp->ls_info) {
 		if (!bgp->ls_info->enable_distribution)
 			return CMD_SUCCESS;
+
+		bgp_redistribute_unset(bgp, AFI_IP6, ZEBRA_ROUTE_ALL, 0);
 
 		bgp->ls_info->enable_distribution = false;
 		bgp->ls_info->instance_id = 0;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -20512,6 +20512,9 @@ DEFPY(bgp_ls_distribute_bgp_fabric,
 		zlog_warn("%s: failed to subscribe to IPv6 ZEBRA_ROUTE_ALL redistribution",
 			  __func__);
 
+	if (bgp_zclient && bgp_zclient->sock >= 0)
+		bgp_zebra_srv6_manager_get_locator(NULL);
+
 	if (bgp_ls_export_bgp_topology(bgp) != 0) {
 		vty_out(vty, "%% Failed to export BGP topology\n");
 		return CMD_WARNING;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -56,6 +56,7 @@
 #include "bgpd/bgp_community.h"
 #include "bgpd/bgp_lcommunity.h"
 #include "bgpd/bgp_srv6.h"
+#include "bgpd/bgp_ls.h"
 #include "bgpd/bgp_ls_ted.h"
 
 /* All information about zebra. */
@@ -4269,6 +4270,8 @@ static int bgp_zebra_process_srv6_locator_add(ZAPI_CALLBACK_ARGS)
 	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
 		return -1;
 
+	bgp_ls_originate_srv6_locator_prefix(bgp_get_default(), &loc);
+
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
 		if (!bgp_srv6_locator_is_configured(bgp))
 			continue;
@@ -4418,6 +4421,8 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 
 	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
 		return -1;
+
+	bgp_ls_withdraw_srv6_locator_prefix(bgp_get_default(), &loc);
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
 		if (!bgp->srv6_locator)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -5065,9 +5065,6 @@ int bgp_zebra_srv6_manager_release_locator_chunk(const char *name)
  */
 int bgp_zebra_srv6_manager_get_locator(const char *name)
 {
-	if (!name)
-		return -1;
-
 	/*
 	 * Send the Get Locator request to the SRv6 Manager and return the
 	 * result

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -528,6 +528,8 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 	struct zapi_route api;
 	union g_addr nexthop = {};
 	ifindex_t ifindex = IFINDEX_INTERNAL;
+	uint32_t seg6local_action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
+	const struct seg6local_context *seg6local_ctx = NULL;
 	int add, i;
 	struct bgp *bgp;
 
@@ -562,6 +564,9 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 		} else
 			nexthop = api.nexthops[0].gate;
 
+		seg6local_action = api.nexthops[0].seg6local_action;
+		seg6local_ctx = &api.nexthops[0].seg6local_ctx;
+
 		/*
 		 * The ADD message is actually an UPDATE and there is no
 		 * explicit DEL
@@ -578,9 +583,9 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 		}
 
 		/* Now perform the add/update. */
-		bgp_redistribute_add(bgp, &api.prefix, &nexthop, ifindex,
-				     nhtype, api.distance, bhtype, api.metric,
-				     api.type, api.instance, api.tag);
+		bgp_redistribute_add(bgp, &api.prefix, &nexthop, ifindex, nhtype, api.distance,
+				     bhtype, api.metric, api.type, api.instance, api.tag,
+				     seg6local_action, seg6local_ctx);
 	} else {
 		bgp_redistribute_delete(bgp, &api.prefix, api.type,
 					api.instance);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2582,7 +2582,9 @@ void bgp_zebra_instance_register(struct bgp *bgp)
 	 * Request SRv6 locator information from Zebra, if SRv6 is enabled
 	 * and a locator is configured for this BGP instance.
 	 */
-	if (bgp_srv6_locator_is_configured(bgp) && !bgp_srv6_locator_lookup(NULL, bgp))
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_zebra_srv6_manager_get_locator(NULL);
+	else if (bgp_srv6_locator_is_configured(bgp) && !bgp_srv6_locator_lookup(NULL, bgp))
 		bgp_zebra_srv6_manager_get_locator(bgp->srv6_locator_name);
 }
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3568,16 +3568,13 @@ int srv6_manager_release_locator_chunk(struct zclient *zclient,
  * Function to request a SRv6 locator in an asynchronous way
  *
  * @param zclient The zclient used to connect to SRv6 Manager (zebra)
- * @param locator_name Name of SRv6 locator
+ * @param locator_name Name of SRv6 locator, or NULL to request all locators
  * @return 0 on success, -1 otherwise
  */
 int srv6_manager_get_locator(struct zclient *zclient, const char *locator_name)
 {
 	struct stream *s;
-	size_t len;
-
-	if (!locator_name)
-		return -1;
+	size_t len = 0;
 
 	if (zclient->sock < 0) {
 		flog_err(EC_LIB_ZAPI_SOCKET, "%s: invalid zclient socket",
@@ -3586,9 +3583,10 @@ int srv6_manager_get_locator(struct zclient *zclient, const char *locator_name)
 	}
 
 	if (zclient_debug)
-		zlog_debug("Getting SRv6 Locator %s", locator_name);
+		zlog_debug("Getting SRv6 Locator %s", locator_name ? locator_name : "<all>");
 
-	len = strlen(locator_name);
+	if (locator_name)
+		len = strlen(locator_name);
 
 	/* Send request */
 	s = zclient->obuf;
@@ -3597,7 +3595,8 @@ int srv6_manager_get_locator(struct zclient *zclient, const char *locator_name)
 
 	/* Locator name */
 	stream_putw(s, len);
-	stream_put(s, locator_name, len);
+	if (len)
+		stream_put(s, locator_name, len);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/r1/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/r1/frr.conf
@@ -1,0 +1,80 @@
+!
+hostname r1
+!
+! Router 1: AS65001, IPv6 iBGP with r2 and BGP-LS to rr
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:1::/48
+    format usid-f3216
+   !
+  static-sids
+   sid fcbb:bbbb:1::/48 locator MAIN behavior uN
+   sid fcbb:bbbb:1:fe01::/64 locator MAIN behavior uA interface r1-eth1
+   sid fcbb:bbbb:fe01::/48 locator MAIN behavior uA interface r1-eth1
+   sid fcbb:bbbb:1:fe00::/64 locator MAIN behavior uA interface r1-eth0
+   sid fcbb:bbbb:fe00::/48 locator MAIN behavior uA interface r1-eth0
+   !
+  !
+ !
+!
+interface lo
+ ip address 10.1.1.1/32
+!
+interface r1-eth1
+ description Link to r2
+ ip address 172.16.1.1/30
+ ipv6 address 2001:db8:12::1/64
+!
+interface r1-eth0
+ description Point-to-point link to RR
+ ip address 10.255.1.1/30
+ ipv6 address 2001:db9:1::1/126
+!
+! Static route for BGP-LS Prefix NLRI
+ip route 192.0.2.0/24 Null0
+ipv6 route 2001:db9:11::/64 Null0
+!
+router bgp 65001
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! iBGP neighbor (r2)
+ neighbor 2001:db8:12::2 remote-as 65001
+ neighbor 2001:db8:12::2 local-link-id 101
+ !
+ ! BGP-LS speaker
+ neighbor 2001:db9:1::2 remote-as 65000
+ !
+ ! IPv4 unicast redistribution
+ address-family ipv4 unicast
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! IPv6 unicast for iBGP session
+ address-family ipv6 unicast
+  neighbor 2001:db8:12::2 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 2001:db9:1::2 activate
+ exit-address-family
+!
+ip forwarding
+ipv6 forwarding
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/r2/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/r2/frr.conf
@@ -1,0 +1,78 @@
+!
+hostname r2
+!
+! Router 2: AS65001, IPv6 iBGP with r1 and BGP-LS to rr
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:2::/48
+    format usid-f3216
+   !
+  static-sids
+   sid fcbb:bbbb:2::/48 locator MAIN behavior uN
+   sid fcbb:bbbb:2:fe01::/64 locator MAIN behavior uA interface r2-eth1
+   sid fcbb:bbbb:fe01::/48 locator MAIN behavior uA interface r2-eth1
+   sid fcbb:bbbb:2:fe00::/64 locator MAIN behavior uA interface r2-eth0
+   sid fcbb:bbbb:fe00::/48 locator MAIN behavior uA interface r2-eth0
+   !
+  !
+ !
+!
+interface lo
+ ip address 10.2.2.2/32
+!
+interface r2-eth1
+ description Link to r1
+ ip address 172.16.1.2/30
+ ipv6 address 2001:db8:12::2/64
+!
+interface r2-eth0
+ description Point-to-point link to RR
+ ip address 10.255.2.1/30
+ ipv6 address 2001:db9:2::1/126
+!
+ipv6 route 2001:db9:22::/64 Null0
+!
+router bgp 65001
+ bgp router-id 2.2.2.2
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! iBGP neighbor (r1)
+ neighbor 2001:db8:12::1 remote-as 65001
+ neighbor 2001:db8:12::1 local-link-id 102
+ !
+ ! BGP-LS speaker
+ neighbor 2001:db9:2::2 remote-as 65000
+ !
+ ! IPv4 unicast redistribution
+ address-family ipv4 unicast
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! IPv6 unicast for iBGP session
+ address-family ipv6 unicast
+  neighbor 2001:db8:12::1 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 2001:db9:2::2 activate
+ exit-address-family
+!
+ip forwarding
+ipv6 forwarding
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/r3/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/r3/frr.conf
@@ -1,0 +1,75 @@
+!
+hostname r3
+!
+! Router 3: AS65002, IPv6 eBGP with r4
+!
+! debug bgp updates
+debug bgp link-state
+debug bgp zebra
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:3::/48
+    format usid-f3216
+  !
+  static-sids
+   sid fcbb:bbbb:3::/48 locator MAIN behavior uN
+   sid fcbb:bbbb:3:fe01::/64 locator MAIN behavior uA interface r3-eth1
+   sid fcbb:bbbb:fe01::/48 locator MAIN behavior uA interface r3-eth1
+   sid fcbb:bbbb:3:fe00::/64 locator MAIN behavior uA interface r3-eth0
+   sid fcbb:bbbb:fe00::/48 locator MAIN behavior uA interface r3-eth0
+  !
+ !
+!
+interface lo
+ ip address 10.3.3.3/32
+!
+interface r3-eth1
+ description Link to r4
+ ipv6 address 2001:db8:1::1/64
+!
+interface r3-eth0
+ description Point-to-point link to RR
+ ipv6 address 2001:db9:3::1/126
+!
+! Static route for BGP-LS Prefix NLRI
+ipv6 route 2001:db9:1:124::/64 Null0
+!
+router bgp 65002
+ bgp router-id 3.3.3.3
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! eBGP neighbor (r4)
+ neighbor 2001:db8:1::2 remote-as 65003
+ neighbor 2001:db8:1::2 local-link-id 103
+ !
+ ! BGP-LS speaker
+ neighbor 2001:db9:3::2 remote-as 65000
+ !
+ address-family ipv4 unicast
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! IPv6 unicast for eBGP session
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::2 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 2001:db9:3::2 activate
+ exit-address-family
+!
+ip forwarding
+ipv6 forwarding
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/r4/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/r4/frr.conf
@@ -1,0 +1,76 @@
+!
+hostname r4
+!
+! Router 4: AS65003, IPv6 eBGP with r3
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix fcbb:bbbb:4::/48
+    format usid-f3216
+   !
+  static-sids
+   sid fcbb:bbbb:4::/48 locator MAIN behavior uN
+   sid fcbb:bbbb:4:fe01::/64 locator MAIN behavior uA interface r4-eth1
+   sid fcbb:bbbb:fe01::/48 locator MAIN behavior uA interface r4-eth1
+   sid fcbb:bbbb:4:fe00::/64 locator MAIN behavior uA interface r4-eth0
+   sid fcbb:bbbb:fe00::/48 locator MAIN behavior uA interface r4-eth0
+  !
+ !
+!
+interface lo
+ ip address 10.4.4.4/32
+!
+interface r4-eth1
+ description Link to r3
+ ipv6 address 2001:db8:1::2/64
+!
+interface r4-eth0
+ description Point-to-point link to RR
+ ipv6 address 2001:db9:4::1/126
+!
+ipv6 route 2001:db9:44::/64 Null0
+!
+!
+router bgp 65003
+ bgp router-id 4.4.4.4
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! eBGP neighbor (r3)
+ neighbor 2001:db8:1::1 remote-as 65002
+ neighbor 2001:db8:1::1 local-link-id 104
+ !
+ ! BGP-LS speaker
+ neighbor 2001:db9:4::2 remote-as 65000
+ !
+ ! IPv4 unicast for static route
+ address-family ipv4 unicast
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! IPv6 unicast for eBGP session
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::1 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 2001:db9:4::2 activate
+ exit-address-family
+!
+ip forwarding
+ipv6 forwarding
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/rr/expected_bgp_ls_srv6.json
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/rr/expected_bgp_ls_srv6.json
@@ -1,0 +1,460 @@
+{
+	"routes": {
+		"[V][B][I0x0][N[c65001][q1.1.1.1]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][B][I0x0][N[c65001][q2.2.2.2]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][B][I0x0][N[c65002][q3.3.3.3]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[V][B][I0x0][N[c65003][q4.4.4.4]]": [
+			{
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Capabilities": {
+						"flags": "0x0"
+					}
+				}
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[pfcbb:bbbb:1::/48]][br0x01]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:1::/48",
+						"bgpRouteType": "local"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[pfcbb:bbbb:2::/48]][br0x01]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:2::/48",
+						"bgpRouteType": "local"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[pfcbb:bbbb:3::/48]][br0x01]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:3::/48",
+						"bgpRouteType": "local"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[pfcbb:bbbb:4::/48]][br0x01]": [
+			{
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "fcbb:bbbb:4::/48",
+						"bgpRouteType": "local"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6Locator": {
+						"flags": "0x0",
+						"algo": 0,
+						"metric": 0
+					}
+				}
+			}
+		],
+		"[S][ST][I0x0][N[q1.1.1.1]][S[sdfcbb:bbbb:1::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"protocolId": 5,
+					"localNodeDescriptors": {
+						"bgpRouterId": "1.1.1.1"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:1::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 0,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][ST][I0x0][N[q2.2.2.2]][S[sdfcbb:bbbb:2::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"protocolId": 5,
+					"localNodeDescriptors": {
+						"bgpRouterId": "2.2.2.2"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:2::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 0,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][ST][I0x0][N[q3.3.3.3]][S[sdfcbb:bbbb:3::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"protocolId": 5,
+					"localNodeDescriptors": {
+						"bgpRouterId": "3.3.3.3"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:3::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 0,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[S][ST][I0x0][N[q4.4.4.4]][S[sdfcbb:bbbb:4::]]": [
+			{
+				"nlri": {
+					"nlriType": "srv6Sid",
+					"protocolId": 5,
+					"localNodeDescriptors": {
+						"bgpRouterId": "4.4.4.4"
+					},
+					"srv6SidDescriptors": {
+						"srv6SidValue": "fcbb:bbbb:4::"
+					}
+				},
+				"linkStateAttrs": {
+					"srv6EndpointBehavior": {
+						"behavior": "0x2b",
+						"flags": "0x0",
+						"algo": 0
+					},
+					"srv6SidStructure": {
+						"lbLen": 32,
+						"lnLen": 16,
+						"funLen": 0,
+						"argLen": 0
+					}
+				}
+			}
+		],
+		"[E][B][I0x0][N[c65001][q1.1.1.1]][R[c65001][q2.2.2.2]][L[l101/0][i2001:db8:12::1][n2001:db8:12::2]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"protocolId": 7,
+						"localNodeDescriptors": {
+							"asn": 65001,
+							"bgpRouterId": "1.1.1.1"
+						},
+						"remoteNodeDescriptors": {
+							"asn": 65001,
+							"bgpRouterId": "2.2.2.2"
+						}
+					},
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:1:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
+							},
+							{
+								"sid": "fcbb:bbbb:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 0,
+									"funLen": 16,
+									"argLen": 0
+								}
+							}
+						]
+					}
+				}
+			],
+		"[E][B][I0x0][N[c65001][q2.2.2.2]][R[c65001][q1.1.1.1]][L[l102/0][i2001:db8:12::2][n2001:db8:12::1]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"protocolId": 7,
+						"localNodeDescriptors": {
+							"asn": 65001,
+							"bgpRouterId": "2.2.2.2"
+						},
+						"remoteNodeDescriptors": {
+							"asn": 65001,
+							"bgpRouterId": "1.1.1.1"
+						}
+					},
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:2:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
+							},
+							{
+								"sid": "fcbb:bbbb:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 0,
+									"funLen": 16,
+									"argLen": 0
+								}
+							}
+						]
+					}
+				}
+			],
+		"[E][B][I0x0][N[c65002][q3.3.3.3]][R[c65003][q4.4.4.4]][L[l103/0][i2001:db8:1::1][n2001:db8:1::2]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"protocolId": 7,
+						"localNodeDescriptors": {
+							"asn": 65002,
+							"bgpRouterId": "3.3.3.3"
+						},
+						"remoteNodeDescriptors": {
+							"asn": 65003,
+							"bgpRouterId": "4.4.4.4"
+						}
+					},
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:3:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
+							},
+							{
+								"sid": "fcbb:bbbb:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 0,
+									"funLen": 16,
+									"argLen": 0
+								}
+							}
+						]
+					}
+				}
+			],
+		"[E][B][I0x0][N[c65003][q4.4.4.4]][R[c65002][q3.3.3.3]][L[l104/0][i2001:db8:1::2][n2001:db8:1::1]]":
+			[
+				{
+					"nlri": {
+						"nlriType": "link",
+						"protocolId": 7,
+						"localNodeDescriptors": {
+							"asn": 65003,
+							"bgpRouterId": "4.4.4.4"
+						},
+						"remoteNodeDescriptors": {
+							"asn": 65002,
+							"bgpRouterId": "3.3.3.3"
+						}
+					},
+					"linkStateAttrs": {
+						"srv6EndxSids": [
+							{
+								"sid": "fcbb:bbbb:4:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 16,
+									"funLen": 16,
+									"argLen": 0
+								}
+							},
+							{
+								"sid": "fcbb:bbbb:fe01::",
+								"behavior": "0x34",
+								"flags": "0x0",
+								"algo": 0,
+								"weight": 0,
+								"srv6SidStructure": {
+									"lbLen": 32,
+									"lnLen": 0,
+									"funLen": 16,
+									"argLen": 0
+								}
+							}
+						]
+					}
+				}
+			]
+	}
+}

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/rr/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/rr/frr.conf
@@ -1,0 +1,55 @@
+!
+hostname rr
+!
+! BGP-LS Speaker (Route Reflector)
+! Collects BGP-LS NLRIs from all routers
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+! debug bgp neighbor-events
+!
+interface rr-eth0
+ description Point-to-point link to r1
+ ip address 10.255.1.2/30
+ ipv6 address 2001:db9:1::2/126
+!
+interface rr-eth1
+ description Point-to-point link to r2
+ ip address 10.255.2.2/30
+ ipv6 address 2001:db9:2::2/126
+!
+interface rr-eth2
+ description Point-to-point link to r3
+ ipv6 address 2001:db9:3::2/126
+!
+interface rr-eth3
+ description Point-to-point link to r4
+ ipv6 address 2001:db9:4::2/126
+!
+route-map BLOCK-ALL deny 10
+!
+router bgp 65000
+ bgp router-id 192.0.2.254
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! Neighbors for BGP-LS collection
+ neighbor 2001:db9:1::1 remote-as 65001
+ neighbor 2001:db9:2::1 remote-as 65001
+ neighbor 2001:db9:3::1 remote-as 65002
+ neighbor 2001:db9:4::1 remote-as 65003
+ !
+ ! Enable Link-State address family
+ address-family link-state link-state
+  neighbor 2001:db9:1::1 activate
+  neighbor 2001:db9:1::1 route-map BLOCK-ALL out
+  neighbor 2001:db9:2::1 activate
+  neighbor 2001:db9:2::1 route-map BLOCK-ALL out
+  neighbor 2001:db9:3::1 activate
+  neighbor 2001:db9:3::1 route-map BLOCK-ALL out
+  neighbor 2001:db9:4::1 activate
+  neighbor 2001:db9:4::1 route-map BLOCK-ALL out
+ exit-address-family
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric_srv6/test_bgp_link_state_bgp_fabric_srv6.py
+++ b/tests/topotests/bgp_link_state_bgp_fabric_srv6/test_bgp_link_state_bgp_fabric_srv6.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026 by Carmine Scarpitta
+
+"""Topotest for BGP-LS BGP-fabric export with SRv6 locators and uN/uA SIDs."""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import create_interface_in_kernel, required_linux_kernel_version
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def _check_rr_srv6_nlris(rr):
+    """Load expected SRv6 JSON and compare against RR's BGP-LS table."""
+    expected_path = os.path.join(CWD, "rr", "expected_bgp_ls_srv6.json")
+    with open(expected_path) as f:
+        expected = json.load(f)
+    return topotest.router_json_cmp(
+        rr, "show bgp link-state link-state json", expected
+    )
+
+
+def build_topo(tgen):
+    """Build test topology with rr collector and iBGP/eBGP peer pairs."""
+
+    tgen.add_router("rr")
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+
+    switch = tgen.add_switch("s-rr-r1")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r1"])
+
+    switch = tgen.add_switch("s-rr-r2")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s-rr-r3")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r3"])
+
+    switch = tgen.add_switch("s-rr-r4")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r4"])
+
+    switch = tgen.add_switch("s-r1-r2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s-r3-r4")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+
+    for idx, rname in enumerate(["r1", "r2", "r3", "r4"], start=1):
+        create_interface_in_kernel(
+            tgen,
+            rname,
+            "sr0",
+            "fcbb:bbbb:{}::1".format(idx),
+            netmask="128",
+            create=True,
+        )
+
+
+def setup_module(mod):
+    """Set up test environment."""
+    result = required_linux_kernel_version("4.10")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    """Tear down test environment."""
+    get_topogen().stop_topology()
+
+
+def test_bgp_convergence():
+    """Test BGP convergence."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Waiting for BGP convergence")
+
+    for router in ["rr", "r1", "r2", "r3", "r4"]:
+        logger.info("Checking BGP convergence on %s", router)
+        test_func = functools.partial(
+            topotest.router_json_cmp,
+            tgen.gears[router],
+            "show bgp summary json",
+            {},
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+        assert result is None, '"{}" BGP convergence failure'.format(router)
+
+
+def test_bgp_ls_srv6_export():
+    """Verify SRv6 NLRIs and attributes on the RR match the expected JSON."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Verifying SRv6 BGP-LS NLRIs on RR against expected JSON")
+
+    rr = tgen.gears["rr"]
+    test_func = functools.partial(_check_rr_srv6_nlris, rr)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assert result is None, "SRv6 BGP-LS NLRI/attribute mismatch on RR: {}".format(
+        result
+    )
+
+    logger.info("SRv6 BGP-LS export validated")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -590,6 +590,15 @@ int zsend_redistribute_route(int cmd, struct zserv *client, const struct route_n
 			api_nh->gate.ipv6 = nexthop->gate.ipv6;
 			api_nh->ifindex = nexthop->ifindex;
 		}
+
+		if (nexthop->nh_srv6 &&
+		    nexthop->nh_srv6->seg6local_action != ZEBRA_SEG6_LOCAL_ACTION_UNSPEC) {
+			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6LOCAL);
+			api_nh->seg6local_action = nexthop->nh_srv6->seg6local_action;
+			memcpy(&api_nh->seg6local_ctx, &nexthop->nh_srv6->seg6local_ctx,
+			       sizeof(struct seg6local_context));
+		}
+
 		count++;
 	}
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3193,10 +3193,13 @@ static void zread_srv6_manager_get_locator(struct zserv *client,
 
 	/* Get data */
 	STREAM_GETW(s, len);
-	STREAM_GET(locator_name, s, len);
+	if (len >= sizeof(locator_name))
+		goto stream_failure;
+	if (len)
+		STREAM_GET(locator_name, s, len);
 
 	/* Call hook to get the locator info using wrapper */
-	srv6_manager_get_locator_call(&locator, client, locator_name);
+	srv6_manager_get_locator_call(&locator, client, len ? locator_name : NULL);
 
 stream_failure:
 	return;

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -2595,6 +2595,19 @@ static int srv6_manager_get_srv6_locator_internal(struct srv6_locator **locator,
 						  struct zserv *client,
 						  const char *locator_name)
 {
+	struct zebra_srv6 *srv6 = zebra_srv6_get_default();
+	struct listnode *node;
+	int ret = 0;
+
+	if (!locator_name) {
+		for (ALL_LIST_ELEMENTS_RO(srv6->locators, node, *locator)) {
+			ret = zsend_zebra_srv6_locator_add(client, *locator);
+			if (ret < 0)
+				return ret;
+		}
+		return 0;
+	}
+
 	*locator = zebra_srv6_locator_lookup(locator_name);
 	if (!*locator)
 		return -1;


### PR DESCRIPTION
When distribute `bgp-fabric-link-state` is enabled via CLI, BGP-LS advertises Node, Link, and Prefix NLRIs, but SRv6 information is missing.

SRv6 capability and SRv6 attributes (locator, End, End.X) should be advertised together with the BGP-fabric topology, but currently are not.

This PR fixes SRv6 advertisement for BGP-LS BGP-fabric export and adds a dedicated topotest that validates SRv6 BGP-LS advertisements.