### PR TITLE
zebra: zebra crash in v6 RA code

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -224,6 +224,7 @@ static int if_zebra_delete_hook(struct interface *ifp)
 			route_table_finish(zebra_if->ipv4_subnets);
 
 		rtadv_if_fini(zebra_if);
+		rtadv_stop_ra(ifp, true);
 
 		bond = &zebra_if->bond_info;
 		if (bond && bond->mbr_zifs)

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1411,6 +1411,13 @@ static void rtadv_start_interface_events(struct zebra_vrf *zvrf,
 {
 	struct adv_if *adv_if = NULL;
 
+	if (!if_is_operative(zif->ifp)) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s(%s) is not up yet, delaying until it is up", zif->ifp->name,
+				   zvrf->vrf->name);
+		return;
+	}
+
 	if (zif->ifp->ifindex == IFINDEX_INTERNAL) {
 		if (IS_ZEBRA_DEBUG_EVENT)
 			zlog_debug(


### PR DESCRIPTION
The crash happens in RA code, when an freed up interface is tried to be processed in wheel timer.

Fix:
Added code to clean up the freed up interface from wheel timer

Signed-off-by: Soumya Roy souroy@nvidia.com