### PR TITLE
isisd: track ipv4 usability per adjacency and do not build routes for node unreachable via ipv4

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -946,3 +946,28 @@ int isis_adj_usage2levels(enum isis_adj_usage usage)
 	assert(!"Reached end of function where we are not expecting to");
 	return -1;
 }
+
+/*
+ * Compute (fresh, never cached) whether this adjacency currently has a
+ * usable IPv4/IPv6 nexthop: the local circuit must have an address in
+ * that address family, and the neighbor must have advertised one too.
+ */
+bool isis_adj_ipv4_usable(const struct isis_adjacency *adj)
+{
+	struct isis_circuit *circuit = adj->circuit;
+
+	if (!circuit)
+		return false;
+
+	return (fabricd_ip_addrs(circuit) && adj->ipv4_address_count);
+}
+
+bool isis_adj_ipv6_usable(const struct isis_adjacency *adj)
+{
+	struct isis_circuit *circuit = adj->circuit;
+
+	if (!circuit)
+		return false;
+
+	return (listcount(circuit->ipv6_link) && adj->ll_ipv6_count);
+}

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -146,4 +146,6 @@ void isis_adj_build_up_list(struct list *adjdb, struct list *list);
 int isis_adj_usage2levels(enum isis_adj_usage usage);
 void isis_bfd_startup_timer(struct event *event);
 const char *isis_adj_name(const struct isis_adjacency *adj);
+bool isis_adj_ipv4_usable(const struct isis_adjacency *adj);
+bool isis_adj_ipv6_usable(const struct isis_adjacency *adj);
 #endif /* ISIS_ADJACENCY_H */

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -49,6 +49,7 @@
 #include "isisd/isis_tx_queue.h"
 #include "isisd/isis_nb.h"
 #include "isisd/isis_ldp_sync.h"
+#include "isisd/isis_spf.h"
 
 DEFINE_MTYPE_STATIC(ISISD, ISIS_CIRCUIT, "ISIS circuit");
 
@@ -278,6 +279,26 @@ struct isis_circuit *circuit_scan_by_ifp(struct interface *ifp)
 DEFINE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
 	    (circuit));
 
+/*
+ * A local IP address was added or removed on this circuit. Re-evaluate
+ * which address families each adjacency can still be used for (we need a
+ * local address in that AF to reach the neighbor's nexthop), then
+ * re-originate our LSP and re-run SPF so any route whose nexthop is no
+ * longer usable is withdrawn. IPv6 adjacencies keep working across an
+ * IPv4 address removal and vice versa.
+ */
+static void isis_circuit_ip_addr_change_update(struct isis_circuit *circuit)
+{
+	if (circuit->area == NULL)
+		return;
+
+	lsp_regenerate_schedule(circuit->area, circuit->is_type, 0);
+	if (circuit->is_type & IS_LEVEL_1)
+		isis_spf_schedule(circuit->area, IS_LEVEL_1);
+	if (circuit->is_type & IS_LEVEL_2)
+		isis_spf_schedule(circuit->area, IS_LEVEL_2);
+}
+
 void isis_circuit_add_addr(struct isis_circuit *circuit,
 			   struct connected *connected)
 {
@@ -308,9 +329,7 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 			SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR);
 		}
 
-		if (circuit->area)
-			lsp_regenerate_schedule(circuit->area, circuit->is_type,
-						0);
+		isis_circuit_ip_addr_change_update(circuit);
 
 #ifdef EXTREME_DEBUG
 		if (IS_DEBUG_EVENTS)
@@ -348,9 +367,7 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 				SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR6);
 			}
 		}
-		if (circuit->area)
-			lsp_regenerate_schedule(circuit->area, circuit->is_type,
-						0);
+		isis_circuit_ip_addr_change_update(circuit);
 
 #ifdef EXTREME_DEBUG
 		if (IS_DEBUG_EVENTS)
@@ -386,9 +403,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 		if (ip) {
 			listnode_delete(circuit->ip_addrs, ip);
 			prefix_ipv4_free(&ip);
-			if (circuit->area)
-				lsp_regenerate_schedule(circuit->area,
-							circuit->is_type, 0);
+			isis_circuit_ip_addr_change_update(circuit);
 		} else {
 			zlog_warn(
 				"Nonexistent ip address %pFX removal attempt from circuit %s",
@@ -449,9 +464,8 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 						  ip6))
 				zlog_warn("  %pFX", (struct prefix *)ip6);
 			zlog_warn("End of addresses");
-		} else if (circuit->area)
-			lsp_regenerate_schedule(circuit->area, circuit->is_type,
-						0);
+		} else
+			isis_circuit_ip_addr_change_update(circuit);
 
 		prefix_ipv6_free(&ipv6);
 	}

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1141,6 +1141,10 @@ static struct spf_adj_ref *adj_find(struct spf_adj_list_head *adj_list, const ui
 		if (mtid == ISIS_MT_IPV4_UNICAST &&
 		    !speaks(adj->nlpids.nlpids, adj->nlpids.count, family))
 			continue;
+		if (family == AF_INET && !isis_adj_ipv4_usable(adj))
+			continue;
+		if (family == AF_INET6 && !isis_adj_ipv6_usable(adj))
+			continue;
 		return ref;
 	}
 


### PR DESCRIPTION
When an IP address is removed from an interface, the ISIS adjacency to the neighbor can remain fully up if the other address family is still usable (IPv6 keeps the adjacency alive). SPF continues to compute routes toward the neighbor's advertised prefixes using the now-unreachable IPv4 nexthop, because nothing tells SPF that the local circuit lost its IPv4 connectivity to that neighbor. The route is left installed pointing at a nexthop the router can no longer forward to.

An earlier version of this fix scheduled an additional local SPF run after lsp_regenerate_schedule() in the address deletion path. Testing showed this does not fix the problem: SPF still recomputes the same route through the same adjacency, since the adjacency itself is unaware that IPv4 is no longer usable on that circuit.

This version fixes the actual root cause:  by introducing isis_adj_ipv4_usable()/isis_adj_ipv6_usable() helper functions that compute AF usability fresh from the circuit's address list and the adjacency's neighbor address count (using fabricd_ip_addrs() for IPv4, matching process_hello()'s existing logic). SPF's adj_find() now calls these helpers and skips an adjacency for a given address family when it is not usable, so no route is built through a neighbor whose nexthop is unreachable in that AF. Usability is never cached on the adjacency struct. It is derived on-the-fly from primary state to avoid staleness.


Fixes: #5946

**FIX:**
isis_circuit_add_addr()/isis_circuit_del_addr() re-originate the local LSP and schedule an SPF run whenever the circuit's IPv4/IPv6 addressing changes, so routes are withdrawn as soon as the local address needed to reach the neighbor's nexthop is removed, while the adjacency (and its other address family) keeps working.
Re-adding the address restores the route.

Note: adj_has_mt() in adj_find() can independently short-circuit the usability check because tlvs_to_adj_mt_set() sets v4/v6 usability into adj->mt_set at hello time. In the address-removal case this doesn't cause any issue (the stale mt_set still includes the topology, so the flow reaches the fresh usability check, where it is detected that the address has been removed, so the routes won't be installed via that neighbour. This is expected.). Whereas, in the re-add case the stale mt_set may delay route restoration until the next hello. This is a pre-existing staleness issue not introduced or worsened by this patch.


**Testing:**
<details> <summary>Full test output</summary>

Testing:
- Pre-built frrouting/frr:latest (WITHOUT fix):
  - Removed address via vtysh "no ip address 12.0.0.10/24"
  - Adjacency stayed UP
  - Route 7.0.0.2/32 remained in FRR RIB (BUG)
  - Kernel had no route (desync)

- Custom build with fix:
  - Removed address via "ip addr del 12.0.0.10/24 dev eth0"
  - Adjacency stayed UP (via IPv6)
  - Route 7.0.0.2/32 correctly removed from FRR RIB (FIX WORKS)
  - FRR and kernel in sync

Note: ip addr del is used instead of vtysh no ip address because the address was assigned by Docker (not via mgmtd), so mgmtd reports "No changes found to be committed!". Both methods ultimately trigger the same kernel netlink notification -> zebra -> isis_circuit_del_addr() code path.

----------------------------------------


reproducing the issue:

ayush@ayush-sys frr-work % echo "BEFORE DELETE"
BEFORE DELETE
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor"

% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Area TEST:
  System Id           Interface   L  State        Holdtime SNPA
 1b9387e4cefd        eth0        1  Up            30       2020.2020.2020
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show ip route"

% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/0] via 12.0.0.1, eth0, 00:02:00
C>* 7.0.0.1/32 is directly connected, lo, 00:01:37
I>* 7.0.0.2/32 [115/20] via 12.0.0.20, eth0, weight 1, 00:01:07
I   12.0.0.0/24 [115/20] via 12.0.0.20, eth0 inactive, weight 1, 00:01:07
C>* 12.0.0.0/24 is directly connected, eth0, 00:02:00
ayush@ayush-sys frr-work % docker exec router1 ip route

default via 12.0.0.1 dev eth0 
7.0.0.2 nhid 8 via 12.0.0.20 dev eth0 proto isis metric 20 
12.0.0.0/24 dev eth0 proto kernel scope link src 12.0.0.10 
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % echo "DELETING ADDRESS"
DELETING ADDRESS
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "conf t" -c "interface eth0" -c "no ip address 12.0.0.10/24" -c "end"

% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % echo "AFTER DELETING"
AFTER DELETING
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor"

% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Area TEST:
  System Id           Interface   L  State        Holdtime SNPA
 1b9387e4cefd        eth0        1  Up            12       2020.2020.2020
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show ip route"
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/0] via 12.0.0.1, eth0, 00:03:03
C>* 7.0.0.1/32 is directly connected, lo, 00:02:40
I>* 7.0.0.2/32 [115/20] via 12.0.0.20, eth0, weight 1, 00:02:10
I   12.0.0.0/24 [115/20] via 12.0.0.20, eth0 inactive, weight 1, 00:02:10
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % docker exec router1 ip route
ayush@ayush-sys frr-work % 



----------------------

After fix:

ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show running-config" | grep -A6 "interface eth0"
interface eth0
 ip address 12.0.0.10/24
 ip router isis TEST
 ipv6 address fc00::10/64
 ipv6 router isis TEST
 isis network point-to-point
exit
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "configure" -c "log file /tmp/dbg.log debugging" -c "debug isis spf-events" -c "debug isis lsp-gen"

ISIS SPF events debugging is on
ISIS LSP generation debugging is on
ayush@ayush-sys frr-work % docker exec router1 sh -c "> /tmp/dbg.log"
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % echo "===== BEFORE DELETE ====="
===== BEFORE DELETE =====
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor detail"
Area TEST:
 fbd7f1dd9796        
    Interface: eth0, Level: 1, State: Up, Expires in 28s
    Adjacency flaps: 1, Last: 2m37s ago
    Circuit type: L1, Speaks: IPv4, IPv6
    SNPA: 2020.2020.2020
    Area Address(es):
      49.0001
    IPv4 Address(es):
      12.0.0.20
    IPv6 Address(es):
      fe80::3459:58ff:fec8:bcd8
    Global IPv6 Address(es):
      fd00:12::3
      fc00::20

ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor"       
Area TEST:
 System Id           Interface   L  State         Holdtime SNPA
 fbd7f1dd9796        eth0        1  Up            30       2020.2020.2020
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % 
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show ip route 7.0.0.2/32"
Routing entry for 7.0.0.2/32
  Known via "isis", distance 115, metric 20, best
  Last update 00:03:08 ago
  Flags: Selected 
  Status: Installed 
  * 12.0.0.20, via eth0, weight 1

ayush@ayush-sys frr-work % docker exec router1 ip route
default via 12.0.0.1 dev eth0 
7.0.0.2 nhid 13 via 12.0.0.20 dev eth0 proto isis metric 20 
12.0.0.0/24 dev eth0 proto kernel scope link src 12.0.0.10 
ayush@ayush-sys frr-work % echo "===== DELETING ADDRESS ====="
===== DELETING ADDRESS =====
ayush@ayush-sys frr-work % docker exec router1 sh -c "echo '##### DELETE NOW #####' >> /tmp/dbg.log"
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "conf t" -c "interface eth0" -c "no ip address 12.0.0.10/24" -c "end"
% Configuration applied with notes:
No changes found to be committed!
ayush@ayush-sys frr-work % docker exec router1 ip addr show eth0 | grep "inet "
ayush@ayush-sys frr % docker exec router1 ip addr show eth0    ---> address got correctly removed
11: eth0@if61: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether e6:40:c1:19:b5:49 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 fc00::10/64 scope global 
       valid_lft forever preferred_lft forever
    inet6 fd00:12::2/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::e440:c1ff:fe19:b549/64 scope link 
       valid_lft forever preferred_lft forever
ayush@ayush-sys frr-work % echo "===== RIGHT AFTER DELETE ====="               
===== RIGHT AFTER DELETE =====
ayush@ayush-sys frr-work % sleep 5
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor"
Area TEST:
 System Id           Interface   L  State         Holdtime SNPA
 fbd7f1dd9796        eth0        1  Up            28       2020.2020.2020
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor detail" ---> neighbour list up
Area TEST:
 fbd7f1dd9796        
    Interface: eth0, Level: 1, State: Up, Expires in 28s
    Adjacency flaps: 1, Last: 6m8s ago
    Circuit type: L1, Speaks: IPv4, IPv6
    SNPA: 2020.2020.2020
    Area Address(es):
      49.0001
    IPv4 Address(es):
      12.0.0.20
    IPv6 Address(es):
      fe80::3459:58ff:fec8:bcd8
    Global IPv6 Address(es):
      fd00:12::3
      fc00::20

ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show ip route 7.0.0.2/32"  ---> correctly got removed from routing table
% Network not in table
ayush@ayush-sys frr-work % docker exec router1 ip route
ayush@ayush-sys frr-work % echo "===== 45s LATER (does it self-resolve?) ====="
===== 45s LATER (does it self-resolve?) =====
ayush@ayush-sys frr-work % sleep 45
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor"  ---> neighbour list still up after 45s
Area TEST:
 System Id           Interface   L  State         Holdtime SNPA
 fbd7f1dd9796        eth0        1  Up            30       2020.2020.2020
ayush@ayush-sys frr-work % docker exec router1 vtysh -c "show isis neighbor detail"  ----> neighbour list is still up due to ipv6 hello packets
Area TEST:
 fbd7f1dd9796        
    Interface: eth0, Level: 1, State: Up, Expires in 28s
    Adjacency flaps: 1, Last: 7m51s ago
    Circuit type: L1, Speaks: IPv4, IPv6
    SNPA: 2020.2020.2020
    Area Address(es):
      49.0001
    IPv4 Address(es):
      12.0.0.20
    IPv6 Address(es):
      fe80::3459:58ff:fec8:bcd8
    Global IPv6 Address(es):
      fd00:12::3
      fc00::20


====ADD has also worked correctly====
ayush@ayush-sys frr % docker exec router1 ip addr add 12.0.0.10/24 dev eth0
sleep 10
docker exec router1 vtysh -c "show ip route 7.0.0.2/32"
Routing entry for 7.0.0.2/32
  Known via "isis", distance 115, metric 20, best
  Last update 00:00:10 ago
  Flags: Selected 
  Status: Installed 
  * 12.0.0.20, via eth0, weight 1



</details>

