### PR TITLE
lib: replace stream_get_ipv4() with STREAM_GET() in link state parsing

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1220,7 +1220,7 @@ static struct ls_node *ls_parse_node(struct stream *s)
 		STREAM_GET(node->name, s, len);
 	}
 	if (CHECK_FLAG(node->flags, LS_NODE_ROUTER_ID))
-		node->router_id.s_addr = stream_get_ipv4(s);
+		STREAM_GET(&node->router_id, s, IPV4_MAX_BYTELEN);
 	if (CHECK_FLAG(node->flags, LS_NODE_ROUTER_ID6))
 		STREAM_GET(&node->router_id6, s, IPV6_MAX_BYTELEN);
 	if (CHECK_FLAG(node->flags, LS_NODE_FLAG))
@@ -1302,9 +1302,9 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 		}
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_LOCAL_ADDR))
-		attr->standard.local.s_addr = stream_get_ipv4(s);
+		STREAM_GET(&attr->standard.local, s, IPV4_MAX_BYTELEN);
 	if (CHECK_FLAG(attr->flags, LS_ATTR_NEIGH_ADDR))
-		attr->standard.remote.s_addr = stream_get_ipv4(s);
+		STREAM_GET(&attr->standard.remote, s, IPV4_MAX_BYTELEN);
 	if (CHECK_FLAG(attr->flags, LS_ATTR_LOCAL_ADDR6))
 		STREAM_GET(&attr->standard.local6, s, IPV6_MAX_BYTELEN);
 	if (CHECK_FLAG(attr->flags, LS_ATTR_NEIGH_ADDR6))
@@ -1323,7 +1323,7 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 	if (CHECK_FLAG(attr->flags, LS_ATTR_REMOTE_AS))
 		STREAM_GETL(s, attr->standard.remote_as);
 	if (CHECK_FLAG(attr->flags, LS_ATTR_REMOTE_ADDR))
-		attr->standard.remote_addr.s_addr = stream_get_ipv4(s);
+		STREAM_GET(&attr->standard.remote_addr, s, IPV4_MAX_BYTELEN);
 	if (CHECK_FLAG(attr->flags, LS_ATTR_REMOTE_ADDR6))
 		STREAM_GET(&attr->standard.remote_addr6, s, IPV6_MAX_BYTELEN);
 	if (CHECK_FLAG(attr->flags, LS_ATTR_DELAY))
@@ -1346,15 +1346,15 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 		STREAM_GETL(s, attr->adj_sid[ADJ_PRI_IPV4].sid);
 		STREAM_GETC(s, attr->adj_sid[ADJ_PRI_IPV4].flags);
 		STREAM_GETC(s, attr->adj_sid[ADJ_PRI_IPV4].weight);
-		attr->adj_sid[ADJ_PRI_IPV4].neighbor.addr.s_addr =
-			stream_get_ipv4(s);
+		STREAM_GET(&attr->adj_sid[ADJ_PRI_IPV4].neighbor.addr,
+			   s, IPV4_MAX_BYTELEN);
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SID)) {
 		STREAM_GETL(s, attr->adj_sid[ADJ_BCK_IPV4].sid);
 		STREAM_GETC(s, attr->adj_sid[ADJ_BCK_IPV4].flags);
 		STREAM_GETC(s, attr->adj_sid[ADJ_BCK_IPV4].weight);
-		attr->adj_sid[ADJ_BCK_IPV4].neighbor.addr.s_addr =
-			stream_get_ipv4(s);
+		STREAM_GET(&attr->adj_sid[ADJ_BCK_IPV4].neighbor.addr,
+			   s, IPV4_MAX_BYTELEN);
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_ADJ_SID6)) {
 		STREAM_GETL(s, attr->adj_sid[ADJ_PRI_IPV6].sid);


### PR DESCRIPTION
The stream_get_ipv4() function calls assert(0) when the stream does not have enough data remaining, which causes the entire process to abort. This is problematic for link state parsing functions (ls_parse_node and ls_parse_attributes) because a malformed or truncated message from an external source should not crash the daemon.

Replace all six stream_get_ipv4() call sites with the STREAM_GET() macro, which uses longjmp to jump to the stream_failure label on underflow. Both ls_parse_node() and ls_parse_attributes() already have proper stream_failure cleanup handlers that log an error, free allocated memory, and return NULL, so this change leverages the existing error recovery paths.

The six replaced call sites are:
  - ls_parse_node(): node->router_id
  - ls_parse_attributes(): attr->standard.local, attr->standard.remote, attr->standard.remote_addr, and two adj_sid neighbor.addr fields (ADJ_PRI_IPV4 and ADJ_BCK_IPV4)

This is consistent with how IPv6 addresses are already read using STREAM_GET() in the same functions, and follows the safe stream reading pattern used throughout the rest of the link state parsing code.