### PR TITLE
zebra: Allow rnh evaluation for a queued and !installed rn

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -738,7 +738,8 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 				continue;
 			}
 
-			if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED)) {
+			if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED) &&
+			    !CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
 						"        Route Entry %s queued",


### PR DESCRIPTION
Currently if you have this situation:

rn -> dest -> re.

If the re is queued when doing evaluation of the route node it is currently continuing the lookup if the re is queued. This can lead to situations, where you have say these nodes installed:

0.0.0.0/0
1.1.1.1/32 ( this is the rn being evaluated, queued, installed )

Now 1.1.1.1/32 is being evaluated, it is also queued, we continue and go to the 0.0.0.0/0 node.  Now if there was a rnh being tracked on the 1.1.1.1/32 route it is moved to the the 0.0.0.0/0 node, and as such upper level protocols are being told about the change to 0.0.0.0/0, and if resolve-via-default is not turned on, the rnh is set to a unresolved status.  Causing protocols that use this to react to this situation.  When the queued status is shortly removed( as that this happens in a suppress-fib situation ) after the kernel signals that the route is usable again, the rnh resolution is done again and moved from the 0.0.0.0/0 node back to the 1.1.1.1/32 node.

This creates churn.  Currently when resolving a prefix through 1.1.1.1/32 we allow the route to be queued and installed.  This just extends that metaphor to the rnh code as well.  Thus prevent churn when
there should be none.