### PR TITLE
pimd: fix BSR failover RP not setting i_am_rp locally

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -541,10 +541,13 @@ static void pim_instate_pend_list(struct bsgrp_node *bsgrp_node)
 		/* This means we searched and got rp node, needs unlock */
 		route_unlock_node(rn);
 
-		if (active && pend) {
-			if (pim_addr_cmp(active->rp_address, pend->rp_address))
-				pim_rp_change(pim, pend->rp_address,
-					      bsgrp_node->group, RP_SRC_BSR);
+		if (pend) {
+			/* Always install the elected RP from the new BSM.
+			 * Skipping pim_rp_change when active and pend carry
+			 * the same address left i_am_rp stale after RP
+			 * failover (#17588).
+			 */
+			pim_rp_change(pim, pend->rp_address, bsgrp_node->group, RP_SRC_BSR);
 		}
 
 		/* Possible when the first BSM has group with 0 rp count */

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -892,11 +892,21 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 
 	old_rp_addr = rp_info->rp.rpf_addr;
 	if (!pim_addr_cmp(new_rp_addr, old_rp_addr)) {
-		if (rp_info->rp_src != rp_src_flag) {
+		int old_i_am_rp = rp_info->i_am_rp;
+
+		if (rp_info->rp_src != rp_src_flag)
 			rp_info->rp_src = rp_src_flag;
-			route_unlock_node(rn);
-			return PIM_SUCCESS;
-		}
+
+		/* RP address unchanged: reconcile i_am_rp and return. NHT
+		 * tracking and rp_list updates below apply only when the
+		 * address changes (g2rp refresh and BSM re-confirm both
+		 * call here with the same address).
+		 */
+		pim_rp_check_interfaces(pim, rp_info);
+		if (old_i_am_rp != rp_info->i_am_rp)
+			pim_rp_refresh_group_to_rp_mapping(pim);
+		route_unlock_node(rn);
+		return PIM_SUCCESS;
 	}
 
 	/* Deregister old RP addr with Zebra NHT */

--- a/tests/topotests/pim_cand_rp_bsr/bsr_rp_failover_helper.py
+++ b/tests/topotests/pim_cand_rp_bsr/bsr_rp_failover_helper.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: ISC
+
+# bsr_rp_failover_helper.py: Helper functions for BSR RP failover tests.
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+import os
+import sys
+
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.pim import verify_pim_rp_info
+from lib.common_config import step
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+sys.path.insert(0, CWD)
+
+from test_pim_cand_rp_bsr import TOPOLOGY, build_topo  # noqa: E402
+
+# Cand-RP holdtime is max(151, 2.5 * advertisement-interval).
+CRP_FAILOVER_TIMEOUT = 180
+
+
+def setup_module(mod):
+    logger.info("PIM BSR RP failover:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        logger.info("Loading router %s", rname)
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+    for router in router_list.values():
+        if router.has_version("<", "4.0"):
+            tgen.set_error("unsupported version")
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def verify_rp_failover_after_daemon_stop(
+    tgen,
+    tc_name,
+    addr_type,
+    group,
+    primary_rp,
+    backup_rp,
+    primary_daemon,
+):
+    step("Verify {} is the active RP for {} before failover".format(primary_rp, group))
+    result = verify_pim_rp_info(
+        tgen,
+        None,
+        "r5",
+        group,
+        oif=None,
+        rp=primary_rp,
+        source="BSR",
+        iamrp=False,
+        addr_type=addr_type,
+        expected=True,
+        retry_timeout=90,
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("Stop {} on primary RP r3 to trigger holdtime expiry".format(primary_daemon))
+    tgen.gears["r3"].killDaemons([primary_daemon], wait=True)
+
+    step("Verify {} becomes RP for {} on r5".format(backup_rp, group))
+    result = verify_pim_rp_info(
+        tgen,
+        None,
+        "r5",
+        group,
+        oif=None,
+        rp=backup_rp,
+        source="BSR",
+        iamrp=False,
+        addr_type=addr_type,
+        expected=True,
+        retry_timeout=CRP_FAILOVER_TIMEOUT,
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("Verify backup RP r4 sees itself as RP (#17588)")
+    result = verify_pim_rp_info(
+        tgen,
+        None,
+        "r4",
+        group,
+        oif=None,
+        rp=backup_rp,
+        source="BSR",
+        iamrp=True,
+        addr_type=addr_type,
+        expected=True,
+        retry_timeout=CRP_FAILOVER_TIMEOUT,
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)

--- a/tests/topotests/pim_cand_rp_bsr/r3/frr.conf
+++ b/tests/topotests/pim_cand_rp_bsr/r3/frr.conf
@@ -31,12 +31,12 @@ interface r3-eth2
  ipv6 ospf6 area 0
 !
 router pim
+  bsr candidate-rp interval 60 priority 10 source address 10.0.3.3
   bsr candidate-rp group 239.0.0.0/16
-  bsr candidate-rp priority 10 source address 10.0.3.3
 !
 router pim6
+ bsr candidate-rp interval 60 priority 10 source address fd00:0:0:3::3
  bsr candidate-rp group ffbb::/64
- bsr candidate-rp priority 10 source address fd00:0:0:3::3
 !
 router ospf
  ospf router-id 10.0.1.3

--- a/tests/topotests/pim_cand_rp_bsr/r4/frr.conf
+++ b/tests/topotests/pim_cand_rp_bsr/r4/frr.conf
@@ -41,16 +41,16 @@ interface r4-eth3
  ipv6 ospf6 area 0
 !
 router pim
+  bsr candidate-rp interval 60 priority 20 source address 10.0.3.4
   bsr candidate-rp group 239.0.0.0/24
   bsr candidate-rp group 239.0.0.0/16
   bsr candidate-rp group 239.0.0.0/8
-  bsr candidate-rp priority 20
 !
 router pim6
+ bsr candidate-rp interval 60 priority 20 source address fd00:0:0:3::4
  bsr candidate-rp group ffbb::/124
  bsr candidate-rp group ffbb::/64
  bsr candidate-rp group ffbb::/108
- bsr candidate-rp priority 20
 !
 router ospf
  ospf router-id 10.0.2.4

--- a/tests/topotests/pim_cand_rp_bsr/test_pim_bsr_rp_failover_ipv4.py
+++ b/tests/topotests/pim_cand_rp_bsr/test_pim_bsr_rp_failover_ipv4.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_pim_bsr_rp_failover_ipv4.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+
+import os
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, CWD)
+
+from lib.topogen import get_topogen
+from lib.common_config import write_test_header
+
+from bsr_rp_failover_helper import (  # pylint: disable=import-error
+    setup_module,
+    teardown_module,
+    verify_rp_failover_after_daemon_stop,
+)
+
+"""
+Failover when the primary IPv4 RP daemon stops.
+
+FRR advertises a minimum Candidate-RP holdtime of 151 seconds, so this
+test waits up to 180 seconds for the backup RP to take over.
+"""
+
+pytestmark = [
+    pytest.mark.pimd,
+    pytest.mark.ospfd,
+    pytest.mark.ospf6d,
+]
+
+
+def test_pim_bsr_rp_failover_ipv4(request):
+    "Failover to backup RP when primary pimd stops (#17588)"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    verify_rp_failover_after_daemon_stop(
+        tgen,
+        tc_name,
+        "ipv4",
+        "239.0.0.0/16",
+        "10.0.3.3",
+        "10.0.3.4",
+        "pimd",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-s"] + sys.argv[1:]))

--- a/tests/topotests/pim_cand_rp_bsr/test_pim_bsr_rp_failover_ipv6.py
+++ b/tests/topotests/pim_cand_rp_bsr/test_pim_bsr_rp_failover_ipv6.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_pim_bsr_rp_failover_ipv6.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+
+import os
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, CWD)
+
+from lib.topogen import get_topogen
+from lib.common_config import write_test_header
+
+from bsr_rp_failover_helper import (  # pylint: disable=import-error
+    setup_module,
+    teardown_module,
+    verify_rp_failover_after_daemon_stop,
+)
+
+"""
+Failover when the primary IPv6 RP daemon stops.
+
+FRR advertises a minimum Candidate-RP holdtime of 151 seconds, so this
+test waits up to 180 seconds for the backup RP to take over.
+"""
+
+pytestmark = [
+    pytest.mark.pim6d,
+    pytest.mark.ospfd,
+    pytest.mark.ospf6d,
+]
+
+
+def test_pim_bsr_rp_failover_ipv6(request):
+    "Failover to backup RP when primary pim6d stops (#17588)"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    verify_rp_failover_after_daemon_stop(
+        tgen,
+        tc_name,
+        "ipv6",
+        "ffbb::0/64",
+        "fd00:0:0:3::3",
+        "fd00:0:0:3::4",
+        "pim6d",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-s"] + sys.argv[1:]))

--- a/tests/topotests/pim_cand_rp_bsr/test_pim_cand_rp_bsr.py
+++ b/tests/topotests/pim_cand_rp_bsr/test_pim_cand_rp_bsr.py
@@ -382,7 +382,23 @@ def test_pim_bsr_rp_info_fallback(request):
         False,
         "ipv4",
         True,
-        retry_timeout=30,
+        retry_timeout=90,
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("Verify r4 sees itself as RP after config-withdrawal fallback")
+    result = verify_pim_rp_info(
+        tgen,
+        None,
+        "r4",
+        "239.0.0.0/16",
+        oif=None,
+        rp="10.0.3.4",
+        source="BSR",
+        iamrp=True,
+        addr_type="ipv4",
+        expected=True,
+        retry_timeout=90,
     )
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
@@ -488,6 +504,58 @@ def test_pimv6_bsr_rp_info(request):
         "ipv6",
         True,
         retry_timeout=30,
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+
+def test_pimv6_bsr_rp_info_fallback(request):
+    "Test IPv6 RP fallback when primary candidate withdraws a group"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    step("Take r3 out from IPv6 RP candidates for group ffbb::/64")
+    r3 = tgen.gears["r3"]
+    r3.vtysh_cmd(
+        """
+        configure
+          router pim6
+            no bsr candidate-rp group ffbb::/64
+        """
+    )
+
+    step("Verify falling back to r4 as the new RP for ffbb::/64")
+    result = verify_pim_rp_info(
+        tgen,
+        None,
+        "r5",
+        "ffbb::0/64",
+        oif=None,
+        rp="fd00:0:0:3::4",
+        source="BSR",
+        iamrp=False,
+        addr_type="ipv6",
+        expected=True,
+        retry_timeout=90,
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("Verify r4 sees itself as IPv6 RP after config-withdrawal fallback")
+    result = verify_pim_rp_info(
+        tgen,
+        None,
+        "r4",
+        "ffbb::0/64",
+        oif=None,
+        rp="fd00:0:0:3::4",
+        source="BSR",
+        iamrp=True,
+        addr_type="ipv6",
+        expected=True,
+        retry_timeout=90,
     )
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 


### PR DESCRIPTION
After BSR RP failover, the backup router could learn the correct RP mapping
while `i_am_rp` stayed false, so it did not behave as RP (#17588).

- Always apply elected RP from a new BSM via `pim_rp_change()`, even when the
  active and pending RP addresses match
- Re-evaluate `i_am_rp` in `pim_rp_change()` when the RP address is unchanged

Fixes #17588