### PR TITLE
bfdd: extend bfddp_session with SBFD/SRv6 fields

### DIFF
--- a/bfdd/bfddp_packet.h
+++ b/bfdd/bfddp_packet.h
@@ -14,6 +14,7 @@
 
 #include <netinet/in.h>
 
+#include <stddef.h>
 #include <stdint.h>
 
 /*
@@ -51,8 +52,16 @@
 #define BFD_SOURCE_PORT_BEGIN 49152
 #define BFD_SOURCE_PORT_END 65535
 
-/** BFD data plane protocol version. */
-#define BFD_DP_VERSION 1
+/**
+ * BFD data plane protocol version.
+ *
+ * Bumped to 2 because `struct bfddp_session` grows to carry appended
+ * SBFD/SRv6 fields. Existing fields keep their wire offsets, but the
+ * current check in `bfdd/dplane.c::bfd_dplane_read` is strict
+ * equality: a peer compiled against v1 is rejected outright. bfdd
+ * and any subscribers must therefore be rebuilt together.
+ */
+#define BFD_DP_VERSION 2
 
 /** BFD data plane message types. */
 enum bfddp_message_type {
@@ -171,7 +180,86 @@ struct bfddp_session {
 	char ifname[64];
 
 	/* TODO: missing authentication. */
+
+	/*
+	 * SBFD over SRv6 extensions.
+	 *
+	 * These fields are appended to the existing payload to preserve the
+	 * offsets of all earlier fields. A subscriber that doesn't care about
+	 * SBFD can ignore the bytes after `ifname[]`. A sender on a system
+	 * that doesn't use SBFD will leave them zeroed.
+	 */
+	/**
+	 * BFD session mode. Values match enum `bfd_mode_type` in
+	 * `bfdd/bfd.h`:
+	 *   0 = BFD_MODE_TYPE_BFD       (classical BFD; default)
+	 *   1 = BFD_MODE_TYPE_SBFD_ECHO (RFC 7881 echo, self-loop initiator)
+	 *   2 = BFD_MODE_TYPE_SBFD_INIT (RFC 7880 §6 initiator)
+	 *
+	 * NOTE: `struct bfd_session::bfd_mode` is stored as `uint32_t`,
+	 * so the cast on the producer side is a narrowing truncation
+	 * guarded only by the current enum range. A future enum that
+	 * grows past 255 would silently lose the high byte; the producer
+	 * (`bfdd/dplane.c::_bfd_dplane_session_fill`) logs an error when
+	 * that branch is hit.
+	 */
+	uint8_t bfd_mode;
+	/**
+	 * Encapsulation type for outgoing BFD/SBFD packets.
+	 *   0 = none (default; classical BFD)
+	 *   1 = SRv6
+	 */
+	uint8_t encap_type;
+	/**
+	 * Number of valid IPv6 SIDs in `seg_list[]` (0 .. SRV6_MAX_SEGS).
+	 *
+	 * The cap matches the compile-time SRV6_MAX_SEGS from `lib/srv6.h`.
+	 */
+	uint8_t seg_num;
+	/** Reserved / zeroed for alignment. */
+	uint8_t zero2;
+	/**
+	 * Remote discriminator known a-priori for `sbfd_init` mode.
+	 * Zero for `bfd` and `sbfd_echo` modes.
+	 */
+	uint32_t remote_discr;
+	/**
+	 * SRv6 outer-IPv6 source address (used when `encap_type == 1`).
+	 * Zero-filled otherwise.
+	 */
+	struct in6_addr srv6_source_ipv6;
+	/**
+	 * SRv6 SID list, in transmission order. `seg_list[0]` becomes the
+	 * outer IPv6 destination; the final SID is the destination End SID
+	 * (typically a reflector). Only the first `seg_num` entries are
+	 * valid.
+	 */
+	struct in6_addr seg_list[8];
+	/**
+	 * Operator-supplied session name (FRR `bfd-name`). Empty string for
+	 * unnamed sessions.
+	 *
+	 * Length-bounded at 64 here to keep the wire payload compact;
+	 * `BFD_NAME_SIZE` in `bfdd/bfd.h` is 255. The producer truncates
+	 * with `strlcpy` and logs a warning when truncation happens, so a
+	 * sender pushing a longer name is observable in the bfdd log
+	 * rather than silently corrupting the key on the subscriber side.
+	 */
+	char bfd_name[64];
 };
+
+/*
+ * Wire-format guard rails for the BFDDP v2 layout.
+ *
+ * These compile-time checks catch ABI drift before it becomes silent
+ * corruption on the wire. `ifname` is the last field of the v1
+ * layout; if a compiler ever pads it differently, the assert fires.
+ * `sizeof` covers the v2-appended tail.
+ */
+_Static_assert(offsetof(struct bfddp_session, ifname) == 68,
+	       "bfddp_session v1 layout: ifname offset must stay at 68");
+_Static_assert(sizeof(struct bfddp_session) == 348,
+	       "bfddp_session v2 layout: total size drifted from expected 348 bytes");
 
 /** BFD packet state values as defined in RFC 5880, Section 4.1. */
 enum bfd_state_value {

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -763,6 +763,60 @@ static void _bfd_dplane_session_fill(const struct bfd_session *bs,
 	msg->data.session.min_rx = htonl(bs->timers.required_min_rx);
 	msg->data.session.min_echo_tx = htonl(bs->timers.desired_min_echo_tx);
 	msg->data.session.min_echo_rx = htonl(bs->timers.required_min_echo_rx);
+
+	/*
+	 * SBFD over SRv6 fields.
+	 *
+	 * For classical BFD sessions (`bfd_mode == BFD_MODE_TYPE_BFD` and
+	 * `segnum == 0`), every appended field below ends up zeroed,
+	 * preserving the wire payload that v1 subscribers used to see.
+	 */
+	if (bs->bfd_mode > UINT8_MAX)
+		zlog_err("bfddp: bfd_mode %u truncated to %u in dplane msg",
+			 bs->bfd_mode, (uint8_t)bs->bfd_mode);
+	msg->data.session.bfd_mode = (uint8_t)bs->bfd_mode;
+	msg->data.session.encap_type = (bs->segnum > 0) ? 1 : 0; /* 1 = SRv6 */
+	msg->data.session.seg_num = bs->segnum;
+	msg->data.session.zero2 = 0;
+	/*
+	 * The wire-format `remote_discr` is documented as zero for non-
+	 * SBFD_INIT modes (see `bfddp_session.remote_discr` in
+	 * `bfddp_packet.h`). For classical BFD the value in
+	 * `bs->discrs.remote_discr` is dynamically learned from the peer's
+	 * CONTROL packets (RFC 5880 §6.8.6) and becomes non-zero after
+	 * the handshake. Without this conditional, the dplane subscriber
+	 * reconnect-replay path (`bfd_key_iterate(_bfd_session_register_
+	 * dplane, ...)` in `bfd_dplane_ctx_new`) would emit the learned
+	 * value for every established classical-BFD session, silently
+	 * violating the contract.
+	 */
+	msg->data.session.remote_discr =
+		(bs->bfd_mode == BFD_MODE_TYPE_SBFD_INIT) ?
+			htonl(bs->discrs.remote_discr) : 0;
+	memcpy(&msg->data.session.srv6_source_ipv6, &bs->out_sip6,
+	       sizeof(struct in6_addr));
+	/*
+	 * `bs->seg_list` is sized to SRV6_MAX_SEGS; so is the wire-format
+	 * `seg_list[]` here. A future bump of SRV6_MAX_SEGS without
+	 * bumping the wire-format would silently truncate, so lock the
+	 * two together at compile time.
+	 */
+	_Static_assert(SRV6_MAX_SEGS == 8,
+		       "wire-format bfddp_session.seg_list[8] must track SRV6_MAX_SEGS");
+	memcpy(msg->data.session.seg_list, bs->seg_list,
+	       sizeof(msg->data.session.seg_list));
+	/*
+	 * Truncate-on-copy: `bs->bfd_name[]` is BFD_NAME_SIZE+1 (256
+	 * bytes); the wire-format buffer is 64. Log when truncation
+	 * actually happens so a longer name doesn't silently corrupt the
+	 * subscriber's lookup key.
+	 */
+	if (strlen(bs->bfd_name) >= sizeof(msg->data.session.bfd_name))
+		zlog_warn("bfddp: bfd_name '%s' (len %zu) truncated to %zu in dplane msg",
+			  bs->bfd_name, strlen(bs->bfd_name),
+			  sizeof(msg->data.session.bfd_name) - 1);
+	strlcpy(msg->data.session.bfd_name, bs->bfd_name,
+		sizeof(msg->data.session.bfd_name));
 }
 
 static int _bfd_dplane_add_session(struct bfd_dplane_ctx *bdc,

--- a/tests/topotests/sbfd_dplane_topo1/r1/frr.conf
+++ b/tests/topotests/sbfd_dplane_topo1/r1/frr.conf
@@ -1,0 +1,8 @@
+hostname r1
+!
+interface r1-eth0
+ ipv6 address 2001:db8:1::1/64
+ ip address 192.0.2.2/24
+!
+bfd
+!

--- a/tests/topotests/sbfd_dplane_topo1/test_sbfd_dplane_topo1.py
+++ b/tests/topotests/sbfd_dplane_topo1/test_sbfd_dplane_topo1.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_sbfd_dplane_topo1.py
+#
+# Verifies the BFDDP wire-payload extension: when an SBFD/SRv6 session
+# is configured in bfdd, the DP_ADD_SESSION frame emitted to a
+# connected data-plane subscriber carries the appended fields
+# (bfd_mode, encap_type, seg_num, remote_discr, srv6_source_ipv6,
+# seg_list[8], bfd_name). A classical-BFD session configured on the
+# same router serves as a regression check that those same fields are
+# zero-filled for non-SBFD sessions.
+#
+# Topology: single router r1; bfdd is launched with
+# `--dplaneaddr unix:<sock>`. The test process plays the data-plane
+# subscriber, connects to that UNIX socket, then issues vtysh config
+# commands and reads back the DP_ADD_SESSION frames.
+
+import os
+import socket
+import struct
+import sys
+import time
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib.common_config import required_linux_kernel_version
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+pytestmark = [pytest.mark.bfdd]
+
+
+# UNIX socket bfdd listens on for the BFDDP data-plane subscriber.
+# /tmp is shared across mininet network namespaces (only NET is
+# namespaced), so the test process and bfdd both see the same path.
+DPLANE_SOCK = "/tmp/sbfd_dplane_topo1_bfddp.sock"
+
+# BFDDP protocol constants -- mirror bfdd/bfddp_packet.h.
+BFD_DP_VERSION = 2
+DP_ADD_SESSION = 2
+DP_DELETE_SESSION = 3
+HEADER_LEN = 8                  # version(1)+zero(1)+type(2)+id(2)+length(2)
+SESSION_PAYLOAD_LEN = 348       # sizeof(struct bfddp_session) in v2
+
+# Field offsets within struct bfddp_session. The wire layout is
+# guarded by _Static_asserts in bfddp_packet.h: offsetof(ifname) == 68,
+# sizeof(struct bfddp_session) == 348. Keep these in lockstep with
+# those asserts.
+OFF_BFD_MODE = 132
+OFF_ENCAP_TYPE = 133
+OFF_SEG_NUM = 134
+OFF_ZERO2 = 135
+OFF_REMOTE_DISCR = 136
+OFF_SRV6_SRC = 140
+OFF_SEG_LIST = 156
+OFF_BFD_NAME = 284
+
+# enum bfd_mode_type values from bfdd/bfd.h.
+BFD_MODE_TYPE_BFD = 0
+BFD_MODE_TYPE_SBFD_ECHO = 1
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    sw = tgen.add_switch("s1")
+    sw.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # bfdd unlinks the socket on bind, but stale state from a crashed
+    # prior run might block the bind. Clear pre-emptively.
+    try:
+        os.unlink(DPLANE_SOCK)
+    except FileNotFoundError:
+        pass
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [(TopoRouter.RD_ZEBRA, None),
+             (TopoRouter.RD_BFD, "--dplaneaddr unix:{}".format(DPLANE_SOCK))],
+        )
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    try:
+        os.unlink(DPLANE_SOCK)
+    except FileNotFoundError:
+        pass
+    tgen.stop_topology()
+
+
+def _connect_dplane(timeout=10.0):
+    """Poll until bfdd's listening socket is ready, then connect."""
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.connect(DPLANE_SOCK)
+            return sock
+        except (FileNotFoundError, ConnectionRefusedError, OSError) as exc:
+            last_err = exc
+            time.sleep(0.2)
+    raise RuntimeError(
+        "could not connect to bfdd dplane socket {}: {}".format(
+            DPLANE_SOCK, last_err))
+
+
+def _recv_exact(sock, want, timeout=5.0):
+    sock.settimeout(timeout)
+    buf = bytearray()
+    while len(buf) < want:
+        chunk = sock.recv(want - len(buf))
+        if not chunk:
+            raise RuntimeError(
+                "dplane socket closed after {} of {} bytes".format(
+                    len(buf), want))
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _read_frame(sock, accept_types):
+    """Read BFDDP frames until one whose `type` is in accept_types arrives."""
+    while True:
+        hdr = _recv_exact(sock, HEADER_LEN)
+        version, _zero, msg_type, _id, length = struct.unpack("!BBHHH", hdr)
+        assert version == BFD_DP_VERSION, (
+            "bfddp header version {} != expected {}".format(
+                version, BFD_DP_VERSION))
+        # A malformed length < HEADER_LEN would underflow `length - HEADER_LEN`
+        # in Python (signed int, no wrap-around), causing _recv_exact to
+        # return empty bytes and surface as an opaque payload-length assert
+        # in _decode_session. Guard here for a clear diagnostic instead.
+        assert length >= HEADER_LEN, (
+            "bfddp frame length {} < HEADER_LEN {}".format(length, HEADER_LEN))
+        body = _recv_exact(sock, length - HEADER_LEN)
+        if msg_type in accept_types:
+            return msg_type, body
+
+
+def _decode_session(body):
+    assert len(body) == SESSION_PAYLOAD_LEN, (
+        "bfddp_session payload {} != expected {} bytes (wire-layout drift?)"
+        .format(len(body), SESSION_PAYLOAD_LEN))
+    fields = {
+        "bfd_mode":  body[OFF_BFD_MODE],
+        "encap_type": body[OFF_ENCAP_TYPE],
+        "seg_num":   body[OFF_SEG_NUM],
+        "zero2":     body[OFF_ZERO2],
+        "remote_discr": struct.unpack_from("!I", body, OFF_REMOTE_DISCR)[0],
+        "srv6_source_ipv6": bytes(body[OFF_SRV6_SRC:OFF_SRV6_SRC + 16]),
+        "seg_list": [
+            bytes(body[OFF_SEG_LIST + i * 16: OFF_SEG_LIST + (i + 1) * 16])
+            for i in range(8)
+        ],
+        "bfd_name": body[OFF_BFD_NAME:OFF_BFD_NAME + 64]
+        .split(b"\x00", 1)[0]
+        .decode("ascii"),
+    }
+    return fields
+
+
+def _ip6(s):
+    return socket.inet_pton(socket.AF_INET6, s)
+
+
+def test_bfddp_session_wire_payload():
+    """
+    Exercise both code paths of `_bfd_dplane_session_fill`:
+      (a) SBFD/SRv6 echo session -- all appended fields populated.
+      (b) Classical BFD peer on the same router -- fields zero-filled.
+    A single dplane connection serves both checks so we don't trigger
+    bfdd's accept-time session replay.
+    """
+    if required_linux_kernel_version("4.5") is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.net["r1"]
+    sock = _connect_dplane()
+    try:
+        # (a) SBFD/SRv6 echo session. In sbfd-echo, peer and local-address
+        #     must be the same (see `sbfd_echo_peer_enter_cmd` in
+        #     bfdd/bfdd_cli.c).
+        r1.cmd(
+            "vtysh -c 'config t' -c 'bfd' "
+            "-c 'peer 2001:db8:1::1 bfd-mode sbfd-echo bfd-name sbfd-echo-1 "
+            "multihop local-address 2001:db8:1::1 "
+            "srv6-source-ipv6 2001:db8:1::1 "
+            "srv6-encap-data 2001:db8:a::100 2001:db8:a::200 2001:db8:1::1'"
+        )
+        _mt, body = _read_frame(sock, {DP_ADD_SESSION})
+        sbfd = _decode_session(body)
+
+        assert sbfd["bfd_mode"] == BFD_MODE_TYPE_SBFD_ECHO, (
+            "bfd_mode {} != SBFD_ECHO".format(sbfd["bfd_mode"]))
+        assert sbfd["encap_type"] == 1, "encap_type != 1 (SRv6)"
+        assert sbfd["seg_num"] == 3, "seg_num != 3"
+        assert sbfd["zero2"] == 0
+        # `remote_discr` is documented as zero for sbfd-echo (see
+        # `bfddp_session.remote_discr` in bfddp_packet.h).
+        assert sbfd["remote_discr"] == 0
+        assert sbfd["srv6_source_ipv6"] == _ip6("2001:db8:1::1")
+        assert sbfd["seg_list"][0] == _ip6("2001:db8:a::100")
+        assert sbfd["seg_list"][1] == _ip6("2001:db8:a::200")
+        assert sbfd["seg_list"][2] == _ip6("2001:db8:1::1")
+        for i in range(3, 8):
+            assert sbfd["seg_list"][i] == b"\x00" * 16, (
+                "seg_list[{}] not zero-filled".format(i))
+        assert sbfd["bfd_name"] == "sbfd-echo-1"
+
+        # (b) Classical BFD peer -- regression: appended fields zero-filled.
+        r1.cmd(
+            "vtysh -c 'config t' -c 'bfd' "
+            "-c 'peer 192.0.2.1 multihop local-address 192.0.2.2'"
+        )
+        _mt, body = _read_frame(sock, {DP_ADD_SESSION})
+        cls = _decode_session(body)
+
+        assert cls["bfd_mode"] == BFD_MODE_TYPE_BFD
+        assert cls["encap_type"] == 0
+        assert cls["seg_num"] == 0
+        assert cls["zero2"] == 0
+        # `remote_discr` is conditionally zeroed in `_bfd_dplane_session_fill`
+        # for non-SBFD_INIT modes (see the comment there). That conditional
+        # is what makes this assertion robust on the dplane reconnect-replay
+        # path; without it, an established classical-BFD session's learned
+        # discriminator would leak to the subscriber and this would fail.
+        assert cls["remote_discr"] == 0
+        assert cls["srv6_source_ipv6"] == b"\x00" * 16
+        for i in range(8):
+            assert cls["seg_list"][i] == b"\x00" * 16, (
+                "classical-bfd seg_list[{}] not zero".format(i))
+        assert cls["bfd_name"] == ""
+    finally:
+        sock.close()


### PR DESCRIPTION
### Summary

The bfddp control-plane protocol carries BFD session state from bfdd
to an external data-plane subscriber, but `struct bfddp_session` has
no fields to describe SBFD over SRv6, so a subscriber cannot install
SBFD/SRv6 sessions in hardware.

This PR extends the wire-format `struct bfddp_session` with:

    bfd_mode, encap_type, seg_num, remote_discr, srv6_source_ipv6,
    seg_list[SRV6_MAX_SEGS], bfd_name[64]

Fields are appended so existing offsets are preserved; non-SBFD
senders zero them. `BFD_DP_VERSION` bumps 1 -> 2 to signal the new
payload length. The strict-equality check in `bfd_dplane_read` will
reject mismatched peers, so bfdd and subscribers must be rebuilt
together.

Two commits:

1. **bfdd: extend bfddp_session with SBFD/SRv6 fields** -- wire
   layout and producer-side wiring in `_bfd_dplane_session_fill`.
   `_Static_assert`s lock `offsetof(ifname) == 68`,
   `sizeof(struct bfddp_session) == 348`, and `SRV6_MAX_SEGS == 8`.
   Conditional zero on the wire-format `remote_discr` for non-
   SBFD_INIT modes prevents the dplane-reconnect replay path from
   leaking the dynamically-learned classical-BFD discriminator.

2. **tests: bfdd sbfd-echo dplane wire-payload topotest** -- new
   `tests/topotests/sbfd_dplane_topo1` configures an SBFD/SRv6 echo
   session and asserts every appended field at the well-known
   offsets, then configures a classical BFD peer on the same
   router and asserts the appended fields are zero-filled
   (regression on the conditional `remote_discr` zero).

### Scope

The wire layout supports both `sbfd_echo` and `sbfd_init`. Only
`sbfd_echo` is exercised by the topotest in this PR; the `sbfd_init`
path is unchanged code-wise and can get its own test in a follow-up.

### Related Issue

None.

### Components

bfdd, tests