### PR TITLE
eigrpd: compute received packet length from actual IP header size

### DIFF
--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -498,7 +498,7 @@ void eigrp_read(struct event *event)
 
 	// Subtract IPv4 header size from EIGRP Packet itself
 	if (iph->ip_v == 4)
-		length = (iph->ip_len) - 20U;
+		length = (iph->ip_len) - (iph->ip_hl << 2);
 
 	srcaddr = iph->ip_src;
 	dstaddr = iph->ip_dst;


### PR DESCRIPTION
eigrp_read derives the EIGRP payload length as iph->ip_len - 20U, which assumes the IPv4 header is always 20 bytes. When a received packet carries IP options the real header is iph->ip_hl * 4, so the length is too large by up to 40 bytes. eigrp_read passes that length to the opcode handlers (eigrp_hello_receive, eigrp_update_receive, eigrp_query_receive, eigrp_reply_receive), which walk a raw TLV pointer over the receive buffer bounded only by it, so a packet near the buffer size reads past the end.

Before, the payload length subtracts a fixed 20 regardless of the header, so options shift the parser past the real data. After, it subtracts iph->ip_hl << 2, the same way ospf_read advances over the IP header before parsing. The behavioral difference is limited to packets that actually carry IP options: those now report the correct, shorter payload and the trailing bytes are no longer treated as TLVs.