### PR TITLE
lib: fix memory leak in link state message ownership model

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1992,6 +1992,9 @@ struct ls_vertex *ls_msg2vertex(struct ls_ted *ted, struct ls_message *msg,
 		break;
 	}
 
+	if (msg->event != LS_MSG_EVENT_DELETE && vertex)
+		msg->data.node = NULL;
+
 	return vertex;
 }
 
@@ -2039,6 +2042,9 @@ struct ls_edge *ls_msg2edge(struct ls_ted *ted, struct ls_message *msg,
 		edge = NULL;
 		break;
 	}
+
+	if (msg->event != LS_MSG_EVENT_DELETE && edge)
+		msg->data.attr = NULL;
 
 	return edge;
 }
@@ -2088,6 +2094,9 @@ struct ls_subnet *ls_msg2subnet(struct ls_ted *ted, struct ls_message *msg,
 		break;
 	}
 
+	if (msg->event != LS_MSG_EVENT_DELETE && subnet)
+		msg->data.prefix = NULL;
+
 	return subnet;
 }
 
@@ -2134,18 +2143,16 @@ void ls_delete_msg(struct ls_message *msg)
 	if (msg == NULL)
 		return;
 
-	if (msg->event == LS_MSG_EVENT_DELETE) {
-		switch (msg->type) {
-		case LS_MSG_TYPE_NODE:
-			ls_node_del(msg->data.node);
-			break;
-		case LS_MSG_TYPE_ATTRIBUTES:
-			ls_attributes_del(msg->data.attr);
-			break;
-		case LS_MSG_TYPE_PREFIX:
-			ls_prefix_del(msg->data.prefix);
-			break;
-		}
+	switch (msg->type) {
+	case LS_MSG_TYPE_NODE:
+		ls_node_del(msg->data.node);
+		break;
+	case LS_MSG_TYPE_ATTRIBUTES:
+		ls_attributes_del(msg->data.attr);
+		break;
+	case LS_MSG_TYPE_PREFIX:
+		ls_prefix_del(msg->data.prefix);
+		break;
 	}
 
 	XFREE(MTYPE_LS_DB, msg);


### PR DESCRIPTION
ls_delete_msg() only frees the inner data (node/attr/prefix) when msg->event == LS_MSG_EVENT_DELETE. For ADD/UPDATE/SYNC events, it assumes the TED (Traffic Engineering Database) has taken ownership of the data via ls_msg2vertex/ls_msg2edge/ls_msg2subnet, which call ls_vertex_add/ls_edge_add (store pointer) or ls_vertex_update/ ls_edge_update (store or free if duplicate).

This assumption breaks when the TED is not initialized or when processing fails. For example, path_ted_rcvd_message() returns early if !path_ted_is_initialized(), so the data is never stored in the TED. ls_delete_msg() then skips freeing because the event is not DELETE, and the inner data (including admin_group bitmap allocated by admin_group_init) leaks.

Fix the ownership model with explicit ownership transfer:

1. In ls_msg2vertex(): for SYNC/ADD/UPDATE, set msg->data.node = NULL after ls_vertex_add/ls_vertex_update (which either stores the pointer in TED or frees it if duplicate -- either way the caller no longer owns it). DELETE only uses the node for lookup via ls_find_vertex_by_id(), so msg->data.node remains valid for cleanup.

2. In ls_msg2edge(): same pattern -- set msg->data.attr = NULL after ls_edge_add/ls_edge_update for SYNC/ADD/UPDATE.

3. In ls_msg2subnet(): same pattern -- set msg->data.prefix = NULL after ls_subnet_add/ls_subnet_update for SYNC/ADD/UPDATE.

4. In ls_delete_msg(): remove the msg->event == LS_MSG_EVENT_DELETE condition. Always call ls_node_del/ls_attributes_del/ls_prefix_del on the inner data. All three functions have NULL checks at entry (e.g., ls_attributes_del checks "if (!attr) return"), so when TED has taken ownership (pointer set to NULL), the call is a safe no-op. When TED has NOT taken ownership, the data is properly freed.