### PR TITLE
bgpd: Rename `bgpevpn` to `bgp_evpn_evi` [Request for Comments]

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -46,7 +46,7 @@
 /*
  * Definitions and external declarations.
  */
-DEFINE_QOBJ_TYPE(bgpevpn);
+DEFINE_QOBJ_TYPE(bgp_evpn_evi);
 DEFINE_QOBJ_TYPE(bgp_evpn_es);
 
 DEFINE_MTYPE_STATIC(BGPD, BGP_EVPN_INFO, "BGP EVPN instance information");
@@ -55,22 +55,22 @@ DEFINE_MTYPE_STATIC(BGPD, VRF_ROUTE_TARGET, "L3 Route Target");
 /*
  * Static function declarations
  */
-static void bgp_evpn_remote_ip_hash_init(struct bgpevpn *evpn);
-static void bgp_evpn_remote_ip_hash_destroy(struct bgpevpn *evpn);
-static void bgp_evpn_remote_ip_hash_add(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_hash_init(struct bgp_evpn_evi *evpn);
+static void bgp_evpn_remote_ip_hash_destroy(struct bgp_evpn_evi *evpn);
+static void bgp_evpn_remote_ip_hash_add(struct bgp_evpn_evi *vpn,
 					struct bgp_path_info *pi);
-static void bgp_evpn_remote_ip_hash_del(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_hash_del(struct bgp_evpn_evi *vpn,
 					struct bgp_path_info *pi);
-static void bgp_evpn_remote_ip_hash_iterate(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_hash_iterate(struct bgp_evpn_evi *vpn,
 					    void (*func)(struct hash_bucket *,
 							 void *),
 					    void *arg);
-static void bgp_evpn_link_to_vni_svi_hash(struct bgp *bgp, struct bgpevpn *vpn);
+static void bgp_evpn_link_to_vni_svi_hash(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 static void bgp_evpn_unlink_from_vni_svi_hash(struct bgp *bgp,
-					      struct bgpevpn *vpn);
+					      struct bgp_evpn_evi *vpn);
 static unsigned int vni_svi_hash_key_make(const void *p);
 static bool vni_svi_hash_cmp(const void *p1, const void *p2);
-static void bgp_evpn_remote_ip_process_nexthops(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_process_nexthops(struct bgp_evpn_evi *vpn,
 						struct ipaddr *addr,
 						bool resolve);
 static void bgp_evpn_remote_ip_hash_link_nexthop(struct hash_bucket *bucket,
@@ -112,7 +112,7 @@ static const char *vxlan_flood_control_str(enum vxlan_flood_control flood_ctrl)
  */
 static unsigned int vni_hash_key_make(const void *p)
 {
-	const struct bgpevpn *vpn = p;
+	const struct bgp_evpn_evi *vpn = p;
 	return (jhash_1word(vpn->vni, 0));
 }
 
@@ -121,16 +121,16 @@ static unsigned int vni_hash_key_make(const void *p)
  */
 static bool vni_hash_cmp(const void *p1, const void *p2)
 {
-	const struct bgpevpn *vpn1 = p1;
-	const struct bgpevpn *vpn2 = p2;
+	const struct bgp_evpn_evi *vpn1 = p1;
+	const struct bgp_evpn_evi *vpn2 = p2;
 
 	return vpn1->vni == vpn2->vni;
 }
 
 int vni_list_cmp(void *p1, void *p2)
 {
-	const struct bgpevpn *vpn1 = p1;
-	const struct bgpevpn *vpn2 = p2;
+	const struct bgp_evpn_evi *vpn1 = p1;
+	const struct bgp_evpn_evi *vpn2 = p2;
 
 	return vpn1->vni - vpn2->vni;
 }
@@ -322,10 +322,10 @@ static struct irt_node *lookup_import_rt(struct bgp *bgp,
 /*
  * Is specified VNI present on the RT's list of "importing" VNIs?
  */
-static int is_vni_present_in_irt_vnis(struct list *vnis, struct bgpevpn *vpn)
+static int is_vni_present_in_irt_vnis(struct list *vnis, struct bgp_evpn_evi *vpn)
 {
 	struct listnode *node, *nnode;
-	struct bgpevpn *tmp_vpn;
+	struct bgp_evpn_evi *tmp_vpn;
 
 	for (ALL_LIST_ELEMENTS(vnis, node, nnode, tmp_vpn)) {
 		if (tmp_vpn == vpn)
@@ -553,7 +553,7 @@ static void unmap_vrf_from_rt(struct bgp *bgp_vrf,
 /*
  * Map one RT to specified VNI.
  */
-static void map_vni_to_rt(struct bgp *bgp, struct bgpevpn *vpn,
+static void map_vni_to_rt(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			  struct ecommunity_val *eval)
 {
 	struct irt_node *irt;
@@ -584,7 +584,7 @@ static void map_vni_to_rt(struct bgp *bgp, struct bgpevpn *vpn,
  * Unmap specified VNI from specified RT. If there are no other
  * VNIs for this RT, then the RT hash is deleted.
  */
-static void unmap_vni_from_rt(struct bgp *bgp, struct bgpevpn *vpn,
+static void unmap_vni_from_rt(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			      struct irt_node *irt)
 {
 	/* Delete VNI from hash list for this RT. */
@@ -594,7 +594,7 @@ static void unmap_vni_from_rt(struct bgp *bgp, struct bgpevpn *vpn,
 	}
 }
 
-static void bgp_evpn_get_rmac_nexthop(struct bgpevpn *vpn,
+static void bgp_evpn_get_rmac_nexthop(struct bgp_evpn_evi *vpn,
 				      const struct prefix_evpn *p,
 				      struct attr *attr, uint8_t flags)
 {
@@ -682,7 +682,7 @@ static void form_auto_rt(struct bgp *bgp, vni_t vni, struct list *rtl,
  * Derive RD and RT for a VNI automatically. Invoked at the time of
  * creation of a VNI.
  */
-static void derive_rd_rt_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
+static void derive_rd_rt_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	bgp_evpn_derive_auto_rd(bgp, vpn);
 	bgp_evpn_derive_auto_rt_import(bgp, vpn);
@@ -886,7 +886,7 @@ bgp_evpn_vni_mac_node_lookup(const struct bgp_table *const table,
 /*
  * Wrapper for node get in both VNI tables.
  */
-struct bgp_dest *bgp_evpn_vni_node_get(struct bgpevpn *vpn,
+struct bgp_dest *bgp_evpn_vni_node_get(struct bgp_evpn_evi *vpn,
 				       const struct prefix_evpn *p,
 				       const struct bgp_path_info *parent_pi)
 {
@@ -900,7 +900,7 @@ struct bgp_dest *bgp_evpn_vni_node_get(struct bgpevpn *vpn,
 /*
  * Wrapper for node lookup in both VNI tables.
  */
-struct bgp_dest *bgp_evpn_vni_node_lookup(const struct bgpevpn *vpn,
+struct bgp_dest *bgp_evpn_vni_node_lookup(const struct bgp_evpn_evi *vpn,
 					  const struct prefix_evpn *p,
 					  const struct bgp_path_info *parent_pi)
 {
@@ -916,7 +916,7 @@ struct bgp_dest *bgp_evpn_vni_node_lookup(const struct bgpevpn *vpn,
  * Add (update) or delete MACIP from zebra.
  */
 static enum zclient_send_status bgp_zebra_send_remote_macip(
-	struct bgp *bgp, struct bgpevpn *vpn, const struct prefix_evpn *p,
+	struct bgp *bgp, struct bgp_evpn_evi *vpn, const struct prefix_evpn *p,
 	const struct ethaddr *mac, struct ipaddr *remote_vtep_ip, int add,
 	uint8_t flags, uint32_t seq, esi_t *esi)
 {
@@ -1015,7 +1015,7 @@ static enum zclient_send_status bgp_zebra_send_remote_macip(
  * Add (update) or delete remote VTEP from zebra.
  */
 static enum zclient_send_status
-bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
+bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			   const struct prefix_evpn *p, int flood_control,
 			   int add)
 {
@@ -1120,7 +1120,7 @@ static void build_evpn_type5_route_extcomm(struct bgp *bgp_vrf,
  * added, if present, based on passed settings - only for non-link-local
  * type-2 routes.
  */
-static void build_evpn_route_extcomm(struct bgpevpn *vpn, struct attr *attr,
+static void build_evpn_route_extcomm(struct bgp_evpn_evi *vpn, struct attr *attr,
 				     int add_l3_ecomm,
 				     struct ecommunity *macvrf_soo)
 {
@@ -1164,7 +1164,7 @@ static void build_evpn_route_extcomm(struct bgpevpn *vpn, struct attr *attr,
 	 * when this should be done.
 	 */
 	if (add_l3_ecomm) {
-		vrf_export_rtl = bgpevpn_get_vrf_export_rtl(vpn);
+		vrf_export_rtl = bgp_evpn_evi_get_vrf_export_rtl(vpn);
 		if (vrf_export_rtl && !list_isempty(vrf_export_rtl)) {
 			for (ALL_LIST_ELEMENTS(vrf_export_rtl, node, nnode,
 					       l3rt))
@@ -1283,7 +1283,7 @@ static void add_mac_mobility_to_attr(uint32_t seq_num, struct attr *attr)
 }
 
 /* Install EVPN route into zebra. */
-enum zclient_send_status evpn_zebra_install(struct bgp *bgp, struct bgpevpn *vpn,
+enum zclient_send_status evpn_zebra_install(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 					    const struct prefix_evpn *p,
 					    struct bgp_path_info *pi)
 {
@@ -1400,7 +1400,7 @@ enum zclient_send_status evpn_zebra_install(struct bgp *bgp, struct bgpevpn *vpn
 
 /* Uninstall EVPN route from zebra. */
 enum zclient_send_status evpn_zebra_uninstall(struct bgp *bgp,
-					      struct bgpevpn *vpn,
+					      struct bgp_evpn_evi *vpn,
 					      const struct prefix_evpn *p,
 					      struct bgp_path_info *pi,
 					      bool is_sync)
@@ -1446,7 +1446,7 @@ enum zclient_send_status evpn_zebra_uninstall(struct bgp *bgp,
  * by a "remote" best route. The prior route has to be deleted and withdrawn
  * from peers.
  */
-static void evpn_delete_old_local_route(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_delete_old_local_route(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 					struct bgp_dest *dest,
 					struct bgp_path_info *old_local,
 					struct bgp_path_info *new_select)
@@ -1499,7 +1499,7 @@ static void evpn_delete_old_local_route(struct bgp *bgp, struct bgpevpn *vpn,
  * if appropriate.
  * Note: vpn is NULL for local EAD-ES routes.
  */
-int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
+int evpn_route_select_install(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			      struct bgp_dest *dest, struct bgp_path_info *pi)
 {
 	struct bgp_path_info *old_select, *new_select, *first;
@@ -2029,20 +2029,20 @@ static void update_evpn_route_entry_sync_info(struct bgp *bgp,
  * Check if the route is a type-2 MAC-IP route with a valid global address
  * (IPv4 or non-link-local IPv6) and the VPN has a valid L3 VNI configured.
  */
-static inline bool bgp_evpn_is_macip_with_l3vni(struct bgpevpn *vpn, const struct prefix_evpn *p)
+static inline bool bgp_evpn_is_macip_with_l3vni(struct bgp_evpn_evi *vpn, const struct prefix_evpn *p)
 {
 	return p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
 	       (is_evpn_prefix_ipaddr_v4(p) ||
 		(is_evpn_prefix_ipaddr_v6(p) &&
 		 !IN6_IS_ADDR_LINKLOCAL(&p->prefix.macip_addr.ip.ipaddr_v6))) &&
-	       CHECK_FLAG(vpn->flags, VNI_FLAG_USE_TWO_LABELS) && bgpevpn_get_l3vni(vpn);
+	       CHECK_FLAG(vpn->flags, VNI_FLAG_USE_TWO_LABELS) && bgp_evpn_evi_get_l3vni(vpn);
 }
 
 /*
  * While adding l3-attrs such as rmac and l3 RTs we need an added check for ES
  * as well along with checking for mac-ip with l3vni.
  */
-static inline bool bgp_evpn_route_add_l3_attrs_ok(struct bgpevpn *vpn, const struct prefix_evpn *p,
+static inline bool bgp_evpn_route_add_l3_attrs_ok(struct bgp_evpn_evi *vpn, const struct prefix_evpn *p,
 						  esi_t *esi)
 {
 	return bgp_evpn_is_macip_with_l3vni(vpn, p) && bgp_evpn_es_add_l3_attrs_ok(esi);
@@ -2052,7 +2052,7 @@ static inline bool bgp_evpn_route_add_l3_attrs_ok(struct bgpevpn *vpn, const str
  * Create or update EVPN route entry. This could be in the VNI route tables
  * or the global route table.
  */
-static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
+static int update_evpn_route_entry(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				   afi_t afi, safi_t safi,
 				   struct bgp_dest *dest, struct attr *attr,
 				   const struct ethaddr *mac,
@@ -2119,7 +2119,7 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 		if (bgp_evpn_is_macip_with_l3vni(vpn, evp)) {
 			vni_t l3vni;
 
-			l3vni = bgpevpn_get_l3vni(vpn);
+			l3vni = bgp_evpn_evi_get_l3vni(vpn);
 			if (l3vni) {
 				vni2label(l3vni, &bgp_labels.label[1]);
 				bgp_labels.num_labels++;
@@ -2158,7 +2158,7 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 			if (bgp_evpn_is_macip_with_l3vni(vpn, evp)) {
 				vni_t l3vni;
 
-				l3vni = bgpevpn_get_l3vni(vpn);
+				l3vni = bgp_evpn_evi_get_l3vni(vpn);
 				if (l3vni) {
 					vni2label(l3vni, &bgp_labels.label[1]);
 					bgp_labels.num_labels++;
@@ -2218,7 +2218,7 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 }
 
 static void evpn_zebra_reinstall_best_route(struct bgp *bgp,
-					    struct bgpevpn *vpn,
+					    struct bgp_evpn_evi *vpn,
 					    struct bgp_dest *dest)
 {
 	struct bgp_path_info *tmp_ri;
@@ -2261,7 +2261,7 @@ static void evpn_zebra_reinstall_best_route(struct bgp *bgp,
  * non-best local path.
  */
 static struct bgp_dest *
-evpn_cleanup_local_non_best_route(struct bgp *bgp, struct bgpevpn *vpn,
+evpn_cleanup_local_non_best_route(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				  struct bgp_dest *dest,
 				  struct bgp_path_info *local_pi)
 {
@@ -2282,7 +2282,7 @@ evpn_cleanup_local_non_best_route(struct bgp *bgp, struct bgpevpn *vpn,
  * Create or update EVPN route (of type based on prefix) for specified VNI
  * and schedule for processing.
  */
-static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
+static int update_evpn_route(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			     struct prefix_evpn *p, uint8_t flags,
 			     uint32_t seq, esi_t *esi)
 {
@@ -2536,7 +2536,7 @@ static int delete_evpn_type5_route(struct bgp *bgp_vrf, const struct bgp_path_in
  * Delete EVPN route (of type based on prefix) for specified VNI and
  * schedule for processing.
  */
-static int delete_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
+static int delete_evpn_route(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			     struct prefix_evpn *p)
 {
 	struct bgp_dest *dest, *global_dest;
@@ -2591,7 +2591,7 @@ static int delete_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	return 0;
 }
 
-void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
+void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				       struct bgp_dest *dest,
 				       struct bgp_path_info *local_pi,
 				       const char *caller)
@@ -2757,7 +2757,7 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	aspath_unintern(&attr.aspath);
 }
 
-static void update_type2_route(struct bgp *bgp, struct bgpevpn *vpn,
+static void update_type2_route(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			       struct bgp_dest *dest)
 {
 	struct bgp_path_info *tmp_pi;
@@ -2780,7 +2780,7 @@ static void update_type2_route(struct bgp *bgp, struct bgpevpn *vpn,
  * Update all type-2 (MACIP) local routes for this VNI - these should also
  * be scheduled for advertise to peers.
  */
-static void update_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static void update_all_type2_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	struct bgp_dest *dest;
 
@@ -2801,7 +2801,7 @@ static void update_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
  * Delete all type-2 (MACIP) local routes for this VNI - only from the
  * global routing table. These are also scheduled for withdraw from peers.
  */
-static void delete_global_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static void delete_global_type2_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	afi_t afi;
 	safi_t safi;
@@ -2857,7 +2857,7 @@ static struct bgp_dest *delete_vni_type2_route(struct bgp *bgp,
 	return dest;
 }
 
-static void delete_vni_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static void delete_vni_type2_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	struct bgp_dest *dest;
 
@@ -2881,7 +2881,7 @@ static void delete_vni_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
  * Delete all type-2 (MACIP) local routes for this VNI - from the global
  * table as well as the per-VNI route table.
  */
-static void delete_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static void delete_all_type2_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	/* First, walk the global route table for this VNI's type-2 local
 	 * routes.
@@ -2894,7 +2894,7 @@ static void delete_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
 /*
  * Delete all routes in the per-VNI route table.
  */
-static void delete_all_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static void delete_all_vni_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	struct bgp_dest *dest;
 	struct bgp_path_info *pi, *nextpi;
@@ -2926,7 +2926,7 @@ static void delete_all_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 
 /* BUM traffic flood mode per-l2-vni */
 static int bgp_evpn_vni_flood_mode_get(struct bgp *bgp,
-					struct bgpevpn *vpn)
+					struct bgp_evpn_evi *vpn)
 {
 	if (bgp_debug_zebra(NULL))
 		zlog_debug("VRF %s vni %u flood mode %d (global flood mode %d)",
@@ -2960,7 +2960,7 @@ static int bgp_evpn_vni_flood_mode_get(struct bgp *bgp,
  * situations need the route in the per-VNI table as well as the global
  * table to be updated (as attributes change).
  */
-int update_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
+int update_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	int ret;
 	struct prefix_evpn p;
@@ -2990,12 +2990,12 @@ int update_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
 static void update_routes_for_vni_hash(struct hash_bucket *bucket,
 				       struct bgp *bgp)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	if (!bucket)
 		return;
 
-	vpn = (struct bgpevpn *)bucket->data;
+	vpn = (struct bgp_evpn_evi *)bucket->data;
 	update_routes_for_vni(bgp, vpn);
 }
 
@@ -3005,7 +3005,7 @@ static void update_routes_for_vni_hash(struct hash_bucket *bucket,
  * the per-VNI table. Invoked upon the VNI being deleted or EVPN
  * (advertise-all-vni) being disabled.
  */
-static int delete_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
+static int delete_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	int ret;
 	struct prefix_evpn p;
@@ -3045,7 +3045,7 @@ static int delete_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
  * remove the type-3 route if any. A new type-3 route will be generated
  * post tunnel_ip update if the new flood mode is head-end-replication.
  */
-static int bgp_evpn_mcast_grp_change(struct bgp *bgp, struct bgpevpn *vpn,
+static int bgp_evpn_mcast_grp_change(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 		struct in_addr mcast_grp)
 {
 	struct prefix_evpn p;
@@ -3070,7 +3070,7 @@ static int bgp_evpn_mcast_grp_change(struct bgp *bgp, struct bgpevpn *vpn,
  * other changes.
  */
 static void handle_tunnel_ip_change(struct bgp *bgp_vrf, struct bgp *bgp_evpn,
-				    struct bgpevpn *vpn,
+				    struct bgp_evpn_evi *vpn,
 				    struct ipaddr *originator_ip)
 {
 	struct prefix_evpn p;
@@ -3382,7 +3382,7 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
  * Common handling for vni route tables install/selection.
  */
 static int install_evpn_route_entry_in_vni_common(
-	struct bgp *bgp, struct bgpevpn *vpn, const struct prefix_evpn *p,
+	struct bgp *bgp, struct bgp_evpn_evi *vpn, const struct prefix_evpn *p,
 	struct bgp_dest *dest, struct bgp_path_info *parent_pi)
 {
 	struct bgp_path_info *pi;
@@ -3506,7 +3506,7 @@ static int install_evpn_route_entry_in_vni_common(
  * Common handling for vni route tables uninstall/selection.
  */
 static int uninstall_evpn_route_entry_in_vni_common(
-	struct bgp *bgp, struct bgpevpn *vpn, const struct prefix_evpn *p,
+	struct bgp *bgp, struct bgp_evpn_evi *vpn, const struct prefix_evpn *p,
 	struct bgp_dest *dest, struct bgp_path_info *parent_pi)
 {
 	struct bgp_path_info *pi;
@@ -3547,7 +3547,7 @@ static int uninstall_evpn_route_entry_in_vni_common(
  * Install route entry into VNI IP table and invoke route selection.
  */
 static int install_evpn_route_entry_in_vni_ip(struct bgp *bgp,
-					      struct bgpevpn *vpn,
+					      struct bgp_evpn_evi *vpn,
 					      const struct prefix_evpn *p,
 					      struct bgp_path_info *parent_pi)
 {
@@ -3574,7 +3574,7 @@ static int install_evpn_route_entry_in_vni_ip(struct bgp *bgp,
  * Install route entry into VNI MAC table and invoke route selection.
  */
 static int install_evpn_route_entry_in_vni_mac(struct bgp *bgp,
-					       struct bgpevpn *vpn,
+					       struct bgp_evpn_evi *vpn,
 					       const struct prefix_evpn *p,
 					       struct bgp_path_info *parent_pi)
 {
@@ -3600,7 +3600,7 @@ static int install_evpn_route_entry_in_vni_mac(struct bgp *bgp,
  * Uninstall route entry from VNI IP table and invoke route selection.
  */
 static int uninstall_evpn_route_entry_in_vni_ip(struct bgp *bgp,
-						struct bgpevpn *vpn,
+						struct bgp_evpn_evi *vpn,
 						const struct prefix_evpn *p,
 						struct bgp_path_info *parent_pi)
 {
@@ -3629,7 +3629,7 @@ static int uninstall_evpn_route_entry_in_vni_ip(struct bgp *bgp,
  * Uninstall route entry from VNI IP table and invoke route selection.
  */
 static int
-uninstall_evpn_route_entry_in_vni_mac(struct bgp *bgp, struct bgpevpn *vpn,
+uninstall_evpn_route_entry_in_vni_mac(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				      const struct prefix_evpn *p,
 				      struct bgp_path_info *parent_pi)
 {
@@ -3747,7 +3747,7 @@ int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_e
 /*
  * Install route entry into the VNI routing tables.
  */
-static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
+static int install_evpn_route_entry(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				    const struct prefix_evpn *p,
 				    struct bgp_path_info *parent_pi)
 {
@@ -3794,7 +3794,7 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 /*
  * Uninstall route entry from the VNI routing tables.
  */
-static int uninstall_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
+static int uninstall_evpn_route_entry(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				      const struct prefix_evpn *p,
 				      struct bgp_path_info *parent_pi)
 {
@@ -3909,7 +3909,7 @@ static int is_route_matching_for_vrf(struct bgp *bgp_vrf,
  * Given a route entry and a VNI, see if this route entry should be
  * imported into the VNI i.e., RTs match.
  */
-static int is_route_matching_for_vni(struct bgp *bgp, struct bgpevpn *vpn,
+static int is_route_matching_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				     struct bgp_path_info *pi)
 {
 	struct attr *attr = pi->attr;
@@ -4188,8 +4188,8 @@ static int install_evpn_remote_route_per_l2vni(struct bgp *bgp, struct bgp_path_
 {
 	int ret = 0;
 	uint8_t vni_iter = 0;
-	struct bgpevpn *t_vpn = NULL;
-	struct bgpevpn *t_vpn_next = NULL;
+	struct bgp_evpn_evi *t_vpn = NULL;
+	struct bgp_evpn_evi *t_vpn_next = NULL;
 
 	for (t_vpn = zebra_l2_vni_first(&bm->zebra_l2_vni_head);
 	     t_vpn && vni_iter < BGP_PROC_L2VNI_LIMIT; t_vpn = t_vpn_next) {
@@ -4222,7 +4222,7 @@ static int install_evpn_remote_route_per_l2vni(struct bgp *bgp, struct bgp_path_
  * Install or uninstall routes of specified type that are appropriate for this
  * particular VNI.
  */
-int install_uninstall_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn, bool install)
+int install_uninstall_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn, bool install)
 {
 	afi_t afi;
 	safi_t safi;
@@ -4358,7 +4358,7 @@ static int install_routes_for_vrf(struct bgp *bgp_vrf)
  * routing table. This is invoked when a VNI becomes "live" or its Import
  * RT is changed.
  */
-static int install_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
+static int install_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	/*
 	 * Install type-3 routes followed by type-2 routes - the ones applicable
@@ -4377,7 +4377,7 @@ static int uninstall_routes_for_vrf(struct bgp *bgp_vrf)
  * Uninstall any existing remote routes for this VNI. One scenario in which
  * this is invoked is upon an import RT change.
  */
-static int uninstall_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
+static int uninstall_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	/*
 	 * Uninstall type-2 routes followed by type-3 routes - the ones
@@ -4443,7 +4443,7 @@ static int install_uninstall_route_in_vnis(struct bgp *bgp, afi_t afi,
 					   struct bgp_path_info *pi,
 					   struct list *vnis, int install)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(vnis, node, nnode, vpn)) {
@@ -4733,7 +4733,7 @@ static void withdraw_router_id_vrf(struct bgp *bgp_vrf)
 	delete_withdraw_vrf_routes(bgp_vrf);
 }
 
-static void update_advertise_vni_route(struct bgp *bgp, struct bgpevpn *vpn,
+static void update_advertise_vni_route(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				       struct bgp_dest *dest)
 {
 	struct bgp_dest *global_dest;
@@ -4813,7 +4813,7 @@ static void update_advertise_vni_route(struct bgp *bgp, struct bgpevpn *vpn,
  * change. Note that the processing is done only on the global route table
  * using routes that already exist in the per-VNI table.
  */
-static void update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static void update_advertise_vni_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	struct prefix_evpn p;
 	struct bgp_dest *dest, *global_dest;
@@ -4870,7 +4870,7 @@ static void update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
  * Delete (and withdraw) local routes for a VNI - only from the global
  * table. Invoked upon router-id change.
  */
-static int delete_withdraw_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
+static int delete_withdraw_vni_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	struct prefix_evpn p;
 	struct bgp_dest *global_dest;
@@ -4912,7 +4912,7 @@ static int delete_withdraw_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
  */
 static void update_router_id_vni(struct hash_bucket *bucket, struct bgp *bgp)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 
 	/* Skip VNIs with configured RD. */
 	if (is_rd_configured(vpn))
@@ -4930,7 +4930,7 @@ static void update_router_id_vni(struct hash_bucket *bucket, struct bgp *bgp)
  */
 static void withdraw_router_id_vni(struct hash_bucket *bucket, struct bgp *bgp)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 
 	/* Skip VNIs with configured RD. */
 	if (is_rd_configured(vpn))
@@ -4941,7 +4941,7 @@ static void withdraw_router_id_vni(struct hash_bucket *bucket, struct bgp *bgp)
 
 static void advertise_withdraw_type3(struct hash_bucket *bucket, void *data)
 {
-	struct bgpevpn *vpn = bucket->data;
+	struct bgp_evpn_evi *vpn = bucket->data;
 	struct bgp *bgp = data;
 	struct prefix_evpn p;
 	int flood_control;
@@ -5422,7 +5422,7 @@ static void evpn_mpattr_encode_type5(struct stream *s, const struct prefix *p,
  *  2) evpn_delete_vni() when user configures "no vni" since the withdraw
  *     of all routes happen in normal cycle.
  */
-void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgpevpn *vpn)
+void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgp_evpn_evi *vpn)
 {
 	struct bgp_dest *dest = NULL;
 	struct bgp_bp_install_node *inode = NULL;
@@ -5463,7 +5463,7 @@ void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgpevpn *vpn)
  */
 static void cleanup_vni_on_disable(struct hash_bucket *bucket, struct bgp *bgp)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 
 	/* Remove EVPN routes and schedule for processing. */
 	delete_routes_for_vni(bgp, vpn);
@@ -5481,7 +5481,7 @@ static void cleanup_vni_on_disable(struct hash_bucket *bucket, struct bgp *bgp)
  */
 static void free_vni_entry(struct hash_bucket *bucket, struct bgp *bgp)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 
 	delete_all_vni_routes(bgp, vpn);
 	bgp_evpn_free(bgp, vpn);
@@ -5489,14 +5489,14 @@ static void free_vni_entry(struct hash_bucket *bucket, struct bgp *bgp)
 
 /*
  * Iterator helper: drain per-VNI route tables (mac_table/ip_table) without
- * freeing the bgpevpn struct itself.  Used during early cleanup so that the
+ * freeing the bgp_evpn_evi struct itself.  Used during early cleanup so that the
  * imported per-VNI bgp_path_info entries (which reference parent path_info
  * and dest objects in the global EVPN RIB) are reaped before the global
  * EVPN RIB is finalized by bgp_cleanup_routes().
  */
 static void drain_vni_routes(struct hash_bucket *bucket, struct bgp *bgp)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 
 	delete_all_vni_routes(bgp, vpn);
 }
@@ -5569,7 +5569,7 @@ static void bgp_evpn_handle_export_rt_change_for_vrf(struct bgp *bgp_vrf)
 {
 	struct bgp *bgp_evpn = NULL;
 	struct listnode *node = NULL;
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 
 	bgp_evpn = bgp_get_evpn();
 	if (!bgp_evpn)
@@ -5588,7 +5588,7 @@ static void bgp_evpn_handle_export_rt_change_for_vrf(struct bgp *bgp_vrf)
  */
 static void update_autort_vni(struct hash_bucket *bucket, struct bgp *bgp)
 {
-	struct bgpevpn *vpn = bucket->data;
+	struct bgp_evpn_evi *vpn = bucket->data;
 
 	if (!is_import_rt_configured(vpn)) {
 		if (is_vni_live(vpn))
@@ -6145,7 +6145,7 @@ struct vni_gr_walk {
  * and calculate the bestpath.
  */
 uint16_t bgp_deferred_path_selection(struct bgp *bgp, afi_t afi, safi_t safi,
-				     struct bgp_table *table, uint16_t cnt, struct bgpevpn *vpn,
+				     struct bgp_table *table, uint16_t cnt, struct bgp_evpn_evi *vpn,
 				     bool evpn_select)
 {
 	struct bgp_dest *dest = NULL;
@@ -6194,7 +6194,7 @@ uint16_t bgp_deferred_path_selection(struct bgp *bgp, afi_t afi, safi_t safi,
 
 static void bgp_evpn_handle_deferred_bestpath_per_vni(struct hash_bucket *bucket, void *arg)
 {
-	struct bgpevpn *vpn = bucket->data;
+	struct bgp_evpn_evi *vpn = bucket->data;
 	struct vni_gr_walk *ctx = arg;
 	struct bgp *bgp = ctx->bgp;
 	afi_t afi = AFI_L2VPN;
@@ -6242,7 +6242,7 @@ void bgp_evpn_handle_deferred_bestpath_for_vnis(struct bgp *bgp, uint16_t cnt)
 /*
  * Handle change to export RT - update and advertise local routes.
  */
-int bgp_evpn_handle_export_rt_change(struct bgp *bgp, struct bgpevpn *vpn)
+int bgp_evpn_handle_export_rt_change(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	return update_routes_for_vni(bgp, vpn);
 }
@@ -6262,7 +6262,7 @@ void bgp_evpn_handle_vrf_rd_change(struct bgp *bgp_vrf, int withdraw)
  * of this VNI being deleted and withdrawn and the next will result
  * in the routes being re-advertised.
  */
-void bgp_evpn_handle_rd_change(struct bgp *bgp, struct bgpevpn *vpn,
+void bgp_evpn_handle_rd_change(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			       int withdraw)
 {
 	if (withdraw)
@@ -6314,7 +6314,7 @@ void bgp_evpn_handle_global_macvrf_soo_change(struct bgp *bgp,
 /*
  * Install routes for this VNI. Invoked upon change to Import RT.
  */
-int bgp_evpn_install_routes(struct bgp *bgp, struct bgpevpn *vpn)
+int bgp_evpn_install_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	return install_routes_for_vni(bgp, vpn);
 }
@@ -6323,7 +6323,7 @@ int bgp_evpn_install_routes(struct bgp *bgp, struct bgpevpn *vpn)
  * Uninstall all routes installed for this VNI. Invoked upon change
  * to Import RT.
  */
-int bgp_evpn_uninstall_routes(struct bgp *bgp, struct bgpevpn *vpn)
+int bgp_evpn_uninstall_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	return uninstall_routes_for_vni(bgp, vpn);
 }
@@ -6679,7 +6679,7 @@ void bgp_evpn_unmap_vrf_from_its_rts(struct bgp *bgp_vrf)
  * Map the RTs (configured or automatically derived) of a VNI to the VNI.
  * The mapping will be used during route processing.
  */
-void bgp_evpn_map_vni_to_its_rts(struct bgp *bgp, struct bgpevpn *vpn)
+void bgp_evpn_map_vni_to_its_rts(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	uint32_t i;
 	struct ecommunity_val *eval;
@@ -6699,7 +6699,7 @@ void bgp_evpn_map_vni_to_its_rts(struct bgp *bgp, struct bgpevpn *vpn)
 /*
  * Unmap the RTs (configured or automatically derived) of a VNI from the VNI.
  */
-void bgp_evpn_unmap_vni_from_its_rts(struct bgp *bgp, struct bgpevpn *vpn)
+void bgp_evpn_unmap_vni_from_its_rts(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	uint32_t i;
 	struct ecommunity_val *eval;
@@ -6734,7 +6734,7 @@ void bgp_evpn_unmap_vni_from_its_rts(struct bgp *bgp, struct bgpevpn *vpn)
  * Derive Import RT automatically for VNI and map VNI to RT.
  * The mapping will be used during route processing.
  */
-void bgp_evpn_derive_auto_rt_import(struct bgp *bgp, struct bgpevpn *vpn)
+void bgp_evpn_derive_auto_rt_import(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	form_auto_rt(bgp, vpn->vni, vpn->import_rtl, false);
 	UNSET_FLAG(vpn->flags, VNI_FLAG_IMPRT_CFGD);
@@ -6746,7 +6746,7 @@ void bgp_evpn_derive_auto_rt_import(struct bgp *bgp, struct bgpevpn *vpn)
 /*
  * Derive Export RT automatically for VNI.
  */
-void bgp_evpn_derive_auto_rt_export(struct bgp *bgp, struct bgpevpn *vpn)
+void bgp_evpn_derive_auto_rt_export(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	form_auto_rt(bgp, vpn->vni, vpn->export_rtl, false);
 	UNSET_FLAG(vpn->flags, VNI_FLAG_EXPRT_CFGD);
@@ -6768,7 +6768,7 @@ void bgp_evpn_derive_auto_rd_for_vrf(struct bgp *bgp)
  * Derive RD automatically for VNI using passed information - it
  * is of the form RouterId:unique-id-for-vni.
  */
-void bgp_evpn_derive_auto_rd(struct bgp *bgp, struct bgpevpn *vpn)
+void bgp_evpn_derive_auto_rd(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	char buf[BGP_EVPN_PREFIX_RD_LEN];
 
@@ -6801,10 +6801,10 @@ bool bgp_evpn_lookup_l3vni_l2vni_table(vni_t vni)
 /*
  * Lookup VNI.
  */
-struct bgpevpn *bgp_evpn_lookup_vni(struct bgp *bgp, vni_t vni)
+struct bgp_evpn_evi *bgp_evpn_lookup_vni(struct bgp *bgp, vni_t vni)
 {
-	struct bgpevpn *vpn;
-	struct bgpevpn tmp;
+	struct bgp_evpn_evi *vpn;
+	struct bgp_evpn_evi tmp;
 
 	memset(&tmp, 0, sizeof(tmp));
 	tmp.vni = vni;
@@ -6815,15 +6815,15 @@ struct bgpevpn *bgp_evpn_lookup_vni(struct bgp *bgp, vni_t vni)
 /*
  * Create a new vpn - invoked upon configuration or zebra notification.
  */
-struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
+struct bgp_evpn_evi *bgp_evpn_new(struct bgp *bgp, vni_t vni,
 		struct ipaddr *originator_ip,
 		vrf_id_t tenant_vrf_id,
 		struct in_addr mcast_grp,
 		ifindex_t svi_ifindex)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
-	vpn = XCALLOC(MTYPE_BGP_EVPN, sizeof(struct bgpevpn));
+	vpn = XCALLOC(MTYPE_BGP_EVPN, sizeof(struct bgp_evpn_evi));
 
 	/* Set values - RD and RT set to defaults. */
 	vpn->vni = vni;
@@ -6856,11 +6856,11 @@ struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
 	bgp_evpn_link_to_vni_svi_hash(bgp, vpn);
 
 	/* add to l2vni list on corresponding vrf */
-	bgpevpn_link_to_l3vni(vpn);
+	bgp_evpn_evi_link_to_l3vni(vpn);
 
 	bgp_evpn_vni_es_init(vpn);
 
-	QOBJ_REG(vpn, bgpevpn);
+	QOBJ_REG(vpn, bgp_evpn_evi);
 	return vpn;
 }
 
@@ -6870,11 +6870,11 @@ struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
  * This just frees appropriate memory, caller should have taken other
  * needed actions.
  */
-void bgp_evpn_free(struct bgp *bgp, struct bgpevpn *vpn)
+void bgp_evpn_free(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	bgp_evpn_remote_ip_hash_destroy(vpn);
 	bgp_evpn_vni_es_cleanup(vpn);
-	bgpevpn_unlink_from_l3vni(vpn);
+	bgp_evpn_evi_unlink_from_l3vni(vpn);
 	bgp_table_unlock(vpn->ip_table);
 	bgp_table_unlock(vpn->mac_table);
 	bgp_evpn_unmap_vni_from_its_rts(bgp, vpn);
@@ -6889,7 +6889,7 @@ void bgp_evpn_free(struct bgp *bgp, struct bgpevpn *vpn)
 	XFREE(MTYPE_BGP_EVPN, vpn);
 }
 
-static void hash_evpn_free(struct bgpevpn *vpn)
+static void hash_evpn_free(struct bgp_evpn_evi *vpn)
 {
 	XFREE(MTYPE_BGP_EVPN, vpn);
 }
@@ -7263,7 +7263,7 @@ void bgp_reimport_evpn_routes_upon_martian_change(
 int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 			     struct ipaddr *ip, int state)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct prefix_evpn p;
 	struct bgp_dest *dest;
 
@@ -7298,7 +7298,7 @@ int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 		struct ipaddr *ip, uint8_t flags, uint32_t seq, esi_t *esi)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct prefix_evpn p;
 
 	/* Lookup VNI hash - should exist. */
@@ -7330,14 +7330,14 @@ int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 static void link_l2vni_hash_to_l3vni(struct hash_bucket *bucket,
 				     struct bgp *bgp_vrf)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	struct bgp *bgp_evpn = NULL;
 
 	bgp_evpn = bgp_get_evpn();
 	assert(bgp_evpn);
 
 	if (vpn->tenant_vrf_id == bgp_vrf->vrf_id)
-		bgpevpn_link_to_l3vni(vpn);
+		bgp_evpn_evi_link_to_l3vni(vpn);
 }
 
 int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id,
@@ -7350,7 +7350,7 @@ int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id,
 	struct bgp *bgp_vrf = NULL; /* bgp VRF instance */
 	struct bgp *bgp_evpn = NULL; /* EVPN bgp instance */
 	struct listnode *node = NULL;
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 	as_t as = 0;
 
 	/* get the EVPN instance - required to get the AS number for VRF
@@ -7515,7 +7515,7 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 	struct bgp *bgp_evpn = NULL; /* EVPN bgp instance */
 	struct listnode *node = NULL;
 	struct listnode *next = NULL;
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 
 	bgp_vrf = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp_vrf) {
@@ -7585,7 +7585,7 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 
 	/* If any L2VNIs point to this instance, unlink them. */
 	for (ALL_LIST_ELEMENTS(bgp_vrf->l2vnis, node, next, vpn))
-		bgpevpn_unlink_from_l3vni(vpn);
+		bgp_evpn_evi_unlink_from_l3vni(vpn);
 
 	UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_L3VNI_PREFIX_ROUTES_ONLY);
 
@@ -7596,7 +7596,7 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 	return 0;
 }
 
-static void bgp_evpn_l2vni_remote_route_processing(struct bgpevpn *vpn)
+static void bgp_evpn_l2vni_remote_route_processing(struct bgp_evpn_evi *vpn)
 {
 	/*
 	 * Anytime BGP gets a Bulk of L2 VNIs ADD/UPD from zebra,
@@ -7651,7 +7651,7 @@ void bgp_evpn_instance_down(struct bgp *bgp)
  */
 int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	/* Locate VNI hash */
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
@@ -7695,7 +7695,7 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 			   struct in_addr mcast_grp,
 			   ifindex_t svi_ifindex)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct prefix_evpn p;
 	struct bgp *bgp_evpn = bgp_get_evpn();
 
@@ -7753,9 +7753,9 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 				(void (*)(struct hash_bucket *, void *))
 					bgp_evpn_remote_ip_hash_unlink_nexthop,
 				vpn);
-			bgpevpn_unlink_from_l3vni(vpn);
+			bgp_evpn_evi_unlink_from_l3vni(vpn);
 			vpn->tenant_vrf_id = tenant_vrf_id;
-			bgpevpn_link_to_l3vni(vpn);
+			bgp_evpn_evi_link_to_l3vni(vpn);
 
 			/*
 			 * Resolve all the gateway IP nexthops for this VNI
@@ -7849,7 +7849,7 @@ void bgp_evpn_flood_control_change(struct bgp *bgp)
  */
 void bgp_evpn_cleanup_on_disable(struct bgp *bgp)
 {
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 	uint32_t vni_count = zebra_l2_vni_count(&bm->zebra_l2_vni_head);
 
 	/* Cleanup VNI FIFO list from this bgp instance */
@@ -8050,7 +8050,7 @@ static bool bgp_evpn_remote_ip_hash_cmp(const void *p1, const void *p2)
 	return !ipaddr_cmp(&ip1->addr, &ip2->addr);
 }
 
-static void bgp_evpn_remote_ip_hash_init(struct bgpevpn *vpn)
+static void bgp_evpn_remote_ip_hash_init(struct bgp_evpn_evi *vpn)
 {
 	if (!evpn_resolve_overlay_index())
 		return;
@@ -8063,7 +8063,7 @@ static void bgp_evpn_remote_ip_hash_init(struct bgpevpn *vpn)
 static void bgp_evpn_remote_ip_hash_free(struct hash_bucket *bucket, void *args)
 {
 	struct evpn_remote_ip *ip = (struct evpn_remote_ip *)bucket->data;
-	struct bgpevpn *vpn = (struct bgpevpn *)args;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)args;
 
 	bgp_evpn_remote_ip_process_nexthops(vpn, &ip->addr, false);
 
@@ -8073,7 +8073,7 @@ static void bgp_evpn_remote_ip_hash_free(struct hash_bucket *bucket, void *args)
 	XFREE(MTYPE_EVPN_REMOTE_IP, ip);
 }
 
-static void bgp_evpn_remote_ip_hash_destroy(struct bgpevpn *vpn)
+static void bgp_evpn_remote_ip_hash_destroy(struct bgp_evpn_evi *vpn)
 {
 	if (!evpn_resolve_overlay_index() || vpn->remote_ip_hash == NULL)
 		return;
@@ -8086,7 +8086,7 @@ static void bgp_evpn_remote_ip_hash_destroy(struct bgpevpn *vpn)
 }
 
 /* Add a remote MAC/IP route to hash table */
-static void bgp_evpn_remote_ip_hash_add(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_hash_add(struct bgp_evpn_evi *vpn,
 					struct bgp_path_info *pi)
 {
 	struct evpn_remote_ip tmp;
@@ -8123,7 +8123,7 @@ static void bgp_evpn_remote_ip_hash_add(struct bgpevpn *vpn,
 }
 
 /* Delete a remote MAC/IP route from hash table */
-static void bgp_evpn_remote_ip_hash_del(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_hash_del(struct bgp_evpn_evi *vpn,
 					struct bgp_path_info *pi)
 {
 	struct evpn_remote_ip tmp;
@@ -8155,7 +8155,7 @@ static void bgp_evpn_remote_ip_hash_del(struct bgpevpn *vpn,
 	}
 }
 
-static void bgp_evpn_remote_ip_hash_iterate(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_hash_iterate(struct bgp_evpn_evi *vpn,
 					    void (*func)(struct hash_bucket *,
 							 void *),
 					    void *arg)
@@ -8183,7 +8183,7 @@ static void show_remote_ip_entry(struct hash_bucket *bucket, void *args)
 
 void bgp_evpn_show_remote_ip_hash(struct hash_bucket *bucket, void *args)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	struct vty *vty = (struct vty *)args;
 
 	vty_out(vty, "VNI: %u\n", vpn->vni);
@@ -8198,7 +8198,7 @@ static void bgp_evpn_remote_ip_hash_link_nexthop(struct hash_bucket *bucket,
 						 void *args)
 {
 	struct evpn_remote_ip *ip = (struct evpn_remote_ip *)bucket->data;
-	struct bgpevpn *vpn = (struct bgpevpn *)args;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)args;
 
 	bgp_evpn_remote_ip_process_nexthops(vpn, &ip->addr, true);
 }
@@ -8207,31 +8207,31 @@ static void bgp_evpn_remote_ip_hash_unlink_nexthop(struct hash_bucket *bucket,
 						   void *args)
 {
 	struct evpn_remote_ip *ip = (struct evpn_remote_ip *)bucket->data;
-	struct bgpevpn *vpn = (struct bgpevpn *)args;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)args;
 
 	bgp_evpn_remote_ip_process_nexthops(vpn, &ip->addr, false);
 }
 
 static unsigned int vni_svi_hash_key_make(const void *p)
 {
-	const struct bgpevpn *vpn = p;
+	const struct bgp_evpn_evi *vpn = p;
 
 	return jhash_1word(vpn->svi_ifindex, 0);
 }
 
 static bool vni_svi_hash_cmp(const void *p1, const void *p2)
 {
-	const struct bgpevpn *vpn1 = p1;
-	const struct bgpevpn *vpn2 = p2;
+	const struct bgp_evpn_evi *vpn1 = p1;
+	const struct bgp_evpn_evi *vpn2 = p2;
 
 	return (vpn1->svi_ifindex == vpn2->svi_ifindex);
 }
 
-static struct bgpevpn *bgp_evpn_vni_svi_hash_lookup(struct bgp *bgp,
+static struct bgp_evpn_evi *bgp_evpn_vni_svi_hash_lookup(struct bgp *bgp,
 						    ifindex_t svi)
 {
-	struct bgpevpn *vpn;
-	struct bgpevpn tmp;
+	struct bgp_evpn_evi *vpn;
+	struct bgp_evpn_evi tmp;
 
 	memset(&tmp, 0, sizeof(tmp));
 	tmp.svi_ifindex = svi;
@@ -8239,7 +8239,7 @@ static struct bgpevpn *bgp_evpn_vni_svi_hash_lookup(struct bgp *bgp,
 	return vpn;
 }
 
-static void bgp_evpn_link_to_vni_svi_hash(struct bgp *bgp, struct bgpevpn *vpn)
+static void bgp_evpn_link_to_vni_svi_hash(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	if (vpn->svi_ifindex == 0)
 		return;
@@ -8248,7 +8248,7 @@ static void bgp_evpn_link_to_vni_svi_hash(struct bgp *bgp, struct bgpevpn *vpn)
 }
 
 static void bgp_evpn_unlink_from_vni_svi_hash(struct bgp *bgp,
-					      struct bgpevpn *vpn)
+					      struct bgp_evpn_evi *vpn)
 {
 	if (vpn->svi_ifindex == 0)
 		return;
@@ -8258,7 +8258,7 @@ static void bgp_evpn_unlink_from_vni_svi_hash(struct bgp *bgp,
 
 void bgp_evpn_show_vni_svi_hash(struct hash_bucket *bucket, void *args)
 {
-	struct bgpevpn *evpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *evpn = (struct bgp_evpn_evi *)bucket->data;
 	struct vty *vty = (struct vty *)args;
 
 	vty_out(vty, "SVI: %u VNI: %u\n", evpn->svi_ifindex, evpn->vni);
@@ -8273,7 +8273,7 @@ void bgp_evpn_show_vni_svi_hash(struct hash_bucket *bucket, void *args)
 bool bgp_evpn_is_gateway_ip_resolved(struct bgp_nexthop_cache *bnc)
 {
 	struct bgp *bgp_evpn = NULL;
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 	struct evpn_remote_ip tmp;
 	struct prefix *p;
 
@@ -8324,7 +8324,7 @@ bool bgp_evpn_is_gateway_ip_resolved(struct bgp_nexthop_cache *bnc)
 }
 
 /* Resolve/Unresolve nexthops when a MAC/IP route is added/deleted */
-static void bgp_evpn_remote_ip_process_nexthops(struct bgpevpn *vpn,
+static void bgp_evpn_remote_ip_process_nexthops(struct bgp_evpn_evi *vpn,
 						struct ipaddr *addr,
 						bool resolve)
 {
@@ -8391,7 +8391,7 @@ static void bgp_evpn_remote_ip_process_nexthops(struct bgpevpn *vpn,
 void bgp_evpn_handle_resolve_overlay_index_set(struct hash_bucket *bucket,
 					       void *arg)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	struct bgp_dest *dest;
 	struct bgp_path_info *pi;
 
@@ -8406,7 +8406,7 @@ void bgp_evpn_handle_resolve_overlay_index_set(struct hash_bucket *bucket,
 void bgp_evpn_handle_resolve_overlay_index_unset(struct hash_bucket *bucket,
 						 void *arg)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 
 	bgp_evpn_remote_ip_hash_destroy(vpn);
 }

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -206,19 +206,19 @@ extern void bgp_aggr_supp_withdraw_from_evpn(struct bgp *bgp, afi_t afi,
 					     safi_t safi);
 
 extern enum zclient_send_status evpn_zebra_install(struct bgp *bgp,
-						   struct bgpevpn *vpn,
+						   struct bgp_evpn_evi *vpn,
 						   const struct prefix_evpn *p,
 						   struct bgp_path_info *pi);
 extern enum zclient_send_status
-evpn_zebra_uninstall(struct bgp *bgp, struct bgpevpn *vpn,
+evpn_zebra_uninstall(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 		     const struct prefix_evpn *p, struct bgp_path_info *pi,
 		     bool is_sync);
 bool bgp_evpn_skip_vrf_import_of_local_es(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
 					  struct bgp_path_info *pi, int install);
 int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
 				      struct bgp_path_info *parent_pi);
-extern void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgpevpn *vpn);
-extern int install_uninstall_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn, bool install);
+extern void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgp_evpn_evi *vpn);
+extern int install_uninstall_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn, bool install);
 extern void bgp_evpn_fill_rmac_nh_to_attr(struct bgp *bgp_vrf, struct attr *attr,
 					  struct prefix_evpn *evp, struct ipaddr *vtep_ip);
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -465,7 +465,7 @@ static void bgp_evpn_es_route_table_purge(struct bgp_evpn_es *es)
  * ESR).
  */
 int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
-			     struct bgpevpn *vpn, afi_t afi, safi_t safi,
+			     struct bgp_evpn_evi *vpn, afi_t afi, safi_t safi,
 			     struct bgp_dest *dest, struct attr *attr,
 			     struct bgp_path_info **ri, int *route_changed)
 {
@@ -592,7 +592,7 @@ int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
  * ESR).
  */
 static int bgp_evpn_mh_route_delete(struct bgp *bgp, struct bgp_evpn_es *es,
-				    struct bgpevpn *vpn,
+				    struct bgp_evpn_evi *vpn,
 				    struct bgp_evpn_es_frag *es_frag,
 				    struct prefix_evpn *p)
 {
@@ -668,7 +668,7 @@ static int bgp_evpn_mh_route_delete(struct bgp *bgp, struct bgp_evpn_es *es,
  * Delete all EAD/EVI local routes for this VNI from the global routing table.
  * These routes are scheduled for withdraw from peers.
  */
-int delete_global_ead_evi_routes(struct bgp *bgp, struct bgpevpn *vpn)
+int delete_global_ead_evi_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	afi_t afi;
 	safi_t safi;
@@ -1048,7 +1048,7 @@ bgp_evpn_type1_es_route_extcomm_build(struct bgp_evpn_es_frag *es_frag,
 
 /* Extended communities associated with EAD-per-EVI */
 static void bgp_evpn_type1_evi_route_extcomm_build(struct bgp_evpn_es *es,
-		struct bgpevpn *vpn, struct attr *attr)
+		struct bgp_evpn_evi *vpn, struct attr *attr)
 {
 	struct ecommunity ecom_encap;
 	struct ecommunity_val eval;
@@ -1076,7 +1076,7 @@ static void bgp_evpn_type1_evi_route_extcomm_build(struct bgp_evpn_es *es,
  * vpn - valid for EAD-EVI routes and NULL for EAD-ES routes
  */
 static int bgp_evpn_type1_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
-				       struct bgpevpn *vpn,
+				       struct bgp_evpn_evi *vpn,
 				       struct bgp_evpn_es_frag *es_frag,
 				       struct prefix_evpn *p)
 {
@@ -1209,7 +1209,7 @@ static void bgp_evpn_ead_es_route_update(struct bgp *bgp,
 
 static void bgp_evpn_ead_evi_route_update(struct bgp *bgp,
 					  struct bgp_evpn_es *es,
-					  struct bgpevpn *vpn,
+					  struct bgp_evpn_evi *vpn,
 					  struct prefix_evpn *p)
 {
 	if (bgp_evpn_type1_route_update(bgp, es, vpn, NULL, p))
@@ -1218,7 +1218,7 @@ static void bgp_evpn_ead_evi_route_update(struct bgp *bgp,
 			 es->esi_str, vpn->vni);
 }
 
-void update_type1_routes_for_evi(struct bgp *bgp, struct bgpevpn *vpn)
+void update_type1_routes_for_evi(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	struct prefix_evpn p;
 	struct bgp_evpn_es *es;
@@ -1262,7 +1262,7 @@ static void bgp_evpn_ead_es_route_delete(struct bgp *bgp,
 
 static int bgp_evpn_ead_evi_route_delete(struct bgp *bgp,
 					 struct bgp_evpn_es *es,
-					 struct bgpevpn *vpn,
+					 struct bgp_evpn_evi *vpn,
 					 struct prefix_evpn *p)
 {
 	return bgp_evpn_mh_route_delete(bgp, es, vpn, NULL, p);
@@ -2250,7 +2250,7 @@ static void bgp_evpn_mac_update_on_es_oper_chg(struct bgp_evpn_es *es)
 	struct bgp_path_es_info *es_info;
 	struct bgp_path_info *pi;
 	struct bgp *bgp;
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	if (!bgp_mh_info->suppress_l3_ecomm_on_inactive_es)
 		return;
@@ -3301,7 +3301,7 @@ void bgp_evpn_es_vrf_ref(struct bgp_evpn_es_evi *es_evi, struct bgp *bgp_vrf)
 /* When the L2-VNI is associated with a L3-VNI/VRF update all the
  * associated ES-EVI entries
  */
-void bgp_evpn_es_evi_vrf_deref(struct bgpevpn *vpn)
+void bgp_evpn_es_evi_vrf_deref(struct bgp_evpn_evi *vpn)
 {
 	struct bgp_evpn_es_evi *es_evi;
 
@@ -3311,7 +3311,7 @@ void bgp_evpn_es_evi_vrf_deref(struct bgpevpn *vpn)
 	RB_FOREACH (es_evi, bgp_es_evi_rb_head, &vpn->es_evi_rb_tree)
 		bgp_evpn_es_vrf_deref(es_evi);
 }
-void bgp_evpn_es_evi_vrf_ref(struct bgpevpn *vpn)
+void bgp_evpn_es_evi_vrf_ref(struct bgp_evpn_evi *vpn)
 {
 	struct bgp_evpn_es_evi *es_evi;
 
@@ -3548,7 +3548,7 @@ void bgp_evpn_es_vrf_show_esi(struct vty *vty, esi_t *esi, bool uj)
 /*****************************************************************************/
 /* Ethernet Segment to EVI association -
  * 1. The ES-EVI entry is maintained as a RB tree per L2-VNI
- * (bgpevpn->es_evi_rb_tree).
+ * (bgp_evpn_evi->es_evi_rb_tree).
  * 2. Each local ES-EVI entry is rxed from zebra and then used by BGP to
  * advertises an EAD-EVI (Type-1 EVPN) route
  * 3. The remote ES-EVI is created when a bgp_evpn_es_evi_vtep references
@@ -3737,7 +3737,7 @@ RB_GENERATE(bgp_es_evi_rb_head, bgp_evpn_es_evi, rb_node, bgp_es_evi_rb_cmp);
 
 /* find the ES-EVI in the per-L2-VNI RB tree */
 static struct bgp_evpn_es_evi *bgp_evpn_es_evi_find(struct bgp_evpn_es *es,
-		struct bgpevpn *vpn)
+		struct bgp_evpn_evi *vpn)
 {
 	struct bgp_evpn_es_evi es_evi;
 
@@ -3750,7 +3750,7 @@ static struct bgp_evpn_es_evi *bgp_evpn_es_evi_find(struct bgp_evpn_es *es,
  * tables.
  */
 static struct bgp_evpn_es_evi *bgp_evpn_es_evi_new(struct bgp_evpn_es *es,
-		struct bgpevpn *vpn)
+		struct bgp_evpn_evi *vpn)
 {
 	struct bgp_evpn_es_evi *es_evi;
 
@@ -3792,7 +3792,7 @@ static struct bgp_evpn_es_evi *bgp_evpn_es_evi_free_internal(struct bgp_evpn_es_
 							     bool force)
 {
 	struct bgp_evpn_es *es = es_evi->es;
-	struct bgpevpn *vpn = es_evi->vpn;
+	struct bgp_evpn_evi *vpn = es_evi->vpn;
 
 	if (BGP_DEBUG(evpn_mh, EVPN_MH_ES))
 		zlog_debug("Freeing ES-EVI for ES %s VNI %u flags 0x%x%s", es->esi_str, vpn->vni,
@@ -3833,7 +3833,7 @@ static struct bgp_evpn_es_evi *bgp_evpn_es_evi_free(struct bgp_evpn_es_evi *es_e
 /* init local info associated with the ES-EVI */
 static void bgp_evpn_es_evi_local_info_set(struct bgp_evpn_es_evi *es_evi)
 {
-	struct bgpevpn *vpn = es_evi->vpn;
+	struct bgp_evpn_evi *vpn = es_evi->vpn;
 
 	if (CHECK_FLAG(es_evi->flags, BGP_EVPNES_EVI_LOCAL))
 		return;
@@ -3852,7 +3852,7 @@ static void bgp_evpn_es_evi_local_info_set(struct bgp_evpn_es_evi *es_evi)
 static struct bgp_evpn_es_evi *
 bgp_evpn_es_evi_local_info_clear(struct bgp_evpn_es_evi *es_evi)
 {
-	struct bgpevpn *vpn = es_evi->vpn;
+	struct bgp_evpn_evi *vpn = es_evi->vpn;
 
 	UNSET_FLAG(es_evi->flags, BGP_EVPNES_EVI_LOCAL);
 	list_delete_node(vpn->local_es_evi_list, &es_evi->l2vni_listnode);
@@ -3929,7 +3929,7 @@ bgp_evpn_local_es_evi_do_del(struct bgp_evpn_es_evi *es_evi)
 
 int bgp_evpn_local_es_evi_del(struct bgp *bgp, esi_t *esi, vni_t vni)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct bgp_evpn_es *es;
 	struct bgp_evpn_es_evi *es_evi;
 	char buf[ESI_STR_LEN];
@@ -3969,7 +3969,7 @@ int bgp_evpn_local_es_evi_del(struct bgp *bgp, esi_t *esi, vni_t vni)
 /* Create ES-EVI and advertise the corresponding EAD routes */
 int bgp_evpn_local_es_evi_add(struct bgp *bgp, esi_t *esi, vni_t vni)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct prefix_evpn p;
 	struct bgp_evpn_es *es;
 	struct bgp_evpn_es_evi *es_evi;
@@ -4034,7 +4034,7 @@ int bgp_evpn_local_es_evi_add(struct bgp *bgp, esi_t *esi, vni_t vni)
  * ES-EVI is implicitly created on first VTEP's reference.
  */
 enum zclient_send_status bgp_evpn_remote_es_evi_add(struct bgp *bgp,
-						    struct bgpevpn *vpn,
+						    struct bgp_evpn_evi *vpn,
 						    const struct prefix_evpn *p,
 							struct bgp_path_info *pi)
 {
@@ -4077,7 +4077,7 @@ enum zclient_send_status bgp_evpn_remote_es_evi_add(struct bgp *bgp,
  * parent es-evi freed up implicitly in last VTEP's deref.
  */
 enum zclient_send_status bgp_evpn_remote_es_evi_del(struct bgp *bgp,
-						    struct bgpevpn *vpn,
+						    struct bgp_evpn_evi *vpn,
 						    const struct prefix_evpn *p,
 						    struct bgp_path_info *pi)
 {
@@ -4153,7 +4153,7 @@ static void bgp_evpn_remote_es_evi_flush(struct bgp_evpn_es_evi *es_evi)
 }
 
 /* Initialize the ES tables maintained per-L2_VNI */
-void bgp_evpn_vni_es_init(struct bgpevpn *vpn)
+void bgp_evpn_vni_es_init(struct bgp_evpn_evi *vpn)
 {
 	/* Initialize the ES-EVI RB tree */
 	RB_INIT(bgp_es_evi_rb_head, &vpn->es_evi_rb_tree);
@@ -4164,7 +4164,7 @@ void bgp_evpn_vni_es_init(struct bgpevpn *vpn)
 }
 
 /* Cleanup the ES info maintained per-L2_VNI */
-void bgp_evpn_vni_es_cleanup(struct bgpevpn *vpn)
+void bgp_evpn_vni_es_cleanup(struct bgp_evpn_evi *vpn)
 {
 	struct bgp_evpn_es_evi *es_evi;
 	struct bgp_evpn_es_evi *es_evi_next;
@@ -4344,7 +4344,7 @@ static void bgp_evpn_es_evi_show_entry_detail(struct vty *vty,
 	}
 }
 
-static void bgp_evpn_es_evi_show_one_vni(struct bgpevpn *vpn, struct vty *vty,
+static void bgp_evpn_es_evi_show_one_vni(struct bgp_evpn_evi *vpn, struct vty *vty,
 		json_object *json_array, bool detail)
 {
 	struct bgp_evpn_es_evi *es_evi;
@@ -4373,7 +4373,7 @@ struct es_evi_show_ctx {
 static void bgp_evpn_es_evi_show_one_vni_hash_cb(struct hash_bucket *bucket,
 		void *ctxt)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	struct es_evi_show_ctx *wctx = (struct es_evi_show_ctx *)ctxt;
 
 	bgp_evpn_es_evi_show_one_vni(vpn, wctx->vty, wctx->json, wctx->detail);
@@ -4417,7 +4417,7 @@ void bgp_evpn_es_evi_show(struct vty *vty, bool uj, bool detail)
 void bgp_evpn_es_evi_show_vni(struct vty *vty, vni_t vni,
 		bool uj, bool detail)
 {
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 	json_object *json_array = NULL;
 	struct bgp *bgp;
 

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -216,7 +216,7 @@ struct bgp_evpn_es_evi {
 	struct bgp_evpn_es *es;
 	/* Only applicableif EVI_LOCAL */
 	struct bgp_evpn_es_frag *es_frag;
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	/* ES-EVI flags */
 	uint32_t flags;
@@ -401,10 +401,10 @@ extern int bgp_evpn_es_route_install_uninstall(struct bgp *bgp,
 		struct bgp_evpn_es *es, afi_t afi, safi_t safi,
 		struct prefix_evpn *evp, struct bgp_path_info *pi,
 		int install);
-extern void update_type1_routes_for_evi(struct bgp *bgp, struct bgpevpn *vpn);
-extern int delete_global_ead_evi_routes(struct bgp *bgp, struct bgpevpn *vpn);
+extern void update_type1_routes_for_evi(struct bgp *bgp, struct bgp_evpn_evi *vpn);
+extern int delete_global_ead_evi_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 extern int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
-				    struct bgpevpn *vpn, afi_t afi, safi_t safi,
+				    struct bgp_evpn_evi *vpn, afi_t afi, safi_t safi,
 				    struct bgp_dest *dest, struct attr *attr,
 				    struct bgp_path_info **ri,
 				    int *route_changed);
@@ -420,18 +420,18 @@ extern int bgp_evpn_local_es_del(struct bgp *bgp, esi_t *esi);
 extern int bgp_evpn_local_es_evi_add(struct bgp *bgp, esi_t *esi, vni_t vni);
 extern int bgp_evpn_local_es_evi_del(struct bgp *bgp, esi_t *esi, vni_t vni);
 extern enum zclient_send_status
-bgp_evpn_remote_es_evi_add(struct bgp *bgp, struct bgpevpn *vpn,
+bgp_evpn_remote_es_evi_add(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			   const struct prefix_evpn *p,
 			   struct bgp_path_info *pi);
 extern enum zclient_send_status
-bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgpevpn *vpn,
+bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			   const struct prefix_evpn *p,
 			   struct bgp_path_info *pi);
 extern void bgp_evpn_mh_init(void);
 extern void bgp_evpn_mh_finish(void);
 extern void bgp_evpn_es_cleanup_routes(struct bgp *bgp);
-void bgp_evpn_vni_es_init(struct bgpevpn *vpn);
-void bgp_evpn_vni_es_cleanup(struct bgpevpn *vpn);
+void bgp_evpn_vni_es_init(struct bgp_evpn_evi *vpn);
+void bgp_evpn_vni_es_cleanup(struct bgp_evpn_evi *vpn);
 void bgp_evpn_es_show_esi(struct vty *vty, esi_t *esi, bool uj);
 void bgp_evpn_es_show(struct vty *vty, bool uj, bool detail);
 void bgp_evpn_es_evi_show_vni(struct vty *vty, vni_t vni,

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -50,7 +50,7 @@ RB_PROTOTYPE(bgp_es_evi_rb_head, bgp_evpn_es_evi, rb_node,
  * on the system (through interaction with zebra) as well as pre-configured
  * VNIs (which need to be defined in the system to become "live").
  */
-struct bgpevpn {
+struct bgp_evpn_evi {
 	vni_t vni;
 	vrf_id_t tenant_vrf_id;
 	ifindex_t svi_ifindex;
@@ -123,9 +123,9 @@ struct bgpevpn {
 	QOBJ_FIELDS;
 };
 
-DECLARE_QOBJ_TYPE(bgpevpn);
+DECLARE_QOBJ_TYPE(bgp_evpn_evi);
 
-DECLARE_LIST(zebra_l2_vni, struct bgpevpn, zl2vni);
+DECLARE_LIST(zebra_l2_vni, struct bgp_evpn_evi, zl2vni);
 
 /* Mapping of Import RT to VNIs.
  * The Import RTs of all VNIs are maintained in a hash table with each
@@ -224,12 +224,12 @@ static inline int bgp_evpn_vrf_rd_matches_existing(struct bgp *bgp_vrf,
 	return (memcmp(&bgp_vrf->vrf_prd.val, prd->val, ECOMMUNITY_SIZE) == 0);
 }
 
-static inline vni_t bgpevpn_get_l3vni(struct bgpevpn *vpn)
+static inline vni_t bgp_evpn_evi_get_l3vni(struct bgp_evpn_evi *vpn)
 {
 	return vpn->bgp_vrf ? vpn->bgp_vrf->l3vni : 0;
 }
 
-static inline void bgpevpn_get_rmac(struct bgpevpn *vpn, struct ethaddr *rmac)
+static inline void bgp_evpn_evi_get_rmac(struct bgp_evpn_evi *vpn, struct ethaddr *rmac)
 {
 	memset(rmac, 0, sizeof(struct ethaddr));
 	if (!vpn->bgp_vrf)
@@ -237,7 +237,7 @@ static inline void bgpevpn_get_rmac(struct bgpevpn *vpn, struct ethaddr *rmac)
 	memcpy(rmac, &vpn->bgp_vrf->rmac, sizeof(struct ethaddr));
 }
 
-static inline struct list *bgpevpn_get_vrf_export_rtl(struct bgpevpn *vpn)
+static inline struct list *bgp_evpn_evi_get_vrf_export_rtl(struct bgp_evpn_evi *vpn)
 {
 	if (!vpn->bgp_vrf)
 		return NULL;
@@ -245,7 +245,7 @@ static inline struct list *bgpevpn_get_vrf_export_rtl(struct bgpevpn *vpn)
 	return vpn->bgp_vrf->vrf_export_rtl;
 }
 
-static inline struct list *bgpevpn_get_vrf_import_rtl(struct bgpevpn *vpn)
+static inline struct list *bgp_evpn_evi_get_vrf_import_rtl(struct bgp_evpn_evi *vpn)
 {
 	if (!vpn->bgp_vrf)
 		return NULL;
@@ -253,10 +253,10 @@ static inline struct list *bgpevpn_get_vrf_import_rtl(struct bgpevpn *vpn)
 	return vpn->bgp_vrf->vrf_import_rtl;
 }
 
-extern void bgp_evpn_es_evi_vrf_ref(struct bgpevpn *vpn);
-extern void bgp_evpn_es_evi_vrf_deref(struct bgpevpn *vpn);
+extern void bgp_evpn_es_evi_vrf_ref(struct bgp_evpn_evi *vpn);
+extern void bgp_evpn_es_evi_vrf_deref(struct bgp_evpn_evi *vpn);
 
-static inline void bgpevpn_unlink_from_l3vni(struct bgpevpn *vpn)
+static inline void bgp_evpn_evi_unlink_from_l3vni(struct bgp_evpn_evi *vpn)
 {
 	/* bail if vpn is not associated to bgp_vrf */
 	if (!vpn->bgp_vrf)
@@ -276,7 +276,7 @@ static inline void bgpevpn_unlink_from_l3vni(struct bgpevpn *vpn)
 	vpn->bgp_vrf = NULL;
 }
 
-static inline void bgpevpn_link_to_l3vni(struct bgpevpn *vpn)
+static inline void bgp_evpn_evi_link_to_l3vni(struct bgp_evpn_evi *vpn)
 {
 	struct bgp *bgp_vrf = NULL;
 
@@ -306,12 +306,12 @@ static inline void bgpevpn_link_to_l3vni(struct bgpevpn *vpn)
 	bgp_evpn_es_evi_vrf_ref(vpn);
 }
 
-static inline int is_vni_configured(struct bgpevpn *vpn)
+static inline int is_vni_configured(struct bgp_evpn_evi *vpn)
 {
 	return (CHECK_FLAG(vpn->flags, VNI_FLAG_CFGD));
 }
 
-static inline int is_vni_live(struct bgpevpn *vpn)
+static inline int is_vni_live(struct bgp_evpn_evi *vpn)
 {
 	return (CHECK_FLAG(vpn->flags, VNI_FLAG_LIVE));
 }
@@ -321,23 +321,23 @@ static inline int is_l3vni_live(struct bgp *bgp_vrf)
 	return (bgp_vrf->l3vni && bgp_vrf->l3vni_svi_ifindex);
 }
 
-static inline int is_rd_configured(struct bgpevpn *vpn)
+static inline int is_rd_configured(struct bgp_evpn_evi *vpn)
 {
 	return (CHECK_FLAG(vpn->flags, VNI_FLAG_RD_CFGD));
 }
 
-static inline int bgp_evpn_rd_matches_existing(struct bgpevpn *vpn,
+static inline int bgp_evpn_rd_matches_existing(struct bgp_evpn_evi *vpn,
 					       struct prefix_rd *prd)
 {
 	return (memcmp(&vpn->prd.val, prd->val, ECOMMUNITY_SIZE) == 0);
 }
 
-static inline int is_import_rt_configured(struct bgpevpn *vpn)
+static inline int is_import_rt_configured(struct bgp_evpn_evi *vpn)
 {
 	return (CHECK_FLAG(vpn->flags, VNI_FLAG_IMPRT_CFGD));
 }
 
-static inline int is_export_rt_configured(struct bgpevpn *vpn)
+static inline int is_export_rt_configured(struct bgp_evpn_evi *vpn)
 {
 	return (CHECK_FLAG(vpn->flags, VNI_FLAG_EXPRT_CFGD));
 }
@@ -717,7 +717,7 @@ static inline void es_get_system_mac(esi_t *esi,
 	memcpy(mac, &esi->val[1], ETH_ALEN);
 }
 
-static inline bool bgp_evpn_is_svi_macip_enabled(struct bgpevpn *vpn)
+static inline bool bgp_evpn_is_svi_macip_enabled(struct bgp_evpn_evi *vpn)
 {
 	struct bgp *bgp_evpn = NULL;
 
@@ -753,41 +753,41 @@ extern void bgp_evpn_unconfigure_import_rt_for_vrf(struct bgp *bgp_vrf,
 						   struct ecommunity *ecomdel);
 extern void bgp_evpn_unconfigure_import_auto_rt_for_vrf(struct bgp *bgp_vrf);
 extern int bgp_evpn_handle_export_rt_change(struct bgp *bgp,
-					    struct bgpevpn *vpn);
+					    struct bgp_evpn_evi *vpn);
 extern void bgp_evpn_handle_autort_change(struct bgp *bgp);
 extern void bgp_evpn_handle_vrf_rd_change(struct bgp *bgp_vrf, int withdraw);
-extern void bgp_evpn_handle_rd_change(struct bgp *bgp, struct bgpevpn *vpn,
+extern void bgp_evpn_handle_rd_change(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				      int withdraw);
 void bgp_evpn_handle_global_macvrf_soo_change(struct bgp *bgp,
 					      struct ecommunity *new_soo);
-extern int bgp_evpn_install_routes(struct bgp *bgp, struct bgpevpn *vpn);
-extern int bgp_evpn_uninstall_routes(struct bgp *bgp, struct bgpevpn *vpn);
+extern int bgp_evpn_install_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn);
+extern int bgp_evpn_uninstall_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 extern void bgp_evpn_map_vrf_to_its_rts(struct bgp *bgp_vrf);
 extern void bgp_evpn_unmap_vrf_from_its_rts(struct bgp *bgp_vrf);
-extern void bgp_evpn_map_vni_to_its_rts(struct bgp *bgp, struct bgpevpn *vpn);
+extern void bgp_evpn_map_vni_to_its_rts(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 extern void bgp_evpn_unmap_vni_from_its_rts(struct bgp *bgp,
-					    struct bgpevpn *vpn);
+					    struct bgp_evpn_evi *vpn);
 extern void bgp_evpn_derive_auto_rt_import(struct bgp *bgp,
-					   struct bgpevpn *vpn);
+					   struct bgp_evpn_evi *vpn);
 extern void bgp_evpn_derive_auto_rt_export(struct bgp *bgp,
-					   struct bgpevpn *vpn);
-extern void bgp_evpn_derive_auto_rd(struct bgp *bgp, struct bgpevpn *vpn);
+					   struct bgp_evpn_evi *vpn);
+extern void bgp_evpn_derive_auto_rd(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 extern void bgp_evpn_derive_auto_rd_for_vrf(struct bgp *bgp);
-extern struct bgpevpn *bgp_evpn_lookup_vni(struct bgp *bgp, vni_t vni);
-extern struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
+extern struct bgp_evpn_evi *bgp_evpn_lookup_vni(struct bgp *bgp, vni_t vni);
+extern struct bgp_evpn_evi *bgp_evpn_new(struct bgp *bgp, vni_t vni,
 		struct ipaddr *originator_ip,
 		vrf_id_t tenant_vrf_id,
 		struct in_addr mcast_grp,
 		ifindex_t svi_ifindex);
-extern void bgp_evpn_free(struct bgp *bgp, struct bgpevpn *vpn);
+extern void bgp_evpn_free(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 extern bool bgp_evpn_lookup_l3vni_l2vni_table(vni_t vni);
-extern int update_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn);
+extern int update_routes_for_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn);
 extern struct bgp_path_info *delete_evpn_route_entry(struct bgp *bgp, afi_t afi, safi_t safi,
 						     struct bgp_dest *dest,
 						     const struct bgp_path_info *originator,
 						     uint32_t addpaht_id);
 int vni_list_cmp(void *p1, void *p2);
-extern int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
+extern int evpn_route_select_install(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				     struct bgp_dest *dest,
 				     struct bgp_path_info *pi);
 extern struct bgp_dest *
@@ -814,15 +814,15 @@ bgp_evpn_vni_mac_node_lookup(const struct bgp_table *const table,
 			     const struct prefix_evpn *evp,
 			     const struct bgp_path_info *parent_pi);
 extern struct bgp_dest *
-bgp_evpn_vni_node_get(struct bgpevpn *vpn, const struct prefix_evpn *p,
+bgp_evpn_vni_node_get(struct bgp_evpn_evi *vpn, const struct prefix_evpn *p,
 		      const struct bgp_path_info *parent_pi);
 extern struct bgp_dest *
-bgp_evpn_vni_node_lookup(const struct bgpevpn *vpn, const struct prefix_evpn *p,
+bgp_evpn_vni_node_lookup(const struct bgp_evpn_evi *vpn, const struct prefix_evpn *p,
 			 const struct bgp_path_info *parent_pi);
 
 extern void bgp_evpn_import_route_in_vrfs(struct bgp_path_info *pi, int import);
 extern void bgp_evpn_update_type2_route_entry(struct bgp *bgp,
-					      struct bgpevpn *vpn,
+					      struct bgp_evpn_evi *vpn,
 					      struct bgp_dest *rn,
 					      struct bgp_path_info *local_pi,
 					      const char *caller);
@@ -836,6 +836,6 @@ extern int bgp_evpn_route_target_cmp(struct ecommunity *ecom1,
 extern void bgp_evpn_handle_deferred_bestpath_for_vnis(struct bgp *bgp, uint16_t cnt);
 extern uint16_t bgp_deferred_path_selection(struct bgp *bgp, afi_t afi, safi_t safi,
 					    struct bgp_table *table, uint16_t cnt,
-					    struct bgpevpn *vpn, bool evpn_select);
+					    struct bgp_evpn_evi *vpn, bool evpn_select);
 
 #endif /* _BGP_EVPN_PRIVATE_H */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -177,7 +177,7 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 	struct ecommunity_as eas;
 	struct ecommunity_ip eip;
 	struct listnode *node, *nnode;
-	struct bgpevpn *tmp_vpn;
+	struct bgp_evpn_evi *tmp_vpn;
 	json_object *json_rt = NULL;
 	json_object *json_vnis = NULL;
 	char rt_buf[RT_ADDRSTRLEN];
@@ -478,7 +478,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		json_object_object_add(json, "exportRts", json_export_rtl);
 }
 
-static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
+static void display_vni(struct vty *vty, struct bgp_evpn_evi *vpn, json_object *json)
 {
 	char *ecom_str;
 	struct listnode *node, *nnode;
@@ -803,7 +803,7 @@ static void bgp_evpn_show_routes_mac_ip_global_es(struct vty *vty, esi_t *esi,
 	bgp_evpn_show_routes_mac_ip_es(vty, esi, json, detail, true);
 }
 
-static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn,
+static void show_vni_routes(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			    struct vty *vty, int type, bool mac_table,
 			    struct ipaddr *vtep_ip, json_object *json,
 			    int detail)
@@ -948,7 +948,7 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn,
 
 static void show_vni_routes_hash(struct hash_bucket *bucket, void *arg)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	struct vni_walk_ctx *wctx = arg;
 	struct vty *vty = wctx->vty;
 	json_object *json = wctx->json;
@@ -972,7 +972,7 @@ static void show_vni_routes_hash(struct hash_bucket *bucket, void *arg)
 
 static void show_vni_routes_all_hash(struct hash_bucket *bucket, void *arg)
 {
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	struct vni_walk_ctx *wctx = arg;
 	struct vty *vty = wctx->vty;
 	json_object *json = wctx->json;
@@ -1150,7 +1150,7 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 	json_object *json_vni = NULL;
 	json_object *json_import_rtl = NULL;
 	json_object *json_export_rtl = NULL;
-	struct bgpevpn *vpn = (struct bgpevpn *)bucket->data;
+	struct bgp_evpn_evi *vpn = (struct bgp_evpn_evi *)bucket->data;
 	char buf1[10];
 	char rt_buf[25];
 	char *ecom_str;
@@ -2176,12 +2176,12 @@ DEFUN(no_evpnrt5_network,
 			      argv[idx_gwip]->arg, argv[idx_ethtag]->arg, NULL);
 }
 
-static void evpn_import_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_import_rt_delete_auto(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	evpn_rt_delete_auto(bgp, vpn->vni, vpn->import_rtl, false);
 }
 
-static void evpn_export_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_export_rt_delete_auto(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	evpn_rt_delete_auto(bgp, vpn->vni, vpn->export_rtl, false);
 }
@@ -2190,7 +2190,7 @@ static void evpn_export_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)
  * Configure the Import RTs for a VNI (vty handler). Caller expected to
  * check that this is a change.
  */
-static void evpn_configure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_configure_import_rt(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				     struct ecommunity *ecomadd)
 {
 	/* If the VNI is "live", we need to uninstall routes using the current
@@ -2220,7 +2220,7 @@ static void evpn_configure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
 /*
  * Unconfigure Import RT(s) for a VNI (vty handler).
  */
-static void evpn_unconfigure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_unconfigure_import_rt(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				       struct ecommunity *ecomdel)
 {
 	struct listnode *node, *nnode, *node_to_del;
@@ -2280,7 +2280,7 @@ static void evpn_unconfigure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
  * allowed for a VNI and any change to configuration is implemented as
  * a "replace" (similar to other configuration).
  */
-static void evpn_configure_export_rt(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_configure_export_rt(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				     struct ecommunity *ecomadd)
 {
 	/* If the auto route-target is in use we must remove it */
@@ -2296,7 +2296,7 @@ static void evpn_configure_export_rt(struct bgp *bgp, struct bgpevpn *vpn,
 /*
  * Unconfigure the Export RT for a VNI (vty handler)
  */
-static void evpn_unconfigure_export_rt(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_unconfigure_export_rt(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 				       struct ecommunity *ecomdel)
 {
 	struct listnode *node, *nnode, *node_to_del;
@@ -2386,7 +2386,7 @@ static void evpn_unconfigure_vrf_rd(struct bgp *bgp_vrf)
 /*
  * Configure RD for a VNI (vty handler)
  */
-static void evpn_configure_rd(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_configure_rd(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 			      struct prefix_rd *rd, const char *rd_pretty)
 {
 	/* If the VNI is "live", we need to delete and withdraw this VNI's
@@ -2410,7 +2410,7 @@ static void evpn_configure_rd(struct bgp *bgp, struct bgpevpn *vpn,
 /*
  * Unconfigure RD for a VNI (vty handler)
  */
-static void evpn_unconfigure_rd(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_unconfigure_rd(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	/* If the VNI is "live", we need to delete and withdraw this VNI's
 	 * local routes with the prior RD first. Then, after resetting RD
@@ -2429,9 +2429,9 @@ static void evpn_unconfigure_rd(struct bgp *bgp, struct bgpevpn *vpn)
 /*
  * Create VNI, if not already present (VTY handler). Mark as configured.
  */
-static struct bgpevpn *evpn_create_update_vni(struct bgp *bgp, vni_t vni)
+static struct bgp_evpn_evi *evpn_create_update_vni(struct bgp *bgp, vni_t vni)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct in_addr mcast_grp = {INADDR_ANY};
 	struct ipaddr orignator_ip = {};
 
@@ -2466,7 +2466,7 @@ static struct bgpevpn *evpn_create_update_vni(struct bgp *bgp, vni_t vni)
  * appropriate action) and the VNI marked as unconfigured; the
  * VNI will continue to exist, purely as a "learnt" entity.
  */
-static void evpn_delete_vni(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_delete_vni(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	if (!is_vni_live(vpn)) {
 		bgp_evpn_free(bgp, vpn);
@@ -2602,7 +2602,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 					  vni_t vni, struct ipaddr *orig_ip,
 					  json_object *json)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct prefix_evpn p;
 	struct bgp_dest *dest;
 	struct bgp_path_info *pi;
@@ -2678,7 +2678,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 				      vni_t vni, struct ethaddr *mac,
 				      struct ipaddr *ip, json_object *json)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct prefix_evpn p;
 	struct prefix_evpn tmp_p;
 	struct bgp_dest *dest;
@@ -2824,7 +2824,7 @@ static void evpn_show_routes_vni(struct vty *vty, struct bgp *bgp, vni_t vni,
 				 int type, bool mac_table,
 				 const union sockunion *_vtep_ip, json_object *json)
 {
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 	struct ipaddr vtep_ip;
 
 	/* Locate VNI. */
@@ -3600,7 +3600,7 @@ static void evpn_show_vni(struct vty *vty, struct bgp *bgp, vni_t vni,
 			  json_object *json)
 {
 	uint8_t found = 0;
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
 	if (vpn) {
@@ -3657,7 +3657,7 @@ static void evpn_show_all_vnis(struct vty *vty, struct bgp *bgp,
 /*
  * evpn - enable advertisement of svi MAC-IP
  */
-static void evpn_set_advertise_svi_macip(struct bgp *bgp, struct bgpevpn *vpn,
+static void evpn_set_advertise_svi_macip(struct bgp *bgp, struct bgp_evpn_evi *vpn,
 					 uint32_t set)
 {
 	if (!vpn) {
@@ -3684,7 +3684,7 @@ static void evpn_set_advertise_svi_macip(struct bgp *bgp, struct bgpevpn *vpn,
 /*
  * evpn - enable advertisement of default g/w
  */
-static void evpn_set_advertise_default_gw(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_set_advertise_default_gw(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	if (!vpn) {
 		if (bgp->advertise_gw_macip)
@@ -3707,7 +3707,7 @@ static void evpn_set_advertise_default_gw(struct bgp *bgp, struct bgpevpn *vpn)
  * evpn - disable advertisement of default g/w
  */
 static void evpn_unset_advertise_default_gw(struct bgp *bgp,
-					    struct bgpevpn *vpn)
+					    struct bgp_evpn_evi *vpn)
 {
 	if (!vpn) {
 		if (!bgp->advertise_gw_macip)
@@ -3765,7 +3765,7 @@ static void evpn_process_default_originate_cmd(struct bgp *bgp_vrf,
  * evpn - enable advertisement of default g/w
  */
 static void evpn_set_advertise_subnet(struct bgp *bgp,
-				      struct bgpevpn *vpn)
+				      struct bgp_evpn_evi *vpn)
 {
 	if (vpn->advertise_subnet)
 		return;
@@ -3777,7 +3777,7 @@ static void evpn_set_advertise_subnet(struct bgp *bgp,
 /*
  * evpn - disable advertisement of default g/w
  */
-static void evpn_unset_advertise_subnet(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_unset_advertise_subnet(struct bgp *bgp, struct bgp_evpn_evi *vpn)
 {
 	if (!vpn->advertise_subnet)
 		return;
@@ -3848,7 +3848,7 @@ static void evpn_unset_advertise_autort_rfc8365(struct bgp *bgp)
 	bgp_evpn_handle_autort_change(bgp);
 }
 
-static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
+static void write_vni_config(struct vty *vty, struct bgp_evpn_evi *vpn)
 {
 	char *ecom_str;
 	struct listnode *node, *nnode;
@@ -3940,7 +3940,7 @@ DEFUN (bgp_evpn_advertise_default_gw_vni,
        "Advertise default g/w mac-ip routes in EVPN for a VNI\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -3957,7 +3957,7 @@ DEFUN (no_bgp_evpn_advertise_default_vni_gw,
        "Withdraw default g/w mac-ip routes from EVPN for a VNI\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -4281,7 +4281,7 @@ DEFPY(bgp_evpn_advertise_svi_ip_vni,
       "Advertise svi mac-ip routes in EVPN for a VNI\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -4353,7 +4353,7 @@ DEFUN_HIDDEN (bgp_evpn_advertise_vni_subnet,
 {
 	struct bgp *bgp_vrf = NULL;
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -4373,7 +4373,7 @@ DEFUN_HIDDEN (no_bgp_evpn_advertise_vni_subnet,
 	      "Advertise All local VNIs\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -4774,7 +4774,7 @@ DEFPY (bgp_evpn_advertise_pip_ip_mac,
 
 	if (is_evpn_enabled()) {
 		struct listnode *node = NULL;
-		struct bgpevpn *vpn = NULL;
+		struct bgp_evpn_evi *vpn = NULL;
 
 		/*
 		 * At this point if bgp_evpn is NULL and evpn is enabled
@@ -6497,12 +6497,12 @@ DEFPY(bgp_evpn_flood_control_vni,
       "Do not flood any BUM packets\n"
       "Flood BUM packets using head-end replication\n")
 {
-	struct bgpevpn *evpn = NULL;
+	struct bgp_evpn_evi *evpn = NULL;
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
 	enum vxlan_flood_control flood_ctrl = VXLAN_FLOOD_INHERIT_GLOBAL;
 
 	if (vty->node == BGP_EVPN_VNI_NODE)
-		evpn = VTY_GET_CONTEXT_SUB(bgpevpn);
+		evpn = VTY_GET_CONTEXT_SUB(bgp_evpn_evi);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -6536,7 +6536,7 @@ DEFUN_NOSH (bgp_evpn_vni,
 {
 	vni_t vni;
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -6563,7 +6563,7 @@ DEFUN (no_bgp_evpn_vni,
 {
 	vni_t vni;
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	struct bgpevpn *vpn;
+	struct bgp_evpn_evi *vpn;
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -6688,7 +6688,7 @@ DEFUN (bgp_evpn_vni_rd,
 {
 	struct prefix_rd prd;
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 	int ret;
 
 	if (!bgp)
@@ -6724,7 +6724,7 @@ DEFUN (no_bgp_evpn_vni_rd,
 {
 	struct prefix_rd prd;
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 	int ret;
 
 	if (!bgp)
@@ -6765,7 +6765,7 @@ DEFUN (no_bgp_evpn_vni_rd_without_val,
        EVPN_RT_DIST_HELP_STR)
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 
 	if (!bgp)
 		return CMD_WARNING;
@@ -6837,7 +6837,7 @@ DEFUN (show_bgp_vrf_l3vni_info,
 	const char *name = NULL;
 	struct bgp *bgp = NULL;
 	struct listnode *node = NULL;
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 	struct vrf_route_target *l3rt;
 	json_object *json = NULL;
 	json_object *json_vnis = NULL;
@@ -7375,7 +7375,7 @@ DEFUN (bgp_evpn_vni_rt,
        "Route target (A.B.C.D:MN|EF:OPQR|GHJK:MN)\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 	int rt_type;
 	struct ecommunity *ecomadd = NULL;
 
@@ -7451,7 +7451,7 @@ DEFUN (no_bgp_evpn_vni_rt,
        EVPN_ASN_IP_HELP_STR)
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 	int rt_type, found_ecomdel;
 	struct ecommunity *ecomdel = NULL;
 
@@ -7555,7 +7555,7 @@ DEFUN (no_bgp_evpn_vni_rt_without_val,
        "export\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
+	VTY_DECLVAR_CONTEXT_SUB(bgp_evpn_evi, vpn);
 	int rt_type;
 
 	if (!bgp)
@@ -7601,8 +7601,8 @@ DEFUN (no_bgp_evpn_vni_rt_without_val,
 
 static int vni_cmp(const void **a, const void **b)
 {
-	const struct bgpevpn *first = *a;
-	const struct bgpevpn *secnd = *b;
+	const struct bgp_evpn_evi *first = *a;
+	const struct bgp_evpn_evi *secnd = *b;
 
 	return secnd->vni - first->vni;
 }
@@ -7619,7 +7619,7 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 	if (hashcount(bgp->vnihash)) {
 		struct list *vnilist = hash_to_list(bgp->vnihash);
 		struct listnode *ln;
-		struct bgpevpn *data;
+		struct bgp_evpn_evi *data;
 
 		list_sort(vnilist, vni_cmp);
 		for (ALL_LIST_ELEMENTS_RO(vnilist, ln, data))

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -87,7 +87,7 @@ struct bgp_dest {
 
 	struct bgp_bp_install_node *za_inode;
 	struct bgp_path_info *za_bgp_pi;
-	struct bgpevpn *za_vpn;
+	struct bgp_evpn_evi *za_vpn;
 	bool za_is_sync;
 
 	uint64_t version;

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -323,7 +323,7 @@ TRACEPOINT_LOGLEVEL(frr_bgp, bgp_path_info_free, TRACE_INFO)
 TRACEPOINT_EVENT(
 	frr_bgp,
 	evpn_mac_ip_zsend,
-	TP_ARGS(int, add, struct bgpevpn *, vpn,
+	TP_ARGS(int, add, struct bgp_evpn_evi *, vpn,
 		const struct prefix_evpn *, pfx,
 		struct ipaddr *, vtep, esi_t *, esi),
 	TP_FIELDS(
@@ -343,7 +343,7 @@ TRACEPOINT_LOGLEVEL(frr_bgp, evpn_mac_ip_zsend, TRACE_INFO)
 TRACEPOINT_EVENT(
 	frr_bgp,
 	evpn_bum_vtep_zsend,
-	TP_ARGS(int, add, struct bgpevpn *, vpn,
+	TP_ARGS(int, add, struct bgp_evpn_evi *, vpn,
 		const struct prefix_evpn *, pfx),
 	TP_FIELDS(
 		ctf_string(action, add ? "add" : "del")

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2036,7 +2036,7 @@ void bgp_zebra_update_fib_install_pending(struct bgp_dest *dest, struct bgp *bgp
  *                                     withdrawn.
  */
 void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
-			     struct bgp *bgp, bool install, struct bgpevpn *vpn,
+			     struct bgp *bgp, bool install, struct bgp_evpn_evi *vpn,
 			     bool is_sync)
 {
 	bool is_evpn = false;
@@ -2722,7 +2722,7 @@ int bgp_zebra_advertise_gw_macip(struct bgp *bgp, int advertise, vni_t vni)
 	return zclient_send_message(bgp_zclient);
 }
 
-int bgp_zebra_vxlan_flood_control(struct bgp *bgp, struct bgpevpn *evpn)
+int bgp_zebra_vxlan_flood_control(struct bgp *bgp, struct bgp_evpn_evi *evpn)
 {
 	struct stream *s;
 	vni_t vni = evpn ? evpn->vni : VNI_MAX;

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -43,7 +43,7 @@ extern int bgp_zebra_get_table_range(struct zclient *zc, uint32_t chunk_size,
 extern int bgp_if_update_all(void);
 extern void bgp_zebra_route_install(struct bgp_dest *dest,
 				    struct bgp_path_info *path, struct bgp *bgp,
-				    bool install, struct bgpevpn *vpn,
+				    bool install, struct bgp_evpn_evi *vpn,
 				    bool is_sync);
 extern void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi);
 
@@ -101,7 +101,7 @@ extern int bgp_zebra_advertise_svi_macip(struct bgp *bgp, int advertise,
 					 vni_t vni);
 extern int bgp_zebra_advertise_all_vni(struct bgp *bgp, int advertise);
 extern int bgp_zebra_dup_addr_detection(struct bgp *bgp);
-extern int bgp_zebra_vxlan_flood_control(struct bgp *bgp, struct bgpevpn *evpn);
+extern int bgp_zebra_vxlan_flood_control(struct bgp *bgp, struct bgp_evpn_evi *evpn);
 
 extern int bgp_zebra_num_connects(void);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4376,7 +4376,7 @@ int bgp_delete(struct bgp *bgp)
 	safi_t safi;
 	int i;
 	uint32_t vni_count;
-	struct bgpevpn *vpn = NULL;
+	struct bgp_evpn_evi *vpn = NULL;
 	struct graceful_restart_info *gr_info;
 	struct bgp *bgp_default = bgp_get_default();
 	struct bgp_clearing_info *cinfo;
@@ -4669,13 +4669,13 @@ int bgp_delete(struct bgp *bgp)
 		 *
 		 * This must run on every teardown of the EVPN-owner instance
 		 * (not only during daemon termination).  Each L2VNI holds a
-		 * bgp_lock on the owner via bgpevpn_link_to_l3vni(); without
+		 * bgp_lock on the owner via bgp_evpn_evi_link_to_l3vni(); without
 		 * releasing those locks here, "no router bgp" of the EVPN
 		 * owner leaks the instance, its peer_self, and any local
 		 * EVPN paths still held in the per-VNI tables.  The per-VNI
 		 * route tables were already drained above; free_vni_entry()
 		 * here re-runs delete_all_vni_routes() which is a no-op (the
-		 * tables are empty) and then frees the bgpevpn structs.
+		 * tables are empty) and then frees the bgp_evpn_evi structs.
 		 */
 		bgp_evpn_cleanup(bgp);
 	}

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1033,7 +1033,7 @@ struct bgp {
 	/* export rt list for the vrf instance */
 	struct list *vrf_export_rtl;
 
-	/* list of corresponding l2vnis (struct bgpevpn) */
+	/* list of corresponding l2vnis (struct bgp_evpn_evi) */
 	struct list *l2vnis;
 
 	/* route map for advertise ipv4/ipv6 unicast (type-5 routes) */


### PR DESCRIPTION
**Note: This is a sibling PR / alternative to https://github.com/FRRouting/frr/pull/22238**

With the 10.7 release approaching, and since renames are generally preferred early in a development cycle, this seems like a good moment to raise a suggestion.

While working on improvements to the EVPN Route Target code in FRR (a task whose scope kept expanding the deeper I got into the code), I repeatedly ran into how hard the EVPN code is to read and reason about. That difficulty was a large part of why the work expanded as much as it did.

A recurring pain point for me is nondescriptive type names, made worse by the relative scarcity of comments. I think renaming a few of the EVPN types would meaningfully improve the readability of this code and make it easier to reason about.

I believe a verbose naming style is something you shouldn't be afraid of in 2026. Within reason, of course.

There's a lot I'd eventually like to rename, but it makes sense to start with one of the (for me) clearest cases: `struct bgpevpn`.

`struct bgpevpn` is a very nondescript term. While, arguably, yes, we are modelling an *E*thernet *V*irtual *P*rivate *N*etwork with this struct, it's neither descriptive nor does it match the RFC's terminology.

`struct bgpevpn` effectively models an EVPN Instance (EVI), so it should be called this way.



I'm filing two PRs with different target names, as I think both are good.

- `bgp_evpn_evi` is the more the conservative, shorter option
- `bgp_evpn_vba_evi` is the precise, more verbose option. It encodes that it's specifically the `VLAN-Based Service interface`, leaving room for a future VLAN-Aware Bundle type (e.g. `bgp_evpn_vabnd_evi`) that follows the same naming pattern and wouldn't clash.

Whether or not including the `vba` in the name is a benefit or not if / when e.g. `VLAN-Aware Bundle Service Interface` EVIs are implemented is difficult to say.

**I think including `vba` is better**, as it makes clear that existing function can only handle the `VLAN-Based Service interface`, because `VLAN-Aware Bundle Service Interface` probably requires a completely different logic. The type `bgp_evpn_evi` could then be introduced as a union for functions that can handle both.

The code changes were obtained by a simple case-sensitive replace across the entire codebase. The changes generally look fine to me from the samples I checked, but there might be some occurrences where finetuning is required.