### PR TITLE
tests: fix flaky IGMP source baseline in pim_boundary_acl

### DIFF
--- a/tests/topotests/pim_boundary_acl/test_pim_boundary_acl.py
+++ b/tests/topotests/pim_boundary_acl/test_pim_boundary_acl.py
@@ -28,8 +28,24 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-ASM_GROUP="229.1.1.1"
-SSM_GROUP="232.1.1.1"
+ASM_GROUP = "229.1.1.1"
+SSM_GROUP = "232.1.1.1"
+
+
+def verify_no_igmp_source(router, group, interface=None):
+    """Return None when group has no IGMP source entries on router."""
+    output = router.vtysh_cmd("show ip igmp sources json", isjson=True)
+    if interface:
+        iface = output.get(interface, {})
+        if group in iface:
+            return "Unexpected IGMP source for {} on {}".format(group, interface)
+        return None
+
+    for ifname, iface in output.items():
+        if isinstance(iface, dict) and group in iface:
+            return "Unexpected IGMP source for {} on {}".format(group, ifname)
+    return None
+
 
 def build_topo(tgen):
     "Build function"
@@ -101,12 +117,8 @@ def test_pim_rp_setup():
 
     r1 = tgen.gears["r1"]
     expected = {
-        "10.254.0.3":[
-            {
-                "outboundInterface":"r1-eth1",
-                "group":"224.0.0.0/4",
-                "source":"Static"
-            }
+        "10.254.0.3": [
+            {"outboundInterface": "r1-eth1", "group": "224.0.0.0/4", "source": "Static"}
         ]
     }
 
@@ -131,43 +143,34 @@ def test_pim_asm_igmp_join_acl():
     r2 = tgen.gears["r2"]
     r1 = tgen.gears["r1"]
 
-    # No IGMP sources other than from self for AutoRP Discovery group initially
-    expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "229.1.1.1":None
-        },
-        "r1-eth2":{
-            "name":"r1-eth2",
-            "229.1.1.1":None
-        }
-    }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip igmp sources json", expected
-    )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
-    assert result is None, "Expected no IGMP sources other than for AutoRP Discovery"
+    # No IGMP sources for the ASM test group initially. Interfaces with
+    # no sources are omitted from "show ip igmp sources json" output.
+    test_func = partial(verify_no_igmp_source, r1, ASM_GROUP)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected no IGMP sources for {}".format(ASM_GROUP)
 
     # Send IGMP join from r2, check if r1 has IGMP source
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface {}
               ip igmp join {}
         """
-    ).format("r2-eth0", ASM_GROUP))
+        ).format("r2-eth0", ASM_GROUP)
+    )
     expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "229.1.1.1":{
-                "group":"229.1.1.1",
-                "sources":[
+        "r1-eth0": {
+            "name": "r1-eth0",
+            "229.1.1.1": {
+                "group": "229.1.1.1",
+                "sources": [
                     {
-                        "source":"*",
-                        "forwarded":False,
+                        "source": "*",
+                        "forwarded": False,
                     }
-                ]
-            }
+                ],
+            },
         }
     }
     test_func = partial(
@@ -178,13 +181,15 @@ def test_pim_asm_igmp_join_acl():
 
     # Test inbound boundary on r1
     # Enable multicast boundary on r1, toggle IGMP join on r2
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               no ip igmp join {}
         """
-    ).format(ASM_GROUP))
+        ).format(ASM_GROUP)
+    )
     r1.vtysh_cmd(
         """
           configure terminal
@@ -192,40 +197,34 @@ def test_pim_asm_igmp_join_acl():
               ip multicast boundary oil pim-oil-plist
         """
     )
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               ip igmp join {}
         """
-    ).format(ASM_GROUP))
-    expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "229.1.1.1":None
-        }
-    }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip igmp sources json", expected
+        ).format(ASM_GROUP)
     )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    test_func = partial(verify_no_igmp_source, r1, ASM_GROUP, "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
     assert result is None, "Expected IGMP source to be absent but is present"
 
     # Test outbound boundary on r2
     # Enable multicast boundary on r2, toggle IGMP join (test outbound)
     # Note: json_cmp treats "*" as wildcard but in this case that's actually what the source is
     expected = {
-        "vrf":"default",
-        "r2-eth0":{
-            "name":"r2-eth0",
-            "groups":[
+        "vrf": "default",
+        "r2-eth0": {
+            "name": "r2-eth0",
+            "groups": [
                 {
-                    "source":"*",
-                    "group":"229.1.1.1",
-                    "primaryAddr":"10.0.20.2",
+                    "source": "*",
+                    "group": "229.1.1.1",
+                    "primaryAddr": "10.0.20.2",
                 }
-            ]
-        }
+            ],
+        },
     }
     test_func = partial(
         topotest.router_json_cmp, r2, "show ip igmp join json", expected
@@ -233,19 +232,18 @@ def test_pim_asm_igmp_join_acl():
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "Expected IGMP join to be present but is absent"
 
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               no ip igmp join {}
               ip multicast boundary oil pim-oil-plist
               ip igmp join {}
         """
-    ).format(ASM_GROUP, ASM_GROUP))
-    expected = {
-        "vrf":"default",
-        "r2-eth0":None
-    }
+        ).format(ASM_GROUP, ASM_GROUP)
+    )
+    expected = {"vrf": "default", "r2-eth0": None}
     test_func = partial(
         topotest.router_json_cmp, r2, "show ip igmp join json", expected
     )
@@ -253,14 +251,23 @@ def test_pim_asm_igmp_join_acl():
     assert result is None, "Expected IGMP join to be absent but is present"
 
     # Cleanup
-    r2.vtysh_cmd((
+    r1.vtysh_cmd(
         """
+          configure terminal
+            interface r1-eth0
+              no ip multicast boundary oil pim-oil-plist
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               no ip igmp join {}
               no ip multicast boundary oil pim-oil-plist
         """
-    ).format(ASM_GROUP))
+        ).format(ASM_GROUP)
+    )
 
 
 def test_pim_ssm_igmp_join_acl():
@@ -276,45 +283,33 @@ def test_pim_ssm_igmp_join_acl():
     r2 = tgen.gears["r2"]
     r1 = tgen.gears["r1"]
 
-    # No IGMP sources other than from self for AutoRP Discovery group initially
-    expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "229.1.1.1":None,
-            "232.1.1.1":None
-        },
-        "r1-eth2":{
-            "name":"r1-eth2",
-            "229.1.1.1":None,
-            "232.1.1.1":None
-        }
-    }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip igmp sources json", {}
-    )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
-    assert result is None, "Expected no IGMP sources other than from AutoRP Discovery"
+    # No IGMP sources for the SSM test group initially.
+    test_func = partial(verify_no_igmp_source, r1, SSM_GROUP)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected no IGMP sources for {}".format(SSM_GROUP)
 
     # Send IGMP join from r2, check if r1 has IGMP source
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               ip igmp join {} 10.0.20.2
         """
-    ).format(SSM_GROUP))
+        ).format(SSM_GROUP)
+    )
     expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "232.1.1.1":{
-                "group":"232.1.1.1",
-                "sources":[
+        "r1-eth0": {
+            "name": "r1-eth0",
+            "232.1.1.1": {
+                "group": "232.1.1.1",
+                "sources": [
                     {
-                        "source":"10.0.20.2",
-                        "forwarded":False,
+                        "source": "10.0.20.2",
+                        "forwarded": False,
                     }
-                ]
-            }
+                ],
+            },
         }
     }
     test_func = partial(
@@ -325,13 +320,15 @@ def test_pim_ssm_igmp_join_acl():
 
     # Test inbound boundary on r1
     # Enable multicast boundary on r1, toggle IGMP join on r2
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               no ip igmp join {} 10.0.20.2
         """
-    ).format(SSM_GROUP))
+        ).format(SSM_GROUP)
+    )
     r1.vtysh_cmd(
         """
           configure terminal
@@ -339,58 +336,58 @@ def test_pim_ssm_igmp_join_acl():
               ip multicast boundary pim-acl
         """
     )
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               ip igmp join {} 10.0.20.2
         """
-    ).format(SSM_GROUP))
-    expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "232.1.1.1":None
-        }
-    }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip igmp sources json", expected
+        ).format(SSM_GROUP)
     )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    test_func = partial(verify_no_igmp_source, r1, SSM_GROUP, "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
     assert result is None, "Expected IGMP source to be absent but is present"
 
     # Add lower, more-specific permit rule to access-list
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               no ip igmp join {} 10.0.20.2
         """
-    ).format(SSM_GROUP))
-    r1.vtysh_cmd((
-        """
+        ).format(SSM_GROUP)
+    )
+    r1.vtysh_cmd(
+        (
+            """
           configure terminal
             access-list pim-acl seq 5 permit ip host 10.0.20.2 {} 0.0.0.128
         """
-    ).format(SSM_GROUP))
-    r2.vtysh_cmd((
-        """
+        ).format(SSM_GROUP)
+    )
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               ip igmp join {} 10.0.20.2
         """
-    ).format(SSM_GROUP))
+        ).format(SSM_GROUP)
+    )
     expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "232.1.1.1":{
-                "group":"232.1.1.1",
-                "sources":[
+        "r1-eth0": {
+            "name": "r1-eth0",
+            "232.1.1.1": {
+                "group": "232.1.1.1",
+                "sources": [
                     {
-                        "source":"10.0.20.2",
-                        "forwarded":False,
+                        "source": "10.0.20.2",
+                        "forwarded": False,
                     }
-                ]
-            }
+                ],
+            },
         }
     }
     test_func = partial(
@@ -402,17 +399,17 @@ def test_pim_ssm_igmp_join_acl():
     # Test outbound boundary on r2
     # Enable multicast boundary on r2, toggle IGMP join (test outbound)
     expected = {
-        "vrf":"default",
-        "r2-eth0":{
-            "name":"r2-eth0",
-            "groups":[
+        "vrf": "default",
+        "r2-eth0": {
+            "name": "r2-eth0",
+            "groups": [
                 {
-                    "source":"10.0.20.2",
-                    "group":"232.1.1.1",
-                    "primaryAddr":"10.0.20.2",
+                    "source": "10.0.20.2",
+                    "group": "232.1.1.1",
+                    "primaryAddr": "10.0.20.2",
                 }
-            ]
-        }
+            ],
+        },
     }
     test_func = partial(
         topotest.router_json_cmp, r2, "show ip igmp join json", expected
@@ -421,73 +418,63 @@ def test_pim_ssm_igmp_join_acl():
     assert result is None, "Expected IGMP join to be present but is absent"
 
     # Enable boundary ACL, check join is absent
-    r2.vtysh_cmd((
-        """
+    r2.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r2-eth0
               no ip igmp join {} 10.0.20.2
               ip multicast boundary pim-acl
               ip igmp join {} 10.0.20.2
         """
-    ).format(SSM_GROUP, SSM_GROUP))
-    expected = {
-        "vrf":"default",
-        "r2-eth0":None
-    }
+        ).format(SSM_GROUP, SSM_GROUP)
+    )
+    expected = {"vrf": "default", "r2-eth0": None}
     test_func = partial(
         topotest.router_json_cmp, r2, "show ip igmp join json", expected
     )
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "Expected IGMP join to be absent but is present"
     # Check sources on r1 again, should be absent even though we permitted it because r2 is blocking it outbound
-    expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "232.1.1.1":None
-        },
-        "r1-eth2":{
-            "name":"r1-eth2",
-            "232.1.1.1":None
-        }
-    }
-    test_func = partial(
-        topotest.router_json_cmp, r1, "show ip igmp sources json", expected
-    )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    test_func = partial(verify_no_igmp_source, r1, SSM_GROUP)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
     assert result is None, "Expected IGMP source to be absent but is present"
 
     # Send IGMP join from r3 with different source, should show up on r1
     # Add lower, more-specific permit rule to access-list
-    r3.vtysh_cmd((
-        """
+    r3.vtysh_cmd(
+        (
+            """
           configure terminal
             interface r3-eth0
               ip igmp join {} 10.0.40.4
         """
-    ).format(SSM_GROUP))
+        ).format(SSM_GROUP)
+    )
+
+    test_func = partial(verify_no_igmp_source, r1, SSM_GROUP, "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected IGMP source to be absent on r1-eth0"
+
     expected = {
-        "r1-eth0":{
-            "name":"r1-eth0",
-            "232.1.1.1":None
-        },
-        "r1-eth2":{
-            "name":"r1-eth2",
-            "232.1.1.1":{
-                "group":"232.1.1.1",
-                "sources":[
+        "r1-eth2": {
+            "name": "r1-eth2",
+            "232.1.1.1": {
+                "group": "232.1.1.1",
+                "sources": [
                     {
-                        "source":"10.0.40.4",
-                        "forwarded":False,
+                        "source": "10.0.40.4",
+                        "forwarded": False,
                     }
-                ]
-            }
-        }
+                ],
+            },
+        },
     }
     test_func = partial(
         topotest.router_json_cmp, r1, "show ip igmp sources json", expected
     )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
-    assert result is None, "Expected IGMP source to be present but is absent"
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected IGMP source to be present on r1-eth2"
 
     # PIM join
     # PIM-DM forwarding


### PR DESCRIPTION
test_pim_asm_igmp_join_acl intermittently failed at its opening check with "expected has key 'r1-eth0' which is not present in output". The test intent was correct (verify no IGMP source for the ASM/SSM group before sending joins), but the assertion did not match how FRR reports IGMP sources.

"show ip igmp sources json" only emits interface keys when that interface has at least one source entry. With no sources joined, the output is simply {}. The old expected dict required r1-eth0/r1-eth2 to exist with 229.1.1.1: None, which json_cmp interprets as "interface present, group key absent". That only passes when some other source keeps the interface in the JSON; an empty output is the normal no-source case and was incorrectly treated as failure.

Add verify_no_igmp_source() to assert directly on the property under test (group has no source entries), and use it for baseline and boundary-blocked negative checks. Keep router_json_cmp for positive presence checks after joins are sent. Also remove the inbound boundary from r1-eth0 during ASM test cleanup.