### PR TITLE
ospfd: Validate PREFIX_SID subtlv len before accessing

### DIFF
--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1135,6 +1135,12 @@ static struct sr_prefix *get_ext_prefix_sid(struct tlv_header *tlvh,
 
 		switch (ntohs(sub_tlvh->type)) {
 		case EXT_SUBTLV_PREFIX_SID:
+			if (ntohs(sub_tlvh->length) < EXT_SUBTLV_PREFIX_SID_SIZE) {
+				zlog_warn("SR : Invalid PREFIX_SID subtlv size");
+				XFREE(MTYPE_OSPF_SR_PARAMS, srp);
+				return NULL;
+			}
+
 			psid = (struct ext_subtlv_prefix_sid *)sub_tlvh;
 			if (psid->algorithm != SR_ALGORITHM_SPF) {
 				flog_err(EC_OSPF_INVALID_ALGORITHM,


### PR DESCRIPTION
Validate the subtlv length before accessing the subtlv data.
This was reported as F-2 in the 6/4/2026 report from causalsecurity.

