### PR TITLE
zebra: fix heap use after free link interface invalid when ifp freed

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -208,6 +208,8 @@ static int if_zebra_delete_hook(struct interface *ifp)
 {
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_bond *bond;
+	struct vrf *vrf;
+	struct interface *p_ifp;
 
 	if (ifp->info) {
 		zebra_if = ifp->info;
@@ -260,6 +262,19 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		XFREE(MTYPE_ZINFO, zebra_if);
 	}
 
+	/* walk over all zebra interfaces; unref link pointer */
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		FOR_ALL_INTERFACES (vrf, p_ifp) {
+			if (p_ifp->info == NULL)
+				continue;
+			zebra_if = p_ifp->info;
+			if (zebra_if->link == ifp) {
+				zebra_if->link = NULL;
+				zebra_if->link_ifindex = IFINDEX_INTERNAL;
+				zebra_if->link_nsid = NS_UNKNOWN;
+			}
+		}
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The following asan heap use after free message can happen:

> ==105345==ERROR: AddressSanitizer: heap-use-after-free on address 0x51200008b280 at pc 0x77484347d96f bp 0x7ffe723b3910 sp 0x7ffe723b30b8
> READ of size 4 at 0x51200008b280 thread T0
>     #0 0x77484347d96e in strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
>     #1 0x7748430379fa in vbprintfrr lib/printf/vfprintf.c:619
>     #2 0x77484303bcab in vasnprintfrr lib/printf/glue.c:92
>     #3 0x774842fafdb7 in vty_out lib/vty.c:273
>     #4 0x5cfd96949bac in if_dump_vty zebra/interface.c:2910
>     #5 0x5cfd9694f407 in show_interface_vrf_all_magic zebra/interface.c:3547
>     #6 0x5cfd9694e752 in show_interface_vrf_all zebra/interface_clippy.c:105
>     #7 0x774842dc36b0 in cmd_execute_command_real lib/command.c:1010
>     #8 0x774842dc3a3d in cmd_execute_command lib/command.c:1069
>     #9 0x774842dc470f in cmd_execute lib/command.c:1235
>     #10 0x774842fb1e1c in vty_command lib/vty.c:627
>     #11 0x774842fb6d03 in vty_execute lib/vty.c:1390
>     #12 0x774842fbd322 in vtysh_read lib/vty.c:2440
>     #13 0x774842fa19d6 in event_call lib/event.c:2011
>     #14 0x774842e6bfe4 in frr_run lib/libfrr.c:1219
>     #15 0x5cfd969660a9 in main zebra/main.c:550
>     #16 0x77484222a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
>     #17 0x77484222a28a in __libc_start_main_impl ../csu/libc-start.c:360
>     #18 0x5cfd96921314 in _start (/usr/lib/frr/zebra+0x1d9314) (BuildId: 1f53edc819a130a3c6818e60f267494aa5f1d5d5)
>
> 0x51200008b280 is located 64 bytes inside of 296-byte region [0x51200008b240,0x51200008b368)
> freed by thread T0 here:
>     #0 0x7748434fc4d8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
>     #1 0x774842e9856a in qfree lib/memory.c:130
>     #2 0x774842e323c1 in if_delete lib/if.c:284
>     #3 0x5cfd9693d08a in if_delete_update zebra/interface.c:832
>     #4 0x5cfd969435d4 in zebra_if_dplane_ifp_handling zebra/interface.c:2005
>     #5 0x5cfd969462b1 in zebra_if_dplane_result zebra/interface.c:2355
>     #6 0x5cfd96ad45da in rib_process_dplane_results zebra/zebra_rib.c:4961
>     #7 0x774842fa19d6 in event_call lib/event.c:2011
>     #8 0x774842e6bfe4 in frr_run lib/libfrr.c:1219
>     #9 0x5cfd969660a9 in main zebra/main.c:550
>     #10 0x77484222a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
>     #11 0x77484222a28a in __libc_start_main_impl ../csu/libc-start.c:360
>     #12 0x5cfd96921314 in _start (/usr/lib/frr/zebra+0x1d9314) (BuildId: 1f53edc819a130a3c6818e60f267494aa5f1d5d5)