### PR TITLE
pimd: guard NULL RP lookups in BSM and RP deletion paths

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -783,7 +783,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 		trp_info = pim_rp_find_match_group(pim, &grp);
 
 		/* RP not found for the group grp */
-		if (pim_rpf_addr_is_inaddr_any(&trp_info->rp)) {
+		if (!trp_info || pim_rpf_addr_is_inaddr_any(&trp_info->rp)) {
 			pim_upstream_rpf_clear(pim, up);
 			pim_rp_set_upstream_addr(pim, &up->upstream_addr,
 						 up->sg.src, up->sg.grp);

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -509,8 +509,9 @@ static void pim_instate_pend_list(struct bsgrp_node *bsgrp_node)
 	 * install the rp from head(if exists) of partial list. List is
 	 * is sorted such that head is the elected RP for the group.
 	 */
-	if (!rn || (prefix_same(&rp_all->group, &bsgrp_node->group) &&
-		    pim_rpf_addr_is_inaddr_any(&rp_all->rp))) {
+	if (!rn || !rp_all ||
+	    (prefix_same(&rp_all->group, &bsgrp_node->group) &&
+	     pim_rpf_addr_is_inaddr_any(&rp_all->rp))) {
 		if (PIM_DEBUG_BSM)
 			zlog_debug("%s: Route node doesn't exist", __func__);
 		if (pend)

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -843,7 +843,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 			trp_info = pim_rp_find_match_group(pim, &grp);
 
 			/* RP not found for the group grp */
-			if (pim_rpf_addr_is_inaddr_any(&trp_info->rp)) {
+			if (!trp_info || pim_rpf_addr_is_inaddr_any(&trp_info->rp)) {
 				pim_upstream_rpf_clear(pim, up);
 				pim_rp_set_upstream_addr(
 					pim, &up->upstream_addr, up->sg.src,


### PR DESCRIPTION
- Fix NULL deref in pim_rp_del() when RP lookup fails after BSM-driven RP deletion ([#6088](https://github.com/FRRouting/frr/issues/6088))
- Guard rp_all in pim_instate_pend_list() when installing pending BSM RPs
- Guard trp_info in pim_bsm_clear() when refreshing upstreams on BSM teardown