### PR TITLE
tests: reap mutini zombies and skip post-teardown support bundles

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -938,6 +938,12 @@ def generate_support_bundle():
         )
         return True
 
+    if getattr(tgen, "topology_stopped", False):
+        logger.warning(
+            "Support bundle skipped: topology %s already torn down", tgen.modname
+        )
+        return True
+
     router_list = tgen.routers()
     test_name = os.environ.get("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0]
 

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -154,6 +154,7 @@ class Topogen(object):
         self.peern = 1
         self.cfg_gen = 0
         self.exabgp_cmd = None
+        self.topology_stopped = False
         self._init_topo(topodef)
 
         logger.info("loading topology: {}".format(self.modname))
@@ -483,6 +484,7 @@ class Topogen(object):
                 logger.error("\n...continuing after error: %s", error)
 
         logger.info("stopping topology: {}".format(self.modname))
+        self.topology_stopped = True
 
         errors = ""
         for gear in self.gears.values():

--- a/tests/topotests/munet/cleanup.py
+++ b/tests/topotests/munet/cleanup.py
@@ -35,6 +35,18 @@ def get_pids_with_env(has_var, has_val=None):
     return result
 
 
+def _reap_zombie_children():
+    """Reap zombie child processes of the current process."""
+    while True:
+        try:
+            wpid, status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break
+        if wpid == 0:
+            break
+        logging.debug("Reaped child pid %s status %s", wpid, status)
+
+
 def _kill_piddict(pids_by_upid, sig):
     ourpid = str(os.getpid())
     for upid, pids in pids_by_upid:
@@ -104,6 +116,7 @@ def _cleanup_pids(ours, rundir):
 
     pids_by_upid = _get_pids_by_upid(ours, rundir).items()
     _kill_piddict(pids_by_upid, signal.SIGKILL)
+    _reap_zombie_children()
 
 
 def cleanup_current():
@@ -112,6 +125,10 @@ def cleanup_current():
     Currently this only scans for old processes.
     """
     _cleanup_pids(True, None)
+    # Reap any mutini/nsenter zombies left as direct children of this xdist
+    # worker.  SIGKILL above does not waitpid(); unreaped zombies prevent the
+    # worker process from exiting and block the pytest-xdist controller.
+    _reap_zombie_children()
 
 
 def cleanup_previous(rundir=None):


### PR DESCRIPTION
* Reap unreaped mutini/nsenter zombie children in xdist worker cleanup so parallel topotest runs exit instead of blocking the controller
* Skip generate_support_bundle() once stop_topology() has started, avoiding useless failures when memleak checks run after module teardown