### PR TITLE
tests: fix grpc topotest xdist collection mismatch in CI 

### DIFF
--- a/tests/topotests/analyze.py
+++ b/tests/topotests/analyze.py
@@ -18,6 +18,9 @@ from collections import OrderedDict
 
 import xmltodict
 
+# pytest-xdist collection errors use the worker id (e.g. gw5) as @name.
+XDIST_WORKER_RE = re.compile(r"^gw\d+$")
+
 
 def get_range_list(rangestr):
     result = []
@@ -124,6 +127,8 @@ def get_filtered(tfilters, results, args):
             if not fname and not cname:
                 name = testcase.get("@name", "")
                 if not name:
+                    continue
+                if XDIST_WORKER_RE.match(name):
                     continue
                 # If we had a failure at the module level we could be here.
                 fname = name.replace(".", "/") + ".py"

--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -17,7 +17,6 @@ import sys
 
 import pytest
 from lib.common_config import step
-from lib.micronet import commander
 from lib.topogen import Topogen, TopoRouter
 from lib.topotest import json_cmp
 
@@ -48,13 +47,6 @@ try:
 except ImportError:
     pytest.skip(
         "skipping; gRPC modules not installed", allow_module_level=True
-    )
-
-try:
-    commander.cmd_raises([script_path, "--check"])
-except Exception:
-    pytest.skip(
-        "skipping; cannot create or import gRPC proto modules", allow_module_level=True
     )
 
 

--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -9,6 +9,7 @@
 test_basic_grpc.py: Test Basic gRPC.
 """
 
+import glob
 import json
 import logging
 import os
@@ -41,12 +42,45 @@ pytestmark = [
 
 script_path = os.path.realpath(os.path.join(CWD, "../lib/grpc-query.py"))
 
+
+def _frr_grpc_module_available():
+    """True when the FRR northbound gRPC module (grpc.so) is installed."""
+    patterns = (
+        "/usr/lib/*/frr/modules/grpc.so",
+        "/usr/lib/frr/modules/grpc.so",
+        "/usr/lib64/*/frr/modules/grpc.so",
+        "/usr/lib64/frr/modules/grpc.so",
+        "/usr/local/lib/*/frr/modules/grpc.so",
+        "/usr/local/lib/frr/modules/grpc.so",
+    )
+    for pattern in patterns:
+        for path in glob.glob(pattern):
+            if os.path.isfile(path):
+                return True
+
+    frr_root = os.path.realpath(os.path.join(CWD, "../../.."))
+    for base in (frr_root, os.environ.get("FRR_BUILD_DIR")):
+        if not base:
+            continue
+        for rel in ("lib/.libs/grpc.so", "lib/grpc.so"):
+            if os.path.isfile(os.path.join(base, rel)):
+                return True
+    return False
+
+
 try:
     import grpc  # noqa: F401
     import grpc_tools  # noqa: F401
 except ImportError:
     pytest.skip(
         "skipping; gRPC modules not installed", allow_module_level=True
+    )
+
+if not _frr_grpc_module_available():
+    pytest.skip(
+        "skipping; FRR gRPC northbound module not installed "
+        "(install frr-grpc or build with --enable-grpc)",
+        allow_module_level=True,
     )
 
 


### PR DESCRIPTION
Fix intermittent CI topotest failures where pytest-xdist aborts with Different tests were collected between gw0 and gw5 because grpc_basic was collected on some workers but module-skipped on others.

Example CI failure [here](https://github.com/FRRouting/frr/actions/runs/26351533992/job/77570891165?pr=22039)