### PR TITLE
bgpd: preserve IPv6 nexthops when importing EVPN IPv4 routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3219,11 +3219,11 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	} else
 		return 0;
 
-	/* EVPN routes currently only support a IPv4 next hop which corresponds
-	 * to the remote VTEP. When importing into a VRF, if it is IPv6 host
-	 * or prefix route, we have to convert the next hop to an IPv4-mapped
-	 * address for the rest of the code to flow through. In the case of IPv4,
-	 * make sure to set the flag for next hop attribute.
+	/* EVPN routes may carry either an IPv4 or IPv6 next hop corresponding
+	 * to the remote VTEP. When importing into a VRF, IPv6 host/prefix routes
+	 * use an IPv6 MP nexthop. For IPv4 routes, set the legacy NEXT_HOP
+	 * attribute only when the imported nexthop is IPv4; IPv6 nexthops are
+	 * preserved as MP nexthops.
 	 */
 	attr = *parent_pi->attr;
 	bre = bgp_attr_get_evpn_overlay(&attr);
@@ -3249,11 +3249,13 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 			SET_FLAG(attr.flag, ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP));
 		}
 	} else {
-		if (afi == AFI_IP6)
+		if (afi == AFI_IP) {
+			if (!BGP_ATTR_MP_NEXTHOP_LEN_IP6(&attr)) {
+				attr.nexthop = attr.mp_nexthop_global_in;
+				bgp_attr_set(&attr, BGP_ATTR_NEXT_HOP);
+			}
+		} else if (afi == AFI_IP6) {
 			evpn_convert_nexthop_to_ipv6(&attr);
-		else {
-			attr.nexthop = attr.mp_nexthop_global_in;
-			SET_FLAG(attr.flag, ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP));
 		}
 	}
 
@@ -3291,11 +3293,17 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 			bgp_path_info_restore(dest, pi);
 
 		/* Mark if nexthop has changed. */
-		if ((afi == AFI_IP
-		     && !IPV4_ADDR_SAME(&pi->attr->nexthop, &attr_new->nexthop))
-		    || (afi == AFI_IP6
-			&& !IPV6_ADDR_SAME(&pi->attr->mp_nexthop_global,
-					   &attr_new->mp_nexthop_global)))
+		if (afi == AFI_IP) {
+			bool old_v6nh = BGP_ATTR_MP_NEXTHOP_LEN_IP6(pi->attr);
+			bool new_v6nh = BGP_ATTR_MP_NEXTHOP_LEN_IP6(attr_new);
+
+			if (old_v6nh != new_v6nh ||
+			    (old_v6nh && !IPV6_ADDR_SAME(&pi->attr->mp_nexthop_global,
+							 &attr_new->mp_nexthop_global)) ||
+			    (!old_v6nh && !IPV4_ADDR_SAME(&pi->attr->nexthop, &attr_new->nexthop)))
+				SET_FLAG(pi->flags, BGP_PATH_IGP_CHANGED);
+		} else if (afi == AFI_IP6 && !IPV6_ADDR_SAME(&pi->attr->mp_nexthop_global,
+							     &attr_new->mp_nexthop_global))
 			SET_FLAG(pi->flags, BGP_PATH_IGP_CHANGED);
 
 		bgp_path_info_set_flag(dest, pi, BGP_PATH_ATTR_CHANGED);

--- a/tests/topotests/bgp_evpn_rt2_v6_vrf_import/pe1/frr.conf
+++ b/tests/topotests/bgp_evpn_rt2_v6_vrf_import/pe1/frr.conf
@@ -1,0 +1,28 @@
+interface eth-pe2
+ ipv6 address 2001:db8:12::1/64
+!
+vrf vrf10
+ vni 10
+ exit-vrf
+!
+router bgp 65001
+ bgp router-id 10.0.0.1
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ neighbor 2001:db8:12::2 remote-as 65002
+ !
+ address-family ipv4 unicast
+  import vrf vrf10
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor 2001:db8:12::2 activate
+  advertise-all-vni
+ exit-address-family
+!
+router bgp 65001 vrf vrf10
+ bgp router-id 10.0.10.1
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_rt2_v6_vrf_import/pe2/frr.conf
+++ b/tests/topotests/bgp_evpn_rt2_v6_vrf_import/pe2/frr.conf
@@ -1,0 +1,24 @@
+interface eth-pe1
+ ipv6 address 2001:db8:12::2/64
+!
+vrf vrf10
+ vni 10
+ exit-vrf
+!
+router bgp 65002
+ bgp router-id 10.0.0.2
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ neighbor 2001:db8:12::1 remote-as 65001
+ !
+ address-family l2vpn evpn
+  neighbor 2001:db8:12::1 activate
+  advertise-all-vni
+ exit-address-family
+!
+router bgp 65002 vrf vrf10
+ bgp router-id 10.0.10.2
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_rt2_v6_vrf_import/test_bgp_evpn_rt2_v6_vrf_import.py
+++ b/tests/topotests/bgp_evpn_rt2_v6_vrf_import/test_bgp_evpn_rt2_v6_vrf_import.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+Test that IPv4 EVPN RT-2 routes learned over an IPv6 VTEP keep their IPv6
+nexthop when leaked again with BGP import vrf.
+"""
+
+import functools
+import os
+import platform
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import step
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
+
+
+def build_topo(tgen):
+    tgen.add_router("pe1")
+    tgen.add_router("pe2")
+    tgen.add_host("h2", "192.168.0.2/24", "via 192.168.0.254")
+
+    switch = tgen.add_switch("s-pe1-pe2")
+    switch.add_link(tgen.gears["pe1"], nodeif="eth-pe2")
+    switch.add_link(tgen.gears["pe2"], nodeif="eth-pe1")
+
+    switch = tgen.add_switch("s-h2-pe2")
+    switch.add_link(tgen.gears["h2"], nodeif="eth-pe2")
+    switch.add_link(tgen.gears["pe2"], nodeif="eth-h2")
+
+
+def _run_cmds(node, commands):
+    for command in commands:
+        node.cmd_raises(command)
+
+
+def _setup_pe(router, idx):
+    vtep = f"2001:db8:12::{idx}"
+    peer_if = "eth-pe2" if idx == 1 else "eth-pe1"
+
+    commands = [
+        "ip link add up vrf10 type vrf table 10",
+        "ip link add up br10 type bridge",
+        "ip link set br10 master vrf10",
+        (
+            f"ip link add up vni10 type vxlan id 10 local {vtep} "
+            f"dev {peer_if} nolearning dstport 4789"
+        ),
+        "ip link set vni10 master br10",
+        "bridge link set dev vni10 learning off",
+        "ip link add up br100 type bridge",
+        "ip link set br100 master vrf10",
+        (
+            f"ip link add up vni100 type vxlan id 100 local {vtep} "
+            f"dev {peer_if} nolearning dstport 4789"
+        ),
+        "ip link set vni100 master br100",
+        "bridge link set dev vni100 learning off",
+        "ip address add 192.168.0.254/24 dev br100",
+    ]
+
+    if idx == 2:
+        commands.extend(
+            [
+                "ip link set eth-h2 master br100",
+                "bridge link set dev eth-h2 learning off",
+                "bridge fdb add 02:00:00:00:00:02 dev eth-h2 master static sticky",
+                "ip neigh add 192.168.0.2 lladdr 02:00:00:00:00:02 dev br100",
+            ]
+        )
+
+    _run_cmds(router, commands)
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    krel = platform.release()
+    if topotest.version_cmp(krel, "4.18") < 0:
+        pytest.skip(f'Skipping EVPN IPv6 VTEP test, kernel "{krel}" is too old')
+
+    _run_cmds(
+        tgen.gears["h2"],
+        [
+            "ip link set eth-pe2 down",
+            "ip link set eth-pe2 address 02:00:00:00:00:02",
+            "ip link set eth-pe2 up",
+        ],
+    )
+
+    for idx in (1, 2):
+        _setup_pe(tgen.gears[f"pe{idx}"], idx)
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_rt2_import_vrf_preserves_ipv6_nexthop():
+    """
+    pe1 imports pe2's RT-2 host route into vrf10, then leaks vrf10 into the
+    default VRF. The leaked IPv4 route must keep pe2's IPv6 VTEP nexthop.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    pe1 = tgen.gears["pe1"]
+
+    step("Wait for pe2's RT-2 host route in pe1 vrf10")
+    expected_vrf = {
+        "192.168.0.2/32": [
+            {
+                "protocol": "bgp",
+                "selected": True,
+                "nexthops": [{"ip": "2001:db8:12::2", "afi": "ipv6"}],
+            }
+        ]
+    }
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        pe1,
+        "show ip route vrf vrf10 192.168.0.2/32 json",
+        expected_vrf,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "pe1 vrf10 did not install the RT-2 route with IPv6 nexthop"
+
+    step("Check the same RT-2 route after import vrf into pe1 default VRF")
+    expected_default_bgp = {
+        "paths": [
+            {
+                "valid": True,
+                "nexthops": [{"ip": "2001:db8:12::2", "afi": "ipv6"}],
+            }
+        ]
+    }
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        pe1,
+        "show bgp ipv4 unicast 192.168.0.2/32 json",
+        expected_default_bgp,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "import vrf did not preserve the RT-2 IPv6 nexthop in BGP"
+
+    expected_default_route = {
+        "192.168.0.2/32": [
+            {
+                "protocol": "bgp",
+                "selected": True,
+                "nexthops": [{"ip": "2001:db8:12::2", "afi": "ipv6"}],
+            }
+        ]
+    }
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        pe1,
+        "show ip route 192.168.0.2/32 json",
+        expected_default_route,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "import vrf did not preserve the RT-2 IPv6 nexthop in zebra"
+
+
+def test_memory_leak():
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
When importing an EVPN route into a VRF unicast table, install_evpn_route_entry_in_vrf() converted every imported IPv4 route into a route with the legacy IPv4 NEXT_HOP attribute set:

    attr.nexthop = attr.mp_nexthop_global_in;
    SET_FLAG(attr.flag, ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP));

This is only valid when the imported EVPN nexthop is IPv4. With IPv6 VTEPs we can get IPv4 prefixes with IPv6 nexthops and the route already has the real nexthop encoded in the MP nexthop fields. In that case setting BGP_ATTR_NEXT_HOP creates an inconsistent attribute: the route has an IPv6 MP nexthop, but is also marked as having a classic IPv4 NEXT_HOP.

This breaks code that uses BGP_ATTR_NEXTHOP_AFI_IP6() to determine the nexthop address family. BGP_ATTR_NEXTHOP_AFI_IP6() sees BGP_ATTR_NEXT_HOP and thinks this is a IPv4 route with a IPv4 nexthop even though mp_nexthop_len indicates an IPv6 nexthop. The result is that VRF import/leak drops the IPv6 nexthop and sends a 0.0.0.0 nexthop to zebra.

Fix this by only assigning attr.nexthop and setting BGP_ATTR_NEXT_HOP when the imported EVPN route does not have an IPv6 MP nexthop. EVPN IPv4 routes with IPv6 nexthops are left as MP-nexthop routes.

This is related to the previous BGP_ATTR_NEXT_HOP cleanup (#21166) and was probably missed there.