### PR TITLE
bgpd: free community json object before regenerating  (backport #22176 to 10.3)

### DIFF
--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -201,6 +201,8 @@ static void set_community_string(struct community *com, bool make_json,
 		return;
 
 	if (make_json) {
+		if (com->json)
+			json_object_put(com->json);
 		com->json = json_object_new_object();
 		json_community_list = json_object_new_array();
 	}

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -179,6 +179,8 @@ static void set_lcommunity_string(struct lcommunity *lcom, bool make_json,
 		return;
 
 	if (make_json) {
+		if (lcom->json)
+			json_object_put(lcom->json);
 		lcom->json = json_object_new_object();
 		json_lcommunity_list = json_object_new_array();
 	}


### PR DESCRIPTION
Free a comm/lcomm object's existing json version before regenerating it ; backport to 10.3

This is the 10.3 backport of #22176 - one of the commits in that PR isn't relevant on 10.3