### PR TITLE
topotests: Fix tmux execution inside Docker containers

### DIFF
--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -45,6 +45,11 @@ if [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
 	TOPOTEST_OPTIONS        These options are appended to the docker-run
 	                        command for starting the tests.
 
+	TOPOTESTS_USE_HOST_TMUX Set automatically when launched from host tmux.
+	                        For custom docker/podman runs with host tmux, pass
+	                        -e TOPOTESTS_USE_HOST_TMUX=1 and bind-mount the
+	                        tmux socket directory.
+
 	TOPOTEST_SANITIZER      Controls whether to use the address sanitizer.
 	                        Enabled by default, set to 0 to disable.
 
@@ -122,7 +127,7 @@ if [ -z "$TOPOTEST_BUILDCACHE" ]; then
 fi
 
 if [[ -n "$TMUX" ]]; then
-    TMUX_OPTIONS="-v $(dirname $TMUX):$(dirname $TMUX) -e TMUX=$TMUX -e TMUX_PANE=$TMUX_PANE"
+    TMUX_OPTIONS="-v $(dirname $TMUX):$(dirname $TMUX) -e TMUX=$TMUX -e TMUX_PANE=$TMUX_PANE -e TOPOTESTS_USE_HOST_TMUX=1"
 fi
 
 if [[ -n "$STY" ]]; then

--- a/tests/topotests/munet/base.py
+++ b/tests/topotests/munet/base.py
@@ -9,6 +9,7 @@
 import asyncio
 import datetime
 import errno
+import functools
 import ipaddress
 import logging
 import os
@@ -45,6 +46,34 @@ PEXPECT_CONTINUATION_PROMPT = "PEXPECT_PROMPT+"
 
 root_hostname = subprocess.check_output("hostname")
 our_pid = os.getpid()
+
+
+@functools.lru_cache(maxsize=1)
+def get_docker_container_id():
+    """Detect if running inside Docker and return container ID.
+
+    Returns the Docker container ID if running inside a container, None otherwise.
+    Used with TOPOTESTS_USE_HOST_TMUX to prepend 'docker exec' when host tmux
+    panes run outside this container but namespaces live inside it.
+    """
+    try:
+        # Try cgroup v1 format first - check any cgroup subsystem, not just cpuset
+        with open("/proc/1/cgroup") as file:
+            cgroup = file.read()
+        m = re.search(r"[0-9]+:[^:]*:/docker/([a-f0-9]{64})", cgroup)
+        if m:
+            return m.group(1)
+
+        # For cgroup v2, check mountinfo for docker container path
+        with open("/proc/self/mountinfo") as file:
+            mountinfo = file.read()
+        m = re.search(r"/docker/containers/([a-f0-9]{64})/", mountinfo)
+        if m:
+            return m.group(1)
+
+    except (IOError, OSError):
+        pass
+    return None
 
 
 detailed_cmd_logging = False
@@ -1507,6 +1536,22 @@ class Commander:  # pylint: disable=R0904
                 + " "
                 + cmd
             )
+
+            # Host tmux panes run outside the container; wrap so nsenter reaches
+            # namespaces inside. Opt-in via TOPOTESTS_USE_HOST_TMUX (set by
+            # frr-topotests.sh when launched from host tmux).
+            if os.environ.get("TOPOTESTS_USE_HOST_TMUX"):
+                container_id = get_docker_container_id()
+                if container_id:
+                    docker_path = get_exec_path_host(["docker", "podman"])
+                    if not docker_path:
+                        docker_path = "/usr/bin/docker"
+                    nscmd = f"{docker_path} exec -it {container_id} {nscmd}"
+                else:
+                    logging.warning(
+                        "TOPOTESTS_USE_HOST_TMUX is set but container ID "
+                        "was not detected; tmux pane commands may fail"
+                    )
 
         if "TMUX" in os.environ and not forcex:
             cmd = [get_exec_path_host("tmux")]


### PR DESCRIPTION
Fixes: https://github.com/FRRouting/frr/issues/22065

## Summary

Fix topotest interactive tmux panes when the test process runs inside a Docker/Podman
container but tmux itself runs on the **host** (with the tmux socket bind-mounted into
the container).

## Problem

When topotests are launched via `frr-topotests.sh` from a **host** tmux session, pytest
and munet run inside the container where network namespaces exist. However, tmux creates
new panes on the **host**, so pane commands (including `nsenter` into router namespaces)
execute in the host context and cannot reach namespaces inside the container.

Typical reproduction:

1. Start tmux on the host (outside the topotest container).
2. Run a test with `--shell`, e.g.:
   ```bash
   ./tests/topotests/docker/frr-topotests.sh bgp_peer_group/test_bgp_peer-group.py --shell all
   ```
3. Router tmux panes do not work as expected (commands fail or panes do not appear).

Previous workaround: enter the container, start tmux **inside** it, then run pytest.

## Solution

This change is **opt-in** so tmux-inside-container workflows are unchanged.

### `TOPOTESTS_USE_HOST_TMUX`

- New environment variable, set automatically by `frr-topotests.sh` when `$TMUX` is
  present at launch (`-e TOPOTESTS_USE_HOST_TMUX=1`, together with the existing tmux
  socket bind-mount).
- Documented in `frr-topotests.sh --help` for custom docker/podman invocations: pass
  `-e TOPOTESTS_USE_HOST_TMUX=1` and bind-mount the tmux socket directory.

When `TOPOTESTS_USE_HOST_TMUX` is set **and** the test process is running inside a
container, commands built for tmux panes are wrapped with
`docker exec -it <container_id>` (or `podman exec`) so they run where the namespaces
live.

### `get_docker_container_id()`

Added in `munet/base.py` (cached with `@functools.lru_cache(maxsize=1)`) to detect
the current container ID:

- **cgroup v1:** `/proc/1/cgroup` — match `/docker/<64-char-hex-id>` on any cgroup
  subsystem (not limited to `cpuset`).
- **cgroup v2:** `/proc/self/mountinfo` — match `/docker/containers/<64-char-hex-id>/`.

Returns `None` if not inside a container or detection fails. If
`TOPOTESTS_USE_HOST_TMUX` is set but no container ID is found, a warning is logged and
pane commands are left unwrapped (they may still fail).

## What is **not** changed

- **Tmux running inside the dev container** is unaffected: without
  `TOPOTESTS_USE_HOST_TMUX`, no `docker exec` wrapping is applied.
- Existing `frr-topotests.sh` tmux socket bind-mount behavior is preserved; this PR only
  adds the env var on top of it.

## Files changed

- `tests/topotests/munet/base.py` — container detection helper; conditional `docker exec`
  wrapping in `run_in_window()`.
- `tests/topotests/docker/frr-topotests.sh` — set `TOPOTESTS_USE_HOST_TMUX=1` when
  launched from host tmux; document manual usage.

## Test plan

- [x] Host tmux + `frr-topotests.sh … --shell all` — router panes reach namespaces inside
      the container.
- [x] Tmux started **inside** the topotest container — still works (no regression).