### PR TITLE
bgpd: Fix stale EVPN type-5 route for suppressed prefix during L3VNI bounce

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5755,8 +5755,9 @@ void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 			if (!is_route_injectable_into_evpn(pi))
 				continue;
 
-			if (!CHECK_FLAG(pi->flags, BGP_PATH_SELECTED) &&
-			    !CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH))
+			if (CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) ||
+			    (!CHECK_FLAG(pi->flags, BGP_PATH_SELECTED) &&
+			     !CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH)))
 				continue;
 
 			bgp_evpn_export_type5_route(bgp_vrf, dest, pi, afi, safi);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5678,11 +5678,13 @@ void bgp_evpn_withdraw_type5_routes(struct bgp *bgp_vrf, afi_t afi, safi_t safi)
 
 	table = bgp_vrf->rib[afi][safi];
 	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		/* Only care about "selected" and "multipath" routes. Also
-		 * ensure that these are routes that are injectable into EVPN.
+		/* Use _non_supp variant: withdraw must not skip suppressed
+		 * routes. A route may have been advertised while unsuppressed
+		 * and later re-suppressed. Skipping it would leave stale
+		 * type-5s in the EVPN table.
 		 */
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
-			if (!is_route_injectable_into_evpn(pi))
+			if (!is_route_injectable_into_evpn_non_supp(pi))
 				continue;
 			addpath_id = bgp_evpn_addpath_id_for_path(bgp_vrf, pi, afi);
 			bgp_evpn_withdraw_type5_route(bgp_vrf, pi, bgp_dest_get_prefix(dest), afi,


### PR DESCRIPTION
**bgpd: Fix stale EVPN type-5 route for suppressed prefix during L3VNI bounce**
```
bgp_evpn_advertise_type5_routes() does not check BGP_PATH_REMOVED flag when walking the VRF table.
During interface flaps with concurrent L3VNI bounce, a route can be in a transient state where it is:
  - BGP_PATH_SELECTED (bgp_process() deferred, hasn't cleared it yet)
  - BGP_PATH_REMOVED (redistribute_delete marked it for deletion)
  - UNSUPPRESSED (bgp_aggregate_decrement removed it from aggregate)

When L3VNI add triggers bgp_evpn_advertise_type5_routes(), such a route passes the SELECTED and injectable checks and gets advertised into EVPN as a type-5 route. Once the interface comes back up and the route gets re-suppressed by the aggregate, no subsequent withdraw or advertise walk will touch it (suppressed routes are skipped), leaving a stale type-5 permanently in the EVPN table.
```

**bgpd: Withdraw type-5 routes regardless of aggregate suppression state**
```
bgp_evpn_withdraw_type5_routes() skips suppressed routes because it uses
is_route_injectable_into_evpn() which filters on suppression. If a route
was advertised while unsuppressed then re-suppressed before the withdraw
walk runs, its stale type-5 is never cleaned up.

Fix is to use is_route_injectable_into_evpn_non_supp() instead,
consistent with bgp_aggr_supp_withdraw_from_evpn() which already
uses this variant.
```


A topotest for this issue is not feasible since it requires a precise race condition within a ~35ms window that is near impossible to reproduce deterministically. It was hit once in internal testing and root-caused through LTTng trace analysis. Please refer https://github.com/FRRouting/frr/pull/21992#issuecomment-4492718426