### PR TITLE
lib: yang: use lyd_find_path for O(1) dnode lookup

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -470,6 +470,29 @@ struct lyd_node *yang_dnode_get(const struct lyd_node *dnode, const char *xpath)
 	if (xpath[0] == '.' && xpath[1] == '/')
 		xpath += 2;
 
+	/*
+	 * Fast O(1) path: lyd_find_path uses libyang hash tables instead of
+	 * the O(K) XPath engine.  It handles absolute paths correctly even
+	 * when dnode is not the first top-level sibling (ly_path_eval_partial
+	 * always walks to the first sibling for absolute paths).
+	 *
+	 * The leading ".." check is a fast-reject for the common parent-axis
+	 * case; embedded ".." (e.g. "sibling/../target") still reaches
+	 * lyd_find_path, which rejects it with LY_EVALID, triggering fallback.
+	 * XPath functions and wildcards are handled the same way.
+	 */
+	if (dnode && dnode->schema && !(xpath[0] == '.' && xpath[1] == '.')) {
+		LY_ERR err = lyd_find_path(dnode, xpath, 0, &dnode_ret);
+
+		if (err == LY_SUCCESS)
+			return dnode_ret;
+		/* LY_ENOTFOUND: path is valid but node absent - no fallback */
+		if (err == LY_ENOTFOUND)
+			return NULL;
+		/* Reset before fallback - lyd_find_path may have set partial value */
+		dnode_ret = NULL;
+	}
+
 	if (lyd_find_xpath(dnode, xpath, &set)) {
 		/*
 		 * Commenting out the below assert failure as it crashes mgmtd
@@ -513,10 +536,31 @@ struct lyd_node *yang_dnode_getf(const struct lyd_node *dnode,
 bool yang_dnode_exists(const struct lyd_node *dnode, const char *xpath)
 {
 	struct ly_set *set = NULL;
+	struct lyd_node *dnode_ret = NULL;
 	bool exists = false;
 
 	if (xpath[0] == '.' && xpath[1] == '/')
 		xpath += 2;
+
+	/*
+	 * lyd_find_path uses ly_path_eval which is O(1) per path segment vs
+	 * the O(K) XPath engine.
+	 *
+	 * The leading ".." check is a fast-reject for the common parent-axis
+	 * case; embedded ".." (e.g. "sibling/../target") still reaches
+	 * lyd_find_path, which rejects it with LY_EVALID, triggering fallback.
+	 * XPath functions and wildcards are handled the same way.
+	 */
+	if (dnode && dnode->schema && !(xpath[0] == '.' && xpath[1] == '.')) {
+		LY_ERR err = lyd_find_path(dnode, xpath, 0, &dnode_ret);
+
+		if (err == LY_SUCCESS)
+			return true;
+		/* LY_ENOTFOUND: path is valid but node absent - no fallback */
+		if (err == LY_ENOTFOUND)
+			return false;
+	}
+
 	if (lyd_find_xpath(dnode, xpath, &set))
 		return false;
 	exists = set->count > 0;


### PR DESCRIPTION
yang_dnode_get() and yang_dnode_exists() previously always used
lyd_find_xpath() which invokes the full XPath engine — O(K) for K
list siblings due to linear sibling scan.

Add a fast path using lyd_find_path(), which drives libyang's hash
tables (lyd_find_sibling_first) giving O(1) per level. It correctly
handles:

- Absolute paths from any node in the tree: ly_path_eval_partial()
  always walks to the first top-level sibling before evaluating the
  path.
- Module-prefixed key values (identity refs, etc.): ly_path_compile
  uses lyd_value_store with LY_VALUE_JSON to resolve them.
- LY_PATH_PREFIX_FIRST semantics match lyd_path(LYD_PATH_STD) output.

Fall back to lyd_find_xpath only when lyd_find_path returns LY_EVALID
or LY_EINCOMPLETE (path couldn't be compiled or partially evaluated),
since those are the cases where lyd_find_xpath might still succeed
via the full XPath engine (e.g., XPath functions, wildcards).

When lyd_find_path returns LY_ENOTFOUND, the path compiled and
evaluated successfully but the node is confirmed absent — no fallback
needed.

lyd_find_path returns LY_SUCCESS only when the full path is found, so
the fast-path return is always the correct match node (never NULL on
success).