### PR TITLE
bgpd: fix BGP session should remain up, if bfd strict mode not used

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5184,7 +5184,9 @@ enum bgp_peer_active peer_active(struct peer_connection *connection)
 				return BGP_PEER_BFD_ADMIN_DOWN;
 			else if (bfd_session_is_down(peer->bfd_config->session))
 				return BGP_PEER_BFD_DOWN;
-		}
+		} else if (peer_established(connection) &&
+			   bfd_session_is_down(peer->bfd_config->session))
+			return BGP_PEER_BFD_DOWN;
 	}
 
 	if (peer->afc[AFI_IP][SAFI_UNICAST] || peer->afc[AFI_IP][SAFI_MULTICAST]


### PR DESCRIPTION
There is a break in the behavior starting from commit ("f900457ed10"), and commit ("4169f27085e8"): whatever the BFD configuration, the BFD DOWN status was displayed on BGP neighbor session. Now, strict mode is mandatory.

Propose to keep the old behavior by taking into account the case where bfd strict is unused.

Fixes: 4169f27085e8 ("bgpd: Add `neighbor X bfd strict` command")

Link: https://github.com/FRRouting/frr/commit/f9400457ed10
Link: https://github.com/FRRouting/frr/commit/4169f27085e8