### PR TITLE
doc: fix broken bgp community-list example

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2839,7 +2839,8 @@ expanded
    will happen user defined order. Once the community list matches to
    communities attribute in BGP updates it return permit or deny by the
    community list definition. When there is no matched entry, deny will be
-   returned. When ``COMMUNITY`` is empty it matches to any routes.
+   returned. To match any community, use an expanded community list with the
+   ``.*`` regular expression.
 
 .. clicmd:: bgp community-list expanded NAME permit|deny COMMUNITY
 
@@ -3083,8 +3084,8 @@ community-list.
      neighbor 192.168.0.1 route-map RMAP in
     exit-address-family
    !
-   bgp community-list standard FILTER deny 1:1
-   bgp community-list standard FILTER permit
+   bgp community-list expanded FILTER deny 1:1
+   bgp community-list expanded FILTER permit .*
    !
    route-map RMAP permit 10
     match community FILTER


### PR DESCRIPTION
The example for filtering BGP routes by community used 'bgp community-list standard FILTER permit' (no value), which the grammar rejects with 'Command incomplete' because the standard form requires at least one AA:NN community value. The clicmd description also incorrectly claimed that an empty COMMUNITY matches any routes.

Switch the example to the expanded form, where '.*' provides the working catch-all permit, and update the clicmd description to point readers at this pattern. The example's multi-entry structure (deny specific + permit catch-all) is preserved.

Note: expanded community-lists match against the printed community string as a regex, so 'deny 1:1' is a substring match rather than the exact subset match of the standard form. For an illustrative example this is acceptable.

Verified against FRR 10.6.1.

Closes: #21361