### PR TITLE
bgpd: remove duplicate snprintf in FlowSpec redirect VRF display

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1439,8 +1439,6 @@ static char *_ecommunity_ecom2str(struct ecommunity *ecom, int format, int filte
 					ECOMMUNITY_FORMAT_DISPLAY);
 				snprintf(encbuf, sizeof(encbuf),
 					 "FS:redirect VRF %s", buf);
-				snprintf(encbuf, sizeof(encbuf),
-					 "FS:redirect VRF %s", buf);
 			} else if (type != ECOMMUNITY_ENCODE_TRANS_EXP)
 				unk_ecom = true;
 			else if (sub_type == ECOMMUNITY_TRAFFIC_ACTION) {


### PR DESCRIPTION
In ecommunity_ecom2str(), the ECOMMUNITY_REDIRECT_VRF display branch has an identical snprintf() call duplicated on consecutive lines. Both calls write "FS:redirect VRF %s" with the same buf argument into the same encbuf destination buffer.

The second call overwrites the first with identical content, producing the correct output by coincidence but wasting a snprintf() invocation on every FlowSpec redirect VRF extended community that is formatted for display (e.g., in show commands and logging).

Remove the duplicate snprintf() call, keeping the first instance.