### PR TITLE
bgpd: Initialize BGP-LS Node MSD only after parsing it

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -4144,7 +4144,7 @@ static int parse_node_msd(struct stream *s, uint16_t length, struct bgp_ls_attr 
 {
 	uint8_t t;
 	uint8_t v;
-	uint8_t msd = 255;
+	uint8_t msd;
 	bool had_msd = false;
 
 	/*
@@ -4174,11 +4174,14 @@ static int parse_node_msd(struct stream *s, uint16_t length, struct bgp_ls_attr 
 		t = stream_getc(s);
 		v = stream_getc(s);
 		if (t == BGP_LS_IGP_MSD_TYPE_BASE_MPLS) {
-			if (had_msd) {
-				flog_warn(EC_BGP_UPDATE_RCV,
-					  "BGP-LS: Several MSD Values of Base MPLS Imposition MSD type, choosing minimum");
+			if (!had_msd) {
+				msd = v;
+				had_msd = true;
+				continue;
 			}
-			had_msd = true;
+
+			flog_warn(EC_BGP_UPDATE_RCV,
+				  "BGP-LS: Several MSD Values of Base MPLS Imposition MSD type, choosing minimum");
 			msd = MIN(msd, v);
 		}
 	}


### PR DESCRIPTION
`parse_node_msd()` initializes msd to 255 before it reads any Base MPLS MSD sub-TLV. The value is only a placeholder that lets the first `MIN()` call keep the first advertised value.

That placeholder is fragile because RFC 8491 defines MSD-Value as the full 0-255 range. If a future change treats msd == 255 as unset, it can incorrectly discard a valid value advertised by a peer.

Do not give msd a placeholder value. Keep had_msd as the only indication that the TLV contains a Base MPLS MSD value. Assign msd from the first matching sub-TLV, then keep the existing minimum selection for later duplicates.