### PR TITLE
docker: Add snmptrapd to list of thingies to install

### DIFF
--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -84,6 +84,7 @@ RUN for i in $(seq 1 ${APT_RETRIES}); do \
         python3 \
         python3-pip \
         snmp \
+	snmptrapd \
         snmp-mibs-downloader \
         snmpd \
         ssmping \


### PR DESCRIPTION
snmptrapd not being installed causes a test to skip. Let's let the docker ci stuff run this test too.