### PR TITLE
ospfd: Implement RFC4222 Recommendation 5

### DIFF
--- a/doc/developer/ospf-adj-pacing.rst
+++ b/doc/developer/ospf-adj-pacing.rst
@@ -1,0 +1,108 @@
+.. _ospf-adj-pacing:
+
+****************
+Adjacency Pacing
+****************
+
+OSPF adjacency pacing implements :rfc:`4222` recommendation 5 as a
+per-interface gate on adjacency formation. The goal is to avoid starting too
+many database exchanges at once on a bandwidth constrained interface.
+
+Overview
+========
+
+Adjacency pacing is tracked in ``struct ospf_adj_pacing`` in
+``ospfd/ospf_interface.h``. Each OSPF interface keeps:
+
+- the pacing mode: disabled, static, or dynamic
+- the current number of adjacencies in progress
+- a first-come, first-served queue of neighbors waiting for a slot
+- dynamic state such as the current limit and watermarks
+
+An adjacency is considered in progress while the neighbor state is
+``ExStart``, ``Exchange``, or ``Loading``.
+
+Static Mode
+===========
+
+Static mode uses a fixed per-interface limit configured with:
+
+.. code-block:: frr
+
+   interface eth0
+    ip ospf adjacency-pacing static 4
+
+When the number of in-progress adjacencies reaches the configured limit, any
+new neighbor that would otherwise advance into adjacency formation is placed on
+the interface queue. Queued neighbors are retried in FIFO order when a slot
+opens.
+
+Dynamic Mode
+============
+
+Dynamic mode adapts the limit according to retransmission pressure on the
+interface:
+
+.. code-block:: frr
+
+   interface eth0
+    ip ospf adjacency-pacing dynamic
+    ip ospf adjacency-pacing dynamic thresholds 100 2
+
+In dynamic mode, the current limit still applies to the number of simultaneous
+adjacencies allowed on the interface. The implementation computes ``U(t)`` as
+the total number of unacknowledged LSAs across neighbors on the interface, and
+uses the configured ``H`` and ``L`` values only as high-water and low-water
+thresholds for that unacknowledged-LSA total. The current adjacency limit is
+then adjusted using hysteresis:
+
+- if ``U(t) > H``, reduce the current limit by the configured factor, down to 1
+- if ``U(t) < L``, increase the current limit by 1, up to the configured maximum
+- if ``L <= U(t) <= H``, keep the current limit unchanged
+
+Current defaults from ``ospfd/ospf_interface.h`` are:
+
+- initial dynamic limit: 1 (simultaneous adjacency)
+- maximum dynamic limit: 50 (simultaneous adjacencies)
+- decrease factor: 2
+- adjustment interval: 1000 ms
+- high-water mark: 100 (unacknowledged LSAs)
+- low-water mark: 2 (unacknowledged LSAs)
+
+Code Paths
+==========
+
+The main control flow lives in ``ospfd/ospf_nsm.c``:
+
+- ``ospf_adj_pacing_allow()`` decides whether a new adjacency may proceed
+- ``ospf_adj_pacing_enqueue()`` and ``ospf_adj_pacing_dequeue()`` manage the
+  per-interface wait queue
+- ``ospf_adj_pacing_kick()`` restarts queued neighbors when slots become
+  available
+- ``ospf_adj_dyn_adjust()`` and ``ospf_adj_dyn_adjust_timer()`` update the
+  dynamic limit
+
+Neighbor state changes update the in-progress count. When a neighbor leaves the
+forming states, the count is decremented and the queue is serviced again.
+
+Unacknowledged LSA Tracking
+============================
+
+``U(t)`` is computed by summing ``ls_rxmt_unacked`` across all neighbors on the
+interface. This counter is incremented in ``ospf_count_sent_lsa()`` when an LSU
+packet is written, and decremented in the LS Acknowledge receive path when the
+matching retransmit entry is removed.
+
+On a broadcast segment the DR floods each LSA once as a multicast, but every
+neighbor is individually tracked — so ``U(t)`` reflects the total ACK
+obligation across all neighbors, not just the number of distinct LSAs on the
+wire. This gives a realistic measure of retransmission pressure regardless of
+network type.
+
+Operational Notes
+=================
+
+- Adjacency pacing is interface scoped, not process scoped.
+- Disabling pacing clears the current mode and runtime state on existing OSPF
+  interfaces.
+- Dynamic thresholds must satisfy ``low < high``.

--- a/doc/developer/ospf.rst
+++ b/doc/developer/ospf.rst
@@ -7,6 +7,7 @@ OSPFD
 .. toctree::
    :maxdepth: 2
 
+   ospf-adj-pacing
    ospf-api
    ospf-ls-retrans
    ospf-dead-timer-reset

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -748,6 +748,44 @@ Interfaces
    Recommendation 2 from RFC 4222 to improve adjacency robustness under
    congestion.
 
+.. clicmd:: ip ospf adjacency-pacing static (1-65535)
+
+   Limit the number of adjacencies that may be formed concurrently on this
+   interface. The configured value is the maximum number of neighbors that may
+   be in ``ExStart``, ``Exchange``, or ``Loading`` at the same time.
+
+   When the limit is reached, additional neighbors that need adjacency
+   formation are queued until one of the active exchanges completes or
+   regresses.
+
+.. clicmd:: ip ospf adjacency-pacing dynamic
+
+   Enable adaptive adjacency pacing on this interface. In dynamic mode, OSPF
+   starts conservatively and adjusts the allowed number of concurrent
+   adjacencies according to retransmission pressure on the interface.
+
+   The current limit starts at 1 and is adjusted using the total number of
+   unacknowledged LSAs (``U``) across all neighbors on the interface. This
+   command is independent of whether explicit thresholds have been configured:
+   if :clicmd:`ip ospf adjacency-pacing dynamic thresholds` has not been issued,
+   the built-in defaults of high-water 100 and low-water 2 are used.
+
+.. clicmd:: ip ospf adjacency-pacing dynamic thresholds (1-1000) (1-1000)
+
+   Configure the dynamic pacing high-water and low-water thresholds used by the
+   adaptive algorithm. The second value must be lower than the first.
+
+   If the total number of unacknowledged LSAs rises above the high-water mark,
+   OSPF reduces the current adjacency limit. If it falls below the low-water
+   mark, OSPF increases the limit. Values between the two thresholds leave the
+   current limit unchanged.
+
+   The default thresholds are high-water 100 and low-water 2.
+
+.. clicmd:: no ip ospf adjacency-pacing
+
+   Disable adjacency pacing on this interface and clear the active pacing mode.
+
 .. clicmd:: ip ospf dscp (all|low-control) (0-63)
 
    Set the DSCP value applied to OSPF control packets. The ``all`` option

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -1185,6 +1185,13 @@ void ospf_ls_retransmit_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		else
 			rxmt_timer_reset = false;
 
+		/* Decrement unacked count if this LSA was counted */
+		if (ls_rxmt_node->counted_sent) {
+			ls_rxmt_node->counted_sent = false;
+			if (nbr->ls_rxmt_unacked)
+				nbr->ls_rxmt_unacked--;
+		}
+
 		lsa->retransmit_counter--;
 
 		/* Keep SA happy */
@@ -1302,8 +1309,7 @@ static void ospf_ls_retransmit_delete_nbr_if(struct ospf_interface *oi,
 			lsr = ospf_ls_retransmit_lookup(nbr, lsa);
 
 			/* If LSA find in ls-retransmit list, remove it. */
-			if (lsr != NULL &&
-			    lsr->data->ls_seqnum == lsa->data->ls_seqnum)
+			if (lsr != NULL && lsr->data->ls_seqnum == lsa->data->ls_seqnum)
 				ospf_ls_retransmit_delete(nbr, lsr);
 		}
 }

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -293,6 +293,37 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 
 	oi->ospf = ospf;
 
+	/* RFC4222/R5 : Per-interface adjacency pacing */
+	oi->adj_pacing.mode = OSPF_ADJ_PACING_NONE;
+	oi->adj_pacing.static_limit = 0;
+	oi->adj_pacing.in_progress = 0;
+	ospf_adj_pacing_queue_init(&oi->adj_pacing);
+	oi->adj_pacing.dynamic_limit = OSPF_ADJ_DYN_LIMIT_INITIAL;
+	oi->adj_pacing.last_adjust_ms = 0;
+	oi->adj_pacing.high_water = OSPF_ADJ_DYN_HIGH_WATER;
+	oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
+	oi->adj_pacing.t_dyn_adjust = NULL;
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: %s adj_pacing initialized: mode=NONE dynamic_limit=%u H=%u L=%u",
+			   ifp->name, oi->adj_pacing.dynamic_limit, oi->adj_pacing.high_water,
+			   oi->adj_pacing.low_water);
+
+	/* Attach params and apply adjacency pacing config if present */
+	oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);
+	if (!oi->params)
+		oi->params = IF_DEF_PARAMS(ifp);
+	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_mode)) {
+		oi->adj_pacing.mode = oi->params->adj_pacing_mode;
+		oi->adj_pacing.static_limit = oi->params->adj_pacing_static_limit;
+	}
+	/* Apply configured dynamic thresholds if present */
+	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_high_water))
+		oi->adj_pacing.high_water = oi->params->adj_pacing_high_water;
+	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_low_water))
+		oi->adj_pacing.low_water = oi->params->adj_pacing_low_water;
+
+
 	QOBJ_REG(oi, ospf_interface);
 
 	/* If first oi, check per-intf write socket */
@@ -360,6 +391,14 @@ void ospf_if_cleanup(struct ospf_interface *oi)
 
 	oi->crypt_seqnum = 0;
 
+
+	/* Stop any pending LSU drain event before we free its data */
+	event_cancel(&oi->t_ls_upd_event);
+
+	/*RFC4222/R5 Changes*/
+	/* Cancel any pending dynamic adjustment timer */
+	event_cancel(&oi->adj_pacing.t_dyn_adjust);
+
 	/* Empty link state update queue */
 	ospf_ls_upd_queue_empty(oi);
 
@@ -407,11 +446,14 @@ void ospf_if_free(struct ospf_interface *oi)
 	listnode_delete(oi->ospf->oiflist, oi);
 	listnode_delete(oi->area->oiflist, oi);
 
-	event_cancel_event(master, oi);
+	/* RFC4222/R5 : Per-interface adjacency pacing */
+	ospf_adj_pacing_queue_fini(&oi->adj_pacing);
 
 	/* If last oi, close per-interface socket */
 	if (ospf_oi_count(ifp) == 0)
 		ospf_ifp_sock_close(ifp);
+
+	event_cancel_event(master, oi);
 
 	memset(oi, 0, sizeof(*oi));
 	XFREE(MTYPE_OSPF_IF, oi);
@@ -605,6 +647,7 @@ static void ospf_del_if_params(struct interface *ifp,
 	XFREE(MTYPE_OSPF_IF_PARAMS, oip);
 }
 
+
 void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 {
 	struct ospf_if_params *oip;
@@ -684,6 +727,7 @@ struct ospf_if_params *ospf_get_if_params(struct interface *ifp,
 	return rn->info;
 }
 
+
 void ospf_if_update_params(struct interface *ifp, struct in_addr addr)
 {
 	struct route_node *rn;
@@ -693,11 +737,25 @@ void ospf_if_update_params(struct interface *ifp, struct in_addr addr)
 		if ((oi = rn->info) == NULL)
 			continue;
 
-		if (IPV4_ADDR_SAME(&oi->address->u.prefix4, &addr))
+		if (IPV4_ADDR_SAME(&oi->address->u.prefix4, &addr)) {
 			oi->params = ospf_lookup_if_params(
 				ifp, oi->address->u.prefix4);
+		}
 	}
 }
+void ospf_if_update_params_all(struct interface *ifp)
+{
+	struct route_node *rn;
+	struct ospf_interface *oi;
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		if ((oi = rn->info) == NULL)
+			continue;
+
+		oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);
+	}
+}
+
 
 int ospf_if_new_hook(struct interface *ifp)
 {
@@ -724,6 +782,8 @@ int ospf_if_new_hook(struct interface *ifp)
 
 	SET_IF_PARAM(IF_DEF_PARAMS(ifp), priority);
 	IF_DEF_PARAMS(ifp)->priority = OSPF_ROUTER_PRIORITY_DEFAULT;
+	IF_DEF_PARAMS(ifp)->adj_pacing_mode = OSPF_ADJ_PACING_NONE;
+	IF_DEF_PARAMS(ifp)->adj_pacing_static_limit = 0;
 
 	IF_DEF_PARAMS(ifp)->mtu_ignore = OSPF_MTU_IGNORE_DEFAULT;
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -749,7 +749,8 @@ void ospf_if_update_params_all(struct interface *ifp)
 	struct ospf_interface *oi;
 
 	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
-		if ((oi = rn->info) == NULL)
+		oi = rn->info;
+		if (!oi)
 			continue;
 
 		oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -197,8 +197,8 @@ enum ospf_adj_pacing_mode {
 /* RFC4222/R5 implementation */
 struct ospf_adj_pacing {
 	enum ospf_adj_pacing_mode mode;
-	uint16_t static_limit; /*N for static mode*/
-	uint16_t in_progress;  /* neighbors in ExStart/Exchange/Loading on this oi*/
+	uint16_t static_limit;		     /*N for static mode*/
+	uint16_t in_progress;		     /* neighbors in ExStart/Exchange/Loading on this oi*/
 	struct ospf_pacing_queue_head queue; /* FCFS queue of struct ospf_neighbor */
 
 	/* Dynamic pacing state */

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -14,6 +14,7 @@
 #include "ospfd/ospf_packet.h"
 #include "ospfd/ospf_spf.h"
 #include <ospfd/ospf_flood.h>
+#include <ospfd/ospf_nsm.h>
 
 #define IF_OSPF_IF_INFO(I) ((struct ospf_if_info *)((I)->info))
 #define IF_DEF_PARAMS(I) (IF_OSPF_IF_INFO (I)->def_params)
@@ -55,6 +56,14 @@ struct ospf_if_params {
 							join multicast groups)
 							*/
 	DECLARE_IF_PARAM(uint8_t, priority); /* OSPF Interface priority */
+	/* RFC4222/R5: adjacency pacing configuration */
+	DECLARE_IF_PARAM(uint8_t, adj_pacing_mode);
+	DECLARE_IF_PARAM(uint16_t, adj_pacing_static_limit);
+
+	/* RFC4222/R5: Add dynamic pacing thresholds */
+	DECLARE_IF_PARAM(uint32_t, adj_pacing_high_water);
+	DECLARE_IF_PARAM(uint32_t, adj_pacing_low_water);
+
 	/* Enable OSPF on this interface with area if_area */
 	DECLARE_IF_PARAM(struct in_addr, if_area);
 	uint32_t if_area_id_fmt;
@@ -168,6 +177,36 @@ struct ospf_vl_data {
 	struct vertex_nexthop nexthop; /* Nexthop router and oi to use */
 	struct in_addr peer_addr;      /* Address used to reach the peer */
 	uint8_t flags;
+};
+
+/* RFC4222/R5 : Per-interface adjacency pacing */
+enum ospf_adj_pacing_mode {
+	OSPF_ADJ_PACING_NONE = 0, /* inherit router default or disabled */
+	OSPF_ADJ_PACING_STATIC,	  /* fixed N*/
+	OSPF_ADJ_PACING_DYNAMIC,  /* adaptive*/
+};
+
+/* RFC4222/R5: Dynamic adjacency pacing defaults */
+#define OSPF_ADJ_DYN_LIMIT_INITIAL 1	/* start conservative */
+#define OSPF_ADJ_DYN_LIMIT_MAX	   50	/* upper bound */
+#define OSPF_ADJ_DYN_FACTOR	   2	/* F for divide when congested */
+#define OSPF_ADJ_DYN_ADJUST_INT_MS 1000 /* min ms between adjustments (1 sec to slow ramp-up) */
+#define OSPF_ADJ_DYN_HIGH_WATER	   100	/* default H threshold */
+#define OSPF_ADJ_DYN_LOW_WATER	   2	/* default L threshold */
+
+/* RFC4222/R5 implementation */
+struct ospf_adj_pacing {
+	enum ospf_adj_pacing_mode mode;
+	uint16_t static_limit; /*N for static mode*/
+	uint16_t in_progress;  /* neighbors in ExStart/Exchange/Loading on this oi*/
+	struct ospf_pacing_queue_head queue; /* FCFS queue of struct ospf_neighbor */
+
+	/* Dynamic pacing state */
+	uint16_t dynamic_limit;	    /* current computed limit (starts at 1) */
+	uint64_t last_adjust_ms;    /* timestamp of last limit adjustment */
+	uint32_t high_water;	    /* H: upper threshold for U(t) */
+	uint32_t low_water;	    /* L: lower threshold for U(t) */
+	struct event *t_dyn_adjust; /* timer to schedule deferred adjustment */
 };
 
 
@@ -295,6 +334,9 @@ struct ospf_interface {
 	struct event *t_ls_upd_event;	 /* event */
 	struct event *t_opaque_lsa_self; /* Type-9 Opaque-LSAs */
 
+	/* RFC4222/R5 : Per-interface adjacency pacing */
+	struct ospf_adj_pacing adj_pacing;
+
 	int on_write_q;
 
 	/* Statistics fields. */
@@ -354,6 +396,8 @@ extern struct ospf_if_params *ospf_get_if_params(struct interface *ifp,
 						 struct in_addr addr);
 extern void ospf_free_if_params(struct interface *ifp, struct in_addr addr);
 extern void ospf_if_update_params(struct interface *ifp, struct in_addr addr);
+
+extern void ospf_if_update_params_all(struct interface *ifp);
 
 extern int ospf_if_new_hook(struct interface *ifp);
 extern void ospf_if_init(void);

--- a/ospfd/ospf_lsdb.c
+++ b/ospfd/ospf_lsdb.c
@@ -43,6 +43,8 @@ ospf_lsdb_linked_node_create(route_table_delegate_t *delegate,
 	node = XCALLOC(MTYPE_OSPF_LSDB_NODE,
 		       sizeof(struct ospf_lsdb_linked_node));
 
+	node->counted_sent = false;
+
 	return (struct route_node *)node;
 }
 

--- a/ospfd/ospf_lsdb.h
+++ b/ospfd/ospf_lsdb.h
@@ -55,6 +55,9 @@ struct ospf_lsdb_linked_node {
 	 * retransmission list.
 	 */
 	struct ospf_lsa_list_entry *lsa_list_entry;
+
+	/* Track if this LSA was sent and counted in ls_rxmt_unacked */
+	bool counted_sent;
 };
 
 /* OSPF LSDB related functions. */

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -95,6 +95,8 @@ struct ospf_neighbor *ospf_nbr_new(struct ospf_interface *oi)
 	nbr->gr_helper_info.helper_exit_reason = OSPF_GR_HELPER_EXIT_NONE;
 	nbr->gr_helper_info.gr_restart_reason = OSPF_GR_UNKNOWN_RESTART;
 
+	nbr->ls_rxmt_unacked = 0;
+
 	nbr->dead_timer_resets = 0; /* rfc 4222 rec 2 */
 	return nbr;
 }

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -10,6 +10,7 @@
 #include <ospfd/ospf_gr.h>
 #include <ospfd/ospf_packet.h>
 #include <ospfd/ospf_flood.h>
+#include <ospfd/ospf_nsm.h>
 
 /* Neighbor Data Structure */
 struct ospf_neighbor {
@@ -70,8 +71,8 @@ struct ospf_neighbor {
 
 	/* Statistics */
 	struct timeval ts_last_progress; /* last advance of NSM            */
-	struct timeval ts_last_regress;  /* last regressive NSM change     */
-	const char *last_regress_str;    /* Event which last regressed NSM */
+	struct timeval ts_last_regress;	 /* last regressive NSM change     */
+	const char *last_regress_str;	 /* Event which last regressed NSM */
 	uint32_t state_change;		 /* NSM state change counter       */
 	uint32_t ls_rxmt_lsa;		 /* Number of LSAs retransmitted.  */
 	uint64_t dead_timer_resets;	 /* Number of times dead-timer was reset RFC4222 rec 2*/
@@ -81,6 +82,11 @@ struct ospf_neighbor {
 
 	/* ospf graceful restart HELPER info */
 	struct ospf_helper_info gr_helper_info;
+
+	uint32_t ls_rxmt_unacked; /* count of sent but unacked retransmit LSAs */
+
+	/* RFC4222/R5: linkage for per-interface adjacency pacing queue */
+	struct ospf_pacing_queue_item pacing_link;
 };
 
 /* Macros. */

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -293,9 +293,7 @@ void ospf_adj_pacing_kick(struct ospf_interface *oi)
 	 * waiters get NSM_AdjOK scheduled, then N-limit of them fail the pacing
 	 * check in nsm_adj_ok and are re-enqueued, repeating on every completion.
 	 */
-	available = (oi->adj_pacing.in_progress < limit)
-			    ? (limit - oi->adj_pacing.in_progress)
-			    : 0;
+	available = (oi->adj_pacing.in_progress < limit) ? (limit - oi->adj_pacing.in_progress) : 0;
 
 	while (available > 0) {
 		nbr = ospf_adj_pacing_dequeue(oi);

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -63,7 +63,7 @@ void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
 	struct ospf_neighbor *nbr;
 	int count = 0;
 
-	frr_each_safe(ospf_pacing_queue, &oi->adj_pacing.queue, nbr) {
+	frr_each_safe (ospf_pacing_queue, &oi->adj_pacing.queue, nbr) {
 		ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
 		if (nbr->state == NSM_TwoWay)
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_AdjOK);
@@ -71,8 +71,8 @@ void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
 	}
 
 	if (count > 0 && IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)",
-			   IF_NAME(oi), count);
+		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)", IF_NAME(oi),
+			   count);
 }
 
 static void nsm_clear_adj(struct ospf_neighbor *);

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -11,6 +11,7 @@
 #include "memory.h"
 #include "hash.h"
 #include "linklist.h"
+#include "typesafe.h"
 #include "prefix.h"
 #include "if.h"
 #include "table.h"
@@ -42,7 +43,271 @@ DEFINE_HOOK(ospf_nsm_change,
 	    (struct ospf_neighbor * on, int state, int oldstate),
 	    (on, state, oldstate));
 
+/* RFC4222/R5: struct ospf_neighbor is fully defined here so DECLARE_LIST
+ * can access pacing_link.  Callers outside this file use the wrappers below.
+ */
+DECLARE_LIST(ospf_pacing_queue, struct ospf_neighbor, pacing_link);
+
+void ospf_adj_pacing_queue_init(struct ospf_adj_pacing *p)
+{
+	ospf_pacing_queue_init(&p->queue);
+}
+
+void ospf_adj_pacing_queue_fini(struct ospf_adj_pacing *p)
+{
+	ospf_pacing_queue_fini(&p->queue);
+}
+
+void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
+{
+	struct ospf_neighbor *nbr;
+	int count = 0;
+
+	frr_each_safe(ospf_pacing_queue, &oi->adj_pacing.queue, nbr) {
+		ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
+		if (nbr->state == NSM_TwoWay)
+			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_AdjOK);
+		count++;
+	}
+
+	if (count > 0 && IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)",
+			   IF_NAME(oi), count);
+}
+
 static void nsm_clear_adj(struct ospf_neighbor *);
+
+/*RFC4222/R5 changes: Track adjacency formation states for pacing*/
+static bool ospf_adj_in_progress_state(int state)
+{
+	return state == NSM_ExStart || state == NSM_Exchange || state == NSM_Loading;
+}
+
+
+/*RFC422/R5 changes: check if interface pacing is enabled */
+static bool ospf_adj_pacing_enabled(struct ospf_interface *oi)
+{
+	return oi->adj_pacing.mode != OSPF_ADJ_PACING_NONE;
+}
+
+/*RFC4222/R5 changes: Compute total unacked LSAs across all neighbors on interface */
+static uint32_t ospf_adj_total_unacked(struct ospf_interface *oi)
+{
+	struct route_node *rn;
+	uint32_t total = 0;
+	uint32_t nbr_count = 0;
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		struct ospf_neighbor *nbr = rn->info;
+
+		if (nbr && nbr != oi->nbr_self) {
+			total += nbr->ls_rxmt_unacked;
+			nbr_count++;
+		}
+	}
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS) && total > 0)
+		zlog_debug("R5-DYN: %s total_unacked=%u across %u neighbors", IF_NAME(oi), total,
+			   nbr_count);
+
+	return total;
+}
+
+/*RFC4222/R5 changes: Timer callback for deferred dynamic adjustment */
+static void ospf_adj_dyn_adjust_timer(struct event *t)
+{
+	struct ospf_interface *oi = EVENT_ARG(t);
+	uint64_t now_ms, elapsed_ms;
+	uint32_t U, H, L;
+	uint16_t limit, new_limit;
+
+	oi->adj_pacing.t_dyn_adjust = NULL;
+
+	if (oi->adj_pacing.mode != OSPF_ADJ_PACING_DYNAMIC)
+		return;
+
+	now_ms = ospf_now_ms();
+	elapsed_ms = now_ms - oi->adj_pacing.last_adjust_ms;
+
+	/* Rate limit: skip if adjusted too recently */
+	if (elapsed_ms < OSPF_ADJ_DYN_ADJUST_INT_MS) {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s rate-limited (elapsed=%" PRIu64 "ms < %ums)",
+				   IF_NAME(oi), elapsed_ms, OSPF_ADJ_DYN_ADJUST_INT_MS);
+		return;
+	}
+
+	/* Compute U(t) - total unacked LSAs on this interface */
+	U = ospf_adj_total_unacked(oi);
+
+	/* Use dynamic pacing thresholds (H and L) */
+	H = oi->adj_pacing.high_water;
+	L = oi->adj_pacing.low_water;
+
+	limit = oi->adj_pacing.dynamic_limit;
+	new_limit = limit;
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5-DYN: %s checking: U=%u H=%u L=%u limit=%u in_progress=%u",
+			   IF_NAME(oi), U, H, L, limit, oi->adj_pacing.in_progress);
+
+	if (U > H) {
+		/* Congestion: decrease limit */
+		new_limit = (limit > OSPF_ADJ_DYN_FACTOR) ? (limit / OSPF_ADJ_DYN_FACTOR) : 1;
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s CONGESTION detected U(%u) > H(%u), decreasing limit %u->%u",
+				   IF_NAME(oi), U, H, limit, new_limit);
+	} else if (U < L) {
+		/* Uncongested: increase limit */
+		new_limit = (limit < OSPF_ADJ_DYN_LIMIT_MAX) ? (limit + 1) : OSPF_ADJ_DYN_LIMIT_MAX;
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s UNCONGESTED U(%u) < L(%u), increasing limit %u->%u",
+				   IF_NAME(oi), U, L, limit, new_limit);
+	} else {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s HYSTERESIS L(%u) <= U(%u) <= H(%u), no change",
+				   IF_NAME(oi), L, U, H);
+	}
+
+	if (new_limit != limit) {
+		oi->adj_pacing.dynamic_limit = new_limit;
+		oi->adj_pacing.last_adjust_ms = now_ms;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s ADJUSTED limit %u->%u U=%u H=%u L=%u elapsed=%" PRIu64
+				   "ms",
+				   IF_NAME(oi), limit, new_limit, U, H, L, elapsed_ms);
+
+		/* Limit increased: kick queue to fill newly opened slots */
+		if (new_limit > limit && oi->adj_pacing.in_progress < new_limit) {
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("R5-DYN: %s limit increased %u->%u, kicking queued adjacencies",
+					   IF_NAME(oi), limit, new_limit);
+			ospf_adj_pacing_kick(oi);
+		}
+	}
+}
+
+/*RFC4222/R5 changes: Schedule dynamic adjustment (deferred to avoid packet processing interference) */
+void ospf_adj_dyn_adjust(struct ospf_interface *oi)
+{
+	if (oi->adj_pacing.mode != OSPF_ADJ_PACING_DYNAMIC)
+		return;
+
+	/* Schedule if not already scheduled */
+	if (!oi->adj_pacing.t_dyn_adjust) {
+		event_add_timer_msec(master, ospf_adj_dyn_adjust_timer, oi, 0,
+				     &oi->adj_pacing.t_dyn_adjust);
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s scheduled deferred adjustment", IF_NAME(oi));
+	}
+}
+
+/*RFC4222/R5 changes : Determine pacing limit for this interface (static or dynamic).*/
+static uint16_t ospf_adj_pacing_limit(struct ospf_interface *oi)
+{
+	if (oi->adj_pacing.mode == OSPF_ADJ_PACING_STATIC)
+		return oi->adj_pacing.static_limit;
+
+	if (oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC) {
+		/* Recompute before returning */
+		ospf_adj_dyn_adjust(oi);
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s returning dynamic_limit=%u", IF_NAME(oi),
+				   oi->adj_pacing.dynamic_limit);
+		return oi->adj_pacing.dynamic_limit;
+	}
+	return 0;
+}
+
+/*RFC4222/R5 changes: can we start another adjacency on this interface? */
+static bool ospf_adj_pacing_allow(struct ospf_interface *oi)
+{
+	/* Returns true if below the per-interface limit or pacing disabled.  */
+	uint16_t limit;
+
+	if (!ospf_adj_pacing_enabled(oi))
+		return true;
+
+	limit = ospf_adj_pacing_limit(oi);
+	if (limit == 0)
+		return true;
+
+	return (oi->adj_pacing.in_progress < limit);
+}
+
+/* RFC4222/R5: Remove a neighbor from the per-interface pacing queue. */
+static void ospf_adj_pacing_remove(struct ospf_neighbor *nbr)
+{
+	struct ospf_interface *oi = nbr->oi;
+
+	if (ospf_pacing_queue_member(&oi->adj_pacing.queue, nbr))
+		ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
+}
+
+/* RFC4222/R5: Enqueue a neighbor to wait for an available pacing slot. */
+static void ospf_adj_pacing_enqueue(struct ospf_neighbor *nbr)
+{
+	struct ospf_interface *oi = nbr->oi;
+
+	if (!ospf_adj_pacing_enabled(oi))
+		return;
+	if (ospf_pacing_queue_member(&oi->adj_pacing.queue, nbr))
+		return;
+
+	ospf_pacing_queue_add_tail(&oi->adj_pacing.queue, nbr);
+}
+
+/* RFC4222/R5: Pop the next queued neighbor for this interface. */
+static struct ospf_neighbor *ospf_adj_pacing_dequeue(struct ospf_interface *oi)
+{
+	struct ospf_neighbor *nbr;
+
+	nbr = ospf_pacing_queue_first(&oi->adj_pacing.queue);
+	if (!nbr)
+		return NULL;
+
+	ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
+	return nbr;
+}
+
+/*RFC4222/R5 changes: start queued adjacencies when a pacing slot opens*/
+void ospf_adj_pacing_kick(struct ospf_interface *oi)
+{
+	struct ospf_neighbor *nbr;
+	uint16_t limit, available;
+
+	if (!ospf_adj_pacing_enabled(oi))
+		return;
+
+	limit = ospf_adj_pacing_limit(oi);
+	if (limit == 0)
+		return;
+
+	/*
+	 * Compute how many slots are open right now.  in_progress is only
+	 * incremented inside ospf_nsm_change_state — i.e. after the scheduled
+	 * NSM_AdjOK event actually fires.  If we loop on ospf_adj_pacing_allow()
+	 * instead, the check always reads the pre-event value of in_progress and
+	 * drains the entire queue every kick, creating O(N²) churn: all N
+	 * waiters get NSM_AdjOK scheduled, then N-limit of them fail the pacing
+	 * check in nsm_adj_ok and are re-enqueued, repeating on every completion.
+	 */
+	available = (oi->adj_pacing.in_progress < limit)
+			    ? (limit - oi->adj_pacing.in_progress)
+			    : 0;
+
+	while (available > 0) {
+		nbr = ospf_adj_pacing_dequeue(oi);
+		if (!nbr)
+			break;
+		if (nbr->state != NSM_TwoWay)
+			continue;
+		available--;
+		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_AdjOK);
+	}
+}
+
 
 /* OSPF NSM Timer functions. */
 static void ospf_inactivity_timer(struct event *event)
@@ -200,9 +465,27 @@ static int nsm_start(struct ospf_neighbor *nbr)
 	return 0;
 }
 
+/*RFC4222/R5 changes: If adjacency is needed but interface pacing blocks it, queue neighbor */
 static int nsm_twoway_received(struct ospf_neighbor *nbr)
 {
 	int adj = nsm_should_adj(nbr);
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: TwoWay recv nbr=%pI4 adj=%d", &nbr->router_id, adj);
+
+	if (adj && !ospf_adj_pacing_allow(nbr->oi)) {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: throttling nbr=%pI4", &nbr->router_id);
+		ospf_adj_pacing_enqueue(nbr);
+		return NSM_TwoWay;
+	}
+	/* if adjacency can proceed, ensure neighbor is nto left queued*/
+	if (adj)
+		ospf_adj_pacing_remove(nbr);
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: TwoWay -> %s nbr=%pI4", adj ? "ExStart" : "TwoWay",
+			   &nbr->router_id);
 
 	/* Send proactive ARP requests */
 	if (adj)
@@ -335,13 +618,23 @@ static int nsm_exchange_done(struct ospf_neighbor *nbr)
 	return NSM_Loading;
 }
 
+
+/* RFC4222/R5 changes: apply per-interface pacing before moving to ExStart*/
 static int nsm_adj_ok(struct ospf_neighbor *nbr)
 {
 	int next_state = nbr->state;
 	int adj = nsm_should_adj(nbr);
 
 	if (nbr->state == NSM_TwoWay && adj == 1) {
+		if (!ospf_adj_pacing_allow(nbr->oi)) {
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("R5: AdjOK throttling nbr=%pI4", &nbr->router_id);
+			ospf_adj_pacing_enqueue(nbr);
+			return NSM_TwoWay;
+		}
+
 		next_state = NSM_ExStart;
+		ospf_adj_pacing_remove(nbr);
 
 		/* Send proactive ARP requests */
 		ospf_proactively_arp(nbr);
@@ -353,6 +646,10 @@ static int nsm_adj_ok(struct ospf_neighbor *nbr)
 		 * per RFC2328 10.4.
 		 */
 		next_state = NSM_ExStart;
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: AdjOK next_state=%s nbr=%pI4",
+			   lookup_msg(ospf_nsm_state_msg, next_state, NULL), &nbr->router_id);
 
 	return next_state;
 }
@@ -379,11 +676,15 @@ static void nsm_clear_adj(struct ospf_neighbor *nbr)
 		UNSET_FLAG(nbr->options, OSPF_OPTION_O);
 }
 
+/*RFC4222/R5 changes: remove neighbor from per-interface packing queue when killed*/
 static int nsm_kill_nbr(struct ospf_neighbor *nbr)
 {
 	struct ospf_interface *oi = nbr->oi;
 	struct ospf_neighbor *on;
 	struct route_node *rn;
+
+	/* R5 changes*/
+	ospf_adj_pacing_remove(nbr);
 
 	/* killing nbr_self is invalid */
 	if (nbr == nbr->oi->nbr_self) {
@@ -675,6 +976,23 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 
 	/* Statistics. */
 	nbr->state_change++;
+
+	/* R5: track per-interface in-progress adjacencies */
+	if (!ospf_adj_in_progress_state(old_state) && ospf_adj_in_progress_state(state)) {
+		oi->adj_pacing.in_progress++;
+	} else if (ospf_adj_in_progress_state(old_state) && !ospf_adj_in_progress_state(state)) {
+		if (oi->adj_pacing.in_progress > 0)
+			oi->adj_pacing.in_progress--;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s in-progress=%u limit=%u", IF_NAME(oi),
+				   oi->adj_pacing.in_progress, ospf_adj_pacing_limit(oi));
+
+		/* Only kick if pacing is enabled */
+		if (ospf_adj_pacing_enabled(oi))
+			ospf_adj_pacing_kick(oi);
+	}
+
 
 	if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
 		vl_area = ospf_area_lookup_by_area_id(oi->ospf,

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -9,6 +9,17 @@
 #define _ZEBRA_OSPF_NSM_H
 
 #include "hook.h"
+#include "typesafe.h"
+
+/* forward declaration so ospf_nsm.h can be included before ospf_interface.h */
+struct ospf_interface;
+
+/* RFC4222/R5: typed list for per-interface adjacency pacing queue.
+ * Only PREDECL_LIST here — DECLARE_LIST lives in ospf_nsm.c where
+ * struct ospf_neighbor is fully defined.  Callers outside ospf_nsm.c
+ * use the wrapper functions below.
+ */
+PREDECL_LIST(ospf_pacing_queue);
 
 /* OSPF Neighbor State Machine State. */
 #define NSM_DependUpon          0
@@ -59,6 +70,19 @@ extern int ospf_db_summary_isempty(struct ospf_neighbor *nbr);
 extern int ospf_db_summary_count(struct ospf_neighbor *nbr);
 extern void ospf_db_summary_clear(struct ospf_neighbor *nbr);
 extern int nsm_should_adj(struct ospf_neighbor *nbr);
+
+/* RFC4222/R5: Dynamic adjacency pacing */
+extern void ospf_adj_dyn_adjust(struct ospf_interface *oi);
+extern void ospf_adj_pacing_kick(struct ospf_interface *oi);
+
+/* RFC4222/R5: pacing queue lifecycle — wrappers around the typesafe list
+ * so callers outside ospf_nsm.c do not need the full ospf_neighbor type.
+ */
+struct ospf_adj_pacing; /* forward declaration — full type in ospf_interface.h */
+extern void ospf_adj_pacing_queue_init(struct ospf_adj_pacing *p);
+extern void ospf_adj_pacing_queue_fini(struct ospf_adj_pacing *p);
+extern void ospf_adj_pacing_queue_flush(struct ospf_interface *oi);
+
 DECLARE_HOOK(ospf_nsm_change,
 	     (struct ospf_neighbor * on, int state, int oldstate),
 	     (on, state, oldstate));

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -146,7 +146,7 @@ static void ospf_packet_sent_lsas_fini(struct ospf_packet *op)
 
 	if (!op)
 		return;
-	frr_each_safe(ospf_lsa_list, &op->sent_lsas, e) {
+	frr_each_safe (ospf_lsa_list, &op->sent_lsas, e) {
 		ospf_lsa_list_del(&op->sent_lsas, e);
 		ospf_lsa_unlock(&e->lsa);
 		XFREE(MTYPE_OSPF_LSA_LIST, e);
@@ -437,8 +437,7 @@ static void ospf_maybe_restart_inactivity(struct ospf_interface *oi, struct ospf
  * Transfers each LSA lock to rn->info then schedules the queue drain.
  * Functionally identical to ospf_ls_upd_send() for the direct/unicast case.
  */
-static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
-				      struct ospf_lsa_list_head *update)
+static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr, struct ospf_lsa_list_head *update)
 {
 	struct ospf_interface *oi = nbr->oi;
 	struct prefix_ipv4 p = { .family = AF_INET,
@@ -453,7 +452,7 @@ static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
 	else
 		route_unlock_node(rn);
 
-	frr_each_safe(ospf_lsa_list, update, e) {
+	frr_each_safe (ospf_lsa_list, update, e) {
 		ospf_lsa_list_del(update, e);
 		listnode_add((struct list *)rn->info, ospf_lsa_lock(e->lsa));
 		ospf_lsa_unlock(&e->lsa);
@@ -461,8 +460,7 @@ static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
 	}
 
 	if (!oi->t_ls_upd_event)
-		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
-				&oi->t_ls_upd_event);
+		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0, &oi->t_ls_upd_event);
 }
 
 /*
@@ -549,8 +547,7 @@ void ospf_ls_rxmt_timer(struct event *event)
 
 			struct ospf_lsa_list_entry *upd_entry;
 
-			upd_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
-					    sizeof(*upd_entry));
+			upd_entry = XCALLOC(MTYPE_OSPF_LSA_LIST, sizeof(*upd_entry));
 			upd_entry->lsa = ospf_lsa_lock(ls_rxmt_list_entry->lsa);
 			ospf_lsa_list_add_tail(&update, upd_entry);
 			rxmt_lsa_count++;
@@ -926,7 +923,7 @@ static void ospf_write(struct event *event)
 		    ospf_lsa_list_first(&op->sent_lsas) != NULL) {
 			struct ospf_lsa_list_entry *sent_e;
 
-			frr_each(ospf_lsa_list, &op->sent_lsas, sent_e) {
+			frr_each (ospf_lsa_list, &op->sent_lsas, sent_e) {
 				/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
 				ospf_count_sent_lsa(oi, op->dst, sent_e->lsa);
 			}
@@ -3811,8 +3808,7 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update, stru
 		if (sent_lsas) {
 			struct ospf_lsa_list_entry *sent_entry;
 
-			sent_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
-					     sizeof(*sent_entry));
+			sent_entry = XCALLOC(MTYPE_OSPF_LSA_LIST, sizeof(*sent_entry));
 			sent_entry->lsa = ospf_lsa_lock(lsa);
 			ospf_lsa_list_add_tail(sent_lsas, sent_entry);
 		}

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -79,6 +79,9 @@ const struct message ospf_packet_type_str[] = {
 
 /* Minimum (besides OSPF_HEADER_SIZE) lengths for OSPF packets of
    particular types, offset is the "type" field of a packet. */
+static void ospf_packet_sent_lsas_fini(struct ospf_packet *op);
+static void ospf_ls_upd_send_queue_event(struct event *event);
+
 static const uint16_t ospf_packet_minlen[] = {
 	0,
 	OSPF_HELLO_MIN_SIZE,
@@ -117,10 +120,113 @@ static struct ospf_packet *ospf_packet_new(size_t size)
 
 void ospf_packet_free(struct ospf_packet *op)
 {
+	if (!op)
+		return;
+
+	/* Free any sent_lsas entries — needed when ospf_fifo_flush discards
+	 * unsent LSU packets at shutdown without going through ospf_packet_delete.
+	 */
+	ospf_packet_sent_lsas_fini(op);
+
 	if (op->s)
 		stream_free(op->s);
 
 	XFREE(MTYPE_OSPF_PACKET, op);
+}
+
+/* RFC4222/R5: init/fini for per-packet sent LSA tracking list */
+static void ospf_packet_sent_lsas_init(struct ospf_packet *op)
+{
+	ospf_lsa_list_init(&op->sent_lsas);
+}
+
+static void ospf_packet_sent_lsas_fini(struct ospf_packet *op)
+{
+	struct ospf_lsa_list_entry *e;
+
+	if (!op)
+		return;
+	frr_each_safe(ospf_lsa_list, &op->sent_lsas, e) {
+		ospf_lsa_list_del(&op->sent_lsas, e);
+		ospf_lsa_unlock(&e->lsa);
+		XFREE(MTYPE_OSPF_LSA_LIST, e);
+	}
+}
+
+extern uint64_t ospf_now_ms(void)
+{
+	struct timeval tv;
+
+	monotime(&tv);
+	return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
+}
+
+static inline bool ospf_dst_is_multicast(struct in_addr dst)
+{
+	return IN_MULTICAST(ntohl(dst.s_addr));
+}
+
+static inline bool ospf_dst_is_allspf(struct in_addr dst)
+{
+	return dst.s_addr == htonl(OSPF_ALLSPFROUTERS); /* 224.0.0.5 */
+}
+
+static inline bool ospf_dst_is_alldr(struct in_addr dst)
+{
+	return dst.s_addr == htonl(OSPF_ALLDROUTERS); /* 224.0.0.6 */
+}
+
+/* True if this neighbor is DR or BDR on the segment (based on its Hello). */
+static inline bool ospf_nbr_is_dr_or_bdr(const struct ospf_neighbor *nbr)
+{
+	const struct in_addr nbr_ip = nbr->address.u.prefix4;
+
+	if (nbr_ip.s_addr == nbr->d_router.s_addr)
+		return true;
+	if (nbr_ip.s_addr == nbr->bd_router.s_addr)
+		return true;
+	return false;
+}
+
+/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+static inline void ospf_count_sent_lsa(struct ospf_interface *oi, struct in_addr dst,
+				       struct ospf_lsa *lsa)
+{
+	struct route_node *rn;
+	struct ospf_neighbor *nbr;
+
+	const bool mcast = ospf_dst_is_multicast(dst);
+	const bool alldr = ospf_dst_is_alldr(dst);
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		nbr = rn->info;
+		if (!nbr || nbr == oi->nbr_self)
+			continue;
+
+		if (nbr->state < NSM_Exchange)
+			continue;
+
+		/* Unicast destination: only the matching neighbor receives it */
+		if (!mcast) {
+			if (nbr->address.u.prefix4.s_addr != dst.s_addr)
+				continue;
+		} else {
+			/* 224.0.0.6 destination: only DR/BDR receive it */
+			if (alldr && !ospf_nbr_is_dr_or_bdr(nbr))
+				continue;
+
+			/* 224.0.0.5: everyone eligible receives it -> no extra filter */
+			(void)ospf_dst_is_allspf; /* (not needed here, kept for clarity) */
+		}
+
+		/* Track unacked LSAs for R5 dynamic adjacency pacing */
+		struct ospf_lsdb_linked_node *linked_node = ospf_lsdb_linked_lookup(&nbr->ls_rxmt,
+										    lsa);
+		if (linked_node && !linked_node->counted_sent) {
+			linked_node->counted_sent = true;
+			nbr->ls_rxmt_unacked++;
+		}
+	}
 }
 
 struct ospf_fifo *ospf_fifo_new(void)
@@ -326,9 +432,43 @@ static void ospf_maybe_restart_inactivity(struct ospf_interface *oi, struct ospf
 	}
 }
 
+/* RFC4222/R5: type adapter — sends a batch of LSAs collected in a typesafe
+ * ospf_lsa_list_head to a neighbor via the existing ls_upd_queue path.
+ * Transfers each LSA lock to rn->info then schedules the queue drain.
+ * Functionally identical to ospf_ls_upd_send() for the direct/unicast case.
+ */
+static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
+				      struct ospf_lsa_list_head *update)
+{
+	struct ospf_interface *oi = nbr->oi;
+	struct prefix_ipv4 p = { .family = AF_INET,
+				 .prefixlen = IPV4_MAX_BITLEN,
+				 .prefix = nbr->address.u.prefix4 };
+	struct route_node *rn;
+	struct ospf_lsa_list_entry *e;
+
+	rn = route_node_get(oi->ls_upd_queue, (struct prefix *)&p);
+	if (rn->info == NULL)
+		rn->info = list_new();
+	else
+		route_unlock_node(rn);
+
+	frr_each_safe(ospf_lsa_list, update, e) {
+		ospf_lsa_list_del(update, e);
+		listnode_add((struct list *)rn->info, ospf_lsa_lock(e->lsa));
+		ospf_lsa_unlock(&e->lsa);
+		XFREE(MTYPE_OSPF_LSA_LIST, e);
+	}
+
+	if (!oi->t_ls_upd_event)
+		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
+				&oi->t_ls_upd_event);
+}
+
 /*
- * OSPF neighbor link state retransmission timer handler. Unicast
- * unacknowledged LSAs to the neighbors.
+ * OSPF neighbor link-state retransmission timer handler.
+ * Retransmits pending unacked LSAs and triggers RFC4222/R5 dynamic
+ * adjacency-pacing adjustment based on retransmit activity.
  */
 void ospf_ls_rxmt_timer(struct event *event)
 {
@@ -345,8 +485,9 @@ void ospf_ls_rxmt_timer(struct event *event)
 		struct timeval current_time, latest_rxmt_time, next_rxmt_time;
 		struct timeval rxmt_interval = { retransmit_interval, 0 };
 		struct timeval rxmt_window;
-		struct list *update;
+		struct ospf_lsa_list_head update;
 
+		ospf_lsa_list_init(&update);
 		/*
 		 * Set the retransmission window based on the configured value
 		 * in milliseconds.
@@ -364,20 +505,68 @@ void ospf_ls_rxmt_timer(struct event *event)
 		timeradd(&current_time, &rxmt_window, &latest_rxmt_time);
 		timeradd(&current_time, &rxmt_interval, &next_rxmt_time);
 
-		update = list_new();
+		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+			zlog_debug("RETRANS_TIMER_CALC: cur=%ld.%06ld, latest_rxmt=%ld.%06ld, next_rxmt=%ld.%06ld",
+				   (long)current_time.tv_sec, (long)current_time.tv_usec,
+				   (long)latest_rxmt_time.tv_sec, (long)latest_rxmt_time.tv_usec,
+				   (long)next_rxmt_time.tv_sec, (long)next_rxmt_time.tv_usec);
+
 		while ((ls_rxmt_list_entry =
 				ospf_lsa_list_first(&nbr->ls_rxmt_list))) {
-			if (timercmp(&ls_rxmt_list_entry->list_entry_time,
-				     &latest_rxmt_time, >))
-				break;
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_CHECK_LSA: Examining LSA %pI4 seq=0x%08x scheduled_time=%ld.%06ld vs latest_rxmt=%ld.%06ld",
+					   &ls_rxmt_list_entry->lsa->data->id,
+					   ntohl(ls_rxmt_list_entry->lsa->data->ls_seqnum),
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_sec,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_usec,
+					   (long)latest_rxmt_time.tv_sec,
+					   (long)latest_rxmt_time.tv_usec);
 
-			listnode_add(update, ls_rxmt_list_entry->lsa);
+			if (timercmp(&ls_rxmt_list_entry->list_entry_time, &latest_rxmt_time, >)) {
+				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+					zlog_debug("RETRANS_SKIP_LSA: LSA %pI4 not ready for retrans yet (%.3f seconds too early)",
+						   &ls_rxmt_list_entry->lsa->data->id,
+						   (ls_rxmt_list_entry->list_entry_time.tv_sec -
+						    latest_rxmt_time.tv_sec) +
+							   (ls_rxmt_list_entry->list_entry_time
+								    .tv_usec -
+							    latest_rxmt_time.tv_usec) /
+								   1000000.0);
+				break;
+			}
+
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_SEND_LSA: Adding LSA %pI4 seq=0x%08x to retransmission packet (was scheduled for %ld.%06ld, %.3f seconds overdue)",
+					   &ls_rxmt_list_entry->lsa->data->id,
+					   ntohl(ls_rxmt_list_entry->lsa->data->ls_seqnum),
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_sec,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_usec,
+					   (current_time.tv_sec -
+					    ls_rxmt_list_entry->list_entry_time.tv_sec) +
+						   (current_time.tv_usec -
+						    ls_rxmt_list_entry->list_entry_time.tv_usec) /
+							   1000000.0);
+
+			struct ospf_lsa_list_entry *upd_entry;
+
+			upd_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
+					    sizeof(*upd_entry));
+			upd_entry->lsa = ospf_lsa_lock(ls_rxmt_list_entry->lsa);
+			ospf_lsa_list_add_tail(&update, upd_entry);
 			rxmt_lsa_count++;
 
 			/*
 			 * Set the next retransmit time for the LSA and move it
 			 * to the end of the neighbor's retransmission list.
 			 */
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_RESCHEDULE: LSA %pI4 rescheduled from %ld.%06ld to %ld.%06ld (next attempt in %d seconds)",
+					   &ls_rxmt_list_entry->lsa->data->id,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_sec,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_usec,
+					   (long)next_rxmt_time.tv_sec,
+					   (long)next_rxmt_time.tv_usec, retransmit_interval);
+
 			ls_rxmt_list_entry->list_entry_time = next_rxmt_time;
 			ospf_lsa_list_del(&nbr->ls_rxmt_list,
 					  ls_rxmt_list_entry);
@@ -387,16 +576,43 @@ void ospf_ls_rxmt_timer(struct event *event)
 			nbr->oi->ls_rxmt_lsa++;
 		}
 
-		if (listcount(update) > 0)
-			ospf_ls_upd_send(nbr, update, OSPF_SEND_PACKET_DIRECT,
-					 0);
-		list_delete(&update);
+		if (ospf_lsa_list_first(&update) != NULL) {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_SEND_PACKET: Sending %d LSAs to neighbor %pI4",
+					   rxmt_lsa_count, &nbr->router_id);
+			ospf_ls_upd_send_lsahead(nbr, &update);
+			/* RFC4222/R5: Retransmitting means ACKs aren't arriving - check congestion */
+			if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC)
+				ospf_adj_dyn_adjust(nbr->oi);
+		} else {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_SEND_NONE: No LSAs ready for retransmission to neighbor %pI4",
+					   &nbr->router_id);
+		}
+
+		ospf_lsa_list_fini(&update);
+	} else {
+		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+			zlog_debug("RETRANS_TIMER_EMPTY: No LSAs in retrans list for neighbor %pI4",
+				   &nbr->router_id);
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("RXmtL(%lu) NBR(%pI4(%s)) timer event - sent %u LSAs",
+		zlog_debug("RXmtL(%lu) NBR(%pI4(%s)) timer event - sending %u LSAs",
 			   ospf_ls_retransmit_count(nbr), &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf), rxmt_lsa_count);
+
+	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+		zlog_debug("RETRANS_TIMER_END: Setting next timer for neighbor %pI4, remaining LSAs=%lu",
+			   &nbr->router_id, ospf_ls_retransmit_count(nbr));
+
+	/* R5 Dynamic adjacency pacing: retransmit indicates congestion */
+	if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC && rxmt_lsa_count > 0) {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s retransmit timer fired for %pI4 (sent %u LSAs), triggering dynamic adjust",
+				   IF_NAME(nbr->oi), &nbr->router_id, rxmt_lsa_count);
+		ospf_adj_dyn_adjust(nbr->oi);
+	}
 
 	/* Set LS Update retransmission timer. */
 	ospf_ls_retransmit_set_timer(nbr);
@@ -705,6 +921,16 @@ static void ospf_write(struct event *event)
 				 "*** sendmsg in %s failed to %pI4, id %d, off %d, len %d, interface %s, mtu %u: %s",
 				 __func__, &dstaddr, iph.ip_id, iph.ip_off, iph.ip_len,
 				 oi->ifp->name, oi->ifp->mtu, safe_strerror(errno));
+
+		if (ret >= 0 && type == OSPF_MSG_LS_UPD &&
+		    ospf_lsa_list_first(&op->sent_lsas) != NULL) {
+			struct ospf_lsa_list_entry *sent_e;
+
+			frr_each(ospf_lsa_list, &op->sent_lsas, sent_e) {
+				/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+				ospf_count_sent_lsa(oi, op->dst, sent_e->lsa);
+			}
+		}
 
 		/* Show debug sending packet. */
 		if (IS_DEBUG_OSPF_PACKET(type - 1, SEND)) {
@@ -2250,6 +2476,10 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 		lsa = ospf_lsa_new();
 		lsa->data = (struct lsa_header *)stream_pnt(s);
 		lsa->vrf_id = oi->ospf->vrf_id;
+		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+			zlog_debug("ACK_LSA: Processing ACK for LSA ID=%pI4 type=%d seq=0x%08x from %pI4",
+				   &lsa->data->id, lsa->data->type, ntohl(lsa->data->ls_seqnum),
+				   &nbr->router_id);
 
 		/* lsah = (struct lsa_header *) stream_pnt (s); */
 		size -= OSPF_LSA_HEADER_SIZE;
@@ -2257,6 +2487,9 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 
 		if (lsa->data->type < OSPF_MIN_LSA
 		    || lsa->data->type >= OSPF_MAX_LSA) {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("ACK_INVALID: Invalid LSA type %d for LSA %pI4, discarding",
+					   lsa->data->type, &lsa->data->id);
 			lsa->data = NULL;
 			ospf_lsa_discard(lsa);
 			continue;
@@ -2264,14 +2497,40 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 
 		lsr = ospf_ls_retransmit_lookup(nbr, lsa);
 
-		if (lsr != NULL && ospf_lsa_more_recent(lsr, lsa) == 0) {
-			ospf_ls_retransmit_delete(nbr, lsr);
-			ospf_check_and_gen_init_seq_lsa(oi, lsa);
+		if (lsr != NULL) {
+			int more_recent_result = ospf_lsa_more_recent(lsr, lsa);
+
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("ACK_FOUND: Found LSA %pI4 in retrans list. more_recent=%d (0=same, >0=lsr newer, <0=lsa newer)",
+					   &lsa->data->id, more_recent_result);
+			if (more_recent_result == 0) {
+				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+					zlog_debug("ACK_MATCH: LSA %pI4 seq=0x%08x matches, removing from retrans list unacked count =%lu",
+						   &lsa->data->id, ntohl(lsa->data->ls_seqnum),
+						   ospf_ls_retransmit_count(nbr));
+				ospf_ls_retransmit_delete(nbr, lsr);
+				/* RFC4222/R5: Trigger dynamic adjacency pacing adjustment */
+				if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC)
+					ospf_adj_dyn_adjust(nbr->oi);
+				ospf_check_and_gen_init_seq_lsa(oi, lsa);
+
+
+			} else {
+				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+					zlog_debug("ACK_MISMATCH: LSA %pI4 found but different version (retrans_seq=0x%08x vs ack_seq=0x%08x)",
+						   &lsa->data->id, ntohl(lsr->data->ls_seqnum),
+						   ntohl(lsa->data->ls_seqnum));
+			}
+		} else {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("ACK_NOTFOUND: LSA %pI4 seq=0x%08x not found in retrans list (already removed or never sent)",
+					   &lsa->data->id, ntohl(lsa->data->ls_seqnum));
 		}
 
 		lsa->data = NULL;
 		ospf_lsa_discard(lsa);
 	}
+	//ospf_ls_retransmit_set_timer(nbr);
 
 	return;
 }
@@ -3504,8 +3763,9 @@ static int ls_age_increment(struct ospf_lsa *lsa, int delay)
 	return age;
 }
 
-static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
-			    struct stream *s)
+static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update, struct stream *s,
+			    struct in_addr dst, uint32_t *out_count,
+			    struct ospf_lsa_list_head *sent_lsas)
 {
 	struct ospf_lsa *lsa;
 	struct listnode *node;
@@ -3513,7 +3773,7 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
 	unsigned int size_noauth;
 	unsigned long delta = stream_get_endp(s);
 	unsigned long pp;
-	int count = 0;
+	uint32_t count = 0;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: Start", __func__);
@@ -3522,7 +3782,6 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
 	stream_forward_endp(s, OSPF_LS_UPD_MIN_SIZE);
 	length += OSPF_LS_UPD_MIN_SIZE;
 
-	/* Calculate amount of packet usable for data. */
 	size_noauth = stream_get_size(s) - ospf_packet_authspace(oi);
 
 	while ((node = listhead(update)) != NULL) {
@@ -3533,40 +3792,40 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
 		assert(lsa->data);
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: List Iteration %d LSA[%s]", __func__,
-				   count, dump_lsa_key(lsa));
+			zlog_debug("%s: List Iteration %d LSA[%s]", __func__, count,
+				   dump_lsa_key(lsa));
 
-		/* Will it fit? Minimum it has to fit at least one */
-		if ((length + delta + ntohs(lsa->data->length) > size_noauth) &&
-				(count > 0))
+		if ((length + delta + ntohs(lsa->data->length) > size_noauth) && (count > 0))
 			break;
 
-		/* Keep pointer to LS age. */
-		lsah = (struct lsa_header *)(STREAM_DATA(s)
-					     + stream_get_endp(s));
+		lsah = (struct lsa_header *)(STREAM_DATA(s) + stream_get_endp(s));
 
-		/* Put LSA to Link State Request. */
 		stream_put(s, lsa->data, ntohs(lsa->data->length));
 
-		/* Set LS age. */
-		/* each hop must increment an lsa_age by transmit_delay
-		   of OSPF interface */
-		ls_age = ls_age_increment(lsa,
-					  OSPF_IF_PARAM(oi, transmit_delay));
+		ls_age = ls_age_increment(lsa, OSPF_IF_PARAM(oi, transmit_delay));
 		lsah->ls_age = htons(ls_age);
 
 		length += ntohs(lsa->data->length);
 		count++;
+		/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+		if (sent_lsas) {
+			struct ospf_lsa_list_entry *sent_entry;
 
+			sent_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
+					     sizeof(*sent_entry));
+			sent_entry->lsa = ospf_lsa_lock(lsa);
+			ospf_lsa_list_add_tail(sent_lsas, sent_entry);
+		}
 		list_delete_node(update, node);
 		ospf_lsa_unlock(&lsa); /* oi->ls_upd_queue */
 	}
 
-	/* Now set #LSAs. */
 	stream_putl_at(s, pp, count);
-
+	if (out_count)
+		*out_count = count;
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: Stop", __func__);
+
 	return length;
 }
 
@@ -3971,6 +4230,7 @@ static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
 {
 	struct ospf_lsa *lsa;
 	struct listnode *ln;
+	struct ospf_packet *op;
 	size_t size;
 	static char warned = 0;
 
@@ -4030,8 +4290,13 @@ static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
 	 *
 	 * P.S. OSPF_MAX_PACKET_SIZE above already includes IP header size
 	 */
-	return ospf_packet_new(size - sizeof(struct ip));
+	op = ospf_packet_new(size - sizeof(struct ip));
+	ospf_packet_sent_lsas_init(op);
+	op->sent_oi = oi; /* optional */
+	return op;
 }
+
+static void ospf_ls_upd_send_queue_event(struct event *thread);
 
 void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 			    struct in_addr addr, int send_lsupd_now)
@@ -4048,6 +4313,8 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 		return;
 
 	op = ospf_ls_upd_packet_new(update, oi);
+	if (!op)
+		return;
 
 	/* Prepare OSPF common header. */
 	ospf_make_header(OSPF_MSG_LS_UPD, oi, op->s);
@@ -4055,14 +4322,20 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 	/* Prepare OSPF Link State Update body.
 	 * Includes Type-7 translation.
 	 */
-	length += ospf_make_ls_upd(oi, update, op->s);
+	uint32_t sent_count = 0;
+
+	length += ospf_make_ls_upd(oi, update, op->s, addr, &sent_count, &op->sent_lsas);
+
+	if (sent_count == 0) {
+		ospf_packet_free(op);
+		return;
+	}
 
 	/* Fill OSPF header. */
 	ospf_fill_header(oi, op->s, length);
 
 	/* Set packet length. */
 	op->length = length;
-
 	/* Decide destination address. */
 	if (oi->type == OSPF_IFTYPE_POINTOPOINT)
 		op->dst.s_addr = htonl(OSPF_ALLSPFROUTERS);
@@ -4071,6 +4344,7 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 
 	/* Add packet to the interface output queue. */
 	ospf_packet_add(oi, op);
+
 	/* Call ospf_write() right away to send ospf packets to neighbors */
 	if (send_lsupd_now) {
 		struct event os_packet_thd;
@@ -4185,32 +4459,35 @@ void ospf_ls_upd_send(struct ospf_neighbor *nbr, struct list *update, int flag,
 
 	rn = route_node_get(oi->ls_upd_queue, (struct prefix *)&p);
 
+	/* Preserve the old locking pattern */
 	if (rn->info == NULL)
 		rn->info = list_new();
 	else
 		route_unlock_node(rn);
 
+	/* Append LSAs */
 	for (ALL_LIST_ELEMENTS_RO(update, node, lsa))
-		listnode_add(rn->info,
-			     ospf_lsa_lock(lsa)); /* oi->ls_upd_queue */
+		listnode_add((struct list *)rn->info, ospf_lsa_lock(lsa));
+
 	if (send_lsupd_now) {
-		struct list *send_update_list;
 		struct route_node *rnext;
 
 		for (rn = route_top(oi->ls_upd_queue); rn; rn = rnext) {
+			struct list *send_update_list;
+
 			rnext = route_next(rn);
 
-			if (rn->info == NULL)
+			send_update_list = rn->info;
+			if (!send_update_list || listcount(send_update_list) == 0)
 				continue;
 
-			send_update_list = (struct list *)rn->info;
-
-			ospf_ls_upd_queue_send(oi, send_update_list,
-					       rn->p.u.prefix4, 1);
+			ospf_ls_upd_queue_send(oi, send_update_list, rn->p.u.prefix4, 1);
 		}
-	} else
-		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
-				&oi->t_ls_upd_event);
+	} else {
+		if (!oi->t_ls_upd_event)
+			event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
+					&oi->t_ls_upd_event);
+	}
 }
 
 static void ospf_ls_ack_send_list(struct ospf_interface *oi,

--- a/ospfd/ospf_packet.h
+++ b/ospfd/ospf_packet.h
@@ -7,6 +7,8 @@
 #ifndef _ZEBRA_OSPF_PACKET_H
 #define _ZEBRA_OSPF_PACKET_H
 
+#include <ospfd/ospf_flood.h>
+
 #define OSPF_HEADER_SIZE         24U
 #define OSPF_AUTH_SIMPLE_SIZE     8U
 #define OSPF_AUTH_MD5_SIZE       16U
@@ -45,6 +47,9 @@ struct ospf_packet {
 
 	/* OSPF packet length. */
 	uint16_t length;
+	/* RFC4222/R5: LSAs serialized into this packet (locked), for ACK tracking */
+	struct ospf_lsa_list_head sent_lsas;
+	struct ospf_interface *sent_oi; /* optional: convenience for logging */
 };
 
 /* OSPF packet queue structure. */
@@ -141,6 +146,7 @@ extern void ospf_ls_ack_send_delayed(struct ospf_interface *oi);
 extern void ospf_ls_retransmit(struct ospf_interface *oi, struct ospf_lsa *lsa);
 extern void ospf_ls_req_event(struct ospf_neighbor *nbr);
 
+extern uint64_t ospf_now_ms(void);
 extern void ospf_ls_rxmt_timer(struct event *event);
 extern void ospf_ls_ack_delayed_timer(struct event *event);
 extern void ospf_poll_timer(struct event *event);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -524,6 +524,264 @@ DEFUN_HIDDEN (no_ospf_passive_interface,
 	return CMD_SUCCESS;
 }
 
+/* RFC4222/R5 implementation*/
+DEFUN( ip_ospf_adj_pacing_static,
+	   ip_ospf_adj_pacing_static_cmd,
+	   "ip ospf adjacency-pacing static (1-65535)",
+	   "IP Information\n"
+	   "OSPF interface commands\n"
+	   "OSPF adjacency pacing configuration\n"
+	   "Set static adjacency pacing limit\n"
+	   "Max number of simultaneous adjacencies in progress\n"
+)
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct route_node *rn;
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	uint16_t limit = strtoul(argv[4]->arg, NULL, 10);
+
+	/* Check if switching from dynamic mode */
+	if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode) &&
+	    params->adj_pacing_mode == OSPF_ADJ_PACING_DYNAMIC) {
+		vty_out(vty, "%% Switching from dynamic to static pacing (limit=%u)\n", limit);
+	}
+
+	params->adj_pacing_mode = OSPF_ADJ_PACING_STATIC;
+	params->adj_pacing_static_limit = limit;
+	SET_IF_PARAM(params, adj_pacing_mode);
+	SET_IF_PARAM(params, adj_pacing_static_limit);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->adj_pacing.mode = OSPF_ADJ_PACING_STATIC;
+		oi->adj_pacing.static_limit = limit;
+		/* Clear dynamic state when switching to static */
+		oi->adj_pacing.dynamic_limit = 0;
+		oi->adj_pacing.last_adjust_ms = 0;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s static pacing ENABLED via CLI, limit=%u (dynamic state cleared)",
+				   IF_NAME(oi), limit);
+
+		/* Kick queue — new limit may open slots for waiting neighbors */
+		if (oi->adj_pacing.in_progress < limit)
+			ospf_adj_pacing_kick(oi);
+	}
+	return CMD_SUCCESS;
+}
+
+/* RFC4222/R5 implementation*/
+DEFUN (ip_ospf_adj_pacing_dynamic,
+       ip_ospf_adj_pacing_dynamic_cmd,
+       "ip ospf adjacency-pacing dynamic",
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n"
+       "Dynamic pacing\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct route_node *rn;
+	struct route_node *first_rn;
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	/* Check if switching from static mode */
+	if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode) &&
+	    params->adj_pacing_mode == OSPF_ADJ_PACING_STATIC) {
+		vty_out(vty, "%% Switching from static (limit=%u) to dynamic pacing\n",
+			params->adj_pacing_static_limit);
+	}
+
+	params->adj_pacing_mode = OSPF_ADJ_PACING_DYNAMIC;
+	params->adj_pacing_static_limit = 0;
+	SET_IF_PARAM(params, adj_pacing_mode);
+	SET_IF_PARAM(params, adj_pacing_static_limit);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+		oi->adj_pacing.mode = OSPF_ADJ_PACING_DYNAMIC;
+		oi->adj_pacing.static_limit = 0;
+		/* Reset dynamic limit to initial value when enabling */
+		oi->adj_pacing.dynamic_limit = OSPF_ADJ_DYN_LIMIT_INITIAL;
+		oi->adj_pacing.last_adjust_ms = 0;
+		/* Apply stored threshold params if configured */
+		if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_high_water))
+			oi->adj_pacing.high_water = params->adj_pacing_high_water;
+		if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_low_water))
+			oi->adj_pacing.low_water = params->adj_pacing_low_water;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s dynamic pacing ENABLED via CLI, initial limit=%u H=%u L=%u",
+				   IF_NAME(oi), OSPF_ADJ_DYN_LIMIT_INITIAL,
+				   oi->adj_pacing.high_water, oi->adj_pacing.low_water);
+	}
+
+	/* Show user what thresholds will be used */
+	first_rn = route_top(IF_OIFS(ifp));
+	if (first_rn) {
+		if (first_rn->info) {
+			struct ospf_interface *first_oi = first_rn->info;
+
+			vty_out(vty, "%% Dynamic pacing initialized: start_limit=%u max=%u H=%u L=%u\n",
+				OSPF_ADJ_DYN_LIMIT_INITIAL, OSPF_ADJ_DYN_LIMIT_MAX,
+				first_oi->adj_pacing.high_water, first_oi->adj_pacing.low_water);
+		}
+		route_unlock_node(first_rn);
+	}
+
+	return CMD_SUCCESS;
+}
+
+/* RFC4222/R5 implementation - Configure dynamic pacing thresholds */
+DEFUN (ip_ospf_adj_pacing_dynamic_thresholds,
+       ip_ospf_adj_pacing_dynamic_thresholds_cmd,
+       "ip ospf adjacency-pacing dynamic thresholds (1-1000) (1-1000)",
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n"
+       "Dynamic pacing\n"
+       "Configure thresholds\n"
+       "High water mark (H) for total unacked LSAs\n"
+       "Low water mark (L) for total unacked LSAs\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	struct route_node *rn;
+	int idx_high = 5;
+	int idx_low = 6;
+	uint32_t high_water = strtoul(argv[idx_high]->arg, NULL, 10);
+	uint32_t low_water = strtoul(argv[idx_low]->arg, NULL, 10);
+
+	if (low_water >= high_water) {
+		vty_out(vty, "%% Error: Low water (%u) must be less than high water (%u)\n",
+			low_water, high_water);
+		return CMD_WARNING;
+	}
+
+	// Store in persistent params
+	params->adj_pacing_high_water = high_water;
+	params->adj_pacing_low_water = low_water;
+	SET_IF_PARAM(params, adj_pacing_high_water);
+	SET_IF_PARAM(params, adj_pacing_low_water);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->adj_pacing.high_water = high_water;
+		oi->adj_pacing.low_water = low_water;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s dynamic pacing thresholds set: H=%u L=%u", IF_NAME(oi),
+				   high_water, low_water);
+	}
+
+	vty_out(vty, "%% Dynamic pacing thresholds: H=%u L=%u\n", high_water, low_water);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222/R5 implementation*/
+DEFUN (no_ip_ospf_adj_pacing,
+       no_ip_ospf_adj_pacing_cmd,
+       "no ip ospf adjacency-pacing",
+       NO_STR
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct route_node *rn;
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	/* Show user what was disabled */
+	if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode)) {
+		if (params->adj_pacing_mode == OSPF_ADJ_PACING_STATIC)
+			vty_out(vty, "%% Disabling static adjacency pacing (was limit=%u)\n",
+				params->adj_pacing_static_limit);
+		else if (params->adj_pacing_mode == OSPF_ADJ_PACING_DYNAMIC)
+			vty_out(vty, "%% Disabling dynamic adjacency pacing\n");
+	}
+
+	params->adj_pacing_mode = OSPF_ADJ_PACING_NONE;
+	params->adj_pacing_static_limit = 0;
+	UNSET_IF_PARAM(params, adj_pacing_mode);
+	UNSET_IF_PARAM(params, adj_pacing_static_limit);
+	UNSET_IF_PARAM(params, adj_pacing_high_water);
+	UNSET_IF_PARAM(params, adj_pacing_low_water);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		/* Cancel dynamic adjustment timer */
+		if (oi->adj_pacing.t_dyn_adjust) {
+			event_cancel(&oi->adj_pacing.t_dyn_adjust);
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("R5: %s cancelled pending AIMD adjustment timer",
+					   IF_NAME(oi));
+		}
+
+		/* Flush queued neighbors - allow them to proceed */
+		ospf_adj_pacing_queue_flush(oi);
+
+		/* Clear mode and limits */
+		oi->adj_pacing.mode = OSPF_ADJ_PACING_NONE;
+		oi->adj_pacing.static_limit = 0;
+		oi->adj_pacing.dynamic_limit = 0;
+		oi->adj_pacing.last_adjust_ms = 0;
+
+		/* Reset thresholds to defaults for consistency */
+		oi->adj_pacing.high_water = OSPF_ADJ_DYN_HIGH_WATER;
+		oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s adjacency pacing DISABLED (mode=NONE, in_progress=%u)",
+				   IF_NAME(oi), oi->adj_pacing.in_progress);
+	}
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_ip_ospf_adj_pacing_dynamic_thresholds,
+       no_ip_ospf_adj_pacing_dynamic_thresholds_cmd,
+       "no ip ospf adjacency-pacing dynamic thresholds",
+       NO_STR
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n"
+       "Dynamic pacing\n"
+       "Clear threshold configuration\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	struct route_node *rn;
+
+	UNSET_IF_PARAM(params, adj_pacing_high_water);
+	UNSET_IF_PARAM(params, adj_pacing_low_water);
+
+	// Reset to defaults on active interfaces
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->adj_pacing.high_water = OSPF_ADJ_DYN_HIGH_WATER;
+		oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
+	}
+
+	return CMD_SUCCESS;
+}
+
 
 DEFUN (ospf_network_area,
        ospf_network_area_cmd,
@@ -12452,6 +12710,26 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				vty_out(vty, "\n");
 			}
 
+			/* RFC4222/R5: Adjacency pacing print (interface-wide). */
+			if (params == IF_DEF_PARAMS(ifp) &&
+			    OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode)) {
+				if (params->adj_pacing_mode == OSPF_ADJ_PACING_STATIC) {
+					vty_out(vty, " ip ospf adjacency-pacing static %u\n",
+						params->adj_pacing_static_limit);
+				} else if (params->adj_pacing_mode == OSPF_ADJ_PACING_DYNAMIC) {
+					vty_out(vty, " ip ospf adjacency-pacing dynamic\n");
+					/* Write dynamic thresholds if configured */
+					if (OSPF_IF_PARAM_CONFIGURED(params,
+								     adj_pacing_high_water) &&
+					    OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_low_water)) {
+						vty_out(vty,
+							" ip ospf adjacency-pacing dynamic thresholds %u %u\n",
+							params->adj_pacing_high_water,
+							params->adj_pacing_low_water);
+					}
+				}
+			}
+
 			/* Retransmit Interval print. */
 			if (OSPF_IF_PARAM_CONFIGURED(params,
 						     retransmit_interval)
@@ -13388,6 +13666,13 @@ static void ospf_vty_if_init(void)
 	/* "ip ospf priority" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_priority_cmd);
 	install_element(INTERFACE_NODE, &no_ip_ospf_priority_cmd);
+
+	/* "ip ospf adjacency-pacing" commands. */
+	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_static_cmd);
+	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_dynamic_cmd);
+	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_dynamic_thresholds_cmd);
+	install_element(INTERFACE_NODE, &no_ip_ospf_adj_pacing_cmd);
+	install_element(INTERFACE_NODE, &no_ip_ospf_adj_pacing_dynamic_thresholds_cmd);
 
 	/* "ip ospf retransmit-interval" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_retransmit_interval_addr_cmd);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -628,7 +628,8 @@ DEFUN (ip_ospf_adj_pacing_dynamic,
 		if (first_rn->info) {
 			struct ospf_interface *first_oi = first_rn->info;
 
-			vty_out(vty, "%% Dynamic pacing initialized: start_limit=%u max=%u H=%u L=%u\n",
+			vty_out(vty,
+				"%% Dynamic pacing initialized: start_limit=%u max=%u H=%u L=%u\n",
 				OSPF_ADJ_DYN_LIMIT_INITIAL, OSPF_ADJ_DYN_LIMIT_MAX,
 				first_oi->adj_pacing.high_water, first_oi->adj_pacing.low_water);
 		}

--- a/tests/topotests/ospf_4222_recommendation_5/r1/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r1/frr.conf
@@ -1,0 +1,32 @@
+frr defaults traditional
+hostname r1
+log syslog informational
+log commands
+service integrated-vtysh-config
+!
+ip router-id 10.0.0.1
+!
+interface eth1
+ ip address 10.0.1.1/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+router ospf
+ ospf router-id 10.0.0.1
+exit
+!
+debug ospf event
+debug ospf nsm
+debug ospf nsm events
+debug ospf packet hello
+debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file /tmp/r1-frr.log debugging
+end

--- a/tests/topotests/ospf_4222_recommendation_5/r1_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r1_broadcast/frr.conf
@@ -1,0 +1,38 @@
+frr defaults traditional
+hostname r1_broadcast
+!
+interface r1-eth0
+ ip address 198.51.100.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+ ip ospf adjacency-pacing dynamic
+ !ip ospf adjacency-pacing static 1
+!
+interface r1-eth1
+ ip address 198.51.101.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+!
+# In FRR vtysh:
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+!debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file /var/log/frr/debug.log debugging
+log file /tmp/r1-frr.rrg
+end

--- a/tests/topotests/ospf_4222_recommendation_5/r1_broadcast_static/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r1_broadcast_static/frr.conf
@@ -1,0 +1,38 @@
+frr defaults traditional
+hostname r1_broadcast_static
+!
+interface r1-eth0
+ ip address 198.51.100.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+ ip ospf adjacency-pacing static 1
+!
+interface r1-eth1
+ ip address 198.51.101.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+ ip ospf adjacency-pacing dynamic
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+!
+# In FRR vtysh:
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+!debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file /var/log/frr/debug.log debugging
+log file /tmp/r1-frr.rrg
+end

--- a/tests/topotests/ospf_4222_recommendation_5/r2/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r2/frr.conf
@@ -1,0 +1,29 @@
+frr defaults traditional
+hostname r2
+log syslog informational
+service integrated-vtysh-config
+!
+ip router-id 10.0.0.2
+!
+interface eth1
+ ip address 10.0.1.2/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+interface eth2
+ ip address 10.0.2.1/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+router ospf
+ ospf router-id 10.0.0.2
+exit
+!
+line vty
+exit

--- a/tests/topotests/ospf_4222_recommendation_5/r2_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r2_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r2_broadcast
+!
+interface r2-eth0
+ ip address 198.51.100.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 200
+!
+router ospf
+ ospf router-id 1.1.1.2
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r3/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r3/frr.conf
@@ -1,0 +1,21 @@
+frr defaults traditional
+hostname r3
+log syslog informational
+service integrated-vtysh-config
+!
+ip router-id 10.0.0.3
+!
+interface eth1
+ ip address 10.0.2.2/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+router ospf
+ ospf router-id 10.0.0.3
+exit
+!
+line vty
+exit

--- a/tests/topotests/ospf_4222_recommendation_5/r3_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r3_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r3_broadcast
+!
+interface r3-eth0
+ ip address 198.51.100.3/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.3
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r4_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r4_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r4_broadcast
+!
+interface r4-eth0
+ ip address 198.51.100.4/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.4
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r5_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r5_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r5_broadcast
+!
+interface r5-eth0
+ ip address 198.51.100.5/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.5
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r6_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r6_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r6_broadcast
+!
+interface r6-eth0
+ ip address 198.51.101.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 200
+!
+router ospf
+ ospf router-id 1.1.1.6
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r7_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r7_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r7_broadcast
+!
+interface r7-eth0
+ ip address 198.51.101.3/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 0
+!
+router ospf
+ ospf router-id 1.1.1.7
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
@@ -10,13 +10,23 @@
 #
 
 """
-test_ospf_adj_pacing_dynamic.py: Test OSPF RFC4222/R5 Dynamic Adjacency Pacing
+test_ospf_adj_pacing_config.py: Test OSPF RFC4222/R5 Adjacency Pacing Configuration
 
-Tests dynamic pacing threshold configuration persistence and functionality:
+Tests static and dynamic pacing configuration persistence and functionality:
+Dynamic:
 1. Config persistence across FRR restart
 2. Config persistence across interface flap
 3. Threshold values used in AIMD algorithm
 4. Config writeback includes thresholds
+
+Static:
+5. Config persistence (write memory / running-config)
+6. Config persistence across FRR restart
+7. Config persistence across interface flap
+8. no-command removes static config
+9. Boundary values (limit=1, limit=65535)
+10. Transition from static to dynamic mode
+11. Transition from dynamic to static mode
 """
 
 import pytest
@@ -407,6 +417,236 @@ def test_adj_pacing_cleanup_on_disable(tgen):
         no ip ospf adjacency-pacing
         end
     """)
+
+
+def test_adj_pacing_static_config_persistence(tgen):
+    """Test that static pacing limit persists in running-config and write memory."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 4
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 4" in running_config, \
+        "Static pacing limit not in running config"
+
+    r1.vtysh_cmd("write memory")
+    startup_config = r1.run("cat /etc/frr/frr.conf")
+    assert "ip ospf adjacency-pacing static 4" in startup_config, \
+        "Static pacing limit not saved to frr.conf"
+
+
+def test_adj_pacing_static_frr_restart(tgen):
+    """Test that static pacing limit persists across ospfd restart."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 3
+        end
+    """)
+    r1.vtysh_cmd("write memory")
+
+    r1.killDaemons(["ospfd"])
+    time.sleep(2)
+    r1.startDaemons(["ospfd"])
+    time.sleep(2)
+    r1.run("vtysh -f /etc/frr/frr.conf")
+    time.sleep(3)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 3" in running_config, \
+        "Static pacing limit lost after ospfd restart"
+
+
+def test_adj_pacing_static_interface_flap(tgen):
+    """Test that static pacing limit survives interface shutdown/no shutdown."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 5
+        end
+    """)
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        shutdown
+        end
+    """)
+    time.sleep(2)
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no shutdown
+        end
+    """)
+    time.sleep(2)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 5" in running_config, \
+        "Static pacing limit lost after interface flap"
+
+
+def test_adj_pacing_static_no_command(tgen):
+    """Test that no ip ospf adjacency-pacing removes static config."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 6
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 6" in running_config, \
+        "Static pacing not configured"
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing" not in running_config, \
+        "Static pacing config not removed by no-command"
+
+
+def test_adj_pacing_static_boundary_values(tgen):
+    """Test static pacing at minimum (1) and maximum (65535) limit values."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Minimum value
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 1
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 1" in running_config, \
+        "Static pacing minimum value (1) not accepted"
+
+    # Maximum value
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 65535
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 65535" in running_config, \
+        "Static pacing maximum value (65535) not accepted"
+
+    # Cleanup
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+
+def test_adj_pacing_static_to_dynamic_transition(tgen):
+    """Test switching from static to dynamic mode replaces config cleanly."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Start with static
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 4
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 4" in running_config, \
+        "Static pacing not configured"
+
+    # Switch to dynamic — static config must disappear
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 60 6
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static" not in running_config, \
+        "Static pacing config still present after switching to dynamic"
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing not present after transition"
+    assert "ip ospf adjacency-pacing dynamic thresholds 60 6" in running_config, \
+        "Dynamic thresholds not present after transition"
+
+
+def test_adj_pacing_dynamic_to_static_transition(tgen):
+    """Test switching from dynamic to static mode replaces config cleanly."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Start with dynamic
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 80 8
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 80 8" in running_config, \
+        "Dynamic pacing not configured"
+
+    # Switch to static — dynamic config must disappear
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 2
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic" not in running_config, \
+        "Dynamic pacing config still present after switching to static"
+    assert "ip ospf adjacency-pacing static 2" in running_config, \
+        "Static pacing not present after transition"
 
 
 if __name__ == "__main__":

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_adj_pacing_dynamic.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_ospf_adj_pacing_dynamic.py: Test OSPF RFC4222/R5 Dynamic Adjacency Pacing
+
+Tests dynamic pacing threshold configuration persistence and functionality:
+1. Config persistence across FRR restart
+2. Config persistence across interface flap
+3. Threshold values used in AIMD algorithm
+4. Config writeback includes thresholds
+"""
+
+import pytest
+import time
+
+from lib.topogen import Topogen
+
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    """Build test topology.
+
+    r1 --- r2 --- r3
+
+    r1-r2: Will have dynamic pacing with custom thresholds
+    r2-r3: Used to create multiple adjacencies on r2
+    """
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    r3 = tgen.add_router("r3")
+
+    tgen.add_link(r1, r2, ifname1="eth1", ifname2="eth1")
+    tgen.add_link(r2, r3, ifname1="eth2", ifname2="eth1")
+
+
+@pytest.fixture(scope="function")
+def tgen(request):
+    """Setup/Teardown the environment and provide tgen argument to tests."""
+
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, router in router_list.items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+    yield tgen
+
+    tgen.stop_topology()
+
+
+def test_adj_pacing_dynamic_config_persistence(tgen):
+    """Test that dynamic pacing thresholds persist in configuration."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with custom thresholds on r1's eth1
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 50 5
+        end
+    """)
+
+    # Step 2: Verify configuration via show running-config
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode not in running config"
+    assert "ip ospf adjacency-pacing dynamic thresholds 50 5" in running_config, \
+        "Dynamic pacing thresholds not in running config"
+
+    # Step 3: Write memory
+    r1.vtysh_cmd("write memory")
+
+    # Step 4: Read the saved config file
+    startup_config = r1.run("cat /etc/frr/frr.conf")
+
+    assert "ip ospf adjacency-pacing dynamic" in startup_config, \
+        "Dynamic pacing mode not in saved config"
+    assert "ip ospf adjacency-pacing dynamic thresholds 50 5" in startup_config, \
+        "Dynamic pacing thresholds not in saved config"
+
+
+def test_adj_pacing_dynamic_interface_flap(tgen):
+    """Test that dynamic pacing thresholds survive interface flap."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 80 10
+        end
+    """)
+
+    # Step 2: Shutdown and no shutdown the interface
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        shutdown
+        end
+    """)
+    time.sleep(2)
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no shutdown
+        end
+    """)
+    time.sleep(2)
+
+    # Step 3: Verify configuration is still present after flap
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic thresholds 80 10" in running_config, \
+        "Dynamic pacing thresholds lost after interface flap"
+
+
+def test_adj_pacing_dynamic_frr_restart(tgen):
+    """Test that dynamic pacing thresholds persist across FRR restart."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 60 8
+        end
+    """)
+
+    # Step 2: Save configuration to frr.conf
+    r1.vtysh_cmd("write memory")
+
+    # Step 3: Kill and restart ospfd to re-read frr.conf from disk
+    r1.killDaemons(["ospfd"])
+    time.sleep(2)
+    r1.startDaemons(["ospfd"])
+    time.sleep(2)
+    # startDaemons only launches the process; push the saved config into it
+    r1.run("vtysh -f /etc/frr/frr.conf")
+    time.sleep(3)
+
+    # Step 4: Verify configuration is still active after daemon re-read frr.conf
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode lost after restart"
+    assert "ip ospf adjacency-pacing dynamic thresholds 60 8" in running_config, \
+        "Dynamic pacing thresholds lost after restart"
+
+
+def test_adj_pacing_dynamic_no_command(tgen):
+    """Test that 'no' command properly removes thresholds."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 70 12
+        end
+    """)
+
+    # Step 2: Verify configuration is present
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 70 12" in running_config, \
+        "Thresholds not configured"
+
+    # Step 3: Remove threshold configuration
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing dynamic thresholds
+        end
+    """)
+
+    # Step 4: Verify thresholds are removed but dynamic mode remains
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode incorrectly removed"
+    assert "ip ospf adjacency-pacing dynamic thresholds" not in running_config, \
+        "Thresholds not removed from config"
+
+
+def test_adj_pacing_dynamic_threshold_validation(tgen):
+    """Test that threshold validation works correctly."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Test 1: Low water >= High water should fail
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic thresholds 50 50
+        end
+    """)
+
+    assert "Error" in output or "must be less" in output, \
+        "Validation should reject low_water >= high_water"
+
+    # Test 2: Low water > High water should fail
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic thresholds 30 40
+        end
+    """)
+
+    assert "Error" in output or "must be less" in output, \
+        "Validation should reject low_water > high_water"
+
+    # Test 3: Valid configuration should succeed
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 100 2
+        end
+    """)
+
+    assert "Error" not in output, \
+        "Valid configuration should succeed"
+
+    # Verify it's actually configured
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 100 2" in running_config, \
+        "Valid thresholds not configured"
+
+
+def test_adj_pacing_dynamic_defaults(tgen):
+    """Test that default thresholds are used when not explicitly configured."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing WITHOUT custom thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        end
+    """)
+
+    # Step 2: Verify mode is in config but no threshold line is written
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode not in config"
+    assert "ip ospf adjacency-pacing dynamic thresholds" not in running_config, \
+        "Default config should not show threshold values"
+
+
+def test_adj_pacing_cleanup_on_disable(tgen):
+    """Test that disabling adjacency pacing properly cleans up all state.
+
+    This test verifies the fix for the cleanup issue where:
+    1. Timer (t_dyn_adjust) is cancelled
+    2. Queued neighbors are flushed and allowed to proceed
+    3. Queue is cleared
+    4. Thresholds are reset to defaults
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Step 1: Configure dynamic pacing with custom thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 50 5
+        end
+    """)
+
+    # Wait for configuration to take effect
+    time.sleep(2)
+
+    # Step 2: Verify pacing is configured
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing not configured"
+    assert "ip ospf adjacency-pacing dynamic thresholds 50 5" in running_config, \
+        "Thresholds not configured"
+
+    # Step 3: Create some adjacency activity by flapping r2's interface
+    # This may create queued neighbors or trigger the AIMD timer
+    r2.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        shutdown
+        end
+    """)
+    time.sleep(1)
+    r2.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no shutdown
+        end
+    """)
+    time.sleep(2)
+
+    # Step 4: Disable adjacency pacing
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+    # Step 5: Verify pacing is removed from config
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing" not in running_config, \
+        "Adjacency pacing still in config after disable"
+
+    # Step 6: Verify cleanup message in output
+    # The command should report what was disabled and how many neighbors were flushed
+    assert "Disabling" in output or "disabled" in output.lower(), \
+        "No confirmation message when disabling pacing"
+
+    # Step 7: Check OSPF interface to ensure neighbors can form properly
+    # After cleanup, new adjacencies should not be blocked
+    time.sleep(5)  # Allow time for adjacency to form
+
+    # Verify r1-r2 adjacency can reach Full state (not stuck in TwoWay)
+    neighbor_output = r1.vtysh_cmd("show ip ospf neighbor json")
+
+    # Parse JSON to check neighbor state
+    import json
+    try:
+        neighbor_data = json.loads(neighbor_output)
+        # Check if there are any neighbors
+        if "default" in neighbor_data:
+            neighbors = neighbor_data["default"]
+            if neighbors:
+                # At least one neighbor should exist and should not be stuck in TwoWay
+                for nbr_id, nbr_info in neighbors.items():
+                    if nbr_info:
+                        state = nbr_info[0].get("nbrState", "")
+                        # State can be "Full/DROther", "Full/DR", etc.
+                        assert "TwoWay" not in state or "Full" in state, \
+                            f"Neighbor {nbr_id} stuck in {state} after pacing cleanup"
+    except json.JSONDecodeError:
+        # If JSON parsing fails, at least verify output exists
+        assert neighbor_output, "No neighbor output after cleanup"
+
+    # Step 8: Verify that we can re-enable pacing without issues
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 80 10
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 80 10" in running_config, \
+        "Cannot re-enable pacing after cleanup"
+
+    # Cleanup: remove pacing configuration
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+
+if __name__ == "__main__":
+    # To run the tests manually
+    import os
+    import sys
+
+    # Allow running from the test directory
+    sys.exit(pytest.main(["-s", __file__]))

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_dynamic_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_dynamic_pacing.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_broadcast_2router_constraint.py
+# Test RFC4222 Rec5 dynamic adjacency pacing with constrained link
+#
+
+import os
+import sys
+from functools import partial
+import pytest
+from time import sleep
+import time
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+from util_pcap import PerInterfacePcapManager
+
+"""
+OSPF broadcast test for dynamic adjacency pacing baseline.
+Start with no constraints, then can incrementally add bandwidth limits to identify when issues trigger.
+"""
+
+TOPOLOGY = """
+                  +-----+  +-----+  +-----+  +-----+
+                  | r2  |  | r3  |  | r4  |  | r5  |
+                  +--+--+  +--+--+  +--+--+  +--+--+
+                     |        |        |        |
+        +-----+      +--------+--------+--------+--------+
+        | r1  |--------------- 198.51.100.0/24 (s0)
+        +--+--+
+           |
+           |         +-----+  +-----+
+           +---------| r6  |  | r7  |
+                     +--+--+  +--+--+
+                        |        |
+                        +--------+-------- 198.51.101.0/24 (s1)
+"""
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.ospfd]
+PM = None
+
+
+def build_topo(tgen):
+    "Build function"
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+    tgen.add_router("r5")
+    tgen.add_router("r6")
+    tgen.add_router("r7")
+
+    switch = tgen.add_switch("s0")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r6"])
+    switch.add_link(tgen.gears["r7"])
+
+
+def setup_module(mod):
+    logger.info("OSPF broadcast baseline topology:\n %s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # Apply network constraints to stress-test dynamic pacing
+    r1 = tgen.gears["r1"]
+    r1.cmd("tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms")
+    r1.cmd("tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms")
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        if rname == "r1":
+            router.load_frr_config(os.path.join(CWD, "r1_broadcast", "frr.conf"))
+        elif rname == "r2":
+            router.load_frr_config(os.path.join(CWD, "r2_broadcast", "frr.conf"))
+        elif rname == "r3":
+            router.load_frr_config(os.path.join(CWD, "r3_broadcast", "frr.conf"))
+        elif rname == "r4":
+            router.load_frr_config(os.path.join(CWD, "r4_broadcast", "frr.conf"))
+        elif rname == "r5":
+            router.load_frr_config(os.path.join(CWD, "r5_broadcast", "frr.conf"))
+        elif rname == "r6":
+            router.load_frr_config(os.path.join(CWD, "r6_broadcast", "frr.conf"))
+        elif rname == "r7":
+            router.load_frr_config(os.path.join(CWD, "r7_broadcast", "frr.conf"))
+
+    tgen.start_router()
+
+    global PM
+    PM = PerInterfacePcapManager(outdir="pcaps", tag="ospf4")
+    PM.start_all(tgen)
+    # Keep captures only for r1 interfaces
+    for (rname, ifn), pid in list(PM.pids.items()):
+        if rname != "r1":
+            router = tgen.routers().get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+            PM.pids.pop((rname, ifn), None)
+
+
+def teardown_module():
+    tgen = get_topogen()
+    global PM
+    if PM:
+        PM.stop_all(tgen)
+    tgen.stop_topology()
+
+
+def wait_for_ospf_ifname(topo_router):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        ifname = next(iter(interfaces.keys()), None)
+        if ifname:
+            ifname_holder["name"] = ifname
+            return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface found on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_ospf_ifname_by_ip(topo_router, ip):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        for ifname, attrs in interfaces.items():
+            if attrs.get("ipAddress") == ip:
+                ifname_holder["name"] = ifname
+                return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface with IP {ip} on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_neighbor_full(tgen, router, neighbor_id):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} neighbor {neighbor_id} FULL")
+
+    def _poll():
+        data = topo_router.vtysh_cmd(
+            f"show ip ospf neighbor {neighbor_id} json", isjson=True
+        )
+        nbr_list = data.get("default", {}).get(neighbor_id)
+        if not nbr_list:
+            return "missing"
+        state = nbr_list[0].get("nbrState", "")
+        if state.split("/", 1)[0] == "Full":
+            return None
+        return state or "unknown"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assertmsg = f"Neighbor {neighbor_id} not FULL on {router}"
+    assert result is None, assertmsg
+
+
+def verify_broadcast_interface(
+    tgen, router, ifname, ip, router_id, nbr_cnt, nbr_adj_cnt, state=None
+):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} broadcast interface settings")
+    iface = {
+        "ospfEnabled": True,
+        "ipAddress": ip,
+        "ipAddressPrefixlen": 24,
+        "ospfIfType": "Broadcast",
+        "area": "0.0.0.0",
+        "routerId": router_id,
+        "networkType": "BROADCAST",
+        "nbrCount": nbr_cnt,
+        "nbrAdjacentCount": nbr_adj_cnt,
+    }
+    if state:
+        iface["state"] = state
+    input_dict = {"interfaces": {ifname: iface}}
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        f"show ip ospf interface {ifname} json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = f"Broadcast interface mismatch on {router}"
+    assert result is None, assertmsg
+
+
+def verify_adjacency_static_pacing(tgen, router, ifname, limit):
+    step(f"Verify {router} adjacency pacing static {limit} on {ifname}")
+    rc, _, _ = tgen.net[router].cmd_status(
+        f"vtysh -c 'show running ospfd' | grep -q 'ip ospf adjacency-pacing static {limit}'",
+        warn=False,
+    )
+    assert rc == 0, f"adjacency pacing static {limit} not present on {router} {ifname}"
+
+
+def verify_dynamic_adjacency_pacing(tgen, router, ifname):
+    """Verify dynamic adjacency pacing is enabled on the interface."""
+    step(f"Verify {router} adjacency pacing dynamic on {ifname}")
+    rc, _, _ = tgen.net[router].cmd_status(
+        f"vtysh -c 'show running ospfd' | grep -q 'ip ospf adjacency-pacing dynamic'",
+        warn=False,
+    )
+    assert rc == 0, f"adjacency pacing dynamic not present on {router} {ifname}"
+
+
+def wait_for_opaque_area_lsa(tgen, router, area, link_state_id, adv_router):
+    topo_router = tgen.gears[router]
+    expected = {
+        "areaLocalOpaqueLsa": {
+            "areas": {
+                area: [
+                    {
+                        "linkStateId": link_state_id,
+                        "advertisingRouter": adv_router,
+                    }
+                ]
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip ospf database opaque-area json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Opaque area LSA {link_state_id} from {adv_router} not found on {router}"
+
+
+def verify_no_adjacency_pacing(tgen, router, ifname):
+    step(f"Verify {router} has no adjacency pacing on {ifname}")
+    cmd = (
+        f"vtysh -c 'show running ospfd' | "
+        f"awk -v ifname='{ifname}' "
+        "'($1==\"interface\" && $2==ifname){f=1} "
+        "($1==\"interface\" && $2!=ifname){f=0} "
+        "($1==\"exit\" || $1==\"!\"){f=0} "
+        "f{print}'"
+    )
+    rc, out, err = tgen.net[router].cmd_status(cmd, warn=False)
+    logger.info("no-pacing check output for %s %s:\n%s", router, ifname, out)
+    if err:
+        logger.info("no-pacing check stderr for %s %s:\n%s", router, ifname, err)
+    rc = 1 if "adjacency-pacing" in out else 0
+    assert not rc, f"unexpected adjacency pacing on {router} {ifname}"
+
+
+def test_ospf_broadcast_7router_neighbors_full():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1_if = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.100.1")
+    r2_if = wait_for_ospf_ifname(tgen.gears["r2"])
+    r3_if = wait_for_ospf_ifname(tgen.gears["r3"])
+    r4_if = wait_for_ospf_ifname(tgen.gears["r4"])
+    r5_if = wait_for_ospf_ifname(tgen.gears["r5"])
+    r6_if = wait_for_ospf_ifname(tgen.gears["r6"])
+    r7_if = wait_for_ospf_ifname(tgen.gears["r7"])
+    r1_if2 = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.101.1")
+    assert r1_if and r1_if2 and r2_if and r3_if and r4_if and r5_if and r6_if and r7_if
+
+    verify_dynamic_adjacency_pacing(tgen, "r1", r1_if)
+    step("Dump r1 show running ospfd")
+    logger.info(
+        "r1 show running ospfd:\n%s",
+        tgen.net["r1"].cmd("vtysh -c 'show running ospfd'"),
+    )
+    verify_no_adjacency_pacing(tgen, "r1", r1_if2)
+
+    # On broadcast networks, DROthers only form FULL adjacencies with DR/BDR.
+    verify_broadcast_interface(
+        tgen, "r1", r1_if, "198.51.100.1", "1.1.1.1", 4, 4, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r2", r2_if, "198.51.100.2", "1.1.1.2", 4, 4, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r3", r3_if, "198.51.100.3", "1.1.1.3", 4, 2)
+    verify_broadcast_interface(tgen, "r4", r4_if, "198.51.100.4", "1.1.1.4", 4, 2)
+    verify_broadcast_interface(tgen, "r5", r5_if, "198.51.100.5", "1.1.1.5", 4, 2)
+
+    verify_broadcast_interface(
+        tgen, "r1", r1_if2, "198.51.101.1", "1.1.1.1", 2, 2, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r6", r6_if, "198.51.101.2", "1.1.1.6", 2, 2, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r7", r7_if, "198.51.101.3", "1.1.1.7", 2, 2)
+
+    #interface r1-eth0
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
+
+    #interface r1-eth1
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
+
+    #BDR neighbors on r1-eth0
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.5")
+
+    #BDR on r1-eth1
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
+
+    sleep(5)
+
+def test_ospf_broadcast_external_lsa_flooding():
+    """
+    After routers reach Full state, generate an LSA storm using
+    redistribute-connected + loopback growth, and monitor pacing behavior.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Ensure key adjacencies are already Full.
+    r1 = tgen.gears["r1"]
+    for nbr in ["1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5"]:
+        wait_for_neighbor_full(tgen, "r1", nbr)
+    for nbr in ["1.1.1.6", "1.1.1.7"]:
+        wait_for_neighbor_full(tgen, "r1", nbr)
+
+    step("Enable redistribute connected on r1 and inject connected prefixes")
+    rc, out, err = tgen.net["r1"].cmd_status(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'redistribute connected'",
+        warn=False,
+    )
+    assert rc == 0, f"failed to enable redistribute connected: stdout={out} stderr={err}"
+
+    for i in range(1, 101):
+        tgen.net["r1"].cmd(f"ip addr add 198.51.110.{i}/32 dev lo")
+        tgen.net["r1"].cmd(f"ip addr add 198.51.111.{i}/32 dev lo")
+
+    # Allow LSAs to originate and flood.
+    time.sleep(3)
+
+    step("Verify key adjacencies remain FULL during LSA storm")
+    for router, nbr in [
+        ("r1", "1.1.1.2"),
+        ("r1", "1.1.1.3"),
+        ("r1", "1.1.1.4"),
+        ("r1", "1.1.1.5"),
+        ("r1", "1.1.1.6"),
+        ("r1", "1.1.1.7"),
+        ("r2", "1.1.1.1"),
+        ("r6", "1.1.1.1"),
+    ]:
+        wait_for_neighbor_full(tgen, router, nbr)
+
+    # Wait for pacing logic to react
+    sleep(5)
+
+    # Check logs for dynamic pacing signal in the run log.
+    step("Check adjacency pacing limit changes in log after LSA flood")
+    log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
+    log_cmd = f"grep -a 'R5-DYN:' {log_path} | tail -20"
+    log_out = tgen.net["r1"].cmd(log_cmd)
+    logger.info("r1 ospfd.log AIMD limit changes after LSA flood:\n%s", log_out)
+
+    assert log_out.strip(), "No dynamic pacing log entries found after external LSA flood"
+
+
+def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
+    """
+    Verify that when AIMD dynamic_limit increases (U drops below L),
+    ospf_adj_pacing_kick() fires immediately to dequeue waiting neighbors.
+
+    Sequence:
+      1. Clean up state from previous test (redistribute + loopbacks) then wait for U < L=2
+      2. Set thresholds H=20, L=6 (steady-state U≈5 < L=6, injecting 50 LSAs gives U>>H=20)
+      3. Inject 50 external LSAs -> U > H=20 -> AIMD decreases dynamic_limit to 1
+      4. Flap r3, r4, r5 to create pacing activity + queued adjacencies
+      5. Confirm congestion is established (log shows CONGESTION.*H(20))
+      6. Mark timestamp, clear LSAs -> U drops to 3 < L=4 -> limit increases -> kick
+      7. Assert all three reach Full within 15s (bounded by one AIMD interval)
+      8. Assert ospfd.log shows "kicking queued adjacencies" AFTER the mark timestamp
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r1_if = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.100.1")
+    log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
+
+    # Step 1: Remove the tc qdisc bandwidth constraint for this test.
+    # The 10kbit limit causes two problems here:
+    #   a) LSA withdrawal from the previous test takes minutes → U never settles
+    #   b) Adjacency formation itself is throttled → Full assertion timeout is unreachable
+    # This test creates its own congestion via LSA injection, so no tc constraint needed.
+    step("Replace 10kbit tc constraint with 1Mbps and clean up previous test state")
+    tgen.net["r1"].cmd("tc qdisc del dev r1-eth0 root 2>/dev/null || true")
+    tgen.net["r1"].cmd(
+        "tc qdisc add dev r1-eth0 root tbf rate 1mbit burst 100kb latency 50ms"
+    )
+    # sch_netem may not be auto-loaded on CI kernels (e.g. i386 Debian 12).
+    # Kernel modules are system-wide so one modprobe suffices for all namespaces.
+    tgen.net["r1"].cmd("modprobe sch_netem 2>/dev/null || true")
+    # r2: 2500ms egress delay keeps r2's LSA ACKs in-flight when AIMD fires.
+    # At 1Mbps with sub-ms netns RTT all 50 LSAs are acked in ~81ms, so U=0 by
+    # the time r3/r4/r5 reach 2-Way (~2.1s after the flap). With 2500ms delay
+    # the first ACK arrives at ~2501ms, so AIMD sees U=50 > H=20 at ~2147ms.
+    tgen.net["r2"].cmd("tc qdisc del dev r2-eth0 root 2>/dev/null || true")
+    tgen.net["r2"].cmd("tc qdisc add dev r2-eth0 root netem delay 2500ms")
+    # r3/r4/r5: 500ms egress delay slows adjacency formation to ~3s per neighbor.
+    # Without this they all form Full in ~100ms, leaving an empty queue when the
+    # AIMD limit-increase fires; with it r4 and r5 are still queued when r3 goes
+    # Full, so the kick dequeues them and the log entry appears after mark_time.
+    for _rname in ["r3", "r4", "r5"]:
+        tgen.net[_rname].cmd(f"tc qdisc del dev {_rname}-eth0 root 2>/dev/null || true")
+        tgen.net[_rname].cmd(f"tc qdisc add dev {_rname}-eth0 root netem delay 500ms")
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'no redistribute connected' 2>/dev/null || true"
+    )
+    for i in range(1, 101):
+        tgen.net["r1"].cmd(f"ip addr del 198.51.110.{i}/32 dev lo 2>/dev/null || true")
+        tgen.net["r1"].cmd(f"ip addr del 198.51.111.{i}/32 dev lo 2>/dev/null || true")
+
+    # At 1Mbps, 200 residual LSA withdrawals (~160KB) complete in ~1.3s.
+    # Steady-state U settles to 0-5 with no pending LSAs. L=6 ensures drain passes.
+    step("Wait for residual unacked LSAs to drain (U < 6) before starting test")
+
+    def _unacked_low():
+        chk = tgen.net["r1"].cmd(
+            f"grep -a 'total_unacked' {log_path} | tail -1"
+        )
+        logger.info("Latest unacked entry: %s", chk.strip())
+        import re
+        m = re.search(r"total_unacked=(\d+)", chk)
+        if m and int(m.group(1)) < 6:
+            return None
+        return "still draining"
+
+    _, result = topotest.run_and_expect(_unacked_low, None, count=60, wait=2)
+    if result is not None:
+        logger.warning("Residual LSAs did not drain below L=6; proceeding anyway")
+
+    # Step 2: Set thresholds H=20, L=6.
+    # Steady-state U=5 < L=6 → UNCONGESTED after LSA removal.
+    # Injecting 50 LSAs across 4 neighbors gives U≈200 >> H=20 → CONGESTION.
+    # At 1Mbps, 50 LSAs × 200B × 4 neighbors = 40KB takes ~320ms — long enough for
+    # the AIMD timer to fire and see high U before most acks arrive.
+    step("Set dynamic pacing thresholds on r1 (H=20, L=6)")
+    r1.vtysh_cmd(f"""
+        configure terminal
+        interface {r1_if}
+        ip ospf adjacency-pacing dynamic thresholds 20 6
+        end
+    """)
+
+    # Step 3: Inject 50 external LSAs to drive U above H=20.
+    # At 1Mbps, 50 LSAs × 200B × 4 neighbors = 40KB → ~320ms transmission.
+    # AIMD timer fires within ~500ms of pacing — U ≈ 200 at that point >> H=20.
+    step("Inject 50 external prefixes on r1 to drive U > H=20 and decrease dynamic_limit")
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'redistribute connected'"
+    )
+    for i in range(1, 51):
+        tgen.net["r1"].cmd(f"ip addr add 198.51.120.{i}/32 dev lo")
+
+    # Step 4: Mark start of the congestion/recovery observation window, then
+    # flap r3/r4/r5 simultaneously right after injecting LSAs.
+    # The earlier mark avoids missing a legitimate queue-kick log that occurs
+    # during the flap/congestion phase instead of strictly after LSA clear.
+    # The flap creates active pacing events — ospf_adj_pacing_allow() fires AIMD timer.
+    # The AIMD timer then sees U > H=20 and decreases dynamic_limit to 1.
+    # Without this flap, all neighbors are Full and AIMD never fires despite high U.
+    mark_time = time.strftime("%Y/%m/%d %H:%M:%S")
+    step("Flap r3, r4, r5 to trigger AIMD and create queued adjacencies")
+    flap_ifaces = {}
+    for rname in ["r3", "r4", "r5"]:
+        flap_ifaces[rname] = wait_for_ospf_ifname(tgen.gears[rname])
+
+    for rname, ifn in flap_ifaces.items():
+        tgen.net[rname].cmd(f"ip link set {ifn} down")
+    time.sleep(1)
+    for rname, ifn in flap_ifaces.items():
+        tgen.net[rname].cmd(f"ip link set {ifn} up")
+
+    # Step 5: Now wait for AIMD to detect congestion.
+    # The pacing activity from step 4 triggers the AIMD timer which sees U > H=20.
+    step("Confirm AIMD detected congestion (U > H=20) and limit=1")
+
+    def _congestion_detected():
+        chk = tgen.net["r1"].cmd(
+            f"grep -a 'CONGESTION.*H(20)' {log_path} | tail -1"
+        )
+        if "CONGESTION" in chk:
+            return None
+        return "congestion not yet detected"
+
+    _, result = topotest.run_and_expect(_congestion_detected, None, count=20, wait=1)
+    assert result is None, "AIMD did not detect congestion — pacing may not be active"
+
+    # Wait for neighbors to settle into queued state (in_progress=1, 2 queued)
+    time.sleep(2)
+
+    # Step 6: Clear LSAs.
+    # U drops below L=6 -> AIMD increases limit -> ospf_adj_pacing_kick fires.
+    step("Remove external LSAs — U drops to ~3 < L=4, AIMD increases limit, kick fires")
+    clear_time = time.time()
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'no redistribute connected'"
+    )
+    for i in range(1, 51):
+        tgen.net["r1"].cmd(f"ip addr del 198.51.120.{i}/32 dev lo 2>/dev/null || true")
+
+    # Step 7: All three neighbors must reach Full within 15s.
+    # Without the fix they stall; with fix they are kicked within one AIMD interval.
+    step("Verify r3, r4, r5 reach Full promptly after queue kick")
+    for nbr in ["1.1.1.3", "1.1.1.4", "1.1.1.5"]:
+        wait_for_neighbor_full(tgen, "r1", nbr)
+    elapsed = time.time() - clear_time
+    logger.info("r3/r4/r5 all Full %.1f seconds after clearing congestion", elapsed)
+    assert elapsed < 15, (
+        f"Neighbors took {elapsed:.1f}s to reach Full after congestion cleared — "
+        "queue kick may not have fired on limit increase"
+    )
+
+    # Step 8: Log check for kick diagnostic (informational only).
+    # The kick is already proved by Step 7: r3/r4/r5 reaching Full within 15s
+    # requires ospf_adj_pacing_kick() to have fired. The "kicking queued
+    # adjacencies" message is inside IS_DEBUG_OSPF(nsm, NSM_EVENTS) and will
+    # only appear when NSM debug is enabled, so asserting on it is fragile.
+    step("Log: check ospfd.log for 'kicking queued adjacencies' (informational)")
+    log_out = tgen.net["r1"].cmd(
+        f"awk -v ts='{mark_time}' '$0 >= ts' {log_path} | grep -a 'kicking queued adjacencies' | tail -5"
+    )
+    logger.info("Queue kick log entries after mark (debug-only, may be empty):\n%s", log_out)
+
+    # Cleanup: disable redistribute, remove injected loopbacks, restore tc and thresholds
+    step("Cleanup: restore r1/r2/r3/r4/r5 to baseline state")
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'no redistribute connected' 2>/dev/null || true"
+    )
+    for i in range(1, 51):
+        tgen.net["r1"].cmd(f"ip addr del 198.51.120.{i}/32 dev lo 2>/dev/null || true")
+    tgen.net["r1"].cmd("tc qdisc del dev r1-eth0 root 2>/dev/null || true")
+    tgen.net["r1"].cmd(
+        "tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms"
+    )
+    tgen.net["r1"].cmd(
+        "tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms"
+    )
+    tgen.net["r2"].cmd("tc qdisc del dev r2-eth0 root 2>/dev/null || true")
+    for _rname in ["r3", "r4", "r5"]:
+        tgen.net[_rname].cmd(f"tc qdisc del dev {_rname}-eth0 root 2>/dev/null || true")
+    r1.vtysh_cmd(f"""
+        configure terminal
+        interface {r1_if}
+        no ip ospf adjacency-pacing dynamic thresholds
+        end
+    """)

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_broadcast_2router_static_constraint.py
+# Test RFC4222 Rec5 static adjacency pacing with constrained link
+#
+
+import os
+import sys
+from functools import partial
+import pytest
+from time import sleep
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+from util_pcap import PerInterfacePcapManager
+
+TOPOLOGY = """
+                  +-----+  +-----+  +-----+  +-----+
+                  | r2  |  | r3  |  | r4  |  | r5  |
+                  +--+--+  +--+--+  +--+--+  +--+--+
+                     |        |        |        |
+        +-----+      +--------+--------+--------+--------+
+        | r1  |--------------- 198.51.100.0/24 (s0)
+        +--+--+
+           |
+           |         +-----+  +-----+
+           +---------| r6  |  | r7  |
+                     +--+--+  +--+--+
+                        |        |
+                        +--------+-------- 198.51.101.0/24 (s1)
+"""
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.ospfd]
+PM = None
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+    tgen.add_router("r5")
+    tgen.add_router("r6")
+    tgen.add_router("r7")
+
+    switch = tgen.add_switch("s0")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r6"])
+    switch.add_link(tgen.gears["r7"])
+
+
+def setup_module(mod):
+    logger.info("OSPF broadcast static topology:\n %s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1 = tgen.gears["r1"]
+    r1.cmd("tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms")
+    r1.cmd("tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms")
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        if rname == "r1":
+            router.load_frr_config(
+                os.path.join(CWD, "r1_broadcast_static", "frr.conf")
+            )
+        elif rname == "r2":
+            router.load_frr_config(os.path.join(CWD, "r2_broadcast", "frr.conf"))
+        elif rname == "r3":
+            router.load_frr_config(os.path.join(CWD, "r3_broadcast", "frr.conf"))
+        elif rname == "r4":
+            router.load_frr_config(os.path.join(CWD, "r4_broadcast", "frr.conf"))
+        elif rname == "r5":
+            router.load_frr_config(os.path.join(CWD, "r5_broadcast", "frr.conf"))
+        elif rname == "r6":
+            router.load_frr_config(os.path.join(CWD, "r6_broadcast", "frr.conf"))
+        elif rname == "r7":
+            router.load_frr_config(os.path.join(CWD, "r7_broadcast", "frr.conf"))
+
+    tgen.start_router()
+
+    global PM
+    PM = PerInterfacePcapManager(outdir="pcaps", tag="ospf4-static")
+    PM.start_all(tgen)
+    for (rname, ifn), pid in list(PM.pids.items()):
+        if rname != "r1":
+            router = tgen.routers().get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+            PM.pids.pop((rname, ifn), None)
+
+
+def teardown_module():
+    tgen = get_topogen()
+    global PM
+    if PM:
+        PM.stop_all(tgen)
+    tgen.stop_topology()
+
+
+def wait_for_ospf_ifname(topo_router):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        ifname = next(iter(interfaces.keys()), None)
+        if ifname:
+            ifname_holder["name"] = ifname
+            return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface found on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_ospf_ifname_by_ip(topo_router, ip):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        for ifname, attrs in interfaces.items():
+            if attrs.get("ipAddress") == ip:
+                ifname_holder["name"] = ifname
+                return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface with IP {ip} on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_neighbor_full(tgen, router, neighbor_id):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} neighbor {neighbor_id} FULL")
+
+    def _poll():
+        data = topo_router.vtysh_cmd(
+            f"show ip ospf neighbor {neighbor_id} json", isjson=True
+        )
+        nbr_list = data.get("default", {}).get(neighbor_id)
+        if not nbr_list:
+            return "missing"
+        state = nbr_list[0].get("nbrState", "")
+        if state.split("/", 1)[0] == "Full":
+            return None
+        return state or "unknown"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"Neighbor {neighbor_id} not FULL on {router}"
+
+
+def verify_broadcast_interface(
+    tgen, router, ifname, ip, router_id, nbr_cnt, nbr_adj_cnt, state=None
+):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} broadcast interface settings")
+    iface = {
+        "ospfEnabled": True,
+        "ipAddress": ip,
+        "ipAddressPrefixlen": 24,
+        "ospfIfType": "Broadcast",
+        "area": "0.0.0.0",
+        "routerId": router_id,
+        "networkType": "BROADCAST",
+        "nbrCount": nbr_cnt,
+        "nbrAdjacentCount": nbr_adj_cnt,
+    }
+    if state:
+        iface["state"] = state
+    input_dict = {"interfaces": {ifname: iface}}
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        f"show ip ospf interface {ifname} json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Broadcast interface mismatch on {router}"
+
+
+def verify_adjacency_static_pacing(tgen, router, ifname, limit):
+    step(f"Verify {router} adjacency pacing static {limit} on {ifname}")
+    cmd = (
+        f"vtysh -c 'show running ospfd' | "
+        f"awk -v ifname='{ifname}' "
+        "'($1==\"interface\" && $2==ifname){f=1} "
+        "($1==\"interface\" && $2!=ifname){f=0} "
+        "($1==\"exit\" || $1==\"!\"){f=0} "
+        "f{print}' | "
+        f"grep -q 'ip ospf adjacency-pacing static {limit}'"
+    )
+    rc, _, _ = tgen.net[router].cmd_status(cmd, warn=False)
+    assert rc == 0, f"adjacency pacing static {limit} not present on {router} {ifname}"
+
+
+def verify_dynamic_adjacency_pacing(tgen, router, ifname):
+    step(f"Verify {router} adjacency pacing dynamic on {ifname}")
+    rc, _, _ = tgen.net[router].cmd_status(
+        f"vtysh -c 'show running ospfd' | grep -q 'ip ospf adjacency-pacing dynamic'",
+        warn=False,
+    )
+    assert rc == 0, f"adjacency pacing dynamic not present on {router} {ifname}"
+
+
+def test_ospf_broadcast_static_pacing_neighbors_full():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1_if = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.100.1")
+    r2_if = wait_for_ospf_ifname(tgen.gears["r2"])
+    r3_if = wait_for_ospf_ifname(tgen.gears["r3"])
+    r4_if = wait_for_ospf_ifname(tgen.gears["r4"])
+    r5_if = wait_for_ospf_ifname(tgen.gears["r5"])
+    r6_if = wait_for_ospf_ifname(tgen.gears["r6"])
+    r7_if = wait_for_ospf_ifname(tgen.gears["r7"])
+    r1_if2 = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.101.1")
+    assert r1_if and r1_if2 and r2_if and r3_if and r4_if and r5_if and r6_if and r7_if
+
+    verify_adjacency_static_pacing(tgen, "r1", r1_if, 1)
+    verify_dynamic_adjacency_pacing(tgen, "r1", r1_if2)
+
+    verify_broadcast_interface(
+        tgen, "r1", r1_if, "198.51.100.1", "1.1.1.1", 4, 4, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r2", r2_if, "198.51.100.2", "1.1.1.2", 4, 4, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r3", r3_if, "198.51.100.3", "1.1.1.3", 4, 2)
+    verify_broadcast_interface(tgen, "r4", r4_if, "198.51.100.4", "1.1.1.4", 4, 2)
+    verify_broadcast_interface(tgen, "r5", r5_if, "198.51.100.5", "1.1.1.5", 4, 2)
+
+    verify_broadcast_interface(
+        tgen, "r1", r1_if2, "198.51.101.1", "1.1.1.1", 2, 2, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r6", r6_if, "198.51.101.2", "1.1.1.6", 2, 2, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r7", r7_if, "198.51.101.3", "1.1.1.7", 2, 2)
+
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
+
+    sleep(5)

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
@@ -241,6 +241,20 @@ def test_ospf_broadcast_static_pacing_neighbors_full():
     verify_adjacency_static_pacing(tgen, "r1", r1_if, 1)
     verify_dynamic_adjacency_pacing(tgen, "r1", r1_if2)
 
+    # Wait for full adjacency on both segments before checking interface
+    # states.  With static pacing (limit=1) on s0 and dynamic pacing on s1,
+    # adjacencies form one at a time; DR/BDR election results are only
+    # guaranteed stable once all neighbors have reached Full.
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
+
     verify_broadcast_interface(
         tgen, "r1", r1_if, "198.51.100.1", "1.1.1.1", 4, 4, state="DR"
     )
@@ -258,15 +272,5 @@ def test_ospf_broadcast_static_pacing_neighbors_full():
         tgen, "r6", r6_if, "198.51.101.2", "1.1.1.6", 2, 2, state="Backup"
     )
     verify_broadcast_interface(tgen, "r7", r7_if, "198.51.101.3", "1.1.1.7", 2, 2)
-
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
-    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
-    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
-    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
 
     sleep(5)

--- a/tests/topotests/ospf_4222_recommendation_5/util_pcap.py
+++ b/tests/topotests/ospf_4222_recommendation_5/util_pcap.py
@@ -1,0 +1,96 @@
+# util_pcap.py
+import re, time, shlex
+from pathlib import Path
+
+OSPFV2_FILTER = "ip proto 89"
+
+class PerInterfacePcapManager:
+    def __init__(self, outdir="pcaps", tag="ospf4"):
+        self.outdir = Path(outdir)
+        self.tag = tag
+        self.pids = {}   # (router, ifname) -> pid
+
+    def _list_ifaces(self, router):
+        txt = router.cmd("ip -o link show")
+        # Lines like: "3: r1-eth0@if4: <BROADCAST,MULTICAST,UP,LOWER_UP> ..."
+        ifaces = []
+        seen = set()
+        for ln in txt.splitlines():
+            m = re.match(r"\d+:\s+([^:]+):\s+<([^>]*)>", ln)
+            if not m:
+                continue
+            ifn = m.group(1).split("@")[0]
+            flags = m.group(2).split(",")
+            up = "UP" in flags
+            if ifn not in seen:
+                seen.add(ifn)
+                ifaces.append((ifn, up))
+        return ifaces
+
+    def start_all(self, tgen):
+        if tgen is None or not tgen.routers():
+            raise RuntimeError("Call start_all() only after tgen.start_router()")
+
+        self.outdir = self.outdir.resolve()
+        self.outdir.mkdir(parents=True, exist_ok=True)
+        # Clean previous captures for a fresh run
+        for old in self.outdir.glob("*.pcap*"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+        for old in self.outdir.glob("*.csv*"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+
+        for rname, router in tgen.routers().items():
+            for ifn, up in self._list_ifaces(router):
+                if ifn == "lo":
+                    continue
+                # If you only want 'UP' links, uncomment:
+                # if not up: continue
+
+                pcap_path = self.outdir / f"{rname}-{ifn}-{self.tag}.pcap"
+                cmd = (
+                    f"nohup tcpdump -i {shlex.quote(ifn)} -U -s 0 "
+                    #f"-w {shlex.quote(str(pcap_path))} {OSPFV2_FILTER} "
+                    f"-w {shlex.quote(str(pcap_path))}"
+                    f">/dev/null 2>&1 & echo $!"
+                )
+                pid = router.cmd(cmd).strip()
+                # Basic sanity: numeric PID?
+                try:
+                    self.pids[(rname, ifn)] = int(pid)
+                except ValueError:
+                    # tcpdump might be missing; surface the router's error
+                    out = router.cmd("which tcpdump || true")
+                    raise RuntimeError(
+                        f"Failed to start tcpdump on {rname}:{ifn} "
+                        f"(got PID '{pid}'). tcpdump path: {out}"
+                    )
+
+        # Small settle to ensure files are created
+        time.sleep(0.3)
+
+    def stop_all(self, tgen=None):
+        # Best-effort terminate inside each router
+        if not self.pids:
+            return
+        # If tgen wasn't passed, try to get it (optional)
+        routers = {}
+        if tgen is not None and tgen.routers():
+            routers = tgen.routers()
+
+        for (rname, ifn), pid in list(self.pids.items()):
+            router = routers.get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+        time.sleep(0.3)
+        for (rname, ifn), pid in list(self.pids.items()):
+            router = routers.get(rname)
+            if router:
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+        self.pids.clear()
+# util_pcap.py


### PR DESCRIPTION
## Summary

Implements RFC 4222 Recommendation 5: per-interface adjacency pacing
to limit the number of simultaneous OSPF adjacency formations and
avoid database-exchange bursts on bandwidth-constrained interfaces.

Two modes are provided:

**Static mode** — a fixed concurrency limit per interface:
  ip ospf adjacency-pacing static <1-65535>

**Dynamic mode** — an AIMD-based limit that adapts to retransmission
pressure on the interface:
  ip ospf adjacency-pacing dynamic
  ip ospf adjacency-pacing dynamic thresholds <H> <L>

In dynamic mode the total unacknowledged LSA count U(t) across all
neighbors on the interface is used as the congestion signal. When
U(t) rises above the high-water mark H the limit is halved; when it
falls below the low-water mark L the limit is incremented by one.
The limit starts at 1 and is bounded at 50. Default thresholds are
H=100, L=2.

Neighbors that cannot immediately enter ExStart are queued per
interface in FIFO order and restarted (via NSM_AdjOK) when a slot
opens.

## Testing

Three topotest files covering:
- Configuration persistence, interface flap, daemon restart,
  no-command cleanup, threshold validation (point-to-point topology)
- AIMD congestion detection under LSA flood and queue-kick on
  limit increase (7-router broadcast topology)
- Static pacing on the broadcast topology

## Documentation

- doc/developer/ospf-adj-pacing.rst — developer reference
- doc/user/ospfd.rst — four new clicmd entries