### PR TITLE
bgpd: BGPd crash due to multiple bnc entry linked to same peer.

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2112,6 +2112,24 @@ void bgp_peer_conf_if_to_su_update(struct peer_connection *connection)
 			 * su if needed.
 			 */
 			connection->su = old_su;
+			/* Let's clean up the bnc attached to
+			 * this peer. Since the connection->su
+			 * has changed, a new bnc will be created
+			 * and attached to the peer, the bnc that
+			 * is attached to the peer will be stale.
+			 * In this case, when peer is deleted it
+			 * just gets the bnc with the connection->su
+			 * and deletes that bnc. The other bnc will
+			 * remain there. So unlink the bnc from the
+			 * peer here. In some cases when 2 bnc entries are
+			 * present for the same peer, and say peer is
+			 * deconfigured and then interface down event comes
+			 * only one bnc is detached from the peer.
+			 * Although the peer is deleted, the other stale
+			 * bnc still holds the previous peer pointer
+			 * and while accesing the peer it crashes.
+			 */
+			bgp_unlink_nexthop_by_peer(peer);
 			hash_release(peer->bgp->connectionhash, connection);
 			listnode_delete(peer->bgp->peer, peer);
 


### PR DESCRIPTION
Issue: BGP crash when bgp neighbors are migrated from one VRF
       to other.

Root Cause: When a BGP unnumbered session re-establishes using
            a different link-local, the old nexthop cache (bnc)
            entry  remain linked to the peer, creating multiple
            bnc entries pointing to the same peer. Neighbor teardown
            only unlinks the first matching bnc entry,
            leaving the other bnc still having a reference to the peer.
            A subsequent ifdown walk could then dereference a freed
            peer->connection and crash.

Fix:        Unlink the peer from all the bnc entries when
            peer->connection->su changes. As when it moves to the new connection->su
            a new BNC will be created and linked to this peer , leaving the previous entry.
            At the time of delete peer, the lookup is based on either peer->connection->su
            ip or an entire walk is performed, but in both the case only one entry will be
            deleted, leaving the other with bnc->nht_info or bnc->nht_info->connection
            having the already freed memory

Ticket: #4967884