### PR TITLE
lib: add prefix_match_with_family() for cross-family-safe matching

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -153,16 +153,13 @@ static int filter_match_zebra(struct filter *mfilter, const struct prefix *p)
 
 	filter = &mfilter->u.zfilter;
 
-	if (filter->prefix.family == p->family) {
-		if (filter->exact) {
-			if (filter->prefix.prefixlen == p->prefixlen)
-				return prefix_match(&filter->prefix, p);
-			else
-				return 0;
-		} else
-			return prefix_match(&filter->prefix, p);
-	} else
+	if (filter->exact) {
+		if (filter->prefix.prefixlen == p->prefixlen)
+			return prefix_match_with_family(&filter->prefix, p);
 		return 0;
+	}
+
+	return prefix_match_with_family(&filter->prefix, p);
 }
 
 static int filter_match_cisco_sadr4(struct filter *mfilter, const struct prefix *src,
@@ -250,16 +247,13 @@ static int filter_match_zebra_sadr(struct filter *mfilter, const struct prefix *
 
 	filter = &mfilter->u.zfilter;
 
-	if (filter->prefix.family == p->family) {
-		if (filter->exact) {
-			if (filter->prefix.prefixlen == p->prefixlen)
-				return prefix_match(&filter->prefix, p);
-			else
-				return 0;
-		} else
-			return prefix_match(&filter->prefix, p);
-	} else
+	if (filter->exact) {
+		if (filter->prefix.prefixlen == p->prefixlen)
+			return prefix_match_with_family(&filter->prefix, p);
 		return 0;
+	}
+
+	return prefix_match_with_family(&filter->prefix, p);
 }
 
 /* Allocate new access list structure. */

--- a/lib/if.c
+++ b/lib/if.c
@@ -605,7 +605,7 @@ struct connected *if_lookup_address(const void *matchaddr, int family,
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		frr_each (if_connected, ifp->connected, c) {
 			if (c->address && (c->address->family == family) &&
-			    prefix_match(CONNECTED_PREFIX(c), &addr) &&
+			    prefix_match_with_family(CONNECTED_PREFIX(c), &addr) &&
 			    (c->address->prefixlen > bestlen)) {
 				bestlen = c->address->prefixlen;
 				match = c;
@@ -1035,10 +1035,9 @@ struct connected *connected_lookup_prefix(struct interface *ifp,
 	match = NULL;
 
 	frr_each (if_connected, ifp->connected, c) {
-		if (c->address && (c->address->family == addr->family)
-		    && prefix_match(CONNECTED_PREFIX(c), addr)
-		    && (!match
-			|| (c->address->prefixlen > match->address->prefixlen)))
+		if (c->address && c->address->family == addr->family
+		    && prefix_match_with_family(CONNECTED_PREFIX(c), addr)
+		    && (!match || (c->address->prefixlen > match->address->prefixlen)))
 			match = c;
 	}
 	return match;

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -741,10 +741,7 @@ static int prefix_list_entry_match(struct prefix_list_entry *pentry,
 {
 	int ret;
 
-	if (pentry->prefix.family != p->family)
-		return 0;
-
-	ret = prefix_match(&pentry->prefix, p);
+	ret = prefix_match_with_family(&pentry->prefix, p);
 	if (!ret)
 		return 0;
 
@@ -1145,8 +1142,7 @@ static int vty_show_prefix_list_prefix(struct vty *vty, afi_t afi,
 			}
 
 		if (type == longer_display) {
-			if ((p.family == pentry->prefix.family)
-			    && (prefix_match(&p, &pentry->prefix)))
+			if (prefix_match_with_family(&p, &pentry->prefix))
 				match = 1;
 		}
 
@@ -1216,8 +1212,7 @@ static int vty_clear_prefix_list(struct vty *vty, afi_t afi, const char *name,
 
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			if (prefix) {
-				if (pentry->prefix.family == p.family
-				    && prefix_match(&pentry->prefix, &p))
+				if (prefix_match_with_family(&pentry->prefix, &p))
 					pentry->hitcnt = 0;
 			} else
 				pentry->hitcnt = 0;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -244,6 +244,18 @@ int prefix_match(union prefixconstptr unet, union prefixconstptr upfx)
 
 }
 
+/* Like prefix_match(), but returns 0 when the prefixes differ in family. */
+int prefix_match_with_family(union prefixconstptr unet, union prefixconstptr upfx)
+{
+	const struct prefix *n = unet.p;
+	const struct prefix *p = upfx.p;
+
+	if (n->family != p->family)
+		return 0;
+
+	return prefix_match(unet, upfx);
+}
+
 /*
  * n is a type5 evpn prefix. This function tries to see if there is an
  * ip-prefix within n which matches prefix p

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -422,6 +422,7 @@ extern const char *prefix2str(union prefixconstptr upfx, char *buffer,
 extern int evpn_type5_prefix_match(const struct prefix *evpn_pfx,
 				   const struct prefix *match_pfx);
 extern int prefix_match(union prefixconstptr unet, union prefixconstptr upfx);
+extern int prefix_match_with_family(union prefixconstptr unet, union prefixconstptr upfx);
 extern int prefix_match_network_statement(union prefixconstptr unet,
 					  union prefixconstptr upfx);
 extern int prefix_same(union prefixconstptr ua, union prefixconstptr ub);


### PR DESCRIPTION
Add a wrapper that rejects mismatched address families before calling `prefix_match()`, and use it at call sites that previously duplicated that check. Leave `prefix_match()` unchanged for single-family contexts such as route table walks.