### PR TITLE
build, lib, zebra: OpenBSD fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1253,12 +1253,14 @@ AS_IF([$needsync], [
   dnl https://marc.info/?l=openbsd-tech&m=147299508409549&w=2
   AC_MSG_CHECKING([for OpenBSD futex() support])
   AC_LINK_IFELSE([AC_LANG_PROGRAM([
+#include <stddef.h>
+#include <stdint.h>
 #include <sys/futex.h>
 int main(void);
 ],
 [
 {
-  return futex(NULL, FUTEX_WAIT, 0, NULL, NULL, 0);
+  return futex(NULL, FUTEX_WAIT, 0, NULL, NULL);
 }
 ])], [
     AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -2627,6 +2627,30 @@ if test "$enable_backtrace" != "no" ; then
           AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
           backtrace_ok=true
         ])
+      ], [
+        # OpenBSD. no idea why the header file is under C++, but it is
+        ac_cflags_save="$CFLAGS"
+        CFLAGS="$CFLAGS -I/usr/include/c++/v1"
+        $as_unset ac_cv_header_libunwind_h
+        AC_CHECK_HEADER([libunwind.h], [
+          # and the actual functions are in libexecinfo, but not public...
+	  # except in execinfo_p, but that's a static library...
+	  # but another copy is in libc++abi...
+          # but that one needs -pthread...
+	  ac_libs_save="$LIBS"
+	  ac_ldflags_save="$LDFLAGS"
+	  LDFLAGS="-pthread $LDFLAGS"
+          $as_unset ac_cv_search_unw_getcontext
+          AC_SEARCH_LIBS([unw_getcontext], [execinfo c++abi execinfo_p], [
+            AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
+            UNWIND_CFLAGS="-I/usr/include/c++/v1"
+            UNWIND_LIBS="-pthread ${ac_cv_search_unw_getcontext}"
+            backtrace_ok=true
+          ])
+	  LDFLAGS="$ac_ldflags_save"
+	  LIBS="$ac_libs_save"
+        ])
+        CFLAGS="$ac_cflags_save"
       ])
     ])
     if test "$enable_backtrace" = "libunwind" -a "$backtrace_ok" = "false"; then

--- a/lib/seqlock.c
+++ b/lib/seqlock.c
@@ -82,6 +82,7 @@ static long sys_futex(void *addr1, int op, int val1,
 
 /*
  * OpenBSD: sys_futex(), almost the same as on Linux
+ * it doesn't have the 6th argument though
  */
 #elif defined(HAVE_SYNC_OPENBSD_FUTEX)
 #include <sys/syscall.h>
@@ -89,12 +90,14 @@ static long sys_futex(void *addr1, int op, int val1,
 
 #define TIME_RELATIVE		1
 
+/* clang-format off */
 #define wait_once(sqlo, val)	\
-	futex((int *)&sqlo->pos, FUTEX_WAIT, (int)val, NULL, NULL, 0)
+	futex((int *)&sqlo->pos, FUTEX_WAIT, (int)val, NULL, NULL)
 #define wait_time(sqlo, val, time, reltime)	\
-	futex((int *)&sqlo->pos, FUTEX_WAIT, (int)val, reltime, NULL, 0)
+	futex((int *)&sqlo->pos, FUTEX_WAIT, (int)val, reltime, NULL)
 #define wait_poke(sqlo)		\
-	futex((int *)&sqlo->pos, FUTEX_WAKE, INT_MAX, NULL, NULL, 0)
+	futex((int *)&sqlo->pos, FUTEX_WAKE, INT_MAX, NULL, NULL)
+/* clang-format on */
 
 /*
  * FreeBSD: _umtx_op()
@@ -211,13 +214,13 @@ bool seqlock_timedwait(struct seqlock *sqlo, seqlock_val_t val,
 
 #define time_arg1 abs_monotime_limit
 #define time_arg2 &reltime
-#define time_prep \
-	clock_gettime(CLOCK_MONOTONIC, &reltime);                              \
-	reltime.tv_sec = abs_monotime_limit.tv_sec - reltime.tv_sec;           \
-	reltime.tv_nsec = abs_monotime_limit.tv_nsec - reltime.tv_nsec;        \
-	if (reltime.tv_nsec < 0) {                                             \
-		reltime.tv_sec--;                                              \
-		reltime.tv_nsec += 1000000000;                                 \
+#define time_prep                                                                                 \
+	clock_gettime(CLOCK_MONOTONIC, &reltime);                                                 \
+	reltime.tv_sec = abs_monotime_limit->tv_sec - reltime.tv_sec;                             \
+	reltime.tv_nsec = abs_monotime_limit->tv_nsec - reltime.tv_nsec;                          \
+	if (reltime.tv_nsec < 0) {                                                                \
+		reltime.tv_sec--;                                                                 \
+		reltime.tv_nsec += 1000000000;                                                    \
 	}
 /*
  * FreeBSD & Linux: absolute time re. CLOCK_MONOTONIC

--- a/python/makefile.py
+++ b/python/makefile.py
@@ -52,8 +52,8 @@ if args.dev_build:
                 basepath,
                 "grep",
                 "-l",
-                "-P",
-                r"^#\s*include.*_clippy.c",
+                "-E",
+                r"^#[ \t]*include.*_clippy.c",
                 "--",
                 "**.c",
             ]

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -254,7 +254,7 @@ static int if_getaddrs(void)
 }
 
 /* Fetch interface information via ioctl(). */
-static void interface_info_ioctl()
+static void interface_info_ioctl(void)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	struct interface *ifp;


### PR DESCRIPTION
* make `--enable-dev-build` work (it uses `git grep -P`, OpenBSD doesn't have that, `-E` does the trick)
* one case of `static void function() { … }` that is missing the `void` in the `()`
* `futex()` detection was pre-release and didn't match what was ultimately shipped
* OpenBSD is weirdly hiding `libunwind`