### PR TITLE
zebra: fix missing cleaning vni entry

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1829,8 +1829,11 @@ interface_bridge_vxlan_vlan_vni_map_update(struct zebra_dplane_ctx *ctx,
 	vlanid_t vid;
 	int i;
 
-	if (vniarray == NULL)
+	if (vniarray == NULL) {
+		vni_table = zebra_vxlan_vni_table_create();
+		zebra_vxlan_if_vni_table_add_update(ifp, vni_table);
 		return;
+	}
 
 	memset(&vni_start, 0, sizeof(vni_start));
 	memset(&vni_end, 0, sizeof(vni_end));


### PR DESCRIPTION
When the last vni mapping is removed from SVD (evpn case), the `vniarray` is NULL in `interface_bridge_vxlan_vlan_vni_map_update()`. So this function will wrongly return without cleaning vni entry:

```
root@debian# bridge fdb show dev vxlan-svd
00:00:00:00:00:00 dst 66.66.66.66 src_vni 66 self permanent
```

Fix this by replacing the old vni table with one empty/new vni table, then the the last/remaining vni fdb entry can be properly cleaned up.