### PR TITLE
bgpd: add STREAM_READABLE pre-check in bgp_open_receive

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1794,6 +1794,13 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 	uint8_t notify_data_holdtime[2];
 
 	/* Parse open packet. */
+	if (STREAM_READABLE(connection->curr) < BGP_OPEN_BODY_MIN_SIZE) {
+		flog_err(EC_BGP_PKT_OPEN, "%s: OPEN message too short (%zu bytes, need %u)",
+			 peer->host, STREAM_READABLE(connection->curr), BGP_OPEN_BODY_MIN_SIZE);
+		bgp_notify_send(connection, BGP_NOTIFY_HEADER_ERR, BGP_NOTIFY_HEADER_BAD_MESLEN);
+		return BGP_Stop;
+	}
+
 	version = stream_getc(connection->curr);
 	memcpy(notify_data_remote_as, stream_pnt(connection->curr), 2);
 	remote_as = stream_getw(connection->curr);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2357,7 +2357,8 @@ struct bgp_nlri {
 #define BGP_ADMIN_SHUTDOWN_MSG_LEN 255
 
 /* BGP minimum message size.  */
-#define BGP_MSG_OPEN_MIN_SIZE                   (BGP_HEADER_SIZE + 10)
+#define BGP_OPEN_BODY_MIN_SIZE                  10 /* Version(1) + AS(2) + Hold(2) + ID(4) + OptLen(1) */
+#define BGP_MSG_OPEN_MIN_SIZE                   (BGP_HEADER_SIZE + BGP_OPEN_BODY_MIN_SIZE)
 #define BGP_MSG_UPDATE_MIN_SIZE                 (BGP_HEADER_SIZE + 4)
 #define BGP_MSG_NOTIFY_MIN_SIZE                 (BGP_HEADER_SIZE + 2)
 #define BGP_MSG_KEEPALIVE_MIN_SIZE              (BGP_HEADER_SIZE + 0)


### PR DESCRIPTION
bgp_open_receive() immediately calls stream_getc(), stream_getw(), and stream_get_ipv4() to parse the OPEN message fixed fields (version, AS number, hold time, BGP Identifier, opt parm len) without first verifying that the stream contains at least 10 bytes of readable data.

While bgp_io.c validates BGP_MSG_OPEN_MIN_SIZE at the I/O layer, that check uses the total packet size including the 19-byte header. If a bug or future refactor changes how the stream getp is positioned before calling bgp_open_receive(), the stream_get*() calls could read past the end of valid data. The stream functions have internal assertions that abort the entire daemon rather than sending a proper NOTIFICATION.

Add a STREAM_READABLE(connection->curr) < 10 guard at the top of bgp_open_receive(). If the stream has fewer than 10 bytes remaining, log an error, send a NOTIFICATION with OPEN Message Error / Malformed Attribute, and return BGP_Stop. This is defense-in-depth: it ensures the function is self-contained in its safety guarantees rather than relying on the caller having validated the size correctly.

RFC 4271 Section 4.2 specifies the OPEN message format with exactly 10 bytes of fixed fields after the header:
  - Version (1 byte)
  - My Autonomous System (2 bytes)
  - Hold Time (2 bytes)
  - BGP Identifier (4 bytes)
  - Optional Parameters Length (1 byte)