### PR TITLE
pimd: fix dense mode State Refresh relay forwarding

### DIFF
--- a/pimd/pim_state_refresh.c
+++ b/pimd/pim_state_refresh.c
@@ -35,6 +35,7 @@ int pim_staterefresh_recv(struct interface *ifp, pim_addr src_addr, uint8_t *buf
 	uint8_t *curr;
 	int curr_size;
 	struct pim_interface *pim_ifp = NULL, *pim_ifp2;
+	struct interface *ifp2;
 	struct pim_ifchannel *ch, *throwaway;
 	struct listnode *neighnode;
 	struct pim_neighbor *neigh;
@@ -155,14 +156,25 @@ int pim_staterefresh_recv(struct interface *ifp, pim_addr src_addr, uint8_t *buf
 
 	/* TODO: condition StateRefreshRateLimit(S,G) not implemented yet!! */
 
-	for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, neighnode, neigh)) {
-		if (!neigh->prefix_list)
+	/*
+	 * RFC 3973 4.5.2: forward the State Refresh on every downstream PIM
+	 * dense-mode interface, i.e. all PIM interfaces except the one the
+	 * message arrived on. Iterating the receiving interface's neighbor list
+	 * would only echo it back onto the incoming segment.
+	 */
+	FOR_ALL_INTERFACES (ifp->vrf, ifp2) {
+		pim_ifp2 = ifp2->info;
+
+		if (!pim_ifp2 || !pim_ifp2->pim_enable || ifp2 == ifp)
 			continue;
 
-		pim_ifp2 = neigh->interface->info;
+		if (!HAVE_DENSE_MODE(pim_ifp2->pim_mode))
+			continue;
+
 		if (pim_is_group_filtered(pim_ifp2, &up->sg.grp, &up->sg.src))
 			continue;
-		pim_ifchannel_find(neigh->interface, &up->sg, &ch, &throwaway);
+
+		pim_ifchannel_find(ifp2, &up->sg, &ch, &throwaway);
 		if (!ch)
 			p = 0;
 		else {
@@ -178,17 +190,19 @@ int pim_staterefresh_recv(struct interface *ifp, pim_addr src_addr, uint8_t *buf
 		}
 
 		pim_msg_size =
-			pim_staterefresh_build_msg(pim_msg, sizeof(pim_msg), neigh->interface,
-						   up->sg.grp, up->sg.src, pim_ifp2->primary_address,
+			pim_staterefresh_build_msg(pim_msg, sizeof(pim_msg), ifp2, up->sg.grp,
+						   up->sg.src, pim_ifp2->primary_address,
 						   up->rpf.source_nexthop.mrib_metric_preference,
 						   up->rpf.source_nexthop.mrib_route_metric, 0,
-						   IPV4_MAX_BITLEN, header->ttl, p, header->n, 1, 0,
-						   pim_ifp2->pim->staterefresh_time);
+						   IPV4_MAX_BITLEN, header->ttl, p, header->n, 1,
+						   0, pim_ifp2->pim->staterefresh_time);
 
-		if (pim_msg_send(pim_ifp2->pim_sock_fd, pim_ifp2->primary_address,
-				 neigh->source_addr, pim_msg, pim_msg_size, neigh->interface)) {
-			zlog_warn("%s: could not send PIM message on interface %s", __func__,
-				  ifp->name);
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp2->pim_neighbor_list, neighnode, neigh)) {
+			if (pim_msg_send(pim_ifp2->pim_sock_fd, pim_ifp2->primary_address,
+					 neigh->source_addr, pim_msg, pim_msg_size, ifp2)) {
+				zlog_warn("%s: could not send PIM message on interface %s",
+					  __func__, ifp2->name);
+			}
 		}
 	}
 
@@ -321,13 +335,10 @@ void pim_send_staterefresh(struct pim_upstream *up)
 							   0, pim_ifp2->pim->staterefresh_time);
 
 			for (ALL_LIST_ELEMENTS_RO(pim_ifp2->pim_neighbor_list, neighnode, neigh)) {
-				if (!neigh->prefix_list)
-					continue;
-
 				if (pim_msg_send(pim_ifp2->pim_sock_fd, pim_ifp2->primary_address,
 						 neigh->source_addr, pim_msg, pim_msg_size, ifp2)) {
 					zlog_warn("%s: could not send PIM message on interface %s",
-						  __func__, ifp->name);
+						  __func__, ifp2->name);
 				}
 			}
 		}

--- a/tests/topotests/pim_dense/test_pim_dense.py
+++ b/tests/topotests/pim_dense/test_pim_dense.py
@@ -1147,6 +1147,71 @@ def test_pim_dense_pruned_state_persists(request):
         assert result is None, "Pruned state lost on {}: {}".format(dut, result)
 
 
+def verify_state_refresh_received(tgen, router, src, group):
+    """Return None once the router has logged a received State Refresh for (S,G).
+
+    R5/R6 only neighbor R3, so any State Refresh they receive must have been
+    relayed downstream through R2 -> R3. This is exactly the forwarding path that
+    pim_staterefresh_recv() implements, so it confirms the relay works end to end.
+    """
+    logfile = os.path.join(tgen.logdir, router, "pimd.log")
+    try:
+        with open(logfile) as f:
+            log = f.read()
+    except IOError:
+        return "could not open {}".format(logfile)
+
+    for line in log.splitlines():
+        if "pim_staterefresh_recv" not in line:
+            continue
+        # The detailed trace logs "pim_staterefresh_recv: from ... (S,G)=(<src>,<group>)"
+        if src in line and group in line:
+            return None
+    return "no State Refresh for ({},{}) received on {}".format(src, group, router)
+
+
+def test_pim_dense_state_refresh_relay(request):
+    """Verify State Refresh is relayed downstream to multi-hop dense routers.
+
+    R5 and R6 are two/three hops below the FHR (H1 -> R1 -> R2 -> R3 -> R5/R6)
+    and only neighbor R3. They can therefore only see a State Refresh if R2 and
+    R3 each forward it on their downstream interfaces. This exercises the
+    pim_staterefresh_recv() relay path.
+    """
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    stop_all_hosts()
+
+    step("Enable State Refresh tracing on the relay-dependent downstream routers")
+    for dut in ("r5", "r6"):
+        tgen.gears[dut].vtysh_cmd("debug pim trace")
+
+    try:
+        step("Send dense traffic so the FHR (r1) originates State Refresh")
+        result = app_helper.run_traffic("h1", DENSE_GROUP, bind_intf="h1-eth0")
+        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+        step("Verify State Refresh propagated through r2 -> r3 to r5 and r6")
+        for dut in ("r5", "r6"):
+            test_func = functools.partial(
+                verify_state_refresh_received, tgen, dut, SRC, DENSE_GROUP
+            )
+            _, result = topotest.run_and_expect(test_func, None, count=45, wait=2)
+            assert result is None, "Testcase {} : Failed Error: {}".format(
+                tc_name, result
+            )
+    finally:
+        for dut in ("r5", "r6"):
+            tgen.gears[dut].vtysh_cmd("no debug pim trace")
+
+    stop_all_hosts()
+
+
 def test_pim_sparse_non_rp_upstream_cleanup(request):
     """Verify non-RP sparse upstream cleans up after the last receiver leaves."""
     tgen = get_topogen()


### PR DESCRIPTION
The State Refresh relay path had two bugs that prevented multi-hop
propagation in dense-mode. 