### PR TITLE
tests: Fix munet namespace and interface race condition

### DIFF
--- a/tests/topotests/munet/base.py
+++ b/tests/topotests/munet/base.py
@@ -2035,6 +2035,14 @@ class LinuxNamespace(Commander, InterfaceMixin):
                 x: os.readlink(f"{unet.proc_path}/{unet.pid}/ns/{x}") for x in nslist
             }
 
+        # The namespace process is forked from *this* (the launching) process and
+        # only later nsenter's into the parent (`nsdict`) namespaces and then
+        # unshares into its own fresh namespaces.  Until it has nsenter'd it is
+        # transiently in our (the launcher's) namespaces, whose ids differ from
+        # `nsdict`.  Record them so the readiness loop below does not mistake that
+        # transient state for the final, freshly-unshared namespaces.
+        launch_nsdict = {x: os.readlink(f"/proc/self/ns/{x}") for x in nslist}
+
         #
         # (A) Basically we need to save the pid of the unshare call for nsenter.
         #
@@ -2380,18 +2388,27 @@ class LinuxNamespace(Commander, InterfaceMixin):
                             "unswitched: error (ok) checking %s: %s", nspath, error
                         )
                         continue
-                    if nsdict[fname] != nsf:
+                    if nsf != nsdict[fname] and nsf != launch_nsdict[fname]:
+                        # Differs from both the parent (`nsdict`) and the launcher
+                        # (`launch_nsdict`): this is the final, freshly-unshared ns.
                         self.logger.debug(
                             "switched: original %s current %s", nsdict[fname], nsf
                         )
                         nslist.remove(fname)
-                    elif unshare_inline:
+                    elif unshare_inline and nsf == nsdict[fname]:
                         logging.warning(
                             "unshare_inline not unshared %s == %s", nsdict[fname], nsf
                         )
                     else:
+                        # Either still in the parent ns (nsdict) or transiently still
+                        # in the launcher's ns (launch_nsdict, before nsenter): the
+                        # unshare has not completed yet, keep waiting.
                         self.logger.debug(
-                            "unswitched: current %s elapsed: %s", nsf, timeout.elapsed()
+                            "unswitched: current %s (parent %s launcher %s) elapsed: %s",
+                            nsf,
+                            nsdict[fname],
+                            launch_nsdict[fname],
+                            timeout.elapsed(),
                         )
                 if not nslist:
                     self.logger.debug(


### PR DESCRIPTION
Fixes a race condition where a new namespace process is thought to be ready before it's actually ready. A short-term transistent time was sometimes read as a signal for the new namespace to be ready and subsequent interface operations failed

The error happened in a recent test
https://ci1.netdef.org/browse/FRR-FRR-ASAN8D13AMD64-9954/test

Problem is that there is a race condition where interfaces in some nodes 
may not always get created. In the failure above it was interface h2-eth1

munet forks an nsenter-mutini process per host that must unshare(mount,net,uts) 
into a fresh namespace, and munet polls /proc/<pid>/ns/* until it sees the 
namespace change before creating the veth pair

The readiness check at base.py:2383 declares the unshare complete as soon as
the child's namespace inode differs from the parent's snapshot (nsdict[fname] 
!= nsf):

```
if nsdict[fname] != nsf:
  self.logger.debug("switched: original %s current %s", ...)
  nslist.remove(fname)
```

But the child (nsenter → mutini) passes through multiple namespaces: it starts
in the host root ns, then nsenters into the unet ns, then mutini finally
unshares into its own fresh ns. The "differs from parent" condition is also
satisfied when munet happens to read the child mid-transition, while it's 
still in the root ns — which is exactly what happened to h2 in the failure
above
Having falsely concluded h2 was ready, munet then ran:
ip link add s7-eth0 type veth peer name h2-eth0 netns 22232
placing the veth endpoint relative to pid 22232's namespace at that instant.
mutini then finished unsharing into its actual fresh namespace, so when munet
next entered pid 22232's (now-correct) net namespace to bring the link up:
nsenter --net=/proc/22232/ns/net ... ip link set h2-eth0 up
--> Cannot find device "h2-eth0"
The device and the namespace munet looked in were out of sync.
