### PR TITLE
ospf6d: flush self-originated LSAs in all areas on restart

### DIFF
--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -969,7 +969,8 @@ void ospf6_lsa_refresh(struct event *event)
 
 void ospf6_flush_self_originated_lsas_now(struct ospf6 *ospf6)
 {
-	struct listnode *node, *nnode;
+	struct listnode *node;
+	struct listnode *if_node, *if_nnode;
 	struct ospf6_area *oa;
 	struct ospf6_lsa *lsa;
 	const struct route_node *end = NULL;
@@ -990,7 +991,7 @@ void ospf6_flush_self_originated_lsas_now(struct ospf6 *ospf6)
 			lsa = ospf6_lsdb_next(end, lsa);
 		}
 
-		for (ALL_LIST_ELEMENTS(oa->if_list, node, nnode, oi)) {
+		for (ALL_LIST_ELEMENTS(oa->if_list, if_node, if_nnode, oi)) {
 			end = ospf6_lsdb_head(oi->lsdb_self, 0, 0,
 					      ospf6->router_id, &lsa);
 			while (lsa) {

--- a/tests/topotests/ospf6_flush_areas/r1/frr.conf
+++ b/tests/topotests/ospf6_flush_areas/r1/frr.conf
@@ -1,0 +1,19 @@
+hostname r1
+!
+ipv6 forwarding
+!
+interface r1-eth0
+ ipv6 address 2001:db8:12::1/64
+ ipv6 ospf6 area 0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+interface r1-eth1
+ ipv6 address 2001:db8:13::1/64
+ ipv6 ospf6 area 1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+router ospf6
+ ospf6 router-id 10.0.0.1
+!

--- a/tests/topotests/ospf6_flush_areas/r2/frr.conf
+++ b/tests/topotests/ospf6_flush_areas/r2/frr.conf
@@ -1,0 +1,13 @@
+hostname r2
+!
+ipv6 forwarding
+!
+interface r2-eth0
+ ipv6 address 2001:db8:12::2/64
+ ipv6 ospf6 area 0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+router ospf6
+ ospf6 router-id 10.0.0.2
+!

--- a/tests/topotests/ospf6_flush_areas/r3/frr.conf
+++ b/tests/topotests/ospf6_flush_areas/r3/frr.conf
@@ -1,0 +1,13 @@
+hostname r3
+!
+ipv6 forwarding
+!
+interface r3-eth0
+ ipv6 address 2001:db8:13::2/64
+ ipv6 ospf6 area 1
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 10
+!
+router ospf6
+ ospf6 router-id 10.0.0.3
+!

--- a/tests/topotests/ospf6_flush_areas/test_ospf6_flush_areas.py
+++ b/tests/topotests/ospf6_flush_areas/test_ospf6_flush_areas.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_ospf6_flush_areas.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2025 by Olasupo Okunaiya
+#
+
+"""
+test_ospf6_flush_areas.py: Test that OSPFv3 flushes self-originated LSAs in
+*all* areas when the process is reset.
+
+When an OSPFv3 process is reset or removed, ospf6d sets its self-originated
+LSAs to MaxAge and refloods them (RFC 2328 section 14.1) so neighbours can
+remove them from their link-state databases. This must happen for every area
+the router participates in, not just the first one.
+
+Topology:
+
+           area 0            area 1
+   r2 ------------- r1 ------------- r3
+
+r1 is an ABR with one interface in area 0 (towards r2) and one in area 1
+(towards r3). Once OSPFv3 has converged, both r2 and r3 hold r1's
+self-originated Router-LSA in their respective area databases.
+
+The test resets the OSPFv3 process on r1 ("clear ipv6 ospf6 process") and
+verifies that r1's Router-LSA is aged out (set to MaxAge) on BOTH neighbours.
+
+Regression test for the bug where ospf6_flush_self_originated_lsas_now()
+reused the area-loop listnode for the inner interface loop, so the area
+iteration stopped after the first area and self-originated LSAs in all
+other areas were never flushed (the area 1 neighbour kept the stale LSA).
+"""
+
+import os
+import sys
+from functools import partial
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.ospf6d]
+
+R1_ROUTER_ID = "10.0.0.1"
+OSPF6_LSA_MAXAGE = 3600
+
+
+def build_topo(tgen):
+    "Build function"
+
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    # r1-eth0 <-> r2-eth0 (area 0), r1-eth1 <-> r3-eth0 (area 1)
+    tgen.gears["r1"].add_link(tgen.gears["r2"])
+    tgen.gears["r1"].add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, rname, "frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _r1_router_lsa_age(router):
+    """Return the age of r1's area-scoped Router-LSA as seen by `router`,
+    or None if it is not present."""
+    tgen = get_topogen()
+    output = tgen.gears[router].vtysh_cmd("show ipv6 ospf6 database router")
+    for line in output.splitlines():
+        fields = line.split()
+        # Type LSId AdvRouter Age SeqNum ...
+        # Rtr  0.0.0.0  10.0.0.1  11  80000002  ...
+        if len(fields) >= 5 and fields[0] == "Rtr" and fields[2] == R1_ROUTER_ID:
+            try:
+                return int(fields[3])
+            except ValueError:
+                return None
+    return None
+
+
+def _r1_full_neighbor_count():
+    "Return how many of r1's neighbours are in Full state."
+    tgen = get_topogen()
+    output = tgen.gears["r1"].vtysh_cmd("show ipv6 ospf6 neighbor json", isjson=True)
+    return len([n for n in output.get("neighbors", []) if n.get("state") == "Full"])
+
+
+def _converged():
+    """Return None once r1 has both adjacencies Full and both neighbours
+    hold r1's Router-LSA."""
+    if _r1_full_neighbor_count() < 2:
+        return "adjacencies not Full"
+    for rname in ("r2", "r3"):
+        if _r1_router_lsa_age(rname) is None:
+            return "r1 Router-LSA missing on {}".format(rname)
+    return None
+
+
+def _expect_maxage(router):
+    age = _r1_router_lsa_age(router)
+    # The LSA must actually be observed at MaxAge. A missing LSA (age is
+    # None) must NOT be treated as success: during "clear ipv6 ospf6
+    # process" the unfixed code path also makes the area 1 neighbour's copy
+    # disappear transiently (adjacency bounce / re-origination), so accepting
+    # None here would let the buggy code pass this regression test.
+    if age is not None and age >= OSPF6_LSA_MAXAGE:
+        return None
+    return "age={}".format(age)
+
+
+def test_ospf6_converge():
+    "Wait until both adjacencies are Full and both neighbours have r1's LSA."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for OSPFv3 to converge")
+    _, result = topotest.run_and_expect(_converged, None, count=90, wait=1)
+    assert result is None, "OSPFv3 did not converge: {}".format(result)
+
+    # Let the link-state databases settle so the flush is reliably flooded.
+    topotest.sleep(3, "settling LSDBs before flush")
+
+
+def test_ospf6_flush_all_areas_on_reset():
+    "Reset the OSPFv3 process on r1 and check it is flushed from all areas."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Sanity: both neighbours currently hold a non-expired copy of r1's LSA.
+    for rname in ("r2", "r3"):
+        age = _r1_router_lsa_age(rname)
+        assert (
+            age is not None and age < OSPF6_LSA_MAXAGE
+        ), "precondition failed on {}: r1 Router-LSA age={}".format(rname, age)
+
+    # Trigger the self-originated LSA flush across all areas.
+    tgen.gears["r1"].vtysh_cmd("clear ipv6 ospf6 process")
+
+    # r1's Router-LSA must be set to MaxAge on BOTH the area 0 neighbour (r2)
+    # and the area 1 neighbour (r3). Without the fix, the flush stops after
+    # the first area and r3 keeps r1's LSA at its normal age.
+    for rname in ("r2", "r3"):
+        logger.info("checking r1's Router-LSA reaches MaxAge on %s", rname)
+        test_func = partial(_expect_maxage, rname)
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, (
+            "r1's self-originated Router-LSA was not flushed (set to MaxAge) "
+            "on {} - self-originated LSAs not flushed in all areas".format(rname)
+        )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
### Summary

`ospf6_flush_self_originated_lsas_now()` reused the outer area-loop
listnode (`node`) for the inner per-area interface loop:

```c
for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
        ...
        for (ALL_LIST_ELEMENTS(oa->if_list, node, nnode, oi)) {
                ...
        }
}
```

`ALL_LIST_ELEMENTS()` advances `node` to `NULL` when the interface loop
finishes. The enclosing `ALL_LIST_ELEMENTS_RO()` then evaluates
`node = listnextnode(node)` on `NULL`, the `node != NULL` test fails, and
the area loop terminates after the **first** area only.

As a result, when the OSPFv3 process is reset (`clear ipv6 ospf6 process`)
or removed (`no router ospf6`), self-originated LSAs in every area other
than the first are never set to MaxAge or reflooded, leaving stale LSAs in
neighbours' link-state databases until they age out naturally.

Fixes #22085

### Fix

Use dedicated listnode variables for the interface loop so the area
iteration completes across all areas.

### Testing

Added `tests/topotests/ospf6_flush_areas`: r1 is an ABR with one interface
in area 0 (towards r2) and one in area 1 (towards r3). After convergence
both neighbours hold r1's self-originated Router-LSA. The test runs
`clear ipv6 ospf6 process` on r1 and verifies r1's Router-LSA is set to
MaxAge on **both** neighbours.

Verified against a native build of current `master`:

* with the fix: the Router-LSA reaches MaxAge on both r2 (area 0) and r3
  (area 1) — test passes.
* without the fix: r3 (area 1) keeps r1's Router-LSA at its normal age and
  the test fails, confirming it is a regression test for this bug.
