### PR TITLE
tests: harden topotest gcov coverage setup and reporting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -364,6 +364,7 @@ dnl if the user has specified any CFLAGS, override our settings
 if test "$enable_gcov" = "yes"; then
    if test "$orig_cflags" = ""; then
       AC_C_FLAG([--coverage])
+      AC_C_FLAG([-fprofile-update=atomic])
       AC_C_FLAG([-O0])
    fi
 

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -23,7 +23,7 @@ from lib.topogen import diagnose_env, get_topogen
 from lib.topolog import get_test_logdir, logger
 from lib.topotest import gdb_core, json_cmp_result
 from munet import cli
-from munet.base import BaseMunet, Commander, proc_error
+from munet.base import BaseMunet, Commander, lcov_ignore_errors, proc_error
 from munet.cleanup import cleanup_current, cleanup_previous
 from munet.config import ConfigOptionsProxy
 from munet.testing.util import pause_test
@@ -934,6 +934,7 @@ done"""
     logger.info("Gathering coverage data into: %s", data_file)
     commander.cmd_raises(
         f"lcov --directory {gcdadir} --capture --output-file {data_file}"
+        f" --ignore-errors {lcov_ignore_errors(commander)}"
     )
 
     # Get coverage info filtered to a specific set of files

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -573,17 +573,39 @@ def setup_coverage(config):
     commander = Commander("pytest")
     if config.option.cov_frr_build_dir:
         bdir = Path(config.option.cov_frr_build_dir).resolve()
-        output = commander.cmd_raises(f"find {bdir} -name zebra_nb.gcno").strip()
     else:
         # Support build sub-directory of main source dir
         bdir = Path(__file__).resolve().parent.parent.parent
-        output = commander.cmd_raises(f"find {bdir} -name zebra_nb.gcno").strip()
-    m = re.match(f"({bdir}.*)/zebra/zebra_nb.gcno", output)
-    if not m:
-        logger.warning(
-            "No coverage data files (*.gcno) found, try specifying --cov-frr-build-dir"
+
+    if not bdir.is_dir():
+        pytest.exit(
+            "--cov-topotest: build directory does not exist: "
+            f"{bdir}\nCheck --cov-frr-build-dir."
         )
-        return
+
+    rc, output, _ = commander.cmd_status(f"find {bdir} -name zebra_nb.gcno")
+    output = output.strip() if output else ""
+    if rc != 0 or not output:
+        output = ""
+
+    m = re.match(f"({re.escape(str(bdir))}.*)/zebra/zebra_nb.gcno", output)
+    if not m:
+        build_dir_hint = ""
+        if config.option.cov_frr_build_dir:
+            build_dir_hint = f"\n  --cov-frr-build-dir={bdir}"
+        else:
+            build_dir_hint = (
+                "\nIf FRR was built in a separate directory, also pass:"
+                "\n  --cov-frr-build-dir=/path/to/build"
+            )
+        pytest.exit(
+            "--cov-topotest requires FRR to be built with --enable-gcov.\n"
+            f"No *.gcno files found under {bdir} (looked for zebra/zebra_nb.gcno)."
+            "\n\nRebuild FRR with coverage enabled, then reinstall:"
+            "\n  ../configure ... --enable-gcov"
+            "\n  make clean && make && sudo make install"
+            f"{build_dir_hint}"
+        )
 
     bdir = Path(m.group(1))
     # Save so we can get later from g_pytest_config
@@ -880,6 +902,15 @@ def pytest_runtest_makereport(item, call):
 
 
 def coverage_finish(terminalreporter, config):
+    if "FRR_BUILD_DIR" not in os.environ or "GCOV_PREFIX" not in os.environ:
+        msg = (
+            "Coverage was not initialized; skipping lcov report. "
+            "Rebuild FRR with --enable-gcov or check --cov-frr-build-dir."
+        )
+        logger.warning(msg)
+        terminalreporter.write(f"\n{msg}\n")
+        return
+
     commander = Commander("pytest")
     rundir = Path(config.option.rundir).resolve()
     bdir = Path(os.environ["FRR_BUILD_DIR"])

--- a/tests/topotests/munet/base.py
+++ b/tests/topotests/munet/base.py
@@ -205,6 +205,14 @@ def get_kernel_version():
     return kv
 
 
+def lcov_ignore_errors(commander):
+    """Return lcov --ignore-errors categories supported by the installed lcov."""
+    _, version, _ = commander.cmd_status("lcov --version")
+    if "LCOV version 2" in (version or ""):
+        return "negative,gcov,source,unexecuted"
+    return "gcov,source"
+
+
 def convert_number(value) -> int:
     """Convert a number value with a possible suffix to an integer.
 

--- a/tests/topotests/munet/native.py
+++ b/tests/topotests/munet/native.py
@@ -52,6 +52,7 @@ from .config import config_to_dict_with_key
 from .config import find_matching_net_config
 from .config import find_with_kv
 from .config import merge_kind_config
+from .base import lcov_ignore_errors
 from .watchlog import WatchLog
 
 
@@ -3486,6 +3487,7 @@ done"""
         self.logger.info("Gathering coverage data into: %s", data_file)
         commander.cmd_raises(
             f"lcov --directory {gcdadir} --capture --output-file {data_file}"
+            f" --ignore-errors {lcov_ignore_errors(commander)}"
         )
 
         # Get coverage info filtered to a specific set of files


### PR DESCRIPTION
- Exit immediately during pytest configure when --cov-topotest is used without a gcov-enabled build, with a clear message instead of failing every test with missing GCOV_* env var errors.
- Make parallel coverage collection reliable under xdist by compiling gcov builds with -fprofile-update=atomic and having lcov ignore corrupted counters so full topotest runs still produce coverage.info.