### PR TITLE
ospf6d: fix missing updating the global table

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -152,9 +152,22 @@ static void ospf6_area_route_hook_remove(struct ospf6_route *route)
 	struct ospf6 *ospf6 = oa->ospf6;
 	struct ospf6_route *copy;
 
-	copy = ospf6_route_lookup_identical(route, ospf6->route_table);
-	if (copy)
-		ospf6_route_remove(copy, ospf6->route_table);
+	/* Find the corresponding route in the global table by prefix + type +
+	 * origin. We cannot use ospf6_route_lookup_identical() here because
+	 * the route may have been modified in-place (e.g., paths/nexthops
+	 * changed during SPF recalculation) before removal, causing an exact
+	 * match to fail.
+	 */
+	for (copy = ospf6_route_lookup(&route->prefix, ospf6->route_table);
+	     copy; copy = copy->next) {
+		if (!ospf6_route_is_same(copy, route))
+			break;
+		if (copy->type == route->type
+		    && ospf6_route_is_same_origin(copy, route)) {
+			ospf6_route_remove(copy, ospf6->route_table);
+			return;
+		}
+	}
 }
 
 static void ospf6_area_stub_update(struct ospf6_area *area)


### PR DESCRIPTION
When two ospfv3 neighbors are established, we found there is **sometimes**  wrong entry via `fe80` on 1.1.1.1: (1.1.1.1 and 2.2.2.2 is with directly connected via vlan100(2001:1:1::/64  and vlan200(2001:1:2::/64).) 

```
# show ipv6 ospf6 route detail

Destination: 2001:1:1::/64
Destination type: Network
Installed Time: 01:10:51 ago
Changed Time: 01:10:07 ago
Lock: 2 Flags: BA-C
Memory: prev: 0x0 this: 0xaaac2a3f60 next: 0xaaac2af740
Associated Area: 0.0.0.0
Path Type: Intra-Area
LS Origin: Intra-Prefix Id: 0.0.0.0 Adv: 1.1.1.1
Options: --|-|--|-|-|--|-|-|--|-|--
Router Bits: --------
Prefix Options: --|--|--|--|--
Metric Type: 1
Metric: 100 (0)
Paths count: 2
Nexthop count: 1
Nexthop:
  :: vlan100


Destination: 2001:1:2::/64
Destination type: Network
Installed Time: 01:10:51 ago
Changed Time: 01:09:07 ago
Lock: 2 Flags: B--C
Memory: prev: 0xaaac2a3f60 this: 0xaaac2af740 next: 0xaaac2af870
Associated Area: 0.0.0.0
Path Type: Intra-Area
LS Origin: Intra-Prefix Id: 0.0.1.18 Adv: 2.2.2.2
Options: --|-|--|-|-|--|-|-|--|-|--
Router Bits: --------
Prefix Options: --|--|--|--|--
Metric Type: 1
Metric: 100 (0)
Paths count: 1
Nexthop count: 1
Nexthop:
  :: vlan200

Destination: 2001:1:2::/64
Destination type: Network
Installed Time: 01:10:02 ago
Changed Time: 01:10:02 ago
Lock: 2 Flags: -A--
Memory: prev: 0xaaac2af740 this: 0xaaac2af870 next: 0x0
Associated Area: 0.0.0.0
Path Type: Intra-Area
LS Origin: Intra-Prefix Id: 0.0.1.18 Adv: 2.2.2.2
Options: --|-|--|-|-|--|-|-|--|-|--
Router Bits: --------
Prefix Options: --|--|--|--|--
Metric Type: 1
Metric: 200 (0)
Paths count: 1
Nexthop count: 1
Nexthop:
  fe80::669d:9920:5d0:51e9 vlan100

```



The log:

```

2026/05/17 03:45:10 OSPF6: [ZM89R-DFBKJ] Re-examin intra-routes for area 0.0.0.0                                                                              
2026/05/17 03:45:10 OSPF6: [WPWF9-9RERJ] area 0.0.0.0 route table 0xaaac29d3f0: route head: 0x0<-[0xaaac2a0530]->0xaaac2a1940
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0x0<-[0xaaac2a0530]->0xaaac2a1940 , route ref count 2
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a0530<-[0xaaac2a1940]->0x0 , route ref count 2
2026/05/17 03:45:10 OSPF6: [SP7PC-FBWF0] ospf6_intra_prefix_lsa_add: LSA [Intra-Prefix Id:0.0.0.0 Adv:1.1.1.1] found
2026/05/17 03:45:10 OSPF6: [TSR77-HNQC2] ospf6_intra_prefix_lsa_add Update route: 2001:1:2::/64 old cost 100 new cost 100 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [T8M3K-FG6Q6] ospf6_intra_prefix_route_ecmp_path: route 2001:1:2::/64 0xaaac2a1940 with final effective paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [SP7PC-FBWF0] ospf6_intra_prefix_lsa_add: LSA [Intra-Prefix Id:0.0.1.17 Adv:2.2.2.2] found
2026/05/17 03:45:10 OSPF6: [TSR77-HNQC2] ospf6_intra_prefix_lsa_add Update route: 2001:1:1::/64 old cost 100 new cost 100 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [T8M3K-FG6Q6] ospf6_intra_prefix_route_ecmp_path: route 2001:1:1::/64 0xaaac2a0530 with final effective paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [SP7PC-FBWF0] ospf6_intra_prefix_lsa_add: LSA [Intra-Prefix Id:0.0.1.18 Adv:2.2.2.2] found
2026/05/17 03:45:10 OSPF6: [TSR77-HNQC2] ospf6_intra_prefix_lsa_add Update route: 2001:1:2::/64 old cost 100 new cost 200 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [JHQAZ-B1HC5] area 0.0.0.0 route table 0xaaac29d3f0: route add 0xaaac2af740: 2001:1:2::/64 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [RYY34-1X1VE] area 0.0.0.0 route table 0xaaac29d3f0: route add 0xaaac2af740 cost 200: another path: prev 0xaaac2a1940, next 0x0 node ref 2
2026/05/17 03:45:10 OSPF6: [WPWF9-9RERJ] area 0.0.0.0 route table 0xaaac29d3f0: route head: 0x0<-[0xaaac2a0530]->0xaaac2a1940
2026/05/17 03:45:10 OSPF6: [N0523-72EA7] ospf6_intra_route_calculation: route 2001:1:1::/64, flag 0x2 
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0x0<-[0xaaac2a0530]->0xaaac2a1940 , route ref count 2
2026/05/17 03:45:10 OSPF6: [JHQAZ-B1HC5] global route table 0xaaac29b920: route add 0xaaac2af870: 2001:1:1::/64 paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [GCSB2-JHX8R] global route table 0xaaac29b920: route add 0xaaac2af870: needless update of 0xaaac2a3f60 old cost 100 
2026/05/17 03:45:10 OSPF6: [N0523-72EA7] ospf6_intra_route_calculation: route 2001:1:2::/64, flag 0x2 
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a0530<-[0xaaac2a1940]->0xaaac2af740 , route ref count 2
2026/05/17 03:45:10 OSPF6: [JHQAZ-B1HC5] global route table 0xaaac29b920: route add 0xaaac2af870: 2001:1:2::/64 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [GCSB2-JHX8R] global route table 0xaaac29b920: route add 0xaaac2af870: needless update of 0xaaac29e200 old cost 100 
2026/05/17 03:45:10 OSPF6: [N0523-72EA7] ospf6_intra_route_calculation: route 2001:1:2::/64, flag 0x2 
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a1940<-[0xaaac2af740]->0x0 , route ref count 2
2026/05/17 03:45:10 OSPF6: [JHQAZ-B1HC5] global route table 0xaaac29b920: route add 0xaaac2af870: 2001:1:2::/64 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [RYY34-1X1VE] global route table 0xaaac29b920: route add 0xaaac2af870 cost 200: another path: prev 0xaaac29e200, next 0x0 node ref 2 <- add it in global table
2026/05/17 03:45:10 OSPF6: [P51Q5-X17ZY] Re-examin intra-routes for area 0.0.0.0: Done

...


2026/05/17 03:45:10 OSPF6: [ZM89R-DFBKJ] Re-examin intra-routes for area 0.0.0.0 
2026/05/17 03:45:10 OSPF6: [WPWF9-9RERJ] area 0.0.0.0 route table 0xaaac29d3f0: route head: 0x0<-[0xaaac2a0530]->0xaaac2a1940
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0x0<-[0xaaac2a0530]->0xaaac2a1940 , route ref count 2
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a0530<-[0xaaac2a1940]->0xaaac2af740 , route ref count 2
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a1940<-[0xaaac2af740]->0x0 , route ref count 2
2026/05/17 03:45:10 OSPF6: [SP7PC-FBWF0] ospf6_intra_prefix_lsa_add: LSA [Intra-Prefix Id:0.0.1.17 Adv:2.2.2.2] found
2026/05/17 03:45:10 OSPF6: [TSR77-HNQC2] ospf6_intra_prefix_lsa_add Update route: 2001:1:1::/64 old cost 100 new cost 100 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [T8M3K-FG6Q6] ospf6_intra_prefix_route_ecmp_path: route 2001:1:1::/64 0xaaac2a0530 with final effective paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [SP7PC-FBWF0] ospf6_intra_prefix_lsa_add: LSA [Intra-Prefix Id:0.0.1.18 Adv:2.2.2.2] found
2026/05/17 03:45:10 OSPF6: [TSR77-HNQC2] ospf6_intra_prefix_lsa_add Update route: 2001:1:2::/64 old cost 100 new cost 100 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [WCNN9-F0CPB] ospf6_intra_prefix_route_ecmp_path: route 2001:1:2::/64 cost old 200 new 100 is not same, replace route
<- update path and nexthop                                                       
2026/05/17 03:45:10 OSPF6: [GDN5E-DSC2N] ospf6_intra_prefix_route_ecmp_path: route 2001:1:2::/64 old cost 200 new cost 100, delete old entry.
2026/05/17 03:45:10 OSPF6: [V2R88-DNDNF] ospf6_intra_prefix_route_ecmp_path: route 2001:1:2::/64 0xaaac2a1940 another path added with nh 1, effective paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [T8M3K-FG6Q6] ospf6_intra_prefix_route_ecmp_path: route 2001:1:2::/64 0xaaac2a1940 with final effective paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [WPWF9-9RERJ] area 0.0.0.0 route table 0xaaac29d3f0: route head: 0x0<-[0xaaac2a0530]->0xaaac2a1940
2026/05/17 03:45:10 OSPF6: [N0523-72EA7] ospf6_intra_route_calculation: route 2001:1:1::/64, flag 0x2
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0x0<-[0xaaac2a0530]->0xaaac2a1940 , route ref count 2
2026/05/17 03:45:10 OSPF6: [JHQAZ-B1HC5] global route table 0xaaac29b920: route add 0xaaac2a1de0: 2001:1:1::/64 paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [GCSB2-JHX8R] global route table 0xaaac29b920: route add 0xaaac2a1de0: needless update of 0xaaac2a3f60 old cost 100
2026/05/17 03:45:10 OSPF6: [N0523-72EA7] ospf6_intra_route_calculation: route 2001:1:2::/64, flag 0x2
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a0530<-[0xaaac2a1940]->0xaaac2af740 , route ref count 2
2026/05/17 03:45:10 OSPF6: [JHQAZ-B1HC5] global route table 0xaaac29b920: route add 0xaaac2a1de0: 2001:1:2::/64 paths 2 nh 1
2026/05/17 03:45:10 OSPF6: [YR7BM-49X7J] global route table 0xaaac29b920: route add 0xaaac2a1de0 cost 100 paths 2 nh 1: update of 0xaaac29e200 cost 100 paths 1 nh 1
2026/05/17 03:45:10 OSPF6: [QF498-VNV2P] ospf6_route_add:  replace old route 2001:1:2::/64
2026/05/17 03:45:10 OSPF6: [N0523-72EA7] ospf6_intra_route_calculation: route 2001:1:2::/64, flag 0x4
2026/05/17 03:45:10 OSPF6: [HE4HB-RCTAN] area 0.0.0.0 route table 0xaaac29d3f0: route next: 0xaaac2a1940<-[0xaaac2af740]->0x0 , route ref count 2
2026/05/17 03:45:10 OSPF6: [JB80J-7T11Z] area 0.0.0.0 route table 0xaaac29d3f0: route remove 0xaaac2af740: 2001:1:2::/64 cost 200 refcount 1
<- remove it(0xaaac2af740) from area table, but didn't remove it from global table.
2026/05/17 03:45:10 OSPF6: [P51Q5-X17ZY] Re-examin intra-routes for area 0.0.0.0: Done


```





When the `old_route->paths` in `ospf6_intra_prefix_route_ecmp_path` changes, the corresponding entry in the area table has already been updated. However, when the global table is updated subsequently, the corresponding entry cannot be deleted due to the changed `old_route->paths`.


So, relax `ospf6_area_route_hook_remove`'s search and ignore the paths. This way,
the corresponding entry in the global table can be successfully updated/removed.