### PR TITLE
pimd: fix AutoRP holdtime parsing and minor cleanup

### DIFF
--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -1376,11 +1376,11 @@ static bool autorp_recv_msg(struct pim_autorp *autorp, char *buf, size_t buf_siz
 	}
 
 	if (h->type == AUTORP_ANNOUNCEMENT_TYPE)
-		return autorp_recv_announcement(autorp, h->rpcnt, htons(h->holdtime),
+		return autorp_recv_announcement(autorp, h->rpcnt, ntohs(h->holdtime),
 						buf + AUTORP_HDRLEN, buf_size - AUTORP_HDRLEN, src);
 
 	if (h->type == AUTORP_DISCOVERY_TYPE)
-		return autorp_recv_discovery(autorp, h->rpcnt, htons(h->holdtime),
+		return autorp_recv_discovery(autorp, h->rpcnt, ntohs(h->holdtime),
 					     buf + AUTORP_HDRLEN, buf_size - AUTORP_HDRLEN, src);
 
 	zlog_warn("%s: Unknown AutoRP message type (%u)", __func__, h->type);
@@ -1712,7 +1712,6 @@ static int pim_autorp_new_announcement_rps(struct pim_autorp *autorp, uint8_t *b
 			plist = prefix_list_lookup(AFI_IP, rp->grplist);
 			if (plist == NULL)
 				continue;
-			plist = prefix_list_lookup(AFI_IP, rp->grplist);
 			for (ple = plist->head; ple; ple = ple->next) {
 				if (pim_addr_is_multicast(ple->prefix.u.prefix4) &&
 				    ple->prefix.prefixlen >= 4)

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -329,6 +329,7 @@ int pim_socket_leave(int fd, pim_addr group, pim_addr ifaddr, ifindex_t ifindex,
 		flog_err(EC_LIB_SOCKET,
 			 "Failure socket leaving fd=%d group %pPAs on interface address %pPAs: %m",
 			 fd, &group, &ifaddr);
+		/* We don't track socket leave errors; reuse joins_failed. */
 		pim_ifp->igmp_ifstat_joins_failed++;
 		return ret;
 	}


### PR DESCRIPTION
Use ntohs for received holdtime and drop a duplicate prefix-list lookup. Note in pim_socket_leave() that leave failures share the joins_failed stat counter.