### PR TITLE
ospf: fix the return value for the invalid VRF name

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11937,8 +11937,10 @@ DEFPY(clear_ip_ospf_neighbor, clear_ip_ospf_neighbor_cmd,
 
 	if (vrf_name) {
 		vrf = vrf_lookup_by_name(vrf_name);
-		if (!vrf)
+		if (!vrf) {
+			vty_out(vty, "%% VRF %s not found\n", vrf_name);
 			return CMD_WARNING;
+		}
 	}
 
 	/* Clear all the ospf processes */
@@ -11989,8 +11991,10 @@ DEFPY(clear_ip_ospf_process, clear_ip_ospf_process_cmd,
 
 	if (vrf_name) {
 		vrf = vrf_lookup_by_name(vrf_name);
-		if (!vrf)
+		if (!vrf) {
+			vty_out(vty, "%% VRF %s not found\n", vrf_name);
 			return CMD_WARNING;
+		}
 	}
 
 	/* Clear all the ospf processes */
@@ -13532,8 +13536,11 @@ DEFUN (clear_ip_ospf_interface,
 		vrf_name = NULL;
 	if (vrf_name) {
 		vrf = vrf_lookup_by_name(vrf_name);
-		if (vrf)
-			vrf_id = vrf->vrf_id;
+		if (!vrf) {
+			vty_out(vty, "%% VRF %s not found\n", vrf_name);
+			return CMD_WARNING;
+		}
+		vrf_id = vrf->vrf_id;
 	}
 	if (!argv_find(argv, argc, "IFNAME", &idx_ifname)) {
 		/* Clear all the ospfv2 interfaces. */


### PR DESCRIPTION
Problem Statement:

While validating OSPF interface/neighbor/process clear actions, it was observed that the operation was returning success even when an invalid or non-existent VRF (other than the default VRF) was provided. 

Fix:

Updated the logic to correctly return an error for invalid or non-existent VRF scenarios during OSPF clear action handling.

Command supported:

```
clear ip ospf vrf invalid_vrf interface
clear ip ospf vrf invalid_vrf neighbour
clear ip ospf vrf invalid_vrf process
```

Before Fix:

```
leaf11# clear ip ospf vrf foo neighbor
leaf11#
leaf11# clear ip ospf vrf foo interface
leaf11#
leaf11# clear ip ospf vrf foo process
leaf11#

```

After Fix :

```
leaf11# clear ip ospf vrf foo neighbor
% VRF foo not found
leaf11#
leaf11# clear ip ospf vrf foo interface
% VRF foo not found
leaf11#
leaf11# clear ip ospf vrf foo process
% VRF foo not found
leaf11#

```

Signed-off-by: Sindhu Parvathi Gopinathan <sgopinathan@nvidia.com>
