### PR TITLE
tests: harden bgp_conditional_advertisement_track_peer convergence waits

### DIFF
--- a/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
+++ b/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
@@ -107,6 +107,16 @@ def test_bgp_conditional_advertisement_track_peer():
     """
     )
 
+    def _bgp_check_r2_received_exist_route():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast 172.16.255.3/32 json"))
+        expected = {"paths": [{"valid": True}]}
+        return topotest.json_cmp(output, expected)
+
+    # Wait for the exist-map route before expecting conditional advertisement.
+    test_func = functools.partial(_bgp_check_r2_received_exist_route)
+    _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+    assert result is None, "R2 SHOULD receive 172.16.255.3/32 from R3"
+
     def _bgp_check_conditional_static_routes_from_r2():
         output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast json"))
         expected = {
@@ -116,13 +126,12 @@ def test_bgp_conditional_advertisement_track_peer():
         }
         return topotest.json_cmp(output, expected)
 
-    # Verify if R1 received 172.16.255.2/32 from R2
-    # The conditional-advertisement scanner is phase-locked at 5s intervals
-    # (see `bgp conditional-advertisement timer 5` in r2/bgpd.conf), so the
-    # worst-case wait is BGP session establishment + one full scanner cycle.
-    # Use a longer window to absorb that on slow CI hosts.
+    # Verify if R1 received 172.16.255.2/32 from R2. The conditional-advertisement
+    # scanner is phase-locked at 5s intervals (see r2/bgpd.conf); after the
+    # exist-map route is present, allow up to two full scanner cycles plus UPDATE
+    # propagation on loaded CI hosts (see doc/developer/topotests.rst).
     test_func = functools.partial(_bgp_check_conditional_static_routes_from_r2)
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assert result is None, "R1 SHOULD receive 172.16.255.2/32 from R2"
 
     step("Disable session between R2 and R3 again")
@@ -134,9 +143,19 @@ def test_bgp_conditional_advertisement_track_peer():
     """
     )
 
+    def _bgp_check_r2_withdrew_exist_route():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast 172.16.255.3/32 json"))
+        expected = {"paths": None}
+        return topotest.json_cmp(output, expected)
+
+    # Wait for the exist-map route to disappear before checking withdrawal.
+    test_func = functools.partial(_bgp_check_r2_withdrew_exist_route)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, "R2 SHOULD withdraw 172.16.255.3/32 from R3"
+
     # Verify if R2 is not sending any routes to R1 again
     test_func = functools.partial(_bgp_converge)
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assert result is None, "R2 SHOULD not send any routes to R1"
 
 


### PR DESCRIPTION
bgp_conditional_advertisement_track_peer.test_bgp_conditional_advertisement_track_peer fails intermittently on loaded CI hosts (e.g. AddressSanitizer Debian 12 amd64):

  AssertionError: R1 SHOULD receive 172.16.255.2/32 from R2

After enabling the R2-R3 session, R1 must learn 172.16.255.2/32 only once R2 receives the exist-map prefix 172.16.255.3/32 from R3 and the conditional advertisement scanner advertises the route. That path serializes:

  1. R2-R3 TCP/BGP session establishment
  2. R3 initial UPDATE -> peer->advmap_table_change on R2
  3. bgp_conditional_adv_timer firing (phase-locked to the configured 5s interval in r2/bgpd.conf)
  4. bgp_conditional_adv_routes() advertising to R1
  5. R1 installing the route

On a busy CI runner the scanner callback itself can fire late, and if a scan happens before R3 is Established no advmap_table_change is set yet, so a second scanner cycle may be required.

To fix the test:
- Poll for the exist-map route on R2 before expecting conditional advertisement on R1, and poll for its withdrawal before checking that R2 stops advertising to R1.
- Use count=130, wait=1 (130 seconds) for all post-action BGP convergence steps, matching other conditional-advertisement topotests.

