### PR TITLE
*: preserve peer prefixlen on point-to-point interfaces

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3191,6 +3191,8 @@ size_t zebra_interface_link_params_write(struct stream *s,
  * :               :
  * |               |
  * +-+-+-+-+-+-+-+-+
+ * |  dst_pfx_len  |  prefixlen of destination (peer) address; 0 = unknown
+ * +-+-+-+-+-+-+-+-+
  */
 
 static int memconstant(const void *s, int c, size_t n)
@@ -3243,6 +3245,7 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 
 	/* Fetch destination address. */
 	STREAM_GET(&d.u.prefix, s, plen);
+	STREAM_GETC(s, d.prefixlen);
 
 	/* N.B. NULL destination pointers are encoded as all zeroes */
 	dp = memconstant(&d.u.prefix, 0, plen) ? NULL : &d;
@@ -3256,10 +3259,19 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 		}
 		if (ifc) {
 			ifc->flags = ifc_flags;
-			if (ifc->destination)
-				ifc->destination->prefixlen =
-					ifc->address->prefixlen;
-			else if (CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
+			if (ifc->destination) {
+				/* Preserve peer-side prefixlen from the wire
+				 * (point-to-point interfaces: local /32, peer
+				 * carries the real subnet prefixlen). Fall
+				 * back to address prefixlen when the sender
+				 * didn't supply one. */
+				if (d.prefixlen)
+					ifc->destination->prefixlen =
+						d.prefixlen;
+				else
+					ifc->destination->prefixlen =
+						ifc->address->prefixlen;
+			} else if (CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
 				/* carp interfaces on OpenBSD with 0.0.0.0/0 as
 				 * "peer" */
 				flog_err(

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -420,7 +420,7 @@ extern int zclient_bfd_session_update(ZAPI_CALLBACK_ARGS);
 #define ZAPI_MESSAGE_SRTE 0x0200
 #define ZAPI_MESSAGE_OPAQUE 0x0400
 
-#define ZSERV_VERSION 6
+#define ZSERV_VERSION 7
 /* Zserv protocol message header */
 struct zmsghdr {
 	uint16_t length;

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3244,9 +3244,19 @@ static int ospf_make_hello(struct ospf_interface *oi, struct stream *s)
 	/* Set netmask of interface. */
 	if (!(CHECK_FLAG(oi->connected->flags, ZEBRA_IFA_UNNUMBERED)
 	      && oi->type == OSPF_IFTYPE_POINTOPOINT)
-	    && oi->type != OSPF_IFTYPE_VIRTUALLINK)
-		masklen2ip(oi->address->prefixlen, &mask);
-	else
+	    && oi->type != OSPF_IFTYPE_VIRTUALLINK) {
+		/* For a peer-addressed interface (point-to-point tunnels:
+		 * gif/gre/ipsec on BSD, vti/gre/sit on Linux, or
+		 * "ip addr add A peer B/N" on Linux) the local address is /32
+		 * and the real subnet prefixlen lives on the peer. Use that
+		 * one so strict OSPF peers (RouterOS, IOS, Junos) don't see a
+		 * /32 mask on a numbered link. */
+		if (CONNECTED_PEER(oi->connected))
+			masklen2ip(oi->connected->destination->prefixlen,
+				   &mask);
+		else
+			masklen2ip(oi->address->prefixlen, &mask);
+	} else
 		memset((char *)&mask, 0, sizeof(struct in_addr));
 	stream_put_ipv4(s, mask.s_addr);
 

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -60,7 +60,10 @@ static void connected_announce(struct interface *ifp, struct connected *ifc)
 		return;
 
 	if (!if_is_loopback(ifp) && ifc->address->family == AF_INET) {
-		if (ifc->address->prefixlen == IPV4_MAX_BITLEN)
+		struct prefix *p = CONNECTED_PEER(ifc) ? ifc->destination
+						       : ifc->address;
+
+		if (p->prefixlen == IPV4_MAX_BITLEN)
 			SET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
 		else
 			UNSET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -309,10 +309,13 @@ int zsend_interface_address(int cmd, struct zserv *client,
 
 	/* Destination. */
 	p = ifc->destination;
-	if (p)
+	if (p) {
 		stream_put(s, &p->u.prefix, blen);
-	else
+		stream_putc(s, p->prefixlen);
+	} else {
 		stream_put(s, NULL, blen);
+		stream_putc(s, 0);
+	}
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));


### PR DESCRIPTION
On a point-to-point interface where the address is configured with a peer ("ip addr add A peer B/N" on Linux, or any gif/gre/ipsec tunnel on FreeBSD), the local address is /32 and the real subnet prefixlen lives on the peer side. Zebra was treating these interfaces as unnumbered and ospfd was advertising a /32 (or 0.0.0.0) netmask in OSPF Hellos, which strict OSPF peers (RouterOS, IOS, Junos) reject.

The kernel layer already populated ifc->destination with the correct peer prefixlen, but two issues dropped it on the floor:

  1. zsend_interface_address() only encoded the destination IP, not its prefixlen, so clients could not recover it.
  2. zebra_interface_address_read() then overwrote ifc->destination->prefixlen with ifc->address->prefixlen (always /32 for peer-addressed interfaces), masking the bug.

Extend the ZEBRA_INTERFACE_ADDRESS_{ADD,DELETE} wire format with one byte for the destination prefixlen, preserve it on the receive side when non-zero (falling back to the address prefixlen otherwise, for backward-compatible behavior on broadcast interfaces), and use it from zebra/connected_announce() and ospfd/ospf_make_hello() to make the right decision.

Reported-by: see https://github.com/FRRouting/frr/pull/8132
Reported-by: see https://github.com/ocochard/BSDRP/issues/27


Regression tests in https://github.com/ocochard/myscripts/blob/master/FreeBSD/ports-tests/frr_tunnel_unnumbered_test.sh