### PR TITLE
tests: Remove router_compare_json_output copy paste

### DIFF
--- a/tests/topotests/bfd_isis_topo1/test_bfd_isis_topo1.py
+++ b/tests/topotests/bfd_isis_topo1/test_bfd_isis_topo1.py
@@ -108,19 +108,9 @@ def print_cmd_result(rname, command):
 
 
 def router_compare_json_output(rname, command, reference, count=120, wait=0.5):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+    return topotest.router_compare_json_output(
+        rname, command, reference, count, wait, CWD
+    )
 
 
 ## TEST STEPS

--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -108,19 +108,9 @@ def print_cmd_result(rname, command):
 
 
 def router_compare_json_output(rname, command, reference, count=40, wait=2):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 80 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+    return topotest.router_compare_json_output(
+        rname, command, reference, count, wait, CWD
+    )
 
 
 ## TEST STEPS

--- a/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
+++ b/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
@@ -177,18 +177,7 @@ def teardown_module():
 
 
 def router_compare_json_output(rname, command, reference, wait=0.5, count=120):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    expected = json.loads(reference)
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+    topotest.router_compare_json_output_data(rname, command, reference, count, wait)
 
 
 #

--- a/tests/topotests/isis_lsp_bits_topo1/test_isis_lsp_bits_topo1.py
+++ b/tests/topotests/isis_lsp_bits_topo1/test_isis_lsp_bits_topo1.py
@@ -139,20 +139,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 #

--- a/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
+++ b/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
@@ -178,19 +178,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    expected = json.loads(reference)
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output_data, count=120, wait=0.5
+)
 
 
 #

--- a/tests/topotests/isis_snmp/test_isis_snmp.py
+++ b/tests/topotests/isis_snmp/test_isis_snmp.py
@@ -155,20 +155,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 80 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=160, wait=0.5, CWD=CWD
+)
 
 
 def generate_oid(numoids, index1, index2):

--- a/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
+++ b/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
@@ -158,21 +158,12 @@ def router_json_cmp_exact_filter(router, cmd, expected):
     return topotest.json_cmp(router_output, expected, exact=True)
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    expected = json.loads(reference)
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(
-        router_json_cmp_exact_filter, tgen.gears[rname], command, expected
-    )
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output_data,
+    count=120,
+    wait=0.5,
+    cmp_func=router_json_cmp_exact_filter,
+)
 
 
 def router_compare_output(rname, command, reference):

--- a/tests/topotests/isis_sr_topo1/test_isis_sr_topo1.py
+++ b/tests/topotests/isis_sr_topo1/test_isis_sr_topo1.py
@@ -145,20 +145,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 #

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -220,22 +220,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = functools.partial(
-        topotest.router_json_cmp, tgen.gears[rname], command, expected
-    )
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = functools.partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 #

--- a/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
+++ b/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
@@ -309,23 +309,13 @@ def regen_data(rname, command, step, file, wait):
 
 
 def router_compare_json_output(rname, command, step, file, count=120, wait=0.5):
-    "Compare router JSON output"
-
     # Regenerate reference data when the REGEN_DATA environment variable is set
     if os.environ.get("REGEN_DATA") is not None:
         regen_data(rname, command, step, file, count * wait)
         return
 
-    tgen = get_topogen()
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-    reference = open("{}/{}/step{}/{}".format(CWD, rname, step, file)).read()
-    expected = json.loads(reference)
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+    reference = open(f"{CWD}/{rname}/step{step}/{file}").read()
+    topotest.router_compare_json_output_data(rname, command, reference, count, wait)
 
 
 #

--- a/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
@@ -124,21 +124,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 80 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
-
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=160, wait=0.5, CWD=CWD
+)
 
 
 def test_ospf_convergence():

--- a/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
+++ b/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
@@ -124,21 +124,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 80 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=160, wait=0.5)
-
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=160, wait=0.5, CWD=CWD
+)
 
 
 def test_ospf_convergence():

--- a/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
+++ b/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
@@ -149,20 +149,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=320, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=320, wait=0.5, CWD=CWD
+)
 
 
 def test_isis_convergence():

--- a/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
+++ b/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
@@ -137,20 +137,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=320, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=320, wait=0.5, CWD=CWD
+)
 
 
 def test_isis_convergence():
@@ -541,7 +530,6 @@ def parse_show_isis_interface_detail(lines, rname):
                     line = next(it)
 
                 while line.startswith(" Level-"):
-
                     level = {}
 
                     level_name = line.split()[0]
@@ -569,7 +557,6 @@ def parse_show_isis_interface_detail(lines, rname):
             areas[area_id] = area
 
         except StopIteration:
-
             areas[area_id] = area
             break
 

--- a/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
+++ b/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
@@ -136,20 +136,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=320, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=320, wait=0.5, CWD=CWD
+)
 
 
 def test_ospf_convergence():

--- a/tests/topotests/ldp_topo1/test_ldp_topo1.py
+++ b/tests/topotests/ldp_topo1/test_ldp_topo1.py
@@ -75,7 +75,6 @@ pytestmark = [pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):
-
     # Setup Routers
     for i in range(1, 5):
         tgen.add_router("r%s" % i)
@@ -102,20 +101,9 @@ def build_topo(tgen):
 #####################################################
 
 
-def router_compare_json_output(rname, command, reference, count=60, wait=1):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count, wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=60, wait=1, CWD=CWD
+)
 
 
 #####################################################
@@ -892,7 +880,6 @@ def test_shutdown_check_memleak():
 
 
 if __name__ == "__main__":
-
     # To suppress tracebacks, either use the following pytest call or add "--tb=no" to cli
     # retval = pytest.main(["-s", "--tb=no"])
     retval = pytest.main(["-s"])

--- a/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
@@ -138,19 +138,9 @@ def teardown_module():
 
 
 def router_compare_json_output(rname, command, reference, count=80, wait=1):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count, wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+    return topotest.router_compare_json_output(
+        rname, command, reference, count, wait, CWD
+    )
 
 
 def test_ospf_convergence():

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -587,6 +587,34 @@ def router_json_cmp_retry(router, cmd, data, exact=False, retry_timeout=10.0):
     return ok
 
 
+def router_compare_json_output_data(
+    rname, command, json_data_str, count, wait, cmp_func=router_json_cmp
+):
+    "Compare router JSON output"
+    from lib.topogen import get_topogen
+
+    logger.info('Comparing router "%s" "%s" output', rname, command)
+
+    tgen = get_topogen()
+    expected = json.loads(json_data_str)
+
+    # Run test function until we get an result. Wait at most count*wait seconds.
+    test_func = functools.partial(cmp_func, tgen.gears[rname], command, expected)
+    _, diff = run_and_expect(test_func, None, count=count, wait=wait)
+    assertmsg = f'"{rname}" JSON output mismatches the expected result: {diff}'
+    assert diff is None, assertmsg
+
+
+def router_compare_json_output(
+    rname, command, reference, count, wait, CWD, cmp_func=router_json_cmp
+):
+    "Compare router JSON output"
+    filename = f"{CWD}/{rname}/{reference}"
+    with open(filename) as f:
+        data = f.read()
+    router_compare_json_output_data(rname, command, data, count, wait, cmp_func)
+
+
 def int2dpid(dpid):
     "Converting Integer to DPID"
 

--- a/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
+++ b/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
@@ -142,19 +142,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference, tries):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=tries, wait=1)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, wait=1, CWD=CWD
+)
 
 
 def expect_grace_lsa(restarting, helper):

--- a/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
+++ b/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
@@ -152,19 +152,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference, tries):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=tries, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, wait=0.5, CWD=CWD
+)
 
 
 def expect_grace_lsa(restarting, area, helper):

--- a/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
+++ b/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
@@ -118,20 +118,9 @@ def print_cmd_result(rname, command):
     print(get_topogen().gears[rname].vtysh_cmd(command, isjson=False))
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 #

--- a/tests/topotests/ospf_sr_topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf_sr_topo1/test_ospf_sr_topo1.py
@@ -148,20 +148,9 @@ def print_cmd_result(rname, command):
     print(get_topogen().gears[rname].vtysh_cmd(command, isjson=False))
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 #

--- a/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
+++ b/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
@@ -118,20 +118,9 @@ def teardown_module():
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 def test_ospf_initial_convergence_step1():

--- a/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
+++ b/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
@@ -64,17 +64,15 @@ def router_compare_json_output(rname, command, reference, count=120, wait=0.5):
         """
         return topotest.json_cmp(json.loads(router.cmd(cmd)), data, exact)
 
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(_router_json_cmp, tgen.gears[rname], command, expected)
-    _, diff = topotest.run_and_expect(test_func, None, count=count, wait=wait)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+    topotest.router_compare_json_output(
+        rname,
+        command,
+        reference,
+        count=count,
+        wait=wait,
+        CWD=CWD,
+        cmp_func=_router_json_cmp,
+    )
 
 
 def test_zebra_srv6_encap_src_addr(tgen):

--- a/tests/topotests/srv6_sid_manager/test_srv6_sid_manager.py
+++ b/tests/topotests/srv6_sid_manager/test_srv6_sid_manager.py
@@ -266,22 +266,9 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def router_compare_json_output(rname, command, reference):
-    "Compare router JSON output"
-
-    logger.info('Comparing router "%s" "%s" output', rname, command)
-
-    tgen = get_topogen()
-    filename = "{}/{}/{}".format(CWD, rname, reference)
-    expected = json.loads(open(filename).read())
-
-    # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = functools.partial(
-        topotest.router_json_cmp, tgen.gears[rname], command, expected
-    )
-    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
-    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
-    assert diff is None, assertmsg
+router_compare_json_output = functools.partial(
+    topotest.router_compare_json_output, count=120, wait=0.5, CWD=CWD
+)
 
 
 def open_json_file(filename):


### PR DESCRIPTION
Add two functions to lib/topotest.py:

`router_compare_json_output_data(rname, command, json_data_str, count, wait)` - compare json output of command `command` on router with name `rname` to json data in `json_data_str`.

`router_compare_json_output(rname, command, reference, count, wait, CWD)` - get json data from file `f"{CWD}/{rname}/{reference}"` and call `router_compare_json_output_data`.

Replace copy-paste of the function in 24 tests with various `partial` or wrapper of more appropriate function of these two.