### PR TITLE
zebra: remove unused struct buf_req

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -96,12 +96,6 @@ struct gw_family_t {
 	union g_addr gate;
 };
 
-struct buf_req {
-	struct nlmsghdr n;
-	struct nhmsg nhm;
-	char buf[];
-};
-
 static const char ipv4_ll_buf[16] = "169.254.0.1";
 static struct in_addr ipv4_ll;
 


### PR DESCRIPTION
It looks like commit
cdd70e2 ("zebra: Generalize signature of End.B6.Encaps encoding helper") did eliminate the need for struct buf_req. Let's remove it.