### PR TITLE
tools, doc: Allow per daemon control of FDS on startup

### DIFF
--- a/doc/user/setup.rst
+++ b/doc/user/setup.rst
@@ -116,6 +116,16 @@ allow this to happen.
 
 ::
 
+   MAX_BGPD_FDS=8192
+
+A per-daemon limit may be specified as ``MAX_<DAEMON>_FDS`` (the daemon name in
+upper case).  When set, it takes precedence over ``MAX_FDS`` for that daemon
+only, falling back to ``MAX_FDS`` when no per-daemon value is present.  This
+allows a single daemon that needs a large number of file descriptors to be
+raised without forcing every other daemon to use the same high value.
+
+::
+
   FRR_NO_ROOT="yes"
 
 This option allows you to run FRR as a non-root user. Use this option

--- a/tools/etc/frr/daemons
+++ b/tools/etc/frr/daemons
@@ -91,6 +91,14 @@ pathd_options="  -A 127.0.0.1"
 # in say BGP.
 #
 #MAX_FDS=1024
+#
+# A per-daemon limit may be specified as MAX_<DAEMON>_FDS (the daemon name in
+# upper case) and, when set, it takes precedence over MAX_FDS for that daemon
+# only.  This allows a single daemon that needs a large number of FD's (for
+# example bgpd with many peers) to be raised without forcing every other
+# daemon to use the same high value.
+#
+#MAX_BGPD_FDS=8192
 
 # Uncomment this option if you want to run FRR as a non-root user. Note that
 # you should know what you are doing since most of the daemons need root

--- a/tools/frr.in
+++ b/tools/frr.in
@@ -110,11 +110,18 @@ check_daemon()
 # The Frr daemons creates the pidfile when starting.
 start()
 {
-	local dmn inst
+	local dmn inst dmn_max_fds dmn_uc
 	dmn="$1"
 	inst="$2"
 
-	ulimit -n $MAX_FDS > /dev/null 2> /dev/null
+	# Allow a per-daemon MAX_<DAEMON>_FDS to override the global MAX_FDS so
+	# that daemons needing a large number of FDs do not force every other
+	# daemon to use an equally high value.  The daemon name is upper cased,
+	# e.g. bgpd uses MAX_BGPD_FDS.
+	dmn_uc="`echo "$dmn" | tr '[:lower:]' '[:upper:]'`"
+	eval dmn_max_fds="\$MAX_${dmn_uc}_FDS"
+	[ "$dmn_max_fds" = "" ] && dmn_max_fds="$MAX_FDS"
+	ulimit -n $dmn_max_fds > /dev/null 2> /dev/null
 	if [ "$dmn" = "watchfrr" ]; then
 
 		# We may need to restart watchfrr if new daemons are added and/or

--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -154,7 +154,7 @@ daemon_prep() {
 }
 
 daemon_start() {
-	local dmninst daemon inst args instopt wrap bin
+	local dmninst daemon inst args instopt wrap bin daemon_max_fds daemon_uc
 
 	is_user_root || exit 1
 
@@ -163,7 +163,14 @@ daemon_start() {
 
 	daemon_inst "$1"
 
-	[ "$MAX_FDS" != "" ] && ulimit -n "$MAX_FDS" > /dev/null 2> /dev/null
+	# Allow a per-daemon MAX_<DAEMON>_FDS to override the global MAX_FDS so
+	# that daemons needing a large number of FDs do not force every other
+	# daemon to use an equally high value.  The daemon name is upper cased,
+	# e.g. bgpd uses MAX_BGPD_FDS.
+	daemon_uc="`echo "$daemon" | tr '[:lower:]' '[:upper:]'`"
+	eval daemon_max_fds="\$MAX_${daemon_uc}_FDS"
+	[ "$daemon_max_fds" = "" ] && daemon_max_fds="$MAX_FDS"
+	[ "$daemon_max_fds" != "" ] && ulimit -n "$daemon_max_fds" > /dev/null 2> /dev/null
 	daemon_prep "$daemon" "$inst" || return 1
 	if test ! -d "$V_PATH"; then
 		install -g "$FRR_GROUP" -o "$FRR_USER" -m "$FRR_CONFIG_MODE" -d "$V_PATH"


### PR DESCRIPTION
Add a `MAX_DAEMON_FDS=XXX` value to the daemons file. This will allow control of that daemons max fd's open. If this is not specified fall back to MAX_FDS for
that daemon.

This is mainly for control over BGPD.  It's not unusual for bgpd to need a large number of fd's but other
daemons not so much.  Modify the code to allow this.