### PR TITLE
tools: Add bfd commands to support bundle generation

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -198,9 +198,12 @@ show isis topology
 CMD_LIST_END
 
 # BFD Support Bundle Command List
-# PROC_NAME:bfd
-# CMD_LIST_START
-# CMD_LIST_END
+PROC_NAME:bfd
+CMD_LIST_START
+show bfd peers
+show bfd static route
+show bfd distributed
+CMD_LIST_END
 
 # STATIC Support Bundle Command List
 # PROC_NAME:static


### PR DESCRIPTION
There were no bfd commands being run to gather bfd data on failure.