### PR TITLE
ospf6d: fix negative timestring display

### DIFF
--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -34,7 +34,9 @@ extern struct event *t_ospf6_cfg;
 /* operation on timeval structure */
 #define timerstring(tv, buf, size)                                             \
 	do {                                                                   \
-		if ((tv)->tv_sec / 60 / 60 / 24)                               \
+		if ((tv)->tv_sec < 0)                                          \
+			snprintf(buf, size, "00:00:00");                       \
+		else if ((tv)->tv_sec / 60 / 60 / 24)                          \
 			snprintf(buf, size, "%lldd%02lld:%02lld:%02lld",       \
 				 (tv)->tv_sec / 60LL / 60 / 24,                \
 				 (tv)->tv_sec / 60LL / 60 % 24,                \


### PR DESCRIPTION
In some cases, the time strings may contain an invalid negative value such as "00:00:-1".

> dut-vm# show ipv6 ospf6 neighbor detail json
> {
>   "10.0.0.2%ntfp2":{
>     "area":"0.0.0.0",
>     "interface":"ntfp2",
>     "interfaceIndex":4,
>     "interfaceState":"BDR",
>     "neighborInterfaceIndex":4,
> [...]
>     "pendingLsaDbDescTime":"00:00:-1",
>     "dbDescSendThread":"off",
>     "pendingLsaDbDesc":[],
>     "pendingLsaLsReqCount":0,
>     "pendingLsaLsReqTime":"00:00:-1",
>     "lsReqSendThread":"off",
>     "pendingLsaLsReq":[],
>     "pendingLsaLsUpdateCount":0,
>     "pendingLsaLsUpdateTime":"00:00:-1",
>     "lsUpdateSendThread":"off",
>     "pendingLsaLsUpdate":[],
>     "pendingLsaLsAckCount":0,
>     "pendingLsaLsAckTime":"00:00:-1",
>     "lsAckSendThread":"off",
>     "pendingLsaLsAck":[],
>     "authStatus":"disabled"
>   }
> }

This can happen when an event is processed slightly later than its scheduled execution time because of CPU load or thread scheduling delays. If thread_send_lsack is overdue when evaluated, now may already be greater than oi->thread_send_lsack->u.sands, resulting in a negative timersub() result.

> timerclear(&res);
> if (event_is_scheduled(oi->thread_send_lsack))
> 	timersub(&oi->thread_send_lsack->u.sands, &now, &res);
> timerstring(&res, duration, sizeof(duration));
>
> json_object_string_add(json_obj, "pendingLsaLsAckTime",
				       duration);

Display "00:00:00" instead.