### PR TITLE
 zebra: EVPN clean up stale L2 NH/NHG from kernel at startup

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -5149,6 +5149,7 @@ static int netlink_fdb_nh_update(uint32_t nh_id, struct ipaddr *vtep_ip)
 	req.n.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
 	req.n.nlmsg_type = cmd;
 	req.nhm.nh_family = ipaddr_family(vtep_ip);
+	req.nhm.nh_protocol = RTPROT_ZEBRA;
 
 	if (!nl_attr_put32(&req.n, sizeof(req), NHA_ID, nh_id))
 		return -1;
@@ -5228,6 +5229,7 @@ static int netlink_fdb_nhg_update(uint32_t nhg_id, uint32_t nh_cnt,
 	req.n.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
 	req.n.nlmsg_type = cmd;
 	req.nhm.nh_family = AF_UNSPEC;
+	req.nhm.nh_protocol = RTPROT_ZEBRA;
 
 	if (!nl_attr_put32(&req.n, sizeof(req), NHA_ID, nhg_id))
 		return -1;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3709,15 +3709,17 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	id = *((uint32_t *)RTA_DATA(tb[NHA_ID]));
 
 	if (zebra_evpn_mh_is_fdb_nh(id)) {
-		/* If this is a L2 NH just ignore it */
-		if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH) {
-			zlog_debug("Ignore kernel update (%u) for fdb-nh 0x%x",
-					h->nlmsg_type, id);
+		if (!startup) {
+			if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH)
+				zlog_debug("In non startup scenario, ignore kernel update (%u) for fdb-nh 0x%x",
+					   h->nlmsg_type, id);
+			frrtrace(2, frr_zebra, netlink_nexthop_change_err, h->nlmsg_type, id);
+			return 0;
 		}
-
-		frrtrace(2, frr_zebra, netlink_nexthop_change_err, h->nlmsg_type, id);
-
-		return 0;
+		/* startup: fall through to process stale FDB NH/NHGs from
+		 * previous zebra instance are added to the NHG hash table so
+		 * the sweep can uninstall them via the standard cleanup path.
+		 */
 	}
 
 	family = nhm->nh_family;
@@ -3757,8 +3759,34 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 				 */
 				nh = netlink_nexthop_process_nh(tb, family,
 								&ifp, ns_id);
-			else {
-
+			else if (zebra_evpn_mh_is_fdb_nh(id)) {
+				/**
+				 * FDB nexthops have a gateway (remote
+				 * VTEP IP) but no outgoing interface.
+				 */
+				if (!tb[NHA_GATEWAY]) {
+					if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH)
+						zlog_debug("FDB Nexthop message received from the kernel with ID (%u) is missing NHA_GATEWAY",
+							   id);
+					return -1;
+				}
+				if (family == AF_INET) {
+					nh.type = NEXTHOP_TYPE_IPV4;
+					memcpy(&nh.gate.ipv4, RTA_DATA(tb[NHA_GATEWAY]),
+					       IPV4_MAX_BYTELEN);
+				} else if (family == AF_INET6) {
+					nh.type = NEXTHOP_TYPE_IPV6;
+					memcpy(&nh.gate.ipv6, RTA_DATA(tb[NHA_GATEWAY]),
+					       IPV6_MAX_BYTELEN);
+				} else {
+					if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH)
+						zlog_debug("FDB Nexthop ID (%u) has unexpected family %u",
+							   id, family);
+					return -1;
+				}
+				/* read back below overwrites local vrf_id */
+				nh.vrf_id = vrf_id;
+			} else {
 				flog_warn(
 					EC_ZEBRA_BAD_NHG_MESSAGE,
 					"Invalid Nexthop message received from the kernel with ID (%u)",

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1278,6 +1278,35 @@ static void zebra_evpn_nhid_free(uint32_t nh_id, struct zebra_evpn_es *es)
 	bf_release_index(zmh_info->nh_id_bitmap, id);
 }
 
+/* Reserve bitmap index for a stale FDB NH/NHG read from kernel at startup,
+ * preventing bf_assign_index() from reusing it before the sweep cleans up.
+ */
+void zebra_evpn_mh_reserve_stale_nhid(uint32_t nh_id)
+{
+	uint32_t id = (nh_id & EVPN_NH_ID_VAL_MASK);
+
+	if (!id || id >= EVPN_NH_ID_MAX || !zmh_info)
+		return;
+
+	bf_set_bit(zmh_info->nh_id_bitmap, id);
+
+	if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH)
+		zlog_debug("Reserved bitmap index %u for stale fdb-nh 0x%x", id, nh_id);
+}
+
+/* Release bitmap index for a stale FDB NH/NHG during NHE cleanup.
+ * Counterpart to zebra_evpn_mh_reserve_stale_nhid().
+ */
+void zebra_evpn_mh_release_stale_nhid(uint32_t nh_id)
+{
+	uint32_t id = (nh_id & EVPN_NH_ID_VAL_MASK);
+
+	if (!id || id >= EVPN_NH_ID_MAX || !zmh_info)
+		return;
+
+	bf_release_index(zmh_info->nh_id_bitmap, id);
+}
+
 static unsigned int zebra_evpn_nh_ip_hash_keymake(const void *p)
 {
 	const struct zebra_evpn_l2_nh *nh = p;

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -337,6 +337,8 @@ static inline bool zebra_evpn_mh_do_adv_svi_mac(void)
 extern esi_t *zero_esi;
 extern void zebra_evpn_mh_init(void);
 extern void zebra_evpn_mh_terminate(void);
+extern void zebra_evpn_mh_reserve_stale_nhid(uint32_t nh_id);
+extern void zebra_evpn_mh_release_stale_nhid(uint32_t nh_id);
 extern bool zebra_evpn_is_if_es_capable(struct zebra_if *zif);
 extern void zebra_evpn_if_init(struct zebra_if *zif);
 extern void zebra_evpn_if_cleanup(struct zebra_if *zif);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3649,9 +3649,21 @@ static int zebra_nhg_sweep_entry(struct hash_bucket *bucket, void *arg)
 	 * we haven't gotten an update about it from the proto since startup.
 	 * This means that either the config for it was removed or the daemon
 	 * didn't get started. This handles graceful restart & retain scenario.
+	 *
+	 * zebra_nhg_decrement_ref may trigger KEEP_AROUND which keeps the entry
+	 * in the hash (refcnt reset to 1, timer started) in that case the
+	 * hash is unmodified and the walk can safely continue to process
+	 * remaining proto-owned entries in the same pass.
 	 */
 	if (PROTO_OWNED(nhe) && nhe->refcnt == 1) {
+		uint32_t id = nhe->id;
+
 		zebra_nhg_decrement_ref(nhe);
+		/* Entry still in hash (KEEP_AROUND) safe to continue.
+		 * Entry freed, hash may be modified, must abort.
+		 */
+		if (zebra_nhg_lookup_id(id))
+			return HASHWALK_CONTINUE;
 		return HASHWALK_ABORT;
 	}
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -29,6 +29,7 @@
 #include "zebra/zapi_msg.h"
 #include "zebra/rib.h"
 #include "zebra/zebra_vxlan.h"
+#include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_trace.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, NHG, "Nexthop Group Entry");
@@ -1169,6 +1170,14 @@ static void zebra_nhg_release(struct nhg_hash_entry *nhe)
 static void zebra_nhg_handle_uninstall(struct nhg_hash_entry *nhe)
 {
 	zebra_nhg_release(nhe);
+
+	/* Release bitmap bit only for stale FDB entries read from kernel
+	 * at startup. Normal FDB entries have their bitmap managed by
+	 * the EVPN-MH layer (zebra_evpn_nhid_free).
+	 */
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_STALE_FDB))
+		zebra_evpn_mh_release_stale_nhid(nhe->id);
+
 	zebra_nhg_free(nhe);
 }
 
@@ -1313,8 +1322,16 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	 * slightly before the zrouter.startup_time.  Then graceful
 	 * restart sweeping will work properly for these nexthop entries
 	 */
-	if (startup)
+	if (startup) {
 		nhe->uptime = zrouter.startup_time - 1;
+		/* tag stale FDB NH/NHG and reserve its bitmap bit; sweep
+		 * releases the bit via zebra_evpn_mh_release_stale_nhid()
+		 */
+		if (zebra_evpn_mh_is_fdb_nh(id)) {
+			SET_FLAG(nhe->flags, NEXTHOP_GROUP_STALE_FDB);
+			zebra_evpn_mh_reserve_stale_nhid(id);
+		}
+	}
 	return 0;
 }
 
@@ -3678,7 +3695,7 @@ static int zebra_nhg_sweep_entry(struct hash_bucket *bucket, void *arg)
 
 		zebra_nhg_decrement_ref(nhe);
 		/* Entry still in hash (KEEP_AROUND) safe to continue.
-		 * Entry freed, hash may be modified, must abort.
+		 * Entry freed hash may be modified, must abort.
 		 */
 		if (zebra_nhg_lookup_id(id))
 			return HASHWALK_CONTINUE;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -865,7 +865,6 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 done:
 	/* Reset time since last update */
 	(*nhe)->uptime = monotime(NULL);
-
 	return created;
 }
 
@@ -985,6 +984,11 @@ static int nhg_ctx_get_afi(const struct nhg_ctx *ctx)
 	return ctx->afi;
 }
 
+static bool nhg_ctx_get_startup(const struct nhg_ctx *ctx)
+{
+	return ctx->startup;
+}
+
 static struct nexthop *nhg_ctx_get_nh(struct nhg_ctx *ctx)
 {
 	return &ctx->u.nh;
@@ -1038,7 +1042,7 @@ done:
 
 static struct nhg_ctx *nhg_ctx_init(uint32_t id, struct nexthop *nh, struct nh_grp *grp,
 				    vrf_id_t vrf_id, afi_t afi, int type, uint16_t count,
-				    struct nhg_resilience *resilience)
+				    struct nhg_resilience *resilience, bool startup)
 {
 	struct nhg_ctx *ctx = NULL;
 
@@ -1049,6 +1053,7 @@ static struct nhg_ctx *nhg_ctx_init(uint32_t id, struct nexthop *nh, struct nh_g
 	ctx->afi = afi;
 	ctx->type = type;
 	ctx->count = count;
+	ctx->startup = startup;
 
 	if (resilience)
 		ctx->resilience = *resilience;
@@ -1245,6 +1250,7 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	vrf_id_t vrf_id = nhg_ctx_get_vrf_id(ctx);
 	int type = nhg_ctx_get_type(ctx);
 	afi_t afi = nhg_ctx_get_afi(ctx);
+	bool startup = nhg_ctx_get_startup(ctx);
 
 	lookup = zebra_nhg_lookup_id(id);
 
@@ -1297,6 +1303,18 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 
+	/*
+	 * On startup Zebra is creating the nexthop group cache entry
+	 * after the router has it's startup time set.  This is because
+	 * the process of grabbing routes and nexthops is now *after*
+	 * the dataplane starts up, which is after the routers startup
+	 * time is set.  So let's just cheat a tiny bit on the time
+	 * and set the nexthop group hash entry startup time to be
+	 * slightly before the zrouter.startup_time.  Then graceful
+	 * restart sweeping will work properly for these nexthop entries
+	 */
+	if (startup)
+		nhe->uptime = zrouter.startup_time - 1;
 	return 0;
 }
 
@@ -1405,7 +1423,7 @@ int zebra_nhg_kernel_find(uint32_t id, struct nexthop *nh, struct nh_grp *grp, u
 		 */
 		id_counter = id;
 
-	ctx = nhg_ctx_init(id, nh, grp, vrf_id, afi, type, count, nhgr);
+	ctx = nhg_ctx_init(id, nh, grp, vrf_id, afi, type, count, nhgr, startup);
 	nhg_ctx_set_op(ctx, NHG_CTX_OP_NEW);
 
 	/* Under startup conditions, we need to handle them immediately
@@ -1428,7 +1446,7 @@ int zebra_nhg_kernel_del(uint32_t id, vrf_id_t vrf_id)
 {
 	struct nhg_ctx *ctx = NULL;
 
-	ctx = nhg_ctx_init(id, NULL, NULL, vrf_id, 0, 0, 0, NULL);
+	ctx = nhg_ctx_init(id, NULL, NULL, vrf_id, 0, 0, 0, NULL, false);
 
 	nhg_ctx_set_op(ctx, NHG_CTX_OP_DEL);
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -247,6 +247,8 @@ struct nhg_ctx {
 	struct nhg_resilience resilience;
 	enum nhg_ctx_op_e op;
 	enum nhg_ctx_status status;
+
+	bool startup;
 };
 
 /* Global control to disable use of kernel nexthops, if available. We can't

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -173,6 +173,11 @@ struct nhg_hash_entry {
 #define NEXTHOP_GROUP_INITIAL_DELAY_INSTALL (1 << 9)
 
 #define NEXTHOP_GROUP_RECEIVED_FROM_EXTERNAL (1 << 10)
+
+/* Stale FDB NH/NHG read from kernel at startup bitmap bit is owned
+ * by the NHG layer, not the EVPN-MH layer.
+ */
+#define NEXTHOP_GROUP_STALE_FDB (1 << 11)
 };
 
 /* Upper 4 bits of the NHG are reserved for indicating the NHG type */


### PR DESCRIPTION
In EVPN-MH deployment, if zebra abruptly shutdowns, it fails to clean up NH/NHGs from
Kernel (fwd plane). Upon zebra startup, it reads kernel NHGs where it skips
L2 NHGs  whereas L3 NHGs are read through via  api zebra_nhg_kernel_find and sweep,
to mark stale and later removes the stale L3 NHGs.

Upon zebra restarting, the same ESI NHG created, with different nexthops set could
lead to undesired behavior

> Code flow:

Marking stale nhg:
netlink_nexthop_change -> zebra_nhg_kernel_find -> nhg_ctx_process -> nhg_ctx_process_new
-> mark stale nhe (reserve nhe in mh bitmap)

Removing stale nhg:
zebra_router_sweep_nhgs -> zebra_nhg_sweep_entry -> zebra_nhg_uninstall_kernel -> zebra_nhg_handle_uninstall
-> sweep/free up the NHG  -> zebra_evpn_mh_release_stale_nhid -> release from bitmap

With fix:

root       16282       1  0 08:57 ?        00:00:00 /usr/lib/frr/watchfrr -d -F datacenter mgmtd zebra bgpd ospfd pimd staticd
frr        16314       1  0 08:57 ?        00:00:00 /usr/lib/frr/zebra -d -F datacenter -M cumulus_mlag -M snmp -A 127.0.0.1 -s 90000000 -M grpc:4223
root       16849   15133  0 08:58 pts/1    00:00:00 grep zebra
torm-11:# kill -9 16282
torm-11:s# kill -9 16314

>>>>>> watchfrr and zebra crashed, below frr created nhgs retained as stale <<<<<<

torm-11:# ip nexthop show | grep fdb
id 268435460 via 27.0.0.5 scope link proto zebra fdb
id 268435464 via 27.0.0.4 scope link proto zebra fdb
<snip>
id 536870918 group 268435465/268435466/268435467 proto zebra fdb
id 536870919 group 268435465/268435466/268435467 proto zebra fdb

torm-11:# systemctl restart frr

>>>>>> upon restart zebra cleaned up the prevous stale NHG  <<<<<<
torm-11:# ip nexthop show | grep fdb

>>>>>> fresh NHGs are created <<<<<<
torm-11:# ip nexthop show | grep fdb
id 268435460 via 27.0.0.4 scope link proto zebra fdb
id 268435461 via 27.0.0.5 scope link proto zebra fdb
<snip>
id 536870919 group 268435465/268435466/268435467 proto zebra fdb
id 536870920 group 268435465/268435466/268435467 proto zebra fdb
