### PR TITLE
bgpd: reject multicast and reserved addresses as BGP Identifier

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1964,6 +1964,9 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 	 * "Bad BGP Identifier".
 	 */
 	if (remote_id.s_addr == INADDR_ANY
+	    || remote_id.s_addr == INADDR_BROADCAST
+	    || IN_CLASSD(ntohl(remote_id.s_addr))
+	    || IN_BADCLASS(ntohl(remote_id.s_addr))
 	    || (peer->sort == BGP_PEER_IBGP
 		&& ntohl(peer->local_id.s_addr) == ntohl(remote_id.s_addr))) {
 		if (bgp_debug_neighbor_events(peer))


### PR DESCRIPTION
RFC 6286 (which updates RFC 4271) requires that the BGP Identifier be a valid unicast IPv4 address. The existing validation in bgp_open_receive() only rejected 0.0.0.0 (INADDR_ANY) and, for iBGP peers, a remote identifier matching the local BGP Identifier.

A remote peer could send an OPEN message with a multicast (224.0.0.0/4), reserved/Class-E (240.0.0.0/4), or broadcast (255.255.255.255) address as its BGP Identifier and the session would be accepted. While not directly exploitable for code execution, invalid identifiers can interfere with:

1. Connection collision detection (RFC 4271 Section 6.8), which compares BGP Identifiers to decide which connection to close. Unusual identifier values could produce unexpected comparison results.

2. Route originator identification and loop detection, which rely on BGP Identifiers being unique valid unicast addresses.

3. Interoperability with other implementations that enforce stricter validation per RFC 6286.

Add checks for IN_CLASSD (multicast 224.0.0.0/4), IN_BADCLASS (Class E/reserved 240.0.0.0/4), and INADDR_BROADCAST (255.255.255.255) to the existing BGP Identifier validation in bgp_open_receive(), rejecting them with a Bad BGP Identifier NOTIFICATION (Error Code 2, Error Subcode 3).