### PR TITLE
zebra:  fix NHGs with down/up interface

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -184,6 +184,26 @@ static void if_down_nhg_dependents(const struct interface *ifp)
 
 	frr_each (nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
 		frrtrace(2, frr_zebra, if_down_nhg_dependents, ifp, rb_node_dep->nhe);
+
+		/* Notify FPM of the deletion so it can clean up. */
+		if (CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL) &&
+		    (CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
+		     CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_QUEUED))) {
+			switch (dplane_nexthop_delete(rb_node_dep->nhe)) {
+			case ZEBRA_DPLANE_REQUEST_QUEUED:
+				SET_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_QUEUED);
+				break;
+			case ZEBRA_DPLANE_REQUEST_FAILURE:
+				flog_err(EC_ZEBRA_DP_DELETE_FAIL,
+					 "Failed to send NHG delete to FPM for %pNG",
+					 rb_node_dep->nhe);
+				break;
+			case ZEBRA_DPLANE_REQUEST_SUCCESS:
+				UNSET_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_INSTALLED);
+				break;
+			}
+		}
+
 		zebra_nhg_check_valid(rb_node_dep->nhe);
 	}
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -4117,14 +4117,6 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 
 	frr_each (nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
 		/*
-		 * If this nhe has 'initial delay' flag set, we should not install this
-		 * in kernel in case of any interface events. Zebra created this entry
-		 * while processing the kernel/connected routes, just to pretend
-		 * the successful kernel install of this NHG
-		 */
-		if (CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL))
-			continue;
-		/*
 		 * The nexthop associated with this was set as !ACTIVE
 		 * so we need to turn it back to active when we get to
 		 * this point again


### PR DESCRIPTION
commit 1:

zebra: notify the deletion of nexthop

Let `if_down_nhg_dependents()` to call `dplane_nexthop_delete()` for
initial-delay NHGs that have been installed in FPM. Ensure only FPM receives
the deletion, and keep FPM state consistent when interface comes down.


commit 2:

Revert "zebra: do not install the nhg for kernel/connected routes"

This reverts commit d7f6d9580b22e7d0de61f25522339abc31d35772.

Remove the skip of `NEXTHOP_GROUP_INITIAL_DELAY_INSTALL` in
`zebra_interface_nhg_reinstall()` added by commit d7f6d9580b22 ("zebra:
do not install the nhg for kernel/connected routes") to properly handle
initial-delay NHGs across interface flaps (for example, from "down" to "up")

The original fix addressed a scenario where an IPv4 "intf_address event"
would trigger `zebra_interface_nhg_reinstall()` and install NHGs meant
to be delayed. After commit e28162b215 ("zebra: Move nhg reinstallation
into if_up proper"), this function is only called from `if_up()`, making
the original trigger impossible.

So, before the commmit e55b5babbcc (zebra: On delay install of NHG send to the fpm),
the skip is just useless but harmless. But now the skip is harmful with
initial-delay NHGs in `zif->nhg_dependents`:
the initial-delay NHGs are never sent to FPM when the interface comes up.

IMHO there shouldn't be such init-delay NHGs on the linked list now because
`zebra_interface_nhg_reinstall` is not triggered by "intf_address event" now.