### PR TITLE
bgpd: add LLGR to capability length validation switch

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -85,7 +85,7 @@ const size_t cap_modsizes[] = {
 	[CAPABILITY_CODE_FQDN] = 1,
 	[CAPABILITY_CODE_ENHANCED_RR] = 1,
 	[CAPABILITY_CODE_EXT_MESSAGE] = 1,
-	[CAPABILITY_CODE_LLGR] = 1,
+	[CAPABILITY_CODE_LLGR] = 7,
 	[CAPABILITY_CODE_ROLE] = 1,
 	[CAPABILITY_CODE_SOFT_VERSION] = 1,
 	[CAPABILITY_CODE_PATHS_LIMIT] = 5,
@@ -1131,6 +1131,7 @@ static int bgp_capability_parse(struct peer_connection *connection, size_t lengt
 		case CAPABILITY_CODE_ROLE:
 		case CAPABILITY_CODE_SOFT_VERSION:
 		case CAPABILITY_CODE_PATHS_LIMIT:
+		case CAPABILITY_CODE_LLGR:
 			/* Check length. */
 			if (caphdr.length < cap_minsizes[caphdr.code]) {
 				zlog_info(

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3853,6 +3853,7 @@ static int bgp_capability_msg_parse(struct peer_connection *connection, uint8_t 
 		case CAPABILITY_CODE_ROLE:
 		case CAPABILITY_CODE_SOFT_VERSION:
 		case CAPABILITY_CODE_PATHS_LIMIT:
+		case CAPABILITY_CODE_LLGR:
 			if (hdr->length < cap_minsizes[hdr->code]) {
 				zlog_info("%pBP: %s Capability length error: got %u, expected at least %u",
 					  peer, capability, hdr->length,


### PR DESCRIPTION
CAPABILITY_CODE_LLGR was missing from the length validation switch in bgp_capability_parse(). All other known capabilities go through cap_minsizes[]/cap_modsizes[] checks, but LLGR fell through to the default:break case, skipping validation entirely.

This means a malformed LLGR capability with an invalid length in a BGP OPEN message would bypass the minimum/modular length checks and proceed directly to parsing, potentially causing bgpd to read beyond the capability data boundary.

Add CAPABILITY_CODE_LLGR to the existing case list so it receives the same cap_minsizes[]/cap_modsizes[] length validation as all other capabilities.