### PR TITLE
mgmtd: skip history recording for per-command VTY commits

### DIFF
--- a/mgmtd/mgmt_txn_cfg.c
+++ b/mgmtd/mgmt_txn_cfg.c
@@ -532,7 +532,9 @@ static void txn_finish_commit(struct txn_req_commit *ccreq, enum mgmt_result res
 	accept_changes = ccreq->phase >= MGMTD_COMMIT_PHASE_APPLY_CFG && apply_op;
 	discard_changes = (result == MGMTD_SUCCESS && ccreq->abort);
 	if (accept_changes) {
-		bool create_cmt_info_rec = (result != MGMTD_NO_CFG_CHANGES && !ccreq->rollback);
+		/* unlock_info == true: per-command implicit commit; skip history. */
+		bool create_cmt_info_rec = (result != MGMTD_NO_CFG_CHANGES && !ccreq->rollback &&
+					    !ccreq->unlock_info);
 
 		mgmt_ds_copy_dss(ccreq->dst_ds_ctx, ccreq->src_ds_ctx, create_cmt_info_rec);
 	}


### PR DESCRIPTION
Each per-command VTY commit (e.g. every 'ip route' in classic CLI mode) triggered mgmt_history_new_record(), which serialises the entire running config to a JSON file.  With N routes already installed, this is an O(N) operation on every commit, making bulk configuration O(N^2) overall.

Per-command commits are identified by unlock_info == true (the datastores are locked and unlocked around each individual command).  These are not meaningful rollback checkpoints — they are fine-grained operational changes, not user-initiated transaction boundaries.  Skip history recording for them; only explicit 'commit' commands and NETCONF/gRPC transactions create history records.