### PR TITLE
bgpd: Fix missing SRv6 unicast SID cleanup on locator delete

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -4267,7 +4267,10 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 	struct bgp_srv6_function *func;
 	struct bgp *bgp_vrf;
 	struct in6_addr *tovpn_sid;
+	struct in6_addr *unicast_sid;
 	struct prefix_ipv6 tmp_prefix;
+	struct srv6_locator *sid_locator;
+	afi_t afi;
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp_vrf)) {
 		if (bgp_vrf->inst_type != BGP_INSTANCE_TYPE_VRF)
@@ -4380,6 +4383,27 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 				bgp_vrf->tovpn_sid_locator = NULL;
 			}
 		}
+	}
+
+	/* Clear SRv6 unicast SIDs */
+	for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
+		unicast_sid = bgp->srv6_unicast[afi].sid;
+		sid_locator = bgp->srv6_unicast[afi].sid_locator;
+		if (!unicast_sid || !sid_locator)
+			continue;
+		if (!strmatch(sid_locator->name, loc->name))
+			continue;
+		tmp_prefix.family = AF_INET6;
+		tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
+		tmp_prefix.prefix = *unicast_sid;
+		if (!prefix_match((struct prefix *)&loc->prefix, (struct prefix *)&tmp_prefix))
+			continue;
+		bgp_srv6_unicast_withdraw(bgp, afi);
+		bgp_srv6_unicast_sid_withdraw(bgp, afi);
+		srv6_locator_free(bgp->srv6_unicast[afi].sid_locator);
+		bgp->srv6_unicast[afi].sid_locator = NULL;
+		sid_unregister(bgp, bgp->srv6_unicast[afi].sid);
+		XFREE(MTYPE_BGP_SRV6_SID, bgp->srv6_unicast[afi].sid);
 	}
 
 	// clear SRv6 locator

--- a/tests/topotests/bgp_srv6_unicast/test_bgp_srv6_unicast.py
+++ b/tests/topotests/bgp_srv6_unicast/test_bgp_srv6_unicast.py
@@ -946,6 +946,144 @@ def test_bgp_srv6_sid_dt46_restore():
     check_ping("c1", "fd00:300::2", True, count=5, wait=0.5)
 
 
+@retry(retry_timeout=15)
+def check_no_unicast_sid(afi):
+    """
+    Verify that R1's GRT unicast SID for the given AFI has been cleared.
+    """
+    tgen = get_topogen()
+    output = tgen.gears["r1"].vtysh_cmd("show bgp segment-routing srv6")
+    match = re.search(r"srv6_unicast\[%s\].sid: ([0-9a-fA-F:]+::)" % afi, output)
+    if match:
+        return "R1 sid[%s] is still set: %s" % (afi, match.group().split()[-1])
+    return True
+
+
+def test_bgp_srv6_no_locator():
+    """
+    Delete the SRv6 locator on R1 with 'no locator default' and verify that:
+    - R1's GRT unicast SIDs (AFI_IP and AFI_IP6) are cleared.
+    - Routes previously advertised with SRv6 encapsulation are withdrawn on R3
+      (strict encap-srv6 peer) after the SID is gone.
+    """
+    tgen = get_topogen()
+
+    # Re-advertise IPv4 and IPv6 prefixes on R1 with auto SID so we have
+    # active SRv6-encapped routes to observe withdrawal.
+    tgen.gears["r1"].vtysh_multicmd(
+        """
+        configure
+        router bgp 65001
+        address-family ipv4 unicast
+        network 10.0.0.1/32
+        sid export auto
+        exit-address-family
+        address-family ipv6 unicast
+        network fd00:200::/64
+        sid export auto
+        """
+    )
+
+    res = get_unicast_sid("AFI_IP")
+    assert res is True, res
+    r1_ipv4_unicast_sid = r1_unicast_sid
+    logger.info("R1 sid[AFI_IP] before no locator: %s" % r1_ipv4_unicast_sid)
+
+    res = get_unicast_sid("AFI_IP6")
+    assert res is True, res
+    r1_ipv6_unicast_sid = r1_unicast_sid
+    logger.info("R1 sid[AFI_IP6] before no locator: %s" % r1_ipv6_unicast_sid)
+
+    logger.info("Check 10.0.0.1/32 with SRv6 SID %s is installed on R3" % r1_ipv4_unicast_sid)
+    res = check_route(tgen.gears["r3"], "show ip route 10.0.0.1/32 json",
+                      "10.0.0.1/32", r1_ipv4_unicast_sid)
+    assert res is True, res
+
+    logger.info("Check fd00:200::/64 with SRv6 SID %s is installed on R3" % r1_ipv6_unicast_sid)
+    res = check_route(tgen.gears["r3"], "show ipv6 route fd00:200::/64 json",
+                      "fd00:200::/64", r1_ipv6_unicast_sid)
+    assert res is True, res
+
+    logger.info("Issue 'no locator default' on R1")
+    tgen.gears["r1"].vtysh_multicmd(
+        """
+        configure
+        segment-routing
+        srv6
+        locators
+        no locator default
+        """
+    )
+
+    logger.info("Verify GRT unicast SID[AFI_IP] is cleared on R1")
+    res = check_no_unicast_sid("AFI_IP")
+    assert res is True, res
+
+    logger.info("Verify GRT unicast SID[AFI_IP6] is cleared on R1")
+    res = check_no_unicast_sid("AFI_IP6")
+    assert res is True, res
+
+    logger.info("Check 10.0.0.1/32 is withdrawn from R3 (strict encap-srv6 peer)")
+    res = check_route(tgen.gears["r3"], "show ip route 10.0.0.1/32 json",
+                      "10.0.0.1/32", r1_ipv4_unicast_sid, expect_installed=False)
+    assert res is True, res
+
+    logger.info("Check fd00:200::/64 is withdrawn from R3 (strict encap-srv6 peer)")
+    res = check_route(tgen.gears["r3"], "show ipv6 route fd00:200::/64 json",
+                      "fd00:200::/64", r1_ipv6_unicast_sid, expect_installed=False)
+    assert res is True, res
+
+    logger.info("Check 10.0.0.1/32 on R2 has no SRv6 encap (encap-srv6-relax peer)")
+    res = check_route(tgen.gears["r2"], "show ip route 10.0.0.1/32 json",
+                      "10.0.0.1/32", "")
+    assert res is True, res
+
+    # Re-add the locator and verify SIDs are re-allocated and routes re-announced.
+    logger.info("Re-add 'locator default' on R1")
+    tgen.gears["r1"].vtysh_multicmd(
+        """
+        configure
+        segment-routing
+        srv6
+        locators
+        locator default
+        prefix 2001:db8:1:1::/64 block-len 40 node-len 24 func-bits 16
+        """
+    )
+
+    logger.info("Wait for R1 GRT unicast SID[AFI_IP] to be re-allocated")
+    res = get_unicast_sid("AFI_IP")
+    assert res is True, res
+    r1_ipv4_unicast_sid = r1_unicast_sid
+    logger.info("R1 sid[AFI_IP] after re-add: %s" % r1_ipv4_unicast_sid)
+
+    logger.info("Check 10.0.0.1/32 with new SID %s is installed on R3" % r1_ipv4_unicast_sid)
+    res = check_route(tgen.gears["r3"], "show ip route 10.0.0.1/32 json",
+                      "10.0.0.1/32", r1_ipv4_unicast_sid)
+    assert res is True, res
+
+    logger.info("Check 10.0.0.1/32 with new SID %s is installed on R2" % r1_ipv4_unicast_sid)
+    res = check_route(tgen.gears["r2"], "show ip route 10.0.0.1/32 json",
+                      "10.0.0.1/32", r1_ipv4_unicast_sid)
+    assert res is True, res
+
+    logger.info("Wait for R1 GRT unicast SID[AFI_IP6] to be re-allocated")
+    res = get_unicast_sid("AFI_IP6")
+    assert res is True, res
+    r1_ipv6_unicast_sid = r1_unicast_sid
+    logger.info("R1 sid[AFI_IP6] after re-add: %s" % r1_ipv6_unicast_sid)
+
+    logger.info("Check fd00:200::/64 with new SID %s is installed on R3" % r1_ipv6_unicast_sid)
+    res = check_route(tgen.gears["r3"], "show ipv6 route fd00:200::/64 json",
+                      "fd00:200::/64", r1_ipv6_unicast_sid)
+    assert res is True, res
+
+    logger.info("Check fd00:200::/64 with new SID %s is installed on R2" % r1_ipv6_unicast_sid)
+    res = check_route(tgen.gears["r2"], "show ipv6 route fd00:200::/64 json",
+                      "fd00:200::/64", r1_ipv6_unicast_sid)
+    assert res is True, res
+
+
 def teardown_module(mod):
     tgen = get_topogen()
     tgen.stop_topology()


### PR DESCRIPTION
When a locator is unconfigured, SID Manager notifies bgpd to clean up SIDs allocated from it. bgpd already releases VPN SIDs in this path, but SRv6 unicast SIDs were missed and could remain allocated.

This PR cleans up matching SRv6 unicast SIDs on locator delete and adds topotest coverage for IPv4 and IPv6 unicast SID cleanup.