### PR TITLE
bgpd: fix AS-path routemap corruption and stale multipath on bestpath, fix tests

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -459,12 +459,16 @@ void bgp_path_info_mpath_update(struct bgp *bgp, struct bgp_dest *dest,
 
 	if (old_best) {
 		old_mpath_count = bgp_path_info_mpath_count(dest);
-		/* Only mark old best as multipath when we have a new best path.
-		 * When new_best is NULL (e.g. only path became invalid/holddown),
-		 * the old path is not "another ECMP path" and should not show
-		 * as multipath.
+		/* Only mark old best as multipath when there is a new best path
+		 * AND it is a different path. When new_best is NULL (e.g. only
+		 * path became invalid/holddown) the old path is not "another
+		 * ECMP path" and should not show as multipath. When new_best
+		 * equals old_best the path is still the bestpath and must not
+		 * carry BGP_PATH_MULTIPATH; the walk-loop below only sets the
+		 * flag on non-best siblings and never clears it on new_best,
+		 * so once set on the (still) best path it would persist.
 		 */
-		if (new_best && old_mpath_count == 1)
+		if (new_best && new_best != old_best && old_mpath_count == 1)
 			SET_FLAG(old_best->flags, BGP_PATH_MULTIPATH);
 		old_cum_bw = bgp_path_info_mpath_cumbw(dest);
 		bgp_path_info_mpath_count_set(dest, 0);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2703,10 +2703,10 @@ route_set_aspath_replace(void *rule, const struct prefix *dummy, void *object)
 	const char *buf;
 	char src_asn[ASN_STRING_MAX_SIZE];
 	char *acl_list_name = NULL;
-	uint32_t acl_list_name_len = 0;
-	char *buf_acl_name = NULL;
+	size_t acl_list_name_len = 0;
 	static const char asp_acl[] = "as-path-access-list";
 	struct as_list *aspath_acl = NULL;
+	enum route_map_cmd_result_t ret = RMAP_NOOP;
 
 	if (path->peer->sort != BGP_PEER_EBGP) {
 		zlog_warn(
@@ -2720,26 +2720,28 @@ route_set_aspath_replace(void *rule, const struct prefix *dummy, void *object)
 					 ? path->peer->change_local_as
 					 : path->peer->local_as;
 	} else if (!strncmp(replace, asp_acl, strlen(asp_acl))) {
+		const char *acl_name_start;
+
 		/* its as-path-acl-list command get the access list name */
 		while (*buf == ' ')
 			buf++;
-		buf_acl_name = (char *)buf;
-		buf = strchr(buf_acl_name, ' ');
+		acl_name_start = buf;
+		buf = strchr(acl_name_start, ' ');
 		if (buf)
-			acl_list_name_len = buf - buf_acl_name;
+			acl_list_name_len = buf - acl_name_start;
 		else
-			acl_list_name_len = strlen(buf_acl_name);
+			acl_list_name_len = strlen(acl_name_start);
 
-		buf_acl_name[acl_list_name_len] = 0;
-		/* get the acl-list */
-		aspath_acl = as_list_lookup(buf_acl_name);
+		acl_list_name = XMALLOC(MTYPE_TMP, acl_list_name_len + 1);
+		memcpy(acl_list_name, acl_name_start, acl_list_name_len);
+		acl_list_name[acl_list_name_len] = '\0';
+
+		aspath_acl = as_list_lookup(acl_list_name);
 		if (!aspath_acl) {
 			zlog_warn("`set as-path replace`, invalid as-path-access-list name: %s",
-				  buf_acl_name);
+				  acl_list_name);
 			goto end_ko;
 		}
-		acl_list_name = XSTRDUP(MTYPE_TMP, buf_acl_name);
-		buf_acl_name[acl_list_name_len] = ' ';
 
 		if (!buf) {
 			configured_asn = path->peer->change_local_as
@@ -2796,16 +2798,11 @@ route_set_aspath_replace(void *rule, const struct prefix *dummy, void *object)
 	}
 	aspath_free(aspath_new);
 
-
-	if (acl_list_name)
-		XFREE(MTYPE_TMP, acl_list_name);
-	return RMAP_OKAY;
+	ret = RMAP_OKAY;
 
 end_ko:
-	if (acl_list_name)
-		XFREE(MTYPE_TMP, acl_list_name);
-	return RMAP_NOOP;
-
+	XFREE(MTYPE_TMP, acl_list_name);
+	return ret;
 }
 
 static const struct route_map_rule_cmd route_set_aspath_replace_cmd = {

--- a/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
+++ b/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
@@ -117,8 +117,12 @@ def test_bgp_conditional_advertisement_track_peer():
         return topotest.json_cmp(output, expected)
 
     # Verify if R1 received 172.16.255.2/32 from R2
+    # The conditional-advertisement scanner is phase-locked at 5s intervals
+    # (see `bgp conditional-advertisement timer 5` in r2/bgpd.conf), so the
+    # worst-case wait is BGP session establishment + one full scanner cycle.
+    # Use a longer window to absorb that on slow CI hosts.
     test_func = functools.partial(_bgp_check_conditional_static_routes_from_r2)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "R1 SHOULD receive 172.16.255.2/32 from R2"
 
     step("Disable session between R2 and R3 again")
@@ -132,7 +136,7 @@ def test_bgp_conditional_advertisement_track_peer():
 
     # Verify if R2 is not sending any routes to R1 again
     test_func = functools.partial(_bgp_converge)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "R2 SHOULD not send any routes to R1"
 
 

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -308,7 +308,7 @@ def check_for_valgrind_memleaks(item: pytest.Item | None = None) -> None:
             logger.debug("Skipping valgrind file %s owned by root", vfile)
             continue
         logger.debug("Checking valgrind file %s not owned by root", vfile)
-        with open(vfile, encoding="ascii") as vf:
+        with open(vfile, encoding="ascii", errors="replace") as vf:
             vfcontent = vf.read()
             match = re.search(r"ERROR SUMMARY: (\d+) errors", vfcontent)
             if match:
@@ -351,7 +351,7 @@ def check_for_memleaks(item: pytest.Item | None = None) -> None:
     for vfile in latest:
         if vfile in existing:
             continue
-        with open(vfile, encoding="ascii") as vf:
+        with open(vfile, encoding="ascii", errors="replace") as vf:
             vfcontent = vf.read()
             num = vfcontent.count("memstats:")
             if num:
@@ -446,7 +446,7 @@ def check_for_backtraces(item: pytest.Item | None = None) -> None:
     latest = glob.glob(os.path.join(tgen.logdir, "*/*.log"))
     backtraces = []
     for vfile in latest:
-        with open(vfile, encoding="ascii") as vf:
+        with open(vfile, encoding="ascii", errors="replace") as vf:
             vfcontent = vf.read()
             btcount = vfcontent.count("Backtrace:")
         if not btcount:


### PR DESCRIPTION
a) Do not error out on non-ascii codes in topotest code itself
b) Stop writing a ` ` to a NULL terminated string and reusing