### PR TITLE
lib, zebra: bound SRv6 locator name length in ZAPI (backport #21868)

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1237,8 +1237,7 @@ done:
 int zapi_srv6_locator_chunk_encode(struct stream *s,
 				   const struct srv6_locator_chunk *c)
 {
-	stream_putw(s, strlen(c->locator_name));
-	stream_put(s, c->locator_name, strlen(c->locator_name));
+	zapi_srv6_locname_encode(s, c->locator_name, __func__);
 	stream_putw(s, c->prefix.prefixlen);
 	stream_put(s, &c->prefix.prefix, sizeof(c->prefix.prefix));
 	stream_putc(s, c->block_bits_length);
@@ -1249,18 +1248,42 @@ int zapi_srv6_locator_chunk_encode(struct stream *s,
 	return 0;
 }
 
-int zapi_srv6_locator_chunk_decode(struct stream *s,
-				   struct srv6_locator_chunk *c)
+void zapi_srv6_locname_encode(struct stream *s, const char *name, const char *caller)
+{
+	size_t len = 0;
+
+	if (name) {
+		len = strnlen(name, SRV6_LOCNAME_SIZE);
+		if (len == SRV6_LOCNAME_SIZE) {
+			zlog_warn("%s: Truncating SRv6 locator name as length exceeds maximum %d",
+				  caller, SRV6_LOCNAME_SIZE - 1);
+			len = SRV6_LOCNAME_SIZE - 1;
+		}
+	}
+	stream_putw(s, (uint16_t)len);
+	if (len)
+		stream_put(s, name, len);
+}
+
+bool zapi_srv6_locname_decode(struct stream *s, char *buf, size_t bufsize, const char *caller)
 {
 	uint16_t len = 0;
 
+	if (!stream_getw2(s, &len))
+		return false;
+	if (len >= bufsize) {
+		zlog_warn("%s: SRv6 locator name length %u exceeds maximum %zu", caller, len,
+			  bufsize - 1);
+		return false;
+	}
+	return stream_get2(buf, s, len);
+}
+
+int zapi_srv6_locator_chunk_decode(struct stream *s, struct srv6_locator_chunk *c)
+{
 	c->prefix.family = AF_INET6;
 
-	STREAM_GETW(s, len);
-	if (len > SRV6_LOCNAME_SIZE)
-		goto stream_failure;
-
-	STREAM_GET(c->locator_name, s, len);
+	ZAPI_GET_SRV6_LOCNAME(c->locator_name, s);
 	STREAM_GETW(s, c->prefix.prefixlen);
 	STREAM_GET(&c->prefix.prefix, s, sizeof(c->prefix.prefix));
 	STREAM_GETC(s, c->block_bits_length);
@@ -1276,8 +1299,7 @@ stream_failure:
 
 int zapi_srv6_locator_encode(struct stream *s, const struct srv6_locator *l)
 {
-	stream_putw(s, strlen(l->name));
-	stream_put(s, l->name, strlen(l->name));
+	zapi_srv6_locname_encode(s, l->name, __func__);
 	stream_putw(s, l->prefix.prefixlen);
 	stream_put(s, &l->prefix.prefix, sizeof(l->prefix.prefix));
 	stream_putc(s, l->block_bits_length);
@@ -1290,13 +1312,7 @@ int zapi_srv6_locator_encode(struct stream *s, const struct srv6_locator *l)
 
 int zapi_srv6_locator_decode(struct stream *s, struct srv6_locator *l)
 {
-	uint16_t len = 0;
-
-	STREAM_GETW(s, len);
-	if (len > SRV6_LOCNAME_SIZE)
-		goto stream_failure;
-
-	STREAM_GET(l->name, s, len);
+	ZAPI_GET_SRV6_LOCNAME(l->name, s);
 	STREAM_GETW(s, l->prefix.prefixlen);
 	STREAM_GET(&l->prefix.prefix, s, sizeof(l->prefix.prefix));
 	l->prefix.family = AF_INET6;
@@ -3500,7 +3516,6 @@ int srv6_manager_get_locator_chunk(struct zclient *zclient,
 				   const char *locator_name)
 {
 	struct stream *s;
-	const size_t len = strlen(locator_name);
 
 	if (zclient_debug)
 		zlog_debug("Getting SRv6-Locator Chunk %s", locator_name);
@@ -3515,8 +3530,7 @@ int srv6_manager_get_locator_chunk(struct zclient *zclient,
 			      VRF_DEFAULT);
 
 	/* locator_name */
-	stream_putw(s, len);
-	stream_put(s, locator_name, len);
+	zapi_srv6_locname_encode(s, locator_name, __func__);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -3535,7 +3549,6 @@ int srv6_manager_release_locator_chunk(struct zclient *zclient,
 				       const char *locator_name)
 {
 	struct stream *s;
-	const size_t len = strlen(locator_name);
 
 	if (zclient_debug)
 		zlog_debug("Releasing SRv6-Locator Chunk %s", locator_name);
@@ -3550,8 +3563,7 @@ int srv6_manager_release_locator_chunk(struct zclient *zclient,
 			      VRF_DEFAULT);
 
 	/* locator_name */
-	stream_putw(s, len);
-	stream_put(s, locator_name, len);
+	zapi_srv6_locname_encode(s, locator_name, __func__);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -3563,16 +3575,12 @@ int srv6_manager_release_locator_chunk(struct zclient *zclient,
  * Function to request a SRv6 locator in an asynchronous way
  *
  * @param zclient The zclient used to connect to SRv6 Manager (zebra)
- * @param locator_name Name of SRv6 locator
+ * @param locator_name Name of SRv6 locator, or NULL to request all locators
  * @return 0 on success, -1 otherwise
  */
 int srv6_manager_get_locator(struct zclient *zclient, const char *locator_name)
 {
 	struct stream *s;
-	size_t len;
-
-	if (!locator_name)
-		return -1;
 
 	if (zclient->sock < 0) {
 		flog_err(EC_LIB_ZAPI_SOCKET, "%s: invalid zclient socket",
@@ -3581,9 +3589,8 @@ int srv6_manager_get_locator(struct zclient *zclient, const char *locator_name)
 	}
 
 	if (zclient_debug)
-		zlog_debug("Getting SRv6 Locator %s", locator_name);
-
-	len = strlen(locator_name);
+		zlog_debug("Getting SRv6 Locator %s",
+			   locator_name ? locator_name : "<all>");
 
 	/* Send request */
 	s = zclient->obuf;
@@ -3591,8 +3598,7 @@ int srv6_manager_get_locator(struct zclient *zclient, const char *locator_name)
 	zclient_create_header(s, ZEBRA_SRV6_MANAGER_GET_LOCATOR, VRF_DEFAULT);
 
 	/* Locator name */
-	stream_putw(s, len);
-	stream_put(s, locator_name, len);
+	zapi_srv6_locname_encode(s, locator_name, __func__);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -3617,7 +3623,6 @@ int srv6_manager_get_sid(struct zclient *zclient, const struct srv6_sid_ctx *ctx
 {
 	struct stream *s;
 	uint8_t flags = 0;
-	size_t len;
 	char buf[256];
 
 	if (zclient->sock < 0) {
@@ -3653,11 +3658,8 @@ int srv6_manager_get_sid(struct zclient *zclient, const struct srv6_sid_ctx *ctx
 		stream_put(s, sid_value, sizeof(struct in6_addr));
 
 	/* SRv6 locator */
-	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR)) {
-		len = strlen(locator_name);
-		stream_putw(s, len);
-		stream_put(s, locator_name, len);
-	}
+	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR))
+		zapi_srv6_locname_encode(s, locator_name, __func__);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -3680,7 +3682,6 @@ int srv6_manager_release_sid(struct zclient *zclient, const struct srv6_sid_ctx 
 {
 	struct stream *s;
 	uint8_t flags = 0;
-	size_t len;
 	char buf[256];
 
 	if (zclient->sock < 0) {
@@ -3711,11 +3712,8 @@ int srv6_manager_release_sid(struct zclient *zclient, const struct srv6_sid_ctx 
 	stream_putc(s, flags);
 
 	/* SRv6 locator */
-	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR)) {
-		len = strlen(locator_name);
-		stream_putw(s, len);
-		stream_put(s, locator_name, len);
-	}
+	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR))
+		zapi_srv6_locname_encode(s, locator_name, __func__);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1162,6 +1162,15 @@ extern int zapi_srv6_locator_chunk_encode(struct stream *s,
 					  const struct srv6_locator_chunk *c);
 extern int zapi_srv6_locator_chunk_decode(struct stream *s,
 					  struct srv6_locator_chunk *c);
+extern bool zapi_srv6_locname_decode(struct stream *s, char *buf, size_t bufsize,
+				     const char *caller);
+extern void zapi_srv6_locname_encode(struct stream *s, const char *name, const char *caller);
+
+#define ZAPI_GET_SRV6_LOCNAME(BUF, S)                                                             \
+	do {                                                                                      \
+		if (!zapi_srv6_locname_decode((S), (BUF), sizeof(BUF), __func__))                 \
+			goto stream_failure;                                                      \
+	} while (0)
 
 extern enum zclient_send_status zebra_send_pw(struct zclient *zclient,
 					      int command, struct zapi_pw *pw);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1055,11 +1055,7 @@ void zsend_srv6_sid_notify(struct zserv *client, const struct srv6_sid_ctx *ctx,
 	/* SRv6 wide SID function */
 	stream_putl(s, wide_func);
 	/* SRv6 locator name optional */
-	if (locator_name) {
-		stream_putw(s, strlen(locator_name));
-		stream_put(s, locator_name, strlen(locator_name));
-	} else
-		stream_putw(s, 0);
+	zapi_srv6_locname_encode(s, locator_name, __func__);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
@@ -3020,17 +3016,10 @@ static void zread_srv6_manager_get_locator_chunk(struct zserv *client,
 						 vrf_id_t vrf_id)
 {
 	struct stream *s = msg;
-	uint16_t len;
 	char locator_name[SRV6_LOCNAME_SIZE] = {0};
 
 	/* Get data. */
-	STREAM_GETW(s, len);
-	if (len > SRV6_LOCNAME_SIZE) {
-		zlog_warn("%s: SRv6 locator name length %u exceeds maximum %d", __func__, len,
-			  SRV6_LOCNAME_SIZE);
-		goto stream_failure;
-	}
-	STREAM_GET(locator_name, s, len);
+	ZAPI_GET_SRV6_LOCNAME(locator_name, s);
 
 	/* call hook to get a chunk using wrapper */
 	struct srv6_locator *loc = NULL;
@@ -3045,17 +3034,10 @@ static void zread_srv6_manager_release_locator_chunk(struct zserv *client,
 						     vrf_id_t vrf_id)
 {
 	struct stream *s = msg;
-	uint16_t len;
 	char locator_name[SRV6_LOCNAME_SIZE] = {0};
 
 	/* Get data. */
-	STREAM_GETW(s, len);
-	if (len > SRV6_LOCNAME_SIZE) {
-		zlog_warn("%s: SRv6 locator name length %u exceeds maximum %d", __func__, len,
-			  SRV6_LOCNAME_SIZE);
-		goto stream_failure;
-	}
-	STREAM_GET(locator_name, s, len);
+	ZAPI_GET_SRV6_LOCNAME(locator_name, s);
 
 	/* call hook to release a chunk using wrapper */
 	srv6_manager_release_locator_chunk_call(client, locator_name, vrf_id);
@@ -3078,7 +3060,6 @@ static void zread_srv6_manager_get_srv6_sid(struct zserv *client,
 	struct in6_addr sid_value = {};
 	struct in6_addr *sid_value_ptr = NULL;
 	char locator[SRV6_LOCNAME_SIZE] = { 0 };
-	uint16_t len;
 	struct zebra_srv6_sid *sid = NULL;
 	uint8_t flags;
 	bool is_localonly = false;
@@ -3093,10 +3074,8 @@ static void zread_srv6_manager_get_srv6_sid(struct zserv *client,
 		STREAM_GET(&sid_value, s, sizeof(struct in6_addr));
 		sid_value_ptr = &sid_value;
 	}
-	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR)) {
-		STREAM_GETW(s, len);
-		STREAM_GET(locator, s, len);
-	}
+	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR))
+		ZAPI_GET_SRV6_LOCNAME(locator, s);
 	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_IS_LOCALONLY))
 		is_localonly = true;
 
@@ -3120,7 +3099,6 @@ static void zread_srv6_manager_release_srv6_sid(struct zserv *client,
 	struct stream *s;
 	struct srv6_sid_ctx ctx = {};
 	char locator[SRV6_LOCNAME_SIZE] = { 0 };
-	uint16_t len;
 	uint8_t flags;
 	bool is_localonly = false;
 
@@ -3130,17 +3108,8 @@ static void zread_srv6_manager_release_srv6_sid(struct zserv *client,
 	/* Get data */
 	STREAM_GET(&ctx, s, sizeof(struct srv6_sid_ctx));
 	STREAM_GETC(s, flags);
-	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR)) {
-		STREAM_GETW(s, len);
-
-		if (len > SRV6_LOCNAME_SIZE) {
-			zlog_warn("Received locator name length (%u) exceeds maximum length (%u)",
-				  len, SRV6_LOCNAME_SIZE);
-			goto stream_failure;
-		}
-
-		STREAM_GET(locator, s, len);
-	}
+	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_HAS_LOCATOR))
+		ZAPI_GET_SRV6_LOCNAME(locator, s);
 	if (CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_IS_LOCALONLY))
 		is_localonly = true;
 
@@ -3161,16 +3130,14 @@ static void zread_srv6_manager_get_locator(struct zserv *client,
 					   struct stream *msg)
 {
 	struct stream *s = msg;
-	uint16_t len;
 	char locator_name[SRV6_LOCNAME_SIZE] = { 0 };
 	struct srv6_locator *locator = NULL;
 
 	/* Get data */
-	STREAM_GETW(s, len);
-	STREAM_GET(locator_name, s, len);
+	ZAPI_GET_SRV6_LOCNAME(locator_name, s);
 
 	/* Call hook to get the locator info using wrapper */
-	srv6_manager_get_locator_call(&locator, client, locator_name);
+	srv6_manager_get_locator_call(&locator, client, locator_name[0] ? locator_name : NULL);
 
 stream_failure:
 	return;


### PR DESCRIPTION
zread_srv6_manager_get_srv6_sid() and zread_srv6_manager_get_locator() read a uint16_t length from the ZAPI stream and pass it directly to STREAM_GET() to copy into a 256-byte stack buffer (SRV6_LOCNAME_SIZE), without bounding the length first. STREAM_GET() only validates the source side of the read; the destination is a raw memcpy. A malformed ZAPI message with len >= SRV6_LOCNAME_SIZE writes past the buffer on Zebra's stack, up to the ZAPI packet cap of around 16 KiB. Normally, stack canaries would catch this and cause Zebra to abort (which could lead to a DoS). Let's fix the root cause of the issue instead of relying on stack canaries by adding a guard in both handlers.

For the other similar guards, change the check to
`len >= SRV6_LOCNAME_SIZE` to accommodate the trailing null terminator. Additionally, print SRV6_LOCNAME_SIZE - 1 as the maximum in the warnings so that the message stays accurate, and make the warning format across the Zebra handlers consistent.

These SRv6 locator name length checks are also refactored into a helper macro so that they do not have to be done manually everywhere.

Also add a helper for the ZAPI send paths that emit an SRv6 locator name. The helper bounds the read with strnlen(), treats NULL as an empty name, and warns then truncates if the input lacks a null terminator within SRV6_LOCNAME_SIZE bytes, so that the byte stream on the wire stays well-formed.

---

Manual backport of https://github.com/FRRouting/frr/pull/21868 for FRR 10.5