### PR TITLE
lib: add missing hook_unregister_arg in mgmt_be_client_destroy

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -1435,6 +1435,9 @@ void mgmt_be_client_destroy(struct mgmt_be_client *client)
 
 	debug_be_client("Destroying MGMTD Backend Client '%s'", client->name);
 
+	hook_unregister_arg(nb_notification_tree_send,
+			    mgmt_be_send_notification, client);
+
 	nb_oper_cancel_all_walks();
 	msg_client_cleanup(&client->client);
 	mgmt_be_cleanup_all_txns(client);


### PR DESCRIPTION
Issue:
mgmt_be_client_create() registers a hook on nb_notification_tree_send but mgmt_be_client_destroy() never unregisters it. During shutdown, the client struct gets freed while the hook still points to it. When the subscription wheel timer fires after that, it dispatches to mgmt_be_send_notification() with the freed pointer and crashes.

```
  ZEBRA: Received signal 11 (si_addr 0x108000001d0)
  libfrr.so.0(nb_notification_tree_send+0x69)
  libfrr.so.0(nb_notification_send+0x165)
  libfrr.so.0(nb_notify_subscriptions+0xb8)
  libfrr.so.0(event_call+0x81)
  in thread wheel_timer_thread scheduled from ../lib/wheel.c:50
```

Fix by adding hook_unregister_arg() before freeing the client.

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>