### PR TITLE
pimd: Fix crash when up->channel_oil is NULL

### DIFF
--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -365,7 +365,7 @@ void pim_dm_prune_iff_on_timer(struct event *t)
 	if (!up)
 		return;
 	pim_upstream_keep_alive_timer_start(up, pim_ifp->pim->keep_alive_time);
-	if (up->channel_oil->installed) {
+	if (up->channel_oil && up->channel_oil->installed) {
 		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 	}

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -329,7 +329,7 @@ static void on_graft_timer(struct event *t)
 		return;
 	}
 
-	if (!up->channel_oil->installed)
+	if (!up->channel_oil || !up->channel_oil->installed)
 		return;
 
 	pim_mroute_update_counters(up->channel_oil);
@@ -359,7 +359,7 @@ static void on_staterefresh_timer(struct event *t)
 		return;
 	}
 
-	if (!up->channel_oil->installed)
+	if (!up->channel_oil || !up->channel_oil->installed)
 		return;
 
 	pim_mroute_update_counters(up->channel_oil);
@@ -391,7 +391,7 @@ static void on_prune_timer(struct event *t)
 		return;
 	}
 
-	if (!up->channel_oil->installed)
+	if (!up->channel_oil || !up->channel_oil->installed)
 		return;
 
 	pim_mroute_update_counters(up->channel_oil);
@@ -2303,7 +2303,7 @@ static bool pim_upstream_sg_running_proc(struct pim_upstream *up)
 	bool rv = false;
 	struct pim_instance *pim = up->pim;
 
-	if (!up->channel_oil->installed)
+	if (!up->channel_oil || !up->channel_oil->installed)
 		return rv;
 
 	pim_mroute_update_counters(up->channel_oil);
@@ -2379,7 +2379,7 @@ static void pim_upstream_sg_running(void *arg)
 	struct pim_instance *pim = up->pim;
 
 	// No packet can have arrived here if this is the case
-	if (!up->channel_oil->installed) {
+	if (!up->channel_oil || !up->channel_oil->installed) {
 		if (PIM_DEBUG_TRACE)
 			zlog_debug("%s: %s[%s] is not installed in mroute",
 				   __func__, up->sg_str, pim->vrf->name);


### PR DESCRIPTION
The up->channel_oil is being de-referenced
without any NULL check.
In events like VRF migration, where the timer fires in some cases when the up->channel_oil is already deleted it could lead to intermittent crash.