### PR TITLE
bgpd: fix return NULL in bool function ecommunity_node_target_match

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -449,7 +449,7 @@ bool ecommunity_node_target_match(struct ecommunity *ecom,
 	bool match = false;
 
 	if (!ecom || !ecom->size)
-		return NULL;
+		return false;
 
 	for (i = 0; i < ecom->size; i++) {
 		const uint8_t *pnt;


### PR DESCRIPTION
ecommunity_node_target_match() is declared as returning bool, but the early-exit path for empty or missing ecommunity uses 'return NULL'.

NULL is a pointer constant ((void*)0), not a boolean value. Returning a pointer type from a bool function relies on an implicit pointer-to- integer conversion, which is undefined behavior per the C standard (C11 6.8.6.4). While most compilers implicitly convert NULL to false (0), this is not guaranteed and produces warnings under -Wpedantic or -Wint-conversion, which can break builds with -Werror enabled.

The function already declares 'bool match = false' and returns match at the end, so the intent of the early-exit is clearly to return false when the ecommunity is empty or NULL.

Change 'return NULL' to 'return false' to match the function's return type and eliminate the undefined behavior.