### PR TITLE
bgpd: random format string fixes

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -432,9 +432,8 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 			 ", localpref %u", attr->local_pref);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AIGP))
-		snprintf(buf + strlen(buf), size - strlen(buf),
-			 ", aigp-metric %" PRIu64,
-			 (unsigned long long)bgp_attr_get_aigp_metric(attr));
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", aigp-metric %" PRIu64,
+			   bgp_attr_get_aigp_metric(attr));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_MULTI_EXIT_DISC))
 		snprintf(buf + strlen(buf), size - strlen(buf), ", metric %u",

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -412,7 +412,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 
 	if (bgp_attr_exists(attr, BGP_ATTR_ORIGIN))
 		snprintfrr(buf + strlen(buf), size - strlen(buf), ", origin %s",
-			 bgp_origin_str[attr->origin]);
+			   bgp_origin_str[attr->origin]);
 
 	/* Add MP case. */
 	if (attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL
@@ -428,41 +428,34 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 		snprintfrr(buf, size, "nexthop %pI4", &attr->nexthop);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_LOCAL_PREF))
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", localpref %u", attr->local_pref);
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", localpref %u",
+			   attr->local_pref);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AIGP))
 		snprintfrr(buf + strlen(buf), size - strlen(buf), ", aigp-metric %" PRIu64,
 			   bgp_attr_get_aigp_metric(attr));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_MULTI_EXIT_DISC))
-		snprintfrr(buf + strlen(buf), size - strlen(buf), ", metric %u",
-			 attr->med);
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", metric %u", attr->med);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_COMMUNITIES))
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", community %s",
-			 community_str(bgp_attr_get_community(attr), false,
-				       true));
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", community %s",
+			   community_str(bgp_attr_get_community(attr), false, true));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_LARGE_COMMUNITIES))
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", large-community %s",
-			 lcommunity_str(bgp_attr_get_lcommunity(attr), false,
-					true));
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", large-community %s",
+			   lcommunity_str(bgp_attr_get_lcommunity(attr), false, true));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_EXT_COMMUNITIES))
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", extcommunity %s",
-			 ecommunity_str(bgp_attr_get_ecommunity(attr)));
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", extcommunity %s",
+			   ecommunity_str(bgp_attr_get_ecommunity(attr)));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_IPV6_EXT_COMMUNITIES))
 		snprintfrr(buf + strlen(buf), size - strlen(buf), ", ipv6-extcommunity %s",
-			 ecommunity_str(bgp_attr_get_ipv6_ecommunity(attr)));
+			   ecommunity_str(bgp_attr_get_ipv6_ecommunity(attr)));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_ATOMIC_AGGREGATE))
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", atomic-aggregate");
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", atomic-aggregate");
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AGGREGATOR))
 		snprintfrr(buf + strlen(buf), size - strlen(buf),
@@ -477,8 +470,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 		struct cluster_list *cluster;
 		int i;
 
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", clusterlist");
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", clusterlist");
 
 		cluster = bgp_attr_get_cluster(attr);
 		for (i = 0; i < cluster->length / 4; i++)
@@ -487,17 +479,17 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 	}
 
 	if (bgp_attr_exists(attr, BGP_ATTR_PMSI_TUNNEL))
-		snprintfrr(buf + strlen(buf), size - strlen(buf),
-			 ", pmsi tnltype %u", bgp_attr_get_pmsi_tnl_type(attr));
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", pmsi tnltype %u",
+			   bgp_attr_get_pmsi_tnl_type(attr));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AS_PATH))
 		snprintfrr(buf + strlen(buf), size - strlen(buf), ", path %s",
-			 aspath_print(attr->aspath));
+			   aspath_print(attr->aspath));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_PREFIX_SID)) {
 		if (attr->label_index != BGP_INVALID_LABEL_INDEX)
-			snprintfrr(buf + strlen(buf), size - strlen(buf),
-				 ", label-index %u", attr->label_index);
+			snprintfrr(buf + strlen(buf), size - strlen(buf), ", label-index %u",
+				   attr->label_index);
 	}
 
 	if (bgp_attr_exists(attr, BGP_ATTR_NHC)) {
@@ -506,8 +498,8 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 
 		for (tlv = nhc->tlvs; tlv; tlv = tlv->next)
 			snprintfrr(buf + strlen(buf), size - strlen(buf),
-				 ", NHC TLV code %d length %d value %p", tlv->code, tlv->length,
-				 tlv->value);
+				   ", NHC TLV code %d length %d value %p", tlv->code, tlv->length,
+				   tlv->value);
 	}
 
 	if (strlen(buf) > 1)
@@ -630,24 +622,19 @@ static void bgp_debug_print_evpn_prefix(struct vty *vty, const char *desc,
 
 	if (p->u.prefix_evpn.route_type == BGP_EVPN_MAC_IP_ROUTE) {
 		if (is_evpn_prefix_ipaddr_none((struct prefix_evpn *)p)) {
-			snprintfrr(
-				evpn_desc, sizeof(evpn_desc),
-				"l2vpn evpn type macip mac %s",
-				prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac,
-					       buf2, sizeof(buf2)));
+			snprintfrr(evpn_desc, sizeof(evpn_desc), "l2vpn evpn type macip mac %s",
+				   prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac, buf2,
+						  sizeof(buf2)));
 		} else {
 			uint8_t family = is_evpn_prefix_ipaddr_v4(
 						(struct prefix_evpn *)p) ?
 							AF_INET : AF_INET6;
-			snprintfrr(
-				evpn_desc, sizeof(evpn_desc),
-				"l2vpn evpn type macip mac %s ip %s",
-				prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac,
-					       buf2, sizeof(buf2)),
-				inet_ntop(
-					family,
-					&p->u.prefix_evpn.macip_addr.ip.ip.addr,
-					buf, PREFIX2STR_BUFFER));
+			snprintfrr(evpn_desc, sizeof(evpn_desc),
+				   "l2vpn evpn type macip mac %s ip %s",
+				   prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac, buf2,
+						  sizeof(buf2)),
+				   inet_ntop(family, &p->u.prefix_evpn.macip_addr.ip.ip.addr, buf,
+					     PREFIX2STR_BUFFER));
 		}
 	} else if (p->u.prefix_evpn.route_type == BGP_EVPN_IMET_ROUTE) {
 		snprintfrr(evpn_desc, sizeof(evpn_desc),
@@ -658,12 +645,10 @@ static void bgp_debug_print_evpn_prefix(struct vty *vty, const char *desc,
 		uint8_t family = is_evpn_prefix_ipaddr_v4(
 					(struct prefix_evpn *)p) ? AF_INET
 								: AF_INET6;
-		snprintfrr(evpn_desc, sizeof(evpn_desc),
-			 "l2vpn evpn type prefix ip %s/%d",
-			 inet_ntop(family,
-				   &p->u.prefix_evpn.prefix_addr.ip.ip.addr,
-				   buf, PREFIX2STR_BUFFER),
-			 p->u.prefix_evpn.prefix_addr.ip_prefix_length);
+		snprintfrr(evpn_desc, sizeof(evpn_desc), "l2vpn evpn type prefix ip %s/%d",
+			   inet_ntop(family, &p->u.prefix_evpn.prefix_addr.ip.ip.addr, buf,
+				     PREFIX2STR_BUFFER),
+			   p->u.prefix_evpn.prefix_addr.ip_prefix_length);
 	}
 
 	vty_out(vty, "%s %s\n", desc, evpn_desc);
@@ -2985,8 +2970,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 	 * sometimes. */
 	pathid_buf[0] = '\0';
 	if (addpath_valid)
-		snprintfrr(pathid_buf, sizeof(pathid_buf), " with addpath ID %u",
-			 addpath_id);
+		snprintfrr(pathid_buf, sizeof(pathid_buf), " with addpath ID %u", addpath_id);
 
 	overlay_index_buf[0] = '\0';
 	if (overlay_index && overlay_index->type == OVERLAY_INDEX_GATEWAY_IP) {
@@ -3001,8 +2985,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 			inet_ntop(AF_INET6, &overlay_index->gw_ip, obuf,
 				  sizeof(obuf));
 
-		snprintfrr(overlay_index_buf, sizeof(overlay_index_buf),
-			 " gateway IP %s", obuf);
+		snprintfrr(overlay_index_buf, sizeof(overlay_index_buf), " gateway IP %s", obuf);
 	}
 
 	tag_buf[0] = '\0';
@@ -3012,8 +2995,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 			char tag_buf2[20];
 
 			bgp_evpn_label2str(label, num_labels, tag_buf2, 20);
-			snprintfrr(tag_buf, sizeof(tag_buf), " label %s",
-				 tag_buf2);
+			snprintfrr(tag_buf, sizeof(tag_buf), " label %s", tag_buf2);
 		} else {
 			mpls_labels2str(label, num_labels, " label ", tag_buf, sizeof(tag_buf));
 		}
@@ -3036,8 +3018,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 				       return_string,
 				       NLRI_STRING_FORMAT_DEBUG, NULL,
 				       family2afi(fs->prefix.family));
-		snprintfrr(str, size, "FS %s Match{%s}", afi2str(afi),
-			 return_string);
+		snprintfrr(str, size, "FS %s Match{%s}", afi2str(afi), return_string);
 	} else
 		snprintfrr(str, size, "%pFX%s%s %s %s", pu.p, tag_buf,
 			   pathid_buf, afi2str(afi), safi2str(safi));

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -411,7 +411,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 		snprintfrr(buf, size, "nexthop %pI4", &attr->nexthop);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_ORIGIN))
-		snprintf(buf + strlen(buf), size - strlen(buf), ", origin %s",
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", origin %s",
 			 bgp_origin_str[attr->origin]);
 
 	/* Add MP case. */
@@ -428,7 +428,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 		snprintfrr(buf, size, "nexthop %pI4", &attr->nexthop);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_LOCAL_PREF))
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", localpref %u", attr->local_pref);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AIGP))
@@ -436,32 +436,32 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 			   bgp_attr_get_aigp_metric(attr));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_MULTI_EXIT_DISC))
-		snprintf(buf + strlen(buf), size - strlen(buf), ", metric %u",
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", metric %u",
 			 attr->med);
 
 	if (bgp_attr_exists(attr, BGP_ATTR_COMMUNITIES))
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", community %s",
 			 community_str(bgp_attr_get_community(attr), false,
 				       true));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_LARGE_COMMUNITIES))
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", large-community %s",
 			 lcommunity_str(bgp_attr_get_lcommunity(attr), false,
 					true));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_EXT_COMMUNITIES))
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", extcommunity %s",
 			 ecommunity_str(bgp_attr_get_ecommunity(attr)));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_IPV6_EXT_COMMUNITIES))
-		snprintf(buf + strlen(buf), size - strlen(buf), ", ipv6-extcommunity %s",
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", ipv6-extcommunity %s",
 			 ecommunity_str(bgp_attr_get_ipv6_ecommunity(attr)));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_ATOMIC_AGGREGATE))
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", atomic-aggregate");
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AGGREGATOR))
@@ -477,7 +477,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 		struct cluster_list *cluster;
 		int i;
 
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", clusterlist");
 
 		cluster = bgp_attr_get_cluster(attr);
@@ -487,16 +487,16 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 	}
 
 	if (bgp_attr_exists(attr, BGP_ATTR_PMSI_TUNNEL))
-		snprintf(buf + strlen(buf), size - strlen(buf),
+		snprintfrr(buf + strlen(buf), size - strlen(buf),
 			 ", pmsi tnltype %u", bgp_attr_get_pmsi_tnl_type(attr));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_AS_PATH))
-		snprintf(buf + strlen(buf), size - strlen(buf), ", path %s",
+		snprintfrr(buf + strlen(buf), size - strlen(buf), ", path %s",
 			 aspath_print(attr->aspath));
 
 	if (bgp_attr_exists(attr, BGP_ATTR_PREFIX_SID)) {
 		if (attr->label_index != BGP_INVALID_LABEL_INDEX)
-			snprintf(buf + strlen(buf), size - strlen(buf),
+			snprintfrr(buf + strlen(buf), size - strlen(buf),
 				 ", label-index %u", attr->label_index);
 	}
 
@@ -505,7 +505,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 		struct bgp_nhc *nhc = bgp_attr_get_nhc(attr);
 
 		for (tlv = nhc->tlvs; tlv; tlv = tlv->next)
-			snprintf(buf + strlen(buf), size - strlen(buf),
+			snprintfrr(buf + strlen(buf), size - strlen(buf),
 				 ", NHC TLV code %d length %d value %p", tlv->code, tlv->length,
 				 tlv->value);
 	}
@@ -630,7 +630,7 @@ static void bgp_debug_print_evpn_prefix(struct vty *vty, const char *desc,
 
 	if (p->u.prefix_evpn.route_type == BGP_EVPN_MAC_IP_ROUTE) {
 		if (is_evpn_prefix_ipaddr_none((struct prefix_evpn *)p)) {
-			snprintf(
+			snprintfrr(
 				evpn_desc, sizeof(evpn_desc),
 				"l2vpn evpn type macip mac %s",
 				prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac,
@@ -639,7 +639,7 @@ static void bgp_debug_print_evpn_prefix(struct vty *vty, const char *desc,
 			uint8_t family = is_evpn_prefix_ipaddr_v4(
 						(struct prefix_evpn *)p) ?
 							AF_INET : AF_INET6;
-			snprintf(
+			snprintfrr(
 				evpn_desc, sizeof(evpn_desc),
 				"l2vpn evpn type macip mac %s ip %s",
 				prefix_mac2str(&p->u.prefix_evpn.macip_addr.mac,
@@ -658,7 +658,7 @@ static void bgp_debug_print_evpn_prefix(struct vty *vty, const char *desc,
 		uint8_t family = is_evpn_prefix_ipaddr_v4(
 					(struct prefix_evpn *)p) ? AF_INET
 								: AF_INET6;
-		snprintf(evpn_desc, sizeof(evpn_desc),
+		snprintfrr(evpn_desc, sizeof(evpn_desc),
 			 "l2vpn evpn type prefix ip %s/%d",
 			 inet_ntop(family,
 				   &p->u.prefix_evpn.prefix_addr.ip.ip.addr,
@@ -2985,7 +2985,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 	 * sometimes. */
 	pathid_buf[0] = '\0';
 	if (addpath_valid)
-		snprintf(pathid_buf, sizeof(pathid_buf), " with addpath ID %u",
+		snprintfrr(pathid_buf, sizeof(pathid_buf), " with addpath ID %u",
 			 addpath_id);
 
 	overlay_index_buf[0] = '\0';
@@ -3001,7 +3001,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 			inet_ntop(AF_INET6, &overlay_index->gw_ip, obuf,
 				  sizeof(obuf));
 
-		snprintf(overlay_index_buf, sizeof(overlay_index_buf),
+		snprintfrr(overlay_index_buf, sizeof(overlay_index_buf),
 			 " gateway IP %s", obuf);
 	}
 
@@ -3012,7 +3012,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 			char tag_buf2[20];
 
 			bgp_evpn_label2str(label, num_labels, tag_buf2, 20);
-			snprintf(tag_buf, sizeof(tag_buf), " label %s",
+			snprintfrr(tag_buf, sizeof(tag_buf), " label %s",
 				 tag_buf2);
 		} else {
 			mpls_labels2str(label, num_labels, " label ", tag_buf, sizeof(tag_buf));
@@ -3036,7 +3036,7 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 				       return_string,
 				       NLRI_STRING_FORMAT_DEBUG, NULL,
 				       family2afi(fs->prefix.family));
-		snprintf(str, size, "FS %s Match{%s}", afi2str(afi),
+		snprintfrr(str, size, "FS %s Match{%s}", afi2str(afi),
 			 return_string);
 	} else
 		snprintfrr(str, size, "%pFX%s%s %s %s", pu.p, tag_buf,

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -336,8 +336,7 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 					ptr += len_written;
 				}
 			}
-			len_written = snprintf(ptr, len_string, " %" PRIu64 " ",
-					       (unsigned long long)value);
+			len_written = snprintf(ptr, len_string, " %" PRIu64 " ", value);
 			if (len_written > 0 && len_written < len_string) {
 				len_string -= len_written;
 				ptr += len_written;
@@ -474,8 +473,7 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 					ptr += len_written;
 				}
 			}
-			len_written = snprintf(ptr, len_string, "%" PRIu64,
-					       (unsigned long long)value);
+			len_written = snprintf(ptr, len_string, "%" PRIu64, value);
 			if (len_written > 0 && len_written < len_string) {
 				len_string -= len_written;
 				ptr += len_written;

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -305,7 +305,7 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 		switch (type) {
 		case BGP_FLOWSPEC_RETURN_STRING:
 			if (loop) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						      ", ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
@@ -313,7 +313,7 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 				}
 			}
 			if (op[5] == 1) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						       "<");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
@@ -321,7 +321,7 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 				}
 			}
 			if (op[6] == 1) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						      ">");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
@@ -329,7 +329,7 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 				}
 			}
 			if (op[7] == 1) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						       "=");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
@@ -436,14 +436,14 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 		switch (type) {
 		case BGP_FLOWSPEC_RETURN_STRING:
 			if (op[1] == 1 && loop != 0) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						       ",&");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			} else if (op[1] == 0 && loop != 0) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						      ",|");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
@@ -451,14 +451,14 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 				}
 			}
 			if (op[7] == 1) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 					       "= ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			} else {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 						       "∋ ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
@@ -466,7 +466,7 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 				}
 			}
 			if (op[6] == 1) {
-				len_written = snprintf(ptr, len_string,
+				len_written = snprintfrr(ptr, len_string,
 					       "! ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -336,7 +336,7 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 					ptr += len_written;
 				}
 			}
-			len_written = snprintf(ptr, len_string, " %" PRIu64 " ", value);
+			len_written = snprintfrr(ptr, len_string, " %" PRIu64 " ", value);
 			if (len_written > 0 && len_written < len_string) {
 				len_string -= len_written;
 				ptr += len_written;
@@ -473,7 +473,7 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 					ptr += len_written;
 				}
 			}
-			len_written = snprintf(ptr, len_string, "%" PRIu64, value);
+			len_written = snprintfrr(ptr, len_string, "%" PRIu64, value);
 			if (len_written > 0 && len_written < len_string) {
 				len_string -= len_written;
 				ptr += len_written;

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -305,32 +305,28 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 		switch (type) {
 		case BGP_FLOWSPEC_RETURN_STRING:
 			if (loop) {
-				len_written = snprintfrr(ptr, len_string,
-						      ", ");
+				len_written = snprintfrr(ptr, len_string, ", ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			}
 			if (op[5] == 1) {
-				len_written = snprintfrr(ptr, len_string,
-						       "<");
+				len_written = snprintfrr(ptr, len_string, "<");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			}
 			if (op[6] == 1) {
-				len_written = snprintfrr(ptr, len_string,
-						      ">");
+				len_written = snprintfrr(ptr, len_string, ">");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			}
 			if (op[7] == 1) {
-				len_written = snprintfrr(ptr, len_string,
-						       "=");
+				len_written = snprintfrr(ptr, len_string, "=");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
@@ -436,38 +432,33 @@ int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 		switch (type) {
 		case BGP_FLOWSPEC_RETURN_STRING:
 			if (op[1] == 1 && loop != 0) {
-				len_written = snprintfrr(ptr, len_string,
-						       ",&");
+				len_written = snprintfrr(ptr, len_string, ",&");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			} else if (op[1] == 0 && loop != 0) {
-				len_written = snprintfrr(ptr, len_string,
-						      ",|");
+				len_written = snprintfrr(ptr, len_string, ",|");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			}
 			if (op[7] == 1) {
-				len_written = snprintfrr(ptr, len_string,
-					       "= ");
+				len_written = snprintfrr(ptr, len_string, "= ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			} else {
-				len_written = snprintfrr(ptr, len_string,
-						       "∋ ");
+				len_written = snprintfrr(ptr, len_string, "∋ ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;
 				}
 			}
 			if (op[6] == 1) {
-				len_written = snprintfrr(ptr, len_string,
-					       "! ");
+				len_written = snprintfrr(ptr, len_string, "! ");
 				if (len_written > 0 && len_written < len_string) {
 					len_string -= len_written;
 					ptr += len_written;

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
 	printchk("first", "%1pSA", sptr);
 	sarr[0] = NULL;
 	printchk("", "%pSA", sptr);
-	printchk("", "%pSA", NULL);
+	printchk("", "%pSA", (char **)NULL);
 
 	*darr_append(sdarr) = "first";
 	*darr_append(sdarr) = "second";


### PR DESCRIPTION
(split off from #21986)

Bunch of `uint64_t` fixery, particularly moving things from `snprintf` to `snprintfrr` because that's what matches the error checking.

In theory, `snprintfrr` is a tiny bit more secure than `snprintf` since it does not support `%n`, so this is a good move anyway. Practically, that's not relevant for the fixes in this particular PR. The behavior for `snprintfrr` simply differs because `lib/compiler.h` redefines things to have a consistent base, and then they don't exactly work for `snprintf` anymore.

…maybe we should just globally redefine `snprintf` to `snprintfrr`… though that's to some degree also confusing.

(All of this will hopefully become a non-issue soon, with ISO C23…)

One `tests/` fix snuck in with the `bgpd` ones :wink: