### PR TITLE
mgmtd: fix link order for libmgmt_be_nb

### DIFF
--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -69,8 +69,7 @@ nodist_mgmtd_mgmtd_SOURCES = \
 	yang/ietf/ietf-netconf-with-defaults.yang.c \
 	# nothing
 mgmtd_mgmtd_CFLAGS = $(AM_CFLAGS) -I ./
-mgmtd_mgmtd_LDADD = mgmtd/libmgmtd.a lib/libfrr.la $(LIBCAP) $(LIBM) $(LIBYANG_LIBS) $(UST_LIBS)
-mgmtd_mgmtd_LDADD += mgmtd/libmgmt_be_nb.la
+mgmtd_mgmtd_LDADD = mgmtd/libmgmtd.a mgmtd/libmgmt_be_nb.la lib/libfrr.la $(LIBCAP) $(LIBM) $(LIBYANG_LIBS) $(UST_LIBS)
 
 
 if STATICD


### PR DESCRIPTION
libmgmt_be_nb.la contains rip_cli.o and ripng_cli.o which reference symbols from libfrr (if_rmap_init, group_distribute_list_ipv4_cli_show, etc.).  With the current link order, libmgmt_be_nb.la is added after libfrr.la, so the linker doesn't know to pull in those symbols when processing libfrr.

Move libmgmt_be_nb.la before libfrr.la in the link order so that its undefined references are resolved by libfrr.

Fixes build failure when configuring with --enable-ripd or --enable-ripngd:

  /usr/bin/ld: mgmtd/.libs/libmgmt_be_nb.a(mgmtd_libmgmt_be_nb_la-rip_cli.o):
    in function 'rip_cli_init':
    ripd/rip_cli.c:1344: undefined reference to 'if_rmap_init'