### PR TITLE
ospf6d: defer AS-External recalc to mitigate processing storm

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -310,6 +310,21 @@ static void ospf6_top_lsdb_hook_remove(struct ospf6_lsa *lsa)
 	}
 }
 
+static void ospf6_asbr_route_calc_timer(struct event *t)
+{
+	struct ospf6 *ospf6 = EVENT_ARG(t);
+
+	ospf6_asbr_recalculate_external_routes(ospf6);
+}
+
+static void ospf6_schedule_asbr_route_calc(struct ospf6 *ospf6)
+{
+	if (event_is_scheduled(ospf6->t_asbr_route_calc))
+		return;
+
+	event_add_event(master, ospf6_asbr_route_calc_timer, ospf6, 0, &ospf6->t_asbr_route_calc);
+}
+
 static void ospf6_top_route_hook_add(struct ospf6_route *route)
 {
 	struct ospf6 *ospf6 = NULL;
@@ -335,7 +350,7 @@ static void ospf6_top_route_hook_add(struct ospf6_route *route)
 	ospf6_zebra_route_update_add(route, ospf6);
 	if (global_scope && route->path.type != OSPF6_PATH_TYPE_EXTERNAL1 &&
 	    route->path.type != OSPF6_PATH_TYPE_EXTERNAL2)
-		ospf6_asbr_recalculate_external_routes(ospf6);
+		ospf6_schedule_asbr_route_calc(ospf6);
 }
 
 static void ospf6_top_route_hook_remove(struct ospf6_route *route)
@@ -364,7 +379,7 @@ static void ospf6_top_route_hook_remove(struct ospf6_route *route)
 	ospf6_zebra_route_update_remove(route, ospf6);
 	if (global_scope && route->path.type != OSPF6_PATH_TYPE_EXTERNAL1 &&
 	    route->path.type != OSPF6_PATH_TYPE_EXTERNAL2)
-		ospf6_asbr_recalculate_external_routes(ospf6);
+		ospf6_schedule_asbr_route_calc(ospf6);
 }
 
 static void ospf6_top_brouter_hook_add(struct ospf6_route *route)
@@ -630,6 +645,7 @@ static void ospf6_disable(struct ospf6 *o)
 		event_cancel(&o->maxage_remover);
 		event_cancel(&o->t_spf_calc);
 		event_cancel(&o->t_ase_calc);
+		event_cancel(&o->t_asbr_route_calc);
 		event_cancel(&o->t_distribute_update);
 		event_cancel(&o->t_ospf6_receive);
 		event_cancel(&o->t_external_aggr);

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -173,6 +173,7 @@ struct ospf6 {
 	/* Threads */
 	struct event *t_spf_calc; /* SPF calculation timer. */
 	struct event *t_ase_calc; /* ASE calculation timer. */
+	struct event *t_asbr_route_calc; /* AS-External route recalculation timer. */
 	struct event *maxage_remover;
 	struct event *t_distribute_update; /* Distribute update timer. */
 	struct event *t_ospf6_receive;	   /* OSPF6 receive timer */


### PR DESCRIPTION
AI slop disclosure: It's all fake, nothing is real anymore.

This PR is the result of collecting 3.7GB of ospf6d debug logs on an FRR 10.6.1 instance and feeding it to a clanker. The hallucinated code change has been verified in a lab setup to reliably mitigate run away memory allocation after an OSPFv3 neighbor establishes connection.

Excerpt of prompt output:
```
● Root Cause: O(N×M) External Route Processing Storm

  The Bug

  Every time a non-external (intra/inter-area) route is added or changed in the
  global route table, ospf6_top_route_hook_add() synchronously calls
  ospf6_asbr_recalculate_external_routes(), which iterates every AS-External LSA
   in the LSDB and does a remove+add on each one.

  Call chain (ospf6_top.c:253, ospf6_area.c:139, ospf6_intra.c:1919):

  ospf6_intra_route_calculation()         [ospf6_intra.c:1919]
    → (hook restored, then for each changed intra route:)
    → ospf6_area_route_hook_add()         [ospf6_area.c:139]
      → ospf6_route_add() to global table
        → ospf6_top_route_hook_add()      [ospf6_top.c:253]
          → ospf6_asbr_recalculate_external_routes()  [ospf6_asbr.c:1039]
            → for ALL M AS-External LSAs: remove + add

  This executes N × M times per SPF run, where:
  - N = number of changed intra-area routes (hundreds–thousands during initial
  convergence)
  - M = number of AS-External LSAs in the LSDB (thousands in an ISP network)

  Evidence from the Log

  The log covers 107 seconds and contains 36 million lines:

  ┌─────────────────────────────────────────────────────┬────────────────────┐
  │                       Metric                        │       Value        │
  ├─────────────────────────────────────────────────────┼────────────────────┤
  │ Total log lines                                     │ 36,068,176         │
  ├─────────────────────────────────────────────────────┼────────────────────┤
  │ Lines from AS-External processing (4 message types) │ 25,500,000+ (70%)  │
  ├─────────────────────────────────────────────────────┼────────────────────┤
  │ Zebra route send messages                           │ 949,138            │
  ├─────────────────────────────────────────────────────┼────────────────────┤
  │ Log generation rate (peak)                          │ ~337,000 lines/sec │
  └─────────────────────────────────────────────────────┴────────────────────┘

  The ~6.4 million AS-External LSA processings represent the O(N×M) storm in
  action. The 949,138 Zebra messages sent in 107 seconds (~8,870/sec) filled
  ospfd's Zebra output socket buffer (zclient->obuf) faster than Zebra could
  drain it.

  Memory Starvation Mechanism

  Each iteration of ospf6_asbr_recalculate_external_routes that results in a
  route change enqueues a message into the stream buffer zclient->obuf in
  ospfd's heap. When ospfd generates messages orders of magnitude faster than
  Zebra reads them:

  1. zclient->obuf grows without bound (each Zebra message is ~100–200 bytes;
  949K messages = ~100–190 MB just for this buffer)
  2. Additionally, each ospf6_asbr_lsa_add() call may allocate temporary
  ospf6_route objects and path list nodes before free
  3. The FRR stream buffer (stream_push* family) reallocates with XREALLOC on
  overflow, doubling each time — this alone can cause large heap fragmentation
  4. ospfd is OOM-killed with no graceful shutdown message in the log

  The ECMP Paths Are Not the Bug

  The log shows ECMP paths growing 2→3→4→5→6→7 for prefixes like
  2001:***:****::/48. This is correct behavior — 7 different ASBRs each
  advertise the same prefix, resulting in 7 valid ECMP paths. Paths stabilize at
   7 and don't leak. The problem is that for each of the N intra-route updates,
  all M external routes (including this 7-path route) are recalculated,
  generating 7 "another path added, effective paths 7" log messages per call per
   such route.

  The Fix

  ospf6_asbr_recalculate_external_routes() must be scheduled/deferred, not
  called inline per route change. The correct pattern (already used elsewhere in
   ospfd for ABR tasks via ospf6_schedule_abr_task()) is:

  // In ospf6_top_route_hook_add(), replace:
  ospf6_asbr_recalculate_external_routes(ospf6);

  // With a flag + single deferred call:
  SET_FLAG(ospf6->flag, OSPF6_FLAG_ASBR_RECALCULATE_NEEDED);
  // (and add a thread/timer event that calls it once after all route updates)

  This reduces O(N×M) to O(M) per SPF cycle. The ospf6_schedule_abr_task() call
  already in ospf6_top_route_hook_add() at line 258 demonstrates the correct
  pattern — the same scheduling approach should be applied to the external route
   recalculation.

  This is a known class of FRR performance bug where a bulk operation is
  triggered per-route rather than being batched per-SPF-cycle. The fix is
  straightforward but requires care to ensure the deferred call fires after all
  intra/inter route changes for the current SPF run are complete, and before the
   next SPF run begins.
```

