### PR TITLE
pimd: fix AutoRP stale RPs and selective multicast joins, add missing docs

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -78,10 +78,12 @@ PIM Routers
    In order to use PIM, it is necessary to configure an RP for join messages to
    be sent to. FRR supports learning RP information dynamically via the AutoRP
    protocol and performs discovery by default. This command will disable the
-   AutoRP discovery protocol.
+   AutoRP discovery protocol. Any RP information previously learned via AutoRP
+   is removed immediately from the running configuration.
    All routers in the PIM network must agree on the network RP information, so
    all routers in the network should have AutoRP either enabled or disabled.
-   This command is VRF-aware.
+   Use ``autorp discovery`` to re-enable AutoRP discovery. This command is
+   VRF-aware.
 
 
 .. clicmd:: autorp announce A.B.C.D [A.B.C.D/M | group-list PREFIX_LIST]
@@ -97,6 +99,24 @@ PIM Routers
    seconds elapsed between advertise messages sent, defaults to 60. Hold time defines
    how long the AutoRP mapping agent will consider the information valid, setting to
    0 will disable expiration of the candidate RP information, defaults to 3 * interval.
+
+.. clicmd:: autorp send-rp-discovery [source <address A.B.C.D | interface IFNAME | loopback | any>]
+
+   Enable the AutoRP mapping agent on this router. The mapping agent listens for
+   candidate RP announcements, aggregates them, and sends AutoRP discovery
+   messages so other routers can learn RP information dynamically. By default the
+   source address is the highest loopback address. Use ``interface`` to select the
+   highest address on an interface, ``address`` to set an explicit address, or
+   ``any`` to use the highest address on any interface. Use ``no autorp
+   send-rp-discovery`` to disable the mapping agent. This command is VRF-aware.
+
+.. clicmd:: autorp send-rp-discovery {scope (0-255) | interval (1-65535) | holdtime (0-65535)}
+
+   Configure AutoRP mapping agent discovery messages. The scope defines the TTL
+   value in the messages to limit the scope, defaults to 31. Interval defines the
+   number of seconds elapsed between discovery messages sent, defaults to 60. Hold
+   time defines how long other routers should consider learned RP information
+   valid, defaults to 180 seconds.
 
 .. clicmd:: rp keep-alive-timer (1-65535)
    :daemon: pim

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -35,6 +35,8 @@ static const char *PIM_AUTORP_ANNOUNCEMENT_GRP = "224.0.1.39";
 static const char *PIM_AUTORP_DISCOVERY_GRP = "224.0.1.40";
 static const in_port_t PIM_AUTORP_PORT = 496;
 
+static bool autorp_config_loaded;
+
 static int pim_autorp_rp_cmp(const struct pim_autorp_rp *l, const struct pim_autorp_rp *r)
 {
 	return pim_addr_cmp(l->addr, r->addr);
@@ -2078,6 +2080,7 @@ void pim_autorp_init(struct pim_instance *pim)
 	autorp->read_event = NULL;
 	autorp->announce_timer = NULL;
 	autorp->do_discovery = false;
+	autorp->discovery_cfg_set = false;
 	autorp->send_discovery_timer = NULL;
 	autorp->send_rp_discovery = false;
 	pim_autorp_rp_init(&(autorp->discovery_rp_list));
@@ -2098,10 +2101,40 @@ void pim_autorp_init(struct pim_instance *pim)
 		zlog_debug("%s: AutoRP Initialized", __func__);
 }
 
+void pim_autorp_discovery_apply_finish(struct pim_instance *pim)
+{
+	struct pim_autorp *autorp = pim->autorp;
+
+	if (!autorp)
+		return;
+
+	autorp_config_loaded = true;
+
+	if (!autorp->discovery_cfg_set)
+		pim_autorp_start_discovery(pim);
+}
+
 void pim_autorp_enable(struct pim_instance *pim)
 {
-	/* Start AutoRP discovery by default on startup */
+	struct pim_autorp *autorp = pim->autorp;
+
+	/* Per-VRF apply_finish handles startup config. For VRFs created at
+	 * runtime after config load, start discovery if not explicitly disabled.
+	 */
+	if (!autorp || !autorp_config_loaded || autorp->discovery_cfg_set)
+		return;
+
 	pim_autorp_start_discovery(pim);
+}
+
+void pim_autorp_discovery_cfg_destroy(struct pim_instance *pim)
+{
+	struct pim_autorp *autorp = pim->autorp;
+
+	if (!autorp)
+		return;
+
+	autorp->discovery_cfg_set = false;
 }
 
 void pim_autorp_finish(struct pim_instance *pim)

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -1954,6 +1954,8 @@ void pim_autorp_stop_discovery(struct pim_instance *pim)
 	autorp->do_discovery = false;
 	autorp_read_off(autorp);
 
+	pim_autorp_rplist_free(&autorp->discovery_rp_list, true);
+
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP Discovery stopped", __func__);
 

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -191,78 +191,176 @@ static bool pim_autorp_should_enable_socket(struct pim_autorp *autorp)
 
 static bool pim_autorp_should_close(struct pim_autorp *autorp)
 {
-	/* If discovery or mapping agent is active, then we need the socket open. We also want to leave
-	 * the socket open if there are any pim interfaces and we have an announcement packet to send.
+	/* Keep the socket open while any AutoRP receive or send role is active.
+	 * For candidate RP, use the configured RP list rather than announce_timer:
+	 * pim_autorp_new_announcement() cancels that timer before rebuilding the
+	 * packet and must not trigger a socket close in between.
 	 */
-	return !autorp->do_discovery && !autorp->send_rp_discovery &&
-	       !(pim_autorp_should_enable_socket(autorp) && autorp->announce_timer != NULL);
+	if (autorp->do_discovery || autorp->send_rp_discovery)
+		return false;
+
+	if (!pim_autorp_should_enable_socket(autorp))
+		return true;
+
+	if (pim_autorp_rp_count(&autorp->candidate_rp_list) > 0)
+		return false;
+
+	return true;
 }
 
-static bool pim_autorp_join_groups(struct interface *ifp)
+static bool pim_autorp_ifp_join_discovery(struct interface *ifp)
 {
-	struct pim_interface *pim_ifp;
-	struct pim_instance *pim;
-	struct pim_autorp *autorp;
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_autorp *autorp = pim_ifp->pim->autorp;
 	pim_addr grp;
 
-	pim_ifp = ifp->info;
-	pim = pim_ifp->pim;
-	autorp = pim->autorp;
-
 	inet_pton(PIM_AF, PIM_AUTORP_DISCOVERY_GRP, &grp);
-	if (pim_socket_join(autorp->sock, grp, pim_ifp->primary_address,
-			    ifp->ifindex, pim_ifp)) {
+	if (pim_socket_join(autorp->sock, grp, pim_ifp->primary_address, ifp->ifindex, pim_ifp)) {
 		zlog_warn("Failed to join group %pI4 on interface %s", &grp, ifp->name);
 		return false;
 	}
 
 	zlog_info("%s: Joined AutoRP discovery group %pPA on interface %s", __func__, &grp,
 		  ifp->name);
-
-	inet_pton(PIM_AF, PIM_AUTORP_ANNOUNCEMENT_GRP, &grp);
-	if (pim_socket_join(pim->autorp->sock, grp, pim_ifp->primary_address, ifp->ifindex,
-			    pim_ifp)) {
-		zlog_warn("Failed to join group %pI4 on interface %s", &grp, ifp->name);
-		return errno;
-	}
-
-	zlog_info("%s: Joined AutoRP announcement group %pPA on interface %s", __func__, &grp,
-		  ifp->name);
-
 	return true;
 }
 
-static bool pim_autorp_leave_groups(struct interface *ifp)
+static bool pim_autorp_ifp_leave_discovery(struct interface *ifp)
 {
-	struct pim_interface *pim_ifp;
-	struct pim_instance *pim;
-	struct pim_autorp *autorp;
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_autorp *autorp = pim_ifp->pim->autorp;
 	pim_addr grp;
 
-	pim_ifp = ifp->info;
-	pim = pim_ifp->pim;
-	autorp = pim->autorp;
-
 	inet_pton(PIM_AF, PIM_AUTORP_DISCOVERY_GRP, &grp);
-	if (pim_socket_leave(autorp->sock, grp, pim_ifp->primary_address,
-			     ifp->ifindex, pim_ifp)) {
+	if (pim_socket_leave(autorp->sock, grp, pim_ifp->primary_address, ifp->ifindex, pim_ifp)) {
 		zlog_warn("Failed to leave group %pI4 on interface %s", &grp, ifp->name);
 		return false;
 	}
 
-	zlog_info("%s: Left AutoRP discovery group %pPA on interface %s", __func__, &grp, ifp->name);
+	zlog_info("%s: Left AutoRP discovery group %pPA on interface %s", __func__, &grp,
+		  ifp->name);
+	return true;
+}
+
+static bool pim_autorp_ifp_join_announce(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_autorp *autorp = pim_ifp->pim->autorp;
+	pim_addr grp;
 
 	inet_pton(PIM_AF, PIM_AUTORP_ANNOUNCEMENT_GRP, &grp);
-	if (pim_socket_leave(pim->autorp->sock, grp, pim_ifp->primary_address, ifp->ifindex,
-			     pim_ifp)) {
+	if (pim_socket_join(autorp->sock, grp, pim_ifp->primary_address, ifp->ifindex, pim_ifp)) {
+		zlog_warn("Failed to join group %pI4 on interface %s", &grp, ifp->name);
+		return false;
+	}
+
+	zlog_info("%s: Joined AutoRP announcement group %pPA on interface %s", __func__, &grp,
+		  ifp->name);
+	return true;
+}
+
+static bool pim_autorp_ifp_leave_announce(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_autorp *autorp = pim_ifp->pim->autorp;
+	pim_addr grp;
+
+	inet_pton(PIM_AF, PIM_AUTORP_ANNOUNCEMENT_GRP, &grp);
+	if (pim_socket_leave(autorp->sock, grp, pim_ifp->primary_address, ifp->ifindex, pim_ifp)) {
 		zlog_warn("Failed to leave group %pI4 on interface %s", &grp, ifp->name);
-		return errno;
+		return false;
 	}
 
 	zlog_info("%s: Left AutoRP announcement group %pPA on interface %s", __func__, &grp,
 		  ifp->name);
-
 	return true;
+}
+
+static void pim_autorp_ifp_groups_apply(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_autorp *autorp;
+
+	if (!autorp_is_pim_interface(ifp) || !pim_ifp || !pim_ifp->pim || !pim_ifp->pim->autorp)
+		return;
+
+	autorp = pim_ifp->pim->autorp;
+	if (autorp->sock == -1)
+		return;
+
+	if (autorp->do_discovery) {
+		if (!pim_ifp->autorp_joined_discovery && pim_autorp_ifp_join_discovery(ifp))
+			pim_ifp->autorp_joined_discovery = true;
+	} else if (pim_ifp->autorp_joined_discovery) {
+		if (pim_autorp_ifp_leave_discovery(ifp))
+			pim_ifp->autorp_joined_discovery = false;
+	}
+
+	if (autorp->send_rp_discovery) {
+		if (!pim_ifp->autorp_joined_announce && pim_autorp_ifp_join_announce(ifp))
+			pim_ifp->autorp_joined_announce = true;
+	} else if (pim_ifp->autorp_joined_announce) {
+		if (pim_autorp_ifp_leave_announce(ifp))
+			pim_ifp->autorp_joined_announce = false;
+	}
+}
+
+static void pim_autorp_groups_apply(struct pim_autorp *autorp)
+{
+	struct interface *ifp;
+
+	FOR_ALL_INTERFACES (autorp->pim->vrf, ifp)
+		pim_autorp_ifp_groups_apply(ifp);
+}
+
+static void pim_autorp_leave_all_groups(struct pim_autorp *autorp)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	if (autorp->sock == -1)
+		return;
+
+	FOR_ALL_INTERFACES (autorp->pim->vrf, ifp) {
+		pim_ifp = ifp->info;
+		if (!pim_ifp)
+			continue;
+
+		if (pim_ifp->autorp_joined_discovery) {
+			pim_autorp_ifp_leave_discovery(ifp);
+			pim_ifp->autorp_joined_discovery = false;
+		}
+		if (pim_ifp->autorp_joined_announce) {
+			pim_autorp_ifp_leave_announce(ifp);
+			pim_ifp->autorp_joined_announce = false;
+		}
+	}
+}
+
+static bool pim_autorp_socket_disable(struct pim_autorp *autorp);
+static void pim_autorp_maybe_close_socket(struct pim_autorp *autorp)
+{
+	if (pim_autorp_should_close(autorp) && !pim_autorp_socket_disable(autorp))
+		zlog_warn("%s: AutoRP failed to close socket", __func__);
+}
+
+static void autorp_read_on(struct pim_autorp *autorp);
+static void autorp_read_off(struct pim_autorp *autorp);
+
+static bool pim_autorp_should_read(struct pim_autorp *autorp)
+{
+	return autorp->do_discovery || autorp->send_rp_discovery;
+}
+
+static void pim_autorp_read_apply(struct pim_autorp *autorp)
+{
+	if (autorp->sock == -1)
+		return;
+
+	if (pim_autorp_should_read(autorp))
+		autorp_read_on(autorp);
+	else
+		autorp_read_off(autorp);
 }
 
 static bool pim_autorp_setup(int fd)
@@ -1027,9 +1125,7 @@ static void autorp_send_discovery_off(struct pim_autorp *autorp)
 			zlog_debug("%s: AutoRP discovery sending disabled", __func__);
 	event_cancel(&(autorp->send_discovery_timer));
 
-	/* Close the socket if we need to */
-	if (pim_autorp_should_close(autorp) && !pim_autorp_socket_disable(autorp))
-		zlog_warn("%s: AutoRP failed to close socket", __func__);
+	pim_autorp_maybe_close_socket(autorp);
 }
 
 static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint16_t holdtime,
@@ -1358,8 +1454,11 @@ static bool pim_autorp_socket_enable(struct pim_autorp *autorp)
 	struct interface *ifp;
 
 	/* Return early if socket is already enabled */
-	if (autorp->sock != -1)
+	if (autorp->sock != -1) {
+		pim_autorp_groups_apply(autorp);
+		pim_autorp_read_apply(autorp);
 		return true;
+	}
 
 	frr_with_privs (&pimd_privs) {
 		fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
@@ -1394,14 +1493,14 @@ static bool pim_autorp_socket_enable(struct pim_autorp *autorp)
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP socket enabled (fd=%u)", __func__, fd);
 
-	if (autorp->do_discovery)
-		autorp_read_on(autorp);
+	pim_autorp_read_apply(autorp);
 
 	if (autorp->send_rp_discovery)
 		autorp_send_discovery_on(autorp);
 
-	/* Try to build a new announcement to make sure the send timer is enabled */
-	pim_autorp_new_announcement(autorp->pim);
+	/* Restart candidate announcements after socket re-open (e.g. interface flap). */
+	if (pim_autorp_rp_count(&autorp->candidate_rp_list) > 0)
+		pim_autorp_new_announcement(autorp->pim);
 
 	return true;
 }
@@ -1409,21 +1508,25 @@ static bool pim_autorp_socket_enable(struct pim_autorp *autorp)
 static void autorp_announcement_off(struct pim_autorp *autorp);
 static bool pim_autorp_socket_disable(struct pim_autorp *autorp)
 {
-	/* Return early if socket is already disabled */
+	int fd;
+
 	if (autorp->sock == -1)
 		return true;
 
-	/* No need to leave the autorp groups explicitly, they are left when the socket is closed */
-	if (close(autorp->sock)) {
-		zlog_warn("Failure closing autorp socket: fd=%d errno=%d: %s", autorp->sock, errno,
+	fd = autorp->sock;
+
+	autorp_read_off(autorp);
+	event_cancel(&(autorp->send_discovery_timer));
+	event_cancel(&(autorp->announce_timer));
+	pim_autorp_leave_all_groups(autorp);
+
+	autorp->sock = -1;
+
+	if (close(fd)) {
+		zlog_warn("Failure closing autorp socket: fd=%d errno=%d: %s", fd, errno,
 			  safe_strerror(errno));
 		return false;
 	}
-
-	autorp_send_discovery_off(autorp);
-	autorp_announcement_off(autorp);
-	autorp_read_off(autorp);
-	autorp->sock = -1;
 
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP socket disabled", __func__);
@@ -1508,9 +1611,7 @@ static void autorp_announcement_off(struct pim_autorp *autorp)
 			zlog_debug("%s: AutoRP announcement sending disabled", __func__);
 	event_cancel(&(autorp->announce_timer));
 
-	/* Close the socket if we need to */
-	if (pim_autorp_should_close(autorp) && !pim_autorp_socket_disable(autorp))
-		zlog_warn("%s: AutoRP failed to close socket", __func__);
+	pim_autorp_maybe_close_socket(autorp);
 }
 
 /* Pack the groups of the RP
@@ -1846,8 +1947,18 @@ void pim_autorp_announce_holdtime(struct pim_instance *pim, int32_t holdtime)
 void pim_autorp_send_discovery_apply(struct pim_autorp *autorp)
 {
 	if (!autorp->mapping_agent_addrsel.run || !autorp->send_rp_discovery) {
+		pim_autorp_groups_apply(autorp);
+		pim_autorp_read_apply(autorp);
 		autorp_send_discovery_off(autorp);
 		return;
+	}
+
+	/* When the socket is already open, socket_enable is a no-op and will not
+	 * refresh group membership or the read callback.
+	 */
+	if (autorp->sock != -1) {
+		pim_autorp_groups_apply(autorp);
+		pim_autorp_read_apply(autorp);
 	}
 
 	autorp_send_discovery_on(autorp);
@@ -1855,14 +1966,8 @@ void pim_autorp_send_discovery_apply(struct pim_autorp *autorp)
 
 void pim_autorp_add_ifp(struct interface *ifp)
 {
-	/* Add a new interface for autorp
-	 *   When autorp is enabled, we must join the autorp groups on all
-	 *   pim/multicast interfaces. When autorp becomes enabled, it finds all
-	 *   current pim enabled interfaces and joins the autorp groups on them.
-	 *   Any new interfaces added after autorp is enabled will use this function
-	 *   to join the autorp groups
-	 * This is called even when adding a new pim interface that is not yet
-	 * active, so make sure the check, it'll call in again once the interface is up.
+	/* Add a new interface for autorp. Join only the AutoRP groups required
+	 * by the active features (discovery and/or mapping agent).
 	 */
 	struct pim_instance *pim;
 	struct pim_interface *pim_ifp;
@@ -1878,21 +1983,16 @@ void pim_autorp_add_ifp(struct interface *ifp)
 			}
 
 			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: Adding interface %s to AutoRP, joining AutoRP groups",
-					   __func__, ifp->name);
-			if (!pim_autorp_join_groups(ifp))
-				zlog_warn("Could not join AutoRP groups, errno=%d, %s", errno,
-					  safe_strerror(errno));
+				zlog_debug("%s: Adding interface %s to AutoRP", __func__,
+					   ifp->name);
+			pim_autorp_ifp_groups_apply(ifp);
 		}
 	}
 }
 
 void pim_autorp_rm_ifp(struct interface *ifp)
 {
-	/* Remove interface for autorp
-	 *   When an interface is no longer enabled for multicast, or at all, then
-	 *   we should leave the AutoRP groups on this interface.
-	 */
+	/* Remove interface for autorp: leave any joined AutoRP groups. */
 	struct pim_instance *pim;
 	struct pim_interface *pim_ifp;
 	struct pim_autorp *autorp = NULL;
@@ -1902,12 +2002,19 @@ void pim_autorp_rm_ifp(struct interface *ifp)
 		pim = pim_ifp->pim;
 		if (pim && pim->autorp) {
 			autorp = pim->autorp;
-			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: Removing interface %s from AutoRP, leaving AutoRP groups",
-					   __func__, ifp->name);
-			if (!pim_autorp_leave_groups(ifp))
-				zlog_warn("Could not leave AutoRP groups, errno=%d, %s", errno,
-					  safe_strerror(errno));
+			if (autorp->sock != -1) {
+				if (PIM_DEBUG_AUTORP)
+					zlog_debug("%s: Removing interface %s from AutoRP",
+						   __func__, ifp->name);
+				if (pim_ifp->autorp_joined_discovery) {
+					pim_autorp_ifp_leave_discovery(ifp);
+					pim_ifp->autorp_joined_discovery = false;
+				}
+				if (pim_ifp->autorp_joined_announce) {
+					pim_autorp_ifp_leave_announce(ifp);
+					pim_ifp->autorp_joined_announce = false;
+				}
+			}
 		}
 	}
 
@@ -1938,8 +2045,6 @@ void pim_autorp_start_discovery(struct pim_instance *pim)
 		return;
 	}
 
-	autorp_read_on(autorp);
-
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP Discovery started", __func__);
 }
@@ -1952,16 +2057,15 @@ void pim_autorp_stop_discovery(struct pim_instance *pim)
 		return;
 
 	autorp->do_discovery = false;
-	autorp_read_off(autorp);
 
 	pim_autorp_rplist_free(&autorp->discovery_rp_list, true);
+	pim_autorp_groups_apply(autorp);
+	pim_autorp_read_apply(autorp);
 
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP Discovery stopped", __func__);
 
-	/* Close the socket if we need to */
-	if (pim_autorp_should_close(autorp) && !pim_autorp_socket_disable(autorp))
-		zlog_warn("%s: AutoRP failed to close socket", __func__);
+	pim_autorp_maybe_close_socket(autorp);
 }
 
 void pim_autorp_init(struct pim_instance *pim)

--- a/pimd/pim_autorp.h
+++ b/pimd/pim_autorp.h
@@ -120,6 +120,9 @@ struct pim_autorp {
 	/* Flag enabling reading discovery packets */
 	bool do_discovery;
 
+	/* True once northbound has explicitly set discovery-enabled. */
+	bool discovery_cfg_set;
+
 	/* Flag enabling mapping agent (reading announcements and sending discovery)*/
 	bool send_rp_discovery;
 
@@ -178,6 +181,8 @@ void pim_autorp_add_ifp(struct interface *ifp);
 void pim_autorp_rm_ifp(struct interface *ifp);
 void pim_autorp_start_discovery(struct pim_instance *pim);
 void pim_autorp_stop_discovery(struct pim_instance *pim);
+void pim_autorp_discovery_cfg_destroy(struct pim_instance *pim);
+void pim_autorp_discovery_apply_finish(struct pim_instance *pim);
 void pim_autorp_init(struct pim_instance *pim);
 void pim_autorp_enable(struct pim_instance *pim);
 void pim_autorp_finish(struct pim_instance *pim);

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -204,6 +204,9 @@ struct pim_interface {
 	uint32_t igmp_ifstat_joins_failed;
 	uint32_t igmp_peak_group_count;
 
+	bool autorp_joined_discovery;
+	bool autorp_joined_announce;
+
 	struct {
 		bool enabled;
 		uint32_t min_rx;

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -21,6 +21,9 @@ const struct frr_yang_module_info frr_pim_info = {
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_pim_address_family_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_pim_address_family_destroy,
+#if PIM_IPV == 4
+				.apply_finish = routing_control_plane_protocols_control_plane_protocol_pim_address_family_apply_finish,
+#endif
 			}
 		},
 		{
@@ -591,6 +594,14 @@ const struct frr_yang_module_info frr_pim_rp_info = {
 				.modify = pim_embedded_rp_maximum_rps_modify,
 			}
 		},
+#if PIM_IPV == 4
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/frr-pim-rp:rp/auto-rp",
+			.cbs = {
+				.apply_finish = routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_auto_rp_apply_finish,
+			}
+		},
+#endif
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/frr-pim-rp:rp/auto-rp/discovery-enabled",
 			.cbs = {

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -206,6 +206,12 @@ int pim_embedded_rp_enable_modify(struct nb_cb_modify_args *args);
 int pim_embedded_rp_group_list_modify(struct nb_cb_modify_args *args);
 int pim_embedded_rp_group_list_destroy(struct nb_cb_destroy_args *args);
 int pim_embedded_rp_maximum_rps_modify(struct nb_cb_modify_args *args);
+#if PIM_IPV == 4
+void routing_control_plane_protocols_control_plane_protocol_pim_address_family_apply_finish(
+	struct nb_cb_apply_finish_args *args);
+void routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_auto_rp_apply_finish(
+	struct nb_cb_apply_finish_args *args);
+#endif
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_auto_rp_discovery_enabled_modify(
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_auto_rp_discovery_enabled_destroy(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -3672,6 +3672,46 @@ pim6_autorp_err(
 
 #if PIM_IPV == 4
 /*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family
+ */
+void routing_control_plane_protocols_control_plane_protocol_pim_address_family_apply_finish(
+	struct nb_cb_apply_finish_args *args)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+
+	vrf = nb_running_get_entry(args->dnode, NULL, true);
+	pim = vrf->info;
+	if (!pim || !pim->autorp)
+		return;
+
+	/* auto-rp apply_finish handles discovery when that container exists. */
+	if (yang_dnode_exists(args->dnode, "./frr-pim-rp:rp/auto-rp"))
+		return;
+
+	pim_autorp_discovery_apply_finish(pim);
+}
+
+/*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/frr-pim-rp:rp/auto-rp
+ */
+void routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_auto_rp_apply_finish(
+	struct nb_cb_apply_finish_args *args)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+
+	vrf = nb_running_get_entry(args->dnode, NULL, true);
+	pim = vrf->info;
+	if (!pim)
+		return;
+
+	pim_autorp_discovery_apply_finish(pim);
+}
+
+/*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/frr-pim-rp:rp/auto-rp/discovery-enabled
  */
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp_auto_rp_discovery_enabled_modify(
@@ -3689,6 +3729,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 	case NB_EV_APPLY:
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pim = vrf->info;
+		if (!pim->autorp)
+			break;
+		pim->autorp->discovery_cfg_set = true;
 		enabled = yang_dnode_get_bool(args->dnode, NULL);
 		if (enabled)
 			pim_autorp_start_discovery(pim);
@@ -3713,8 +3756,7 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 	case NB_EV_APPLY:
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pim = vrf->info;
-		/* Run AutoRP discovery by default */
-		pim_autorp_start_discovery(pim);
+		pim_autorp_discovery_cfg_destroy(pim);
 		break;
 	}
 

--- a/tests/topotests/pim_autorp/test_pim_autorp.py
+++ b/tests/topotests/pim_autorp/test_pim_autorp.py
@@ -449,6 +449,93 @@ def test_pim_autorp_discovery_rp(request):
         )
 
 
+def test_pim_autorp_discovery_disable_purge_rp(request):
+    "Test learned AutoRP RPs are removed when discovery is disabled"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.routers()["r3"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp announce 10.0.0.2 224.0.0.0/4
+          autorp announce scope 31 interval 1 holdtime 60
+        """
+    )
+    tgen.routers()["r1"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp send-rp-discovery source interface r1-eth0
+          autorp send-rp-discovery scope 31 interval 1 holdtime 60
+        """
+    )
+
+    step("Verify AutoRP learned RP on r2")
+    expected = json.loads(
+        """
+        {
+          "10.0.3.4":[
+            {
+              "rpAddress":"10.0.3.4",
+              "group":"224.0.1.0/24",
+              "source":"Static"
+            }
+          ],
+          "10.0.0.2":[
+            {
+              "rpAddress":"10.0.0.2",
+              "group":"224.0.0.0/4",
+              "source":"AutoRP"
+            }
+          ]
+        }"""
+    )
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r2"],
+        "show ip pim rp-info json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, "r2 does not have correct rp-info before disable"
+
+    step("Disable AutoRP discovery on r2")
+    tgen.routers()["r2"].vtysh_cmd(
+        """
+        conf
+         router pim
+          no autorp discovery
+        """
+    )
+
+    step("Verify learned AutoRP RP is removed immediately on r2")
+    expected = json.loads(
+        """
+        {
+          "10.0.3.4":[
+            {
+              "rpAddress":"10.0.3.4",
+              "group":"224.0.1.0/24",
+              "source":"Static"
+            }
+          ]
+        }"""
+    )
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r2"],
+        "show ip pim rp-info json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, "r2 did not purge learned AutoRP RP after disable"
+
+
 def test_pim_autorp_discovery_multiple_rp_same(request):
     "Test PIM AutoRP Discovery with multiple RP's for same group prefix"
     tgen = get_topogen()

--- a/tests/topotests/pim_autorp/test_pim_autorp.py
+++ b/tests/topotests/pim_autorp/test_pim_autorp.py
@@ -167,18 +167,18 @@ def test_pim_autorp_disable_enable(request):
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    step("Ensure AutoRP groups are joined on all routers")
+    step("Ensure AutoRP discovery group is joined on all routers")
     for rtr in ["r1", "r2", "r3", "r4"]:
         expected = {
             f"{rtr}-eth0": {
                 "name": f"{rtr}-eth0",
-                "224.0.1.39": "*",
                 "224.0.1.40": "*",
+                "224.0.1.39": None,
             },
             f"{rtr}-eth1": {
                 "name": f"{rtr}-eth1",
-                "224.0.1.39": "*",
                 "224.0.1.40": "*",
+                "224.0.1.39": None,
             },
         }
 
@@ -228,18 +228,18 @@ def test_pim_autorp_disable_enable(request):
             """
         )
 
-    step("Ensure AutoRP groups are re-joined on all routers")
+    step("Ensure AutoRP discovery group is re-joined on all routers")
     for rtr in ["r1", "r2", "r3", "r4"]:
         expected = {
             f"{rtr}-eth0": {
                 "name": f"{rtr}-eth0",
-                "224.0.1.39": "*",
                 "224.0.1.40": "*",
+                "224.0.1.39": None,
             },
             f"{rtr}-eth1": {
                 "name": f"{rtr}-eth1",
-                "224.0.1.39": "*",
                 "224.0.1.40": "*",
+                "224.0.1.39": None,
             },
         }
 
@@ -252,6 +252,148 @@ def test_pim_autorp_disable_enable(request):
         _, result = topotest.run_and_expect(test_func, None)
         assert result is None, "{} does not have correct autorp groups joined".format(
             rtr
+        )
+
+
+def test_pim_autorp_selective_group_joins(request):
+    "Test AutoRP IGMP joins follow active features only"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Disable discovery everywhere first so neighbor IGMP reports on the shared
+    # LANs do not mask whether this router joined Auto-RP groups locally.
+    step("Disable AutoRP discovery on all routers")
+    for rtr in ["r1", "r2", "r3", "r4"]:
+        tgen.routers()[rtr].vtysh_cmd(
+            """
+            conf
+             router pim
+              no autorp discovery
+            """
+        )
+
+    step("Verify AutoRP groups are gone on all routers")
+    for rtr in ["r1", "r2", "r3", "r4"]:
+        expected = {f"{rtr}-eth0": None, f"{rtr}-eth1": None}
+        test_func = partial(
+            topotest.router_json_cmp,
+            tgen.gears[rtr],
+            "show ip igmp sources json",
+            expected,
+        )
+        _, result = topotest.run_and_expect(test_func, None)
+        assert result is None, "{} still shows AutoRP IGMP groups".format(rtr)
+
+    step("Configure candidate-only on r2")
+    tgen.routers()["r2"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp announce 10.0.0.2 224.0.0.0/4
+          autorp announce scope 31 interval 1 holdtime 5
+        """
+    )
+
+    step("Verify candidate-only router does not join AutoRP groups")
+    expected = {"r2-eth0": None, "r2-eth1": None}
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r2"],
+        "show ip igmp sources json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, "r2 joined AutoRP groups as candidate-only"
+
+    step("Configure mapping-agent-only on r1")
+    tgen.routers()["r1"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp send-rp-discovery source interface r1-eth0
+          autorp send-rp-discovery scope 31 interval 1 holdtime 5
+        """
+    )
+
+    step("Verify mapping-agent router joins only the announcement group")
+    expected = {
+        "r1-eth0": {
+            "name": "r1-eth0",
+            "224.0.1.39": "*",
+            "224.0.1.40": None,
+        },
+        "r1-eth1": {
+            "name": "r1-eth1",
+            "224.0.1.39": "*",
+            "224.0.1.40": None,
+        },
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show ip igmp sources json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, "r1 has incorrect AutoRP group joins as mapping-agent-only"
+
+    step("Re-enable discovery on r1 and verify both groups are joined")
+    tgen.routers()["r1"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp discovery
+        """
+    )
+    expected = {
+        "r1-eth0": {
+            "name": "r1-eth0",
+            "224.0.1.39": "*",
+            "224.0.1.40": "*",
+        },
+        "r1-eth1": {
+            "name": "r1-eth1",
+            "224.0.1.39": "*",
+            "224.0.1.40": "*",
+        },
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show ip igmp sources json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert (
+        result is None
+    ), "r1 does not have both AutoRP groups after re-enabling discovery"
+
+    step("Restore default AutoRP state for following tests")
+    tgen.routers()["r1"].vtysh_cmd(
+        """
+        conf
+         router pim
+          no autorp send-rp-discovery
+        """
+    )
+    tgen.routers()["r2"].vtysh_cmd(
+        """
+        conf
+         router pim
+          no autorp announce 10.0.0.2 224.0.0.0/4
+        """
+    )
+    for rtr in ["r1", "r2", "r3", "r4"]:
+        tgen.routers()[rtr].vtysh_cmd(
+            """
+            conf
+             router pim
+              autorp discovery
+            """
         )
 
 
@@ -463,7 +605,7 @@ def test_pim_autorp_discovery_disable_purge_rp(request):
         conf
          router pim
           autorp announce 10.0.0.2 224.0.0.0/4
-          autorp announce scope 31 interval 1 holdtime 60
+          autorp announce scope 31 interval 1 holdtime 5
         """
     )
     tgen.routers()["r1"].vtysh_cmd(
@@ -471,7 +613,7 @@ def test_pim_autorp_discovery_disable_purge_rp(request):
         conf
          router pim
           autorp send-rp-discovery source interface r1-eth0
-          autorp send-rp-discovery scope 31 interval 1 holdtime 60
+          autorp send-rp-discovery scope 31 interval 1 holdtime 5
         """
     )
 
@@ -534,6 +676,22 @@ def test_pim_autorp_discovery_disable_purge_rp(request):
     )
     _, result = topotest.run_and_expect(test_func, None)
     assert result is None, "r2 did not purge learned AutoRP RP after disable"
+
+    step("Restore AutoRP state for following tests")
+    tgen.routers()["r2"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp discovery
+        """
+    )
+    tgen.routers()["r1"].vtysh_cmd(
+        """
+        conf
+         router pim
+          autorp send-rp-discovery scope 31 interval 1 holdtime 5
+        """
+    )
 
 
 def test_pim_autorp_discovery_multiple_rp_same(request):


### PR DESCRIPTION
* Purge learned AutoRP RPs when discovery is disabled. `no autorp discovery` now clears discovery_rp_list immediately instead of waiting for hold timers (default ~180s) to expire.
* Join AutoRP multicast groups based on active role. Routers join only the groups needed to receive Auto-RP traffic:
  - autorp discovery → 224.0.1.40
  - autorp send-rp-discovery (mapping agent) → 224.0.1.39
  - autorp announce (candidate only) → neither
* Fix AutoRP socket lifecycle bugs. Avoid recursive socket close during candidate RP reconfiguration and keep the socket open while candidate RPs are configured.
* Tests and docs. Topotest coverage for RP purge and selective joins; user guide updated for discovery purge behavior and autorp send-rp-discovery.