### PR TITLE
pimd: defer static mroute install until interfaces are ready

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -37,6 +37,7 @@
 #include "pim_jp_agg.h"
 #include "pim_igmp_join.h"
 #include "pim_vxlan.h"
+#include "pim_static.h"
 #include "pim_tib.h"
 #include "pim_util.h"
 #include "pim_routemap.h"
@@ -1025,6 +1026,7 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 
 	/* if the device qualifies as pim_vxlan iif/oif update vxlan entries */
 	pim_vxlan_add_vif(ifp);
+	pim_static_reconcile(pim_ifp->pim);
 	return 0;
 }
 

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -35,6 +35,7 @@ static void pim_instance_terminate(struct pim_instance *pim)
 
 	if (pim->static_routes)
 		list_delete(&pim->static_routes);
+	pim_static_route_configs_fini(pim);
 
 	pim_instance_mlag_terminate(pim);
 
@@ -110,6 +111,7 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 
 	pim->static_routes = list_new();
 	pim->static_routes->del = (void (*)(void *))pim_static_route_free;
+	pim_static_route_cfgs_init(&pim->static_route_configs);
 
 	pim->send_v6_secondary = 1;
 

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -20,6 +20,7 @@
 #include "pim_mroute.h"
 #include "pim_autorp.h"
 #include "pim_nht.h"
+#include "pim_static.h"
 
 enum pim_spt_switchover {
 	PIM_SPT_IMMEDIATE,
@@ -141,6 +142,8 @@ struct pim_instance {
 
 	// List of static routes;
 	struct list *static_routes;
+	/* Static mroutes waiting for interface/VIF readiness at boot. */
+	struct pim_static_route_cfgs_head static_route_configs;
 
 	// Upstream vrf specific information
 	struct rb_pim_upstream_head upstream_head;

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -474,7 +474,7 @@ const struct frr_yang_module_info frr_pim_info = {
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/mroute",
 			.cbs = {
 				.create = lib_interface_pim_address_family_mroute_create,
-				.destroy = lib_interface_pim_address_family_mroute_oif_destroy,
+				.destroy = lib_interface_pim_address_family_mroute_destroy,
 			}
 		},
 		{

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -176,6 +176,7 @@ int lib_interface_pim_address_family_multicast_boundary_acl_modify(struct nb_cb_
 int lib_interface_pim_address_family_multicast_boundary_acl_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_mroute_create(
 	struct nb_cb_create_args *args);
+int lib_interface_pim_address_family_mroute_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_mroute_oif_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_mroute_oif_destroy(
 	struct nb_cb_destroy_args *args);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -3265,16 +3265,11 @@ int lib_interface_pim_address_family_mroute_oif_create(struct nb_cb_create_args 
 
 		oifname = yang_dnode_get_string(args->dnode, NULL);
 		oif = if_lookup_by_name(oifname, pim->vrf->vrf_id);
-		if (!oif) {
-			snprintf(args->errmsg, args->errmsg_len, "No such interface name %s",
-				 oifname);
-			return NB_ERR_INCONSISTENCY;
-		}
 
 		yang_dnode_get_pimaddr(&source_addr, args->dnode, "../source-addr");
 		yang_dnode_get_pimaddr(&group_addr, args->dnode, "../group-addr");
 
-		if (pim_static_add(pim, iif, oif, group_addr, source_addr)) {
+		if (pim_static_add(pim, iif, oif, oifname, group_addr, source_addr)) {
 			snprintf(args->errmsg, args->errmsg_len, "Failed to add static mroute");
 			return NB_ERR_INCONSISTENCY;
 		}
@@ -3321,16 +3316,11 @@ int lib_interface_pim_address_family_mroute_oif_destroy(struct nb_cb_destroy_arg
 
 		oifname = yang_dnode_get_string(args->dnode, NULL);
 		oif = if_lookup_by_name(oifname, pim->vrf->vrf_id);
-		if (!oif) {
-			snprintf(args->errmsg, args->errmsg_len, "No such interface name %s",
-				 oifname);
-			return NB_ERR_INCONSISTENCY;
-		}
 
 		yang_dnode_get_pimaddr(&source_addr, args->dnode, "../source-addr");
 		yang_dnode_get_pimaddr(&group_addr, args->dnode, "../group-addr");
 
-		if (pim_static_del(pim, iif, oif, group_addr, source_addr)) {
+		if (pim_static_del(pim, iif, oif, oifname, group_addr, source_addr)) {
 			snprintf(args->errmsg, args->errmsg_len, "Failed to del static mroute");
 			return NB_ERR_INCONSISTENCY;
 		}

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -3187,6 +3187,27 @@ int lib_interface_pim_address_family_mroute_create(
 	return NB_OK;
 }
 
+int lib_interface_pim_address_family_mroute_destroy(struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		/*
+		 * Per-oif cleanup is handled by
+		 * lib_interface_pim_address_family_mroute_oif_destroy().
+		 * This runs when the mroute list entry itself is removed
+		 * (e.g. after the last oif is deleted); do not call
+		 * pim_static_del() here with a non-oif dnode.
+		 */
+		break;
+	}
+
+	return NB_OK;
+}
+
 /*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/mroute/oif
  */

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -19,10 +19,18 @@
 #include "pim_time.h"
 #include "pim_str.h"
 #include "pim_iface.h"
+#include "pim_memory.h"
+
+DEFINE_MTYPE_STATIC(PIMD, PIM_STATIC_ROUTE_CFG, "PIM Static Route config");
 
 void pim_static_route_free(struct static_route *s_route)
 {
 	XFREE(MTYPE_PIM_STATIC_ROUTE, s_route);
+}
+
+void pim_static_route_config_free(struct static_route_config *cfg)
+{
+	XFREE(MTYPE_PIM_STATIC_ROUTE_CFG, cfg);
 }
 
 static struct static_route *static_route_alloc(void)
@@ -30,11 +38,11 @@ static struct static_route *static_route_alloc(void)
 	return XCALLOC(MTYPE_PIM_STATIC_ROUTE, sizeof(struct static_route));
 }
 
-static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif,
-					     pim_addr group,
+static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif, pim_addr group,
 					     pim_addr source)
 {
 	struct static_route *s_route;
+
 	s_route = static_route_alloc();
 
 	s_route->group = group;
@@ -51,76 +59,140 @@ static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif,
 	return s_route;
 }
 
+static bool pim_static_if_vif_ready(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp;
 
-int pim_static_add(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, pim_addr group, pim_addr source)
+	if (!ifp || !ifp->info)
+		return false;
+
+	pim_ifp = ifp->info;
+	return pim_ifp->mroute_vif_index > 0;
+}
+
+/*
+ * Deferred-configuration queue helpers.
+ *
+ * Static mroutes configured before their interfaces have valid VIF indices
+ * (e.g. while applying the startup config at boot) are queued here, keyed by
+ * interface name, and installed by pim_static_reconcile() once the VIFs are
+ * ready.  Pending entries are also emitted in the running-config so they
+ * survive a reload.
+ */
+static struct static_route_config *static_route_config_find(struct pim_instance *pim,
+							    const char *iifname,
+							    const char *oifname, pim_addr group,
+							    pim_addr source)
+{
+	struct static_route_config *cfg;
+
+	frr_each (pim_static_route_cfgs, &pim->static_route_configs, cfg) {
+		if (strcmp(cfg->iifname, iifname))
+			continue;
+		if (strcmp(cfg->oifname, oifname))
+			continue;
+		if (pim_addr_cmp(cfg->group, group))
+			continue;
+		if (pim_addr_cmp(cfg->source, source))
+			continue;
+		return cfg;
+	}
+
+	return NULL;
+}
+
+static int static_route_config_add(struct pim_instance *pim, const char *iifname,
+				   const char *oifname, pim_addr group, pim_addr source)
+{
+	struct static_route_config *cfg;
+
+	if (static_route_config_find(pim, iifname, oifname, group, source))
+		return -3;
+
+	cfg = XCALLOC(MTYPE_PIM_STATIC_ROUTE_CFG, sizeof(*cfg));
+	strlcpy(cfg->iifname, iifname, sizeof(cfg->iifname));
+	strlcpy(cfg->oifname, oifname, sizeof(cfg->oifname));
+	cfg->group = group;
+	cfg->source = source;
+	pim_static_route_cfgs_add_tail(&pim->static_route_configs, cfg);
+
+	if (PIM_DEBUG_STATIC)
+		zlog_debug("%s: deferred static route (iif=%s,oif=%s,group=%pPAs,source=%pPAs)",
+			   __func__, iifname, oifname, &group, &source);
+
+	return 0;
+}
+
+static int static_route_config_del(struct pim_instance *pim, const char *iifname,
+				   const char *oifname, pim_addr group, pim_addr source)
+{
+	struct static_route_config *cfg;
+
+	cfg = static_route_config_find(pim, iifname, oifname, group, source);
+	if (!cfg)
+		return -1;
+
+	pim_static_route_cfgs_del(&pim->static_route_configs, cfg);
+	pim_static_route_config_free(cfg);
+
+	if (PIM_DEBUG_STATIC)
+		zlog_debug("%s: removed deferred static route (iif=%s,oif=%s,group=%pPAs,source=%pPAs)",
+			   __func__, iifname, oifname, &group, &source);
+
+	return 0;
+}
+
+/*
+ * Install a static mroute into the kernel.  Both interfaces are guaranteed by
+ * the caller to have valid VIF indices.
+ */
+static int pim_static_add_install(struct pim_instance *pim, struct interface *iif,
+				  struct interface *oif, pim_addr group, pim_addr source)
 {
 	struct listnode *node = NULL;
 	struct static_route *s_route = NULL;
 	struct static_route *original_s_route = NULL;
-	struct pim_interface *pim_iif = iif ? iif->info : NULL;
-	struct pim_interface *pim_oif = oif ? oif->info : NULL;
-	ifindex_t iif_index = pim_iif ? pim_iif->mroute_vif_index : 0;
-	ifindex_t oif_index = pim_oif ? pim_oif->mroute_vif_index : 0;
-
-	if (!iif_index || !oif_index || iif_index == -1 || oif_index == -1) {
-		zlog_warn(
-			"%s %s: Unable to add static route: Invalid interface index(iif=%d,oif=%d)",
-			__FILE__, __func__, iif_index, oif_index);
-		return -2;
-	}
+	struct pim_interface *pim_iif = iif->info;
+	struct pim_interface *pim_oif = oif->info;
+	ifindex_t iif_index = pim_iif->mroute_vif_index;
+	ifindex_t oif_index = pim_oif->mroute_vif_index;
 
 #ifdef PIM_ENFORCE_LOOPFREE_MFC
 	if (iif_index == oif_index) {
-		/* looped MFC entry */
-		zlog_warn(
-			"%s %s: Unable to add static route: Looped MFC entry(iif=%d,oif=%d)",
-			__FILE__, __func__, iif_index, oif_index);
+		zlog_warn("%s %s: Unable to add static route: Looped MFC entry(iif=%d,oif=%d)",
+			  __FILE__, __func__, iif_index, oif_index);
 		return -4;
 	}
 #endif
-	if (iif->vrf->vrf_id != oif->vrf->vrf_id) {
-		return -3;
-	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, s_route)) {
 		if (!pim_addr_cmp(s_route->group, group) &&
-		    !pim_addr_cmp(s_route->source, source) &&
-		    (s_route->iif == iif_index)) {
-
+		    !pim_addr_cmp(s_route->source, source) && (s_route->iif == iif_index)) {
 			if (s_route->oif_ttls[oif_index]) {
-				zlog_warn(
-					"%s %s: Unable to add static route: Route already exists (iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
-					__FILE__, __func__, iif_index,
-					oif_index, &group, &source);
+				zlog_warn("%s %s: Unable to add static route: Route already exists (iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+					  __FILE__, __func__, iif_index, oif_index, &group,
+					  &source);
 				return -3;
 			}
 
-			/* Ok, from here on out we will be making changes to the
-			 * s_route structure, but if
-			 * for some reason we fail to commit these changes to
-			 * the kernel, we want to be able
-			 * restore the state of the list. So copy the node data
-			 * and if need be, we can copy
-			 * back if it fails.
+			/*
+			 * Making changes to the s_route structure; if we fail
+			 * to commit them to the kernel we want to be able to
+			 * restore the previous state, so save a copy.
 			 */
 			original_s_route = static_route_alloc();
-			memcpy(original_s_route, s_route,
-			       sizeof(struct static_route));
+			memcpy(original_s_route, s_route, sizeof(struct static_route));
 
-			/* Route exists and has the same input interface, but
-			 * adding a new output interface */
+			/* Adding a new output interface to an existing route. */
 			s_route->oif_ttls[oif_index] = 1;
 			oil_if_set(&s_route->c_oil, oif_index, 1);
-			s_route->c_oil.oif_creation[oif_index] =
-				pim_time_monotonic_sec();
+			s_route->c_oil.oif_creation[oif_index] = pim_time_monotonic_sec();
 			++s_route->c_oil.oil_ref_count;
 			break;
 		}
 	}
 
-	/* If node is null then we reached the end of the list without finding a
-	 * match */
+	/* No existing route matched, create a fresh one. */
 	if (!node) {
 		s_route = static_route_new(iif_index, oif_index, group, source);
 		listnode_add(pim->static_routes, s_route);
@@ -129,150 +201,232 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 	s_route->c_oil.pim = pim;
 
 	if (pim_static_mroute_add(&s_route->c_oil, __func__)) {
-		zlog_warn(
-			"%s %s: Unable to add static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
-			__FILE__, __func__, iif_index, oif_index, &group,
-			&source);
+		zlog_warn("%s %s: Unable to add static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+			  __FILE__, __func__, iif_index, oif_index, &group, &source);
 
-		/* Need to put s_route back to the way it was */
+		/* Restore the previous state. */
 		if (original_s_route) {
-			memcpy(s_route, original_s_route,
-			       sizeof(struct static_route));
+			memcpy(s_route, original_s_route, sizeof(struct static_route));
+			pim_static_route_free(original_s_route);
 		} else {
-			/* we never stored off a copy, so it must have been a
-			 * fresh new route */
 			listnode_delete(pim->static_routes, s_route);
 			pim_static_route_free(s_route);
-		}
-
-		if (original_s_route) {
-			pim_static_route_free(original_s_route);
 		}
 
 		return -1;
 	}
 
-	/* Make sure we free the memory for the route copy if used */
-	if (original_s_route) {
+	if (original_s_route)
 		pim_static_route_free(original_s_route);
-	}
 
-	if (PIM_DEBUG_STATIC) {
-		zlog_debug(
-			"%s: Static route added(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
-			__func__, iif_index, oif_index, &group,
-			&source);
-	}
+	if (PIM_DEBUG_STATIC)
+		zlog_debug("%s: Static route added(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+			   __func__, iif_index, oif_index, &group, &source);
 
 	return 0;
 }
 
-int pim_static_del(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, pim_addr group, pim_addr source)
+int pim_static_add(struct pim_instance *pim, struct interface *iif, struct interface *oif,
+		   const char *oifname, pim_addr group, pim_addr source)
+{
+	if (!iif || !iif->info || !oifname || !oifname[0])
+		return -2;
+
+	if (oif && iif->vrf->vrf_id != oif->vrf->vrf_id)
+		return -3;
+
+#ifdef PIM_ENFORCE_LOOPFREE_MFC
+	if (oif && iif->ifindex == oif->ifindex)
+		return -4;
+#endif
+
+	/* Both VIFs ready: install now. Otherwise defer until reconcile. */
+	if (pim_static_if_vif_ready(iif) && oif && pim_static_if_vif_ready(oif))
+		return pim_static_add_install(pim, iif, oif, group, source);
+
+	return static_route_config_add(pim, iif->name, oif ? oif->name : oifname, group, source);
+}
+
+/*
+ * Remove one output interface from an installed static route, matched by VIF
+ * index. Both interfaces are guaranteed by the caller to have valid VIFs.
+ */
+static int pim_static_del_install(struct pim_instance *pim, struct interface *iif,
+				  struct interface *oif, pim_addr group, pim_addr source)
 {
 	struct listnode *node = NULL;
 	struct listnode *nextnode = NULL;
 	struct static_route *s_route = NULL;
-	struct pim_interface *pim_iif = iif ? iif->info : 0;
-	struct pim_interface *pim_oif = oif ? oif->info : 0;
-	ifindex_t iif_index = pim_iif ? pim_iif->mroute_vif_index : 0;
-	ifindex_t oif_index = pim_oif ? pim_oif->mroute_vif_index : 0;
-
-	if (!iif_index || !oif_index) {
-		zlog_warn(
-			"%s %s: Unable to remove static route: Invalid interface index(iif=%d,oif=%d)",
-			__FILE__, __func__, iif_index, oif_index);
-		return -2;
-	}
+	struct pim_interface *pim_iif = iif->info;
+	struct pim_interface *pim_oif = oif->info;
+	ifindex_t iif_index = pim_iif->mroute_vif_index;
+	ifindex_t oif_index = pim_oif->mroute_vif_index;
 
 	for (ALL_LIST_ELEMENTS(pim->static_routes, node, nextnode, s_route)) {
-		if (s_route->iif == iif_index
-		    && !pim_addr_cmp(s_route->group, group)
-		    && !pim_addr_cmp(s_route->source, source)
-		    && s_route->oif_ttls[oif_index]) {
-			s_route->oif_ttls[oif_index] = 0;
-			oil_if_set(&s_route->c_oil, oif_index, 0);
-			--s_route->c_oil.oil_ref_count;
+		if (s_route->iif != iif_index || pim_addr_cmp(s_route->group, group) ||
+		    pim_addr_cmp(s_route->source, source) || !s_route->oif_ttls[oif_index])
+			continue;
 
-			/* If there are no more outputs then delete the whole
-			 * route, otherwise set the route with the new outputs
-			 */
-			if (s_route->c_oil.oil_ref_count <= 0
-				    ? pim_mroute_del(&s_route->c_oil, __func__)
-				    : pim_static_mroute_add(&s_route->c_oil,
-							    __func__)) {
-				zlog_warn(
-					"%s %s: Unable to remove static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
-					__FILE__, __func__, iif_index,
-					oif_index, &group, &source);
+		s_route->oif_ttls[oif_index] = 0;
+		oil_if_set(&s_route->c_oil, oif_index, 0);
+		--s_route->c_oil.oil_ref_count;
 
-				s_route->oif_ttls[oif_index] = 1;
-				oil_if_set(&s_route->c_oil, oif_index, 1);
-				++s_route->c_oil.oil_ref_count;
+		/*
+		 * If there are no more outputs then delete the whole route,
+		 * otherwise update the route with the remaining outputs.
+		 */
+		if (s_route->c_oil.oil_ref_count <= 0
+			    ? pim_mroute_del(&s_route->c_oil, __func__)
+			    : pim_static_mroute_add(&s_route->c_oil, __func__)) {
+			zlog_warn("%s %s: Unable to remove static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+				  __FILE__, __func__, iif_index, oif_index, &group, &source);
 
-				return -1;
-			}
+			s_route->oif_ttls[oif_index] = 1;
+			oil_if_set(&s_route->c_oil, oif_index, 1);
+			++s_route->c_oil.oil_ref_count;
 
-			s_route->c_oil.oif_creation[oif_index] = 0;
-
-			if (s_route->c_oil.oil_ref_count <= 0) {
-				listnode_delete(pim->static_routes, s_route);
-				pim_static_route_free(s_route);
-			}
-
-			if (PIM_DEBUG_STATIC) {
-				zlog_debug(
-					"%s: Static route removed(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
-					__func__, iif_index, oif_index,
-					&group, &source);
-			}
-
-			break;
+			return -1;
 		}
+
+		s_route->c_oil.oif_creation[oif_index] = 0;
+
+		if (s_route->c_oil.oil_ref_count <= 0) {
+			listnode_delete(pim->static_routes, s_route);
+			pim_static_route_free(s_route);
+		}
+
+		if (PIM_DEBUG_STATIC)
+			zlog_debug("%s: Static route removed(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
+				   __func__, iif_index, oif_index, &group, &source);
+
+		return 0;
 	}
 
-	if (!node) {
-		zlog_warn(
-			"%s %s: Unable to remove static route: Route does not exist(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
-			__FILE__, __func__, iif_index, oif_index, &group,
-			&source);
-		return -3;
-	}
-
-	return 0;
+	return -3;
 }
 
-int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
-			    struct interface *ifp)
+int pim_static_del(struct pim_instance *pim, struct interface *iif, struct interface *oif,
+		   const char *oifname, pim_addr group, pim_addr source)
+{
+	const char *oname;
+
+	if (!iif || !iif->info || !oifname || !oifname[0])
+		return -2;
+
+	oname = oif ? oif->name : oifname;
+
+	/* A still-pending (never installed) route is removed from the queue. */
+	if (!static_route_config_del(pim, iif->name, oname, group, source))
+		return 0;
+
+	/* Otherwise it must be installed; delete it by VIF index. */
+	if (oif && pim_static_if_vif_ready(iif) && pim_static_if_vif_ready(oif))
+		return pim_static_del_install(pim, iif, oif, group, source);
+
+	zlog_warn("%s %s: Unable to remove static route: route does not exist (iif=%s,oif=%s,group=%pPAs,source=%pPAs)",
+		  __FILE__, __func__, iif->name, oname, &group, &source);
+
+	return -3;
+}
+
+void pim_static_route_configs_fini(struct pim_instance *pim)
+{
+	struct static_route_config *cfg;
+
+	frr_each_safe (pim_static_route_cfgs, &pim->static_route_configs, cfg) {
+		pim_static_route_cfgs_del(&pim->static_route_configs, cfg);
+		pim_static_route_config_free(cfg);
+	}
+
+	/* Generated _fini asserts the list is empty in debug builds. */
+	pim_static_route_cfgs_fini(&pim->static_route_configs);
+}
+
+/*
+ * Called whenever a new VIF becomes available. Walk the deferred queue and
+ * install any route whose input and output interfaces are now both ready.
+ */
+void pim_static_reconcile(struct pim_instance *pim)
+{
+	struct static_route_config *cfg;
+
+	frr_each_safe (pim_static_route_cfgs, &pim->static_route_configs, cfg) {
+		struct interface *iif, *oif;
+		int ret;
+
+		iif = if_lookup_by_name(cfg->iifname, pim->vrf->vrf_id);
+		oif = if_lookup_by_name(cfg->oifname, pim->vrf->vrf_id);
+		if (!iif || !oif)
+			continue;
+		if (!pim_static_if_vif_ready(iif) || !pim_static_if_vif_ready(oif))
+			continue;
+
+		pim_static_route_cfgs_del(&pim->static_route_configs, cfg);
+
+		ret = pim_static_add_install(pim, iif, oif, cfg->group, cfg->source);
+		if (ret == -1) {
+			/* Transient kernel failure: re-queue and retry later. */
+			pim_static_route_cfgs_add_tail(&pim->static_route_configs, cfg);
+			continue;
+		}
+
+		if (ret && PIM_DEBUG_STATIC)
+			zlog_debug("%s: dropping deferred static route (iif=%s,oif=%s,group=%pPAs,source=%pPAs): install returned %d",
+				   __func__, cfg->iifname, cfg->oifname, &cfg->group, &cfg->source,
+				   ret);
+
+		pim_static_route_config_free(cfg);
+	}
+}
+
+int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty, struct interface *ifp)
 {
 	struct pim_interface *pim_ifp = ifp->info;
 	struct listnode *node;
 	struct static_route *sroute;
+	struct static_route_config *cfg;
 	int count = 0;
 
 	if (!pim_ifp)
 		return 0;
 
+	/* Installed routes. */
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, sroute)) {
-		if (sroute->iif == pim_ifp->mroute_vif_index) {
-			int i;
-			for (i = 0; i < MAXVIFS; i++)
-				if (sroute->oif_ttls[i]) {
-					struct interface *oifp =
-						pim_if_find_by_vif_index(pim,
-									 i);
-					if (pim_addr_is_any(sroute->source))
-						vty_out(vty,
-							" " PIM_AF_NAME " mroute %s %pPA\n",
-							oifp->name, &sroute->group);
-					else
-						vty_out(vty,
-							" " PIM_AF_NAME " mroute %s %pPA %pPA\n",
-							oifp->name, &sroute->group,
-							&sroute->source);
-					count++;
-				}
+		if (sroute->iif != pim_ifp->mroute_vif_index)
+			continue;
+
+		for (int i = 0; i < MAXVIFS; i++) {
+			struct interface *oifp;
+
+			if (!sroute->oif_ttls[i])
+				continue;
+
+			oifp = pim_if_find_by_vif_index(pim, i);
+			if (!oifp)
+				continue;
+
+			if (pim_addr_is_any(sroute->source))
+				vty_out(vty, " " PIM_AF_NAME " mroute %s %pPA\n", oifp->name,
+					&sroute->group);
+			else
+				vty_out(vty, " " PIM_AF_NAME " mroute %s %pPA %pPA\n", oifp->name,
+					&sroute->group, &sroute->source);
+			count++;
 		}
+	}
+
+	/* Still-pending (deferred) routes, so they survive a reload. */
+	frr_each (pim_static_route_cfgs, &pim->static_route_configs, cfg) {
+		if (strcmp(cfg->iifname, ifp->name))
+			continue;
+
+		if (pim_addr_is_any(cfg->source))
+			vty_out(vty, " " PIM_AF_NAME " mroute %s %pPA\n", cfg->oifname,
+				&cfg->group);
+		else
+			vty_out(vty, " " PIM_AF_NAME " mroute %s %pPA %pPA\n", cfg->oifname,
+				&cfg->group, &cfg->source);
+		count++;
 	}
 
 	return count;

--- a/pimd/pim_static.h
+++ b/pimd/pim_static.h
@@ -8,9 +8,14 @@
 #define PIM_STATIC_H_
 
 #include <zebra.h>
+
+#include "typesafe.h"
+
 #include "pim_mroute.h"
 #include "pim_oil.h"
 #include "if.h"
+
+PREDECL_DLIST(pim_static_route_cfgs);
 
 struct static_route {
 	/* Each static route is unique by these pair of addresses */
@@ -22,12 +27,31 @@ struct static_route {
 	unsigned char oif_ttls[MAXVIFS];
 };
 
-void pim_static_route_free(struct static_route *s_route);
+/*
+ * Static mroute configuration deferred until both the input and output
+ * interfaces exist and have valid multicast VIF indices (e.g. at boot).
+ * Identified purely by interface name, which is the configuration identity.
+ */
+struct static_route_config {
+	struct pim_static_route_cfgs_item item;
 
-int pim_static_add(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, pim_addr group, pim_addr source);
-int pim_static_del(struct pim_instance *pim, struct interface *iif,
-		   struct interface *oif, pim_addr group, pim_addr source);
+	char iifname[IF_NAMESIZE];
+	char oifname[IF_NAMESIZE];
+	pim_addr group;
+	pim_addr source;
+};
+
+DECLARE_DLIST(pim_static_route_cfgs, struct static_route_config, item);
+
+void pim_static_route_free(struct static_route *s_route);
+void pim_static_route_config_free(struct static_route_config *cfg);
+void pim_static_route_configs_fini(struct pim_instance *pim);
+
+int pim_static_add(struct pim_instance *pim, struct interface *iif, struct interface *oif,
+		   const char *oifname, pim_addr group, pim_addr source);
+int pim_static_del(struct pim_instance *pim, struct interface *iif, struct interface *oif,
+		   const char *oifname, pim_addr group, pim_addr source);
+void pim_static_reconcile(struct pim_instance *pim);
 int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
 			    struct interface *ifp);
 

--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -350,6 +350,69 @@ def test_pim_static_mroute():
     assert result is None, "failed to converge final mroute state"
 
 
+def test_pim_static_mroute_deferred():
+    "Static mroutes install once output-interface VIF is ready (#4636)"
+    logger.info("Testing deferred static routes at boot")
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        """
+        conf t
+           interface r1-eth1
+              no ip pim
+    """
+    )
+    r1.vtysh_cmd(
+        """
+        conf t
+           interface r1-eth0
+              ip mroute r1-eth1 239.9.9.9 10.0.0.9
+    """
+    )
+
+    expected = {"239.9.9.9": None}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+    assert result is None, "mroute installed before output VIF was ready"
+
+    r1.vtysh_cmd(
+        """
+        conf t
+           interface r1-eth1
+              ip pim
+    """
+    )
+
+    expected = {"239.9.9.9": {"10.0.0.9": {"oil": {"r1-eth1": "*", "r1-eth2": None}}}}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "deferred static mroute was not installed"
+
+    output = r1.vtysh_cmd("show running-config")
+    assert "ip mroute r1-eth1 239.9.9.9 10.0.0.9" in output
+
+    r1.vtysh_cmd(
+        """
+        conf t
+           interface r1-eth0
+              no ip mroute r1-eth1 239.9.9.9 10.0.0.9
+    """
+    )
+    expected = {"239.9.9.9": None}
+    test_func = partial(topotest.router_json_cmp, r1, "show ip mroute json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "failed to remove deferred static mroute"
+
+    output = r1.vtysh_cmd("show running-config")
+    assert "ip mroute r1-eth1 239.9.9.9 10.0.0.9" not in output
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
Static ip mroute config can be applied before zebra delivers interface
addresses and VIF indices at boot causing them to fail and never get applied.
Queue those routes and install them when VIFs become available

fixes #4636