### PR TITLE
zebra: decouple zserv listener start from sweep deferral

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -352,6 +352,12 @@ struct mgmt_be_client_cbs zebra_be_client_data = {
 
 void zebra_main_router_started(void)
 {
+	static bool started;
+
+	if (started)
+		return;
+	started = true;
+
 	/*
 	 * Clean up zebra-originated routes. The requests will be sent to OS
 	 * immediately, so originating PID in notifications from kernel

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -25,6 +25,7 @@
 #include "table_manager.h"
 #include "zebra_errors.h"
 #include "zebra_dplane.h"
+#include "zserv.h"
 
 extern struct zebra_privs_t zserv_privs;
 
@@ -350,6 +351,18 @@ int zebra_ns_enable(ns_id_t ns_id, void **info)
 	kernel_init(zns);
 	zebra_dplane_ns_enable(zns, true);
 	interface_list(zns);
+
+	/* Accept client connections as soon as the namespace is enabled.
+	 * Before a1d86d4ccdce this happened synchronously via the kernel
+	 * dplane startup chain (interface_list -> ADDRESSES_READ ->
+	 * zebra_main_router_started -> zserv_start). That commit moved
+	 * zebra_main_router_started behind the metaQ to fix sweep
+	 * ordering, but zserv_start was collateral: deferring the
+	 * listener lets mgmtd push config to routing daemons before they
+	 * connect to zebra and learn about VRFs/interfaces.
+	 * The call is idempotent (started_p guard in zserv_start).
+	 */
+	zserv_start(NULL);
 
 	return 0;
 }


### PR DESCRIPTION
Commit a1d86d4ccdce ("zebra: Fixup some startup issues") moved zebra_main_router_started() behind rib_add_finished_startup() so that the rib sweep runs only after all initial dplane items have been drained through the metaQ. The sweep deferral is correct, but zserv_start() was moved along with it as collateral.

Before that commit, zserv_start() ran synchronously from the ZEBRA_DPLANE_ADDRESSES_READ handler via zebra_main_router_started(). With the built-in kernel dplane this happened during zebra_ns_init() in main(), before frr_run() entered the event loop. Routing daemons could connect and receive VRF/interface redistributions well before mgmtd pushed their persisted configuration.

After the commit, zserv_start() is deferred through the metaQ along with the sweep. This introduces a race: mgmtd may push configuration to routing daemons before they have connected to zebra. When staticd processes a static route whose nexthop VRF has not been redistributed yet, vrf_lookup_by_name() returns NULL, nh_vrf_id is set to VRF_UNKNOWN, and the route is silently dropped with no retry.

The race is hidden with the built-in kernel dplane because its startup chain completes before the event loop starts: by the time daemons boot and connect, the metaQ has long processed zebra_main_router_started(). Non-built-in dplane providers that run inside the event loop have tighter timing and can hit this race.

Fix both issues:

Call zserv_start() directly from zebra_ns_enable(), restoring the pre-a1d86d4ccdce listener timing. The call is idempotent (started_p guard) so the subsequent call from zebra_main_router_started() is harmless. The sweep deferral through the metaQ is preserved.

Add a static guard to zebra_main_router_started() so it only executes once. The ZEBRA_DPLANE_FINISHED_READING signal can be delivered more than once when vrf_enable() triggers interface_list() which restarts the kernel startup chain. Without the guard, a delay-0 sweep timer fires and clears t_rib_sweep; a subsequent zebra_main_router_started() call then arms a spurious second sweep.

Fixes: a1d86d4ccdce ("zebra: Fixup some startup issues")