### PR TITLE
pimd: fix shared-LAN (S,G) MFC loop and expand ssm topotest

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -1229,28 +1229,16 @@ int pim_mroute_del_vif(struct interface *ifp)
  * IGMP must be protected against adding looped MFC entries created
  * by both source and receiver attached to the same interface. See
  * TODO T22.
- * We shall allow igmp to create upstream when it is DR for the intf.
- * Assume RP reachable via non DR.
+ *
+ * Local IGMP/MLD membership is delivered by the stack on the receiving
+ * interface; the MFC must not list that interface as an OIF (split
+ * horizon).  VXLAN is the only exception (ALLOW_IIF_IN_OIL).
  */
 bool pim_mroute_allow_iif_in_oil(struct channel_oil *c_oil,
 		int oif_index)
 {
 #ifdef PIM_ENFORCE_LOOPFREE_MFC
-	struct interface *ifp_out;
-	struct pim_interface *pim_ifp;
-
-	if (c_oil->up &&
-		PIM_UPSTREAM_FLAG_TEST_ALLOW_IIF_IN_OIL(c_oil->up->flags))
-		return true;
-
-	ifp_out = pim_if_find_by_vif_index(c_oil->pim, oif_index);
-	if (!ifp_out)
-		return false;
-	pim_ifp = ifp_out->info;
-	if (!pim_ifp)
-		return false;
-	if ((c_oil->oif_flags[oif_index] & PIM_OIF_FLAG_PROTO_GM) &&
-	    PIM_I_am_DR(pim_ifp))
+	if (c_oil->up && PIM_UPSTREAM_FLAG_TEST_ALLOW_IIF_IN_OIL(c_oil->up->flags))
 		return true;
 
 	return false;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -15,10 +15,12 @@
 
 #include "pimd.h"
 #include "pim_oil.h"
+#include "pim_mroute.h"
 #include "pim_str.h"
 #include "pim_iface.h"
 #include "pim_time.h"
 #include "pim_vxlan.h"
+#include "pim_ssm.h"
 
 static void pim_channel_update_mute(struct channel_oil *c_oil);
 
@@ -439,6 +441,24 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	assertf(pim_ifp->mroute_vif_index >= 0,
 		"trying to add OIF %s with VIF (%d)", oif->name,
 		pim_ifp->mroute_vif_index);
+
+	/*
+	 * Never forward (S,G) back out the incoming interface (split horizon).
+	 * Limit to SSM: ASM may briefly have IIF == OIF on the receiver
+	 * interface during RPT-to-SPT transition before the true RPF IIF is
+	 * installed.  (*,G) is handled separately in pim_mroute_add().
+	 */
+	if (!pim_addr_is_any(*oil_origin(channel_oil)) &&
+	    pim_is_grp_ssm(channel_oil->pim, *oil_mcastgrp(channel_oil)) &&
+	    *oil_incoming_vif(channel_oil) < MAXVIFS &&
+	    pim_ifp->mroute_vif_index == *oil_incoming_vif(channel_oil) &&
+	    !pim_mroute_allow_iif_in_oil(channel_oil, pim_ifp->mroute_vif_index)) {
+		if (PIM_DEBUG_GM_TRACE || PIM_DEBUG_MROUTE)
+			zlog_debug("%s(%s): not adding OIF %s (vif %d): same as IIF for (S,G)=(%pPAs,%pPAs)",
+				   __func__, caller, oif->name, pim_ifp->mroute_vif_index,
+				   oil_origin(channel_oil), oil_mcastgrp(channel_oil));
+		return 0;
+	}
 
 	/* Prevent single protocol from subscribing same interface to
 	   channel (S,G) multiple times */

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -60,13 +60,12 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	}
 
 	/*
-	 * Protect IGMP against adding looped MFC entries created by both
-	 * source and receiver attached to the same interface. See TODO T22.
-	 * Block only when the intf is non DR DR must create upstream.
+	 * Non-DR must not create (S,G) state when the RPF interface for the
+	 * source is the same as the IGMP oif (see TODO T22).  The DR still
+	 * creates channel_oil here; looped OIF=IIF is blocked in
+	 * pim_channel_add_oif().
 	 */
-	if ((input_iface_vif_index == pim_oif->mroute_vif_index) &&
-	    !(PIM_I_am_DR(pim_oif))) {
-		/* ignore request for looped MFC entry */
+	if ((input_iface_vif_index == pim_oif->mroute_vif_index) && !(PIM_I_am_DR(pim_oif))) {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				"%s: ignoring request for looped MFC entry (S,G)=%pSG: oif=%s vif_index=%d",

--- a/tests/topotests/lib/mcast-tester.py
+++ b/tests/topotests/lib/mcast-tester.py
@@ -94,9 +94,7 @@ def group_source_req_32bit(ifindex, group, source):
     "Packs the information into 'struct group_source_req' format."
     mreq = struct.pack("<I", ifindex)
     group_bytes = (
-        struct.pack("<HHI", socket.AF_INET6, 0, 0)
-        + group.packed
-        + struct.pack("<I", 0)
+        struct.pack("<HHI", socket.AF_INET6, 0, 0) + group.packed + struct.pack("<I", 0)
     )
     group_bytes += struct.pack(f"<{128 - len(group_bytes)}x")
 
@@ -128,7 +126,9 @@ def multicast_join(sock, ifindex, group, port, source=None):
             opt = socket.IPV6_JOIN_GROUP
         else:
             if ctypes.sizeof(ctypes.c_voidp) == 4:
-                mreq = group_source_req_32bit(ifindex, group, ipaddress.ip_address(source))
+                mreq = group_source_req_32bit(
+                    ifindex, group, ipaddress.ip_address(source)
+                )
             else:
                 mreq = group_source_req(ifindex, group, ipaddress.ip_address(source))
             opt = 46
@@ -149,6 +149,17 @@ parser.add_argument("--socket", help="Point to topotest UNIX socket")
 parser.add_argument("--source", help="Source address for multicast")
 parser.add_argument(
     "--send", help="Transmit instead of join with interval", type=float, default=0
+)
+parser.add_argument(
+    "--report-sources",
+    help="In RX mode, collect per-source packet counts and print JSON report",
+    action="store_true",
+)
+parser.add_argument(
+    "--report-duration",
+    help="How long to collect RX source stats when --report-sources is used",
+    type=float,
+    default=5.0,
 )
 args = parser.parse_args()
 
@@ -203,12 +214,15 @@ if args.send > 0:
     msock.setblocking(True)
 else:
     multicast_join(msock, ifindex, args.group, args.port, args.source)
+    if args.report_sources:
+        msock.settimeout(0.2)
 
 
 def should_exit():
     if not toposock:
-        # If we are sending then we have slept
-        if not args.send:
+        # Legacy receiver mode idles forever until topotest closes socket.
+        # Source-reporting mode uses a bounded runtime, so don't sleep here.
+        if not args.send and not args.report_sources:
             time.sleep(100)
         return False
     else:
@@ -222,11 +236,37 @@ def should_exit():
 
 
 counter = 0
+source_counts = {}
+start_time = time.time()
 while not should_exit():
     if args.send > 0:
         msock.sendto(b"test %d" % counter, (str(args.group), args.port))
         counter += 1
         time.sleep(args.send)
+    elif args.report_sources:
+        try:
+            _, peer = msock.recvfrom(65535)
+            src = str(peer[0])
+            source_counts[src] = source_counts.get(src, 0) + 1
+        except socket.timeout:
+            pass
+        except BlockingIOError:
+            pass
+
+        if (time.time() - start_time) >= args.report_duration:
+            break
 
 msock.close()
+if args.report_sources:
+    print(
+        json.dumps(
+            {
+                "group": str(args.group),
+                "port": args.port,
+                "duration": args.report_duration,
+                "sources": source_counts,
+            },
+            sort_keys=True,
+        )
+    )
 sys.exit(0)

--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -4230,7 +4230,9 @@ class McastTesterHelper(HostApplicationHelper):
     def __str__(self):
         return "McastTesterHelper({})".format(self.script_path)
 
-    def run_join(self, host, join_addrs, join_towards=None, join_intf=None):
+    def run_join(
+        self, host, join_addrs, join_towards=None, join_intf=None, source=None
+    ):
         """
         Join a UDP multicast group.
 
@@ -4242,6 +4244,7 @@ class McastTesterHelper(HostApplicationHelper):
         * `join_addrs`: multicast address (or addresses) to join to
         * `join_intf`: the interface to bind the join[s] to
         * `join_towards`: router whos interface to bind the join[s] to
+        * `source`: optional SSM source address (IGMPv3 INCLUDE)
         """
         if not isinstance(join_addrs, list) and not isinstance(join_addrs, tuple):
             join_addrs = [join_addrs]
@@ -4254,7 +4257,10 @@ class McastTesterHelper(HostApplicationHelper):
             assert join_intf
 
         for join in join_addrs:
-            self.run(host, [join, join_intf])
+            cmd = [join, join_intf]
+            if source:
+                cmd = ["--source={}".format(source), join, join_intf]
+            self.run(host, cmd)
 
         return True
 

--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -6,8 +6,10 @@
 
 import datetime
 import functools
+import json
 import os
 import re
+import subprocess
 import sys
 import traceback
 from copy import deepcopy
@@ -4282,6 +4284,63 @@ class McastTesterHelper(HostApplicationHelper):
             self.run(host, ["--send=0.7", send_to, bind_intf])
 
         return True
+
+    def collect_receiver_sources(
+        self, host, group_addr, recv_intf, port=1000, duration=5, source=None
+    ):
+        """
+        Run mcast-tester in bounded RX-report mode and return per-source counts.
+
+        Returns:
+        --------
+        Dict in mcast-tester JSON format:
+        {
+            "group": "<group>",
+            "port": <port>,
+            "duration": <seconds>,
+            "sources": {"<src-ip>": <pkt-count>, ...}
+        }
+        """
+        cmd = list(self.base_cmd)
+        cmd.extend(
+            [
+                "--report-sources",
+                "--report-duration={}".format(duration),
+                "--port={}".format(port),
+            ]
+        )
+        if source:
+            cmd.append("--source={}".format(source))
+        cmd.extend([group_addr, recv_intf])
+
+        p = self.tgen.gears[host].popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
+        )
+        out, err = p.communicate()
+        if p.returncode != 0:
+            raise RuntimeError(
+                "collect_receiver_sources failed on {}: rc={} stderr={}".format(
+                    host, p.returncode, err.strip()
+                )
+            )
+
+        out = out.strip()
+        if not out:
+            return {
+                "group": group_addr,
+                "port": port,
+                "duration": duration,
+                "sources": {},
+            }
+
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                "invalid source report JSON on {}: {} output={!r}".format(
+                    host, exc, out
+                )
+            )
 
     def stop_traffic_senders(self):
         """

--- a/tests/topotests/multicast_ssm_topo1/r1/frr.conf
+++ b/tests/topotests/multicast_ssm_topo1/r1/frr.conf
@@ -1,5 +1,7 @@
 log commands
 !
+ip route 224.0.0.0/4 r1-eth0
+!
 interface r1-eth0
  ip address 192.168.1.1/24
  ip ospf area 0

--- a/tests/topotests/multicast_ssm_topo1/r2/frr.conf
+++ b/tests/topotests/multicast_ssm_topo1/r2/frr.conf
@@ -1,25 +1,25 @@
 log commands
 !
-interface r1-eth0
- ip address 192.168.1.1/24
+interface r2-eth0
+ ip address 192.168.1.2/24
  ip ospf area 0
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip igmp
  ip pim passive
- ipv6 address 2001:db8:1::1/64
+ ipv6 address 2001:db8:1::2/64
  ipv6 mld
  ipv6 pim passive
 exit
 !
-interface r1-eth1
- ip address 10.0.1.1/24
+interface r2-eth1
+ ip address 10.0.2.1/24
  ip ospf area 0
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip igmp
  ip pim passive
- ipv6 address 2001:db8:10::1/64
+ ipv6 address 2001:db8:20::1/64
  ipv6 mld
  ipv6 pim passive
 exit

--- a/tests/topotests/multicast_ssm_topo1/r3/frr.conf
+++ b/tests/topotests/multicast_ssm_topo1/r3/frr.conf
@@ -6,6 +6,7 @@ interface r3-eth0
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip igmp
+ ip igmp join-group 230.0.0.100 192.168.1.1
  ip igmp join-group 230.0.0.100 10.0.1.2
  ip pim passive
  ipv6 address 2001:db8:1::3/64

--- a/tests/topotests/multicast_ssm_topo1/r3/frr.conf
+++ b/tests/topotests/multicast_ssm_topo1/r3/frr.conf
@@ -1,25 +1,25 @@
 log commands
 !
-interface r1-eth0
- ip address 192.168.1.1/24
+interface r3-eth0
+ ip address 192.168.1.3/24
  ip ospf area 0
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip igmp
  ip pim passive
- ipv6 address 2001:db8:1::1/64
+ ipv6 address 2001:db8:1::3/64
  ipv6 mld
  ipv6 pim passive
 exit
 !
-interface r1-eth1
- ip address 10.0.1.1/24
+interface r3-eth1
+ ip address 10.0.3.1/24
  ip ospf area 0
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip igmp
  ip pim passive
- ipv6 address 2001:db8:10::1/64
+ ipv6 address 2001:db8:30::1/64
  ipv6 mld
  ipv6 pim passive
 exit

--- a/tests/topotests/multicast_ssm_topo1/r3/frr.conf
+++ b/tests/topotests/multicast_ssm_topo1/r3/frr.conf
@@ -6,6 +6,7 @@ interface r3-eth0
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip igmp
+ ip igmp join-group 230.0.0.100 10.0.1.2
  ip pim passive
  ipv6 address 2001:db8:1::3/64
  ipv6 mld

--- a/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
+++ b/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
@@ -15,6 +15,10 @@ test_multicast_ssm_topo1.py: Test PIM SSM configuration and (S,G) join state.
 r3 uses a configured IGMP join-group only to inject local membership; the
 test checks that the SSM (S,G) is reflected on all routers on the shared LAN.
 
+test_ssm_r1_to_h3_multicast_traffic exercises McastTesterHelper.
+collect_receiver_sources(): r1 sends on the shared LAN, r3 join-group on
+eth0 pulls (192.168.1.1, G) to r3, then traffic is forwarded to h3 on r3-eth1.
+
 Topology:
 
     h1          h2          h3
@@ -58,6 +62,8 @@ LAN_SSM_SOURCE = "192.168.1.1"
 SHARED_LAN_IF = "eth0"
 TRAFFIC_MONITOR_COUNT = 5
 TRAFFIC_MONITOR_WAIT = 1
+HOST_RX_DURATION = 10
+MIN_HOST_RX_PACKETS = 5
 
 
 def expect_igmp_ssm_group(router, interface):
@@ -343,6 +349,59 @@ def test_ssm_mroute_no_iif_oif_loop():
             assert False, err
 
     mcast.stop_traffic_senders()
+
+
+def test_ssm_r1_to_h3_multicast_traffic():
+    """
+    End-to-end SSM delivery using collect_receiver_sources.
+
+    r1 sends (192.168.1.1, 230.0.0.100) on the shared LAN.  r3 already has
+    join-group on r3-eth0 for that (S,G), so traffic reaches r3; h3 joins the
+    same (S,G) and receives on r3-eth1.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    mcast = McastTesterHelper(tgen)
+
+    mcast.run_join(
+        "h3",
+        SSM_GROUP,
+        join_intf="h3-eth0",
+        source=LAN_SSM_SOURCE,
+    )
+
+    def mroute_installed_on_r3():
+        output = tgen.gears["r3"].vtysh_cmd("show ip mroute json", isjson=True)
+        try:
+            entry = output[SSM_GROUP][LAN_SSM_SOURCE]
+        except (KeyError, TypeError):
+            return False
+        return bool(entry.get("installed"))
+
+    _, result = topotest.run_and_expect(mroute_installed_on_r3, True, count=60, wait=1)
+    assert (
+        result is True
+    ), f"r3: missing installed mroute ({LAN_SSM_SOURCE}, {SSM_GROUP})"
+
+    mcast.run_traffic("r1", SSM_GROUP, bind_intf="r1-eth0")
+
+    report = mcast.collect_receiver_sources(
+        "h3",
+        SSM_GROUP,
+        "h3-eth0",
+        source=LAN_SSM_SOURCE,
+        duration=HOST_RX_DURATION,
+    )
+    rx_count = report.get("sources", {}).get(LAN_SSM_SOURCE, 0)
+    assert rx_count >= MIN_HOST_RX_PACKETS, (
+        f"h3: expected >= {MIN_HOST_RX_PACKETS} packets from "
+        f"{LAN_SSM_SOURCE}, got {rx_count}: {report}"
+    )
+
+    mcast.stop_traffic_senders()
+    mcast.stop_host("h3")
 
 
 def test_memory_leak():

--- a/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
+++ b/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
@@ -38,10 +38,12 @@ import pytest
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
+sys.path.append(os.path.join(CWD, "../lib/"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.pim import McastTesterHelper
 
 # Required to instantiate the topology builder class.
 from lib.topogen import Topogen, get_topogen
@@ -51,6 +53,11 @@ pytestmark = [pytest.mark.ospfd, pytest.mark.pimd]
 
 SSM_GROUP = "230.0.0.100"
 SSM_SOURCE = "10.0.1.2"
+# Source on the shared LAN (r1-eth0); matches r3 join-group in r3/frr.conf
+LAN_SSM_SOURCE = "192.168.1.1"
+SHARED_LAN_IF = "eth0"
+TRAFFIC_MONITOR_COUNT = 5
+TRAFFIC_MONITOR_WAIT = 1
 
 
 def expect_igmp_ssm_group(router, interface):
@@ -82,6 +89,82 @@ def expect_igmp_ssm_group(router, interface):
     assert (
         result is None
     ), f"{router}: missing IGMP group ({SSM_SOURCE}, {SSM_GROUP}) on {interface}"
+
+
+def _mroute_iif_oif_loop_error(router, source, group, lan_intf):
+    """
+    Return an error string if (S,G) lists the IIF as an OIF; None if OK,
+    absent, or not installed (kernel cannot loop without an installed MFC).
+    """
+    tgen = get_topogen()
+    output = tgen.gears[router].vtysh_cmd("show ip mroute json", isjson=True)
+
+    if group not in output or source not in output[group]:
+        return None
+
+    entry = output[group][source]
+    if not entry.get("installed"):
+        return None
+
+    iif = entry.get("iif")
+    if iif != f"{router}-{lan_intf}":
+        return (
+            f"{router}: ({source}, {group}) expected IIF "
+            f"{router}-{lan_intf}, got {iif}"
+        )
+
+    oil = entry.get("oil")
+    if not oil:
+        return None
+
+    for oif_data in oil.values():
+        outbound = oif_data.get("outboundInterface")
+        if outbound == iif:
+            return (
+                f"{router}: ({source}, {group}) loops on {iif} "
+                f"(IIF listed as OIF {outbound})"
+            )
+
+    return None
+
+
+def wait_mroute_split_horizon(router, source, group, lan_intf=SHARED_LAN_IF):
+    "Wait until (S,G) mroute does not forward back out the incoming interface"
+
+    def check():
+        return _mroute_iif_oif_loop_error(router, source, group, lan_intf)
+
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    assert (
+        result is None
+    ), f"{router}: split-horizon check failed for ({source}, {group}): {result}"
+
+
+def poll_mroute_split_horizon_during_traffic(
+    router,
+    source,
+    group,
+    lan_intf=SHARED_LAN_IF,
+    count=TRAFFIC_MONITOR_COUNT,
+    wait=TRAFFIC_MONITOR_WAIT,
+):
+    "Poll while traffic runs; fail fast if loop appears, succeed after count clean polls"
+    polls = {"remaining": count}
+
+    def check():
+        err = _mroute_iif_oif_loop_error(router, source, group, lan_intf)
+        if err is not None:
+            assert False, err
+        polls["remaining"] -= 1
+        if polls["remaining"] <= 0:
+            return None
+        return "polling"
+
+    _, result = topotest.run_and_expect(check, None, count=count, wait=wait)
+    assert result is None, (
+        f"{router}: split-horizon check failed during traffic "
+        f"for ({source}, {group}): {result}"
+    )
 
 
 def expect_pim_sg_join(router, interface, source, group):
@@ -220,6 +303,46 @@ def test_ssm_join_state():
 
     for rname in ("r1", "r2", "r3"):
         expect_pim_sg_join(rname, f"{rname}-eth0", SSM_SOURCE, SSM_GROUP)
+
+
+def test_ssm_mroute_no_iif_oif_loop():
+    """
+    With source and local join-group on the shared LAN, (S,G) must not
+    install an MFC with OIF equal to IIF (split horizon).  Without that,
+    the router re-injects multicast onto the segment (duplicate packets,
+    local router MAC, stepping TTL).
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    mcast = McastTesterHelper(tgen)
+
+    def mroute_installed_on_r3():
+        output = tgen.gears["r3"].vtysh_cmd("show ip mroute json", isjson=True)
+        try:
+            entry = output[SSM_GROUP][LAN_SSM_SOURCE]
+        except (KeyError, TypeError):
+            return False
+        return bool(entry.get("installed"))
+
+    _, result = topotest.run_and_expect(mroute_installed_on_r3, True, count=60, wait=1)
+    assert result is True, "r3: missing installed mroute before traffic"
+
+    mcast.run_traffic("r1", SSM_GROUP, bind_intf="r1-eth0")
+
+    # r3 has join-group (192.168.1.1, G) on eth0 — primary regression target
+    poll_mroute_split_horizon_during_traffic("r3", LAN_SSM_SOURCE, SSM_GROUP)
+
+    # r1 is the sender; r2 may have PIM state without a local join
+    for rname in ("r1", "r2"):
+        err = _mroute_iif_oif_loop_error(
+            rname, LAN_SSM_SOURCE, SSM_GROUP, SHARED_LAN_IF
+        )
+        if err is not None:
+            assert False, err
+
+    mcast.stop_traffic_senders()
 
 
 def test_memory_leak():

--- a/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
+++ b/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
@@ -10,7 +10,10 @@
 #
 
 """
-test_multicast_ssm_topo1.py: Test PIM SSM configuration.
+test_multicast_ssm_topo1.py: Test PIM SSM configuration and (S,G) join state.
+
+r3 uses a configured IGMP join-group only to inject local membership; the
+test checks that the SSM (S,G) is reflected on all routers on the shared LAN.
 
 Topology:
 
@@ -29,6 +32,7 @@ Topology:
 
 import os
 import sys
+from functools import partial
 import pytest
 
 # Save the Current Working Directory to find configuration files.
@@ -44,6 +48,65 @@ from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 pytestmark = [pytest.mark.ospfd, pytest.mark.pimd]
+
+SSM_GROUP = "230.0.0.100"
+SSM_SOURCE = "10.0.1.2"
+
+
+def expect_igmp_ssm_group(router, interface):
+    "Wait until SSM (S,G) IGMP group state is present on interface"
+    tgen = get_topogen()
+    expected = {
+        interface: {
+            "groups": [
+                {
+                    "group": SSM_GROUP,
+                    "mode": "INCLUDE",
+                    "sources": [
+                        {
+                            "source": SSM_SOURCE,
+                            "forwarded": True,
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show ip igmp groups detail json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert (
+        result is None
+    ), f"{router}: missing IGMP group ({SSM_SOURCE}, {SSM_GROUP}) on {interface}"
+
+
+def expect_pim_sg_join(router, interface, source, group):
+    "Wait until (S,G) PIM join state is present on interface"
+    tgen = get_topogen()
+    expected = {
+        interface: {
+            group: {
+                source: {
+                    "source": source,
+                    "group": group,
+                }
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show ip pim join json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert (
+        result is None
+    ), f"{router}: missing PIM join ({source}, {group}) on {interface}"
 
 
 def build_topo(tgen):
@@ -130,6 +193,33 @@ def test_multicast_ssm():
                 check_group_type_v6, test["type"], count=20, wait=1
             )
             assert result == test["type"], f"{rname}: wrong IPv6 group type"
+
+
+def test_ssm_join_state():
+    "Verify SSM (S,G) IGMP and PIM join state on all routers"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ("r1", "r2", "r3"):
+        router = tgen.gears[rname]
+
+        def check_group_type_ssm():
+            output = router.vtysh_cmd(
+                f"show ip pim group-type {SSM_GROUP} json", isjson=True
+            )
+            return output.get("groupType")
+
+        _, result = topotest.run_and_expect(
+            check_group_type_ssm, "SSM", count=20, wait=1
+        )
+        assert result == "SSM", f"{rname}: group {SSM_GROUP} is not SSM"
+
+    for rname in ("r1", "r2", "r3"):
+        expect_igmp_ssm_group(rname, f"{rname}-eth0")
+
+    for rname in ("r1", "r2", "r3"):
+        expect_pim_sg_join(rname, f"{rname}-eth0", SSM_SOURCE, SSM_GROUP)
 
 
 def test_memory_leak():

--- a/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
+++ b/tests/topotests/multicast_ssm_topo1/test_multicast_ssm_topo1.py
@@ -11,13 +11,24 @@
 
 """
 test_multicast_ssm_topo1.py: Test PIM SSM configuration.
+
+Topology:
+
+    h1          h2          h3
+    |           |           |
+   r1          r2          r3
+    +-----------+-----------+
+                s1
+         (shared LAN)
+
+  s1:  192.168.1.0/24, 2001:db8:1::/64  (r1-eth0, r2-eth0, r3-eth0, OSPFv2 area 0)
+  h1:  10.0.1.0/24 via r1-eth1 (.1)
+  h2:  10.0.2.0/24 via r2-eth1 (.1)
+  h3:  10.0.3.0/24 via r3-eth1 (.1)
 """
 
 import os
 import sys
-import json
-from functools import partial
-import re
 import pytest
 
 # Save the Current Working Directory to find configuration files.
@@ -29,14 +40,35 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 
 # Required to instantiate the topology builder class.
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.ospfd, pytest.mark.pimd]
 
 
 def build_topo(tgen):
-    tgen.add_router(f"r1")
+    """
+    Three routers on a shared LAN, each with a host on a dedicated access link.
+    """
+
+    for rname in ("r1", "r2", "r3"):
+        tgen.add_router(rname)
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+
+    hosts = (
+        ("h1", "r1", "10.0.1.2/24", "via 10.0.1.1", "s2"),
+        ("h2", "r2", "10.0.2.2/24", "via 10.0.2.1", "s3"),
+        ("h3", "r3", "10.0.3.2/24", "via 10.0.3.1", "s4"),
+    )
+    for hname, rname, hip, hroute, sname in hosts:
+        host = tgen.add_host(hname, hip, hroute)
+        switch = tgen.add_switch(sname)
+        switch.add_link(tgen.gears[rname])
+        switch.add_link(host)
 
 
 def setup_module(mod):
@@ -44,7 +76,8 @@ def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
     tgen.start_topology()
 
-    tgen.gears["r1"].load_frr_config(os.path.join(CWD, f"r1/frr.conf"))
+    for rname in ("r1", "r2", "r3"):
+        tgen.gears[rname].load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
     tgen.start_router()
 
 
@@ -55,7 +88,7 @@ def teardown_module():
 
 
 def test_multicast_ssm():
-    "Test SSM group"
+    "Test SSM group type on all routers"
     pim_test = [
         {"address": "229.0.0.100", "type": "ASM"},
         {"address": "230.0.0.100", "type": "SSM"},
@@ -69,33 +102,34 @@ def test_multicast_ssm():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    router = tgen.gears["r1"]
+    for rname in ("r1", "r2", "r3"):
+        router = tgen.gears[rname]
 
-    for test in pim_test:
+        for test in pim_test:
 
-        def check_group_type_v4():
-            output = router.vtysh_cmd(
-                f"show ip pim group-type {test['address']} json", isjson=True
+            def check_group_type_v4():
+                output = router.vtysh_cmd(
+                    f"show ip pim group-type {test['address']} json", isjson=True
+                )
+                return output.get("groupType")
+
+            _, result = topotest.run_and_expect(
+                check_group_type_v4, test["type"], count=20, wait=1
             )
-            return output.get("groupType")
+            assert result == test["type"], f"{rname}: wrong IPv4 group type"
 
-        _, result = topotest.run_and_expect(
-            check_group_type_v4, test["type"], count=20, wait=1
-        )
-        assert result == test["type"], "Wrong group type"
+        for test in pim6_test:
 
-    for test in pim6_test:
+            def check_group_type_v6():
+                output = router.vtysh_cmd(
+                    f"show ipv6 pim group-type {test['address']} json", isjson=True
+                )
+                return output.get("groupType")
 
-        def check_group_type_v6():
-            output = router.vtysh_cmd(
-                f"show ipv6 pim group-type {test['address']} json", isjson=True
+            _, result = topotest.run_and_expect(
+                check_group_type_v6, test["type"], count=20, wait=1
             )
-            return output.get("groupType")
-
-        _, result = topotest.run_and_expect(
-            check_group_type_v6, test["type"], count=20, wait=1
-        )
-        assert result == test["type"], "Wrong group type"
+            assert result == test["type"], f"{rname}: wrong IPv6 group type"
 
 
 def test_memory_leak():


### PR DESCRIPTION
When a router had a local `ip igmp join-group` on the same interface where
the SSM source arrives (e.g. r3 `join-group` on `eth0`, sender r1 on
192.168.1.0/24), FRR could install an MFC with **IIF == OIF**. The kernel
then re-forwarded packets back onto the segment, causing duplicate traffic
(router MAC as Ethernet source, stepping TTL, same IP ID).

This was triggered by an old carve-out in `pim_mroute_allow_iif_in_oil()`
(DR + `PIM_OIF_FLAG_PROTO_GM`) and lack of a guard in
`pim_channel_add_oif()`.

- Fix a multicast reinjection loop when an IGMP/MLD `(S,G)` join and the
  source are on the same interface (shared LAN).
- Remove the DR + IGMP exception that allowed the incoming VIF to appear in
  the OIL for `(S,G)` kernel MFC entries.
- Block adding an OIF equal to IIF in `pim_channel_add_oif()`; strip stale
  OIF state if IIF later moves onto that VIF.