### PR TITLE
ospfd: remove unnecessary space

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -12284,7 +12284,7 @@ static int interface_config_auth_str(struct ospf_if_params *params, char *buf)
 		break;
 
 	case OSPF_AUTH_SIMPLE:
-		snprintf(buf, BUFSIZ, " ");
+		buf[0] = '\0';
 		break;
 
 	case OSPF_AUTH_CRYPTOGRAPHIC:


### PR DESCRIPTION
Remove unnecessary spaces in config written with `interface_config_auth_str()`.

Before:
```
interface enp1s0
 ip ospf authentication  1.2.3.4
```

After:
```
interface enp1s0
 ip ospf authentication 1.2.3.4
```

Also, remove trailing one from "area <> virtual-link <> authentication" in this same way.