### PR TITLE
Have zebra create a NHG instead of singletons when it receives a route

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -613,6 +613,83 @@ def get_textdiff(text1, text2, title1="", title2="", **opts):
     return diff
 
 
+def normalize_iproute_nhg_output(output):
+    """Canonicalize ``ip [-4|-6] route`` output for comparison across
+    NHA_GATEWAY (singleton) and NHA_GROUP (group-of-one) renderings.
+
+    The Linux kernel renders a route differently depending on whether the
+    route's nexthop id refers to a singleton (NHA_GATEWAY/NHA_OIF) or a
+    group (NHA_GROUP):
+
+        singleton:
+            <prefix> nhid <X> via <gw> dev <if> proto <P> metric <M>[ pref medium]
+
+        group of one:
+            <prefix> nhid <X> proto <P> metric <M> pref medium
+                    nexthop via <gw> dev <if> weight 1
+
+    Zebra now wraps every route's nexthop set in a kernel NHA_GROUP so
+    that ECMP membership changes can be expressed as in-place
+    NLM_F_REPLACE on the same id.  That means routes that used to render
+    in singleton form now render in group-of-one form.  This helper
+    collapses the latter back into the former so existing reference
+    tables (which were captured with singleton renderings) keep matching.
+
+    Multi-nh group entries (more than one ``nexthop`` line) are passed
+    through unchanged.
+    """
+    lines = output.splitlines()
+    out = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # Look for a header that has nhid but no inline "via"/"dev" -- those
+        # are the group-form headers that the kernel emits for routes whose
+        # nhid points at an NHA_GROUP.
+        if re.search(r"\bnhid\b", line) and " via " not in line and " dev " not in line:
+            # Collect any indented nexthop lines that immediately follow.
+            members = []
+            j = i + 1
+            while j < len(lines) and re.match(r"\s+nexthop\b", lines[j]):
+                members.append(lines[j])
+                j += 1
+            if len(members) == 1:
+                # Group-of-one: fold the single member back into the header
+                # so the route looks like the singleton form.
+                m = re.match(
+                    r"\s*nexthop\s+(.*?)\s+weight\s+\d+\s*$",
+                    members[0],
+                )
+                if m:
+                    nh = m.group(1)
+                    # Insert "<nh>" after the nhid token. Header looks like
+                    #   "<prefix> nhid <X> proto <P> metric <M> pref medium"
+                    # so split after "nhid <X>".
+                    header = re.sub(
+                        r"(\bnhid\s+\S+)\s+",
+                        r"\1 " + nh + " ",
+                        line,
+                        count=1,
+                    )
+                    # Some refs were captured without "pref medium" trailing
+                    # the singleton -- leave any existing trailing tokens
+                    # untouched, the ref-vs-actual comparison just needs the
+                    # via/dev tokens to be on the same line.
+                    out.append(header)
+                    i = j
+                    continue
+            # Either no members or multi-nh group: keep header + members
+            # exactly as they were.
+            out.append(line)
+            for m in members:
+                out.append(m)
+            i = j
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
+
+
 def difflines(text1, text2, title1="", title2="", **opts):
     "Wrapper for get_textdiff to avoid string transformations."
     text1 = ("\n".join(text1.rstrip().splitlines()) + "\n").splitlines(1)
@@ -919,7 +996,8 @@ def ip4_route(node):
         }
     }
     """
-    output = normalize_text(node.run("ip route")).splitlines()
+    raw = normalize_iproute_nhg_output(normalize_text(node.run("ip route")))
+    output = raw.splitlines()
     result = {}
     for line in output:
         columns = line.split(" ")
@@ -1003,7 +1081,8 @@ def ip6_route(node):
         }
     }
     """
-    output = normalize_text(node.run("ip -6 route")).splitlines()
+    raw = normalize_iproute_nhg_output(normalize_text(node.run("ip -6 route")))
+    output = raw.splitlines()
     result = {}
     for line in output:
         columns = line.split(" ")
@@ -1043,9 +1122,10 @@ def ip6_vrf_route(node):
         }
     }
     """
-    output = normalize_text(
-        node.run("ip -6 route show vrf {0}-cust1".format(node.name))
-    ).splitlines()
+    raw = normalize_iproute_nhg_output(
+        normalize_text(node.run("ip -6 route show vrf {0}-cust1".format(node.name)))
+    )
+    output = raw.splitlines()
     result = {}
     for line in output:
         columns = line.split(" ")

--- a/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
+++ b/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
@@ -265,6 +265,9 @@ def test_linux_ipv6_kernel_routingTable():
     for i in range(1, 5):
         # Actual output from router
         actual = tgen.gears["r{}".format(i)].run("ip -6 route").rstrip()
+        # Normalize NHA_GROUP-of-one routes back to singleton rendering so
+        # the reference tables (captured with singleton output) keep matching.
+        actual = topotest.normalize_iproute_nhg_output(actual)
         if "nhid" in actual:
             refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
         else:

--- a/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
@@ -265,6 +265,9 @@ def test_linux_ipv6_kernel_routingTable():
     for i in range(1, 5):
         # Actual output from router
         actual = tgen.gears["r{}".format(i)].run("ip -6 route").rstrip()
+        # Normalize NHA_GROUP-of-one routes back to singleton rendering so
+        # the reference tables (captured with singleton output) keep matching.
+        actual = topotest.normalize_iproute_nhg_output(actual)
         if "nhid" in actual:
             refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
         else:

--- a/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
@@ -309,6 +309,9 @@ def test_linux_ipv6_kernel_routingTable():
             .run("ip -6 route show vrf r{}-cust1".format(i))
             .rstrip()
         )
+        # Normalize NHA_GROUP-of-one routes back to singleton rendering so
+        # the reference tables (captured with singleton output) keep matching.
+        actual = topotest.normalize_iproute_nhg_output(actual)
         if "nhid" in actual:
             refTableFile = os.path.join(CWD, "r{}/ip_6_address.nhg.ref".format(i))
         else:

--- a/tests/topotests/static_simple/test_static_simple.py
+++ b/tests/topotests/static_simple/test_static_simple.py
@@ -99,11 +99,32 @@ def check_kernel(r1, super_prefix, src_prefix, count, add, is_blackhole, vrf, ma
 
         if is_blackhole:
             route = f"blackhole {netfull}(?: dev lo)? proto (static|196) metric 20"
+            assert re.search(
+                route, kernel
+            ), f"Failed to find \n'{route}'\n in \n'{kernel}'"
         else:
-            route = (
+            # The kernel renders a route differently depending on whether the
+            # nexthop id refers to a singleton (NHA_GATEWAY) or a group
+            # (NHA_GROUP):
+            #
+            #   singleton: "<prefix> nhid <X> via <gw> dev <if> proto static metric 20"
+            #   group of one: "<prefix> nhid <X> proto static metric 20 pref medium
+            #                       nexthop via <gw> dev <if> weight 1"
+            #
+            # Zebra now wraps every route's nexthop set in a kernel NHA_GROUP
+            # so that ECMP membership changes can be expressed as in-place
+            # NLM_F_REPLACE on the same id, so accept either rendering.
+            singleton = (
                 f"{netfull}(?: nhid [0-9]+)? {matchvia} proto (static|196) metric 20"
             )
-        assert re.search(route, kernel), f"Failed to find \n'{route}'\n in \n'{kernel}'"
+            group_header = (
+                f"{netfull}(?: nhid [0-9]+)? proto (static|196) metric 20 pref medium"
+            )
+            group_member = rf"\s*nexthop {matchvia} weight [0-9]+"
+            group = group_header + r"\n" + group_member
+            assert re.search(singleton, kernel) or re.search(
+                group, kernel
+            ), f"Failed to find \n'{singleton}'\n or \n'{group}'\n in \n'{kernel}'"
 
 
 def do_config_inner(

--- a/tests/topotests/zebra_mtu_ipv6_change/test_zebra_mtu_ipv6_change.py
+++ b/tests/topotests/zebra_mtu_ipv6_change/test_zebra_mtu_ipv6_change.py
@@ -60,6 +60,18 @@ def test_zebra_mtu_ipv6_change():
 
     def _kernel_route_installed():
         output = json.loads(r1.run("ip -6 -j route show fdfd::/64"))
+        # The kernel renders a route differently depending on whether the
+        # route's nexthop id is a singleton (NHA_GATEWAY) or a group
+        # (NHA_GROUP):
+        #   singleton: {"dst": ..., "dev": ..., "protocol": ...}
+        #   group:     {"dst": ..., "protocol": ..., "nexthops": [{"dev": ..., ...}]}
+        # Zebra now wraps every route's nexthop set in an NHA_GROUP, so the
+        # outgoing interface lives in the first nexthop member. Lift it back
+        # up to the top level for an apples-to-apples json_cmp check.
+        if isinstance(output, list):
+            for entry in output:
+                if "dev" not in entry and entry.get("nexthops"):
+                    entry["dev"] = entry["nexthops"][0].get("dev")
         return topotest.json_cmp(
             output, [{"dst": "fdfd::/64", "dev": "r1-eth0", "protocol": "bgp"}]
         )

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -4235,9 +4235,18 @@ int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 
 	nexthop_group_copy(&(ctx->u.rinfo.nhe.ng), &(nhe->nhg));
 
-	/* If this is a group, convert it to a grp array of ids */
-	if (!zebra_nhg_depends_is_empty(nhe)
-	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))
+	/*
+	 * If the NHE has any depends (a multi-nh group, a zebra-owned
+	 * single-nh wrapped as a group of one, or a recursive parent
+	 * with a resolved depend), build the child-id array.
+	 * zebra_nhg_nhe2grp -> zebra_nhg_nhe2grp_internal will resolve
+	 * a recursive depend to the resolved nhe's id, so recursive
+	 * parents emit NHA_GROUP { resolved_id } rather than a flattened
+	 * singleton -- this keeps every zebra-built kernel NHE in
+	 * group form so future ECMP grow/shrink can reuse the same
+	 * parent id via NLM_F_REPLACE.
+	 */
+	if (!zebra_nhg_depends_is_empty(nhe))
 		ctx->u.rinfo.nhe.nh_grp_count = zebra_nhg_nhe2grp(
 			ctx->u.rinfo.nhe.nh_grp, nhe, MULTIPATH_NUM);
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -361,37 +361,44 @@ void zebra_nhe_init(struct nhg_hash_entry *nhe, afi_t afi,
 	memset(nhe, 0, sizeof(struct nhg_hash_entry));
 	nhe->vrf_id = VRF_DEFAULT;
 	nhe->type = ZEBRA_ROUTE_NHG;
+
+	/*
+	 * Default to AFI_UNSPEC: nhes built through this function represent
+	 * a route's parent NHE -- they get wrapped in a kernel NHA_GROUP
+	 * even when the route has a single (gateway) nexthop, so that ECMP
+	 * grow/shrink can reuse the same parent id with NLM_F_REPLACE. The
+	 * leaf singletons that hang off the parent are built via
+	 * zebra_nhg_find / zebra_nhg_find_nexthop and use specific AFIs, so
+	 * the parent-vs-leaf split is what keeps them from hash-colliding.
+	 *
+	 * The exception is IFINDEX-only and BLACKHOLE single-nh routes:
+	 * those nh types are afi-agnostic in zebra (the same "dev lo" nh
+	 * can satisfy both an IPv4 and an IPv6 route) but the kernel
+	 * singleton that ultimately gets programmed is afi-specific via
+	 * NHM nh_family. If we let those parents live at AFI_UNSPEC, the
+	 * hash would collapse the IPv4 and IPv6 parents onto the same id
+	 * and the second-installed family would be rejected by the kernel
+	 * because the underlying singleton was created for the first
+	 * family. Pin those parents to a specific AFI so each family gets
+	 * its own parent/leaf pair. zebra_nhe_find treats afi != UNSPEC
+	 * single-nh nhes as leaves (no depend wrapping), so these stay as
+	 * direct kernel singletons -- they do not need ECMP grow/shrink
+	 * support anyway.
+	 */
 	nhe->afi = AFI_UNSPEC;
 
-	/* There are some special rules that apply to groups representing
-	 * a single nexthop.
-	 */
-	if (nh && (nh->next == NULL)) {
+	if (nh && nh->next == NULL) {
 		switch (nh->type) {
-			/*
-			 * This switch case handles setting the afi different
-			 * for ipv4/v6 routes. Ifindex nexthop
-			 * objects cannot be ambiguous, they must be Address
-			 * Family specific as that the kernel relies on these
-			 * for some reason.  blackholes can be v6 because the
-			 * v4 kernel infrastructure allows the usage of v6
-			 * blackholes in this case.   if we get here, we will
-			 * either use the AF of the route, or the one we got
-			 * passed from here from the kernel.
-			 */
 		case NEXTHOP_TYPE_IFINDEX:
 			nhe->afi = afi;
 			break;
 		case NEXTHOP_TYPE_BLACKHOLE:
 			nhe->afi = AFI_IP6;
 			break;
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
 		case NEXTHOP_TYPE_IPV4:
-			nhe->afi = AFI_IP;
-			break;
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
+		case NEXTHOP_TYPE_IPV4_IFINDEX:
 		case NEXTHOP_TYPE_IPV6:
-			nhe->afi = AFI_IP6;
+		case NEXTHOP_TYPE_IPV6_IFINDEX:
 			break;
 		}
 	}
@@ -457,9 +464,17 @@ static void *zebra_nhg_hash_alloc(void *arg)
 	 * Add the ifp now if it's not a group or recursive and has ifindex.
 	 *
 	 * A proto-owned ID is always a group.
+	 *
+	 * Only the leaf singleton (afi != AFI_UNSPEC) should be associated
+	 * with the interface. The zebra-owned parent NHE that wraps a single
+	 * nexthop in a group-of-one lives at AFI_UNSPEC; it is is-singleton by
+	 * nexthop count but carries a depend, so it must NOT be treated as an
+	 * interface singleton. The leaf drives its parent's reinstall via the
+	 * nhg_dependents walk in zebra_interface_nhg_reinstall().
 	 */
-	if (!PROTO_OWNED(nhe) && (ZEBRA_NHG_IS_SINGLETON(nhe) && nhe->nhg.nexthop->ifindex &&
-				  !CHECK_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_RECURSIVE))) {
+	if (!PROTO_OWNED(nhe) && nhe->afi != AFI_UNSPEC &&
+	    (ZEBRA_NHG_IS_SINGLETON(nhe) && nhe->nhg.nexthop->ifindex &&
+	     !CHECK_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_RECURSIVE))) {
 		struct interface *ifp = NULL;
 
 		ifp = if_lookup_by_index(nhe->nhg.nexthop->ifindex,
@@ -679,15 +694,28 @@ static void handle_recursive_depend(struct nhg_connected_tree_head *nhg_depends,
 				    struct nexthop *nh, afi_t afi, int type)
 {
 	struct nhg_hash_entry *depend = NULL;
-	struct nexthop_group resolved_ng = {};
-
-	resolved_ng.nexthop = nh;
+	struct nhg_hash_entry rt_nhe = {};
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: head %p, nh %pNHv",
 			   __func__, nhg_depends, nh);
 
-	depend = zebra_nhg_rib_find(0, &resolved_ng, afi, type);
+	/*
+	 * Build a parent-style lookup (afi=AFI_UNSPEC) for the resolved
+	 * nexthop list, matching what a route with this nh set would
+	 * create via zebra_nhg_rib_find_nhe(). When the resolving route
+	 * has already created its parent NHE in the hash, this lookup
+	 * finds and reuses it, so the recursive parent's depend is the
+	 * resolving route's parent NHE -- i.e. zebra_nhg_resolve() peels
+	 * the recursive parent down to the resolving route's NHA_ID and
+	 * both routes end up programmed in the kernel with the same
+	 * group id.
+	 */
+	zebra_nhe_init(&rt_nhe, afi, nh);
+	rt_nhe.nhg.nexthop = nh;
+	rt_nhe.type = type;
+
+	depend = zebra_nhg_rib_find_nhe(&rt_nhe, afi);
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: nh %pNHv => %p (%u)",
@@ -776,11 +804,30 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 		goto done;
 	}
 
-	/* Prepare dependency relationships if this is not a
-	 * singleton nexthop. There are two cases: a single
-	 * recursive nexthop, where we need a relationship to the
-	 * resolving nexthop; or a group of nexthops, where we need
-	 * relationships with the corresponding singletons.
+	/*
+	 * Prepare dependency relationships. Three cases:
+	 *
+	 *   1. A single recursive nexthop on a zebra-owned id: build a
+	 *      depend on the resolving nexthop and mark the parent
+	 *      NEXTHOP_GROUP_RECURSIVE so install ordering walks the
+	 *      resolution chain correctly.
+	 *
+	 *   2. A leaf singleton -- either kernel-learned (from_dplane), or a
+	 *      zebra-built leaf reached via depends_find_singleton. Leaves
+	 *      always use a specific AFI (set in zebra_nhg_find), while
+	 *      parent NHEs (built via zebra_nhe_init) use AFI_UNSPEC. So
+	 *      "single non-recursive nh + (from_dplane || afi != UNSPEC)"
+	 *      identifies the leaf side of the parent/leaf split. Leaves
+	 *      keep nhg_depends empty -- they are the bottom of the
+	 *      dependency tree and are what the kernel actually programs
+	 *      as NHA_GATEWAY/NHA_OIF singletons.
+	 *
+	 *   3. Everything else -- multi-nexthop groups, proto-owned NHGs,
+	 *      and zebra-owned parent NHEs (afi == AFI_UNSPEC) wrapping a
+	 *      single non-recursive nexthop -- builds a depend per nh.
+	 *      This guarantees every zebra-built parent NHE is encoded as
+	 *      NHA_GROUP (size >= 1), so future ECMP grow/shrink can be
+	 *      expressed as NLM_F_REPLACE on the same parent id.
 	 */
 	zebra_nhg_depends_init(newnhe);
 
@@ -789,17 +836,24 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE))
 		SET_FLAG(newnhe->flags, NEXTHOP_GROUP_VALID);
 
-	if (nh->next == NULL && newnhe->id < ZEBRA_NHG_PROTO_LOWER) {
-		if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE)) {
-			/* Single recursive nexthop */
-			handle_recursive_depend(&newnhe->nhg_depends,
-						nh->resolved, afi,
-						newnhe->type);
-			recursive = true;
-		}
+	if (nh->next == NULL && CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE) &&
+	    newnhe->id < ZEBRA_NHG_PROTO_LOWER) {
+		/* Case 1: single recursive zebra-owned nexthop */
+		handle_recursive_depend(&newnhe->nhg_depends, nh->resolved, afi, newnhe->type);
+		recursive = true;
+	} else if (nh->next == NULL && !CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE) &&
+		   (from_dplane || newnhe->afi != AFI_UNSPEC)) {
+		/*
+		 * Case 2: leaf singleton -- kernel-learned, or zebra-built
+		 * leaf reached via depends_find_singleton (which sets a
+		 * specific AFI). Keep nhg_depends empty so we don't recurse
+		 * back through depends_find_add for ourselves.
+		 */
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: leaf singleton NH %pNHv afi=%d%s", __func__, nh,
+				   newnhe->afi, from_dplane ? " (from dplane)" : "");
 	} else {
-		/* Proto-owned are groups by default */
-		/* List of nexthops */
+		/* Case 3: build depends per nexthop */
 		for (nh = newnhe->nhg.nexthop; nh; nh = nh->next) {
 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 				zlog_debug("%s: depends NH %pNHv %s",
@@ -1121,8 +1175,13 @@ void zebra_nhg_check_valid(struct nhg_hash_entry *nhe)
 	struct nhg_connected *rb_node_dep = NULL;
 	bool valid = false;
 
-	/* Singleton means it has no depends and has only dependents */
-	if (ZEBRA_NHG_IS_SINGLETON(nhe)) {
+	/*
+	 * A true leaf singleton has no depends and only dependents. Note that
+	 * a zebra-owned parent NHE wrapping a single nexthop in a group-of-one
+	 * is is-singleton by nexthop count but carries a depend, so guard on an
+	 * empty depends tree to avoid clobbering the parent's own nexthop flags.
+	 */
+	if (ZEBRA_NHG_IS_SINGLETON(nhe) && zebra_nhg_depends_is_empty(nhe)) {
 		UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_FIB);
 		UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 	}
@@ -4141,8 +4200,14 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 					   ifp->name);
 		}
 
-		/* Check for singleton NHG associated to interface */
-		if (!nexthop_is_blackhole(nh) && ZEBRA_NHG_IS_SINGLETON(rb_node_dep->nhe)) {
+		/*
+		 * Check for a true leaf singleton NHG associated to the
+		 * interface. A parent group-of-one is is-singleton by nexthop
+		 * count but carries a depend; it is reinstalled below via the
+		 * leaf's nhg_dependents walk, not directly here.
+		 */
+		if (!nexthop_is_blackhole(nh) && ZEBRA_NHG_IS_SINGLETON(rb_node_dep->nhe) &&
+		    zebra_nhg_depends_is_empty(rb_node_dep->nhe)) {
 			struct nhg_connected *rb_node_dependent;
 
 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4559,6 +4559,11 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p, struct prefix_ip
 		}
 	}
 
+	if ((re->type == ZEBRA_ROUTE_KERNEL || re->type == ZEBRA_ROUTE_CONNECT ||
+	     re->type == ZEBRA_ROUTE_LOCAL) &&
+	    n->nhg.nexthop && n->nhg.nexthop->next == NULL && n->afi == AFI_UNSPEC)
+		n->afi = afi;
+
 	ret = rib_add_multipath_nhe(afi, safi, p, src_p, re, n, startup, replace);
 
 	/* In error cases, free the route also */


### PR DESCRIPTION
Currently when a protocol sends a route to zebra with only one nexthop you get a singleton nexthop in zebra.   The problem here is that once the number of nexthops changes you end up with new nexthops as the ecmp grows.  This is not ideal if you are trying to reduce the number of nexthop groups and nexthop group churn in the kernel because a singleton nexthop group cannot become a ecmp nhg and vice versa.  You are always forced to change the nhg id. 

Modify the code such that zebra just creates a nhg, instead of a singleton when receiving a route with a single nexthop.  This way future code changes can take advantage of this and when ecmp grows the nhg id stays the same.