### PR TITLE
mgmtd: emit valid empty JSON for missing xpath in datastore dump

### DIFF
--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -68,8 +68,17 @@ static int mgmt_ds_dump_in_memory(struct mgmt_ds_ctx *ds_ctx,
 					      ? ds_ctx->root.cfg_root->dnode
 					      : ds_ctx->root.dnode_root,
 				      base_xpath);
-	if (!root)
+	if (!root) {
+		/*
+		 * No node resolves at the requested xpath. Emit a valid empty
+		 * JSON document so callers always receive parseable output
+		 * instead of an empty buffer that ends up rendered as
+		 * "(null)" by vty_out("%s\n", str).
+		 */
+		if (format == LYD_JSON)
+			ly_print(out, "{}");
 		return -1;
+	}
 
 	options = ds_ctx->config_ds ? LYD_PRINT_WD_TRIM :
 		LYD_PRINT_WD_EXPLICIT;
@@ -578,7 +587,7 @@ void mgmt_ds_dump_tree(struct vty *vty, struct mgmt_ds_ctx *ds_ctx,
 	mgmt_ds_dump_in_memory(ds_ctx, base_xpath, format, out);
 
 	if (!f)
-		vty_out(vty, "%s\n", str);
+		vty_out(vty, "%s\n", str ? str : "");
 
 	ly_out_free(out, NULL, 0);
 }


### PR DESCRIPTION
Closes #21479.

When `show mgmt datastore-contents [ds] xpath X json` is given an xpath
that does not resolve, the existing code path returns from
`mgmt_ds_dump_in_memory()` without writing to the libyang output
handle. `mgmt_ds_dump_tree()` then calls `vty_out("%s\n", str)` with
`str` still NULL, which glibc renders as the literal `"(null)"` —
not valid JSON.

This matches @mjstapp's earlier comment on #21479 ("the pattern we
try to use is that we send at least an empty json object").

### Fix

* In `mgmt_ds_dump_in_memory()`, when no node matches the xpath and
  the requested format is JSON, write `{}` to the libyang output
  handle so the caller always gets a valid empty document. Both the
  terminal-output path and the file-output path benefit.
* In `mgmt_ds_dump_tree()`, add a defensive NULL guard before
  `vty_out()` so a NULL buffer can never reach the `%s` conversion.

### Verification (FRR 10.6.1, Ubuntu 24.04)

Before:

    # vtysh -c "show mgmt datastore-contents running xpath /no/such/path json"
    (null)

After:

    # vtysh -c "show mgmt datastore-contents running xpath /no/such/path json"
    {}

Full case matrix (all behave as expected):

| Format | Output | xpath state         | Result              |
|--------|--------|---------------------|---------------------|
| JSON   | vtysh  | missing             | `{}`                |
| XML    | vtysh  | missing             | (empty)             |
| JSON   | vtysh  | valid               | unchanged           |
| XML    | vtysh  | valid               | unchanged           |
| JSON   | file   | missing             | file contains `{}`  |
| XML    | file   | missing             | file empty          |
| JSON   | vtysh  | absent (whole DS)   | unchanged           |