### PR TITLE
Cleanup of memory allocation and usage of events

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2556,9 +2556,9 @@ void bfd_vrf_toggle_echo(struct bfd_vrf_global *bfd_vrf)
 	if (bfd_vrf->bg_echov6 == -1)
 		bfd_vrf->bg_echov6 = bp_echov6_socket(bfd_vrf->vrf);
 
-	if (bfd_vrf->bg_ev[4] == NULL && bfd_vrf->bg_echo != -1)
+	if (!event_is_scheduled(bfd_vrf->bg_ev[4]) && bfd_vrf->bg_echo != -1)
 		event_add_read(master, bfd_recv_cb, bfd_vrf, bfd_vrf->bg_echo, &bfd_vrf->bg_ev[4]);
-	if (bfd_vrf->bg_ev[5] == NULL && bfd_vrf->bg_echov6 != -1)
+	if (!event_is_scheduled(bfd_vrf->bg_ev[5]) && bfd_vrf->bg_echov6 != -1)
 		event_add_read(master, bfd_recv_cb, bfd_vrf, bfd_vrf->bg_echov6, &bfd_vrf->bg_ev[5]);
 }
 
@@ -2935,19 +2935,19 @@ int bfd_vrf_start_sockets(struct bfd_vrf_global *bvrf)
 	if (bvrf->bg_initv6 == -1)
 		bvrf->bg_initv6 = bp_initv6_socket(bvrf->vrf);
 
-	if (bvrf->bg_ev[0] == NULL && bvrf->bg_shop != -1)
+	if (!event_is_scheduled(bvrf->bg_ev[0]) && bvrf->bg_shop != -1)
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop,
 			       &bvrf->bg_ev[0]);
-	if (bvrf->bg_ev[1] == NULL && bvrf->bg_mhop != -1)
+	if (!event_is_scheduled(bvrf->bg_ev[1]) && bvrf->bg_mhop != -1)
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop,
 			       &bvrf->bg_ev[1]);
-	if (bvrf->bg_ev[2] == NULL && bvrf->bg_shop6 != -1)
+	if (!event_is_scheduled(bvrf->bg_ev[2]) && bvrf->bg_shop6 != -1)
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop6,
 			       &bvrf->bg_ev[2]);
-	if (bvrf->bg_ev[3] == NULL && bvrf->bg_mhop6 != -1)
+	if (!event_is_scheduled(bvrf->bg_ev[3]) && bvrf->bg_mhop6 != -1)
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop6,
 			       &bvrf->bg_ev[3]);
-	if (bvrf->bg_ev[6] == NULL && bvrf->bg_initv6 != -1)
+	if (!event_is_scheduled(bvrf->bg_ev[6]) && bvrf->bg_initv6 != -1)
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_initv6,
 			       &bvrf->bg_ev[6]);
 

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1107,7 +1107,6 @@ static bool bfd_check_auth(struct bfd_session *bfd, const struct bfd_pkt *cp)
 		/* Zero out the 20-byte digest field in the temp packet before hashing */
 		memset(msgbuf + BFD_PKT_LEN + 8, 0, digest_len);
 
-		md_alg = EVP_sha1();
 		HMAC(md_alg, key->string, strlen(key->string), msgbuf, cp->len, computed_digest,
 		     &digest_len);
 

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -437,7 +437,7 @@ static int bfd_dplane_enqueue(struct bfd_dplane_ctx *bdc, const void *buf,
 		bdc->out_bytes_peak = rlen;
 
 	/* Schedule if it is not yet. */
-	if (bdc->outbufev == NULL)
+	if (!event_is_scheduled(bdc->outbufev))
 		event_add_write(master, bfd_dplane_write, bdc, bdc->sock,
 				&bdc->outbufev);
 

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3285,7 +3285,7 @@ DEFPY(show_bmp,
 
 				uptime[0] = '\0';
 
-				if (ba->t_timer) {
+				if (event_is_scheduled(ba->t_timer)) {
 					long trem = event_timer_remain_second(
 						ba->t_timer);
 
@@ -3293,7 +3293,7 @@ DEFPY(show_bmp,
 						    uptime, sizeof(uptime),
 						    false, NULL);
 					state_str = "RetryWait";
-				} else if (ba->t_read) {
+				} else if (event_is_scheduled(ba->t_read)) {
 					state_str = "Connecting";
 				} else if (ba->resq.callback) {
 					state_str = "Resolving";

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2026,8 +2026,6 @@ static void bmp_read(struct event *t)
 	char buf[1024];
 	ssize_t n;
 
-	bmp->t_read = NULL;
-
 	n = read(bmp->socket, buf, sizeof(buf));
 	if (n >= 1) {
 		zlog_info("bmp[%s]: unexpectedly received %zu bytes", bmp->remote, n);

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -164,7 +164,6 @@ static void bgp_reuse_timer(struct event *t)
 	time_t t_now, t_diff;
 	struct bgp_damp_config *bdc = EVENT_ARG(t);
 
-	bdc->t_reuse = NULL;
 	event_add_timer(bm->master, bgp_reuse_timer, bdc, DELTA_REUSE,
 			&bdc->t_reuse);
 

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -5270,8 +5270,7 @@ void bgp_evpn_mh_finish(void)
 		/* Clear local info (attempts normal cleanup and may free es) */
 		bgp_evpn_es_local_info_clear(es, true);
 	}
-	if (bgp_mh_info->t_cons_check)
-		event_cancel(&bgp_mh_info->t_cons_check);
+	event_cancel(&bgp_mh_info->t_cons_check);
 	list_delete(&bgp_mh_info->local_es_list);
 	list_delete(&bgp_mh_info->pend_es_list);
 	list_delete(&bgp_mh_info->ead_es_export_rtl);

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -4457,7 +4457,8 @@ void bgp_evpn_es_evi_show_vni(struct vty *vty, vni_t vni,
  */
 static void bgp_evpn_es_cons_checks_timer_start(void)
 {
-	if (!bgp_mh_info->consistency_checking || bgp_mh_info->t_cons_check)
+	if (!bgp_mh_info->consistency_checking ||
+	    event_is_scheduled(bgp_mh_info->t_cons_check))
 		return;
 
 	if (BGP_DEBUG(evpn_mh, EVPN_MH_ES))

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -929,7 +929,7 @@ void bgp_start_tier2_deferral_timer(struct bgp *bgp, afi_t afi, safi_t safi)
 	/*
 	 * tier-2 deferral timer is already running
 	 */
-	if (gr_info->t_select_deferral_tier2) {
+	if (event_is_scheduled(gr_info->t_select_deferral_tier2)) {
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 			zlog_debug("%s: tier-2 path-select deferral timer for %s, duration %d is running",
 				   bgp->name_pretty, get_afi_safi_str(afi, safi, false),
@@ -1022,7 +1022,7 @@ static bool bgp_update_delay_applicable(struct bgp *bgp)
 
 bool bgp_update_delay_active(struct bgp *bgp)
 {
-	if (bgp->t_update_delay)
+	if (event_is_scheduled(bgp->t_update_delay))
 		return true;
 	return false;
 }
@@ -1046,7 +1046,7 @@ bool bgp_advertisement_delay_applicable(struct bgp *bgp)
 
 bool bgp_advertisement_delay_active(struct bgp *bgp)
 {
-	if (bgp->t_advertisement_delay)
+	if (event_is_scheduled(bgp->t_advertisement_delay))
 		return true;
 	return false;
 }
@@ -1208,7 +1208,7 @@ void bgp_adjust_routeadv(struct peer *peer)
 	 *
 	 *                     (MRAI - m) < r
 	 */
-	if (connection->t_routeadv)
+	if (event_is_scheduled(connection->t_routeadv))
 		remain = event_timer_remain_second(connection->t_routeadv);
 	else
 		remain = peer->v_routeadv;
@@ -1235,7 +1235,7 @@ bool bgp_maxmed_onstartup_configured(struct bgp *bgp)
 
 bool bgp_maxmed_onstartup_active(struct bgp *bgp)
 {
-	if (bgp->t_maxmed_onstartup)
+	if (event_is_scheduled(bgp->t_maxmed_onstartup))
 		return true;
 	return false;
 }
@@ -1248,7 +1248,7 @@ void bgp_maxmed_update(struct bgp *bgp)
 	if (bgp->v_maxmed_admin) {
 		maxmed_active = 1;
 		maxmed_value = bgp->maxmed_admin_value;
-	} else if (bgp->t_maxmed_onstartup) {
+	} else if (event_is_scheduled(bgp->t_maxmed_onstartup)) {
 		maxmed_active = 1;
 		maxmed_value = bgp->maxmed_onstartup_value;
 	} else {
@@ -1673,7 +1673,7 @@ void bgp_gr_check_path_select(struct bgp *bgp, afi_t afi, safi_t safi)
 		 */
 		if (!BGP_SUPPRESS_FIB_ENABLED(bgp) || !bgp->gr_info[afi][safi].gr_deferred ||
 		    !bgp_fibupd_safi(safi)) {
-			if (gr_info->t_select_deferral) {
+			if (event_is_scheduled(gr_info->t_select_deferral)) {
 				void *info = EVENT_ARG(gr_info->t_select_deferral);
 
 				XFREE(MTYPE_TMP, info);
@@ -1686,7 +1686,7 @@ void bgp_gr_check_path_select(struct bgp *bgp, afi_t afi, safi_t safi)
 		 * then cancel the timer.
 		 */
 		if (!multihop_eors_pending) {
-			if (gr_info->t_select_deferral_tier2) {
+			if (event_is_scheduled(gr_info->t_select_deferral_tier2)) {
 				void *info = EVENT_ARG(gr_info->t_select_deferral_tier2);
 
 				XFREE(MTYPE_TMP, info);
@@ -1858,7 +1858,7 @@ void bgp_gr_start_all_deferral_timers(struct bgp *bgp)
 			continue;
 
 		gr_info = &(bgp->gr_info[afi][safi]);
-		if (!gr_info->t_select_deferral)
+		if (!event_is_scheduled(gr_info->t_select_deferral))
 			bgp_start_deferral_timer(bgp, afi, safi, gr_info);
 	}
 }
@@ -1904,7 +1904,8 @@ static void bgp_gr_process_peer_up_include(struct bgp *bgp, struct peer *peer)
 		} else {
 			SET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_GR_WAIT_EOR);
 			gr_info = &(bgp->gr_info[afi][safi]);
-			if (!gr_info->t_select_deferral && !gr_info->select_defer_over)
+			if (!event_is_scheduled(gr_info->t_select_deferral) &&
+			    !gr_info->select_defer_over)
 				bgp_start_deferral_timer(bgp, afi, safi, gr_info);
 		}
 	}
@@ -1974,7 +1975,7 @@ static bool gr_path_select_deferral_applicable(struct bgp *bgp)
 	 * settings and GR is not complete and path selection
 	 * deferral not yet done for this instance
 	 */
-	if (!bgp->t_startup && !bgp_in_graceful_restart())
+	if (!event_is_scheduled(bgp->t_startup) && !bgp_in_graceful_restart())
 		return false;
 
 	FOREACH_AFI_SAFI_NSF (afi, safi) {
@@ -2183,7 +2184,7 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 		}
 
 		/* graceful restart */
-		if (connection->t_gr_stale) {
+		if (event_is_scheduled(connection->t_gr_stale)) {
 			event_cancel(&connection->t_gr_stale);
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%pBP graceful restart stalepath timer stopped for %s",
@@ -2212,7 +2213,7 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 		}
 
 		/* Stop route-refresh stalepath timer */
-		if (peer->t_refresh_stalepath) {
+		if (event_is_scheduled(peer->t_refresh_stalepath)) {
 			event_cancel(&peer->t_refresh_stalepath);
 
 			if (bgp_debug_neighbor_events(peer))
@@ -2551,7 +2552,7 @@ bgp_connect_success_w_delayopen(struct peer_connection *connection)
 	peer->v_delayopen = peer->delayopen;
 
 	/* Start the DelayOpenTimer if it is not already running */
-	if (!connection->t_delayopen)
+	if (!event_is_scheduled(connection->t_delayopen))
 		BGP_TIMER_ON(connection->t_delayopen, bgp_delayopen_timer, peer->v_delayopen);
 
 	frrtrace(2, frr_bgp, session_state_change, peer, 6);
@@ -2837,7 +2838,7 @@ static void bgp_peer_process_gr_cap_clear_stale(struct peer *peer)
 	safi_t safi;
 	int nsf_af_count = 0;
 
-	if (peer->connection->t_gr_restart) {
+	if (event_is_scheduled(peer->connection->t_gr_restart)) {
 		event_cancel(&peer->connection->t_gr_restart);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%pBP: graceful restart timer stopped", peer);
@@ -2880,7 +2881,7 @@ static void bgp_peer_process_gr_cap_clear_stale(struct peer *peer)
 		SET_FLAG(peer->sflags, PEER_STATUS_NSF_MODE);
 	else {
 		UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_MODE);
-		if (peer->connection->t_gr_stale) {
+		if (event_is_scheduled(peer->connection->t_gr_stale)) {
 			event_cancel(&peer->connection->t_gr_stale);
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%s: graceful restart stalepath timer stopped",
@@ -2977,7 +2978,7 @@ bgp_establish(struct peer_connection *connection)
 	 * Stop Long-lived Graceful Restart timers.
 	 */
 	FOREACH_AFI_SAFI (afi, safi) {
-		if (peer->t_llgr_stale[afi][safi]) {
+		if (event_is_scheduled(peer->t_llgr_stale[afi][safi])) {
 			event_cancel(&peer->t_llgr_stale[afi][safi]);
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%pBP Long-lived stale timer stopped for afi/safi: %d/%d for %s",

--- a/bgpd/bgp_labelpool.c
+++ b/bgpd/bgp_labelpool.c
@@ -1485,8 +1485,7 @@ static void lptest_stop(void)
 		return;
 	}
 
-	if (tcb->event_thread)
-		event_cancel(&tcb->event_thread);
+	event_cancel(&tcb->event_thread);
 
 	lpt_inprogress = false;
 }
@@ -1774,8 +1773,7 @@ static void lptest_delete(void *val)
 		tcb->timestamps_dealloc = NULL;
 	}
 
-	if (tcb->event_thread)
-		event_cancel(&tcb->event_thread);
+	event_cancel(&tcb->event_thread);
 
 	memset(tcb, 0, sizeof(*tcb));
 

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1666,7 +1666,7 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer_connection
 	rcapp = stream_get_endp(s);
 	stream_putc(s, 0);
 	restart_time = bgp->restart_time;
-	if (peer->bgp->t_startup || bgp_in_graceful_restart()) {
+	if (event_is_scheduled(peer->bgp->t_startup) || bgp_in_graceful_restart()) {
 		SET_FLAG(restart_time, GRACEFUL_RESTART_R_BIT);
 		SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_R_BIT_ADV);
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -222,7 +222,7 @@ void bgp_check_update_delay(struct bgp *bgp)
 		 * establish wait timer is on, or establish wait option is not
 		 * given with the update-delay command
 		 */
-		if (bgp->t_establish_wait
+		if (event_is_scheduled(bgp->t_establish_wait)
 		    || (bgp->v_establish_wait == bgp->v_update_delay))
 			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 				if (CHECK_FLAG(peer->flags,
@@ -407,7 +407,7 @@ static void bgp_write_proceed_actions(struct peer_connection *connection)
 
 		/* No packets to send, see if EOR is pending */
 		if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV)) {
-			if (!subgrp->t_coalesce && peer->afc_nego[afi][safi]
+			if (!event_is_scheduled(subgrp->t_coalesce) && peer->afc_nego[afi][safi]
 			    && peer->synctime
 			    && !CHECK_FLAG(peer->af_sflags[afi][safi],
 					   PEER_STATUS_EOR_SEND)
@@ -460,11 +460,12 @@ void bgp_generate_updgrp_packets(struct event *event)
 	 * processing is done and routes needs to be conditionally advertised or
 	 * withdrawn.
 	 */
-	if (connection->t_routeadv && !CHECK_FLAG(peer->sflags, PEER_STATUS_COND_ADV_PENDING))
+	if (event_is_scheduled(connection->t_routeadv) &&
+	    !CHECK_FLAG(peer->sflags, PEER_STATUS_COND_ADV_PENDING))
 		return;
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_COND_ADV_PENDING)) {
-		if (connection->t_routeadv && bgp_debug_neighbor_events(peer))
+		if (event_is_scheduled(connection->t_routeadv) && bgp_debug_neighbor_events(peer))
 			zlog_debug("%pBP: Pending conditional advertisement, ignoring MRAI timer",
 				   peer);
 	}
@@ -539,7 +540,7 @@ void bgp_generate_updgrp_packets(struct event *event)
 			 * yet.
 			 */
 			if (!next_pkt || !next_pkt->buffer) {
-				if (!paf->t_announce_route) {
+				if (!event_is_scheduled(paf->t_announce_route)) {
 					/* If route-refresh BoRR message was
 					 * already sent and we are done with
 					 * re-announcing tables for a decent
@@ -580,8 +581,8 @@ void bgp_generate_updgrp_packets(struct event *event)
 				 *   general, and thus the practice is
 				 *   recommended.
 				 */
-				if (!(PAF_SUBGRP(paf))->t_coalesce && peer->afc_nego[afi][safi] &&
-				    peer->synctime &&
+				if (!event_is_scheduled((PAF_SUBGRP(paf))->t_coalesce) &&
+				    peer->afc_nego[afi][safi] && peer->synctime &&
 				    !CHECK_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_EOR_SEND) &&
 				    advertise_list_is_empty(PAF_SUBGRP(paf))) {
 					/* If EOR is disabled, the message is
@@ -1345,7 +1346,7 @@ void bgp_capability_send(struct peer_connection *connection, afi_t afi, safi_t s
 		stream_putc(s, 0);
 		gr_restart_time = peer->bgp->restart_time;
 
-		if (peer->bgp->t_startup || bgp_in_graceful_restart()) {
+		if (event_is_scheduled(peer->bgp->t_startup) || bgp_in_graceful_restart()) {
 			SET_FLAG(gr_restart_time, GRACEFUL_RESTART_R_BIT);
 			SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_R_BIT_ADV);
 		}
@@ -2287,7 +2288,7 @@ static void bgp_update_receive_eor(struct peer_connection *connection, afi_t afi
 		/* graceful-restart related processing */
 		UNSET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_GR_WAIT_EOR);
 
-		if ((bgp->t_startup || bgp_in_graceful_restart() ||
+		if ((event_is_scheduled(bgp->t_startup) || bgp_in_graceful_restart() ||
 		     BGP_MULTIHOP_GR_PENDING(bgp, afi, safi)) &&
 		    bgp_gr_supported_for_afi_safi(afi, safi)) {
 			struct graceful_restart_info *gr_info;
@@ -3055,7 +3056,7 @@ static int bgp_route_refresh_receive(struct peer_connection *connection, bgp_siz
 			return BGP_PACKET_NOOP;
 		}
 
-		if (peer->t_refresh_stalepath) {
+		if (event_is_scheduled(peer->t_refresh_stalepath)) {
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug(
 					"%pBP rcvd route-refresh (BoRR) for %s/%s, whereas BoRR already received",
@@ -3088,7 +3089,7 @@ static int bgp_route_refresh_receive(struct peer_connection *connection, bgp_siz
 				peer, afi2str(afi), safi2str(safi),
 				peer->bgp->stalepath_time);
 	} else if (subtype == BGP_ROUTE_REFRESH_EORR) {
-		if (!peer->t_refresh_stalepath) {
+		if (!event_is_scheduled(peer->t_refresh_stalepath)) {
 			flog_err(EC_BGP_ROUTE_REFRESH_INVALID,
 				 "%pBP rcvd route-refresh (EoRR) for %s/%s, whereas no BoRR received",
 				 peer, afi2str(afi), safi2str(safi));

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2255,8 +2255,6 @@ static void bgp_refresh_stalepath_timer_expire(struct event *event)
 	safi_t safi = paf->safi;
 	struct peer *peer = paf->peer;
 
-	peer->t_refresh_stalepath = NULL;
-
 	if (peer->nsf[afi][safi])
 		bgp_clear_stale_route(peer, afi, safi);
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4240,7 +4240,7 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 	if (old_select || new_select) {
 		bgp_bump_version(dest);
 
-		if (!bgp->t_rmap_def_originate_eval &&
+		if (!event_is_scheduled(bgp->t_rmap_def_originate_eval) &&
 		    bgp->rmap_def_originate_eval_timer)
 			event_add_timer(
 				bm->master,
@@ -4442,7 +4442,7 @@ void bgp_dest_decrement_gr_fib_install_pending_count(struct bgp_dest *dest)
 	    bgp->gr_route_sync_pending) {
 		struct graceful_restart_info *gr_info = &(bgp->gr_info[afi][safi]);
 
-		if (gr_info->t_select_deferral) {
+		if (event_is_scheduled(gr_info->t_select_deferral)) {
 			void *info = EVENT_ARG(gr_info->t_select_deferral);
 
 			XFREE(MTYPE_TMP, info);
@@ -6790,7 +6790,7 @@ void bgp_default_originate(struct peer *peer, afi_t afi, safi_t safi,
  */
 void bgp_stop_announce_route_timer(struct peer_af *paf)
 {
-	if (!paf->t_announce_route)
+	if (!event_is_scheduled(paf->t_announce_route))
 		return;
 
 	event_cancel(&paf->t_announce_route);
@@ -6850,7 +6850,7 @@ void bgp_announce_route(struct peer *peer, afi_t afi, safi_t safi, bool force)
 	if (force)
 		SET_FLAG(subgrp->sflags, SUBGRP_STATUS_FORCE_UPDATES);
 
-	if (paf->t_announce_route)
+	if (event_is_scheduled(paf->t_announce_route))
 		return;
 
 	/*
@@ -7110,7 +7110,7 @@ bool bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi)
 		 */
 		bgp_soft_reconfig_table_flag(table, true);
 
-		if (!table->soft_reconfig_thread)
+		if (!event_is_scheduled(table->soft_reconfig_thread))
 			event_add_event(bm->master,
 					bgp_soft_reconfig_table_task, table, 0,
 					&table->soft_reconfig_thread);
@@ -7404,7 +7404,7 @@ void bgp_clear_route(struct peer *peer, afi_t afi, safi_t safi)
 	 * the unlock will happen upon work-queue completion; other wise, the
 	 * unlock happens at the end of this function.
 	 */
-	if (!peer->clear_node_queue->event)
+	if (!event_is_scheduled(peer->clear_node_queue->event))
 		peer_lock(peer);
 
 	if (safi != SAFI_MPLS_VPN && safi != SAFI_ENCAP && safi != SAFI_EVPN)
@@ -7420,7 +7420,7 @@ void bgp_clear_route(struct peer *peer, afi_t afi, safi_t safi)
 		}
 
 	/* unlock if no nodes got added to the clear-node-queue. */
-	if (!peer->clear_node_queue->event)
+	if (!event_is_scheduled(peer->clear_node_queue->event))
 		peer_unlock(peer);
 }
 
@@ -13546,7 +13546,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 		}
 	}
 
-	if (path->peer->connection->t_gr_restart &&
+	if (event_is_scheduled(path->peer->connection->t_gr_restart) &&
 	    CHECK_FLAG(path->flags, BGP_PATH_STALE)) {
 		unsigned long gr_remaining = event_timer_remain_second(
 			path->peer->connection->t_gr_restart);
@@ -13561,7 +13561,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 				gr_remaining);
 	}
 
-	if (path->peer->t_llgr_stale[afi][safi] &&
+	if (event_is_scheduled(path->peer->t_llgr_stale[afi][safi]) &&
 	    bgp_attr_get_community(attr) &&
 	    community_include(bgp_attr_get_community(attr),
 			      COMMUNITY_LLGR_STALE)) {

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1523,8 +1523,6 @@ static void update_subgroup_merge_check_thread_cb(struct event *event)
 
 	subgrp = EVENT_ARG(event);
 
-	subgrp->t_merge_check = NULL;
-
 	update_subgroup_check_merge(subgrp, "triggered merge check");
 }
 
@@ -1547,7 +1545,6 @@ bool update_subgroup_trigger_merge_check(struct update_subgroup *subgrp,
 	if (!force && !update_subgroup_ready_for_merge(subgrp))
 		return false;
 
-	subgrp->t_merge_check = NULL;
 	event_add_timer_msec(bm->master, update_subgroup_merge_check_thread_cb,
 			     subgrp, 0, &subgrp->t_merge_check);
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1539,7 +1539,7 @@ static void update_subgroup_merge_check_thread_cb(struct event *event)
 bool update_subgroup_trigger_merge_check(struct update_subgroup *subgrp,
 					 int force)
 {
-	if (subgrp->t_merge_check)
+	if (event_is_scheduled(subgrp->t_merge_check))
 		return true;
 
 	if (!force && !update_subgroup_ready_for_merge(subgrp))
@@ -2267,7 +2267,7 @@ void peer_af_announce_route(struct peer_af *paf, int combine)
 			if (cur_paf == paf)
 				continue;
 
-			if (cur_paf->t_announce_route)
+			if (event_is_scheduled(cur_paf->t_announce_route))
 				continue;
 
 			all_pending = 0;

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -405,7 +405,6 @@ static void subgroup_coalesce_timer(struct event *event)
 	frrtrace(3, frr_bgp, upd_announce_route_on_coalesce_timer_expiry,
 		 (SUBGRP_UPDGRP(subgrp))->id, subgrp->id, subgrp->v_coalesce);
 
-	subgrp->t_coalesce = NULL;
 	subgrp->v_coalesce = 0;
 	bgp = SUBGRP_INST(subgrp);
 	subgroup_announce_route(subgrp);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -239,7 +239,7 @@ static int group_announce_route_walkcb(struct update_group *updgrp, void *arg)
 			/* Send withdrawals without waiting for coalesting timer
 			 * to expire.
 			 */
-			if (subgrp->t_coalesce) {
+			if (event_is_scheduled(subgrp->t_coalesce)) {
 				subgrp_withdraw_stale_addpath(ctx, subgrp);
 
 				goto done;
@@ -261,7 +261,7 @@ static int group_announce_route_walkcb(struct update_group *updgrp, void *arg)
 			/* Send withdrawals without waiting for coalesting timer
 			 * to expire.
 			 */
-			if (subgrp->t_coalesce) {
+			if (event_is_scheduled(subgrp->t_coalesce)) {
 				if (!ctx->pi || CHECK_FLAG(ctx->pi->flags, BGP_PATH_UNUSEABLE)) {
 					RB_FOREACH_SAFE (adj, bgp_adj_out_rb, &ctx->dest->adj_out,
 							 adj_next) {
@@ -1168,7 +1168,7 @@ void subgroup_announce_all(struct update_subgroup *subgrp)
 	/*
 	 * We should wait for the coalesce timer. Arm the timer if not done.
 	 */
-	if (!subgrp->t_coalesce) {
+	if (!event_is_scheduled(subgrp->t_coalesce)) {
 		event_add_timer_msec(bm->master, subgroup_coalesce_timer,
 				     subgrp, subgrp->v_coalesce,
 				     &subgrp->t_coalesce);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2432,7 +2432,7 @@ DEFUN (no_bgp_maxmed_onstartup,
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	/* Cancel max-med onstartup if its on */
-	if (bgp->t_maxmed_onstartup) {
+	if (event_is_scheduled(bgp->t_maxmed_onstartup)) {
 		event_cancel(&bgp->t_maxmed_onstartup);
 		bgp->maxmed_onstartup_over = 1;
 	}
@@ -4028,7 +4028,7 @@ DEFUN (bgp_neighbor_graceful_restart_disable_set,
 
 	ret = bgp_neighbor_graceful_restart(peer, PEER_DISABLE_CMD);
 	if (ret == BGP_GR_SUCCESS) {
-		if (peer->bgp->t_startup || bgp_in_graceful_restart())
+		if (event_is_scheduled(peer->bgp->t_startup) || bgp_in_graceful_restart())
 			bgp_peer_gr_flags_update(peer);
 
 		VTY_BGP_GR_ROUTER_DETECT(bgp, peer, peer->bgp->peer);
@@ -8646,7 +8646,7 @@ DEFUN (bgp_set_route_map_delay_timer,
 		 * running, stop the timer and act as if the timer has already
 		 * fired.
 		 */
-		if (!rmap_delay_timer && bm->t_rmap_update) {
+		if (!rmap_delay_timer && event_is_scheduled(bm->t_rmap_update)) {
 			event_cancel(&bm->t_rmap_update);
 			event_execute(bm->master, bgp_route_map_update_timer,
 				      NULL, 0, NULL);
@@ -12671,7 +12671,7 @@ static void print_bgp_vrfs(struct bgp *bgp, struct vty *vty, json_object *json,
 				json_object_boolean_add(json_gr, "grPathSelectionDeferral",
 							event_is_scheduled(
 								gr_info->t_select_deferral));
-				if (gr_info->t_select_deferral)
+				if (event_is_scheduled(gr_info->t_select_deferral))
 					json_object_int_add(json_gr, "grDeferralRemainingTimeSec",
 							    event_timer_remain_second(
 								    gr_info->t_select_deferral));
@@ -12930,7 +12930,7 @@ static int show_bgp_vrfs_detail_common(struct vty *vty, struct bgp *bgp,
 						event_is_scheduled(gr_info->t_select_deferral)
 							? "DONE"
 							: "IN-PROGRESS");
-					if (gr_info->t_select_deferral)
+					if (event_is_scheduled(gr_info->t_select_deferral))
 						vty_out(vty,
 							"  Path selection deferral timer running, remaining time %lds\n",
 							event_timer_remain_second(
@@ -15351,7 +15351,7 @@ static void bgp_show_peer_gr_info_afi_safi(struct vty *vty, struct peer *peer, b
 			json_object_int_add(json_timer, "llgrStaleTime",
 					    peer->llgr[afi][safi].stale_time);
 
-			if (peer->connection->t_gr_stale != NULL) {
+			if (event_is_scheduled(peer->connection->t_gr_stale)) {
 				json_object_int_add(json_timer,
 						    "stalePathTimerRemaining",
 						    event_timer_remain_second(
@@ -15399,7 +15399,7 @@ static void bgp_show_peer_gr_info_afi_safi(struct vty *vty, struct peer *peer, b
 				"        Configured Stale Path Time(sec): %u\n",
 				peer->bgp->stalepath_time);
 
-			if (peer->connection->t_gr_stale != NULL)
+			if (event_is_scheduled(peer->connection->t_gr_stale))
 				vty_out(vty,
 					"      Stale Path Remaining(sec): %ld\n",
 					event_timer_remain_second(
@@ -15462,11 +15462,11 @@ static void bgp_show_neighbor_graceful_restart_time(struct vty *vty,
 		json_object_int_add(json_timer, "receivedRestartTimer",
 				    p->v_gr_restart);
 
-		if (p->connection->t_gr_restart != NULL)
+		if (event_is_scheduled(p->connection->t_gr_restart))
 			json_object_int_add(json_timer, "restartTimerRemaining",
 					    event_timer_remain_second(
 						    p->connection->t_gr_restart));
-		if (p->connection->t_gr_stale)
+		if (event_is_scheduled(p->connection->t_gr_stale))
 			json_object_int_add(json_timer, "gracefulStalepathTimerSec",
 					    event_timer_remain_second(p->connection->t_gr_stale));
 
@@ -15481,7 +15481,7 @@ static void bgp_show_neighbor_graceful_restart_time(struct vty *vty,
 			p->v_gr_restart);
 		vty_out(vty, "      Configured LLGR Stale Path Time(sec): %u\n",
 			p->bgp->llgr_stale_time);
-		if (p->connection->t_gr_restart != NULL)
+		if (event_is_scheduled(p->connection->t_gr_restart))
 			vty_out(vty, "      Restart Time Remaining(sec): %ld\n",
 				event_timer_remain_second(
 					p->connection->t_gr_restart));
@@ -16326,11 +16326,11 @@ static void bgp_show_peer_gr_extra_info(struct vty *vty, struct peer *p, bool us
 		json_object_object_add(json_grace, "endOfRibRecv", json_grace_recv);
 
 
-		if (p->connection->t_gr_restart)
+		if (event_is_scheduled(p->connection->t_gr_restart))
 			json_object_int_add(json_grace, "gracefulRestartTimerSec",
 					    event_timer_remain_second(p->connection->t_gr_restart));
 
-		if (p->connection->t_gr_stale)
+		if (event_is_scheduled(p->connection->t_gr_stale))
 			json_object_int_add(json_grace, "gracefulStalepathTimerSec",
 					    event_timer_remain_second(p->connection->t_gr_stale));
 		/* more gr info in new format */
@@ -16359,11 +16359,11 @@ static void bgp_show_peer_gr_extra_info(struct vty *vty, struct peer *p, bool us
 			vty_out(vty, "\n");
 		}
 
-		if (p->connection->t_gr_restart)
+		if (event_is_scheduled(p->connection->t_gr_restart))
 			vty_out(vty, "    The remaining time of restart timer is %ld\n",
 				event_timer_remain_second(p->connection->t_gr_restart));
 
-		if (p->connection->t_gr_stale)
+		if (event_is_scheduled(p->connection->t_gr_stale))
 			vty_out(vty, "    The remaining time of stalepath timer is %ld\n",
 				event_timer_remain_second(p->connection->t_gr_stale));
 
@@ -18033,7 +18033,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 			vty_out(vty,
 				"  Peer had exceeded the max. no. of prefixes configured.\n");
 
-		if (p->connection->t_pmax_restart) {
+		if (event_is_scheduled(p->connection->t_pmax_restart)) {
 			if (use_json) {
 				json_object_boolean_true_add(
 					json_neigh, "reducePrefixNumFrom");
@@ -18205,19 +18205,19 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 						!!CHECK_FLAG(p->sflags,
 							     PEER_STATUS_BFD_STRICT_HOLD_TIME_EXPIRED));
 		}
-		if (p->connection->t_start)
+		if (event_is_scheduled(p->connection->t_start))
 			json_object_int_add(json_neigh,
 					    "nextStartTimerDueInMsecs",
 					    event_timer_remain_second(
 						    p->connection->t_start) *
 						    1000);
-		if (p->connection->t_connect)
+		if (event_is_scheduled(p->connection->t_connect))
 			json_object_int_add(json_neigh,
 					    "nextConnectTimerDueInMsecs",
 					    event_timer_remain_second(
 						    p->connection->t_connect) *
 						    1000);
-		if (p->connection->t_routeadv) {
+		if (event_is_scheduled(p->connection->t_routeadv)) {
 			json_object_int_add(json_neigh, "mraiInterval",
 					    p->v_routeadv);
 			json_object_int_add(json_neigh, "mraiTimerExpireInMsecs",
@@ -18229,7 +18229,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 			json_object_int_add(json_neigh, "authenticationEnabled",
 					    1);
 
-		if (p->connection->t_read)
+		if (event_is_scheduled(p->connection->t_read))
 			json_object_string_add(json_neigh, "readThread", "on");
 		else
 			json_object_string_add(json_neigh, "readThread", "off");
@@ -18251,15 +18251,15 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 					"Shutdown when RTT > %dms, count > %u\n",
 					p->rtt_expected, p->rtt_keepalive_rcv);
 		}
-		if (p->connection->t_start)
+		if (event_is_scheduled(p->connection->t_start))
 			vty_out(vty, "Next start timer due in %ld seconds\n",
 				event_timer_remain_second(
 					p->connection->t_start));
-		if (p->connection->t_connect)
+		if (event_is_scheduled(p->connection->t_connect))
 			vty_out(vty, "Next connect timer due in %ld seconds\n",
 				event_timer_remain_second(
 					p->connection->t_connect));
-		if (p->connection->t_routeadv)
+		if (event_is_scheduled(p->connection->t_routeadv))
 			vty_out(vty,
 				"MRAI (interval %u) timer expires in %ld seconds\n",
 				p->v_routeadv,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9070,8 +9070,7 @@ DEFPY (bgp_def_originate_eval,
 
 	bgp->rmap_def_originate_eval_timer = no ? 0 : timer;
 
-	if (bgp->t_rmap_def_originate_eval)
-		event_cancel(&bgp->t_rmap_def_originate_eval);
+	event_cancel(&bgp->t_rmap_def_originate_eval);
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -4934,7 +4934,7 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 
 
 	/* Check if the client is connected */
-	if ((bgp_zclient->sock < 0) || (bgp_zclient->t_connect)) {
+	if ((bgp_zclient->sock < 0) || event_is_scheduled(bgp_zclient->t_connect)) {
 		if (BGP_DEBUG(zebra, ZEBRA) || BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 			zlog_debug("%s: %s client not connected", __func__,
 				   bgp->name_pretty);
@@ -5013,7 +5013,7 @@ int bgp_zebra_update(struct bgp *bgp, afi_t afi, safi_t safi,
 	}
 
 	/* Check if the client is connected */
-	if ((bgp_zclient->sock < 0) || (bgp_zclient->t_connect)) {
+	if ((bgp_zclient->sock < 0) || event_is_scheduled(bgp_zclient->t_connect)) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: %s client not connected", __func__,
 				   bgp->name_pretty);
@@ -5056,7 +5056,7 @@ int bgp_zebra_stale_timer_update(struct bgp *bgp)
 	}
 
 	/* Check if the client is connected */
-	if ((bgp_zclient->sock < 0) || (bgp_zclient->t_connect)) {
+	if ((bgp_zclient->sock < 0) || event_is_scheduled(bgp_zclient->t_connect)) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: %s client not connected", __func__,
 				   bgp->name_pretty);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3725,8 +3725,6 @@ static void bgp_startup_timer_expire(struct event *event)
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug("%s: Startup timer expired", bgp->name_pretty);
-
-	bgp->t_startup = NULL;
 }
 
 /*
@@ -4211,8 +4209,6 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 	bgp_tip_hash_init(bgp);
 	bgp_scan_init(bgp);
 	*bgp_val = bgp;
-
-	bgp->t_rmap_def_originate_eval = NULL;
 
 	/* If Default instance or VRF, link to the VRF structure, if present. */
 	if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT
@@ -9213,7 +9209,6 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	bm->addresses = addresses;
 	bm->master = master;
 	bm->start_time = monotime(NULL);
-	bm->t_rmap_update = NULL;
 	bm->rmap_update_timer = RMAP_DEFAULT_UPDATE_TIMER;
 	bm->v_update_delay = BGP_UPDATE_DELAY_DEFAULT;
 	bm->v_establish_wait = BGP_UPDATE_DELAY_DEFAULT;
@@ -9224,14 +9219,10 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	bm->ip_tos = IPTOS_PREC_INTERNETCONTROL;
 	bm->inq_limit = BM_DEFAULT_Q_LIMIT;
 	bm->outq_limit = BM_DEFAULT_Q_LIMIT;
-	bm->t_bgp_sync_label_manager = NULL;
-	bm->t_bgp_start_label_manager = NULL;
-	bm->t_bgp_zebra_route = NULL;
 	bm->restart_time = BGP_DEFAULT_RESTART_TIME;
 	bm->stalepath_time = BGP_DEFAULT_STALEPATH_TIME;
 	bm->select_defer_time = BGP_DEFAULT_SELECT_DEFERRAL_TIME;
 	bm->rib_stale_time = BGP_DEFAULT_RIB_STALE_TIME;
-	bm->t_bgp_zebra_l2_vni = NULL;
 
 	bm->peer_clearing_batch_id = 1;
 	/* TODO -- make these configurable */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2933,12 +2933,12 @@ void peer_nsf_stop(struct peer *peer)
 		event_cancel(&peer->t_llgr_stale[afi][safi]);
 	}
 
-	if (peer->connection->t_gr_restart) {
+	if (event_is_scheduled(peer->connection->t_gr_restart)) {
 		event_cancel(&peer->connection->t_gr_restart);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%pBP graceful restart timer stopped", peer);
 	}
-	if (peer->connection->t_gr_stale) {
+	if (event_is_scheduled(peer->connection->t_gr_stale)) {
 		event_cancel(&peer->connection->t_gr_stale);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug(
@@ -5502,7 +5502,7 @@ static void peer_flag_modify_action(struct peer *peer, uint64_t flag)
 
 			UNSET_FLAG(peer->sflags, PEER_STATUS_PREFIX_OVERFLOW);
 
-			if (peer->connection->t_pmax_restart) {
+			if (event_is_scheduled(peer->connection->t_pmax_restart)) {
 				event_cancel(&peer->connection->t_pmax_restart);
 				if (bgp_debug_neighbor_events(peer))
 					zlog_debug(
@@ -8545,7 +8545,7 @@ static bool peer_maximum_prefix_clear_overflow(struct peer *peer)
 		return false;
 
 	UNSET_FLAG(peer->sflags, PEER_STATUS_PREFIX_OVERFLOW);
-	if (peer->connection->t_pmax_restart) {
+	if (event_is_scheduled(peer->connection->t_pmax_restart)) {
 		event_cancel(&peer->connection->t_pmax_restart);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug(
@@ -9405,7 +9405,7 @@ static int peer_unshut_after_cfg(struct bgp *bgp)
 	 * If this VRF doesn't have GR configured at global and neighbor level
 	 * then return
 	 */
-	if ((!bgp_in_graceful_restart() && !bgp->t_startup) ||
+	if ((!bgp_in_graceful_restart() && !event_is_scheduled(bgp->t_startup)) ||
 	    (global_gr_mode != GLOBAL_GR && !gr_cfgd_at_nbr))
 		return 0;
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4317,8 +4317,7 @@ void bgp_instance_down(struct bgp *bgp)
 	hook_call(bgp_instance_state, bgp);
 
 	/* Stop timers. */
-	if (bgp->t_rmap_def_originate_eval)
-		event_cancel(&bgp->t_rmap_def_originate_eval);
+	event_cancel(&bgp->t_rmap_def_originate_eval);
 
 	/* Bring down peers, so corresponding routes are purged. */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, next, peer)) {
@@ -4545,8 +4544,7 @@ int bgp_delete(struct bgp *bgp)
 	vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP6);
 
 	/* Stop timers. */
-	if (bgp->t_rmap_def_originate_eval)
-		event_cancel(&bgp->t_rmap_def_originate_eval);
+	event_cancel(&bgp->t_rmap_def_originate_eval);
 
 	/* Inform peers we're going down. */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, next, peer))

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2788,7 +2788,7 @@ rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 	assert(bpi->extra);
 	if (lifetime > UINT32_MAX / 1001) {
 		/* sub-optimal case, but will probably never happen */
-		bpi->extra->vnc->vnc.import.timer = NULL;
+		event_cancel(&bpi->extra->vnc->vnc.import.timer);
 		event_add_timer(bm->master, timer_service_func, wcb, lifetime,
 				&bpi->extra->vnc->vnc.import.timer);
 	} else {
@@ -2804,7 +2804,7 @@ rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 
 		lifetime_msec = (lifetime * 1000) + jitter;
 
-		bpi->extra->vnc->vnc.import.timer = NULL;
+		event_cancel(&bpi->extra->vnc->vnc.import.timer);
 		event_add_timer_msec(bm->master, timer_service_func, wcb,
 				     lifetime_msec,
 				     &bpi->extra->vnc->vnc.import.timer);

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -285,7 +285,7 @@ static void rfapi_info_free(struct rfapi_info *goner)
 			rfapiFreeRfapiVnOptionChain(goner->vn_options);
 			goner->vn_options = NULL;
 		}
-		if (goner->timer) {
+		if (event_is_scheduled(goner->timer)) {
 			struct rfapi_rib_tcb *tcb;
 
 			tcb = EVENT_ARG(goner->timer);
@@ -355,7 +355,7 @@ static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
 {
 	struct rfapi_rib_tcb *tcb = NULL;
 
-	if (ri->timer) {
+	if (event_is_scheduled(ri->timer)) {
 		tcb = EVENT_ARG(ri->timer);
 		event_cancel(&ri->timer);
 	} else {
@@ -548,7 +548,7 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 							    NULL,
 							    (void **)&ri)) {
 
-						if (ri->timer) {
+						if (event_is_scheduled(ri->timer)) {
 							struct rfapi_rib_tcb
 								*tcb;
 
@@ -943,7 +943,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 				rfapiFreeBgpTeaOptionChain(ri->tea_options);
 				ri->tea_options = NULL;
 
-				if (ri->timer) {
+				if (event_is_scheduled(ri->timer)) {
 					struct rfapi_rib_tcb *tcb;
 
 					tcb = EVENT_ARG(ri->timer);
@@ -1029,7 +1029,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 				listnode_add(delete_list, ori);
 				rfapiFreeBgpTeaOptionChain(ori->tea_options);
 				ori->tea_options = NULL;
-				if (ori->timer) {
+				if (event_is_scheduled(ori->timer)) {
 					struct rfapi_rib_tcb *tcb;
 
 					tcb = EVENT_ARG(ori->timer);
@@ -1365,7 +1365,7 @@ callback:
 
 				RFAPI_RIB_CHECK_COUNTS(0, delete_list->count);
 				/* cancel normal expire timer */
-				if (ri->timer) {
+				if (event_is_scheduled(ri->timer)) {
 					struct rfapi_rib_tcb *tcb;
 
 					tcb = EVENT_ARG(ri->timer);

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1759,7 +1759,7 @@ void vnc_direct_bgp_rh_del_route(struct bgp *bgp, afi_t afi,
 	eti = vnc_eti_get(bgp, EXPORT_TYPE_BGP, prefix, peer,
 			  ZEBRA_ROUTE_VNC_DIRECT_RH, BGP_ROUTE_REDISTRIBUTE);
 
-	if (!eti->timer && eti->lifetime <= INT32_MAX) {
+	if (!event_is_scheduled(eti->timer) && eti->lifetime <= INT32_MAX) {
 		eti->timer = NULL;
 		event_add_timer(bm->master, vncExportWithdrawTimer, eti,
 				eti->lifetime, &eti->timer);

--- a/bgpd/rfapi/vnc_export_table.c
+++ b/bgpd/rfapi/vnc_export_table.c
@@ -172,7 +172,7 @@ struct vnc_export_info *vnc_eti_checktimer(struct bgp *bgp,
 
 	agg_unlock_node(etn);
 
-	if (eti && eti->timer)
+	if (eti && event_is_scheduled(eti->timer))
 		return eti;
 
 	return NULL;

--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -193,7 +193,7 @@ void show_ip_eigrp_neighbor_sub(struct vty *vty, struct eigrp_neighbor *nbr,
 {
 
 	vty_out(vty, "%-3u %-17pI4 %-21s", 0, &nbr->src, IF_NAME(nbr->ei));
-	if (nbr->t_holddown)
+	if (event_is_scheduled(nbr->t_holddown))
 		vty_out(vty, "%-7lu",
 			event_timer_remain_second(nbr->t_holddown));
 	else

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -268,7 +268,6 @@ void eigrp_distribute_timer_interface(struct event *event)
 	struct eigrp_interface *ei;
 
 	ei = EVENT_ARG(event);
-	ei->t_distribute = NULL;
 
 	/* execute GR for interface */
 	eigrp_update_send_interface_GR(ei, EIGRP_GR_FILTER, NULL);

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -767,7 +767,7 @@ void eigrp_hello_send(struct eigrp_interface *ei, uint8_t flags,
 			ei->on_write_q = 1;
 		}
 
-		if (ei->eigrp->t_write == NULL) {
+		if (!event_is_scheduled(ei->eigrp->t_write)) {
 			if (flags & EIGRP_HELLO_GRACEFUL_SHUTDOWN) {
 				event_execute(master, eigrp_write, ei->eigrp,
 					      ei->eigrp->fd, NULL);

--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -263,7 +263,7 @@ void fabricd_initial_sync_hello(struct isis_circuit *circuit)
 	long timeout = 2L * circuit->hello_interval[1] * circuit->hello_multiplier[1];
 
 	f->initial_sync_circuit = circuit;
-	if (f->initial_sync_timeout)
+	if (event_is_scheduled(f->initial_sync_timeout))
 		return;
 
 	event_add_timer(master, fabricd_initial_sync_timeout, f, timeout,
@@ -418,7 +418,7 @@ static void fabricd_tier_calculation_cb(struct event *event)
 static void fabricd_bump_tier_calculation_timer(struct fabricd *f)
 {
 	/* Cancel timer if we already know our tier */
-	if (f->tier != ISIS_TIER_UNDEFINED || f->tier_set_timer) {
+	if (f->tier != ISIS_TIER_UNDEFINED || event_is_scheduled(f->tier_set_timer)) {
 		event_cancel(&f->tier_calculation_timer);
 		return;
 	}
@@ -707,7 +707,7 @@ void fabricd_trigger_csnp(struct isis_area *area, bool circuit_scoped)
 	struct isis_circuit *circuit;
 
 	frr_each (isis_circuit_list, &area->circuit_list, circuit) {
-		if (!circuit->t_send_csnp[1])
+		if (!event_is_scheduled(circuit->t_send_csnp[1]))
 			continue;
 
 		event_cancel(&circuit->t_send_csnp[ISIS_LEVEL2 - 1]);

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -498,7 +498,6 @@ void isis_adj_expire(struct event *event)
 	 */
 	adj = EVENT_ARG(event);
 	assert(adj);
-	adj->t_expire = NULL;
 
 	/* trigger the adj expire event */
 	isis_adj_state_change(&adj, ISIS_ADJ_DOWN, "holding time expired");

--- a/isisd/isis_dynhn.c
+++ b/isisd/isis_dynhn.c
@@ -63,8 +63,6 @@ static void dyn_cache_cleanup(struct event *event)
 
 	isis = EVENT_ARG(event);
 
-	isis->t_dync_clean = NULL;
-
 	for (ALL_LIST_ELEMENTS(isis->dyn_cache, node, nnode, dyn)) {
 		if ((now - dyn->refresh) < MAX_LSP_LIFETIME)
 			continue;

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -363,7 +363,7 @@ void isis_ldp_sync_holddown_timer_add(struct isis_circuit *circuit)
 	 *  once expires returns cost to original value
 	 *  if timer is already running or holddown time is off just return
 	 */
-	if (ldp_sync_info->t_holddown ||
+	if (event_is_scheduled(ldp_sync_info->t_holddown) ||
 	    ldp_sync_info->holddown == LDP_IGP_SYNC_HOLDDOWN_DEFAULT)
 		return;
 
@@ -567,7 +567,7 @@ static void isis_circuit_ldp_sync_print_vty(struct isis_circuit *circuit,
 		vty_out(vty, "  State: Sync achieved\n");
 		break;
 	case LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP:
-		if (ldp_sync_info->t_holddown != NULL) {
+		if (event_is_scheduled(ldp_sync_info->t_holddown)) {
 			struct timeval remain =
 				event_timer_remain(ldp_sync_info->t_holddown);
 			vty_out(vty,

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -345,7 +345,6 @@ static void isis_ldp_sync_holddown_timer(struct event *event)
 	ldp_sync_info = circuit->ldp_sync_info;
 
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_UP;
-	ldp_sync_info->t_holddown = NULL;
 
 	ils_debug("%s: holddown timer expired for %s state:sync achieved",
 		  __func__, circuit->interface->name);

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -444,8 +444,6 @@ void set_overload_on_start_timer(struct event *event)
 	struct isis_area *area = EVENT_ARG(event);
 	assert(area);
 
-	area->t_overload_on_startup_timer = NULL;
-
 	/* Check if set-overload-bit is not currently configured */
 	if (!area->overload_configured)
 		isis_area_overload_bit_set(area, false);
@@ -2142,7 +2140,6 @@ void lsp_tick(struct event *event)
 
 	area = EVENT_ARG(event);
 	assert(area);
-	area->t_tick = NULL;
 	event_add_timer(master, lsp_tick, area, 1, &area->t_tick);
 
 	struct isis_circuit *fabricd_init_c = fabricd_initial_sync_circuit(area);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1855,8 +1855,6 @@ void isis_receive(struct event *event)
 	circuit = EVENT_ARG(event);
 	assert(circuit);
 
-	circuit->t_read = NULL;
-
 	isis_circuit_stream(circuit, &circuit->rcv_stream);
 
 #if ISIS_METHOD != ISIS_METHOD_BPF

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2005,7 +2005,7 @@ int _isis_spf_schedule(struct isis_area *area, int level, const char *func, cons
 		 * restart holdoff timer - compare
 		 * draft-ietf-rtgwg-backoff-algo-04 */
 		long delay = spf_backoff_schedule(area->spf_delay_ietf[level - 1]);
-		if (area->spf_timer[level - 1])
+		if (event_is_scheduled(area->spf_timer[level - 1]))
 			return ISIS_OK;
 
 		event_add_timer_msec(master, isis_run_spf_cb, isis_run_spf_arg(area, level), delay,
@@ -2013,7 +2013,7 @@ int _isis_spf_schedule(struct isis_area *area, int level, const char *func, cons
 		return ISIS_OK;
 	}
 
-	if (area->spf_timer[level - 1])
+	if (event_is_scheduled(area->spf_timer[level - 1]))
 		return ISIS_OK;
 
 	/* wait configured min_spf_interval before doing the SPF */

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -579,10 +579,10 @@ void isis_area_destroy(struct isis_area *area)
 
 	spftree_area_del(area);
 
-	if (area->spf_timer[0])
+	if (event_is_scheduled(area->spf_timer[0]))
 		isis_spf_timer_free(EVENT_ARG(area->spf_timer[0]));
 	event_cancel(&area->spf_timer[0]);
-	if (area->spf_timer[1])
+	if (event_is_scheduled(area->spf_timer[1]))
 		isis_spf_timer_free(EVENT_ARG(area->spf_timer[1]));
 	event_cancel(&area->spf_timer[1]);
 
@@ -2289,7 +2289,7 @@ static void isis_spf_ietf_common(struct vty *vty, struct isis *isis)
 
 			vty_out(vty, "  Level-%d:\n", level);
 			vty_out(vty, "    SPF delay status: ");
-			if (area->spf_timer[level - 1]) {
+			if (event_is_scheduled(area->spf_timer[level - 1])) {
 				struct timeval remain = event_timer_remain(
 					area->spf_timer[level - 1]);
 				vty_out(vty, "Pending, due in %lld msec\n",
@@ -2454,7 +2454,7 @@ static void common_isis_summary_json(struct json_object *json,
 					    area->lsp_gen_count[level - 1]);
 			json_object_int_add(level_json, "lsp-purged",
 					    area->lsp_purge_count[level - 1]);
-			if (area->spf_timer[level - 1])
+			if (event_is_scheduled(area->spf_timer[level - 1]))
 				json_object_string_add(level_json, "spf",
 						       "pending");
 			else
@@ -2542,7 +2542,7 @@ static void common_isis_summary_vty(struct vty *vty, struct isis *isis)
 			vty_out(vty, "         LSPs purged: %" PRIu64 "\n",
 				area->lsp_purge_count[level - 1]);
 
-			if (area->spf_timer[level - 1])
+			if (event_is_scheduled(area->spf_timer[level - 1]))
 				vty_out(vty, "    SPF: (pending)\n");
 			else
 				vty_out(vty, "    SPF:\n");
@@ -3191,7 +3191,7 @@ static void area_resign_level(struct isis_area *area, int level)
 	}
 #endif /* ifndef FABRICD */
 
-	if (area->spf_timer[level - 1])
+	if (event_is_scheduled(area->spf_timer[level - 1]))
 		isis_spf_timer_free(EVENT_ARG(area->spf_timer[level - 1]));
 
 	event_cancel(&area->spf_timer[level - 1]);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -3286,10 +3286,8 @@ void isis_area_overload_bit_set(struct isis_area *area, bool overload_bit)
 			area->overload_counter++;
 		} else {
 			/* Cancel overload on startup timer if it's running */
-			if (area->t_overload_on_startup_timer) {
+			if (area->t_overload_on_startup_timer)
 				event_cancel(&area->t_overload_on_startup_timer);
-				area->t_overload_on_startup_timer = NULL;
-			}
 		}
 
 #ifndef FABRICD

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -3286,8 +3286,7 @@ void isis_area_overload_bit_set(struct isis_area *area, bool overload_bit)
 			area->overload_counter++;
 		} else {
 			/* Cancel overload on startup timer if it's running */
-			if (area->t_overload_on_startup_timer)
-				event_cancel(&area->t_overload_on_startup_timer);
+			event_cancel(&area->t_overload_on_startup_timer);
 		}
 
 #ifndef FABRICD

--- a/ldpd/accept.c
+++ b/ldpd/accept.c
@@ -112,8 +112,6 @@ static void accept_cb(struct event *event)
 
 static void accept_timeout(struct event *event)
 {
-	accept_queue.evt = NULL;
-
 	log_debug(__func__);
 	accept_arm();
 }

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -165,8 +165,6 @@ static void adj_itimer(struct event *event)
 {
 	struct adj *adj = EVENT_ARG(event);
 
-	adj->inactivity_timer = NULL;
-
 	log_debug("%s: lsr-id %pI4", __func__, &adj->lsr_id);
 
 	if (adj->source.type == HELLO_TARGETED) {
@@ -186,7 +184,6 @@ void
 adj_start_itimer(struct adj *adj)
 {
 	event_cancel(&adj->inactivity_timer);
-	adj->inactivity_timer = NULL;
 	event_add_timer(master, adj_itimer, adj, adj->holdtime,
 			&adj->inactivity_timer);
 }
@@ -335,7 +332,6 @@ static void tnbr_hello_timer(struct event *event)
 {
 	struct tnbr *tnbr = EVENT_ARG(event);
 
-	tnbr->hello_timer = NULL;
 	send_hello(HELLO_TARGETED, NULL, tnbr);
 	tnbr_start_hello_timer(tnbr);
 }
@@ -344,7 +340,6 @@ static void
 tnbr_start_hello_timer(struct tnbr *tnbr)
 {
 	event_cancel(&tnbr->hello_timer);
-	tnbr->hello_timer = NULL;
 	event_add_timer(master, tnbr_hello_timer, tnbr,
 			tnbr_get_hello_interval(tnbr), &tnbr->hello_timer);
 }

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -121,11 +121,9 @@ static void control_accept(struct event *event)
 
 	imsg_init(&c->iev.ibuf, connfd);
 	c->iev.handler_read = control_dispatch_imsg;
-	c->iev.ev_read = NULL;
 	event_add_read(master, c->iev.handler_read, &c->iev, c->iev.ibuf.fd,
 		       &c->iev.ev_read);
 	c->iev.handler_write = ldp_write_handler;
-	c->iev.ev_write = NULL;
 
 	TAILQ_INSERT_TAIL(&ctl_conns, c, entry);
 }
@@ -189,8 +187,6 @@ static void control_dispatch_imsg(struct event *event)
 		log_warnx("%s: fd %d: not found", __func__, fd);
 		return;
 	}
-
-	c->iev.ev_read = NULL;
 
 	if (((n = imsg_read(&c->iev.ibuf)) == -1 && errno != EAGAIN) || n == 0) {
 		control_close(fd);

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -448,7 +448,6 @@ static void if_hello_timer(struct event *event)
 {
 	struct iface_af *ia = EVENT_ARG(event);
 
-	ia->hello_timer = NULL;
 	send_hello(HELLO_LINK, ia, NULL);
 	if_start_hello_timer(ia);
 }

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -253,8 +253,6 @@ static void lde_dispatch_imsg(struct event *event)
 	ssize_t			 n;
 	int			 shut = 0;
 
-	iev->ev_read = NULL;
-
 	if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
 		fatal("imsg_read error");
 	if (n == 0)	/* connection closed */
@@ -477,8 +475,6 @@ static void lde_dispatch_parent(struct event *event)
 	struct ldp_rlfa_client	 *rclient;
 	struct zapi_rlfa_request *rlfa_req;
 	struct zapi_rlfa_igp	 *rlfa_igp;
-
-	iev->ev_read = NULL;
 
 	if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
 		fatal("imsg_read error");

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -581,8 +581,6 @@ static void main_dispatch_ldpe(struct event *event)
 	ssize_t			 n;
 	int			 shut = 0;
 
-	iev->ev_read = NULL;
-
 	if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
 		fatal("imsg_read error");
 
@@ -645,8 +643,6 @@ static void main_dispatch_lde(struct event *event)
 	ssize_t		 n;
 	int		 shut = 0;
 	struct zapi_rlfa_response *rlfa_labels;
-
-	iev->ev_read = NULL;
 
 	if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
 		fatal("imsg_read error");
@@ -747,8 +743,6 @@ void ldp_write_handler(struct event *event)
 	struct imsgev *iev = EVENT_ARG(event);
 	struct imsgbuf	*ibuf = &iev->ibuf;
 	ssize_t		 n;
-
-	iev->ev_write = NULL;
 
 	if ((n = msgbuf_write(&ibuf->w)) == -1 && errno != EAGAIN)
 		fatal("msgbuf_write");

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -305,8 +305,6 @@ static void ldpe_dispatch_main(struct event *event)
 	struct zapi_rlfa_request *rlfa_req;
 	struct zapi_rlfa_igp	 *rlfa_igp;
 
-	iev->ev_read = NULL;
-
 	if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
 		fatal("imsg_read error");
 	if (n == 0)	/* connection closed */
@@ -628,8 +626,6 @@ static void ldpe_dispatch_lde(struct event *event)
 	struct notify_msg	*nm;
 	struct nbr		*nbr;
 	int			 n, shut = 0;
-
-	iev->ev_read = NULL;
 
 	if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
 		fatal("imsg_read error");

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -408,7 +408,6 @@ static void nbr_ktimer(struct event *event)
 {
 	struct nbr *nbr = EVENT_ARG(event);
 
-	nbr->keepalive_timer = NULL;
 	send_keepalive(nbr);
 	nbr_start_ktimer(nbr);
 }
@@ -421,7 +420,6 @@ nbr_start_ktimer(struct nbr *nbr)
 	/* send three keepalives per period */
 	secs = nbr->keepalive / KEEPALIVE_PER_PERIOD;
 	event_cancel(&nbr->keepalive_timer);
-	nbr->keepalive_timer = NULL;
 	event_add_timer(master, nbr_ktimer, nbr, secs, &nbr->keepalive_timer);
 }
 
@@ -437,8 +435,6 @@ static void nbr_ktimeout(struct event *event)
 {
 	struct nbr *nbr = EVENT_ARG(event);
 
-	nbr->keepalive_timeout = NULL;
-
 	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
 	session_shutdown(nbr, S_KEEPALIVE_TMR, 0, 0);
@@ -448,7 +444,6 @@ static void
 nbr_start_ktimeout(struct nbr *nbr)
 {
 	event_cancel(&nbr->keepalive_timeout);
-	nbr->keepalive_timeout = NULL;
 	event_add_timer(master, nbr_ktimeout, nbr, nbr->keepalive,
 			&nbr->keepalive_timeout);
 }
@@ -477,7 +472,6 @@ nbr_start_itimeout(struct nbr *nbr)
 
 	secs = INIT_FSM_TIMEOUT;
 	event_cancel(&nbr->init_timeout);
-	nbr->init_timeout = NULL;
 	event_add_timer(master, nbr_itimeout, nbr, secs, &nbr->init_timeout);
 }
 
@@ -492,8 +486,6 @@ nbr_stop_itimeout(struct nbr *nbr)
 static void nbr_idtimer(struct event *event)
 {
 	struct nbr *nbr = EVENT_ARG(event);
-
-	nbr->initdelay_timer = NULL;
 
 	log_debug("%s: lsr-id %pI4", __func__, &nbr->id);
 
@@ -514,7 +506,6 @@ nbr_start_idtimer(struct nbr *nbr)
 	}
 
 	event_cancel(&nbr->initdelay_timer);
-	nbr->initdelay_timer = NULL;
 	event_add_timer(master, nbr_idtimer, nbr, secs, &nbr->initdelay_timer);
 }
 
@@ -541,8 +532,6 @@ static void nbr_connect_cb(struct event *event)
 	struct nbr *nbr = EVENT_ARG(event);
 	int		 error;
 	socklen_t	 len;
-
-	nbr->ev_connect = NULL;
 
 	len = sizeof(error);
 	if (getsockopt(nbr->fd, SOL_SOCKET, SO_ERROR, &error, &len) < 0) {

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -606,8 +606,6 @@ static void session_write(struct event *event)
 	struct tcp_conn *tcp = EVENT_ARG(event);
 	struct nbr	*nbr = tcp->nbr;
 
-	tcp->wbuf.ev = NULL;
-
 	if (msgbuf_write(&tcp->wbuf.wbuf) <= 0)
 		if (errno != EAGAIN && nbr)
 			nbr_fsm(nbr, NBR_EVT_CLOSE_SESSION);
@@ -757,7 +755,6 @@ pending_conn_new(int fd, int af, union ldpd_addr *addr)
 	pconn->af = af;
 	pconn->addr = *addr;
 	TAILQ_INSERT_TAIL(&global.pending_conns, pconn, entry);
-	pconn->ev_timeout = NULL;
 	event_add_timer(master, pending_conn_timeout, pconn,
 			PENDING_CONN_TIMEOUT, &pconn->ev_timeout);
 
@@ -788,8 +785,6 @@ static void pending_conn_timeout(struct event *event)
 {
 	struct pending_conn *pconn = EVENT_ARG(event);
 	struct tcp_conn		*tcp;
-
-	pconn->ev_timeout = NULL;
 
 	log_debug("%s: no adjacency with remote end: %s", __func__,
 	    log_addr(pconn->af, &pconn->addr));

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -88,8 +88,7 @@ char *buffer_getstr(struct buffer *b)
 
 	for (data = b->head; data; data = data->next)
 		totlen += data->cp - data->sp;
-	if (!(s = XMALLOC(MTYPE_TMP, totlen + 1)))
-		return NULL;
+	s = XMALLOC(MTYPE_TMP, totlen + 1);
 	p = s;
 	for (data = b->head; data; data = data->next) {
 		memcpy(p, data->data + data->sp, data->cp - data->sp);

--- a/lib/frr_zmq.c
+++ b/lib/frr_zmq.c
@@ -83,7 +83,7 @@ static void frrzmq_read_msg(struct event *t)
 				frrzmq_check_events(cbp, &cb->write,
 						    ZMQ_POLLOUT);
 				cb->read.event = NULL;
-				if (cb->write.cancelled && !cb->write.event)
+				if (cb->write.cancelled && !event_is_scheduled(cb->write.event))
 					XFREE(MTYPE_ZEROMQ_CB, *cbp);
 
 				return;
@@ -115,7 +115,7 @@ static void frrzmq_read_msg(struct event *t)
 				frrzmq_check_events(cbp, &cb->write,
 						    ZMQ_POLLOUT);
 				cb->read.event = NULL;
-				if (cb->write.cancelled && !cb->write.event)
+				if (cb->write.cancelled && !event_is_scheduled(cb->write.event))
 					XFREE(MTYPE_ZEROMQ_CB, *cbp);
 
 				return;
@@ -233,7 +233,7 @@ static void frrzmq_write_msg(struct event *t)
 			if (cb->write.cancelled) {
 				frrzmq_check_events(cbp, &cb->read, ZMQ_POLLIN);
 				cb->write.event = NULL;
-				if (cb->read.cancelled && !cb->read.event)
+				if (cb->read.cancelled && !event_is_scheduled(cb->read.event))
 					XFREE(MTYPE_ZEROMQ_CB, *cbp);
 
 				return;
@@ -316,8 +316,8 @@ void frrzmq_thread_cancel(struct frrzmq_cb **cb, struct cb_core *core)
 		return;
 
 	/* Ok to free the callback context if no more ... context. */
-	if ((*cb)->read.cancelled && !(*cb)->read.event && (*cb)->write.cancelled &&
-	    ((*cb)->write.event == NULL))
+	if ((*cb)->read.cancelled && !event_is_scheduled((*cb)->read.event) &&
+	    (*cb)->write.cancelled && !event_is_scheduled((*cb)->write.event))
 		XFREE(MTYPE_ZEROMQ_CB, *cb);
 }
 
@@ -337,7 +337,7 @@ void frrzmq_check_events(struct frrzmq_cb **cbp, struct cb_core *core,
 	len = sizeof(events);
 	if (zmq_getsockopt(cb->zmqsock, ZMQ_EVENTS, &events, &len))
 		return;
-	if ((events & event) && core->event && !core->cancelled) {
+	if ((events & event) && event_is_scheduled(core->event) && !core->cancelled) {
 		struct event_loop *tm = core->event->master;
 
 		event_cancel(&core->event);

--- a/lib/ldp_sync.c
+++ b/lib/ldp_sync.c
@@ -35,7 +35,6 @@ struct ldp_sync_info *ldp_sync_info_create(void)
 	ldp_sync_info->enabled = LDP_IGP_SYNC_DEFAULT;
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
 	ldp_sync_info->holddown = LDP_IGP_SYNC_HOLDDOWN_DEFAULT;
-	ldp_sync_info->t_holddown = NULL;
 	return ldp_sync_info;
 }
 

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -504,8 +504,6 @@ struct ls_vertex *ls_vertex_add(struct ls_ted *ted, struct ls_node *node)
 
 	/* Create Vertex and add it to the TED */
 	new = XCALLOC(MTYPE_LS_DB, sizeof(struct ls_vertex));
-	if (!new)
-		return NULL;
 
 	new->key = key;
 	new->node = node;

--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -878,8 +878,7 @@ void msg_server_cleanup(struct msg_server *server)
 {
 	DEBUGD(server->debug, "Closing %s server", server->idtag);
 
-	if (server->listen_ev)
-		event_cancel(&server->listen_ev);
+	event_cancel(&server->listen_ev);
 
 	msg_server_list_del(&msg_servers, server);
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -638,7 +638,6 @@ void nexthop_del_labels(struct nexthop *nexthop)
 
 void nexthop_change_labels(struct nexthop *nexthop, struct mpls_label_stack *new_stack)
 {
-	struct mpls_label_stack *nh_label_tmp;
 	uint32_t i;
 
 	/* Enforce limit on label stack size */
@@ -647,14 +646,10 @@ void nexthop_change_labels(struct nexthop *nexthop, struct mpls_label_stack *new
 
 	/* Resize the array to accommodate the new label stack */
 	if (new_stack->num_labels > nexthop->nh_label->num_labels) {
-		nh_label_tmp = XREALLOC(MTYPE_NH_LABEL, nexthop->nh_label,
-					sizeof(struct mpls_label_stack) +
-						new_stack->num_labels * sizeof(mpls_label_t));
-		if (nh_label_tmp) {
-			nexthop->nh_label = nh_label_tmp;
-			nexthop->nh_label->num_labels = new_stack->num_labels;
-		} else
-			new_stack->num_labels = nexthop->nh_label->num_labels;
+		nexthop->nh_label = XREALLOC(MTYPE_NH_LABEL, nexthop->nh_label,
+					     sizeof(struct mpls_label_stack) +
+						     new_stack->num_labels * sizeof(mpls_label_t));
+		nexthop->nh_label->num_labels = new_stack->num_labels;
 	}
 
 	/* Copy the label stack into the array */

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -405,7 +405,7 @@ static int nb_cli_commit(struct vty *vty, bool force,
 	int ret;
 
 	/* Check if there's a pending confirmed commit. */
-	if (vty->t_confirmed_commit_timeout) {
+	if (event_is_scheduled(vty->t_confirmed_commit_timeout)) {
 		if (confirmed_timeout) {
 			/* Reset timeout if "commit confirmed" is used again. */
 			vty_out(vty,

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -437,7 +437,6 @@ static int nb_cli_commit(struct vty *vty, bool force,
 	if (confirmed_timeout) {
 		vty->confirmed_commit_rollback = nb_config_dup(running_config);
 
-		vty->t_confirmed_commit_timeout = NULL;
 		event_add_timer(master, nb_cli_confirmed_commit_timeout, vty,
 				confirmed_timeout * 60,
 				&vty->t_confirmed_commit_timeout);

--- a/lib/privs.c
+++ b/lib/privs.c
@@ -179,16 +179,14 @@ static pset_t *zcaps2sys(zebra_capabilities_t *zcaps, int num)
 	for (i = 0; i < num; i++)
 		count += cap_map[zcaps[i]].num;
 
-	if ((syscaps = XCALLOC(MTYPE_PRIVS, sizeof(pset_t))) == NULL) {
-		fprintf(stderr, "%s: could not allocate syscaps!", __func__);
-		return NULL;
-	}
+	syscaps = XCALLOC(MTYPE_PRIVS, sizeof(pset_t));
 
-	syscaps->caps = XCALLOC(MTYPE_PRIVS, (sizeof(pvalue_t) * count));
-
-	if (!syscaps->caps) {
-		fprintf(stderr, "%s: could not XCALLOC caps!", __func__);
-		return NULL;
+	syscaps->num = count;
+	if (syscaps->num)
+		syscaps->caps = XCALLOC(MTYPE_PRIVS, sizeof(pvalue_t) * (size_t)count);
+	else {
+		syscaps->caps = NULL;
+		return syscaps;
 	}
 
 	/* copy the capabilities over */

--- a/lib/pullwr.c
+++ b/lib/pullwr.c
@@ -78,7 +78,7 @@ void pullwr_cfg(struct pullwr *pullwr, int64_t max_spin_usec,
 
 void pullwr_bump(struct pullwr *pullwr)
 {
-	if (pullwr->writer)
+	if (event_is_scheduled(pullwr->writer))
 		return;
 
 	event_add_timer(pullwr->tm, pullwr_run, pullwr, 0, &pullwr->writer);

--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -86,7 +86,7 @@ static struct resolver_fd *resolver_fd_get(int fd,
 
 static void resolver_fd_drop_maybe(struct resolver_fd *resfd)
 {
-	if (resfd->t_read || resfd->t_write)
+	if (event_is_scheduled(resfd->t_read) || event_is_scheduled(resfd->t_write))
 		return;
 
 	if (resolver_debug)
@@ -166,13 +166,13 @@ static void ares_socket_cb(void *data, ares_socket_t fd, int readable,
 
 	if (!readable)
 		event_cancel(&resfd->t_read);
-	else if (!resfd->t_read)
+	else if (!event_is_scheduled(resfd->t_read))
 		event_add_read(r->master, resolver_cb_socket_readable, resfd,
 			       fd, &resfd->t_read);
 
 	if (!writable)
 		event_cancel(&resfd->t_write);
-	else if (!resfd->t_write)
+	else if (!event_is_scheduled(resfd->t_write))
 		event_add_write(r->master, resolver_cb_socket_writable, resfd,
 				fd, &resfd->t_write);
 

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -203,7 +203,7 @@ void spf_backoff_show(struct spf_backoff *backoff, struct vty *vty,
 		backoff->long_delay);
 	vty_out(vty, "%sHolddown timer:    %ld msec\n", prefix,
 		backoff->holddown);
-	if (backoff->t_holddown) {
+	if (event_is_scheduled(backoff->t_holddown)) {
 		struct timeval remain = event_timer_remain(backoff->t_holddown);
 
 		vty_out(vty, "%s                   Still runs for %lld msec\n",
@@ -216,7 +216,7 @@ void spf_backoff_show(struct spf_backoff *backoff, struct vty *vty,
 
 	vty_out(vty, "%sTimeToLearn timer: %ld msec\n", prefix,
 		backoff->timetolearn);
-	if (backoff->t_timetolearn) {
+	if (event_is_scheduled(backoff->t_timetolearn)) {
 		struct timeval remain =
 			event_timer_remain(backoff->t_timetolearn);
 		vty_out(vty, "%s                   Still runs for %lld msec\n",

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -164,8 +164,7 @@ struct stream *stream_dupcat(const struct stream *s1, const struct stream *s2,
 		return NULL;
 	}
 
-	if ((new = stream_new(s1->endp + s2->endp)) == NULL)
-		return NULL;
+	new = stream_new(s1->endp + s2->endp);
 
 	new->allow_expansion = s1->allow_expansion || s2->allow_expansion;
 	memcpy(new->data, s1->data, offset);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -141,7 +141,7 @@ void vty_resume_response(struct vty *vty, int ret)
 	if (vty->type != VTY_FILE) {
 		header[3] = ret;
 		buffer_put(vty->obuf, header, 4);
-		if (!vty->t_write && (vtysh_flush(vty) < 0)) {
+		if (!event_is_scheduled(vty->t_write) && (vtysh_flush(vty) < 0)) {
 			zlog_err("failed to vtysh_flush");
 			/* Try to flush results; exit if a write error occurs */
 			return;
@@ -2313,7 +2313,7 @@ static void vtysh_read(struct event *event)
 					vty->pass_fd_status[3] = ret;
 					vty->status = VTY_PASSFD;
 
-					if (!vty->t_write)
+					if (!event_is_scheduled(vty->t_write))
 						vty_event(VTYSH_WRITE, vty);
 
 					/* this introduces a "sequence point"
@@ -2357,7 +2357,7 @@ static void vtysh_read(struct event *event)
 				header[3] = ret;
 				buffer_put(vty->obuf, header, 4);
 
-				if (!vty->t_write && (vtysh_flush(vty) < 0))
+				if (!event_is_scheduled(vty->t_write) && (vtysh_flush(vty) < 0))
 					/* Try to flush results; exit if a write
 					 * error occurs. */
 					break;
@@ -2878,7 +2878,7 @@ int vty_config_node_exit(struct vty *vty)
 	(void)nb_cli_pending_commit_check(vty);
 
 	/* Check if there's a pending confirmed commit. */
-	if (vty->t_confirmed_commit_timeout) {
+	if (event_is_scheduled(vty->t_confirmed_commit_timeout)) {
 		vty_out(vty,
 			"exiting with a pending confirmed commit. Rolling back to previous configuration.\n\n");
 		nb_cli_confirmed_commit_rollback(vty);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -832,7 +832,7 @@ int zclient_start(struct zclient *zclient)
 		return 0;
 
 	/* Check connect thread. */
-	if (zclient->t_connect)
+	if (event_is_scheduled(zclient->t_connect))
 		return 0;
 
 	if (zclient_socket_connect(zclient) < 0) {

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -350,7 +350,6 @@ static void zclient_flush_data(struct event *event)
 {
 	struct zclient *zclient = EVENT_ARG(event);
 
-	zclient->t_write = NULL;
 	if (zclient->sock < 0)
 		return;
 	switch (buffer_flush_available(zclient->wb, zclient->sock)) {
@@ -362,7 +361,6 @@ static void zclient_flush_data(struct event *event)
 		zclient_failed(zclient);
 		return;
 	case BUFFER_PENDING:
-		zclient->t_write = NULL;
 		event_add_write(zclient->master, zclient_flush_data, zclient,
 				zclient->sock, &zclient->t_write);
 		break;
@@ -911,7 +909,6 @@ static void zclient_connect(struct event *t)
 	struct zclient *zclient;
 
 	zclient = EVENT_ARG(t);
-	zclient->t_connect = NULL;
 
 	if (zclient_debug)
 		zlog_debug("zclient_connect is called");
@@ -4786,7 +4783,6 @@ static void zclient_read(struct event *event)
 
 	/* Get socket to zebra. */
 	zclient = EVENT_ARG(event);
-	zclient->t_read = NULL;
 
 	/* Read zebra header (if we don't have it already). */
 	already = stream_get_endp(zclient->ibuf);

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -679,7 +679,7 @@ static void zlog_backtrace_msg(const struct xref_logmsg *xref, int prio)
 	}
 	free(names);
 #endif
-	if (!found_thread && tc)
+	if (!found_thread && event_is_scheduled(tc))
 		zlog(prio, "| (%s) scheduled from %s(), %s:%u", uid,
 		     tc->xref->xref.func, tc->xref->xref.file,
 		     tc->xref->xref.line);

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -195,7 +195,6 @@ static void nhrp_cache_do_free(struct event *t)
 {
 	struct nhrp_cache *c = EVENT_ARG(t);
 
-	c->t_timeout = NULL;
 	nhrp_cache_free(c);
 }
 
@@ -203,7 +202,6 @@ static void nhrp_cache_do_timeout(struct event *t)
 {
 	struct nhrp_cache *c = EVENT_ARG(t);
 
-	c->t_timeout = NULL;
 	if (c->cur.type != NHRP_CACHE_INVALID)
 		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL,
 					  NULL);
@@ -394,7 +392,7 @@ static void nhrp_cache_authorize_binding(struct nhrp_reqid *r, void *arg)
 static void nhrp_cache_do_auth_timeout(struct event *t)
 {
 	struct nhrp_cache *c = EVENT_ARG(t);
-	c->t_auth = NULL;
+
 	nhrp_cache_authorize_binding(&c->eventid, (void *)"timeout");
 }
 

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -318,7 +318,7 @@ static void nhrp_cache_update_timers(struct nhrp_cache *c)
 
 	switch (c->cur.type) {
 	case NHRP_CACHE_INVALID:
-		if (!c->t_auth)
+		if (!event_is_scheduled(c->t_auth))
 			event_add_timer_msec(master, nhrp_cache_do_free, c, 10,
 					     &c->t_timeout);
 		break;

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -59,7 +59,6 @@ static void nhrp_peer_notify_up(struct event *t)
 	struct interface *ifp = p->ifp;
 	struct nhrp_interface *nifp = ifp->info;
 
-	p->t_fallback = NULL;
 	if (nifp->enabled && (!nifp->ipsec_profile || vc->ipsec)) {
 		p->online = 1;
 		nhrp_peer_ref(p);

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -162,7 +162,7 @@ static void nhrp_shortcut_delete(struct nhrp_shortcut *s,
 static void nhrp_shortcut_do_purge(struct event *t)
 {
 	struct nhrp_shortcut *s = EVENT_ARG(t);
-	s->t_shortcut_purge = NULL;
+
 	event_cancel(&s->t_retry_resolution);
 	nhrp_shortcut_delete(s, NULL);
 }

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -813,12 +813,12 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 		else
 			json_object_boolean_false_add(json, "used");
 
-		if (c->t_timeout)
+		if (event_is_scheduled(c->t_timeout))
 			json_object_boolean_true_add(json, "timeout");
 		else
 			json_object_boolean_false_add(json, "timeout");
 
-		if (c->t_auth)
+		if (event_is_scheduled(c->t_auth))
 			json_object_boolean_true_add(json, "auth");
 		else
 			json_object_boolean_false_add(json, "auth");

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -881,7 +881,7 @@ static void ospf6_neighbor_show(struct vty *vty, struct ospf6_neighbor *on,
 
 	/* Dead time */
 	h = m = s = 0;
-	if (on->inactivity_timer) {
+	if (event_is_scheduled(on->inactivity_timer)) {
 		s = monotime_until(&on->inactivity_timer->u.sands, NULL) /
 		    1000000LL;
 		h = s / 3600;

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -1540,10 +1540,7 @@ struct ospf_lsa *ospf_apiserver_opaque_lsa_new(struct ospf_area *area,
 	}
 
 	/* Create a stream for internal opaque LSA */
-	if ((s = stream_new(OSPF_MAX_LSA_SIZE)) == NULL) {
-		zlog_warn("%s: stream_new failed", __func__);
-		return NULL;
-	}
+	s = stream_new(OSPF_MAX_LSA_SIZE);
 
 	newlsa = (struct lsa_header *)STREAM_DATA(s);
 

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -238,9 +238,9 @@ static struct ospf_apiserver *lookup_apiserver_by_lsa(struct ospf_lsa *lsa)
 struct ospf_apiserver *ospf_apiserver_new(int fd_sync, int fd_async)
 {
 	struct ospf_apiserver *new =
-		XMALLOC(MTYPE_APISERVER, sizeof(struct ospf_apiserver));
+		XCALLOC(MTYPE_APISERVER, sizeof(struct ospf_apiserver));
 
-	new->filter = XMALLOC(MTYPE_APISERVER_MSGFILTER,
+	new->filter = XCALLOC(MTYPE_APISERVER_MSGFILTER,
 			      sizeof(struct lsa_filter_type));
 
 	new->fd_sync = fd_sync;
@@ -252,21 +252,12 @@ struct ospf_apiserver *ospf_apiserver_new(int fd_sync, int fd_async)
 	/* Initialize temporary storage for LSA instances to be refreshed. */
 	if (IS_DEBUG_OSPF_CLIENT_API)
 		zlog_debug("API: Initiallize the reserve LSDB");
-	memset(&new->reserve, 0, sizeof(struct ospf_lsdb));
 	ospf_lsdb_init(&new->reserve);
 
 	new->out_sync_fifo = msg_fifo_new();
 	new->out_async_fifo = msg_fifo_new();
-	new->t_sync_read = NULL;
-#ifdef USE_ASYNC_READ
-	new->t_async_read = NULL;
-#endif /* USE_ASYNC_READ */
-	new->t_sync_write = NULL;
-	new->t_async_write = NULL;
 
-	new->filter->typemask = 0; /* filter all LSAs */
 	new->filter->origin = ANY_ORIGIN;
-	new->filter->num_areas = 0;
 
 	return new;
 }

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -276,7 +276,6 @@ void ospf_apiserver_event(enum ospf_apiserver_event event, int fd,
 		break;
 #ifdef USE_ASYNC_READ
 	case OSPF_APISERVER_ASYNC_READ:
-		apiserv->t_async_read = NULL;
 		event_add_read(master, ospf_apiserver_read, apiserv, fd,
 			       &apiserv->t_async_read);
 		break;
@@ -363,7 +362,6 @@ void ospf_apiserver_read(struct event *e)
 
 	if (fd == apiserv->fd_sync) {
 		event = OSPF_APISERVER_SYNC_READ;
-		apiserv->t_sync_read = NULL;
 
 		if (IS_DEBUG_OSPF_CLIENT_API)
 			zlog_debug("API: %s: Peer: %pI4/%u", __func__,
@@ -373,7 +371,6 @@ void ospf_apiserver_read(struct event *e)
 #ifdef USE_ASYNC_READ
 	else if (fd == apiserv->fd_async) {
 		event = OSPF_APISERVER_ASYNC_READ;
-		apiserv->t_async_read = NULL;
 
 		if (IS_DEBUG_OSPF_CLIENT_API)
 			zlog_debug("API: %s: Peer: %pI4/%u", __func__,
@@ -420,8 +417,6 @@ void ospf_apiserver_sync_write(struct event *event)
 	apiserv = EVENT_ARG(event);
 	assert(apiserv);
 	fd = EVENT_FD(event);
-
-	apiserv->t_sync_write = NULL;
 
 	/* Sanity check */
 	if (fd != apiserv->fd_sync) {
@@ -480,8 +475,6 @@ void ospf_apiserver_async_write(struct event *event)
 	apiserv = EVENT_ARG(event);
 	assert(apiserv);
 	fd = EVENT_FD(event);
-
-	apiserv->t_async_write = NULL;
 
 	/* Sanity check */
 	if (fd != apiserv->fd_async) {

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -380,8 +380,6 @@ static void ospf_asbr_redist_update_timer(struct event *event)
 	struct ospf *ospf = EVENT_ARG(event);
 	int type;
 
-	ospf->t_asbr_redist_update = NULL;
-
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("Running ASBR redistribution update on timer");
 
@@ -472,8 +470,6 @@ bool is_valid_summary_addr(struct prefix_ipv4 *p)
 void ospf_asbr_external_aggregator_init(struct ospf *instance)
 {
 	instance->rt_aggr_tbl = route_table_init();
-
-	instance->t_external_aggr = NULL;
 
 	instance->aggr_action = 0;
 
@@ -1158,7 +1154,6 @@ static void ospf_asbr_external_aggr_process(struct event *event)
 	struct ospf *ospf = EVENT_ARG(event);
 	int operation = 0;
 
-	ospf->t_external_aggr = NULL;
 	operation = ospf->aggr_action;
 
 	if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -1177,7 +1177,7 @@ static void ospf_external_aggr_timer(struct ospf *ospf,
 {
 	aggr->action = operation;
 
-	if (ospf->t_external_aggr) {
+	if (event_is_scheduled(ospf->t_external_aggr)) {
 		if (ospf->aggr_action == OSPF_ROUTE_AGGR_ADD || operation != OSPF_ROUTE_AGGR_ADD) {
 			if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
 				zlog_debug("%s: Not required to restart timer,set is already added.",

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -568,7 +568,6 @@ static void ospf_ase_calculate_timer(struct event *t)
 	struct timeval start_time, stop_time;
 
 	ospf = EVENT_ARG(t);
-	ospf->t_ase_calc = NULL;
 
 	if (ospf->ase_calc) {
 		ospf->ase_calc = 0;

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -1248,8 +1248,7 @@ void ospf_ls_retransmit_set_timer(struct ospf_neighbor *nbr)
 {
 	struct ospf_lsa_list_entry *ls_rxmt_list_entry;
 
-	if (nbr->t_ls_rxmt)
-		event_cancel(&nbr->t_ls_rxmt);
+	event_cancel(&nbr->t_ls_rxmt);
 
 	ls_rxmt_list_entry = ospf_lsa_list_first(&nbr->ls_rxmt_list);
 	if (ls_rxmt_list_entry) {

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -138,7 +138,7 @@ static void ospf_flood_delayed_lsa_ack(struct ospf_neighbor *inbr,
 	ospf_lsa_list_add_tail(&oi->ls_ack_delayed, ls_ack_list_entry);
 
 	/* Set LS Ack timer if it is not already scheduled. */
-	if (!oi->t_ls_ack_delayed)
+	if (!event_is_scheduled(oi->t_ls_ack_delayed))
 		OSPF_ISM_TIMER_ON(oi->t_ls_ack_delayed,
 				  ospf_ls_ack_delayed_timer,
 				  oi->v_ls_ack_delayed);
@@ -1164,7 +1164,7 @@ void ospf_ls_retransmit_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		 * Reset the neighbor LSA retransmission timer if isn't currently
 		 * running or the LSA at the head of the list was updated.
 		 */
-		if (!nbr->t_ls_rxmt || rxmt_head_replaced)
+		if (!event_is_scheduled(nbr->t_ls_rxmt) || rxmt_head_replaced)
 			ospf_ls_retransmit_set_timer(nbr);
 	}
 }

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -552,7 +552,6 @@ static void ospf_gr_grace_period_expired(struct event *event)
 {
 	struct ospf *ospf = EVENT_ARG(event);
 
-	ospf->gr_info.t_grace_period = NULL;
 	ospf_gr_restart_exit(ospf, "grace period has expired");
 }
 

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -498,8 +498,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 	}
 
 	if (OSPF_GR_IS_ACTIVE_HELPER(restarter)) {
-		if (restarter->gr_helper_info.t_grace_timer)
-			event_cancel(&restarter->gr_helper_info.t_grace_timer);
+		event_cancel(&restarter->gr_helper_info.t_grace_timer);
 
 		if (ospf->active_restarter_cnt > 0)
 			ospf->active_restarter_cnt--;

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -334,8 +334,6 @@ static void ospf_handle_grace_timer_expiry(struct event *event)
 {
 	struct ospf_neighbor *nbr = EVENT_ARG(event);
 
-	nbr->gr_helper_info.t_grace_timer = NULL;
-
 	ospf_gr_helper_exit(nbr, OSPF_GR_HELPER_GRACE_TIMEOUT);
 }
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -286,8 +286,6 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 	oi->nbr_self = NULL;
 
 	oi->ls_upd_queue = route_table_init();
-	oi->t_ls_upd_event = NULL;
-	oi->t_ls_ack_direct = NULL;
 
 	oi->crypt_seqnum = frr_sequence32_next();
 

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -250,7 +250,6 @@ void ospf_hello_timer(struct event *event)
 	struct ospf_interface *oi;
 
 	oi = EVENT_ARG(event);
-	oi->t_hello = NULL;
 
 	/* Check if the GR hello-delay is active. */
 	if (oi->gr.hello_delay.t_grace_send)
@@ -271,7 +270,6 @@ static void ospf_wait_timer(struct event *event)
 	struct ospf_interface *oi;
 
 	oi = EVENT_ARG(event);
-	oi->t_wait = NULL;
 
 	if (IS_DEBUG_OSPF(ism, ISM_TIMERS))
 		zlog_debug("ISM[%s]: Timer (Wait timer expire)", IF_NAME(oi));

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -375,7 +375,7 @@ void ospf_ldp_sync_holddown_timer_add(struct interface *ifp)
 	 *  once expires returns cost to original value
 	 *  if timer is already running or holddown time is off just return
 	 */
-	if (ldp_sync_info->t_holddown ||
+	if (event_is_scheduled(ldp_sync_info->t_holddown) ||
 	    ldp_sync_info->holddown == LDP_IGP_SYNC_HOLDDOWN_DEFAULT)
 		return;
 
@@ -556,7 +556,7 @@ static void show_ip_ospf_mpls_ldp_interface_sub(struct vty *vty,
 			vty_out(vty, "  State: Sync achieved\n");
 		break;
 	case LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP:
-		if (ldp_sync_info->t_holddown != NULL) {
+		if (event_is_scheduled(ldp_sync_info->t_holddown)) {
 			if (use_json) {
 				long time_store;
 

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -779,8 +779,6 @@ static void ospf_stub_router_timer(struct event *t)
 {
 	struct ospf_area *area = EVENT_ARG(t);
 
-	area->t_stub_router = NULL;
-
 	SET_FLAG(area->stub_router_state, OSPF_AREA_WAS_START_STUB_ROUTED);
 
 	/* clear stub route state and generate router-lsa refresh, don't
@@ -3247,8 +3245,6 @@ void ospf_maxage_lsa_remover(struct event *event)
 	struct route_node *rn;
 	int reschedule = 0;
 
-	ospf->t_maxage = NULL;
-
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 		zlog_debug("LSA[MaxAge]: remover Start");
 
@@ -3500,8 +3496,6 @@ void ospf_lsa_maxage_walker(struct event *event)
 	struct ospf_lsa *lsa;
 	struct ospf_area *area;
 	struct listnode *node, *nnode;
-
-	ospf->t_maxage_walker = NULL;
 
 	for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area)) {
 		LSDB_LOOP (ROUTER_LSDB(area), rn, lsa)
@@ -4302,7 +4296,6 @@ void ospf_lsa_refresh_walker(struct event *e)
 		}
 	}
 
-	ospf->t_lsa_refresher = NULL;
 	event_add_timer(master, ospf_lsa_refresh_walker, ospf,
 			ospf->lsa_refresh_interval, &ospf->t_lsa_refresher);
 	ospf->lsa_refresher_started = monotime(NULL);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3850,7 +3850,7 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 	 * Make sure that the MaxAge LSA remover is executed immediately,
 	 * without conflicting to other threads.
 	 */
-	if (ospf->t_maxage != NULL) {
+	if (event_is_scheduled(ospf->t_maxage)) {
 		event_cancel(&ospf->t_maxage);
 		event_execute(master, ospf_maxage_lsa_remover, ospf, 0, NULL);
 	}

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -455,8 +455,7 @@ static struct ospf_neighbor *ospf_nbr_add(struct ospf_interface *oi,
 				nbr_nbma->nbr = nbr;
 				nbr->nbr_nbma = nbr_nbma;
 
-				if (nbr_nbma->t_poll)
-					event_cancel(&nbr_nbma->t_poll);
+				event_cancel(&nbr_nbma->t_poll);
 
 				nbr->state_change = nbr_nbma->state_change + 1;
 			}

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -329,7 +329,7 @@ static int nsm_exchange_done(struct ospf_neighbor *nbr)
 		return NSM_Full;
 
 	/* Send Link State Request. */
-	if (nbr->t_ls_req == NULL)
+	if (!event_is_scheduled(nbr->t_ls_req))
 		ospf_ls_req_send(nbr);
 
 	return NSM_Loading;

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -50,7 +50,6 @@ static void ospf_inactivity_timer(struct event *event)
 	struct ospf_neighbor *nbr;
 
 	nbr = EVENT_ARG(event);
-	nbr->t_inactivity = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
 		zlog_debug("NSM[%s:%pI4:%s]: Timer (Inactivity timer expire)",
@@ -88,7 +87,6 @@ static void ospf_db_desc_timer(struct event *event)
 	struct ospf_neighbor *nbr;
 
 	nbr = EVENT_ARG(event);
-	nbr->t_db_desc = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
 		zlog_debug("NSM[%s:%pI4:%s]: Timer (DD Retransmit timer expire)",

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -136,7 +136,6 @@ int ospf_opaque_type9_lsa_init(struct ospf_interface *oi)
 
 	oi->opaque_lsa_self = list_new();
 	oi->opaque_lsa_self->del = free_opaque_info_per_type_del;
-	oi->t_opaque_lsa_self = NULL;
 	return 0;
 }
 
@@ -156,7 +155,6 @@ int ospf_opaque_type10_lsa_init(struct ospf_area *area)
 
 	area->opaque_lsa_self = list_new();
 	area->opaque_lsa_self->del = free_opaque_info_per_type_del;
-	area->t_opaque_lsa_self = NULL;
 	if (!ospf_opaque_lsa_hooks_registered) {
 		hook_register(ospf_lsa_update, ospf_opaque_lsa_update_hook);
 		hook_register(ospf_lsa_delete, ospf_opaque_lsa_delete_hook);
@@ -184,7 +182,6 @@ int ospf_opaque_type11_lsa_init(struct ospf *top)
 
 	top->opaque_lsa_self = list_new();
 	top->opaque_lsa_self->del = free_opaque_info_per_type_del;
-	top->t_opaque_lsa_self = NULL;
 
 	return 0;
 }
@@ -1438,7 +1435,6 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 			zlog_debug(
 				"Schedule Type-9 Opaque-LSA origination in %d ms later.",
 				delay);
-		oi->t_opaque_lsa_self = NULL;
 		event_add_timer_msec(master, ospf_opaque_type9_lsa_originate,
 				     oi, delay, &oi->t_opaque_lsa_self);
 		delay += top->min_ls_interval;
@@ -1456,7 +1452,6 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 			zlog_debug(
 				"Schedule Type-10 Opaque-LSA origination in %d ms later.",
 				delay);
-		area->t_opaque_lsa_self = NULL;
 		event_add_timer_msec(master, ospf_opaque_type10_lsa_originate,
 				     area, delay, &area->t_opaque_lsa_self);
 		delay += top->min_ls_interval;
@@ -1474,7 +1469,6 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 			zlog_debug(
 				"Schedule Type-11 Opaque-LSA origination in %d ms later.",
 				delay);
-		top->t_opaque_lsa_self = NULL;
 		event_add_timer_msec(master, ospf_opaque_type11_lsa_originate,
 				     top, delay, &top->t_opaque_lsa_self);
 		delay += top->min_ls_interval;
@@ -1568,7 +1562,6 @@ static void ospf_opaque_type9_lsa_originate(struct event *t)
 	struct ospf_interface *oi;
 
 	oi = EVENT_ARG(t);
-	oi->t_opaque_lsa_self = NULL;
 
 	if (IS_DEBUG_OSPF_OPAQUE_LSA)
 		zlog_debug("Timer[Type9-LSA]: Originate Opaque-LSAs for OI %s",
@@ -1582,7 +1575,6 @@ static void ospf_opaque_type10_lsa_originate(struct event *t)
 	struct ospf_area *area;
 
 	area = EVENT_ARG(t);
-	area->t_opaque_lsa_self = NULL;
 
 	if (IS_DEBUG_OSPF_OPAQUE_LSA)
 		zlog_debug(
@@ -1597,7 +1589,6 @@ static void ospf_opaque_type11_lsa_originate(struct event *t)
 	struct ospf *top;
 
 	top = EVENT_ARG(t);
-	top->t_opaque_lsa_self = NULL;
 
 	if (IS_DEBUG_OSPF_OPAQUE_LSA)
 		zlog_debug(

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1490,8 +1490,8 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 			 * list_isempty (oipt->id_list)
 			 * not being empty.
 			 */
-			if (oipt->t_opaque_lsa_self
-				    != NULL /* Waiting for a thread call. */
+			if (event_is_scheduled(oipt->t_opaque_lsa_self)
+				    /* Waiting for a thread call. */
 			    || oipt->status == PROC_SUSPEND) /* Cannot
 								originate
 								now. */
@@ -1515,8 +1515,8 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 			 * list_isempty (oipt->id_list)
 			 * not being empty.
 			 */
-			if (oipt->t_opaque_lsa_self
-				    != NULL /* Waiting for a thread call. */
+			if (event_is_scheduled(oipt->t_opaque_lsa_self)
+				    /* Waiting for a thread call. */
 			    || oipt->status == PROC_SUSPEND) /* Cannot
 								originate
 								now. */
@@ -1540,8 +1540,8 @@ void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi, int *delay0)
 			 * list_isempty (oipt->id_list)
 			 * not being empty.
 			 */
-			if (oipt->t_opaque_lsa_self
-				    != NULL /* Waiting for a thread call. */
+			if (event_is_scheduled(oipt->t_opaque_lsa_self)
+				    /* Waiting for a thread call. */
 			    || oipt->status == PROC_SUSPEND) /* Cannot
 								originate
 								now. */
@@ -1869,7 +1869,7 @@ void ospf_opaque_lsa_reoriginate_schedule(void *lsa_type_dependent,
 		}
 	}
 
-	if (oipt->t_opaque_lsa_self != NULL) {
+	if (event_is_scheduled(oipt->t_opaque_lsa_self)) {
 		if (IS_DEBUG_OSPF_OPAQUE_LSA)
 			zlog_debug(
 				"Type-%u Opaque-LSA has already scheduled to RE-ORIGINATE: [opaque-type=%u]",
@@ -2066,7 +2066,7 @@ void ospf_opaque_lsa_refresh_schedule(struct ospf_lsa *lsa0)
 		goto out;
 	}
 
-	if (oipi->t_opaque_lsa_self != NULL) {
+	if (event_is_scheduled(oipi->t_opaque_lsa_self)) {
 		if (IS_DEBUG_OSPF_OPAQUE_LSA)
 			zlog_debug(
 				"Type-%u Opaque-LSA has already scheduled to REFRESH: [opaque-type=%u, opaque-id=%x]",

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1185,7 +1185,7 @@ static void ospf_db_desc_proc(struct stream *s, struct ospf_interface *oi,
 	/* Save received neighbor values from DD. */
 	ospf_db_desc_save_current(nbr, dd);
 
-	if (!nbr->t_ls_req)
+	if (!event_is_scheduled(nbr->t_ls_req))
 		ospf_ls_req_send(nbr);
 }
 
@@ -4338,7 +4338,7 @@ void ospf_ls_ack_send_direct(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	ls_ack_list_entry->lsa = ospf_lsa_lock(lsa);
 	ospf_lsa_list_add_tail(&nbr->oi->ls_ack_direct, ls_ack_list_entry);
 
-	if (oi->t_ls_ack_direct == NULL)
+	if (!event_is_scheduled(oi->t_ls_ack_direct))
 		event_add_event(master, ospf_ls_ack_send_direct_event, oi, 0,
 				&oi->t_ls_ack_direct);
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -280,7 +280,6 @@ static void ospf_ls_req_timer(struct event *event)
 	struct ospf_neighbor *nbr;
 
 	nbr = EVENT_ARG(event);
-	nbr->t_ls_req = NULL;
 
 	/* Send Link State Request. */
 	if (ospf_ls_request_count(nbr))
@@ -337,7 +336,6 @@ void ospf_ls_rxmt_timer(struct event *event)
 	int retransmit_interval, retransmit_window, rxmt_lsa_count = 0;
 
 	nbr = EVENT_ARG(event);
-	nbr->t_ls_rxmt = NULL;
 	retransmit_interval = nbr->v_ls_rxmt;
 	retransmit_window = OSPF_IF_PARAM(nbr->oi, retransmit_window);
 
@@ -409,7 +407,6 @@ void ospf_ls_ack_delayed_timer(struct event *event)
 	struct ospf_interface *oi;
 
 	oi = EVENT_ARG(event);
-	oi->t_ls_ack_delayed = NULL;
 
 	/* Send Link State Acknowledgment. */
 	if (ospf_lsa_list_count(&oi->ls_ack_delayed))
@@ -3737,7 +3734,6 @@ void ospf_poll_timer(struct event *event)
 	struct ospf_nbr_nbma *nbr_nbma;
 
 	nbr_nbma = EVENT_ARG(event);
-	nbr_nbma->t_poll = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
 		zlog_debug("NSM[%s:%pI4]: Timer (Poll timer expire)",
@@ -3756,7 +3752,6 @@ void ospf_hello_reply_timer(struct event *event)
 	struct ospf_neighbor *nbr;
 
 	nbr = EVENT_ARG(event);
-	nbr->t_hello_reply = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_TIMERS))
 		zlog_debug("NSM[%s:%pI4]: Timer (hello-reply timer expire)",
@@ -4117,8 +4112,6 @@ static void ospf_ls_upd_send_queue_event(struct event *event)
 	struct list *update;
 	char again = 0;
 
-	oi->t_ls_upd_event = NULL;
-
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s start", __func__);
 
@@ -4145,7 +4138,6 @@ static void ospf_ls_upd_send_queue_event(struct event *event)
 			zlog_debug(
 				"%s: update lists not cleared, %d nodes to try again, raising new event",
 				__func__, again);
-		oi->t_ls_upd_event = NULL;
 		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
 				&oi->t_ls_upd_event);
 	}
@@ -4265,8 +4257,6 @@ static void ospf_ls_ack_send_direct_event(struct event *event)
 {
 	struct ospf_interface *oi = EVENT_ARG(event);
 	struct in_addr dst = { INADDR_ANY };
-
-	oi->t_ls_ack_direct = NULL;
 
 	while (ospf_lsa_list_count(&oi->ls_ack_direct))
 		ospf_ls_ack_send_list(oi, &(oi->ls_ack_direct), true, true, dst);

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1854,8 +1854,6 @@ static void ospf_spf_calculate_schedule_worker(struct event *event)
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("SPF: Timer (SPF calculation expire)");
 
-	ospf->t_spf_calc = NULL;
-
 	ospf_vl_unapprove(ospf);
 
 	/* Execute SPF for each area including backbone, see RFC 2328 16.1. */
@@ -2042,7 +2040,6 @@ void ospf_spf_calculate_schedule(struct ospf *ospf, ospf_spf_reason_t reason)
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("SPF: calculation timer delay = %ld msec", delay);
 
-	ospf->t_spf_calc = NULL;
 	event_add_timer_msec(master, ospf_spf_calculate_schedule_worker, ospf,
 			     delay, &ospf->t_spf_calc);
 }

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -2001,7 +2001,7 @@ void ospf_spf_calculate_schedule(struct ospf *ospf, ospf_spf_reason_t reason)
 	ospf_spf_set_reason(reason);
 
 	/* SPF calculation timer is already scheduled. */
-	if (ospf->t_spf_calc) {
+	if (event_is_scheduled(ospf->t_spf_calc)) {
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"SPF: calculation timer is already scheduled: %p",

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2835,7 +2835,7 @@ static void show_ip_ospf_area(struct vty *vty, struct ospf_area *area,
 				       OSPF_AREA_ADMIN_STUB_ROUTED))
 				json_object_boolean_true_add(
 					json_area, "indefiniteActiveAdmin");
-			if (area->t_stub_router) {
+			if (event_is_scheduled(area->t_stub_router)) {
 				long time_store;
 				time_store =
 					monotime_until(
@@ -2854,7 +2854,7 @@ static void show_ip_ospf_area(struct vty *vty, struct ospf_area *area,
 				       OSPF_AREA_ADMIN_STUB_ROUTED))
 				vty_out(vty,
 					"     Administratively activated (indefinitely)\n");
-			if (area->t_stub_router)
+			if (event_is_scheduled(area->t_stub_router))
 				vty_out(vty,
 					"     Active from startup, %s remaining\n",
 					ospf_timer_dump(area->t_stub_router,
@@ -3074,7 +3074,7 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 	}
 
 	/* Graceful shutdown */
-	if (ospf->t_deferred_shutdown) {
+	if (event_is_scheduled(ospf->t_deferred_shutdown)) {
 		if (json) {
 			long time_store;
 			time_store =
@@ -3203,7 +3203,7 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 	}
 
 	if (json) {
-		if (ospf->t_spf_calc) {
+		if (event_is_scheduled(ospf->t_spf_calc)) {
 			long time_store;
 			time_store =
 				monotime_until(&ospf->t_spf_calc->u.sands, NULL)
@@ -3966,7 +3966,7 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 			char timebuf[OSPF_TIME_DUMP_SIZE];
 			if (use_json) {
 				long time_store = 0;
-				if (oi->t_hello)
+				if (event_is_scheduled(oi->t_hello))
 					time_store =
 						monotime_until(
 							&oi->t_hello->u.sands,
@@ -4617,7 +4617,7 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 				       lookup_msg(ospf_ism_state_msg,
 						  ospf_nbr_ism_state(nbr),
 						  NULL));
-		if (nbr->t_inactivity) {
+		if (event_is_scheduled(nbr->t_inactivity)) {
 			long time_store;
 
 			time_store = monotime_until(&nbr->t_inactivity->u.sands,
@@ -5211,7 +5211,7 @@ static void show_ip_ospf_nbr_nbma_detail_sub(struct vty *vty,
 		vty_out(vty, "    Poll interval %d\n", nbr_nbma->v_poll);
 
 	/* Show poll-interval timer. */
-	if (nbr_nbma->t_poll) {
+	if (event_is_scheduled(nbr_nbma->t_poll)) {
 		if (use_json) {
 			long time_store;
 			time_store = monotime_until(&nbr_nbma->t_poll->u.sands,
@@ -5227,7 +5227,7 @@ static void show_ip_ospf_nbr_nbma_detail_sub(struct vty *vty,
 
 	/* Show poll-interval timer thread. */
 	if (use_json) {
-		if (nbr_nbma->t_poll != NULL)
+		if (event_is_scheduled(nbr_nbma->t_poll))
 			json_object_string_add(json_sub,
 					       "pollIntervalTimerThread", "on");
 	} else
@@ -5428,7 +5428,7 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 
 	/* Show Router Dead interval timer. */
 	if (use_json) {
-		if (nbr->t_inactivity) {
+		if (event_is_scheduled(nbr->t_inactivity)) {
 			long time_store;
 			time_store = monotime_until(&nbr->t_inactivity->u.sands,
 						    NULL)
@@ -5479,7 +5479,7 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 
 	/* Show inactivity timer thread. */
 	if (use_json) {
-		if (nbr->t_inactivity != NULL)
+		if (event_is_scheduled(nbr->t_inactivity))
 			json_object_string_add(json_neigh,
 					       "threadInactivityTimer", "on");
 	} else
@@ -5488,7 +5488,7 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 
 	/* Show Database Description retransmission thread. */
 	if (use_json) {
-		if (nbr->t_db_desc != NULL)
+		if (event_is_scheduled(nbr->t_db_desc))
 			json_object_string_add(
 				json_neigh,
 				"threadDatabaseDescriptionRetransmission",
@@ -5500,7 +5500,7 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 
 	/* Show Link State Request Retransmission thread. */
 	if (use_json) {
-		if (nbr->t_ls_req != NULL)
+		if (event_is_scheduled(nbr->t_ls_req))
 			json_object_string_add(
 				json_neigh,
 				"threadLinkStateRequestRetransmission", "on");
@@ -5511,7 +5511,7 @@ static void show_ip_ospf_neighbor_detail_sub(struct vty *vty,
 
 	/* Show Link State Update Retransmission thread. */
 	if (use_json) {
-		if (nbr->t_ls_rxmt != NULL)
+		if (event_is_scheduled(nbr->t_ls_rxmt))
 			json_object_string_add(
 				json_neigh,
 				"threadLinkStateUpdateRetransmission",

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1642,8 +1642,6 @@ static void ospf_distribute_list_update_timer(struct event *event)
 	if (ospf == NULL)
 		return;
 
-	ospf->t_distribute_update = NULL;
-
 	zlog_info("Zebra[Redistribute]: vrf: %s distribute-list update timer fired!",
 		  ospf_vrf_id_to_name(ospf->vrf_id));
 

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -379,7 +379,6 @@ struct ospf *ospf_new_alloc(unsigned short instance, const char *name)
 	/* MaxAge init. */
 	new->maxage_delay = OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT;
 	new->maxage_lsa = route_table_init();
-	new->t_maxage_walker = NULL;
 	event_add_timer(master, ospf_lsa_maxage_walker, new,
 			OSPF_LSA_MAXAGE_CHECK_INTERVAL, &new->t_maxage_walker);
 
@@ -392,14 +391,12 @@ struct ospf *ospf_new_alloc(unsigned short instance, const char *name)
 	new->lsa_refresh_queue.index = 0;
 	new->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;
 	new->lsa_refresh_timer = OSPF_LS_REFRESH_TIME;
-	new->t_lsa_refresher = NULL;
 	event_add_timer(master, ospf_lsa_refresh_walker, new,
 			new->lsa_refresh_interval, &new->t_lsa_refresher);
 	new->lsa_refresher_started = monotime(NULL);
 
 	new->ibuf = stream_new(OSPF_MAX_PACKET_SIZE + 1);
 
-	new->t_read = NULL;
 	new->oi_write_q = list_new();
 	new->write_oi_count = OSPF_WRITE_INTERFACE_COUNT_DEFAULT;
 
@@ -1922,7 +1919,6 @@ int ospf_timers_refresh_unset(struct ospf *ospf)
 
 	if (time_left > OSPF_LSA_REFRESH_INTERVAL_DEFAULT) {
 		event_cancel(&ospf->t_lsa_refresher);
-		ospf->t_lsa_refresher = NULL;
 		event_add_timer(master, ospf_lsa_refresh_walker, ospf,
 				OSPF_LSA_REFRESH_INTERVAL_DEFAULT,
 				&ospf->t_lsa_refresher);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -582,7 +582,7 @@ static void ospf_deferred_shutdown_check(struct ospf *ospf)
 	struct ospf_area *area;
 
 	/* deferred shutdown already running? */
-	if (ospf->t_deferred_shutdown)
+	if (event_is_scheduled(ospf->t_deferred_shutdown))
 		return;
 
 	/* Should we try push out max-metric LSAs? */

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -336,10 +336,8 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 		return 0;
 	}
 
-	if (pcc_state->t_reconnect != NULL) {
+	if (pcc_state->t_reconnect != NULL)
 		event_cancel(&pcc_state->t_reconnect);
-		pcc_state->t_reconnect = NULL;
-	}
 
 	select_transport_address(pcc_state);
 
@@ -404,10 +402,8 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	}
 
 	// In case some best pce alternative were waiting to activate
-	if (pcc_state->t_update_best != NULL) {
+	if (pcc_state->t_update_best != NULL)
 		event_cancel(&pcc_state->t_update_best);
-		pcc_state->t_update_best = NULL;
-	}
 
 	pcc_state->status = PCEP_PCC_CONNECTING;
 
@@ -1554,7 +1550,6 @@ void cancel_session_timeout(struct ctrl_state *ctrl_state,
 
 	PCEP_DEBUG_PCEP("Cancel session_timeout timer");
 	pcep_thread_cancel_timer(&pcc_state->t_session_timeout);
-	pcc_state->t_session_timeout = NULL;
 }
 
 void send_pcep_message(struct pcc_state *pcc_state, struct pcep_message *msg)

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -336,8 +336,7 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 		return 0;
 	}
 
-	if (pcc_state->t_reconnect != NULL)
-		event_cancel(&pcc_state->t_reconnect);
+	event_cancel(&pcc_state->t_reconnect);
 
 	select_transport_address(pcc_state);
 
@@ -402,8 +401,7 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	}
 
 	// In case some best pce alternative were waiting to activate
-	if (pcc_state->t_update_best != NULL)
-		event_cancel(&pcc_state->t_update_best);
+	event_cancel(&pcc_state->t_update_best);
 
 	pcc_state->status = PCEP_PCC_CONNECTING;
 

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -1541,7 +1541,7 @@ void cancel_session_timeout(struct ctrl_state *ctrl_state,
 			    struct pcc_state *pcc_state)
 {
 	/* No need to schedule timeout if multiple PCEs are connected */
-	if (pcc_state->t_session_timeout == NULL) {
+	if (!event_is_scheduled(pcc_state->t_session_timeout)) {
 		PCEP_DEBUG_PCEP("cancel_session_timeout timer thread NULL");
 		return;
 	}
@@ -1666,7 +1666,7 @@ void send_comp_request(struct ctrl_state *ctrl_state,
 {
 	assert(req != NULL);
 
-	if (req->t_retry)
+	if (event_is_scheduled(req->t_retry))
 		return;
 
 	assert(req->path != NULL);

--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -648,10 +648,7 @@ void path_ted_timer_handler_refresh(struct event *event)
  */
 void path_ted_timer_sync_cancel(void)
 {
-	if (ted_state_g.t_link_state_sync != NULL) {
-		event_cancel(&ted_state_g.t_link_state_sync);
-		ted_state_g.t_link_state_sync = NULL;
-	}
+	event_cancel(&ted_state_g.t_link_state_sync);
 }
 
 /**
@@ -663,10 +660,7 @@ void path_ted_timer_sync_cancel(void)
  */
 void path_ted_timer_refresh_cancel(void)
 {
-	if (ted_state_g.t_segment_list_refresh != NULL) {
-		event_cancel(&ted_state_g.t_segment_list_refresh);
-		ted_state_g.t_segment_list_refresh = NULL;
-	}
+	event_cancel(&ted_state_g.t_segment_list_refresh);
 }
 
 /**

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -1309,7 +1309,7 @@ void trigger_pathd_candidate_created(struct srte_candidate *candidate)
 	pathd. In addition, a minimum amount of time need to pass before
 	the hook is called to prevent the hook to be called multiple times
 	from changing the candidate by hand with the console */
-	if (candidate->hook_timer != NULL)
+	if (event_is_scheduled(candidate->hook_timer))
 		return;
 	event_add_timer(master, trigger_pathd_candidate_created_timer,
 			(void *)candidate, HOOK_DELAY, &candidate->hook_timer);
@@ -1329,7 +1329,7 @@ void trigger_pathd_candidate_updated(struct srte_candidate *candidate)
 	pathd. In addition, a minimum amount of time need to pass before
 	the hook is called to prevent the hook to be called multiple times
 	from changing the candidate by hand with the console */
-	if (candidate->hook_timer != NULL)
+	if (event_is_scheduled(candidate->hook_timer))
 		return;
 	event_add_timer(master, trigger_pathd_candidate_updated_timer,
 			(void *)candidate, HOOK_DELAY, &candidate->hook_timer);

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -1346,10 +1346,7 @@ void trigger_pathd_candidate_removed(struct srte_candidate *candidate)
 {
 	/* The hook needs to be call synchronously, otherwise the candidate
 	path will be already deleted when the handler is called */
-	if (candidate->hook_timer != NULL) {
-		event_cancel(&candidate->hook_timer);
-		candidate->hook_timer = NULL;
-	}
+	event_cancel(&candidate->hook_timer);
 	hook_call(pathd_candidate_removed, candidate);
 }
 

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -691,7 +691,7 @@ static void gm_packet_sg_remove_sources(struct gm_if *gm_ifp,
 
 static void gm_sg_expiry_cancel(struct gm_sg *sg)
 {
-	if (sg->t_sg_expire && PIM_DEBUG_GM_TRACE)
+	if (event_is_scheduled(sg->t_sg_expire) && PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_sg(sg, "alive, cancelling expiry timer"));
 	event_cancel(&sg->t_sg_expire);
 	sg->query_sbit = true;
@@ -1371,7 +1371,7 @@ static void gm_sg_timer_start(struct gm_if *gm_ifp, struct gm_sg *sg,
 	if (PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_sg(sg, "expiring in %pTVI"), &expire_wait);
 
-	if (sg->t_sg_expire) {
+	if (event_is_scheduled(sg->t_sg_expire)) {
 		struct timeval remain;
 
 		remain = event_timer_remain(sg->t_sg_expire);
@@ -2486,7 +2486,7 @@ void gm_ifp_update(struct interface *ifp)
 		gm_ifp->cur_max_resp = cfg_max_response;
 
 	/* Only adjust the QRV if no other querier is available */
-	if (gm_ifp->t_other_querier == NULL)
+	if (!event_is_scheduled(gm_ifp->t_other_querier))
 		gm_ifp->cur_qrv = pim_ifp->gm_default_robustness_variable;
 
 	gm_ifp->cur_lmqc = if_gm_last_member_query_count(pim_ifp);

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -526,7 +526,7 @@ static void on_assert_timer(struct event *t)
 static void assert_timer_off(struct pim_ifchannel *ch)
 {
 	if (PIM_DEBUG_PIM_TRACE) {
-		if (ch->t_ifassert_timer) {
+		if (event_is_scheduled(ch->t_ifassert_timer)) {
 			zlog_debug(
 				"%s: (S,G)=%s cancelling timer on interface %s",
 				__func__, ch->sg_str, ch->interface->name);

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -506,8 +506,6 @@ static void on_assert_timer(struct event *t)
 			   __func__, ch->sg_str, ifp->name);
 	}
 
-	ch->t_ifassert_timer = NULL;
-
 	switch (ch->ifassert_state) {
 	case PIM_IFASSERT_I_AM_WINNER:
 		assert_action_a3(ch);

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -1111,7 +1111,7 @@ static void autorp_send_discovery_on(struct pim_autorp *autorp)
 	if (interval > autorp->discovery_interval)
 		interval = autorp->discovery_interval;
 
-	if (autorp->send_discovery_timer)
+	if (event_is_scheduled(autorp->send_discovery_timer))
 		if (PIM_DEBUG_AUTORP)
 			zlog_debug("%s: AutoRP discovery sending enabled in %u seconds", __func__,
 				   interval);
@@ -1122,7 +1122,7 @@ static void autorp_send_discovery_on(struct pim_autorp *autorp)
 
 static void autorp_send_discovery_off(struct pim_autorp *autorp)
 {
-	if (autorp->send_discovery_timer)
+	if (event_is_scheduled(autorp->send_discovery_timer))
 		if (PIM_DEBUG_AUTORP)
 			zlog_debug("%s: AutoRP discovery sending disabled", __func__);
 	event_cancel(&(autorp->send_discovery_timer));
@@ -1598,7 +1598,7 @@ static void autorp_announcement_on(struct pim_autorp *autorp)
 	if (interval > autorp->announce_interval)
 		interval = autorp->announce_interval;
 
-	if (autorp->announce_timer == NULL)
+	if (!event_is_scheduled(autorp->announce_timer))
 		if (PIM_DEBUG_AUTORP)
 			zlog_debug("%s: AutoRP announcement sending enabled", __func__);
 
@@ -1608,7 +1608,7 @@ static void autorp_announcement_on(struct pim_autorp *autorp)
 
 static void autorp_announcement_off(struct pim_autorp *autorp)
 {
-	if (autorp->announce_timer != NULL)
+	if (event_is_scheduled(autorp->announce_timer))
 		if (PIM_DEBUG_AUTORP)
 			zlog_debug("%s: AutoRP announcement sending disabled", __func__);
 	event_cancel(&(autorp->announce_timer));

--- a/pimd/pim_bsr_rpdb.c
+++ b/pimd/pim_bsr_rpdb.c
@@ -221,7 +221,7 @@ static void pim_bsm_generate_sched(struct bsm_scope *scope)
 {
 	assertf(scope->state == BSR_ELECTED, "state=%d", scope->state);
 
-	if (scope->t_ebsr_regen_bsm)
+	if (event_is_scheduled(scope->t_ebsr_regen_bsm))
 		return;
 
 	event_add_timer(router->master, pim_bsm_generate_timer, scope, 1,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -293,7 +293,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 				json_object_int_add(json_row, "version",
 						    pim_ifp->igmp_version);
 
-				if (igmp->t_igmp_query_timer) {
+				if (event_is_scheduled(igmp->t_igmp_query_timer)) {
 					json_object_boolean_true_add(json_row,
 								     "querier");
 					json_object_string_add(json_row,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1468,7 +1468,8 @@ void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 		 * If the upstream is not dummy and it has a J/P timer for the
 		 * neighbor display that
 		 */
-		if (!up->t_join_timer && up->rpf.source_nexthop.interface) {
+		if (!event_is_scheduled(up->t_join_timer) &&
+		    up->rpf.source_nexthop.interface) {
 			struct pim_neighbor *nbr;
 
 			nbr = pim_neighbor_find(

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -74,8 +74,7 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 					if (pim_upstream_up_connected(c_oil->up) &&
 					    PIM_UPSTREAM_DM_TEST_PRUNE(c_oil->up->flags)) {
 						PIM_UPSTREAM_DM_UNSET_PRUNE(c_oil->up->flags);
-						if (c_oil->up->t_prune_timer)
-							event_cancel(&c_oil->up->t_prune_timer);
+						event_cancel(&c_oil->up->t_prune_timer);
 						pim_dm_graft_send(c_oil->up->rpf, c_oil->up);
 						graft_timer_start(c_oil->up);
 					}
@@ -88,8 +87,7 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 				oil_if_set(c_oil, pim_ifp->mroute_vif_index, 0);
 				pim_upstream_mroute_update(c_oil, __func__);
 				if (!pim_upstream_up_connected(c_oil->up)) {
-					if (c_oil->up->t_graft_timer)
-						event_cancel(&c_oil->up->t_graft_timer);
+					event_cancel(&c_oil->up->t_graft_timer);
 					PIM_UPSTREAM_DM_SET_PRUNE(c_oil->up->flags);
 					pim_dm_prune_send(c_oil->up->rpf, c_oil->up, 0);
 					prune_timer_start(c_oil->up);
@@ -261,16 +259,14 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 
 		if (ch) {
 			PIM_UPSTREAM_DM_UNSET_PRUNE(ch->flags);
-			if (ch->t_ifjoin_expiry_timer)
-				event_cancel(&ch->t_ifjoin_expiry_timer);
+			event_cancel(&ch->t_ifjoin_expiry_timer);
 			pim_ifchannel_delete(ch);
 		}
 
 		/* dm: forward graft message */
 		if (PIM_UPSTREAM_DM_TEST_PRUNE(up->flags)) {
 			PIM_UPSTREAM_DM_UNSET_PRUNE(up->flags);
-			if (up->t_prune_timer)
-				event_cancel(&up->t_prune_timer);
+			event_cancel(&up->t_prune_timer);
 			pim_dm_graft_send(up->rpf, up);
 			graft_timer_start(up);
 		}
@@ -339,8 +335,7 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 					       PIM_UPSTREAM_DM_FLAG_MASK_PRUNE);
 		PIM_UPSTREAM_DM_SET_PRUNE(ch->flags);
 		ch->prune_holdtime = holdtime;
-		if (ch->t_ifjoin_expiry_timer)
-			event_cancel(&ch->t_ifjoin_expiry_timer);
+		event_cancel(&ch->t_ifjoin_expiry_timer);
 		event_add_timer(router->master, pim_dm_prune_iff_on_timer, ch, holdtime,
 				&ch->t_ifjoin_expiry_timer);
 	}

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -922,7 +922,7 @@ void pim_ifchannel_join_add(struct interface *ifp, pim_addr neigh_addr,
 		  a
 		  previously received join message with holdtime=0xFFFF.
 		 */
-		if (ch->t_ifjoin_expiry_timer) {
+		if (event_is_scheduled(ch->t_ifjoin_expiry_timer)) {
 			unsigned long remain = event_timer_remain_second(
 				ch->t_ifjoin_expiry_timer);
 			if (remain > holdtime) {
@@ -990,7 +990,7 @@ void pim_ifchannel_join_add(struct interface *ifp, pim_addr neigh_addr,
 
 		pim_ifchannel_ifjoin_handler(ch, pim_ifp);
 
-		if (ch->t_ifjoin_expiry_timer) {
+		if (event_is_scheduled(ch->t_ifjoin_expiry_timer)) {
 			unsigned long remain = event_timer_remain_second(
 				ch->t_ifjoin_expiry_timer);
 
@@ -1118,7 +1118,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 			 * current value and the HoldTime from the triggering
 			 * Join/Prune message.
 			 */
-			if (ch->t_ifjoin_expiry_timer) {
+			if (event_is_scheduled(ch->t_ifjoin_expiry_timer)) {
 				unsigned long rem = event_timer_remain_second(
 					ch->t_ifjoin_expiry_timer);
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -585,8 +585,6 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 	ch->local_ifmembership = PIM_IFMEMBERSHIP_NOINFO;
 
 	ch->ifjoin_state = PIM_IFJOIN_NOINFO;
-	ch->t_ifjoin_expiry_timer = NULL;
-	ch->t_ifjoin_prune_pending_timer = NULL;
 	ch->ifjoin_creation = 0;
 
 	ch->prune_holdtime = 0;
@@ -605,7 +603,6 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 	ch->ifassert_winner = PIMADDR_ANY;
 
 	/* Assert state */
-	ch->t_ifassert_timer = NULL;
 	ch->ifassert_state = PIM_IFASSERT_NOINFO;
 	reset_ifassert_state(ch);
 	if (pim_macro_ch_could_assert_eval(ch))

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1202,9 +1202,6 @@ static struct gm_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	igmp->interface = ifp;
 	igmp->ifaddr = ifaddr;
 	igmp->querier_addr = ifaddr;
-	igmp->t_igmp_read = NULL;
-	igmp->t_igmp_query_timer = NULL;
-	igmp->t_other_querier_timer = NULL; /* no other querier present */
 	igmp->querier_robustness_variable =
 		pim_ifp->gm_default_robustness_variable;
 	igmp->sock_creation = pim_time_monotonic_sec();
@@ -1469,8 +1466,6 @@ struct gm_group *igmp_add_group_by_addr(struct gm_sock *igmp,
 	group->group_source_list = list_new();
 	group->group_source_list->del = (void (*)(void *))igmp_source_free;
 
-	group->t_group_timer = NULL;
-	group->t_group_query_retransmit_timer = NULL;
 	group->group_specific_query_retransmit_count = 0;
 	group->group_addr = group_addr;
 	group->interface = igmp->interface;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -344,7 +344,7 @@ static void pim_igmp_other_querier_expire(struct event *t)
 	 * Adjust the querier robustness value to our own configuration if the
 	 * other querier is no longer present.
 	 */
-	if (igmp->t_other_querier_timer == NULL) {
+	if (!event_is_scheduled(igmp->t_other_querier_timer)) {
 		struct pim_interface *pim_ifp = igmp->interface->info;
 
 		igmp->querier_robustness_variable = pim_ifp->gm_default_robustness_variable;
@@ -374,7 +374,7 @@ void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
 
 	pim_ifp = igmp->interface->info;
 
-	if (igmp->t_other_querier_timer) {
+	if (event_is_scheduled(igmp->t_other_querier_timer)) {
 		/*
 		  There is other querier present already,
 		  then reset the other-querier-present timer.
@@ -433,7 +433,7 @@ void pim_igmp_other_querier_timer_off(struct gm_sock *igmp)
 	assert(igmp);
 
 	if (PIM_DEBUG_GM_TRACE) {
-		if (igmp->t_other_querier_timer) {
+		if (event_is_scheduled(igmp->t_other_querier_timer)) {
 			zlog_debug("IGMP querier %pI4s fd=%d cancelling other-querier-present TIMER event on %s",
 				   &igmp->ifaddr, igmp->fd, igmp->interface->name);
 		}
@@ -568,7 +568,7 @@ static int igmp_recv_query(struct gm_sock *igmp, int query_version, int max_resp
 
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
 					  group)) {
-			if (!group->t_group_query_retransmit_timer)
+			if (!event_is_scheduled(group->t_group_query_retransmit_timer))
 				continue;
 
 			if (PIM_DEBUG_GM_TRACE)
@@ -908,7 +908,7 @@ void pim_igmp_general_query_off(struct gm_sock *igmp)
 	assert(igmp);
 
 	if (PIM_DEBUG_GM_TRACE) {
-		if (igmp->t_igmp_query_timer) {
+		if (event_is_scheduled(igmp->t_igmp_query_timer)) {
 			zlog_debug("IGMP querier %pI4s fd=%d cancelling query TIMER event on %s",
 				   &igmp->ifaddr, igmp->fd, igmp->interface->name);
 		}
@@ -970,7 +970,7 @@ static void sock_close(struct gm_sock *igmp)
 	pim_igmp_general_query_off(igmp);
 
 	if (PIM_DEBUG_GM_TRACE_DETAIL) {
-		if (igmp->t_igmp_read) {
+		if (event_is_scheduled(igmp->t_igmp_read)) {
 			zlog_debug(
 				"Cancelling READ event on IGMP socket %pI4 fd=%d on interface %s",
 				&igmp->ifaddr, igmp->fd,
@@ -1355,7 +1355,7 @@ static void igmp_group_timer(struct event *t)
 
 static void group_timer_off(struct gm_group *group)
 {
-	if (!group->t_group_timer)
+	if (!event_is_scheduled(group->t_group_timer))
 		return;
 
 	if (PIM_DEBUG_GM_TRACE) {

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -155,7 +155,7 @@ static void igmp_source_timer(struct event *t)
 
 static void source_timer_off(struct gm_group *group, struct gm_source *source)
 {
-	if (!source->t_source_timer)
+	if (!event_is_scheduled(source->t_source_timer))
 		return;
 
 	if (PIM_DEBUG_GM_TRACE) {
@@ -252,7 +252,7 @@ static int source_mark_send_flag_by_timer(struct gm_group *group)
 
 	for (ALL_LIST_ELEMENTS_RO(group->group_source_list, src_node, src)) {
 		/* Is source timer running? */
-		if (src->t_source_timer) {
+		if (event_is_scheduled(src->t_source_timer)) {
 			IGMP_SOURCE_DO_SEND(src->source_flags);
 			++num_marked_sources;
 		} else {
@@ -362,7 +362,7 @@ void igmp_source_delete_expired(struct list *source_list)
 	struct gm_source *src;
 
 	for (ALL_LIST_ELEMENTS(source_list, src_node, src_nextnode, src))
-		if (!src->t_source_timer)
+		if (!event_is_scheduled(src->t_source_timer))
 			igmp_source_delete(src);
 }
 
@@ -733,7 +733,7 @@ static void toin_excl(struct gm_group *group, int num_sources,
 		if (!source)
 			continue;
 
-		if (source->t_source_timer) {
+		if (event_is_scheduled(source->t_source_timer)) {
 			/* If found and timer running, clear SEND flag
 			 * (X*A) */
 			IGMP_SOURCE_DONT_SEND(source->source_flags);
@@ -893,7 +893,7 @@ static void toex_excl(struct gm_group *group, int num_sources,
 		/* make sure reported source has DELETE flag unset */
 		assert(!IGMP_SOURCE_TEST_DELETE(source->source_flags));
 
-		if (source->t_source_timer) {
+		if (event_is_scheduled(source->t_source_timer)) {
 			/* if source timer>0 mark SEND flag: Q(G,A-Y) */
 			IGMP_SOURCE_DO_SEND(source->source_flags);
 			++num_sources_tosend;
@@ -1243,7 +1243,7 @@ static void group_retransmit_timer_on(struct gm_group *group)
 	long lmqi_msec; /* Last Member Query Interval */
 
 	/* if group retransmit timer is running, do nothing */
-	if (group->t_group_query_retransmit_timer) {
+	if (event_is_scheduled(group->t_group_query_retransmit_timer)) {
 		return;
 	}
 
@@ -1378,7 +1378,7 @@ static void block_excl(struct gm_group *group, int num_sources,
 			assert(source->t_source_timer); /* (A-X-Y) timer > 0 */
 		}
 
-		if (source->t_source_timer) {
+		if (event_is_scheduled(source->t_source_timer)) {
 			/* 4. if source timer>0 mark SEND flag: Q(G,A-Y) */
 			IGMP_SOURCE_DO_SEND(source->source_flags);
 			++num_sources_tosend;
@@ -1663,7 +1663,7 @@ void igmp_v3_recv_query(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 	 * Interval] value, unless that most recently received QQI was zero,
 	 * in which case the receiving routers use the default.
 	 */
-	if (igmp->t_other_querier_timer) {
+	if (event_is_scheduled(igmp->t_other_querier_timer)) {
 		/* other querier present */
 		uint8_t qqic;
 		uint16_t qqi;

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -419,13 +419,9 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 	if (new)
 		*new = true;
 
-	src->t_source_timer = NULL;
 	src->source_group = group; /* back pointer */
 	src->source_addr = src_addr;
 	src->source_creation = pim_time_monotonic_sec();
-	src->source_flags = 0;
-	src->source_query_retransmit_count = 0;
-	src->source_channel_oil = NULL;
 
 	listnode_add(group->group_source_list, src);
 

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -548,7 +548,7 @@ have_up:
 	/*
 	 * If we've received a register suppress
 	 */
-	if (!up->t_rs_timer) {
+	if (!event_is_scheduled(up->t_rs_timer)) {
 		if (pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
 			if (PIM_DEBUG_PIM_REG)
 				zlog_debug(

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -464,7 +464,8 @@ static bool pim_msdp_sa_local_add_ok(struct pim_upstream *up)
 	/* we are the FHR-DR for this stream  or we are RP and have seen
 	 * registers
 	 * from a FHR for this source */
-	if (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) || up->t_msdp_reg_timer) {
+	if (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) ||
+	    event_is_scheduled(up->t_msdp_reg_timer)) {
 		return true;
 	}
 

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -202,7 +202,6 @@ void pim_msdp_write(struct event *event)
 	int work_max_cnt = 100;
 
 	mp = EVENT_ARG(event);
-	mp->t_write = NULL;
 
 	if (PIM_DEBUG_MSDP_INTERNAL) {
 		zlog_debug("MSDP peer %s pim_msdp_write", mp->key_str);
@@ -780,7 +779,6 @@ void pim_msdp_read(struct event *event)
 	uint32_t len;
 
 	mp = EVENT_ARG(event);
-	mp->t_read = NULL;
 
 	if (PIM_DEBUG_MSDP_INTERNAL) {
 		zlog_debug("MSDP peer %s pim_msdp_read", mp->key_str);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -427,7 +427,7 @@ static void igmp_sock_query_reschedule(struct gm_sock *igmp)
 	if (igmp->mtrace_only)
 		return;
 
-	if (igmp->t_igmp_query_timer) {
+	if (event_is_scheduled(igmp->t_igmp_query_timer)) {
 		/* other querier present */
 		assert(igmp->t_igmp_query_timer);
 		assert(!igmp->t_other_querier_timer);
@@ -517,7 +517,7 @@ static void change_query_max_response_time(struct interface *ifp,
 			/* reset source timers for sources with running
 			 * timers
 			 */
-			if (src->t_source_timer)
+			if (event_is_scheduled(src->t_source_timer))
 				igmp_source_reset_gmi(grp, src);
 		}
 	}
@@ -5042,7 +5042,7 @@ int lib_interface_gmp_address_family_robustness_variable_modify(struct nb_cb_mod
 
 		/* Update all addresses that are acting as querier */
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, node, igmp)) {
-			if (igmp->t_other_querier_timer)
+			if (event_is_scheduled(igmp->t_other_querier_timer))
 				continue;
 
 			igmp->querier_robustness_variable = pim_ifp->gm_default_robustness_variable;

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -292,7 +292,6 @@ pim_neighbor_new(struct interface *ifp, pim_addr source_addr,
 	neigh->dr_priority = dr_priority;
 	neigh->generation_id = generation_id;
 	neigh->prefix_list = addr_list;
-	neigh->t_expire_timer = NULL;
 	neigh->interface = ifp;
 
 	neigh->upstream_jp_agg = list_new();

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -1081,7 +1081,7 @@ int pim_sock_add(struct interface *ifp)
 
 	pim_socket_ip_hdr(pim_ifp->pim_sock_fd);
 
-	pim_ifp->t_pim_sock_read = NULL;
+	event_cancel(&pim_ifp->t_pim_sock_read);
 	pim_ifp->pim_sock_creation = pim_time_monotonic_sec();
 
 	/*

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -617,9 +617,7 @@ void pim_sock_reset(struct interface *ifp)
 
 	pim_ifp->pim_sock_fd = -1;
 	pim_ifp->pim_sock_creation = 0;
-	pim_ifp->t_pim_sock_read = NULL;
 
-	pim_ifp->t_pim_hello_timer = NULL;
 	pim_ifp->pim_hello_period = PIM_DEFAULT_HELLO_PERIOD;
 	pim_ifp->pim_default_holdtime =
 		-1; /* unset: means 3.5 * pim_hello_period */

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -66,7 +66,7 @@ static void sock_close(struct interface *ifp)
 	struct pim_interface *pim_ifp = ifp->info;
 
 	if (PIM_DEBUG_PIM_TRACE) {
-		if (pim_ifp->t_pim_sock_read) {
+		if (event_is_scheduled(pim_ifp->t_pim_sock_read)) {
 			zlog_debug(
 				"Cancelling READ event for PIM socket fd=%d on interface %s",
 				pim_ifp->pim_sock_fd, ifp->name);
@@ -75,7 +75,7 @@ static void sock_close(struct interface *ifp)
 	event_cancel(&pim_ifp->t_pim_sock_read);
 
 	if (PIM_DEBUG_PIM_TRACE) {
-		if (pim_ifp->t_pim_hello_timer) {
+		if (event_is_scheduled(pim_ifp->t_pim_hello_timer)) {
 			zlog_debug(
 				"Cancelling PIM hello timer for interface %s",
 				ifp->name);
@@ -1028,7 +1028,7 @@ void pim_hello_restart_triggered(struct interface *ifp)
 	// triggered_hello_delay_msec = 1000 *
 	// pim_ifp->pim_triggered_hello_delay;
 
-	if (pim_ifp->t_pim_hello_timer) {
+	if (event_is_scheduled(pim_ifp->t_pim_hello_timer)) {
 		long remain_msec =
 			pim_time_timer_remain_msec(pim_ifp->t_pim_hello_timer);
 		if (remain_msec <= triggered_hello_delay_msec) {

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -347,10 +347,8 @@ static struct ssmpingd_sock *ssmpingd_new(struct pim_instance *pim,
 
 	ss->pim = pim;
 	ss->sock_fd = sock_fd;
-	ss->t_sock_read = NULL;
 	ss->source_addr = source_addr;
 	ss->creation = pim_time_monotonic_sec();
-	ss->requests = 0;
 
 	listnode_add(pim->ssmpingd_list, ss);
 

--- a/pimd/pim_time.c
+++ b/pimd/pim_time.c
@@ -123,7 +123,7 @@ static int pim_time_hhmmss(char *buf, int buf_size, long sec)
 
 void pim_time_timer_to_mmss(char *buf, int buf_size, struct event *t_timer)
 {
-	if (t_timer) {
+	if (event_is_scheduled(t_timer)) {
 		pim_time_mmss(buf, buf_size,
 			      event_timer_remain_second(t_timer));
 	} else {
@@ -133,7 +133,7 @@ void pim_time_timer_to_mmss(char *buf, int buf_size, struct event *t_timer)
 
 void pim_time_timer_to_hhmmss(char *buf, int buf_size, struct event *t_timer)
 {
-	if (t_timer) {
+	if (event_is_scheduled(t_timer)) {
 		pim_time_hhmmss(buf, buf_size,
 				event_timer_remain_second(t_timer));
 	} else {

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -637,7 +637,7 @@ void pim_upstream_join_suppress(struct pim_upstream *up, pim_addr rpf,
 		MIN(pim_if_t_suppressed_msec(up->rpf.source_nexthop.interface),
 		    1000 * holdtime);
 
-	if (up->t_join_timer)
+	if (event_is_scheduled(up->t_join_timer))
 		join_timer_remain_msec =
 			pim_time_timer_remain_msec(up->t_join_timer);
 	else {
@@ -690,7 +690,7 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 	t_override_msec =
 		pim_if_t_override_msec(up->rpf.source_nexthop.interface);
 
-	if (up->t_join_timer) {
+	if (event_is_scheduled(up->t_join_timer)) {
 		join_timer_remain_msec =
 			pim_time_timer_remain_msec(up->t_join_timer);
 	} else {

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1215,12 +1215,6 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	pim_upstream_find_new_children(pim, up);
 	up->flags = flags;
 	up->ref_count = 1;
-	up->t_join_timer = NULL;
-	up->t_ka_timer = NULL;
-	up->t_rs_timer = NULL;
-	up->t_msdp_reg_timer = NULL;
-	up->t_graft_timer = NULL;
-	up->t_prune_timer = NULL;
 	up->join_state = PIM_UPSTREAM_NOTJOINED;
 	up->reg_state = PIM_REG_NOINFO;
 	up->state_transition = pim_time_monotonic_sec();

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -395,7 +395,7 @@ void sched_rpf_cache_refresh(struct pim_instance *pim)
 
 	pim_rpf_set_refresh_time(pim);
 
-	if (pim->rpf_cache_refresher) {
+	if (event_is_scheduled(pim->rpf_cache_refresher)) {
 		/* Refresh timer is already running */
 		return;
 	}

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -130,7 +130,6 @@ void zclient_lookup_new(void)
 	}
 
 	pim_zlookup->sock = -1;
-	pim_zlookup->t_connect = NULL;
 	pim_zlookup->privs = &pimd_privs;
 
 	zclient_lookup_sched_now(pim_zlookup);

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -92,7 +92,7 @@ static void zclient_lookup_sched_now(struct zclient *zlookup)
 /* Schedule reconnection, if needed. */
 static void zclient_lookup_reconnect(struct zclient *zlookup)
 {
-	if (zlookup->t_connect) {
+	if (event_is_scheduled(zlookup->t_connect)) {
 		return;
 	}
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2850,7 +2850,7 @@ void rip_event(struct rip *rip, enum rip_event event, int sock)
 				&rip->t_update);
 		break;
 	case RIP_TRIGGERED_UPDATE:
-		if (rip->t_triggered_interval)
+		if (event_is_scheduled(rip->t_triggered_interval))
 			rip->trigger = 1;
 		else
 			event_add_event(master, rip_triggered_update, rip, 0,

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1980,7 +1980,7 @@ void ripng_event(struct ripng *ripng, enum ripng_event event, int sock)
 				&ripng->t_update);
 		break;
 	case RIPNG_TRIGGERED_UPDATE:
-		if (ripng->t_triggered_interval)
+		if (event_is_scheduled(ripng->t_triggered_interval))
 			ripng->trigger = 1;
 		else
 			event_add_event(master, ripng_triggered_update, ripng,

--- a/staticd/static_bfd.c
+++ b/staticd/static_bfd.c
@@ -32,7 +32,7 @@ static void static_bfd_holddown_timer_cancel(
 	struct static_nexthop *sn,
 	enum static_bfd_holddown_cancel_reason reason)
 {
-	if (!sn->t_bfd_admin_holddown)
+	if (!event_is_scheduled(sn->t_bfd_admin_holddown))
 		return;
 
 	event_cancel(&sn->t_bfd_admin_holddown);

--- a/tests/lib/test_memory.c
+++ b/tests/lib/test_memory.c
@@ -87,9 +87,7 @@ int main(int argc, char **argv)
 		memset(a[1], 1, 1024 / 2);
 
 		printf("realloc 0 1024\n");
-		a[3] = XREALLOC(MTYPE_TEST, a[0], 2048); /* invalidate cache */
-		if (a[3] != NULL)
-			a[0] = a[3];
+		a[0] = XREALLOC(MTYPE_TEST, a[0], 2048); /* invalidate cache */
 		memset(a[0], 1, 1024);
 
 		printf("calloc 2 512\n");

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -565,7 +565,6 @@ static void wakeup_down(struct event *t_wakeup)
 {
 	struct daemon *dmn = EVENT_ARG(t_wakeup);
 
-	dmn->t_wakeup = NULL;
 	if (try_connect(dmn) < 0)
 		SET_WAKEUP_DOWN(dmn);
 	if ((dmn->connect_tries > 1) && (dmn->state != DAEMON_UP))
@@ -576,7 +575,6 @@ static void wakeup_init(struct event *t_wakeup)
 {
 	struct daemon *dmn = EVENT_ARG(t_wakeup);
 
-	dmn->t_wakeup = NULL;
 	if (try_connect(dmn) < 0) {
 		zlog_info(
 			"%s state -> down : initial connection attempt failed",
@@ -640,7 +638,6 @@ static void handle_read(struct event *t_read)
 	ssize_t rc;
 	struct timeval delay;
 
-	dmn->t_read = NULL;
 	if ((rc = read(dmn->fd, buf, sizeof(buf))) < 0) {
 		char why[100];
 
@@ -766,7 +763,6 @@ static void check_connect(struct event *t_write)
 	int sockerr;
 	socklen_t reslen = sizeof(sockerr);
 
-	dmn->t_write = NULL;
 	if (getsockopt(dmn->fd, SOL_SOCKET, SO_ERROR, (char *)&sockerr, &reslen)
 	    < 0) {
 		zlog_warn("%s: check_connect: getsockopt failed: %s", dmn->name,
@@ -793,7 +789,6 @@ static void wakeup_connect_hanging(struct event *t_wakeup)
 	struct daemon *dmn = EVENT_ARG(t_wakeup);
 	char why[100];
 
-	dmn->t_wakeup = NULL;
 	snprintf(why, sizeof(why),
 		 "connection attempt timed out after %ld seconds", gs.timeout);
 	daemon_down(dmn, why);
@@ -941,7 +936,6 @@ static void wakeup_unresponsive(struct event *t_wakeup)
 {
 	struct daemon *dmn = EVENT_ARG(t_wakeup);
 
-	dmn->t_wakeup = NULL;
 	if (dmn->state != DAEMON_UNRESPONSIVE)
 		flog_err(EC_WATCHFRR_CONNECTION,
 			 "%s: no longer unresponsive (now %s), wakeup should have been cancelled!",
@@ -956,7 +950,6 @@ static void wakeup_no_answer(struct event *t_wakeup)
 {
 	struct daemon *dmn = EVENT_ARG(t_wakeup);
 
-	dmn->t_wakeup = NULL;
 	dmn->state = DAEMON_UNRESPONSIVE;
 	if (dmn->ignore_timeout)
 		return;
@@ -973,7 +966,6 @@ static void wakeup_send_echo(struct event *t_wakeup)
 	ssize_t rc;
 	struct daemon *dmn = EVENT_ARG(t_wakeup);
 
-	dmn->t_wakeup = NULL;
 	if (((rc = write(dmn->fd, echocmd, sizeof(echocmd))) < 0)
 	    || ((size_t)rc != sizeof(echocmd))) {
 		char why[100 + sizeof(echocmd)];

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -679,7 +679,7 @@ void zebra_evpn_print_mac(struct zebra_mac *mac, struct vty *vty, json_object *j
 			json_object_boolean_true_add(json_mac, "peerProxy");
 		if (CHECK_FLAG(mac->flags, ZEBRA_MAC_ES_PEER_ACTIVE))
 			json_object_boolean_true_add(json_mac, "peerActive");
-		if (mac->hold_timer)
+		if (event_is_scheduled(mac->hold_timer))
 			json_object_string_add(
 				json_mac, "peerActiveHold",
 				event_timer_to_hhmmss(thread_buf,
@@ -768,7 +768,7 @@ void zebra_evpn_print_mac(struct zebra_mac *mac, struct vty *vty, json_object *j
 			vty_out(vty, " peer-proxy");
 		if (CHECK_FLAG(mac->flags, ZEBRA_MAC_ES_PEER_ACTIVE))
 			vty_out(vty, " peer-active");
-		if (mac->hold_timer)
+		if (event_is_scheduled(mac->hold_timer))
 			vty_out(vty, " (ht: %s)",
 				event_timer_to_hhmmss(thread_buf,
 						      sizeof(thread_buf),
@@ -1559,7 +1559,7 @@ static void zebra_evpn_mac_hold_exp_cb(struct event *t)
 
 static inline void zebra_evpn_mac_start_hold_timer(struct zebra_mac *mac)
 {
-	if (mac->hold_timer)
+	if (event_is_scheduled(mac->hold_timer))
 		return;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_MAC) {
@@ -1575,7 +1575,7 @@ static inline void zebra_evpn_mac_start_hold_timer(struct zebra_mac *mac)
 
 void zebra_evpn_mac_stop_hold_timer(struct zebra_mac *mac)
 {
-	if (!mac->hold_timer)
+	if (!event_is_scheduled(mac->hold_timer))
 		return;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_MAC) {

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1098,7 +1098,7 @@ struct zebra_mac *zebra_evpn_mac_add(struct zebra_evpn *zevpn,
 	mac = hash_get(zevpn->mac_table, &tmp_mac, zebra_evpn_mac_alloc);
 
 	mac->zevpn = zevpn;
-	mac->dad_mac_auto_recovery_timer = NULL;
+	event_cancel(&mac->dad_mac_auto_recovery_timer);
 
 	mac->neigh_list = list_new();
 	mac->neigh_list->cmp = neigh_list_cmp;

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1889,7 +1889,7 @@ static bool zebra_evpn_es_run_df_election(struct zebra_evpn_es *es,
 	 * our Type-4 routes and for the switch to import the peers' Type-4
 	 * routes
 	 */
-	if (es->df_delay_timer) {
+	if (event_is_scheduled(es->df_delay_timer)) {
 		new_non_df = true;
 		return zebra_evpn_es_df_change(es, new_non_df, caller,
 					       "df-delay");
@@ -2452,7 +2452,7 @@ static void zebra_evpn_es_local_info_set(struct zebra_evpn_es *es,
 			false /* es_evi_re_reval */);
 
 	/* Start the DF delay timer on the local ES */
-	if (!es->df_delay_timer)
+	if (!event_is_scheduled(es->df_delay_timer))
 		event_add_timer(zrouter.master, zebra_evpn_es_df_delay_exp_cb,
 				es, ZEBRA_EVPN_MH_DF_DELAY_TIME,
 				&es->df_delay_timer);
@@ -3358,7 +3358,7 @@ static void zebra_evpn_es_show_entry_detail(struct vty *vty,
 				    listcount(es->es_evi_list));
 		json_object_int_add(json, "macCount", listcount(es->mac_list));
 		json_object_int_add(json, "dfPreference", es->df_pref);
-		if (es->df_delay_timer)
+		if (event_is_scheduled(es->df_delay_timer))
 			json_object_string_add(
 				json, "dfDelayTimer",
 				event_timer_to_hhmmss(thread_buf,
@@ -3404,7 +3404,7 @@ static void zebra_evpn_es_show_entry_detail(struct vty *vty,
 			vty_out(vty, " DF status: %s \n",
 				(es->flags & ZEBRA_EVPNES_NON_DF) ? "non-df"
 								  : "df");
-		if (es->df_delay_timer)
+		if (event_is_scheduled(es->df_delay_timer))
 			vty_out(vty, " DF delay: %s\n",
 				event_timer_to_hhmmss(thread_buf,
 						      sizeof(thread_buf),
@@ -3944,7 +3944,7 @@ static void zebra_evpn_mh_startup_delay_exp_cb(struct event *t)
 
 static void zebra_evpn_mh_startup_delay_timer_start(const char *rc)
 {
-	if (zmh_info->startup_delay_timer) {
+	if (event_is_scheduled(zmh_info->startup_delay_timer)) {
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 			zlog_debug("startup-delay timer cancelled");
 		event_cancel(&zmh_info->startup_delay_timer);
@@ -4073,7 +4073,7 @@ int zebra_evpn_mh_startup_delay_update(struct vty *vty, uint32_t duration,
 	/* if startup_delay_timer is running allow it to be adjusted
 	 * up or down
 	 */
-	if (zmh_info->startup_delay_timer)
+	if (event_is_scheduled(zmh_info->startup_delay_timer))
 		zebra_evpn_mh_startup_delay_timer_start("config");
 
 	return 0;

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -389,7 +389,7 @@ static void zebra_evpn_neigh_hold_exp_cb(struct event *t)
 
 static inline void zebra_evpn_neigh_start_hold_timer(struct zebra_neigh *n)
 {
-	if (n->hold_timer)
+	if (event_is_scheduled(n->hold_timer))
 		return;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_NEIGH && n->zevpn)
@@ -1759,7 +1759,7 @@ void zebra_evpn_print_neigh(const struct zebra_neigh *n, void *ctxt, json_object
 			vty_out(vty, " peer-active");
 			sync_info = true;
 		}
-		if (n->hold_timer) {
+		if (event_is_scheduled(n->hold_timer)) {
 			vty_out(vty, " (ht: %s)",
 				event_timer_to_hhmmss(thread_buf,
 						      sizeof(thread_buf),
@@ -1782,7 +1782,7 @@ void zebra_evpn_print_neigh(const struct zebra_neigh *n, void *ctxt, json_object
 			json_object_boolean_true_add(json, "peerProxy");
 		if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_ES_PEER_ACTIVE))
 			json_object_boolean_true_add(json, "peerActive");
-		if (n->hold_timer)
+		if (event_is_scheduled(n->hold_timer))
 			json_object_string_add(
 				json, "peerActiveHold",
 				event_timer_to_hhmmss(thread_buf,

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -508,7 +508,7 @@ static struct zebra_neigh *zebra_evpn_neigh_add(struct zebra_evpn *zevpn,
 
 	n->state = ZEBRA_NEIGH_INACTIVE;
 	n->zevpn = zevpn;
-	n->dad_ip_auto_recovery_timer = NULL;
+	event_cancel(&n->dad_ip_auto_recovery_timer);
 	n->flags = n_flags;
 	n->uptime = monotime(NULL);
 	n->gr_refresh_time = monotime(NULL);

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -181,7 +181,7 @@ static inline bool zebra_evpn_neigh_is_ready_for_bgp(struct zebra_neigh *n)
 
 static inline void zebra_evpn_neigh_stop_hold_timer(struct zebra_neigh *n)
 {
-	if (!n->hold_timer)
+	if (!event_is_scheduled(n->hold_timer))
 		return;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_NEIGH)

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1674,8 +1674,6 @@ static void zfpm_iterate_rmac_table(struct hash_bucket *bucket, void *args)
  */
 static void zfpm_stats_timer_cb(struct event *t)
 {
-	zfpm_g->t_stats = NULL;
-
 	/*
 	 * Remember the stats collected in the last interval for display
 	 * purposes.

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1462,7 +1462,7 @@ static int zfpm_trigger_update(struct route_node *rn, const char *reason)
 	/*
 	 * Make sure that writes are enabled.
 	 */
-	if (zfpm_g->t_write)
+	if (event_is_scheduled(zfpm_g->t_write))
 		return 0;
 
 	zfpm_write_on();
@@ -1635,7 +1635,7 @@ static int zfpm_trigger_rmac_update(struct zebra_mac *rmac,
 	zfpm_g->stats.updates_triggered++;
 
 	/* If writes are already enabled, return. */
-	if (zfpm_g->t_write)
+	if (event_is_scheduled(zfpm_g->t_write))
 		return 0;
 
 	zfpm_write_on();
@@ -1699,7 +1699,7 @@ static void zfpm_stats_timer_cb(struct event *t)
  */
 static void zfpm_stop_stats_timer(void)
 {
-	if (!zfpm_g->t_stats)
+	if (!event_is_scheduled(zfpm_g->t_stats))
 		return;
 
 	zfpm_debug("Stopping existing stats timer");

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -545,7 +545,6 @@ static void zebra_gr_route_stale_delete_timer_expiry(struct event *event)
 	struct zserv *client;
 	struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
-	info->t_stale_removal = NULL;
 	if (zrouter.graceful_restart)
 		client = (struct zserv *)info->client_ptr;
 	else

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -92,7 +92,7 @@ void zebra_gr_stale_client_cleanup(void)
 				    ninfo) {
 
 			/* Cancel the stale timer */
-			if (info->t_stale_removal != NULL) {
+			if (event_is_scheduled(info->t_stale_removal)) {
 				event_cancel(&info->t_stale_removal);
 				info->do_delete = true;
 				info->stale_client = true;
@@ -400,7 +400,7 @@ void zread_client_capabilities(ZAPI_HANDLER_ARGS)
 		       zebra_route_string(client->proto));
 
 		/* Update the stale removal timer */
-		if (info && info->t_stale_removal == NULL) {
+		if (info && !event_is_scheduled(info->t_stale_removal)) {
 
 			LOG_GR("%s: vrf %s(%u) Stale time: %d is now update to: %d",
 			       __func__, VRF_LOGNAME(vrf), info->vrf_id,
@@ -813,7 +813,7 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 	 * Also perform the cleanup if FRR itself is gracefully restarting.
 	 */
 	info->route_sync_done_time = monotime(NULL);
-	if (info->t_stale_removal || zrouter.graceful_restart) {
+	if (event_is_scheduled(info->t_stale_removal) || zrouter.graceful_restart) {
 		struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
 		LOG_GR("%s: Client %s route update complete for all AFI/SAFI in vrf %s(%d)",

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -618,8 +618,6 @@ void zebra_mlag_init(void)
 	zrouter.mlag_info.mlag_fifo = stream_fifo_new();
 	zrouter.mlag_info.zebra_pth_mlag = NULL;
 	zrouter.mlag_info.th_master = NULL;
-	zrouter.mlag_info.t_read = NULL;
-	zrouter.mlag_info.t_write = NULL;
 	test_mlag_in_progress = false;
 	zebra_mlag_reset_read_buffer();
 }

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -167,7 +167,7 @@ static void zebra_ptm_flush_messages(struct event *event)
 		close(ptm_cb.ptm_sock);
 		ptm_cb.ptm_sock = -1;
 		zebra_ptm_reset_status(0);
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return;
@@ -191,7 +191,7 @@ static int zebra_ptm_send_message(char *data, int size)
 		close(ptm_cb.ptm_sock);
 		ptm_cb.ptm_sock = -1;
 		zebra_ptm_reset_status(0);
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return -1;
@@ -218,7 +218,7 @@ void zebra_ptm_connect(struct event *t)
 
 	if (ptm_cb.ptm_sock != -1) {
 		if (init) {
-			ptm_cb.t_read = NULL;
+			event_cancel(&ptm_cb.t_read);
 			event_add_read(zrouter.master, zebra_ptm_sock_read,
 				       NULL, ptm_cb.ptm_sock, &ptm_cb.t_read);
 			zebra_bfd_peer_replay_req();
@@ -614,7 +614,7 @@ void zebra_ptm_sock_read(struct event *event)
 		close(ptm_cb.ptm_sock);
 		ptm_cb.ptm_sock = -1;
 		zebra_ptm_reset_status(0);
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return;
@@ -655,7 +655,7 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 			   zebra_route_string(client->proto), hdr->length);
 
 	if (ptm_cb.ptm_sock == -1) {
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return;
@@ -814,7 +814,7 @@ void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 			   zebra_route_string(client->proto), hdr->length);
 
 	if (ptm_cb.ptm_sock == -1) {
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return;
@@ -942,7 +942,7 @@ void zebra_ptm_bfd_client_register(ZAPI_HANDLER_ARGS)
 	STREAM_GETL(s, pid);
 
 	if (ptm_cb.ptm_sock == -1) {
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return;
@@ -1001,7 +1001,7 @@ int zebra_ptm_bfd_client_deregister(struct zserv *client)
 			   zebra_route_string(proto));
 
 	if (ptm_cb.ptm_sock == -1) {
-		ptm_cb.t_timer = NULL;
+		event_cancel(&ptm_cb.t_timer);
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return 0;

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -153,8 +153,6 @@ void zebra_ptm_finish(void)
 
 static void zebra_ptm_flush_messages(struct event *event)
 {
-	ptm_cb.t_write = NULL;
-
 	if (ptm_cb.ptm_sock == -1)
 		return;
 
@@ -172,7 +170,6 @@ static void zebra_ptm_flush_messages(struct event *event)
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return;
 	case BUFFER_PENDING:
-		ptm_cb.t_write = NULL;
 		event_add_write(zrouter.master, zebra_ptm_flush_messages, NULL,
 				ptm_cb.ptm_sock, &ptm_cb.t_write);
 		break;
@@ -230,7 +227,6 @@ void zebra_ptm_connect(struct event *t)
 		if (ptm_cb.reconnect_time > ZEBRA_PTM_RECONNECT_TIME_MAX)
 			ptm_cb.reconnect_time = ZEBRA_PTM_RECONNECT_TIME_MAX;
 
-		ptm_cb.t_timer = NULL;
 		event_add_timer(zrouter.master, zebra_ptm_connect, NULL,
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 	} else if (ptm_cb.reconnect_time >= ZEBRA_PTM_RECONNECT_TIME_MAX) {
@@ -620,7 +616,6 @@ void zebra_ptm_sock_read(struct event *event)
 		return;
 	}
 
-	ptm_cb.t_read = NULL;
 	event_add_read(zrouter.master, zebra_ptm_sock_read, NULL,
 		       ptm_cb.ptm_sock, &ptm_cb.t_read);
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3890,7 +3890,7 @@ DEFUN (show_zebra,
 	vty_out(vty, "Zebra started%s at time %s",
 		zrouter.graceful_restart ? " gracefully" : "", timebuf);
 
-	if (zrouter.t_rib_sweep)
+	if (event_is_scheduled(zrouter.t_rib_sweep))
 		vty_out(vty,
 			"Zebra RIB sweep timer running, remaining time %lds\n",
 			event_timer_remain_second(zrouter.t_rib_sweep));

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1523,7 +1523,7 @@ static void zebra_show_stale_client_detail(struct vty *vty, struct zserv *client
 
 				vty_out(vty, "Stalepath removal time: %d sec\n",
 					info->stale_removal_time);
-				if (info->t_stale_removal) {
+				if (event_is_scheduled(info->t_stale_removal)) {
 					vty_out(vty,
 						"Stale delete timer: %ld sec\n",
 						event_timer_remain_second(


### PR DESCRIPTION
Cleanup of both memory allocation and usage of events across of FRR to make the whole thing be consistent.

a) ldpd: event cleanup of unnecessary pointer setting for events, fix bug using malloc instead of calloc
b) lib: Fix null deref in frr_signal_timer
c) ospfd: Cleanup of ospf_apiserver usage of XMALLOC to XCALLOC
d) bgpd, use event_cancel instead of NULL setting in rfapi code
e) pimd, use event_cancel instead of NULL setting.
f) zebra, use event cancel instead of NULL setting.
g) Drop redundant Null setting inside of event handlers
h) Drop redundant if guards before event_cancel calling
i) Use `event_is_scheduled()` for truthiness of event being active or not
j) Don't need to check for NULL when using alloc functions
k) Create a test that shows bgp bmp mirroring is broken
l) Fix broken bmp mirroring.
