### PR TITLE
pimd: fix multicast boundary list lifetime and ACL evaluation

### DIFF
--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -152,6 +152,7 @@ int main(int argc, char **argv, char **envp)
 
 	access_list_init();
 	access_list_add_hook(pim_access_list_update);
+	access_list_delete_hook(pim_access_list_update);
 	prefix_list_init();
 
 	/*

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -17,6 +17,7 @@
 #include "hash.h"
 #include "ferr.h"
 #include "network.h"
+#include "filter.h"
 
 #include "pimd.h"
 #include "pim_instance.h"
@@ -240,9 +241,104 @@ void pim_if_delete(struct interface *ifp)
 
 	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->nbr_plist);
 	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->allow_rp_plist);
+	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->boundary_oil_plist);
+	pim_ifp->boundary_oil_plist_p = NULL;
+	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->boundary_acl);
+	pim_ifp->boundary_acl_p = NULL;
 	XFREE(MTYPE_PIM_INTERFACE, pim_ifp);
 
 	ifp->info = NULL;
+}
+
+void pim_boundary_oil_plist_set(struct pim_interface *pim_ifp, const char *name)
+{
+	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->boundary_oil_plist);
+	pim_ifp->boundary_oil_plist_p = NULL;
+
+	if (!name)
+		return;
+
+	pim_ifp->boundary_oil_plist = XSTRDUP(MTYPE_PIM_PLIST_NAME, name);
+	pim_ifp->boundary_oil_plist_p = prefix_list_lookup(AFI_IP, name);
+}
+
+void pim_boundary_acl_set(struct pim_interface *pim_ifp, const char *name)
+{
+	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->boundary_acl);
+	pim_ifp->boundary_acl_p = NULL;
+
+	if (!name)
+		return;
+
+	pim_ifp->boundary_acl = XSTRDUP(MTYPE_PIM_PLIST_NAME, name);
+	pim_ifp->boundary_acl_p = access_list_lookup(AFI_IP, name);
+}
+
+static void pim_boundary_prefix_list_update_intf(struct pim_interface *pim_ifp,
+						 struct prefix_list *plist)
+{
+	if (!pim_ifp->boundary_oil_plist)
+		return;
+
+	if (pim_ifp->boundary_oil_plist_p == plist)
+		pim_ifp->boundary_oil_plist_p = NULL;
+
+	if (plist && !strcmp(pim_ifp->boundary_oil_plist, prefix_list_name(plist)))
+		pim_ifp->boundary_oil_plist_p = prefix_list_lookup(AFI_IP,
+								   pim_ifp->boundary_oil_plist);
+}
+
+static void pim_boundary_access_list_update_intf(struct pim_interface *pim_ifp,
+						 struct access_list *access)
+{
+	if (!pim_ifp->boundary_acl)
+		return;
+
+	if (pim_ifp->boundary_acl_p == access)
+		pim_ifp->boundary_acl_p = NULL;
+
+	if (access && !strcmp(pim_ifp->boundary_acl, access->name))
+		pim_ifp->boundary_acl_p = access_list_lookup(AFI_IP, pim_ifp->boundary_acl);
+}
+
+void pim_boundary_prefix_list_update(struct prefix_list *plist)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		if (!vrf->info)
+			continue;
+
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			pim_ifp = ifp->info;
+			if (!pim_ifp)
+				continue;
+
+			pim_boundary_prefix_list_update_intf(pim_ifp, plist);
+		}
+	}
+}
+
+void pim_boundary_access_list_update(struct access_list *access)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		if (!vrf->info)
+			continue;
+
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			pim_ifp = ifp->info;
+			if (!pim_ifp)
+				continue;
+
+			pim_boundary_access_list_update_intf(pim_ifp, access);
+		}
+	}
 }
 
 void pim_if_update_could_assert(struct interface *ifp)

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -18,6 +18,9 @@
 #include "pim_igmp.h"
 #include "pim_upstream.h"
 #include "pim_ifchannel.h"
+
+struct prefix_list;
+struct access_list;
 #include "bfd.h"
 #include "pim_str.h"
 #include "pim_routemap.h"
@@ -163,9 +166,11 @@ struct pim_interface {
 	int pim_dr_num_nondrpri_neighbors; /* neighbors without dr_pri */
 
 	/* boundary prefix-list (group) */
-	struct prefix_list *boundary_oil_plist;
+	char *boundary_oil_plist;
+	struct prefix_list *boundary_oil_plist_p;
 	/* boundary access-list (source and group) */
-	struct access_list *boundary_acl;
+	char *boundary_acl;
+	struct access_list *boundary_acl_p;
 
 	/* Turn on Active-Active for this interface */
 	bool activeactive;
@@ -303,6 +308,11 @@ int pim_if_ifchannel_count(struct pim_interface *pim_ifp);
 void pim_iface_init(void);
 void pim_pim_interface_delete(struct interface *ifp);
 void pim_gm_interface_delete(struct interface *ifp);
+
+void pim_boundary_oil_plist_set(struct pim_interface *pim_ifp, const char *name);
+void pim_boundary_acl_set(struct pim_interface *pim_ifp, const char *name);
+void pim_boundary_prefix_list_update(struct prefix_list *plist);
+void pim_boundary_access_list_update(struct access_list *access);
 
 const char *pim_mod_str(enum pim_iface_mode mode);
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1899,9 +1899,9 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 		       sizeof(struct in_addr));
 
 		if (PIM_DEBUG_GM_PACKETS) {
-			zlog_debug("    Recv IGMP report v3 (type %d) from %pI4s on %s: record=%d type=%d auxdatalen=%d sources=%d group=%pI4",
-				   rec_type, &from, ifp->name, i, rec_type, rec_auxdatalen,
-				   rec_num_sources, &rec_group);
+			zlog_debug("    Recv IGMP report v3 (type %d) from %pI4s on %s: record=%d auxdatalen=%d sources=%d group=%pI4",
+				   rec_type, &from, ifp->name, i, rec_auxdatalen, rec_num_sources,
+				   &rec_group);
 		}
 
 		/* Scan sources */

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1777,10 +1777,9 @@ static bool igmp_pkt_grp_addr_ok(struct interface *ifp, struct in_addr from, str
 		if (PIM_DEBUG_GM_PACKETS) {
 			zlog_debug("Filtering IGMPv3 group record %pI4 from %pI4s on %s per prefix-list %s or access-list %s",
 				   &grp.s_addr, &from, ifp->name,
-				   (pim_ifp->boundary_oil_plist ? pim_ifp->boundary_oil_plist->name
+				   (pim_ifp->boundary_oil_plist ? pim_ifp->boundary_oil_plist
 								: "(not found)"),
-				   (pim_ifp->boundary_acl ? pim_ifp->boundary_acl->name
-							  : "(not found)"));
+				   (pim_ifp->boundary_acl ? pim_ifp->boundary_acl : "(not found)"));
 		}
 		return false;
 	}

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -118,6 +118,7 @@ int main(int argc, char **argv, char **envp)
 	pim_vrf_init();
 	access_list_init();
 	access_list_add_hook(pim_access_list_update);
+	access_list_delete_hook(pim_access_list_update);
 	prefix_list_init();
 	prefix_list_add_hook(pim_prefix_list_update);
 	prefix_list_delete_hook(pim_prefix_list_update);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -3068,8 +3068,7 @@ int lib_interface_pim_address_family_multicast_boundary_oil_modify(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		pim_ifp->boundary_oil_plist =
-			prefix_list_lookup(AFI_IP, yang_dnode_get_string(args->dnode, NULL));
+		pim_boundary_oil_plist_set(pim_ifp, yang_dnode_get_string(args->dnode, NULL));
 
 		break;
 	}
@@ -3099,7 +3098,7 @@ int lib_interface_pim_address_family_multicast_boundary_oil_destroy(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		pim_ifp->boundary_oil_plist = NULL;
+		pim_boundary_oil_plist_set(pim_ifp, NULL);
 		break;
 	}
 
@@ -3135,8 +3134,7 @@ int lib_interface_pim_address_family_multicast_boundary_acl_modify(struct nb_cb_
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		pim_ifp->boundary_acl =
-			access_list_lookup(AFI_IP, yang_dnode_get_string(args->dnode, NULL));
+		pim_boundary_acl_set(pim_ifp, yang_dnode_get_string(args->dnode, NULL));
 		break;
 	}
 
@@ -3164,7 +3162,7 @@ int lib_interface_pim_address_family_multicast_boundary_acl_destroy(struct nb_cb
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		pim_ifp->boundary_acl = NULL;
+		pim_boundary_acl_set(pim_ifp, NULL);
 		break;
 	}
 

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -150,15 +150,17 @@ static bool pim_cisco_match(const struct filter *filter, const struct in_addr *s
 	uint32_t source_addr;
 	uint32_t group_addr;
 
-	group_addr = group->s_addr & ~cfilter->wtf.mask_mask.s_addr;
-
 	if (cfilter->extended) {
 		source_addr = source->s_addr & ~cfilter->wtf.addr_mask.s_addr;
+		group_addr = group->s_addr & ~cfilter->wtf.mask_mask.s_addr;
 		if (group_addr == cfilter->wtf.mask.s_addr &&
 		    source_addr == cfilter->wtf.addr.s_addr)
 			return true;
-	} else if (group_addr == cfilter->addr.s_addr)
-		return true;
+	} else {
+		group_addr = group->s_addr & ~cfilter->addr_mask.s_addr;
+		if (group_addr == cfilter->addr.s_addr)
+			return true;
+	}
 
 	return false;
 }

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -165,6 +165,19 @@ static bool pim_cisco_match(const struct filter *filter, const struct in_addr *s
 	return false;
 }
 
+static bool pim_acl_prefix_match(const struct filter *filter, const struct prefix *p)
+{
+	const struct filter_zebra *zfilter = &filter->u.zfilter;
+
+	if (zfilter->prefix.family != p->family)
+		return false;
+
+	if (zfilter->exact && zfilter->prefix.prefixlen != p->prefixlen)
+		return false;
+
+	return prefix_match(&zfilter->prefix, p);
+}
+
 enum filter_type pim_access_list_apply(struct access_list *access, const struct in_addr *source,
 				       const struct in_addr *group)
 {
@@ -174,17 +187,20 @@ enum filter_type pim_access_list_apply(struct access_list *access, const struct 
 	if (access == NULL)
 		return FILTER_DENY;
 
+	group_prefix.family = AF_INET;
+	group_prefix.prefixlen = IPV4_MAX_BITLEN;
+	group_prefix.u.prefix4.s_addr = group->s_addr;
+
 	for (filter = access->head; filter; filter = filter->next) {
 		if (filter->cisco) {
 			if (pim_cisco_match(filter, source, group))
 				return filter->type;
+		} else if (pim_acl_prefix_match(filter, &group_prefix)) {
+			return filter->type;
 		}
 	}
 
-	group_prefix.family = AF_INET;
-	group_prefix.prefixlen = IPV4_MAX_BITLEN;
-	group_prefix.u.prefix4.s_addr = group->s_addr;
-	return access_list_apply(access, &group_prefix);
+	return FILTER_DENY;
 }
 
 bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp, pim_addr *src)

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -198,27 +198,28 @@ bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp, pim_add
 	pim_addr_to_prefix(&grp_pfx, *grp);
 
 	/* Filter if either group or (S,G) are denied */
-	if (pim_ifp->boundary_oil_plist) {
-		is_filtered = prefix_list_apply_ext(pim_ifp->boundary_oil_plist, NULL, &grp_pfx,
+	if (pim_ifp->boundary_oil_plist_p) {
+		is_filtered = prefix_list_apply_ext(pim_ifp->boundary_oil_plist_p, NULL, &grp_pfx,
 						    true) == PREFIX_DENY;
 		if (is_filtered && PIM_DEBUG_EVENTS) {
 			zlog_debug("Filtering group %pI4 per prefix-list %s", grp,
-				   pim_ifp->boundary_oil_plist->name);
+				   pim_ifp->boundary_oil_plist);
 		}
 	}
-	if (!is_filtered && pim_ifp->boundary_acl) {
+	if (!is_filtered && pim_ifp->boundary_acl_p) {
 		/* If src not provided, set to "any" (*)? */
 		if (!src)
 			src = &any_src;
 		/* S,G filtering using extended access-list syntax */
-		is_filtered = pim_access_list_apply(pim_ifp->boundary_acl, src, grp) == FILTER_DENY;
+		is_filtered = pim_access_list_apply(pim_ifp->boundary_acl_p, src, grp) ==
+			      FILTER_DENY;
 		if (is_filtered && PIM_DEBUG_EVENTS) {
 			if (pim_addr_is_any(*src)) {
 				zlog_debug("Filtering (S,G)=(*, %pI4) per access-list %s", grp,
-					   pim_ifp->boundary_acl->name);
+					   pim_ifp->boundary_acl);
 			} else {
 				zlog_debug("Filtering (S,G)=(%pI4, %pI4) per access-list %s", src,
-					   grp, pim_ifp->boundary_acl->name);
+					   grp, pim_ifp->boundary_acl);
 			}
 		}
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -611,13 +611,12 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 	/* boundary */
 	if (pim_ifp->boundary_oil_plist) {
 		vty_out(vty, " " PIM_AF_NAME " multicast boundary oil %s\n",
-			pim_ifp->boundary_oil_plist->name);
+			pim_ifp->boundary_oil_plist);
 		++writes;
 	}
 
 	if (pim_ifp->boundary_acl) {
-		vty_out(vty, " " PIM_AF_NAME " multicast boundary %s\n",
-			pim_ifp->boundary_acl->name);
+		vty_out(vty, " " PIM_AF_NAME " multicast boundary %s\n", pim_ifp->boundary_acl);
 		++writes;
 	}
 

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -37,6 +37,7 @@
 #include "pim_zebra.h"
 #include "pim_mlag.h"
 #include "pim_autorp.h"
+#include "pim_iface.h"
 
 #if MAXVIFS > 256
 CPP_NOTICE("Work needs to be done to make this work properly via the pim mroute socket\n");
@@ -76,11 +77,14 @@ void pim_prefix_list_update(struct prefix_list *plist)
 		pim_autorp_prefix_list_update(pim, plist);
 #endif
 	}
+
+	pim_boundary_prefix_list_update(plist);
 }
 
 void pim_access_list_update(struct access_list *access)
 {
 	pim_filter_ref_update();
+	pim_boundary_access_list_update(access);
 }
 
 static void pim_free(void)

--- a/tests/topotests/pim_boundary_acl/test_pim_boundary_acl.py
+++ b/tests/topotests/pim_boundary_acl/test_pim_boundary_acl.py
@@ -47,6 +47,25 @@ def verify_no_igmp_source(router, group, interface=None):
     return None
 
 
+def verify_igmp_source(router, group, source, interface):
+    """Return None when the expected IGMP source is present on an interface."""
+    output = router.vtysh_cmd("show ip igmp sources json", isjson=True)
+    iface = output.get(interface, {})
+    group_data = iface.get(group, {})
+    for entry in group_data.get("sources", []):
+        if entry.get("source") == source:
+            return None
+    return "Expected IGMP source {} for {} on {}".format(source, group, interface)
+
+
+def verify_router_running(router):
+    """Return None when all configured daemons are running."""
+    result = router.check_router_running()
+    if result:
+        return "{} daemons are not running: {}".format(router.name, result)
+    return None
+
+
 def build_topo(tgen):
     "Build function"
 
@@ -478,6 +497,225 @@ def test_pim_ssm_igmp_join_acl():
 
     # PIM join
     # PIM-DM forwarding
+
+
+def test_pim_boundary_list_deletion_and_mixed_acl():
+    "Test boundary behavior after list deletion and mixed ACL first-match order"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+    r3 = tgen.gears["r3"]
+
+    # Leave prior tests in a known state.
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            interface r1-eth0
+              no ip multicast boundary pim-acl
+              no ip multicast boundary oil pim-oil-plist
+            no access-list pim-acl seq 5 permit ip host 10.0.20.2 232.1.1.0 0.0.0.128
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              no ip igmp join {}
+              no ip igmp join {} 10.0.20.2
+              no ip multicast boundary pim-acl
+              no ip multicast boundary oil pim-oil-plist
+        """
+        ).format(ASM_GROUP, SSM_GROUP)
+    )
+    r3.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r3-eth0
+              no ip igmp join {} 10.0.40.4
+        """
+        ).format(SSM_GROUP)
+    )
+
+    # Deleting a prefix-list while boundary oil remains configured must not
+    # crash pimd; filtering should stop once the list is gone.
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            interface r1-eth0
+              ip multicast boundary oil pim-oil-plist
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              ip igmp join {}
+        """
+        ).format(ASM_GROUP)
+    )
+    test_func = partial(verify_no_igmp_source, r1, ASM_GROUP, "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected IGMP source to be absent but is present"
+
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            no ip prefix-list pim-oil-plist
+        """
+    )
+    test_func = partial(verify_router_running, r1)
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=1)
+    assert result is None, result
+
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              no ip igmp join {}
+              ip igmp join {}
+        """
+        ).format(ASM_GROUP, ASM_GROUP)
+    )
+    test_func = partial(verify_igmp_source, r1, ASM_GROUP, "*", "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert (
+        result is None
+    ), "Expected IGMP source to be present after prefix-list deletion"
+
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            interface r1-eth0
+              no ip multicast boundary oil pim-oil-plist
+            ip prefix-list pim-oil-plist seq 10 deny 229.1.1.0/24
+            ip prefix-list pim-oil-plist seq 20 permit any
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              no ip igmp join {}
+        """
+        ).format(ASM_GROUP)
+    )
+
+    # Same for access-lists referenced by ip multicast boundary.
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            interface r1-eth0
+              ip multicast boundary pim-acl
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              ip igmp join {} 10.0.20.2
+        """
+        ).format(SSM_GROUP)
+    )
+    test_func = partial(verify_no_igmp_source, r1, SSM_GROUP, "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected IGMP source to be absent but is present"
+
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            no access-list pim-acl
+        """
+    )
+    test_func = partial(verify_router_running, r1)
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=1)
+    assert result is None, result
+
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              no ip igmp join {} 10.0.20.2
+              ip igmp join {} 10.0.20.2
+        """
+        ).format(SSM_GROUP, SSM_GROUP)
+    )
+    test_func = partial(verify_igmp_source, r1, SSM_GROUP, "10.0.20.2", "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert (
+        result is None
+    ), "Expected IGMP source to be present after access-list deletion"
+
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            interface r1-eth0
+              no ip multicast boundary pim-acl
+            access-list pim-acl seq 10 deny ip host 10.0.20.2 232.1.1.0 0.0.0.255
+            access-list pim-acl seq 20 permit ip any any
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              no ip igmp join {} 10.0.20.2
+        """
+        ).format(SSM_GROUP)
+    )
+
+    # Mixed standard + extended ACL entries must honor first-match order.
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            access-list pim-mixed-acl seq 10 permit 232.1.1.0/24
+            access-list pim-mixed-acl seq 20 deny ip host 10.0.20.2 232.1.1.0 0.0.0.255
+            interface r1-eth0
+              ip multicast boundary pim-mixed-acl
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              ip igmp join {} 10.0.20.2
+        """
+        ).format(SSM_GROUP)
+    )
+    test_func = partial(verify_igmp_source, r1, SSM_GROUP, "10.0.20.2", "r1-eth0")
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert result is None, "Expected mixed ACL permit rule to win over later deny"
+
+    # Cleanup
+    r1.vtysh_cmd(
+        """
+          configure terminal
+            interface r1-eth0
+              no ip multicast boundary pim-mixed-acl
+            no access-list pim-mixed-acl
+        """
+    )
+    r2.vtysh_cmd(
+        (
+            """
+          configure terminal
+            interface r2-eth0
+              no ip igmp join {} 10.0.20.2
+        """
+        ).format(SSM_GROUP)
+    )
 
 
 def test_memory_leak():


### PR DESCRIPTION
- Fix dangling boundary list pointers by storing names and looking them up at use time
- Preserve ACL first-match order for mixed cisco/standard entries
- Clean up duplicate IGMPv3 debug output
- Add topotest coverage for list deletion and mixed ACL ordering