### PR TITLE
Update topotest container to Debian 13

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -1,96 +1,127 @@
-FROM ubuntu:22.04
+FROM debian:13
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 
-RUN apt update -y && apt upgrade -y && \
-    # Basic build requirements from documentation
+# Add non-free to sources if not already present, needed for snmp-mibs-downloader
+RUN sed -i '/^Components:/ {/non-free\([^-]\|$\)/! s/$/ non-free/}' /etc/apt/sources.list.d/debian.sources && \
+    apt update -y && apt upgrade -y && \
+    # Basic build requirements from docs (building-frr-for-debian13.rst)
     apt-get install -y \
+            git \
             autoconf \
             automake \
-            bison \
-            build-essential \
-            flex \
-            git \
-            install-info \
-            libc-ares-dev \
-            libcap-dev \
-            libelf-dev \
-            libjson-c-dev \
-            libpam0g-dev \
-            libreadline-dev \
-            libsnmp-dev \
-            libsqlite3-dev \
-            lsb-release \
             libtool \
-            lcov \
             make \
-            perl \
-            pkg-config \
+            build-essential \
             python3-dev \
+            python3-pytest \
             python3-sphinx \
-            screen \
+            libjson-c-dev \
+            libelf-dev \
+            libreadline-dev \
+            cmake \
+            libcap-dev \
+            bison \
+            flex \
+            pkg-config \
             texinfo \
-            tmux \
+            gdb \
     && \
-    # Protobuf build requirements
-    apt-get install -y \
-        libprotobuf-c-dev \
-        protobuf-c-compiler \
+    # Optional dependency, but having it only has pros
+    apt-get install -y libunwind8 libunwind8-dev \
     && \
-    # Libyang2 extra build requirements
-    apt-get install -y \
-        cmake \
-        libpcre2-dev \
+    # Debian 13 happens to ship a suitable version of libyang we can install right away
+    apt-get install -y libyang-dev \
     && \
-    # GRPC extra build requirements
-    apt-get install -y \
-        libgrpc-dev \
-        libgrpc++-dev \
-        protobuf-compiler-grpc \
+    # Diverse protobuf deps from docs (building-frr-for-debian13.rst)
+    # Debian ships protobuf-compiler 3.21.X
+    apt-get install -y libprotobuf-c-dev \
+    protobuf-c-compiler \
+    libgrpc-dev \
+    libgrpc++-dev \
+    python3-grpc-tools \
+    libprotoc-dev \
+    protobuf-compiler \
+    libprotobuf-dev \
+    protobuf-compiler-grpc \
     && \
     # Runtime/triage/testing requirements
     apt-get install -y \
+        # Deps from topotests.rst "Installing Topotest Requirements"
+        gdb \
+        iproute2 \
+        net-tools \
+        python3-pip \
+        iputils-ping \
+        iptables \
+        tshark \
+        valgrind \
+        ssmping \
+        # SNMP Deps from topotests.rst "SNMP Utilities Installation"
+        libsnmp-dev \
+        snmpd \
+        snmp \
+        snmptrapd \
+        snmp-mibs-downloader \
+        # Misc tools needed for debugging and triaging
+        # Yeah, we definitely need python, let's make sure it's there
+        python3 \
+        # Pretty sure someone is going to need it..
+        nftables \
+        # lcov is needed for code coverage tests
+        lcov \
+        # RR is a time travel debugger, topotest have built-in support for it
+        rr \
+        # tmux and screen are recommended for running the tests
+        tmux \
+        screen \
+        # diverse file fetch / sync utilities
         rsync \
         curl \
-        gdb \
+        wget \
+        # Now all the remaining utilities that have accumulated over time
         kmod \
-        iproute2 \
-        iputils-ping \
         liblua5.3-dev \
         libssl-dev \
         lua5.3 \
-        net-tools \
-        python3 \
-        python3-pip \
-        snmp \
-        snmp-mibs-downloader \
-        snmpd \
         sudo \
         time \
-        tshark \
-        valgrind \
         yodl \
         strace \
         tcpdump \
       && \
     download-mibs && \
-    wget --tries=5 --waitretry=10 --retry-connrefused https://raw.githubusercontent.com/FRRouting/frr-mibs/main/iana/IANA-IPPM-METRICS-REGISTRY-MIB -O /usr/share/snmp/mibs/iana/IANA-IPPM-METRICS-REGISTRY-MIB && \
-    wget --tries=5 --waitretry=10 --retry-connrefused https://raw.githubusercontent.com/FRRouting/frr-mibs/main/ietf/SNMPv2-PDU -O /usr/share/snmp/mibs/ietf/SNMPv2-PDU && \
-    wget --tries=5 --waitretry=10 --retry-connrefused https://raw.githubusercontent.com/FRRouting/frr-mibs/main/ietf/IPATM-IPMC-MIB -O /usr/share/snmp/mibs/ietf/IPATM-IPMC-MIB && \
-    python3 -m pip install wheel && \
-    python3 -m pip install 'protobuf<4' grpcio grpcio-tools && \
-    python3 -m pip install 'pytest>=6.2.4' 'pytest-xdist>=2.3.0' && \
-    python3 -m pip install 'scapy>=2.4.5' && \
-    python3 -m pip install xmltodict && \
-    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
+    # SNMP download from docs
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianasmf-mib/ianasmf-mib -O /usr/share/snmp/mibs/iana/IANA-SMF-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianaentity-mib/ianaentity-mib -O /usr/share/snmp/mibs/iana/IANA-ENTITY-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianapowerstateset-mib/ianapowerstateset-mib -O /usr/share/snmp/mibs/iana/IANAPowerStateSet-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianaolsrv2linkmetrictype-mib/ianaolsrv2linkmetrictype-mib -O /usr/share/snmp/mibs/iana/IANA-OLSRv2-LINK-METRIC-TYPE-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianaenergyrelation-mib/ianaenergyrelation-mib -O /usr/share/snmp/mibs/iana/IANA-ENERGY-RELATION-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianabfdtcstd-mib/ianabfdtcstd-mib -O /usr/share/snmp/mibs/iana/IANA-BFD-TC-STD-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.iana.org/assignments/ianastoragemediatype-mib/ianastoragemediatype-mib -O /usr/share/snmp/mibs/iana/IANA-STORAGE-MEDIA-TYPE-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.ieee802.org/1/files/public/MIBs/IEEE8021-CFM-MIB.mib -O /usr/share/snmp/mibs/IEEE8021-CFM-MIB  && \
+    wget --tries=5 --waitretry=10 --retry-connrefused https://www.ieee802.org/1/files/public/MIBs/LLDP-MIB-200505060000Z.mib -O /usr/share/snmp/mibs/LLDP-MIB  && \
+    # Fixup the snmp.conf as descibed in topotests.rst "SNMP Utilities Installation"
+    sed -i 's/^mibs :$/mibs +ALL/' /etc/snmp/snmp.conf && \
+    # Python deps from topotests.rst "Installing Topotest Requirements"
+    # Debian uses a system-managed python, so we install as many deps as debian packages as possible..
+    apt-get install -y python3-wheel \
+        python3-pytest \
+        python3-pytest-asyncio \
+        python3-pytest-xdist \
+        python3-scapy \
+        python3-yaml \
+        python3-xmltodict \
+        python3-grpcio \
+        python3-grpc-tools \
+        # Debian ships matching protobuf and python protobuf versions
+        python3-protobuf && \
+    # some deps are not packaged, and we don't want to deal with running FRR inside venv
+    # and for those 2 deps it seems to be okay to "break" the system packages...
+    python3 -m pip install --break-system-packages 'libyang<4' && \
+    python3 -m pip install --break-system-packages git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
 
-# Install FRR built packages
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -s -o /etc/apt/keyrings/frrouting.gpg https://deb.frrouting.org/frr/keys.gpg && \
-    echo deb '[signed-by=/etc/apt/keyrings/frrouting.gpg]' https://deb.frrouting.org/frr \
-        $(lsb_release -s -c) "frr-stable" > /etc/apt/sources.list.d/frr.list && \
-    apt-get update && apt-get install -y librtr-dev libyang2-dev libyang2-tools
 
 RUN apt install -y openvswitch-switch
 


### PR DESCRIPTION
When I tried to run the topotests on my relatively recent FRR fork, I got some build errors related to `libyang` (I used the pre-built container from Dockerhub, as mentioned in the manual)

I thought that it might be time to update the topotest container to Debian 13 (from Ubuntu 22.04). Why Debian? Well, personal preference. I stopped using Ubuntu as they started forcing stuff like snaps on to their users. Functionally, there probably isn't a big difference for topotests.

There were some more changes required to python related stuff, as Debian 13 uses a PEP 668 Python externally-managed-environment (-> You can not  / should not install globally available packages via pip). Therefore, as many python packages as possible are installed via `apt`. `libyang` and `exabgp` are not available as debian package, so I decided to use the `--break-system-packages` flag on those two packages and install them via pip globally.

I tried to sync the apt install sections with the relevant documentation (e.g. https://docs.frrouting.org/projects/dev-guide/en/latest/building-frr-for-debian13.html) and add comments why certain packages are installed (mostly refers to the docs) for easier traceability.

I hope I didn't accidentally remove any package that's needed, but it's looking fine so far.

Upgrading to Debian 13 also removes the dependency on FRR's own deb repo for `libyang`, because Debian 13 ships a suitable version.

While I was on it, I added `rr` (time travel debugger - topotest already has support for that), `libunwind` and `nftables`. The remaining packages should be relatively identical.
