### PR TITLE
yang: use relative path for remaining route-map when clauses

### DIFF
--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -682,7 +682,7 @@ identity set-extcommunity-color {
     }
 
     case rpki-extcommunity {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-bgp-route-map:rpki-extcommunity')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-bgp-route-map:rpki-extcommunity')";
       leaf rpki-extcommunity {
         type enumeration {
           enum "valid" {

--- a/yang/frr-pim-route-map.yang
+++ b/yang/frr-pim-route-map.yang
@@ -106,7 +106,7 @@ module frr-pim-route-map {
        addresses, group addresses, prefix lists, and interfaces.";
 
     case multicast-source {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-source')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-source')";
 
       leaf ipv4-multicast-source-address {
         type inet:ipv4-address;
@@ -116,7 +116,7 @@ module frr-pim-route-map {
     }
 
     case multicast-source-v6 {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-source')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-source')";
 
       leaf ipv6-multicast-source-address {
         type inet:ipv6-address;
@@ -126,7 +126,7 @@ module frr-pim-route-map {
     }
 
     case multicast-group {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-group')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-group')";
 
       leaf ipv4-multicast-group-address {
         type inet:ipv4-address;
@@ -136,7 +136,7 @@ module frr-pim-route-map {
     }
 
     case multicast-group-v6 {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-group')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-group')";
 
       leaf ipv6-multicast-group-address {
         type inet:ipv6-address;
@@ -146,7 +146,7 @@ module frr-pim-route-map {
     }
 
     case multicast-interface {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:multicast-interface')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:multicast-interface')";
 
       leaf multicast-interface {
         type frr-interface:interface-ref;
@@ -156,7 +156,7 @@ module frr-pim-route-map {
     }
 
     case multicast-source-interface {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:multicast-source-interface')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:multicast-source-interface')";
 
       leaf multicast-source-interface {
         type frr-interface:interface-ref;
@@ -166,10 +166,10 @@ module frr-pim-route-map {
     }
 
     case prefix-list-name {
-      when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-source-prefix-list') or "
-      + "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-source-prefix-list') or "
-      + "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-group-prefix-list') or "
-      + "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-group-prefix-list')";
+      when "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-source-prefix-list') or "
+      + "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-source-prefix-list') or "
+      + "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv4-multicast-group-prefix-list') or "
+      + "derived-from-or-self(../frr-route-map:condition, 'frr-pim-route-map:ipv6-multicast-group-prefix-list')";
 
       leaf list-name {
         type frr-filter:prefix-list-ref;


### PR DESCRIPTION
f1ea52bee9 ("yang: use relative path instead of absolute one for route-map") converted most absolute XPath expressions in route-map YANG modules to relative paths, but missed 8 occurrences:

  - frr-bgp-route-map.yang: rpki-extcommunity (1)
  - frr-pim-route-map.yang: multicast match conditions (7)

Using absolute XPath is not optimal for finding the target node. libyang's lyd_find_xpath() incurs O(N) overhead when resolving paths from the document root.  Relative paths are much faster.

Convert the remaining:
  /frr-route-map:lib/frr-route-map:route-map/.../frr-route-map:condition
to:
  ../frr-route-map:condition