### PR TITLE
Rename *_prefix_match to *_prefix_contains

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -358,8 +358,8 @@ static bool bgp_debug_list_remove_entry(struct list *list, const char *host,
 			XFREE(MTYPE_BGP_DEBUG_STR, filter->plist_name);
 			XFREE(MTYPE_BGP_DEBUG_FILTER, filter);
 			return true;
-		} else if (p && filter->p->prefixlen == p->prefixlen
-			   && prefix_match(filter->p, p)) {
+		} else if (p && filter->p->prefixlen == p->prefixlen &&
+			   prefix_contains(filter->p, p)) {
 			listnode_delete(list, filter);
 			prefix_free(&filter->p);
 			XFREE(MTYPE_BGP_DEBUG_FILTER, filter);
@@ -386,10 +386,8 @@ static bool bgp_debug_list_has_entry(struct list *list, const char *host,
 			if (strmatch(filter->host, host))
 				return true;
 		} else if (p) {
-			if (filter->p->prefixlen == p->prefixlen
-			    && prefix_match(filter->p, p)) {
+			if (filter->p->prefixlen == p->prefixlen && prefix_contains(filter->p, p))
 				return true;
-			}
 		}
 	}
 
@@ -2800,8 +2798,8 @@ static int bgp_debug_per_prefix(const struct prefix *p,
 
 			for (ALL_LIST_ELEMENTS(per_prefix_list, node, nnode,
 					       filter))
-				if (filter->p->prefixlen == p->prefixlen
-				    && prefix_match(filter->p, p))
+				if (filter->p->prefixlen == p->prefixlen &&
+				    prefix_contains(filter->p, p))
 					return 1;
 
 			return 0;

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -683,7 +683,7 @@ bool bgp_subgrp_multiaccess_check_v6(struct in6_addr nexthop,
 	np.prefixlen = IPV6_MAX_BITLEN;
 	np.u.prefix6 = nexthop;
 
-	p.family = AF_INET;
+	p.family = AF_INET6;
 	p.prefixlen = IPV6_MAX_BITLEN;
 
 	bgp = SUBGRP_INST(subgrp);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1143,17 +1143,17 @@ static bool make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p,
 			tmp_prefix.prefix = srv6_l3service->sid;
 			if (bgp_nexthop->vpn_policy[afi].tovpn_sid_locator &&
 			    bgp_nexthop->vpn_policy[afi].tovpn_sid)
-				local_sid = prefix_match(&bgp_nexthop->vpn_policy[afi]
-								  .tovpn_sid_locator->prefix,
-							 &tmp_prefix);
+				local_sid = prefix_contains(&bgp_nexthop->vpn_policy[afi]
+								     .tovpn_sid_locator->prefix,
+							    &tmp_prefix);
 			else if (bgp_nexthop->tovpn_sid_locator && bgp_nexthop->tovpn_sid)
-				local_sid = prefix_match(&bgp_nexthop->tovpn_sid_locator->prefix,
-							 &tmp_prefix);
+				local_sid = prefix_contains(&bgp_nexthop->tovpn_sid_locator->prefix,
+							    &tmp_prefix);
 			else if (bgp_nexthop->srv6_unicast[afi].sid_locator &&
 				 bgp_nexthop->srv6_unicast[afi].sid)
-				local_sid = prefix_match(&bgp_nexthop->srv6_unicast[afi]
-								  .sid_locator->prefix,
-							 &tmp_prefix);
+				local_sid = prefix_contains(&bgp_nexthop->srv6_unicast[afi]
+								     .sid_locator->prefix,
+							    &tmp_prefix);
 		}
 		if (local_sid == false && srv6_l3service) {
 			p->prefixlen = IPV6_MAX_BITLEN;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14973,8 +14973,7 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp, struct bgp_
 				 * Get prefixlen of the ip-prefix within type5
 				 * evpn route
 				 */
-				if (evpn_type5_prefix_match(rm_p, &match)
-				    && rm->info) {
+				if (evpn_type5_prefix_contains(rm_p, &match) && rm->info) {
 					longest_pfx = rm;
 					int type5_pfxlen =
 						bgp_evpn_get_type5_prefixlen(

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14041,7 +14041,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 			}
 			if (type == bgp_show_type_prefix_longer) {
 				p = output_arg;
-				if (!prefix_match(p, dest_p))
+				if (!prefix_contains(p, dest_p))
 					continue;
 			}
 			if (type == bgp_show_type_community_all) {

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -264,14 +264,14 @@ struct bgp_dest *bgp_table_subtree_lookup(const struct bgp_table *table,
 		struct route_node *node = dest->rn;
 
 		if (dest_p->prefixlen >= p->prefixlen) {
-			if (!prefix_match(p, dest_p))
+			if (!prefix_contains(p, dest_p))
 				return NULL;
 
 			matched = dest;
 			break;
 		}
 
-		if (!prefix_match(dest_p, p))
+		if (!prefix_contains(dest_p, p))
 			return NULL;
 
 		if (dest_p->prefixlen == p->prefixlen) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5115,8 +5115,7 @@ static struct peer_group *listen_range_exists(struct bgp *bgp,
 			if (exact)
 				match = prefix_same(range, lr);
 			else
-				match = (prefix_match(range, lr)
-					 || prefix_match(lr, range));
+				match = (prefix_contains(range, lr) || prefix_contains(lr, range));
 			if (match)
 				return group;
 		}

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -635,7 +635,7 @@ struct interface *if_lookup_by_ipv4(struct in_addr *addr, vrf_id_t vrf_id)
 			cp = connected->address;
 
 			if (cp->family == AF_INET)
-				if (prefix_match(cp, (struct prefix *)&p))
+				if (prefix_contains(cp, (struct prefix *)&p))
 					return ifp;
 		}
 	}
@@ -687,7 +687,7 @@ struct interface *if_lookup_by_ipv6(struct in6_addr *addr, ifindex_t ifindex,
 			cp = connected->address;
 
 			if (cp->family == AF_INET6)
-				if (prefix_match(cp, (struct prefix *)&p)) {
+				if (prefix_contains(cp, (struct prefix *)&p)) {
 					if (IN6_IS_ADDR_LINKLOCAL(
 						    &cp->u.prefix6)) {
 						if (ifindex == ifp->ifindex)
@@ -3859,8 +3859,8 @@ static int bgp_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 		tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 		tmp_prefix.prefix = sid_addr;
 
-		if (!prefix_match((struct prefix *)&locator_bgp->prefix,
-				  (struct prefix *)&tmp_prefix)) {
+		if (!prefix_contains((struct prefix *)&locator_bgp->prefix,
+				     (struct prefix *)&tmp_prefix)) {
 			/* locator may have changed - release the SID */
 			if (BGP_DEBUG(zebra, ZEBRA))
 				zlog_debug("SRv6 SID %pI6 %s : locator prefix mismatch (%s), releasing it.",
@@ -4313,7 +4313,8 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 
 	// refresh chunks
 	for (ALL_LIST_ELEMENTS(bgp->srv6_locator_chunks, node, nnode, chunk))
-		if (prefix_match((struct prefix *)&loc->prefix, (struct prefix *)&chunk->prefix)) {
+		if (prefix_contains((struct prefix *)&loc->prefix,
+				    (struct prefix *)&chunk->prefix)) {
 			listnode_delete(bgp->srv6_locator_chunks, chunk);
 			srv6_locator_chunk_free(&chunk);
 		}
@@ -4323,7 +4324,7 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 		tmp_prefix.family = AF_INET6;
 		tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 		tmp_prefix.prefix = func->sid;
-		if (prefix_match((struct prefix *)&loc->prefix, (struct prefix *)&tmp_prefix)) {
+		if (prefix_contains((struct prefix *)&loc->prefix, (struct prefix *)&tmp_prefix)) {
 			listnode_delete(bgp->srv6_functions, func);
 			srv6_function_free(func);
 		}
@@ -4351,8 +4352,8 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 			tmp_prefix.family = AF_INET6;
 			tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefix.prefix = *tovpn_sid;
-			if (prefix_match((struct prefix *)&loc->prefix,
-					 (struct prefix *)&tmp_prefix)) {
+			if (prefix_contains((struct prefix *)&loc->prefix,
+					    (struct prefix *)&tmp_prefix)) {
 				XFREE(MTYPE_BGP_SRV6_SID,
 				      bgp_vrf->vpn_policy[AFI_IP].tovpn_sid);
 				/* refresh vpnv4 tovpn_sid_locator */
@@ -4367,8 +4368,8 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 			tmp_prefix.family = AF_INET6;
 			tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefix.prefix = *tovpn_sid;
-			if (prefix_match((struct prefix *)&loc->prefix,
-					 (struct prefix *)&tmp_prefix)) {
+			if (prefix_contains((struct prefix *)&loc->prefix,
+					    (struct prefix *)&tmp_prefix)) {
 				XFREE(MTYPE_BGP_SRV6_SID,
 				      bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid);
 				/* refresh vpnv6 tovpn_sid_locator */
@@ -4383,8 +4384,8 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 			tmp_prefix.family = AF_INET6;
 			tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefix.prefix = *tovpn_sid;
-			if (prefix_match((struct prefix *)&loc->prefix,
-					 (struct prefix *)&tmp_prefix)) {
+			if (prefix_contains((struct prefix *)&loc->prefix,
+					    (struct prefix *)&tmp_prefix)) {
 				XFREE(MTYPE_BGP_SRV6_SID, bgp_vrf->tovpn_sid);
 				/* refresh per-vrf tovpn_sid_locator */
 				srv6_locator_free(bgp_vrf->tovpn_sid_locator);
@@ -4404,7 +4405,7 @@ static void bgp_zebra_process_srv6_locator_delete_per_bgp(struct srv6_locator *l
 		tmp_prefix.family = AF_INET6;
 		tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 		tmp_prefix.prefix = *unicast_sid;
-		if (!prefix_match((struct prefix *)&loc->prefix, (struct prefix *)&tmp_prefix))
+		if (!prefix_contains((struct prefix *)&loc->prefix, (struct prefix *)&tmp_prefix))
 			continue;
 		bgp_srv6_unicast_withdraw(bgp, afi);
 		bgp_srv6_unicast_sid_withdraw(bgp, afi);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3560,7 +3560,7 @@ int peer_group_listen_range_del(struct peer_group *group, struct prefix *range)
 			continue;
 
 		if (sockunion2hostprefix(&peer->connection->su, &prefix2) &&
-		    prefix_match(prefix, &prefix2)) {
+		    prefix_contains(prefix, &prefix2)) {
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug(
 					"Deleting dynamic neighbor %s group %s upon delete of listen range %pFX",
@@ -5002,7 +5002,7 @@ peer_group_lookup_dynamic_neighbor_range(struct peer_group *group,
 	if (group->listen_range[afi])
 		for (ALL_LIST_ELEMENTS(group->listen_range[afi], node, nnode,
 				       range))
-			if (prefix_match(range, prefix))
+			if (prefix_contains(range, prefix))
 				return range;
 
 	return NULL;

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -793,7 +793,7 @@ static void rfapiMonitorMoveLonger(struct agg_node *new_vpn_node)
 		 * If new longest match for monitor prefix is the new
 		 * route's prefix, move monitor to new route's prefix
 		 */
-		if (prefix_match(new_vpn_node_p, &monitor->p)) {
+		if (prefix_contains(new_vpn_node_p, &monitor->p)) {
 			/* detach */
 			if (mlast) {
 				mlast->next = monitor->next;
@@ -4463,12 +4463,10 @@ static void rfapiDeleteRemotePrefixesIt(
 					qpt_valid = 1;
 
 				if (vn) {
-					if (!qpt_valid
-					    || !prefix_match(vn, &qpt)) {
+					if (!qpt_valid || !prefix_contains(vn, &qpt)) {
 #ifdef DEBUG_L2_EXTRA
-						vnc_zlog_debug_verbose(
-							"%s: continue at vn && !qpt_valid || !prefix_match(vn, &qpt)",
-							__func__);
+						vnc_zlog_debug_verbose("%s: continue at vn && !qpt_valid || !prefix_contains(vn, &qpt)",
+								       __func__);
 #endif
 						continue;
 					}
@@ -4478,12 +4476,10 @@ static void rfapiDeleteRemotePrefixesIt(
 					qct_valid = 1;
 
 				if (un) {
-					if (!qct_valid
-					    || !prefix_match(un, &qct)) {
+					if (!qct_valid || !prefix_contains(un, &qct)) {
 #ifdef DEBUG_L2_EXTRA
-						vnc_zlog_debug_verbose(
-							"%s: continue at un && !qct_valid || !prefix_match(un, &qct)",
-							__func__);
+						vnc_zlog_debug_verbose("%s: continue at un && !qct_valid || !prefix_contains(un, &qct)",
+								       __func__);
 #endif
 						continue;
 					}

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -813,7 +813,7 @@ void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd,
 
 			p_node = agg_node_get_prefix(m->node);
 			/* NB order of test is significant ! */
-			if (!m->node || prefix_match(p_node, p)) {
+			if (!m->node || prefix_contains(p_node, p)) {
 				rfapiMonitorTimerRestart(m);
 			}
 		}

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -1817,7 +1817,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	/*
 	 * prefix covers target address, so allow prefix
 	 */
-	if (prefix_match(p, pfx_target_original)) {
+	if (prefix_contains(p, pfx_target_original)) {
 #ifdef DEBUG_FTD_FILTER_RECENT
 		vnc_zlog_debug_verbose("%s: prefix covers target, allowed",
 				       __func__);
@@ -2398,8 +2398,8 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 				routes_total++;
 				nhs_total += skiplist_count(sl);
 
-				if (pfx_match && !prefix_match(pfx_match, p)
-				    && !prefix_match(p, pfx_match))
+				if (pfx_match && !prefix_contains(pfx_match, p) &&
+				    !prefix_contains(p, pfx_match))
 					continue;
 
 				if (!printedheader) {

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -875,8 +875,8 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 
 				++queries_total;
 
-				if (pfx_match && !prefix_match(pfx_match, p)
-				    && !prefix_match(p, pfx_match))
+				if (pfx_match && !prefix_contains(pfx_match, p) &&
+				    !prefix_contains(p, pfx_match))
 					continue;
 
 				++queries_displayed;
@@ -945,9 +945,8 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 				pfx_mac.prefixlen = 48;
 				pfx_mac.u.prefix_eth = mon_eth->macaddr;
 
-				if (pfx_match
-				    && !prefix_match(pfx_match, &pfx_mac)
-				    && !prefix_match(&pfx_mac, pfx_match))
+				if (pfx_match && !prefix_contains(pfx_match, &pfx_mac) &&
+				    !prefix_contains(&pfx_mac, pfx_match))
 					continue;
 
 				++queries_displayed;
@@ -1213,8 +1212,8 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 			int count_only;
 
 			/* allow for wider or more narrow mask from user */
-			if (prefix_only && !prefix_match(prefix_only, p)
-			    && !prefix_match(p, prefix_only))
+			if (prefix_only && !prefix_contains(prefix_only, p) &&
+			    !prefix_contains(p, prefix_only))
 				count_only = 1;
 			else
 				count_only = 0;
@@ -1674,13 +1673,13 @@ void rfapiPrintMatchingDescriptors(struct vty *vty, struct prefix *vn_prefix,
 
 		if (vn_prefix) {
 			assert(!rfapiRaddr2Qprefix(&rfd->vn_addr, &pfx));
-			if (!prefix_match(vn_prefix, &pfx))
+			if (!prefix_contains(vn_prefix, &pfx))
 				continue;
 		}
 
 		if (un_prefix) {
 			assert(!rfapiRaddr2Qprefix(&rfd->un_addr, &pfx));
-			if (!prefix_match(un_prefix, &pfx))
+			if (!prefix_contains(un_prefix, &pfx))
 				continue;
 		}
 
@@ -4208,13 +4207,13 @@ static int rfapi_show_nves(struct vty *vty, struct prefix *vn_prefix,
 
 		if (vn_prefix) {
 			assert(!rfapiRaddr2Qprefix(&rfd->vn_addr, &pfx));
-			if (!prefix_match(vn_prefix, &pfx))
+			if (!prefix_contains(vn_prefix, &pfx))
 				continue;
 		}
 
 		if (un_prefix) {
 			assert(!rfapiRaddr2Qprefix(&rfd->un_addr, &pfx));
-			if (!prefix_match(un_prefix, &pfx))
+			if (!prefix_contains(un_prefix, &pfx))
 				continue;
 		}
 

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -2107,8 +2107,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 			rfapiUnicastNexthop2Prefix(afi, bpi_exterior->attr,
 						   &pfx_nexthop);
 
-			if (prefix_match(p, &pfx_nexthop)) {
-
+			if (prefix_contains(p, &pfx_nexthop)) {
 				struct bgp_path_info *bpi;
 				struct prefix_rd *prd;
 				struct attr new_attr;
@@ -2257,8 +2256,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 		rfapiUnicastNexthop2Prefix(afi, bpi_exterior->attr,
 					   &pfx_nexthop);
 
-		if (prefix_match(p, &pfx_nexthop)) {
-
+		if (prefix_contains(p, &pfx_nexthop)) {
 			struct prefix_rd *prd;
 			struct attr new_attr;
 			uint32_t label;

--- a/eigrpd/eigrp_siaquery.c
+++ b/eigrpd/eigrp_siaquery.c
@@ -80,7 +80,7 @@ void eigrp_siaquery_receive(struct eigrp *eigrp, struct ip *iph,
 				break;
 			}
 
-			dest_addr.family = AFI_IP;
+			dest_addr.family = AF_INET;
 			dest_addr.u.prefix4 = tlv->destination;
 			dest_addr.prefixlen = tlv->prefix_length;
 			struct eigrp_prefix_descriptor *dest =

--- a/eigrpd/eigrp_siareply.c
+++ b/eigrpd/eigrp_siareply.c
@@ -79,7 +79,7 @@ void eigrp_siareply_receive(struct eigrp *eigrp, struct ip *iph,
 				break;
 			}
 
-			dest_addr.family = AFI_IP;
+			dest_addr.family = AF_INET;
 			dest_addr.u.prefix4 = tlv->destination;
 			dest_addr.prefixlen = tlv->prefix_length;
 			struct eigrp_prefix_descriptor *dest =

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1306,8 +1306,8 @@ static int isis_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 		/* Free the SRv6 locator chunks */
 		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_locator_chunks, node,
 				       nnode, chunk)) {
-			if (prefix_match((struct prefix *)&loc.prefix,
-					 (struct prefix *)&chunk->prefix)) {
+			if (prefix_contains((struct prefix *)&loc.prefix,
+					    (struct prefix *)&chunk->prefix)) {
 				listnode_delete(
 					area->srv6db.srv6_locator_chunks,
 					chunk);
@@ -1476,8 +1476,8 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 			tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefix.prefix = sid_addr;
 
-			if (!prefix_match((struct prefix *)&locator->prefix,
-					  (struct prefix *)&tmp_prefix)) {
+			if (!prefix_contains((struct prefix *)&locator->prefix,
+					     (struct prefix *)&tmp_prefix)) {
 				sr_debug("%s : ignoring SRv6 SID notify: locator (area %s) does not match",
 					 __func__, area->area_tag);
 				continue;

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -1643,7 +1643,7 @@ ldp_vty_dispatch_lib(struct vty *vty, struct imsg *imsg,
 				filtered = true;
 				return (0);
 			} else if (params->lib.longer_prefixes &&
-			    !prefix_match(&params->lib.prefix, &prefix)) {
+				   !prefix_contains(&params->lib.prefix, &prefix)) {
 				filtered = true;
 				return (0);
 			}

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -156,11 +156,11 @@ static int filter_match_zebra(struct filter *mfilter, const struct prefix *p)
 	if (filter->prefix.family == p->family) {
 		if (filter->exact) {
 			if (filter->prefix.prefixlen == p->prefixlen)
-				return prefix_match(&filter->prefix, p);
+				return prefix_contains(&filter->prefix, p);
 			else
 				return 0;
 		} else
-			return prefix_match(&filter->prefix, p);
+			return prefix_contains(&filter->prefix, p);
 	} else
 		return 0;
 }
@@ -253,11 +253,11 @@ static int filter_match_zebra_sadr(struct filter *mfilter, const struct prefix *
 	if (filter->prefix.family == p->family) {
 		if (filter->exact) {
 			if (filter->prefix.prefixlen == p->prefixlen)
-				return prefix_match(&filter->prefix, p);
+				return prefix_contains(&filter->prefix, p);
 			else
 				return 0;
 		} else
-			return prefix_match(&filter->prefix, p);
+			return prefix_contains(&filter->prefix, p);
 	} else
 		return 0;
 }

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -153,16 +153,12 @@ static int filter_match_zebra(struct filter *mfilter, const struct prefix *p)
 
 	filter = &mfilter->u.zfilter;
 
-	if (filter->prefix.family == p->family) {
-		if (filter->exact) {
-			if (filter->prefix.prefixlen == p->prefixlen)
-				return prefix_contains(&filter->prefix, p);
-			else
-				return 0;
-		} else
+	if (filter->exact) {
+		if (filter->prefix.prefixlen == p->prefixlen)
 			return prefix_contains(&filter->prefix, p);
-	} else
 		return 0;
+	}
+	return prefix_contains(&filter->prefix, p);
 }
 
 static int filter_match_cisco_sadr4(struct filter *mfilter, const struct prefix *src,
@@ -250,16 +246,12 @@ static int filter_match_zebra_sadr(struct filter *mfilter, const struct prefix *
 
 	filter = &mfilter->u.zfilter;
 
-	if (filter->prefix.family == p->family) {
-		if (filter->exact) {
-			if (filter->prefix.prefixlen == p->prefixlen)
-				return prefix_contains(&filter->prefix, p);
-			else
-				return 0;
-		} else
+	if (filter->exact) {
+		if (filter->prefix.prefixlen == p->prefixlen)
 			return prefix_contains(&filter->prefix, p);
-	} else
 		return 0;
+	}
+	return prefix_contains(&filter->prefix, p);
 }
 
 /* Allocate new access list structure. */

--- a/lib/if.c
+++ b/lib/if.c
@@ -605,7 +605,7 @@ struct connected *if_lookup_address(const void *matchaddr, int family,
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		frr_each (if_connected, ifp->connected, c) {
 			if (c->address && (c->address->family == family) &&
-			    prefix_match(CONNECTED_PREFIX(c), &addr) &&
+			    prefix_contains(CONNECTED_PREFIX(c), &addr) &&
 			    (c->address->prefixlen > bestlen)) {
 				bestlen = c->address->prefixlen;
 				match = c;
@@ -1035,10 +1035,9 @@ struct connected *connected_lookup_prefix(struct interface *ifp,
 	match = NULL;
 
 	frr_each (if_connected, ifp->connected, c) {
-		if (c->address && (c->address->family == addr->family)
-		    && prefix_match(CONNECTED_PREFIX(c), addr)
-		    && (!match
-			|| (c->address->prefixlen > match->address->prefixlen)))
+		if (c->address && (c->address->family == addr->family) &&
+		    prefix_contains(CONNECTED_PREFIX(c), addr) &&
+		    (!match || (c->address->prefixlen > match->address->prefixlen)))
 			match = c;
 	}
 	return match;

--- a/lib/if.h
+++ b/lib/if.h
@@ -502,9 +502,9 @@ struct nbr_connected {
 
 /* Identifying address.  We guess that if there's a peer address, but the
    local address is in the same prefix, then the local address may be unique. */
-#define CONNECTED_ID(C)                                                        \
-	((CONNECTED_PEER(C) && !prefix_match((C)->destination, (C)->address))  \
-		 ? (C)->destination                                            \
+#define CONNECTED_ID(C)                                                                           \
+	((CONNECTED_PEER(C) && !prefix_contains((C)->destination, (C)->address))                  \
+		 ? (C)->destination                                                               \
 		 : (C)->address)
 
 /* There are some interface flags which are only supported by some

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -744,7 +744,7 @@ static int prefix_list_entry_match(struct prefix_list_entry *pentry,
 	if (pentry->prefix.family != p->family)
 		return 0;
 
-	ret = prefix_match(&pentry->prefix, p);
+	ret = prefix_contains(&pentry->prefix, p);
 	if (!ret)
 		return 0;
 
@@ -1145,8 +1145,8 @@ static int vty_show_prefix_list_prefix(struct vty *vty, afi_t afi,
 			}
 
 		if (type == longer_display) {
-			if ((p.family == pentry->prefix.family)
-			    && (prefix_match(&p, &pentry->prefix)))
+			if ((p.family == pentry->prefix.family) &&
+			    (prefix_contains(&p, &pentry->prefix)))
 				match = 1;
 		}
 
@@ -1216,8 +1216,8 @@ static int vty_clear_prefix_list(struct vty *vty, afi_t afi, const char *name,
 
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			if (prefix) {
-				if (pentry->prefix.family == p.family
-				    && prefix_match(&pentry->prefix, &p))
+				if (pentry->prefix.family == p.family &&
+				    prefix_contains(&pentry->prefix, &p))
 					pentry->hitcnt = 0;
 			} else
 				pentry->hitcnt = 0;

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -741,9 +741,6 @@ static int prefix_list_entry_match(struct prefix_list_entry *pentry,
 {
 	int ret;
 
-	if (pentry->prefix.family != p->family)
-		return 0;
-
 	ret = prefix_contains(&pentry->prefix, p);
 	if (!ret)
 		return 0;
@@ -1145,8 +1142,7 @@ static int vty_show_prefix_list_prefix(struct vty *vty, afi_t afi,
 			}
 
 		if (type == longer_display) {
-			if ((p.family == pentry->prefix.family) &&
-			    (prefix_contains(&p, &pentry->prefix)))
+			if (prefix_contains(&p, &pentry->prefix))
 				match = 1;
 		}
 
@@ -1216,8 +1212,7 @@ static int vty_clear_prefix_list(struct vty *vty, afi_t afi, const char *name,
 
 		for (pentry = plist->head; pentry; pentry = pentry->next) {
 			if (prefix) {
-				if (pentry->prefix.family == p.family &&
-				    prefix_contains(&pentry->prefix, &p))
+				if (prefix_contains(&pentry->prefix, &p))
 					pentry->hitcnt = 0;
 			} else
 				pentry->hitcnt = 0;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -191,11 +191,11 @@ const char *safi2str(safi_t safi)
 	return "DEV ESCAPE";
 }
 
-/* If n includes p prefix then return 1 else return 0. */
-int prefix_match(union prefixconstptr unet, union prefixconstptr upfx)
+/* If unetwork includes uprefix then return 1 else return 0. */
+int prefix_contains(union prefixconstptr unetwork, union prefixconstptr uprefix)
 {
-	const struct prefix *n = unet.p;
-	const struct prefix *p = upfx.p;
+	const struct prefix *n = unetwork.p;
+	const struct prefix *p = uprefix.p;
 	int offset;
 	int shift;
 	const uint8_t *np, *pp;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -249,7 +249,7 @@ int prefix_contains(union prefixconstptr unetwork, union prefixconstptr uprefix)
  * ip-prefix within n which matches prefix p
  * If n includes p prefix then return 1 else return 0.
  */
-int evpn_type5_prefix_match(const struct prefix *n, const struct prefix *p)
+int evpn_type5_prefix_contains(const struct prefix *n, const struct prefix *p)
 {
 	int offset;
 	int shift;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -200,6 +200,9 @@ int prefix_contains(union prefixconstptr unetwork, union prefixconstptr uprefix)
 	int shift;
 	const uint8_t *np, *pp;
 
+	if (n->family != p->family)
+		return 0;
+
 	/* If n's prefix is longer than p's one return 0. */
 	if (n->prefixlen > p->prefixlen)
 		return 0;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -419,8 +419,8 @@ extern void prefix_mcast_ip_dump(const char *onfail, const struct ipaddr *addr,
 extern const char *prefix_sg2str(const struct prefix_sg *sg, char *str);
 extern const char *prefix2str(union prefixconstptr upfx, char *buffer,
 			      int size);
-extern int evpn_type5_prefix_match(const struct prefix *evpn_pfx,
-				   const struct prefix *match_pfx);
+extern int evpn_type5_prefix_contains(const struct prefix *evpn_network_pfx,
+				      const struct prefix *match_pfx);
 extern int prefix_contains(union prefixconstptr unetwork, union prefixconstptr uprefix);
 extern int prefix_match_network_statement(union prefixconstptr unet,
 					  union prefixconstptr upfx);

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -421,7 +421,7 @@ extern const char *prefix2str(union prefixconstptr upfx, char *buffer,
 			      int size);
 extern int evpn_type5_prefix_match(const struct prefix *evpn_pfx,
 				   const struct prefix *match_pfx);
-extern int prefix_match(union prefixconstptr unet, union prefixconstptr upfx);
+extern int prefix_contains(union prefixconstptr unetwork, union prefixconstptr uprefix);
 extern int prefix_match_network_statement(union prefixconstptr unet,
 					  union prefixconstptr upfx);
 extern int prefix_same(union prefixconstptr ua, union prefixconstptr ub);

--- a/lib/table.c
+++ b/lib/table.c
@@ -245,8 +245,7 @@ struct route_node *route_node_match(struct route_table *table,
 
 	/* Walk down tree.  If there is matched route then store it to
 	   matched. */
-	while (node && node->p.prefixlen <= p->prefixlen
-	       && prefix_match(&node->p, p)) {
+	while (node && node->p.prefixlen <= p->prefixlen && prefix_contains(&node->p, p)) {
 		if (node->info)
 			matched = node;
 
@@ -333,8 +332,7 @@ struct route_node *route_node_get(struct route_table *table,
 
 	match = NULL;
 	node = table->top;
-	while (node && node->p.prefixlen <= prefixlen
-	       && prefix_match(&node->p, p)) {
+	while (node && node->p.prefixlen <= prefixlen && prefix_contains(&node->p, p)) {
 		if (node->p.prefixlen == prefixlen) {
 			if (p->family == AF_FLOWSPEC)
 				prefix_flowspec_ptr_free(p);
@@ -629,8 +627,7 @@ int route_table_prefix_iter_cmp(const struct prefix *p1,
 	struct prefix *common = &common_space;
 
 	if (p1->prefixlen <= p2->prefixlen) {
-		if (prefix_match(p1, p2)) {
-
+		if (prefix_contains(p1, p2)) {
 			/*
 			 * p1 contains p2, or is equal to it.
 			 */
@@ -641,7 +638,7 @@ int route_table_prefix_iter_cmp(const struct prefix *p1,
 		/*
 		 * Check if p2 contains p1.
 		 */
-		if (prefix_match(p2, p1))
+		if (prefix_contains(p2, p1))
 			return 1;
 	}
 
@@ -724,9 +721,9 @@ route_table_get_next_internal(struct route_table *table,
 		int match;
 
 		if (node->p.prefixlen < p->prefixlen)
-			match = prefix_match(&node->p, p);
+			match = prefix_contains(&node->p, p);
 		else
-			match = prefix_match(p, &node->p);
+			match = prefix_contains(p, &node->p);
 
 		if (match) {
 			if (node->p.prefixlen == p->prefixlen) {

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -579,7 +579,7 @@ static void nhrp_shortcut_purge_prefix(struct nhrp_shortcut *s, void *ctx)
 {
 	struct purge_ctx *pctx = ctx;
 
-	if (prefix_match(pctx->p, s->p))
+	if (prefix_contains(pctx->p, s->p))
 		nhrp_shortcut_purge(s, pctx->deleted || !s->cache);
 }
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1432,7 +1432,7 @@ static void ospf6_external_lsa_fwd_addr_set(struct ospf6 *ospf6,
 				continue;
 			if (IN6_IS_ADDR_LINKLOCAL(&connected->address->u.prefix6))
 				continue;
-			if (!prefix_match(connected->address, &nh))
+			if (!prefix_contains(connected->address, &nh))
 				continue;
 
 			*fwd_addr = *nexthop;

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -294,7 +294,7 @@ const struct route_node *ospf6_lsdb_head(struct ospf6_lsdb *lsdb, int argmode,
 					   sizeof(adv_router));
 
 		node = route_table_get_next(lsdb->table, &key);
-		if (!node || !prefix_match((struct prefix *)&key, &node->p))
+		if (!node || !prefix_contains((struct prefix *)&key, &node->p))
 			return NULL;
 
 		for (end = node; end && end->parent

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1040,8 +1040,7 @@ struct ospf6_route *ospf6_route_match_head(struct prefix *prefix,
 
 	/* Walk down tree. */
 	node = table->table->top;
-	while (node && node->p.prefixlen < prefix->prefixlen
-	       && prefix_match(&node->p, prefix))
+	while (node && node->p.prefixlen < prefix->prefixlen && prefix_contains(&node->p, prefix))
 		node = node->link[prefix_bit(&prefix->u.prefix,
 					     node->p.prefixlen)];
 
@@ -1053,7 +1052,7 @@ struct ospf6_route *ospf6_route_match_head(struct prefix *prefix,
 		return NULL;
 	route_unlock_node(node);
 
-	if (!prefix_match(prefix, &node->p))
+	if (!prefix_contains(prefix, &node->p))
 		return NULL;
 
 	route = node->info;
@@ -1067,7 +1066,7 @@ struct ospf6_route *ospf6_route_match_next(struct prefix *prefix,
 	struct ospf6_route *next;
 
 	next = ospf6_route_next(route);
-	if (next && !prefix_match(prefix, &next->prefix)) {
+	if (next && !prefix_contains(prefix, &next->prefix)) {
 		ospf6_route_unlock(next);
 		next = NULL;
 	}

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -606,6 +606,7 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 			   &lsa->data->id);
 
 	ext7 = (struct as_external_lsa *)(lsa->data);
+	p.family = AF_INET;
 	p.prefix = lsa->data->id;
 	p.prefixlen = ip_masklen(ext7->mask);
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -504,8 +504,7 @@ struct ospf_interface *ospf_if_lookup_recv_if(struct ospf *ospf,
 
 		if (CHECK_FLAG(oi->connected->flags, ZEBRA_IFA_UNNUMBERED))
 			unnumbered_match = oi;
-		else if (prefix_match(CONNECTED_PREFIX(oi->connected),
-				      (struct prefix *)&addr)) {
+		else if (prefix_contains(CONNECTED_PREFIX(oi->connected), (struct prefix *)&addr)) {
 			if ((match == NULL) || (match->address->prefixlen
 						< oi->address->prefixlen))
 				match = oi;

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1648,7 +1648,7 @@ static struct in_addr ospf_external_lsa_nexthop_get(struct ospf *ospf,
 	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi))
 		if (if_is_operative(oi->ifp))
 			if (oi->address->family == AF_INET)
-				if (prefix_match(oi->address, &nh))
+				if (prefix_contains(oi->address, &nh))
 					return nexthop;
 
 	return fwd;

--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -924,7 +924,7 @@ void ospf_ti_lfa_generate_p_spaces(struct ospf_area *area,
 				 * Q spaces so we can later on generate a
 				 * backup path for the link.
 				 */
-				if (prefix_match(&stub_prefix, &child_prefix)) {
+				if (prefix_contains(&stub_prefix, &child_prefix)) {
 					zlog_info(
 						"%s: Generating P space for %pI4",
 						__func__, &l->link_id);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2044,8 +2044,7 @@ void ospf_nbr_nbma_if_update(struct ospf *ospf, struct ospf_interface *oi)
 				p.prefix = nbr_nbma->addr;
 				p.prefixlen = IPV4_MAX_BITLEN;
 
-				if (prefix_match(oi->address,
-						 (struct prefix *)&p))
+				if (prefix_contains(oi->address, (struct prefix *)&p))
 					ospf_nbr_nbma_add(nbr_nbma, oi);
 			}
 }
@@ -2094,7 +2093,7 @@ int ospf_nbr_nbma_set(struct ospf *ospf, struct in_addr nbr_addr)
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi)) {
 		if (OSPF_IF_NON_BROADCAST(oi))
-			if (prefix_match(oi->address, (struct prefix *)&p)) {
+			if (prefix_contains(oi->address, (struct prefix *)&p)) {
 				ospf_nbr_nbma_add(nbr_nbma, oi);
 				break;
 			}

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2889,7 +2889,7 @@ static void gm_show_joins_one(struct vty *vty, struct gm_if *gm_ifp,
 			struct prefix grp_p;
 
 			pim_addr_to_prefix(&grp_p, sg->sgaddr.grp);
-			if (!prefix_match(groups, &grp_p))
+			if (!prefix_contains(groups, &grp_p))
 				break;
 		}
 
@@ -2897,7 +2897,7 @@ static void gm_show_joins_one(struct vty *vty, struct gm_if *gm_ifp,
 			struct prefix src_p;
 
 			pim_addr_to_prefix(&src_p, sg->sgaddr.src);
-			if (!prefix_match(sources, &src_p))
+			if (!prefix_contains(sources, &src_p))
 				continue;
 		}
 

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -947,7 +947,8 @@ static size_t autorp_build_disc_rps(struct pim_autorp *autorp, uint8_t *buf, siz
 		 */
 		skip = false;
 		frr_each (pim_autorp_grppfix, &rp->grp_pfix_list, grp2) {
-			if (prefix_match(&grp2->grp, &grp->grp) && grp->negative == grp2->negative) {
+			if (prefix_contains(&grp2->grp, &grp->grp) &&
+			    grp->negative == grp2->negative) {
 				skip = true;
 				break;
 			}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1878,9 +1878,9 @@ struct prefix *pim_if_connected_to_source(struct interface *ifp, pim_addr src)
 	frr_each (if_connected, ifp->connected, c) {
 		if (c->address->family != PIM_AF)
 			continue;
-		if (prefix_match(c->address, &p))
+		if (prefix_contains(c->address, &p))
 			return c->address;
-		if (CONNECTED_PEER(c) && prefix_match(c->destination, &p))
+		if (CONNECTED_PEER(c) && prefix_contains(c->destination, &p))
 			/* this is not a typo, on PtP we need to return the
 			 * *local* address that lines up with src.
 			 */

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -523,7 +523,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 		/*
 		 * Barf if group is a non-multicast subnet
 		 */
-		if (!prefix_match(&rp_all->group, &rp_info->group)) {
+		if (!prefix_contains(&rp_all->group, &rp_info->group)) {
 			XFREE(MTYPE_PIM_RP, rp_info);
 			return PIM_GROUP_BAD_ADDRESS;
 		}
@@ -1244,7 +1244,7 @@ void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 		const char *group_type =
 			pim_is_grp_ssm(pim, group) ? "SSM" : "ASM";
 
-		if (range && !prefix_match(&rp_info->group, range))
+		if (range && !prefix_contains(&rp_info->group, range))
 			continue;
 
 		if (rp_info->rp_src == RP_SRC_STATIC)

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -169,9 +169,6 @@ static bool pim_acl_prefix_match(const struct filter *filter, const struct prefi
 {
 	const struct filter_zebra *zfilter = &filter->u.zfilter;
 
-	if (zfilter->prefix.family != p->family)
-		return false;
-
 	if (zfilter->exact && zfilter->prefix.prefixlen != p->prefixlen)
 		return false;
 

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -107,7 +107,7 @@ int pim_is_group_224_0_0_0_24(struct in_addr group_addr)
 	group.u.prefix4 = group_addr;
 	group.prefixlen = IPV4_MAX_BITLEN;
 
-	return prefix_match(&group_224, &group);
+	return prefix_contains(&group_224, &group);
 }
 
 int pim_is_group_224_4(struct in_addr group_addr)
@@ -126,7 +126,7 @@ int pim_is_group_224_4(struct in_addr group_addr)
 	group.u.prefix4 = group_addr;
 	group.prefixlen = IPV4_MAX_BITLEN;
 
-	return prefix_match(&group_all, &group);
+	return prefix_contains(&group_all, &group);
 }
 
 bool pim_is_group_ff00_8(struct in6_addr group_address)
@@ -140,7 +140,7 @@ bool pim_is_group_ff00_8(struct in6_addr group_address)
 	group.u.prefix6 = group_address;
 	group.prefixlen = IPV6_MAX_BITLEN;
 
-	return prefix_match(&group_all, &group);
+	return prefix_contains(&group_all, &group);
 }
 
 static bool pim_cisco_match(const struct filter *filter, const struct in_addr *source,
@@ -175,7 +175,7 @@ static bool pim_acl_prefix_match(const struct filter *filter, const struct prefi
 	if (zfilter->exact && zfilter->prefix.prefixlen != p->prefixlen)
 		return false;
 
-	return prefix_match(&zfilter->prefix, p);
+	return prefix_contains(&zfilter->prefix, p);
 }
 
 enum filter_type pim_access_list_apply(struct access_list *access, const struct in_addr *source,

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -75,19 +75,19 @@ class PrefixBase(RenderHandler):
 
 class Prefix4Handler(PrefixBase):
     argtype = "const struct prefix_ipv4 *"
-    decl = Template("struct prefix_ipv4 $varname = { };")
+    decl = Template("struct prefix_ipv4 $varname = { .family = AF_INET };")
     code = Template("_fail = !str2prefix_ipv4(argv[_i]->arg, &$varname);")
 
 
 class Prefix6Handler(PrefixBase):
     argtype = "const struct prefix_ipv6 *"
-    decl = Template("struct prefix_ipv6 $varname = { };")
+    decl = Template("struct prefix_ipv6 $varname = { .family = AF_INET6 };")
     code = Template("_fail = !str2prefix_ipv6(argv[_i]->arg, &$varname);")
 
 
 class PrefixEthHandler(PrefixBase):
     argtype = "struct prefix_eth *"
-    decl = Template("struct prefix_eth $varname = { };")
+    decl = Template("struct prefix_eth $varname = { .family = AF_ETHERNET };")
     code = Template("_fail = !str2prefix_eth(argv[_i]->arg, &$varname);")
 
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2158,9 +2158,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 					"RIPv1 mask check, %pFX considered for output",
 					&rp->p);
 
-			if (subnetted &&
-			    prefix_match((struct prefix *)&ifaddrclass,
-					 &rp->p)) {
+			if (subnetted && prefix_contains((struct prefix *)&ifaddrclass, &rp->p)) {
 				if ((ifc->address->prefixlen !=
 				     rp->p.prefixlen) &&
 				    (rp->p.prefixlen != IPV4_MAX_BITLEN))
@@ -2218,8 +2216,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 			if (!suppress && rinfo->type == ZEBRA_ROUTE_CONNECT) {
 				frr_each (if_connected, ifc->ifp->connected,
 					  tmp_ifc)
-					if (prefix_match((struct prefix *)p,
-							 tmp_ifc->address)) {
+					if (prefix_contains((struct prefix *)p, tmp_ifc->address)) {
 						suppress = 1;
 						break;
 					}
@@ -2328,8 +2325,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 			    rinfo->type == ZEBRA_ROUTE_CONNECT) {
 				frr_each (if_connected, ifc->ifp->connected,
 					  tmp_ifc)
-					if (prefix_match((struct prefix *)p,
-							 tmp_ifc->address)) {
+					if (prefix_contains((struct prefix *)p, tmp_ifc->address)) {
 						rinfo->metric_out =
 							RIP_METRIC_INFINITY;
 						break;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -1028,7 +1028,7 @@ static bool is_srv6_sid_localonly(const struct static_srv6_sid *sid)
 
 	locator = sid->locator->prefix;
 
-	if (prefix_match(&block, &sid->addr) && !prefix_match(&locator, &sid->addr))
+	if (prefix_contains(&block, &sid->addr) && !prefix_contains(&locator, &sid->addr))
 		return true;
 
 	return false;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -612,7 +612,7 @@ struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
 		return NULL;
 
 	memset(&p, 0, sizeof(p));
-	p.family = afi;
+	p.family = afi2family(afi);
 	if (afi == AFI_IP) {
 		p.u.prefix4 = addr->ipv4;
 		p.prefixlen = IPV4_MAX_BITLEN;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -957,7 +957,7 @@ void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
 	}
 
 	for (rn = route_top(table); rn; rn = route_next(rn)) {
-		if (p && !prefix_match(&rn->p, p))
+		if (p && !prefix_contains(&rn->p, p))
 			continue;
 
 		if (rn->info)

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -597,7 +597,7 @@ zebra_srv6_sid_block_lookup(struct prefix_ipv6 *prefix)
 	struct listnode *node;
 
 	for (ALL_LIST_ELEMENTS_RO(srv6->sid_blocks, node, block))
-		if (prefix_match(prefix, &block->prefix))
+		if (prefix_contains(prefix, &block->prefix))
 			return block;
 
 	return NULL;
@@ -1350,8 +1350,7 @@ static bool zebra_srv6_sid_decompose(struct in6_addr *sid_value,
 		 * Check if the locator prefix includes the temporary prefix
 		 * representing the SID.
 		 */
-		if (prefix_match((struct prefix *)&l->prefix,
-				 (struct prefix *)&tmp_prefix)) {
+		if (prefix_contains((struct prefix *)&l->prefix, (struct prefix *)&tmp_prefix)) {
 			format = l->sid_format;
 
 			if (format) {
@@ -1417,8 +1416,7 @@ static bool zebra_srv6_sid_decompose(struct in6_addr *sid_value,
 		 * Check if the block prefix includes the temporary prefix
 		 * representing the SID
 		 */
-		if (prefix_match((struct prefix *)&b->prefix,
-				 (struct prefix *)&tmp_prefix)) {
+		if (prefix_contains((struct prefix *)&b->prefix, (struct prefix *)&tmp_prefix)) {
 			format = b->sid_format;
 
 			if (format) {

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -878,7 +878,7 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
 		dest = rib_dest_from_rnode(rn);
 
-		if (longer_prefix_p && !prefix_match(longer_prefix_p, &rn->p))
+		if (longer_prefix_p && !prefix_contains(longer_prefix_p, &rn->p))
 			continue;
 
 		RNODE_FOREACH_RE (rn, re) {


### PR DESCRIPTION
a) Fix a bunch of places that the incorrect afi was set for a `struct prefix`
b) Fix clippy generation of afi for prefixes handed to cli functions in DEFPY's
c)  rename prefix_match to prefix_contains.  This better encapsulates what this function is doing.  I have to look up what this function does every time because the name does not make 100% sense to me.  Let's name it better
d) rename evpn_type5_prefix_match to evpn_type5_prefix_contains.  Same reasoning.
e) Modify prefix_contains to match on afi too
f) Modify code that checks afi before calling prefix_contains to no longer do that.