### PR TITLE
yang: Prefix mismatch in frr-zebra.yang

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -3135,7 +3135,7 @@ module frr-zebra {
         type identityref {
           base frr-rt:afi-safi-type;
         }
-        must ". = 'frr-routing:ipv4-unicast' or . = 'frr-routing:ipv4-multicast' or . = 'frr-routing:ipv6-unicast' or . = 'frr-routing:ipv6-multicast'" {
+        must ". = 'frr-rt:ipv4-unicast' or . = 'frr-rt:ipv4-multicast' or . = 'frr-rt:ipv6-unicast' or . = 'frr-rt:ipv6-multicast'" {
           error-message "Only IPv4 and IPv6 unicast and multicast import-table entries are supported.";
         }
         description


### PR DESCRIPTION
frr-zebra.yang:3138: warning: "frr-routing" looks like a prefix but is not defined
Prefix mismatch in frr-zebra.yangng