### PR TITLE
bgpd: fix NLRI addpath boundary check off-by-one

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8296,8 +8296,9 @@ int bgp_nlri_parse_ip(struct peer *peer, struct attr *attr,
 
 		if (addpath_capable) {
 
-			/* When packet overflow occurs return immediately. */
-			if (pnt + BGP_ADDPATH_ID_LEN >= lim)
+			/* When packet overflow occurs return immediately.
+			 * Need addpath ID (4 bytes) + at least 1 byte for prefix length. */
+			if (pnt + BGP_ADDPATH_ID_LEN + 1 > lim)
 				return BGP_NLRI_PARSE_ERROR_PACKET_OVERFLOW;
 
 			memcpy(&addpath_id, pnt, BGP_ADDPATH_ID_LEN);


### PR DESCRIPTION
The addpath-capable NLRI parsing loop in bgp_nlri_parse_ip() checks `pnt + BGP_ADDPATH_ID_LEN >= lim` before reading the 4-byte addpath ID. This uses >= instead of >, which means the check incorrectly passes when exactly BGP_ADDPATH_ID_LEN (4) bytes remain. After consuming those 4 bytes, pnt equals lim, and the subsequent `p.prefixlen = *pnt++` dereferences one byte past the end of the NLRI data -- an out-of-bounds read.

Additionally, the check does not account for the 1-byte prefix length field that must follow the addpath ID per the NLRI encoding. Even if the 4-byte addpath ID read itself were in-bounds, there would be no room for the mandatory prefix length byte.

Change the guard to `pnt + BGP_ADDPATH_ID_LEN + 1 > lim`, which ensures at least 5 bytes remain: 4 for the addpath ID and 1 for the prefix length. The operator is changed from >= to > so that the boundary condition is correct (we need strictly more data than the minimum to safely proceed with both reads).

RFC 4271 Section 4.3 requires that NLRI fields are fully contained within the UPDATE message. A crafted UPDATE with a truncated NLRI field could trigger the out-of-bounds read, potentially leaking stack/heap data or crashing the BGP daemon.