### PR TITLE
bgpd: skip stalepath-timer clear for LLGR-negotiated AFI/SAFIs

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -881,10 +881,39 @@ static void bgp_graceful_stale_timer_expire(struct event *event)
 		zlog_debug("%pBP graceful restart stalepath timer expired for %s", peer,
 			   bgp_peer_get_connection_direction_string(connection));
 
-	/* NSF delete stale route */
-	FOREACH_AFI_SAFI_NSF (afi, safi)
-		if (peer->nsf[afi][safi])
-			bgp_clear_stale_route(peer, afi, safi);
+	/*
+	 * RFC 9494 §4.3: for LLGR-negotiated AFI/SAFI, retention is bounded
+	 * by the Long-Lived Stale Time, not stalepath-time. Skip the delete
+	 * if LLGR retention is (or will be) active for this AFI/SAFI:
+	 *   - t_llgr_stale[afi][safi] scheduled: the LLGR window is already
+	 *     running; t_gr_restart has fired but didn't cancel t_gr_stale
+	 *     (bgp_graceful_restart_timer_off() bails when any AFI/SAFI is
+	 *     in PEER_STATUS_LLGR_WAIT).
+	 *   - t_gr_restart scheduled and LLGR negotiated for this AFI/SAFI:
+	 *     still in the restart-time window; t_llgr_stale will be armed
+	 *     by bgp_graceful_restart_timer_expire() when t_gr_restart fires.
+	 * Using the t_llgr_stale scheduled state (rather than the configured
+	 * stale_time) also covers the case where stale_time is reconfigured
+	 * to 0 mid-flight while the timer is still running.
+	 * Non-LLGR AFI/SAFIs keep the original delete-now behaviour.
+	 */
+	FOREACH_AFI_SAFI_NSF (afi, safi) {
+		if (!peer->nsf[afi][safi])
+			continue;
+
+		if (event_is_scheduled(peer->t_llgr_stale[afi][safi]) ||
+		    (peer->llgr[afi][safi].stale_time &&
+		     event_is_scheduled(connection->t_gr_restart))) {
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug("%pBP graceful restart stalepath timer expired for %s: LLGR active for %s, skip stale route clear",
+					   peer,
+					   bgp_peer_get_connection_direction_string(connection),
+					   get_afi_safi_str(afi, safi, false));
+			continue;
+		}
+
+		bgp_clear_stale_route(peer, afi, safi);
+	}
 }
 
 /*


### PR DESCRIPTION
Rootcause and Impact :

A helper router silently drops every route that LLGR was supposed to retain, breaking RFC 9494 §4.3 ("Procedures for the Receiving Speaker" during the Long-Lived Stale Time window). Downstream routers stop seeing the `LLGR_STALE` community, fall back to whatever (worse) path they had, and forwarding loses the longer-lived retention guarantee that LLGR is supposed to provide.

When a GR-capable peer's session goes down, `bgp_stop()` arms **two** timers in parallel:

`t_gr_restart` = peer-advertised restart-time (LLGR-aware path)
 `t_gr_stale` = local `stalepath-time` (was NOT LLGR-aware earlier without our fix)

Whichever fires first wins:

| `stalepath ≥ restart` (typical defaults) | `t_gr_restart` fires first → `bgp_graceful_restart_timer_off()` cancels `t_gr_stale` → LLGR works fine | | `stalepath < restart` (this bug) | `t_gr_stale` fires first → unconditional delete → LLGR has nothing left to retain

Default FRR ships `stalepath-time=360s` and `restart-time=120s`, which hides the bug for most users. Operators tuning a longer restart window on the restarter, or shortening stalepath on the helper, expose it.

Fix:
Teach `bgp_graceful_stale_timer_expire()` to defer to the LLGR path when LLGR is negotiated for that AFI/SAFI and `t_gr_restart` is still running. `bgp_graceful_restart_timer_expire()` already implements the RFC-correct LLGR transition (sets `PEER_STATUS_LLGR_WAIT`, tags paths with `LLGR_STALE` via `bgp_set_llgr_stale()`, arms `t_llgr_stale`); we just have to stop the stalepath-timer from racing it.

For non-LLGR AFI/SAFIs the original delete behavior is preserved.

RFC 9494 §4.3 — Procedures for the Receiving Speaker.

> When the "Restart Time" period ends, the LLGR period is said to have
> begun and the following procedures MUST be performed:
>
> *  The helper router MUST start a timer for the "Long-lived Stale
>    Time"...
> *  The helper router MUST attach the LLGR_STALE community for the
>    stale routes being retained...

For these MUST clauses to have meaning, the routes have to *exist* at the moment `t_gr_restart` expires. The pre-fix stalepath-timer path deletes them earlier, which the RFC does not anticipate.