### PR TITLE
tests: fix bgp_soo topotest by separating IPv4/IPv6 address families

### DIFF
--- a/tests/topotests/bgp_soo/cpe1/bgpd.conf
+++ b/tests/topotests/bgp_soo/cpe1/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65000
  no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
  neighbor 192.168.1.2 remote-as external
  neighbor 192.168.1.2 timers 1 3
  neighbor 192.168.1.2 timers connect 1
@@ -9,6 +10,8 @@ router bgp 65000
  neighbor 10.0.0.2 remote-as internal
  neighbor 2001:db8:10::2 remote-as internal
  address-family ipv4 unicast
+  neighbor 192.168.1.2 activate
+  neighbor 10.0.0.2 activate
   redistribute connected
  exit-address-family
  address-family ipv6 unicast

--- a/tests/topotests/bgp_soo/cpe2/bgpd.conf
+++ b/tests/topotests/bgp_soo/cpe2/bgpd.conf
@@ -1,5 +1,6 @@
 router bgp 65000
  no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
  neighbor 192.168.2.2 remote-as external
  neighbor 192.168.2.2 timers 1 3
  neighbor 192.168.2.2 timers connect 1
@@ -9,6 +10,8 @@ router bgp 65000
  neighbor 10.0.0.1 remote-as internal
  neighbor 2001:db8:10::1 remote-as internal
  address-family ipv4 unicast
+  neighbor 192.168.2.2 activate
+  neighbor 10.0.0.1 activate
   redistribute connected
  exit-address-family
  address-family ipv6 unicast

--- a/tests/topotests/bgp_soo/pe1/bgpd.conf
+++ b/tests/topotests/bgp_soo/pe1/bgpd.conf
@@ -14,6 +14,7 @@ router bgp 65001
 router bgp 65001 vrf RED
  bgp router-id 192.168.1.2
  no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
  neighbor 192.168.1.1 remote-as external
  neighbor 192.168.1.1 timers 1 3
  neighbor 192.168.1.1 timers connect 1
@@ -21,6 +22,7 @@ router bgp 65001 vrf RED
  neighbor 2001:db8:1::1 timers 1 3
  neighbor 2001:db8:1::1 timers connect 1
  address-family ipv4 unicast
+  neighbor 192.168.1.1 activate
   neighbor 192.168.1.1 as-override
   neighbor 192.168.1.1 soo 65000:1
   label vpn export 1111
@@ -31,6 +33,7 @@ router bgp 65001 vrf RED
   import vpn
  exit-address-family
  address-family ipv6 unicast
+  neighbor 2001:db8:1::1 activate
   neighbor 2001:db8:1::1 as-override
   neighbor 2001:db8:1::1 soo 65000:1
   label vpn export 1111

--- a/tests/topotests/bgp_soo/pe2/bgpd.conf
+++ b/tests/topotests/bgp_soo/pe2/bgpd.conf
@@ -11,6 +11,7 @@ router bgp 65001
 router bgp 65001 vrf RED
  bgp router-id 192.168.2.2
  no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
  neighbor 192.168.2.1 remote-as external
  neighbor 192.168.2.1 timers 1 3
  neighbor 192.168.2.1 timers connect 1
@@ -18,6 +19,7 @@ router bgp 65001 vrf RED
  neighbor 2001:db8:2::1 timers 1 3
  neighbor 2001:db8:2::1 timers connect 1
  address-family ipv4 unicast
+  neighbor 192.168.2.1 activate
   neighbor 192.168.2.1 as-override
   neighbor 192.168.2.1 route-map cpe2-in in
   label vpn export 2222

--- a/tests/topotests/bgp_soo/test_bgp_soo.py
+++ b/tests/topotests/bgp_soo/test_bgp_soo.py
@@ -10,6 +10,16 @@
 Test if BGP SoO per neighbor works correctly. Routes having SoO
 extended community MUST be rejected if the neighbor is configured
 with soo (neighbor soo).
+
+test_bgp_soo() validates the core SoO functionality:
+- PE1 attaches SoO 65000:1 to routes received from CPE1
+- PE2 imports these routes via VPN
+- When PE2 has "neighbor soo 65000:1" configured for CPE2, routes
+  with matching SoO are filtered (not advertised to CPE2)
+
+The remaining tests use this SoO/VPN topology to validate the JSON
+output format for neighbor routes and advertised-routes commands.
+They verify JSON structure and path counts, not SoO behavior.
 """
 
 import os
@@ -225,7 +235,7 @@ def test_bgp_soo_pe1_neighbor_routes_json():
                 ],
             },
             "totalRoutes": 4,
-            "totalPaths": 12,
+            "totalPaths": 8,
             "numRoutes": 4,
         }
         return topotest.json_cmp(output, expected)
@@ -261,26 +271,26 @@ def test_bgp_soo_pe1_neighbor_routes_brief_json():
                 "10.0.0.0/24": {
                     "flags": {"bestPathExists": True},
                     "pathCount": 1,
-                    "multiPathCount": 2,
+                    "multiPathCount": 1,
                 },
                 "172.16.255.1/32": {
                     "flags": {"bestPathExists": True},
                     "pathCount": 1,
-                    "multiPathCount": 2,
+                    "multiPathCount": 1,
                 },
                 "192.168.1.0/24": {
                     "flags": {"bestPathExists": True},
                     "pathCount": 1,
-                    "multiPathCount": 2,
+                    "multiPathCount": 1,
                 },
                 "192.168.2.0/24": {
                     "flags": {"bestPathExists": True},
                     "pathCount": 1,
-                    "multiPathCount": 2,
+                    "multiPathCount": 1,
                 },
             },
             "totalRoutes": 4,
-            "totalPaths": 12,
+            "totalPaths": 8,
             "numRoutes": 4,
         }
         return topotest.json_cmp(output, expected)
@@ -412,7 +422,7 @@ def test_bgp_soo_ipv4_advertised_routes_brief_json():
             "advertisedRoutes": {
                 "10.0.0.0/24": {
                     "flags": {"bestPathExists": True},
-                    "pathCount": 3,
+                    "pathCount": 2,
                     "multiPathCount": 1,
                 },
                 "172.16.255.1/32": {
@@ -427,8 +437,8 @@ def test_bgp_soo_ipv4_advertised_routes_brief_json():
                 },
                 "192.168.2.0/24": {
                     "flags": {"bestPathExists": True},
-                    "pathCount": 2,
-                    "multiPathCount": 2,
+                    "pathCount": 1,
+                    "multiPathCount": 1,
                 },
             }
         }


### PR DESCRIPTION
The bgp_soo topotest was flaky because IPv4 routes were being advertised over both IPv4 and IPv6 BGP sessions due to the default behavior of "bgp default ipv4-unicast" which auto-activates IPv4 unicast for all neighbors.

This caused inconsistent path counts depending on timing:
- Sometimes multiPathCount showed 2 or 3 instead of expected values
- The duplicate paths from IPv6 sessions carrying IPv4 routes caused the flakiness

Fix by adding "no bgp default ipv4-unicast" to all routers and explicitly activating only the appropriate neighbors in each address-family:
- IPv4 unicast: only IPv4 peers activated
- IPv6 unicast: only IPv6 peers activated

Update test expectations to reflect the correct path counts now that duplicate paths are eliminated.

Note: The core SoO functionality is validated by test_bgp_soo() which checks route filtering based on SoO extended community matching. The pathCount/multiPathCount changes in other tests only affect JSON output format validation, not SoO behavior. Updated docstrings to clarify this.