### PR TITLE
bgpd: Harden BGP-LS Node NLRI descriptor length validation

### DIFF
--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -3407,6 +3407,7 @@ int bgp_ls_decode_node_nlri(struct stream *s, struct bgp_ls_nlri *nlri, uint16_t
 {
 	uint16_t desc_type, desc_len;
 	size_t start_pos;
+	size_t consumed = 0;
 
 	if (!s || !nlri)
 		return -1;
@@ -3445,6 +3446,14 @@ int bgp_ls_decode_node_nlri(struct stream *s, struct bgp_ls_nlri *nlri, uint16_t
 	if (desc_type != BGP_LS_TLV_LOCAL_NODE_DESC) {
 		flog_warn(EC_BGP_LS_PACKET, "BGP-LS: Expected Local Node Descriptor TLV %u, got %u",
 			  BGP_LS_TLV_LOCAL_NODE_DESC, desc_type);
+		return -1;
+	}
+
+	consumed = stream_get_getp(s) - start_pos;
+	if (consumed > nlri_length || desc_len > nlri_length - consumed) {
+		flog_warn(EC_BGP_LS_PACKET,
+			  "BGP-LS: Local Node Descriptor TLV length %u exceeds NLRI boundary",
+			  desc_len);
 		return -1;
 	}
 


### PR DESCRIPTION
The Node NLRI decoder reads the Local Node Descriptor TLV length and passes it directly to the node descriptor parser. The generic TLV header helper only checks the remaining stream bytes, not the current NLRI boundary.

When multiple BGP-LS NLRIs share the same stream, a malformed Node NLRI can make the descriptor parser consume bytes from the next NLRI before the final length check reports the mismatch.

Reject Local Node Descriptor TLVs that do not fit inside the declared Node NLRI length, matching the existing checks in the Link and Prefix NLRI decoders.