### PR TITLE
zebra: fix neighbor entries ns_id

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -84,6 +84,7 @@ show ip fib
 show ipv6 fib
 show nexthop-group rib
 show route-map
+show neighbor
 show mpls table
 show mpls fec
 show mpls pseudowires

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4650,7 +4650,7 @@ static int netlink_neigh_table(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (ndm->ndm_family != AF_INET && ndm->ndm_family != AF_INET6)
 		return 0;
 
-	return netlink_neigh_change(h, len);
+	return netlink_neigh_change(h, ns_id);
 }
 
 /* Request for IP neighbor information from the kernel */


### PR DESCRIPTION
Neighbor entries may not be removed from zebra neighbor tables due to a wrong ns_id when they were created.

ns_id = 0 in netlink_neigh_table() but is changed to 48 in netlink_neigh_change().

> #0  dplane_ctx_set_ns_id (ctx=0x61900010a980, nsid=48) at zebra/zebra_dplane.c:1387
> #1  0x00005555557625f0 in netlink_ipneigh_change (h=0x62d000096400, len=48, ns_id=48) at zebra/rt_netlink.c:4556
> #2  0x000055555576402a in netlink_neigh_change (h=0x62d000096400, ns_id=48) at zebra/rt_netlink.c:4786
> #3  0x00005555557634ba in netlink_neigh_table (h=0x62d000096400, ns_id=0, startup=1) at zebra/rt_netlink.c:4653
> #4  0x0000555555732037 in netlink_parse_info (filter=0x555555763397 <netlink_neigh_table>, nl=0x6160000b5378, zns=0x6190000fb8c8, count=0, startup=true) at zebra/kernel_netlink.c:1007
> #5  0x0000555555763e09 in kernel_read_neigh (ctx=0x6190000fb480) at zebra/rt_netlink.c:4753
> #6  0x00005555557c537e in kernel_dplane_process_neigh_read (prov=0x6110000ab440, ctx=0x6190000fb480) at zebra/zebra_dplane.c:7601
> #7  0x00005555557c584f in kernel_dplane_process_func (prov=0x6110000ab440) at zebra/zebra_dplane.c:7673
> #8  0x00005555557c6cdd in dplane_thread_loop (event=0x7ffff20a5b00) at zebra/zebra_dplane.c:8164
> #9  0x00007ffff6f8c939 in event_call (event=0x7ffff20a5b00) at lib/event.c:2740
> #10 0x00007ffff6e047d8 in fpt_run (arg=0x6110000c1ec0) at lib/frr_pthread.c:386
> #11 0x00007ffff6e03240 in frr_pthread_inner (arg=0x6110000c1ec0) at lib/frr_pthread.c:179
> #12 0x00007ffff7e27ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
> #13 0x00007ffff6b27adf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95