### PR TITLE
bgpd: fix IPv6 nexthop for IPv4 peers to use IPv4-mapped address

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -527,7 +527,19 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 			gnh_modified = 1;
 		}
 
-		if (IN6_IS_ADDR_UNSPECIFIED(mod_v6nhg)) {
+		/* IPv4 peer advertising IPv6 prefixes (RFC 4798/4659):
+		 * Synthesize IPv4-mapped IPv6 nexthop from
+		 * the peer's IPv4 address, unless a route-map
+		 * already set the nexthop.
+		 */
+		if (peer->connection->su_local &&
+		    peer->connection->su_local->sa.sa_family == AF_INET &&
+		    peer->nexthop.v4.s_addr != INADDR_ANY &&
+		    !route_map_sets_nh) {
+			ipv4_to_ipv4_mapped_ipv6(&v6nhglobal, peer->nexthop.v4);
+			mod_v6nhg = &v6nhglobal;
+			gnh_modified = 1;
+		} else if (IN6_IS_ADDR_UNSPECIFIED(mod_v6nhg)) {
 			if (peer->nexthop.v4.s_addr != INADDR_ANY) {
 				ipv4_to_ipv4_mapped_ipv6(mod_v6nhg,
 							 peer->nexthop.v4);


### PR DESCRIPTION
## Summary

When an IPv4 BGP peer advertises IPv6 prefixes (RFC 5549), the nexthop in UPDATE messages must be an IPv4-mapped IPv6 address (`::ffff:x.x.x.x`).

Currently, `bgp_zebra_nexthop_set()` calls `if_get_ipv6_global()` which stores the first non-link-local IPv6 address found on the interface into `peer->nexthop.v6_global`. In `bpacket_reformat_for_peer()`, the existing synthesis path (`ipv4_to_ipv4_mapped_ipv6`) only fires when `mod_v6nhg` is all-zeros, and the `IS_MAPPED_IPV6` override only fires when `v6_global` is already IPv4-mapped. Neither triggers when `v6_global` contains a real global IPv6 address from the interface.

**Result:** When the outgoing interface has both a global IPv6 address and an IPv4 address (e.g., a loopback with `2001:db8::1/128` and `172.32.0.13/32`), the UPDATE is sent with the wrong nexthop (the global IPv6 address instead of `::ffff:172.32.0.13`), causing the receiver to fail recursive nexthop resolution in the IPv4 RIB.

## Fix

Always synthesize the IPv4-mapped IPv6 nexthop from `peer->nexthop.v4` when the peer connection is `AF_INET`, regardless of what `v6_global` contains. The existing fallback path for IPv6 peers is preserved as an else-if branch.

## Receive side

Note that the receive side already correctly handles IPv4-mapped IPv6 nexthops:
- `bgp_find_or_add_nexthop()` in `bgp_nht.c` detects `IS_MAPPED_IPV6()` and forces `AFI_IP` for resolution
- `make_prefix()` extracts the IPv4 address via `ipv4_mapped_ipv6_to_ipv4()`
- Zebra's `nexthop_active()` also handles v4-mapped addresses correctly

Only the send side was broken.

Signed-off-by: Jia Chen <jchen1@paloaltonetworks.com>