### PR TITLE
ci: fail topotest step when parallel run lacks JUnit failures

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -313,8 +313,8 @@ jobs:
           # Now get the failed tests (if any) from the archived results directory.
           rerun_tests=$(./tests/topotests/analyze.py -r test-results-${{ matrix.cfg.platform }} | cut -f1 -d: | sort -u)
           if [ -z "$rerun_tests" ]; then
-            echo "All tests passed during parallel run."
-            exit 0
+            echo "ERROR: Parallel pytest run failed but no failures found in topotests.xml." >&2
+            exit 1
           fi
 
           echo "ERROR: Some tests failed during parallel run, rerunning serially." >&2


### PR DESCRIPTION
When the parallel pytest run exits non-zero but analyze.py finds no failures in topotests.xml, fail the step instead of treating it as a pass.