### PR TITLE
lib: Some smaller code fixes for typesafe hash _member function

### DIFF
--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -1009,10 +1009,11 @@ macro_pure bool prefix ## _member(const struct prefix##_head *h,               \
 	const struct thash_item *hitem = h->hh.entries[hbits];                 \
 	while (hitem && hitem->hashval < hval)                                 \
 		hitem = hitem->next;                                           \
-	for (hitem = h->hh.entries[hbits]; hitem && hitem->hashval <= hval;    \
-	     hitem = hitem->next)                                              \
+	while (hitem && hitem->hashval == hval) {                              \
 		if (hitem == &item->field.hi)                                  \
 			return true;                                           \
+		hitem = hitem->next;                                           \
+	}                                                                       \
 	return false;                                                          \
 }                                                                              \
 MACRO_REQUIRE_SEMICOLON() /* end */

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -1004,7 +1004,7 @@ macro_pure bool prefix ## _member(const struct prefix##_head *h,               \
 				  const type *item)                            \
 {                                                                              \
 	if (!h->hh.tabshift)                                                   \
-		return NULL;                                                   \
+		return false;                                                   \
 	uint32_t hval = item->field.hi.hashval, hbits = HASH_KEY(h->hh, hval); \
 	const struct thash_item *hitem = h->hh.entries[hbits];                 \
 	while (hitem && hitem->hashval < hval)                                 \


### PR DESCRIPTION
While looking through the code for the typesafe hash, I noticed some smaller inconsistencies in the typeseafe hash `_member` function:

1. `if (!h->hh.tabshift)` did `return NULL`. The functions return type is `bool`. While this works, it's misleading
2. Unnecessary comparison loop. The result of the `while` loop was simply discarded in the `for` init and loop did not do anything useful. Replaced the `for` with another `while`, so this aligns e.g. with `_del`