### PR TITLE
zebra: Track netlink carrier changes value

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1388,6 +1388,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	ifindex_t master_infindex = IFINDEX_INTERNAL;
 	uint8_t bypass = 0;
 	uint32_t txqlen = 0;
+	uint32_t cchanges = 0;
 
 	frrtrace(3, frr_zebra, netlink_interface, h, ns_id, startup);
 
@@ -1477,6 +1478,9 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (tb[IFLA_TXQLEN])
 		txqlen = *(uint32_t *)RTA_DATA(tb[IFLA_TXQLEN]);
 
+	if (tb[IFLA_CARRIER_CHANGES])
+		cchanges = *(uint32_t *)RTA_DATA(tb[IFLA_CARRIER_CHANGES]);
+
 	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
 	dplane_ctx_set_ns_id(ctx, ns_id);
 	dplane_ctx_set_ifp_link_nsid(ctx, link_nsid);
@@ -1486,6 +1490,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	dplane_ctx_set_startup(ctx, startup);
 	dplane_ctx_set_ifp_family(ctx, ifi->ifi_family);
 	dplane_ctx_set_intf_txqlen(ctx, txqlen);
+	dplane_ctx_set_intf_carrier_changes(ctx, cchanges);
 
 	/* We are interested in some AF_BRIDGE notifications. */
 #ifndef AF_BRIDGE

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2039,6 +2039,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		char *desc;
 		uint8_t family;
 		uint64_t change_flags;
+		uint32_t cchanges;
 
 		/* If VRF, create or update the VRF structure itself. */
 		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns()) {
@@ -2064,6 +2065,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		desc = dplane_ctx_get_ifp_desc(ctx);
 		family = dplane_ctx_get_ifp_family(ctx);
 		change_flags = dplane_ctx_get_ifp_change_flags(ctx);
+		cchanges = dplane_ctx_get_intf_carrier_changes(ctx);
 
 #ifndef AF_BRIDGE
 		/*
@@ -2362,6 +2364,8 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			XFREE(MTYPE_ZIF_DESC, zif->desc);
 			if (desc[0])
 				zif->desc = XSTRDUP(MTYPE_ZIF_DESC, desc);
+
+			zif->carrier_changes = cchanges;
 		}
 	}
 }
@@ -2822,6 +2826,7 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		zebra_if->up_last[0] ? zebra_if->up_last : "(never)");
 	vty_out(vty, "  Link downs: %5u    last: %s\n", zebra_if->down_count,
 		zebra_if->down_last[0] ? zebra_if->down_last : "(never)");
+	vty_out(vty, "  Total Carrier Changes: %u\n", zebra_if->carrier_changes);
 
 	zebra_ptm_show_status(vty, NULL, ifp);
 
@@ -3533,6 +3538,7 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 	json_object_int_add(json_if, "outputErrors", ifp->stats.ifi_oerrors);
 	json_object_int_add(json_if, "collisions", ifp->stats.ifi_collisions);
 #endif /* HAVE_NET_RT_IFLIST */
+	json_object_int_add(json_if, "carrierChanges", zebra_if->carrier_changes);
 }
 
 static void interface_update_stats(void)

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -136,6 +136,7 @@ struct zebra_if {
 	char up_last[FRR_TIMESTAMP_LEN];
 	unsigned int down_count;
 	char down_last[FRR_TIMESTAMP_LEN];
+	uint32_t carrier_changes;
 
 	struct rtadvconf rtadv;
 	unsigned int ra_sent, ra_rcvd;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -234,6 +234,7 @@ struct dplane_intf_info {
 	uint32_t rc_bitfield;
 
 	uint32_t txqlen;
+	uint32_t cchanges;
 
 	uint32_t metric;
 	uint32_t flags;
@@ -2903,6 +2904,20 @@ uint32_t dplane_ctx_get_intf_txqlen(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.intf.txqlen;
+}
+
+void dplane_ctx_set_intf_carrier_changes(struct zebra_dplane_ctx *ctx, uint32_t cchanges)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.cchanges = cchanges;
+}
+
+uint32_t dplane_ctx_get_intf_carrier_changes(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.cchanges;
 }
 
 /* Accessors for MAC information */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -757,6 +757,8 @@ const char *dplane_ctx_get_intf_label(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_intf_label(struct zebra_dplane_ctx *ctx, const char *label);
 void dplane_ctx_set_intf_txqlen(struct zebra_dplane_ctx *ctx, uint32_t txqlen);
 uint32_t dplane_ctx_get_intf_txqlen(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_intf_carrier_changes(struct zebra_dplane_ctx *ctx, uint32_t cchanges);
+uint32_t dplane_ctx_get_intf_carrier_changes(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for MAC information */
 vlanid_t dplane_ctx_mac_get_vlan(const struct zebra_dplane_ctx *ctx);


### PR DESCRIPTION
Turns out netlink lets us know how many times a carrier change has happened.  Keep track of it.  At this point do nothing with it.