### PR TITLE
bgpd: fix spelling in 'show bgp neighbors json'

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17190,10 +17190,9 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint16_t sh_flags, bo
 								"recieved"); /* misspelled for compatibility */
 						}
 					}
-					json_object_object_add(
-						json_cap,
-						"extendedNexthopFamililesByPeer",
-						json_nxt);
+					json_object_object_add(json_cap,
+							       "extendedNexthopFamiliesByPeer",
+							       json_nxt);
 				}
 			}
 

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_enhe.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_enhe.py
@@ -131,7 +131,7 @@ def test_bgp_dynamic_capability_enhe():
                 "neighborCapabilities": {
                     "dynamic": "advertisedAndReceived",
                     "extendedNexthop": "advertisedAndReceived",
-                    "extendedNexthopFamililesByPeer": {
+                    "extendedNexthopFamiliesByPeer": {
                         "ipv4Unicast": "recieved",
                     },
                 },


### PR DESCRIPTION
Change misspelled 'extendedNexthopFamililesByPeer' JSON keyword to 'extendedNexthopFamiliesByPeer'.