### PR TITLE
bgpd: prevent root node poisoning in prefix tree

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -636,10 +636,13 @@ static void bgp_bnc_mark_nht_important(struct bgp_nexthop_cache *bnc, struct zap
 	if (prefix_same(&bnc->resolved_prefix, &nhr->prefix))
 		return;
 
-	dest = bgp_afi_node_get(table, afi, nhr->safi, &bnc->resolved_prefix, NULL);
-	if (dest) {
-		UNSET_FLAG(dest->flags, BGP_NODE_NHT_RESOLVED_NODE);
-		bgp_dest_unlock_node(dest);
+	if (bnc->resolved_prefix.family != 0) {
+		dest = bgp_afi_node_get(table, afi, nhr->safi,
+					&bnc->resolved_prefix, NULL);
+		if (dest) {
+			UNSET_FLAG(dest->flags, BGP_NODE_NHT_RESOLVED_NODE);
+			bgp_dest_unlock_node(dest);
+		}
 	}
 
 	dest = bgp_afi_node_get(table, afi, nhr->safi, &nhr->prefix, NULL);


### PR DESCRIPTION
When a BNC is first created via XCALLOC, resolved_prefix is {family=0, prefixlen=0}. If bgp_bnc_mark_nht_important fires before resolved_prefix is updated, it passes the zeroed prefix to bgp_afi_node_get which creates a {family=0, prefixlen=0} node in the radix trie, poisoning the table root.

Skip the old resolved_prefix lookup when family is still 0.

Signed-off-by: Soumya Roy <souroy@nvidia.com>

Steps:
1. Two routers with one unnumbered BGP link, each advertising loopbacks
2. Add a numbered eBGP peer between them using loopback IPs — the remote loopback is reachable via a BGP-learned route (from the unnumbered session)
3. Since the remote loopback resolves via a BGP route, zebra sends NHT update with nhr->type = ZEBRA_ROUTE_BGP, which triggers bgp_bnc_mark_nht_important — but resolved_prefix is still {family=0} (XCALLOC zeroed) at this point, so it poisons the radix trie root
4. Inject 0.0.0.0/0 from the remote peer — paths attach to the poisoned root via prefix_match