### PR TITLE
lib: test the right bytes in flowspec prefixes

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -215,8 +215,8 @@ int prefix_match(union prefixconstptr unet, union prefixconstptr upfx)
 			return 0;
 
 		/* Set both prefix's head pointer. */
-		np = (const uint8_t *)&n->u.prefix_flowspec.ptr;
-		pp = (const uint8_t *)&p->u.prefix_flowspec.ptr;
+		np = (const uint8_t *)n->u.prefix_flowspec.ptr;
+		pp = (const uint8_t *)p->u.prefix_flowspec.ptr;
 
 		offset = n->u.prefix_flowspec.prefixlen;
 
@@ -440,8 +440,8 @@ int prefix_same(union prefixconstptr up1, union prefixconstptr up2)
 			if (p1->u.prefix_flowspec.prefixlen !=
 			    p2->u.prefix_flowspec.prefixlen)
 				return 0;
-			if (!memcmp(&p1->u.prefix_flowspec.ptr,
-				    &p2->u.prefix_flowspec.ptr,
+			if (!memcmp((void *)p1->u.prefix_flowspec.ptr,
+				    (void *)p2->u.prefix_flowspec.ptr,
 				    p2->u.prefix_flowspec.prefixlen))
 				return 1;
 		}


### PR DESCRIPTION
A couple of the comparisons used for FLOWSPEC prefix types used the address of the flowspec data blob rather than the blob bytes. Test the blob, not the pointers to blobs.
this was F-080 from the 2026_05_27 batch of reports from Qifan Zhang