### PR TITLE
bgpd: free srv6_l3service object in failed parse path

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3464,8 +3464,12 @@ bgp_attr_srv6_service(struct bgp_attr_parser_args *args)
 		if (length > BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO_LENGTH) {
 			err = bgp_attr_srv6_service_data(args);
 
-			if (err != BGP_ATTR_PARSE_PROCEED)
+			/* l3service object hasn't been interned yet - must free it */
+			if (err != BGP_ATTR_PARSE_PROCEED) {
+				bgp_attr_srv6_l3service_free(attr->srv6_l3service);
+				attr->srv6_l3service = NULL;
 				return err;
+			}
 		}
 
 		attr->srv6_l3service = bgp_attr_srv6_l3service_intern(attr->srv6_l3service);


### PR DESCRIPTION
If the srv6_l3service parse fails, ensure we delete the un-interned l3service object that was allocated. (This is the 10.6 and earlier version of PR #22198 )
