### PR TITLE
pimd: fix heap OOB write in BSM fragmenter

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -846,6 +846,29 @@ static bool pim_bsm_send_intf(uint8_t *buf, int len, struct interface *ifp,
 	return true;
 }
 
+/* Send the current fragment and construct the next one. Reuse old packet
+ * buffer; PIM/BSM headers remain, pkt resets to firstgrp_ptr.
+ */
+static void pim_bsm_frag_flush(struct pim_interface *pim_ifp, uint8_t *pak_start, uint8_t **pkt,
+			       uint8_t *firstgrp_ptr, uint32_t *this_pkt_rem, uint32_t pim_mtu,
+			       pim_addr dst_addr, struct interface *ifp, bool no_fwd)
+{
+	uint32_t this_pkt_len;
+
+	if (*pkt <= firstgrp_ptr) {
+		*this_pkt_rem = pim_mtu - (PIM_BSM_HDR_LEN + PIM_MSG_HEADER_LEN);
+		return;
+	}
+
+	this_pkt_len = pim_mtu - *this_pkt_rem;
+	pim_msg_build_header(pim_ifp->primary_address, dst_addr, pak_start, this_pkt_len,
+			     PIM_MSG_TYPE_BOOTSTRAP, no_fwd);
+	pim_bsm_send_intf(pak_start, this_pkt_len, ifp, dst_addr);
+
+	*pkt = firstgrp_ptr;
+	*this_pkt_rem = pim_mtu - (PIM_BSM_HDR_LEN + PIM_MSG_HEADER_LEN);
+}
+
 static bool pim_bsm_frag_send(uint8_t *buf, uint32_t len, struct interface *ifp,
 			      uint32_t pim_mtu, pim_addr dst_addr, bool no_fwd)
 {
@@ -917,6 +940,20 @@ static bool pim_bsm_frag_send(uint8_t *buf, uint32_t len, struct interface *ifp,
 		 *                     the frag
 		 * this_rp_cnt    ---> how many rp have we parsed
 		 */
+		if (parsed_len + PIM_BSM_GRP_LEN > len) {
+			if (PIM_DEBUG_BSM)
+				zlog_debug("%s: truncated BSM group header", __func__);
+			XFREE(MTYPE_PIM_BSM_PKT_VAR_MEM, pak_start);
+			return false;
+		}
+
+		/* Flush when the current fragment cannot hold another group + one RP */
+		if (this_pkt_rem < PIM_BSM_GRP_LEN + PIM_BSM_RP_LEN) {
+			pim_bsm_frag_flush(pim_ifp, pak_start, &pkt, firstgrp_ptr, &this_pkt_rem,
+					   pim_mtu, dst_addr, ifp, no_fwd);
+			pak_pending = false;
+		}
+
 		grpinfo = (struct bsmmsg_grpinfo *)buf;
 		memcpy(pkt, buf, PIM_BSM_GRP_LEN);
 		curgrp = (struct bsmmsg_grpinfo *)pkt;
@@ -928,6 +965,21 @@ static bool pim_bsm_frag_send(uint8_t *buf, uint32_t len, struct interface *ifp,
 		/* initialize rp count and total_rp_cnt before the rp loop */
 		this_rp_cnt = 0;
 		total_rp_cnt = grpinfo->frag_rp_count;
+
+		/* Bound RP count against remaining source bytes (byte-exact) */
+		if ((uint32_t)total_rp_cnt * PIM_BSM_RP_LEN > (uint32_t)(len - parsed_len)) {
+			if (PIM_DEBUG_BSM)
+				zlog_debug("%s: BSM frag_rp_count exceeds remaining input",
+					   __func__);
+			XFREE(MTYPE_PIM_BSM_PKT_VAR_MEM, pak_start);
+			return false;
+		}
+
+		if (total_rp_cnt == 0) {
+			/* Group with no RPs in this fragment; outer loop only */
+			pak_pending = (pkt > firstgrp_ptr);
+			continue;
+		}
 
 		/* Loop till all RPs for the group parsed */
 		while (this_rp_cnt < total_rp_cnt) {
@@ -946,9 +998,31 @@ static bool pim_bsm_frag_send(uint8_t *buf, uint32_t len, struct interface *ifp,
 			else
 				frag_rp_cnt = rp_fit_cnt;
 
+			/* Unreachable: the outer-loop pre-flush guarantees
+			 * this_pkt_rem >= GRP_LEN + RP_LEN before the group
+			 * header is written, so rp_fit_cnt >= 1 here and
+			 * frag_rp_cnt >= 1 by the loop guard.  Guard anyway
+			 * so a future refactor cannot silently spin forever.
+			 */
+			if (frag_rp_cnt == 0) {
+				if (PIM_DEBUG_BSM)
+					zlog_debug("%s: BUG: frag_rp_cnt zero in RP loop",
+						   __func__);
+				XFREE(MTYPE_PIM_BSM_PKT_VAR_MEM, pak_start);
+				return false;
+			}
+
+			copy_byte_count = frag_rp_cnt * PIM_BSM_RP_LEN;
+			if (parsed_len + copy_byte_count > len) {
+				if (PIM_DEBUG_BSM)
+					zlog_debug("%s: BSM RP data exceeds remaining input",
+						   __func__);
+				XFREE(MTYPE_PIM_BSM_PKT_VAR_MEM, pak_start);
+				return false;
+			}
+
 			/* populate the frag rp count for the current grp */
 			curgrp->frag_rp_count = frag_rp_cnt;
-			copy_byte_count = frag_rp_cnt * PIM_BSM_RP_LEN;
 
 			/* copy all the rp that we are fitting in this
 			 * frag for the grp
@@ -967,25 +1041,25 @@ static bool pim_bsm_frag_send(uint8_t *buf, uint32_t len, struct interface *ifp,
 			    || (this_pkt_rem
 				< (PIM_BSM_GRP_LEN + PIM_BSM_RP_LEN))) {
 				/* No space to fit in more rp, send this pkt */
-				this_pkt_len = pim_mtu - this_pkt_rem;
-				pim_msg_build_header(
-					pim_ifp->primary_address, dst_addr,
-					pak_start, this_pkt_len,
-					PIM_MSG_TYPE_BOOTSTRAP, no_fwd);
-				pim_bsm_send_intf(pak_start, this_pkt_len, ifp,
-						  dst_addr);
-
-				/* Construct next fragment. Reuse old packet */
-				pkt = firstgrp_ptr;
-				this_pkt_rem = pim_mtu - (PIM_BSM_HDR_LEN
-							  + PIM_MSG_HEADER_LEN);
+				pim_bsm_frag_flush(pim_ifp, pak_start, &pkt, firstgrp_ptr,
+						   &this_pkt_rem, pim_mtu, dst_addr, ifp, no_fwd);
 
 				/* If pkt can't accommodate next group + at
 				 * least one rp, we must break out of this inner
 				 * loop and process next RP
 				 */
-				if (total_rp_cnt == this_rp_cnt)
+				if (total_rp_cnt == this_rp_cnt) {
+					pak_pending = false;
 					break;
+				}
+
+				if (this_pkt_rem < PIM_BSM_GRP_LEN + PIM_BSM_RP_LEN) {
+					if (PIM_DEBUG_BSM)
+						zlog_debug("%s: fragment MTU too small for continuation group",
+							   __func__);
+					XFREE(MTYPE_PIM_BSM_PKT_VAR_MEM, pak_start);
+					return false;
+				}
 
 				/* If some more RPs for the same group pending,
 				 * fill grp hdr
@@ -1349,6 +1423,13 @@ bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 		if (grpinfo.rp_count == 0) {
 			struct bsm_rpinfo *old_rpinfo;
 
+			if (grpinfo.frag_rp_count != 0) {
+				if (PIM_DEBUG_BSM)
+					zlog_debug("%s: rp_count zero but frag_rp_count %u",
+						   __func__, grpinfo.frag_rp_count);
+				return false;
+			}
+
 			/* BSR explicitly no longer has RPs for this group */
 			if (!bsgrp)
 				continue;
@@ -1366,6 +1447,13 @@ bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 			pim_free_bsgrp_node(scope->bsrp_table, &bsgrp->group);
 			pim_free_bsgrp_data(bsgrp);
 			continue;
+		}
+
+		if (grpinfo.frag_rp_count > grpinfo.rp_count) {
+			if (PIM_DEBUG_BSM)
+				zlog_debug("%s: frag_rp_count %u exceeds rp_count %u", __func__,
+					   grpinfo.frag_rp_count, grpinfo.rp_count);
+			return false;
 		}
 
 		if (!bsgrp) {


### PR DESCRIPTION
Prevent pre-auth heap overflow when forwarding oversized BSMs with zero-RP group records by bounding fragment output and source RP copies, and reject rp_count/frag_rp_count mismatches at parse time.