### PR TITLE
bgpd: Fixes in comm/lcomm/ecomm str functions

### DIFF
--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -201,6 +201,8 @@ static void set_community_string(struct community *com, bool make_json,
 		return;
 
 	if (make_json) {
+		if (com->json)
+			json_object_put(com->json);
 		com->json = json_object_new_object();
 		json_community_list = json_object_new_array();
 	}

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1158,22 +1158,35 @@ static char *_ecommunity_ecom2str(struct ecommunity *ecom, int format, int filte
 	uint8_t sub_type = 0;
 	int str_size;
 	char *str_buf;
+	char encbuf[128];
 
 	if (!ecom || ecom->size == 0)
 		return XCALLOC(MTYPE_ECOMMUNITY_STR, 1);
 
-	/* ecom strlen + space + null term */
-	str_size = (ecom->size * (ECOMMUNITY_STRLEN + 1)) + 1;
-	str_buf = XCALLOC(MTYPE_ECOMMUNITY_STR, str_size);
+	if (index != -1 && (uint32_t)index >= ecom->size)
+		return XCALLOC(MTYPE_ECOMMUNITY_STR, 1);
 
-	char encbuf[128];
+	/* ecom strlen + space + null term */
+	if (index == -1)
+		str_size = (ecom->size * (ECOMMUNITY_STRLEN + 1)) + 1;
+	else
+		str_size = (ECOMMUNITY_STRLEN + 1) + 1;
+
+	str_buf = XCALLOC(MTYPE_ECOMMUNITY_STR, str_size);
 
 	for (i = 0; i < ecom->size; i++) {
 		bool unk_ecom = false;
+
+		/* If we're only formatting one item, stop when we've found it */
+		if (index != -1) {
+			if (i < (uint32_t)index)
+				continue;
+			else if (i > (uint32_t)index)
+				break;
+		}
+
 		memset(encbuf, 0x00, sizeof(encbuf));
 
-		if (index != -1 && (uint32_t)index != i)
-			continue;
 		/* Space between each value.  */
 		if (index == -1 && i > 0)
 			strlcat(str_buf, " ", str_size);

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -179,6 +179,8 @@ static void set_lcommunity_string(struct lcommunity *lcom, bool make_json,
 		return;
 
 	if (make_json) {
+		if (lcom->json)
+			json_object_put(lcom->json);
 		lcom->json = json_object_new_object();
 		json_lcommunity_list = json_object_new_array();
 	}


### PR DESCRIPTION
Reduce the memory and cpu footprint when formatting a single index in an ecomm.
When refreshing the json version of a comm or lcomm, free any existing json object before regenerating a new one.

Part of this was reported as F-078 in the 2026_05_27 batch of reports from Qifan Zhang
