### PR TITLE
lib: Solve race condition in Link State

### DIFF
--- a/doc/developer/link-state.rst
+++ b/doc/developer/link-state.rst
@@ -188,6 +188,15 @@ Vertex, Edges and Subnets management functions
    Vertex, Edge or Subnet are created from, respectively the Link State Node,
    Attribute or Prefix structure. Data structure are dynamically allocated.
 
+   **NOTE:** TED is based on an RB_TREE_UNIQ data structure. Thus, if a Vertex,
+   Edge or Subnet with the same key already exists in the TED, the new one is
+   not added and pointer to the existing element is returned. It is up to the
+   caller to check if the returned element is NULL (element has been inserted
+   in the TED) or the current element in case insertion failed. Free new element
+   in case or error is also up to the caller. 'ls_find_xxx()' functions could
+   be used prior to call 'ls_xxx_add()' functions to check if an element already
+   exists in the TED.
+
 .. c:function:: struct ls_vertex *ls_vertex_update(struct ls_ted *ted, struct ls_node *node)
 .. c:function:: struct ls_edge *ls_edge_update(struct ls_ted *ted, struct ls_attributes *attributes)
 .. c:function:: struct ls_subnet *ls_subnet_update(struct ls_ted *ted, struct ls_prefix *pref)
@@ -444,6 +453,16 @@ Functions
 .. c:function:: int ls_request_sync(struct zclient *zclient)
 
    Request initial Synchronisation to collect the whole Link State Database.
+
+   **NOTE:** Before consumer call 'ls_request_sync()' function, it is up to
+   the caller to verify that the TED is empty to avoid any confusion between
+   the initial synchronisation and any existing data. 'ls_ted_clean()' function
+   could be used for that purpose. If cleaning TED is not possible, it is up
+   to the caller to reconcille existing TED elements and new ones received
+   during synchronisation. For that purpose, ORPHAN status could be used:
+   First, mark all elements in the TED as ORPHAN, then request TED sync.
+   Once got all SYNC messages, search for ORPHAN elements in the TED in order
+   to remove them or take appropriate action.
 
 .. c:function:: struct ls_message *ls_parse_msg(struct stream *s)
 

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1844,6 +1844,7 @@ int ls_send_msg(struct zclient *zclient, struct ls_message *msg,
 
 	return zclient_send_message(zclient);
 }
+
 struct ls_message *ls_vertex2msg(struct ls_message *msg,
 				 struct ls_vertex *vertex)
 {
@@ -1951,17 +1952,26 @@ struct ls_message *ls_subnet2msg(struct ls_message *msg,
 struct ls_vertex *ls_msg2vertex(struct ls_ted *ted, struct ls_message *msg,
 				bool delete)
 {
+	if (!msg || !msg->data.node)
+		return NULL;
+
 	struct ls_node *node = msg->data.node;
-	struct ls_vertex *vertex = NULL;
+	struct ls_vertex *vertex = ls_find_vertex_by_id(ted, node->adv);
 
 	switch (msg->event) {
 	case LS_MSG_EVENT_SYNC:
-		vertex = ls_vertex_add(ted, node);
+		if (vertex)
+			vertex = ls_vertex_update(ted, node);
+		else
+			vertex = ls_vertex_add(ted, node);
 		if (vertex)
 			vertex->status = SYNC;
 		break;
 	case LS_MSG_EVENT_ADD:
-		vertex = ls_vertex_add(ted, node);
+		if (vertex)
+			vertex = ls_vertex_update(ted, node);
+		else
+			vertex = ls_vertex_add(ted, node);
 		if (vertex)
 			vertex->status = NEW;
 		break;
@@ -1971,7 +1981,6 @@ struct ls_vertex *ls_msg2vertex(struct ls_ted *ted, struct ls_message *msg,
 			vertex->status = UPDATE;
 		break;
 	case LS_MSG_EVENT_DELETE:
-		vertex = ls_find_vertex_by_id(ted, node->adv);
 		if (vertex) {
 			if (delete) {
 				ls_vertex_del_all(ted, vertex);
@@ -1991,17 +2000,26 @@ struct ls_vertex *ls_msg2vertex(struct ls_ted *ted, struct ls_message *msg,
 struct ls_edge *ls_msg2edge(struct ls_ted *ted, struct ls_message *msg,
 			    bool delete)
 {
+	if (!msg || !msg->data.attr)
+		return NULL;
+
 	struct ls_attributes *attr = msg->data.attr;
-	struct ls_edge *edge = NULL;
+	struct ls_edge *edge = ls_find_edge_by_source(ted, attr);
 
 	switch (msg->event) {
 	case LS_MSG_EVENT_SYNC:
-		edge = ls_edge_add(ted, attr);
+		if (edge)
+			edge = ls_edge_update(ted, attr);
+		else
+			edge = ls_edge_add(ted, attr);
 		if (edge)
 			edge->status = SYNC;
 		break;
 	case LS_MSG_EVENT_ADD:
-		edge = ls_edge_add(ted, attr);
+		if (edge)
+			edge = ls_edge_update(ted, attr);
+		else
+			edge = ls_edge_add(ted, attr);
 		if (edge)
 			edge->status = NEW;
 		break;
@@ -2011,7 +2029,6 @@ struct ls_edge *ls_msg2edge(struct ls_ted *ted, struct ls_message *msg,
 			edge->status = UPDATE;
 		break;
 	case LS_MSG_EVENT_DELETE:
-		edge = ls_find_edge_by_source(ted, attr);
 		if (edge) {
 			if (delete) {
 				ls_edge_del_all(ted, edge);
@@ -2031,17 +2048,26 @@ struct ls_edge *ls_msg2edge(struct ls_ted *ted, struct ls_message *msg,
 struct ls_subnet *ls_msg2subnet(struct ls_ted *ted, struct ls_message *msg,
 				bool delete)
 {
+	if (!msg || !msg->data.prefix)
+		return NULL;
+
 	struct ls_prefix *pref = msg->data.prefix;
-	struct ls_subnet *subnet = NULL;
+	struct ls_subnet *subnet = ls_find_subnet(ted, &pref->pref);
 
 	switch (msg->event) {
 	case LS_MSG_EVENT_SYNC:
-		subnet = ls_subnet_add(ted, pref);
+		if (subnet)
+			subnet = ls_subnet_update(ted, pref);
+		else
+			subnet = ls_subnet_add(ted, pref);
 		if (subnet)
 			subnet->status = SYNC;
 		break;
 	case LS_MSG_EVENT_ADD:
-		subnet = ls_subnet_add(ted, pref);
+		if (subnet)
+			subnet = ls_subnet_update(ted, pref);
+		else
+			subnet = ls_subnet_add(ted, pref);
 		if (subnet)
 			subnet->status = NEW;
 		break;
@@ -2051,7 +2077,6 @@ struct ls_subnet *ls_msg2subnet(struct ls_ted *ted, struct ls_message *msg,
 			subnet->status = UPDATE;
 		break;
 	case LS_MSG_EVENT_DELETE:
-		subnet = ls_find_subnet(ted, &pref->pref);
 		if (subnet) {
 			if (delete) {
 				ls_subnet_del_all(ted, subnet);


### PR DESCRIPTION
When a consumer request a TED synchronization by calling `ls_request_sync()`, producer send TED elements with SYNC message which are in turn parse by `ls_msg2ted()` function or individual `ls_msg2vertex()`, `ls_msg2edge()` or `ls_msg2subnet()` function. In all cases, `ls_xxx_add()` functions are called.
However, in some race condition, TED is not empty and already contains the same element that is under synchronization. As TED is an RB_TREE_UNIQ structure, it is not allowed duplicate entry. The problem occurs when `ls_xxx_add()` functions try to add a sync element while it already exist. This element is not inserted in the TED and allocated memory lost at the end of caller leaving memory leaks when daemon stop.

This patch check if element already exist in `ls_msg2xxx()` functions prior to process message. Call to `ls_xxx_add()` functions is performed only if element is not present, however call to `ls_xxx_update()` functions is done.

Notes about RB_TREE_UNIQ nature of TED and potential problem with sync request have been also added to the link state documentation.