### PR TITLE
tests: Remove unknown `pytest.mark.tools`

### DIFF
--- a/tests/topotests/frr_reload_interface_section_deletion/test_frr_reload_interface_section_deletion.py
+++ b/tests/topotests/frr_reload_interface_section_deletion/test_frr_reload_interface_section_deletion.py
@@ -33,8 +33,6 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.tools]
-
 
 def build_topo(tgen):
     r1 = tgen.add_router("r1")


### PR DESCRIPTION
This is not an actual pytest mark, so let's remove it.