### PR TITLE
pimd: compensate for missing WRVIFWHOLE upcall on old kernels

### DIFF
--- a/doc/developer/topotest-multicast.rst
+++ b/doc/developer/topotest-multicast.rst
@@ -96,6 +96,9 @@ The simplest approach uses two separate scripts:
   Demonstrates sending multicast traffic
 - ``tests/topotests/pim_basic/test_pim.py::test_pim_igmp_report()`` -
   Demonstrates IGMP join using mcast-rx.py
+- ``tests/topotests/pim_wrongvif_compat/`` -
+  WRONGVIF compensation when ``IGMPMSG_WRVIFWHOLE`` is unavailable (kernels
+  before 4.19); join-before-data, same-LAN FHR, LHR/SPT, and FRR restart cases
 
 Method 2: Unified Tester Script (mcast-tester.py)
 ---------------------------------------------------
@@ -423,6 +426,8 @@ Additional Resources
 ---------------------
 
 - ``tests/topotests/pim_basic/test_pim.py`` - Basic PIM tests using direct scripts
+- ``tests/topotests/pim_wrongvif_compat/test_pim_wrongvif_compat.py`` -
+  WRONGVIF compensation when WRVIFWHOLE upcalls are unavailable
 - ``tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py`` -
   Comprehensive multicast tests using McastTesterHelper
 - ``tests/topotests/pim_igmp_vrf/test_pim_vrf.py`` - VRF multicast testing

--- a/doc/user/about.rst
+++ b/doc/user/about.rst
@@ -242,6 +242,14 @@ The indicators have the following semantics:
 Known Kernel Issues
 -------------------
 
+- Linux < 4.19
+
+  PIM-SM (ASM) - Kernels before 4.19 do not deliver the ``IGMPMSG_WRVIFWHOLE``
+  multicast upcall.  *pimd* provides best-effort compensation using
+  ``IGMPMSG_WRONGVIF`` for several ASM scenarios; see :ref:`pim` for details.
+  Kernel 4.19 or newer is recommended for full PIM-SM operation, including
+  register encapsulation of the first data packet on the FHR.
+
 - Linux < 4.11
 
   v6 Route Replacement - Linux kernels before 4.11 can cause issues with v6

--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -13,7 +13,22 @@ network for optimizing forwarding of overlay BUM traffic.
 
 .. note::
 
-   On Linux for PIM-SM operation you *must* have kernel version 4.19 or greater.
+   On Linux, kernel version 4.19 or greater is *recommended* for PIM-SM (ASM).
+   Kernels from 4.19 onward deliver the ``IGMPMSG_WRVIFWHOLE`` upcall, which
+   carries the ingress interface and the full packet.  That path drives
+   first-hop router (FHR) activation and PIM register encapsulation of the
+   first data packet to the RP.
+
+   On Linux kernels older than 4.19 (for example some RHEL/Rocky 8 systems),
+   only ``IGMPMSG_WRONGVIF`` is available.  *pimd* detects this at runtime and
+   compensates via the WRONGVIF handler for several cases (join-before-data,
+   source and receiver on the same LAN, LHR / SPT switch, and ``(S,G)``
+   MFC recovery after *pimd* restart).  This support is best-effort: WRONGVIF
+   does not include the packet buffer, so register encapsulation of the
+   first data packet still requires ``IGMPMSG_WRVIFWHOLE`` (kernel >= 4.19).
+   On kernels that deliver WRVIFWHOLE, compensation is not used after the
+   first such upcall.
+
    To use PIM for EVPN BUM forwarding, kernels 5.0 or greater are required.
    OpenBSD has no multicast support and FreeBSD, and NetBSD only
    have support for SSM.

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -45,6 +45,24 @@
 
 static void mroute_read_on(struct pim_instance *pim);
 
+/*
+ * Set when the first IGMPMSG_WRVIFWHOLE upcall is received on this host.
+ * Kernel-wide capability shared by all pim_instance / VRFs in this process.
+ *
+ * On Linux, starts false after every daemon restart; the first WRVIFWHOLE
+ * upcall sets this true and disables compensation.  Until then WRONGVIF may
+ * briefly trigger the compat path on capable kernels (harmless overlap).
+ *
+ * On non-Linux, WRVIFWHOLE is unavailable so initialize true to keep the
+ * original WRONGVIF behavior (no compensation).
+ */
+static bool mroute_wrvifwhole_supported =
+#if defined linux
+	false;
+#else
+	true;
+#endif
+
 int pim_mroute_set(struct pim_instance *pim, int enable)
 {
 	int err;
@@ -695,6 +713,11 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
 
 	pim_ifp = ifp->info;
 	pim = pim_ifp->pim;
+
+	if (!mroute_wrvifwhole_supported) {
+		mroute_wrvifwhole_supported = true;
+		zlog_info("pimd: IGMPMSG_WRVIFWHOLE received, kernel supports WRVIFWHOLE upcalls");
+	}
 
 	memset(&sg, 0, sizeof(sg));
 	sg.src = IPV_SRC(ip_hdr);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -590,10 +590,55 @@ have_up:
 	return 0;
 }
 
+/*
+ * pim_upstream_activate_stream - drive FHR upstream state for a newly-seen
+ * (S,G) data flow when the kernel has not delivered IGMPMSG_WRVIFWHOLE.
+ *
+ * Mirrors the FHR activation block in pim_mroute_msg_wrvifwhole() (without
+ * register encapsulation, which requires the packet buffer).  Only called
+ * from pim_mroute_msg_wrongvif() when !mroute_wrvifwhole_supported and
+ * there is no (S,G) ifchannel on the ingress interface (including the
+ * bidirectional case where only a (*,G) ifchannel exists).
+ *
+ * The caller guarantees:
+ *   - ifp and ifp->info are non-NULL and PIM-enabled
+ *   - sg is the (S,G) extracted from the upcall message
+ *   - ifp is source-connected for sg->src
+ */
+static int pim_upstream_activate_stream(struct interface *ifp, pim_sgaddr *sg)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_upstream *up;
+
+	up = pim_upstream_find(pim_ifp->pim, sg);
+	if (!up) {
+		up = pim_upstream_add(pim_ifp->pim, sg, ifp, PIM_UPSTREAM_FLAG_MASK_FHR, __func__,
+				      NULL);
+		if (!up)
+			return -1;
+	}
+
+	PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
+	pim_upstream_keep_alive_timer_start(up, pim_ifp->pim->keep_alive_time);
+	up->channel_oil->cc.pktcnt++;
+
+	if (!pim_is_group_filtered(pim_ifp, &sg->grp, &sg->src) && pim_upstream_could_register(up))
+		pim_register_join(up);
+
+	pim_upstream_inherited_olist(pim_ifp->pim, up);
+
+	if (!up->channel_oil->installed)
+		pim_upstream_mroute_add(up->channel_oil, __func__);
+
+	return 0;
+}
+
 int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 {
 	struct pim_ifchannel *ch, *throwaway;
 	struct pim_interface *pim_ifp;
+	bool sg_channel = false;
+	bool any_channel = false;
 	pim_sgaddr sg;
 
 	memset(&sg, 0, sizeof(sg));
@@ -629,8 +674,12 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 	}
 
 	pim_ifchannel_find(ifp, &sg, &ch, &throwaway);
-	if (!ch) {
+	if (ch) {
+		sg_channel = true;
+		any_channel = true;
+	} else {
 		pim_sgaddr star_g = sg;
+
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
 				"%s: WRONGVIF (S,G)=%pSG could not find channel on interface %s",
@@ -638,14 +687,30 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 
 		star_g.src = PIMADDR_ANY;
 		pim_ifchannel_find(ifp, &star_g, &ch, &throwaway);
-		if (!ch) {
-			if (PIM_DEBUG_MROUTE)
-				zlog_debug(
-					"%s: WRONGVIF (*,G)=%pSG could not find channel on interface %s",
-					__func__, &star_g, ifp->name);
-			return -3;
-		}
+		if (ch)
+			any_channel = true;
+		else if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: WRONGVIF (*,G)=%pSG could not find channel on interface %s",
+				   __func__, &star_g, ifp->name);
 	}
+
+	if (!mroute_wrvifwhole_supported) {
+		/*
+		 * Old kernels without WRVIFWHOLE: on the source-connected
+		 * interface, WRONGVIF may be the only signal for (S,G) data.
+		 * Mirror the FHR activation that pim_mroute_msg_wrvifwhole()
+		 * would have performed when there is no (S,G) ifchannel --
+		 * including join-before-data (no ifchannel at all) and the
+		 * bidirectional case where only a (*,G) ifchannel exists.
+		 */
+		if (!sg_channel && !pim_iface_grp_dm(pim_ifp, sg.grp) &&
+		    ifp != pim_ifp->pim->regiface && pim_if_connected_to_source(ifp, sg.src) &&
+		    PIM_I_am_DR(pim_ifp))
+			return pim_upstream_activate_stream(ifp, &sg);
+	}
+
+	if (!any_channel)
+		return -3;
 
 	if (pim_iface_grp_dm(pim_ifp, sg.grp)) {
 		if (PIM_DEBUG_PIM_J_P)

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -616,17 +616,115 @@ static int pim_upstream_activate_stream(struct interface *ifp, pim_sgaddr *sg)
 				      NULL);
 		if (!up)
 			return -1;
+	} else if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)) {
+		/*
+		 * Upstream may already exist from join-before-data without
+		 * FHR (e.g. partial MFC).  Promote once; do not call ref on
+		 * every WRONGVIF as that would inflate ref_count.
+		 */
+		pim_upstream_ref(up, PIM_UPSTREAM_FLAG_MASK_FHR, __func__);
+		PIM_UPSTREAM_FLAG_UNSET_USE_RPT(up->flags);
 	}
 
 	PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
 	pim_upstream_keep_alive_timer_start(up, pim_ifp->pim->keep_alive_time);
 	up->channel_oil->cc.pktcnt++;
 
+	/* resolve mfcc_parent prior to mroute_add in channel_add_oif */
+	if (up->rpf.source_nexthop.interface && *oil_incoming_vif(up->channel_oil) >= MAXVIFS)
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+
 	if (!pim_is_group_filtered(pim_ifp, &sg->grp, &sg->src) && pim_upstream_could_register(up))
 		pim_register_join(up);
 
 	pim_upstream_inherited_olist(pim_ifp->pim, up);
 
+	if (!up->channel_oil->installed)
+		pim_upstream_mroute_add(up->channel_oil, __func__);
+	else
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+
+	return 0;
+}
+
+/*
+ * pim_upstream_wrongvif_wrvifwhole_compat - mirror pim_mroute_msg_wrvifwhole()
+ * when IGMPMSG_WRVIFWHOLE is unavailable.  Handles LHR / SPT (S,G) state and
+ * MFC reinstall on WRONGVIF where there is no (S,G) ifchannel on ingress.
+ * Register encapsulation is omitted (no packet buffer on WRONGVIF).
+ */
+static int pim_upstream_wrongvif_wrvifwhole_compat(struct interface *ifp, pim_sgaddr *sg)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_instance *pim = pim_ifp->pim;
+	struct pim_upstream *up;
+	struct pim_upstream *parent;
+	pim_sgaddr star_g;
+
+	up = pim_upstream_find(pim, sg);
+	if (up) {
+		struct pim_nexthop source;
+		struct pim_rpf *rpf = RP(pim, sg->grp);
+		struct pim_interface *rpf_pim_ifp;
+
+		if (!rpf || !rpf->source_nexthop.interface || !rpf->source_nexthop.interface->info)
+			return 0;
+
+		star_g = *sg;
+		star_g.src = PIMADDR_ANY;
+		parent = pim_upstream_find(pim, &star_g);
+		if (parent && parent->rpf.source_nexthop.interface == ifp)
+			return 0;
+
+		rpf_pim_ifp = rpf->source_nexthop.interface->info;
+		memset(&source, 0, sizeof(source));
+
+		if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)) {
+			if (!pim_addr_is_any(up->upstream_register) &&
+			    pim_nht_lookup(rpf_pim_ifp->pim, &source, up->upstream_register,
+					   up->sg.grp, false)) {
+				pim_register_stop_send(source.interface, sg,
+						       rpf_pim_ifp->primary_address,
+						       up->upstream_register);
+				up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
+			}
+
+			pim_upstream_inherited_olist(pim, up);
+		} else {
+			if (I_am_RP(rpf_pim_ifp->pim, up->sg.grp)) {
+				if (pim_nht_lookup(rpf_pim_ifp->pim, &source,
+						   up->upstream_register, up->sg.grp, false))
+					pim_register_stop_send(source.interface, sg,
+							       rpf_pim_ifp->primary_address,
+							       up->upstream_register);
+				up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
+			} else {
+				if (up->sptbit != PIM_UPSTREAM_SPTBIT_TRUE && up->parent &&
+				    up->rpf.source_nexthop.interface !=
+					    up->parent->rpf.source_nexthop.interface) {
+					up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
+					pim_jp_agg_single_upstream_send(&up->parent->rpf,
+									up->parent, true);
+				}
+			}
+			pim_upstream_keep_alive_timer_start(up, pim->keep_alive_time);
+			pim_upstream_inherited_olist(pim, up);
+		}
+
+		if (!up->channel_oil->installed)
+			pim_upstream_mroute_add(up->channel_oil, __func__);
+		else
+			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+
+		return 0;
+	}
+
+	if (pim_if_connected_to_source(ifp, sg->src) && PIM_I_am_DR(pim_ifp))
+		return pim_upstream_activate_stream(ifp, sg);
+
+	up = pim_upstream_add(pim, sg, ifp, PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE, __func__, NULL);
+	if (!up)
+		return -1;
 	if (!up->channel_oil->installed)
 		pim_upstream_mroute_add(up->channel_oil, __func__);
 
@@ -696,17 +794,26 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 
 	if (!mroute_wrvifwhole_supported) {
 		/*
-		 * Old kernels without WRVIFWHOLE: on the source-connected
-		 * interface, WRONGVIF may be the only signal for (S,G) data.
-		 * Mirror the FHR activation that pim_mroute_msg_wrvifwhole()
-		 * would have performed when there is no (S,G) ifchannel --
-		 * including join-before-data (no ifchannel at all) and the
-		 * bidirectional case where only a (*,G) ifchannel exists.
+		 * Old kernels without WRVIFWHOLE: WRONGVIF may be the only
+		 * upcall.  Mirror pim_mroute_msg_wrvifwhole() when there is no
+		 * (S,G) ifchannel on ingress -- FHR on the source-connected
+		 * interface (join-before-data, bidirectional) and LHR / SPT
+		 * switch on upstream interfaces (e.g. (S,G) MFC reinstall after
+		 * pimd restart).
 		 */
 		if (!sg_channel && !pim_iface_grp_dm(pim_ifp, sg.grp) &&
-		    ifp != pim_ifp->pim->regiface && pim_if_connected_to_source(ifp, sg.src) &&
-		    PIM_I_am_DR(pim_ifp))
-			return pim_upstream_activate_stream(ifp, &sg);
+		    ifp != pim_ifp->pim->regiface) {
+			/*
+			 * FHR activation requires DR: only the DR originates
+			 * register state on a shared LAN.
+			 * pim_mroute_msg_wrvifwhole() omits this check because
+			 * WRVIFWHOLE carries the packet and the kernel already
+			 * selected this router's VIF.
+			 */
+			if (pim_if_connected_to_source(ifp, sg.src) && PIM_I_am_DR(pim_ifp))
+				return pim_upstream_activate_stream(ifp, &sg);
+			return pim_upstream_wrongvif_wrvifwhole_compat(ifp, &sg);
+		}
 	}
 
 	if (!any_channel)

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -149,6 +149,13 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 
 	if (enable) {
 #if defined linux
+		/*
+		 * MRT_PIM value selects the highest PIM upcall type delivered.
+		 * GMMSG_WRVIFWHOLE (4) enables WRONGVIF and WRVIFWHOLE; kernels
+		 * before 4.19 only deliver WRONGVIF.  To test the WRONGVIF
+		 * compensation path on a modern kernel, temporarily use
+		 * GMMSG_WRONGVIF here instead (PIM + assert, no WRVIFWHOLE).
+		 */
 		int upcalls = GMMSG_WRVIFWHOLE;
 		opt = MRT_PIM;
 

--- a/tests/topotests/pim_wrongvif_compat/fhr/frr.conf
+++ b/tests/topotests/pim_wrongvif_compat/fhr/frr.conf
@@ -1,0 +1,30 @@
+hostname fhr
+!
+service integrated-vtysh-config
+!
+interface fhr-eth0
+ ip address 10.10.3.1/24
+ ip pim
+!
+interface fhr-eth1
+ ip address 10.10.4.1/24
+ ip igmp
+ ip pim
+!
+interface fhr-eth2
+ ip address 10.10.5.1/24
+ ip igmp
+ ip pim
+!
+ip forwarding
+!
+router pim
+ rp 10.255.0.1
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+!
+ip route 10.255.0.1/32 10.10.3.2
+ip route 10.10.1.0/24 10.10.3.2
+ip route 10.10.2.0/24 10.10.3.2
+!

--- a/tests/topotests/pim_wrongvif_compat/l1/frr.conf
+++ b/tests/topotests/pim_wrongvif_compat/l1/frr.conf
@@ -1,0 +1,26 @@
+hostname l1
+!
+service integrated-vtysh-config
+!
+interface l1-eth0
+ ip address 10.10.1.1/24
+ ip igmp
+ ip pim
+!
+interface l1-eth1
+ ip address 10.10.2.1/24
+ ip pim
+!
+ip forwarding
+!
+router pim
+ rp 10.255.0.1
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+!
+ip route 10.255.0.1/32 10.10.2.2
+ip route 10.10.3.0/24 10.10.2.2
+ip route 10.10.4.0/24 10.10.2.2
+ip route 10.10.5.0/24 10.10.2.2
+!

--- a/tests/topotests/pim_wrongvif_compat/rp/frr.conf
+++ b/tests/topotests/pim_wrongvif_compat/rp/frr.conf
@@ -1,0 +1,31 @@
+hostname rp
+!
+service integrated-vtysh-config
+!
+interface rp-eth0
+ ip address 10.10.2.2/24
+ ip pim
+!
+interface rp-eth1
+ ip address 10.10.3.2/24
+ ip pim
+!
+interface lo
+ ip address 10.255.0.1/32
+ ip pim
+!
+ip forwarding
+!
+router pim
+ rp 10.255.0.1
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+ register-accept-list ACCEPT
+!
+ip prefix-list ACCEPT seq 5 permit any
+!
+ip route 10.10.1.0/24 10.10.2.1
+ip route 10.10.4.0/24 10.10.3.1
+ip route 10.10.5.0/24 10.10.3.1
+!

--- a/tests/topotests/pim_wrongvif_compat/test_pim_wrongvif_compat.py
+++ b/tests/topotests/pim_wrongvif_compat/test_pim_wrongvif_compat.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+
+#
+# test_pim_wrongvif_compat.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+
+
+"""
+Topotest for pimd WRONGVIF compensation when IGMPMSG_WRVIFWHOLE is unavailable
+(kernels before 4.19).  Also runs on newer kernels where WRVIFWHOLE handles
+first-packet events; no minimum kernel version skip is applied here.
+
+Topology (see frr.conf under l1/, rp/, fhr/):
+
+    h_recv ---- l1 ---- rp ---- fhr ---- h_src
+                             +---- h_local
+
+Scenarios (issue #11411 + commit 648e747325 extensions):
+
+1. Join-before-data at FHR (partial MFC promotion via pim_upstream_activate_stream)
+2. Bidirectional same-LAN on FHR (*,G) only until data
+3. LHR / SPT path on transit router (pim_upstream_wrongvif_wrvifwhole_compat)
+4. FHR FRR restart -> (S,G) state and mroutes recover via WRONGVIF compensation
+5. LHR FRR restart -> (S,G) state and mroutes recover via WRONGVIF compensation
+"""
+
+import os
+import sys
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.pimd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.common_config import (
+    start_router,
+    step,
+    stop_router,
+    write_test_footer,
+    write_test_header,
+)
+from lib.pim import (
+    McastTesterHelper,
+    clear_mroute,
+    verify_igmp_groups,
+    verify_mroutes,
+    verify_pim_neighbors,
+    verify_upstream_iif,
+)
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+TOPOLOGY = """
+    h_recv ---- l1 (LHR) ---- rp (RP) ---- fhr (FHR) ---- h_src
+                                        +---- h_local
+
+    RP address: 10.255.0.1 (rp lo)
+    Source:     10.10.4.2 (h_src)
+"""
+
+SOURCE = "10.10.4.2"
+RP_ADDR = "10.255.0.1"
+
+# One group per test so state does not collide across cases.
+GROUP_JOIN_BEFORE = "225.1.1.1"
+GROUP_BIDIR = "225.1.1.2"
+GROUP_LHR_COMPAT = "225.1.1.3"
+GROUP_FHR_RESTART = "225.1.1.4"
+GROUP_LHR_RESTART = "225.1.1.5"
+
+# Interface names from build_topo() below.
+L1_TO_RP = "l1-eth1"
+L1_TO_RECV = "l1-eth0"
+RP_TO_L1 = "rp-eth0"
+RP_TO_FHR = "rp-eth1"
+FHR_TO_RP = "fhr-eth0"
+FHR_TO_SRC = "fhr-eth1"
+FHR_TO_LOCAL = "fhr-eth2"
+
+PIM_TOPO = {
+    "routers": {
+        "l1": {
+            "links": {
+                "rp": {"interface": L1_TO_RP, "ipv4": "10.10.2.1/24", "pim": "enable"},
+            }
+        },
+        "rp": {
+            "links": {
+                "l1": {"interface": RP_TO_L1, "ipv4": "10.10.2.2/24", "pim": "enable"},
+                "fhr": {
+                    "interface": RP_TO_FHR,
+                    "ipv4": "10.10.3.2/24",
+                    "pim": "enable",
+                },
+            }
+        },
+        "fhr": {
+            "links": {
+                "rp": {"interface": FHR_TO_RP, "ipv4": "10.10.3.1/24", "pim": "enable"},
+            }
+        },
+    }
+}
+
+app_helper = McastTesterHelper()
+
+
+def build_topo(tgen):
+    """Build LHR / RP / FHR chain with three host nodes."""
+
+    tgen.add_router("l1")
+    tgen.add_router("rp")
+    tgen.add_router("fhr")
+
+    tgen.add_host("h_recv", "10.10.1.2/24", "via 10.10.1.1")
+    tgen.add_host("h_src", "10.10.4.2/24", "via 10.10.4.1")
+    tgen.add_host("h_local", "10.10.5.2/24", "via 10.10.5.1")
+
+    tgen.add_link(tgen.gears["h_recv"], tgen.gears["l1"], "h_recv-eth0", "l1-eth0")
+    tgen.add_link(tgen.gears["l1"], tgen.gears["rp"], "l1-eth1", "rp-eth0")
+    tgen.add_link(tgen.gears["rp"], tgen.gears["fhr"], "rp-eth1", "fhr-eth0")
+    tgen.add_link(tgen.gears["h_src"], tgen.gears["fhr"], "h_src-eth0", "fhr-eth1")
+    tgen.add_link(tgen.gears["h_local"], tgen.gears["fhr"], "h_local-eth0", "fhr-eth2")
+
+
+def setup_module(mod):
+    """Create topology and load per-router frr.conf files."""
+
+    logger.info("Testsuite start time: %s", time.asctime(time.localtime(time.time())))
+    logger.info("Topology:\n%s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    app_helper.init(tgen)
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    result = verify_pim_neighbors(tgen, PIM_TOPO)
+    assert result is True, "PIM neighbors failed to establish: {}".format(result)
+
+
+def teardown_module():
+    """Tear down topology."""
+
+    tgen = get_topogen()
+    app_helper.cleanup()
+    tgen.stop_topology()
+
+
+def prepare_test(tgen):
+    """Reset host traffic and kernel mroutes before each testcase."""
+
+    app_helper.stop_all_hosts()
+    clear_mroute(tgen)
+
+
+def restart_frr(tgen, router):
+    """Stop and start all FRR daemons on a router (proven topotest pattern)."""
+
+    stop_router(tgen, router)
+    start_router(tgen, router)
+
+
+def verify_register_tx(tgen, dut, interface, min_count=1):
+    """Poll until registerTx on the given interface reaches min_count."""
+
+    router = tgen.routers()[dut]
+
+    def _check():
+        stats = router.vtysh_cmd("show ip pim interface traffic json", isjson=True)
+        return stats[interface]["registerTx"] >= min_count
+
+    _, result = topotest.run_and_expect(_check, True, count=30, wait=1)
+    return result
+
+
+def verify_upstream_json(tgen, dut, source, group, expected_fields):
+    """
+    Poll show ip pim upstream json until expected fields match for (S,G).
+
+    expected_fields example:
+        {"inboundInterface": "fhr-eth1", "firstHopRouter": True,
+         "sourceStream": True, "joinState": "Joined"}
+    """
+
+    router = tgen.routers()[dut]
+
+    def _check():
+        output = router.vtysh_cmd("show ip pim upstream json", isjson=True)
+        upstream = output.get(group, {}).get(source)
+        if not upstream:
+            return False
+        for key, val in expected_fields.items():
+            if upstream.get(key) != val:
+                return False
+        return True
+
+    _, result = topotest.run_and_expect(_check, True, count=60, wait=1)
+    return result
+
+
+def verify_fhr_sg_pimreg_iif(tgen, dut, source, group):
+    """Return True when (S,G) IIF is pimreg (optional join-before-data state)."""
+
+    router = tgen.routers()[dut]
+
+    def _check():
+        mroutes = router.vtysh_cmd("show ip mroute json", isjson=True)
+        entry = mroutes.get(group, {}).get(source)
+        if not entry:
+            return False
+        return entry.get("iif") == "pimreg"
+
+    _, result = topotest.run_and_expect(_check, True, count=60, wait=1)
+    return result
+
+
+def verify_end_to_end_path(tgen, group, tc_name):
+    """Verify (*,G) and (S,G) mroutes on l1, rp, and fhr."""
+
+    checks = [
+        {"dut": "l1", "src": SOURCE, "iif": L1_TO_RP, "oil": L1_TO_RECV},
+        {"dut": "l1", "src": "*", "iif": L1_TO_RP, "oil": L1_TO_RECV},
+        {"dut": "rp", "src": SOURCE, "iif": RP_TO_FHR, "oil": RP_TO_L1},
+        {"dut": "fhr", "src": SOURCE, "iif": FHR_TO_SRC, "oil": FHR_TO_RP},
+    ]
+    for check in checks:
+        result = verify_mroutes(
+            tgen, check["dut"], check["src"], group, check["iif"], check["oil"]
+        )
+        assert result is True, "{}: mroute check failed: {}".format(tc_name, result)
+
+
+def start_remote_join_and_traffic(tgen, group):
+    """IGMP join on h_recv, then source traffic on h_src."""
+
+    assert app_helper.run_join("h_recv", group, join_intf="h_recv-eth0") is True
+    assert verify_igmp_groups(tgen, "l1", L1_TO_RECV, group) is True
+    assert verify_mroutes(tgen, "l1", "*", group, L1_TO_RP, L1_TO_RECV) is True
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth0") is True
+
+
+def test_wrongvif_compensation_join_before_data(request):
+    """
+    Case 1: join-before-data at FHR.  Partial MFC from join processing is
+    promoted to FHR when WRONGVIF arrives on the source-connected interface.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    group = GROUP_JOIN_BEFORE
+
+    step("Send IGMP join from h_recv on LHR before any source traffic")
+    assert app_helper.run_join("h_recv", group, join_intf="h_recv-eth0") is True
+
+    step("Verify IGMP join and (*,G) on LHR before source traffic")
+    assert verify_igmp_groups(tgen, "l1", L1_TO_RECV, group) is True
+    assert verify_mroutes(tgen, "l1", "*", group, L1_TO_RP, L1_TO_RECV) is True
+
+    step("Verify FHR partial (S,G) with pimreg IIF when installed pre-traffic")
+    if not verify_fhr_sg_pimreg_iif(tgen, "fhr", SOURCE, group):
+        logger.info("%s: no pre-traffic (S,G)/pimreg on FHR; continuing", tc_name)
+
+    step("Start multicast source traffic on FHR-connected host h_src")
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth0") is True
+
+    step("Verify end-to-end mroutes after WRONGVIF compensation on FHR")
+    verify_end_to_end_path(tgen, group, tc_name)
+
+    step("Verify FHR upstream promoted to FHR with active source stream")
+    result = verify_upstream_json(
+        tgen,
+        "fhr",
+        SOURCE,
+        group,
+        {
+            "inboundInterface": FHR_TO_SRC,
+            "firstHopRouter": True,
+            "sourceStream": True,
+        },
+    )
+    assert result is True, "{}: FHR upstream flags failed: {}".format(tc_name, result)
+
+    step("Verify FHR sent PIM Register toward RP after data arrival")
+    assert verify_register_tx(tgen, "fhr", FHR_TO_RP) is True
+
+    write_test_footer(tc_name)
+
+
+def test_wrongvif_compensation_bidirectional_same_lan(request):
+    """
+    Case 2: source and receiver on FHR.  Only (*,G) ifchannel exists until
+    (S,G) data triggers pim_upstream_activate_stream() on the source LAN.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    group = GROUP_BIDIR
+
+    step("Send IGMP join from local receiver h_local on FHR")
+    assert app_helper.run_join("h_local", group, join_intf="h_local-eth0") is True
+
+    step("Verify IGMP group on FHR local receiver interface")
+    assert verify_igmp_groups(tgen, "fhr", FHR_TO_LOCAL, group) is True
+
+    step("Start multicast source on FHR source interface")
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth0") is True
+
+    step("Verify (S,G) on FHR forwards from source IIF to local receiver OIF")
+    result = verify_mroutes(tgen, "fhr", SOURCE, group, FHR_TO_SRC, FHR_TO_LOCAL)
+    assert result is True, "{}: FHR (S,G) mroute failed: {}".format(tc_name, result)
+
+    step("Verify (*,G) on FHR also includes local receiver OIF")
+    result = verify_mroutes(tgen, "fhr", "*", group, FHR_TO_RP, FHR_TO_LOCAL)
+    assert result is True, "{}: FHR (*,G) mroute failed: {}".format(tc_name, result)
+
+    step("Verify FHR upstream for (S,G) uses source-connected IIF")
+    result = verify_upstream_iif(tgen, "fhr", FHR_TO_SRC, SOURCE, group)
+    assert result is True, "{}: upstream IIF check failed: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
+def test_wrongvif_compensation_lhr_compat(request):
+    """
+    LHR / SPT path: WRONGVIF on l1 (not source-connected) with only (*,G)
+    ifchannel is handled by pim_upstream_wrongvif_wrvifwhole_compat().
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    group = GROUP_LHR_COMPAT
+
+    step("Establish remote join and source traffic through LHR")
+    start_remote_join_and_traffic(tgen, group)
+    verify_end_to_end_path(tgen, group, tc_name)
+
+    step("Verify LHR (S,G) upstream uses RP-facing IIF, not FHR role")
+    result = verify_upstream_json(
+        tgen,
+        "l1",
+        SOURCE,
+        group,
+        {
+            "inboundInterface": L1_TO_RP,
+            "firstHopRouter": False,
+            "joinState": "Joined",
+        },
+    )
+    assert result is True, "{}: LHR upstream check failed: {}".format(tc_name, result)
+
+    step("Verify LHR is not incorrectly marked as FHR for this (S,G)")
+    upstream = tgen.routers()["l1"].vtysh_cmd("show ip pim upstream json", isjson=True)
+    assert not upstream[group][SOURCE].get(
+        "firstHopRouter"
+    ), "{}: LHR must not be FHR for ({},{})".format(tc_name, SOURCE, group)
+
+    write_test_footer(tc_name)
+
+
+def test_wrongvif_compensation_fhr_frr_restart(request):
+    """
+    FHR FRR restart: after stop/start, ongoing source traffic must drive
+    WRONGVIF compensation to restore (S,G) upstream and mroutes on FHR.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    group = GROUP_FHR_RESTART
+
+    step("Establish join-before-data flow and verify baseline mroutes")
+    start_remote_join_and_traffic(tgen, group)
+    verify_end_to_end_path(tgen, group, tc_name)
+
+    step("Restart FRR on FHR while source traffic continues")
+    restart_frr(tgen, "fhr")
+
+    step("Verify FHR (S,G) mroute recovers after FRR restart")
+    result = verify_mroutes(tgen, "fhr", SOURCE, group, FHR_TO_SRC, FHR_TO_RP)
+    assert result is True, "{}: FHR (S,G) after restart failed: {}".format(
+        tc_name, result
+    )
+
+    step("Verify FHR upstream and source stream restored after restart")
+    result = verify_upstream_json(
+        tgen,
+        "fhr",
+        SOURCE,
+        group,
+        {
+            "inboundInterface": FHR_TO_SRC,
+            "firstHopRouter": True,
+            "sourceStream": True,
+        },
+    )
+    assert result is True, "{}: FHR upstream after restart failed: {}".format(
+        tc_name, result
+    )
+
+    step("Verify downstream LHR still receives (S,G) after FHR restart")
+    result = verify_mroutes(tgen, "l1", SOURCE, group, L1_TO_RP, L1_TO_RECV)
+    assert result is True, "{}: LHR (S,G) after FHR restart failed: {}".format(
+        tc_name, result
+    )
+
+    write_test_footer(tc_name)
+
+
+def test_wrongvif_compensation_lhr_frr_restart(request):
+    """
+    LHR FRR restart: WRONGVIF compat must restore (S,G) on the transit LHR
+    when FRR state is lost but IGMP join and source traffic continue.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    group = GROUP_LHR_RESTART
+
+    step("Establish join-before-data flow and verify baseline mroutes")
+    start_remote_join_and_traffic(tgen, group)
+    verify_end_to_end_path(tgen, group, tc_name)
+
+    step("Restart FRR on LHR while join and source traffic continue")
+    restart_frr(tgen, "l1")
+
+    step("Re-verify IGMP group on LHR after FRR restart")
+    assert verify_igmp_groups(tgen, "l1", L1_TO_RECV, group) is True
+
+    step("Verify LHR (*,G) and (S,G) mroutes recover after FRR restart")
+    result = verify_mroutes(tgen, "l1", "*", group, L1_TO_RP, L1_TO_RECV)
+    assert result is True, "{}: LHR (*,G) after restart failed: {}".format(
+        tc_name, result
+    )
+    result = verify_mroutes(tgen, "l1", SOURCE, group, L1_TO_RP, L1_TO_RECV)
+    assert result is True, "{}: LHR (S,G) after restart failed: {}".format(
+        tc_name, result
+    )
+
+    step("Verify LHR upstream (S,G) on RP-facing IIF after restart")
+    result = verify_upstream_json(
+        tgen,
+        "l1",
+        SOURCE,
+        group,
+        {
+            "inboundInterface": L1_TO_RP,
+            "firstHopRouter": False,
+            "joinState": "Joined",
+        },
+    )
+    assert result is True, "{}: LHR upstream after restart failed: {}".format(
+        tc_name, result
+    )
+
+    write_test_footer(tc_name)


### PR DESCRIPTION
Linux kernels before 4.19 deliver IGMPMSG_WRONGVIF but not IGMPMSG_WRVIFWHOLE, so FHR/LHR first-packet handling in pim_mroute_msg_wrvifwhole() never runs. This PR detects WRVIFWHOLE at runtime and, when it is unavailable, mirrors that logic from pim_mroute_msg_wrongvif() via:

- pim_upstream_activate_stream() — FHR (join-before-data, same-LAN, partial MFC promotion)
- pim_upstream_wrongvif_wrvifwhole_compat() — LHR/SPT switch and (S,G) MFC recovery after restart

Compensation is gated by !mroute_wrvifwhole_supported and is inert on kernels ≥ 4.19 after the first WRVIFWHOLE upcall. Register encapsulation of the first data packet still requires WRVIFWHOLE (kernel ≥ 4.19).

User docs now recommend 4.19+ for full ASM and describe this as best-effort on older kernels (e.g. some RHEL/Rocky 8).

Fixed #11411