### PR TITLE
bgpd: fix holdtime_ptr unsafe pointer aliasing in OPEN receive path

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1791,13 +1791,13 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 	uint8_t notify_data_remote_as[2];
 	uint8_t notify_data_remote_as4[4];
 	uint8_t notify_data_remote_id[4];
-	uint16_t *holdtime_ptr;
+	uint8_t notify_data_holdtime[2];
 
 	/* Parse open packet. */
 	version = stream_getc(connection->curr);
 	memcpy(notify_data_remote_as, stream_pnt(connection->curr), 2);
 	remote_as = stream_getw(connection->curr);
-	holdtime_ptr = (uint16_t *)stream_pnt(connection->curr);
+	memcpy(notify_data_holdtime, stream_pnt(connection->curr), 2);
 	holdtime = stream_getw(connection->curr);
 	memcpy(notify_data_remote_id, stream_pnt(connection->curr), 4);
 	remote_id.s_addr = stream_get_ipv4(connection->curr);
@@ -2078,7 +2078,7 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 	if (holdtime < 3 && holdtime != 0) {
 		bgp_notify_send_with_data(connection, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_UNACEP_HOLDTIME,
-					  (uint8_t *)holdtime_ptr, 2);
+					  notify_data_holdtime, 2);
 		return BGP_Stop;
 	}
 
@@ -2088,7 +2088,7 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 	    && peer->bgp->default_min_holdtime != 0) {
 		bgp_notify_send_with_data(connection, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_UNACEP_HOLDTIME,
-					  (uint8_t *)holdtime_ptr, 2);
+					  notify_data_holdtime, 2);
 		return BGP_Stop;
 	}
 


### PR DESCRIPTION
In bgp_open_receive(), holdtime_ptr was obtained by casting the return value of stream_pnt(connection->curr) from uint8_t* to uint16_t*. This introduced two problems:

1. Unaligned access: stream_pnt() returns a uint8_t* with no alignment guarantee. Casting to uint16_t* and dereferencing violates C strict aliasing rules and is undefined behavior. On strict-alignment architectures (ARM, MIPS, SPARC) this can cause a SIGBUS crash.

2. Dangling pointer risk: holdtime_ptr pointed directly into the stream's internal buffer. Between the pointer capture at the beginning of bgp_open_receive() and its use in NOTIFICATION data approximately 280 lines later, the stream buffer could potentially be reallocated, leaving holdtime_ptr dangling. This is inconsistent with notify_data_remote_as and notify_data_remote_id which are safely copied to stack buffers via memcpy at capture time.

Replace the uint16_t* holdtime_ptr with a uint8_t[2] stack buffer (notify_data_holdtime), populated via memcpy before stream_getw() advances the read pointer. Update both NOTIFICATION send sites (holdtime < 3 check and default_min_holdtime check) to use the new stack buffer directly, eliminating the unsafe cast.

This aligns holdtime handling with the safe pattern already used for remote_as and remote_id notification data in the same function.