### PR TITLE
bgpd: fix attr comparison when using attr_intern_reuse cache

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1473,7 +1473,7 @@ struct attr *bgp_attr_intern(struct attr *attr)
 		find->refcnt++;
 		/* Populate cache only for the unchanged-parsed-attr case */
 		if (reuse_anchor && reuse_anchor->attr_intern_reuse.parsed_attr &&
-		    attrhash_cmp(attr, reuse_anchor->attr_intern_reuse.parsed_attr)) {
+		    attrhash_cmp(find, reuse_anchor->attr_intern_reuse.parsed_attr)) {
 			reuse_anchor->attr_intern_reuse.valid = true;
 			reuse_anchor->attr_intern_reuse.interned = find;
 		}


### PR DESCRIPTION
When the attr_intern_reuse cache is activated during NLRI processing, a special case in bgp_attr_intern() attempts to avoid a costly hash key computation by caching an attr and using just the attrhash_cmp() function. But the logic that populates the cached entry was comparing the input attr after using it in a call to hash_get() -> bgp_attr_hash_alloc(). That alloc function has a side-effect - it NULLs a couple of sub-attributes, such as the encap_subtlvs. Comparing the input attr after that call modified it could mean that the cached object in "find" had embedded encap_subtlvs, and the ongoing use of the cached object could bring its refcount out of sync with the embedded sub-objects.

The test to decide whether to cache now uses the object allocated by the hash call, "find", so that it will only be cached if it actually matches the input parsed_attr.
