### PR TITLE
bgpd: Fix BGP-LS Attribute Node Name TLV

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -1009,8 +1009,10 @@ int bgp_ls_originate_bgp_node(struct bgp *bgp)
 	ls_attr = bgp_ls_attr_alloc();
 
 	/* TLV 1026: Node Name */
-	ls_attr->node_name = XSTRDUP(MTYPE_BGP_LS_ATTR, bgp->peer_self->host);
-	SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_NODE_NAME_BIT);
+	if (bgp->peer_self->hostname) {
+		ls_attr->node_name = XSTRDUP(MTYPE_BGP_LS_ATTR, bgp->peer_self->hostname);
+		SET_FLAG(ls_attr->present_tlvs, BGP_LS_ATTR_NODE_NAME_BIT);
+	}
 
 	ret = bgp_ls_update(bgp, nlri, ls_attr);
 	if (ret != 0) {

--- a/tests/topotests/bgp_link_state_bgp_fabric/rr/expected_bgp_ls.json
+++ b/tests/topotests/bgp_link_state_bgp_fabric/rr/expected_bgp_ls.json
@@ -21,6 +21,9 @@
 						"bgpRouterId": "1.1.1.1"
 					}
 				},
+				"linkStateAttrs": {
+					"nodeName": "r1"
+				},
 				"weight": 0,
 				"peerId": "10.255.1.1",
 				"path": "65001",
@@ -43,6 +46,9 @@
 						"bgpRouterId": "2.2.2.2"
 					}
 				},
+				"linkStateAttrs": {
+					"nodeName": "r2"
+				},
 				"weight": 0,
 				"peerId": "10.255.2.1",
 				"path": "65001",
@@ -64,6 +70,9 @@
 						"asn": 65002,
 						"bgpRouterId": "3.3.3.3"
 					}
+				},
+				"linkStateAttrs": {
+					"nodeName": "r3"
 				},
 				"weight": 0,
 				"peerId": "2001:db9:3::1",
@@ -97,6 +106,9 @@
 						"asn": 65003,
 						"bgpRouterId": "4.4.4.4"
 					}
+				},
+				"linkStateAttrs": {
+					"nodeName": "r4"
 				},
 				"weight": 0,
 				"peerId": "2001:db9:4::1",


### PR DESCRIPTION
When exporting BGP-only fabric topology into BGP-LS, the BGP-LS Attribute for the local router has the Node Name TLV (TLV 1026) populated from `peer_self->host`. That field contains the internal "Static announcement" label used for locally originated routes.

As a result, the exported Node Name TLV carries "Static announcement" instead of the configured router hostname, for example "r1".

Use the configured router hostname `peer_self->hostname` when populating the Node Name TLV.