### PR TITLE
bgpd: fix strlcat/strlcpy size parameter in NOTIFICATION send path

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1002,24 +1002,24 @@ static void bgp_notify_send_internal(struct peer_connection *connection,
 	{
 		struct bgp_notify bgp_notify;
 		int first = 0;
-		int i;
+		size_t i;
 		char c[4];
 
 		bgp_notify.code = code;
 		bgp_notify.subcode = sub_code;
 		bgp_notify.data = NULL;
-		bgp_notify.length = datalen;
+		bgp_notify.length = datalen * 3;
 		bgp_notify.raw_data = data;
 
 		peer->notify.code = bgp_notify.code;
 		peer->notify.subcode = bgp_notify.subcode;
-		peer->notify.length = bgp_notify.length;
+		peer->notify.length = datalen;
 		peer->notify.hard_reset = hard_reset;
 
 		if (bgp_notify.length && data) {
 			bgp_notify.data = XMALLOC(MTYPE_BGP_NOTIFICATION,
-						  bgp_notify.length * 3);
-			for (i = 0; i < bgp_notify.length; i++)
+						  bgp_notify.length);
+			for (i = 0; i < datalen; i++)
 				if (first) {
 					snprintf(c, sizeof(c), " %02x",
 						 data[i]);


### PR DESCRIPTION
In bgp_notify_send_internal(), the hex-formatted notification data buffer is allocated with size bgp_notify.length * 3, since each byte is formatted as " %02x" (3 characters). However, the strlcat() and strlcpy() calls were incorrectly passed bgp_notify.length as the buffer size limit instead of bgp_notify.length * 3.

This caused severe truncation of the debug output string. For example, a 30-byte notification data would allocate a 90-byte buffer, but strlcpy would only allow writing 30 bytes, displaying roughly the first 10 bytes of hex values and silently discarding the rest.

The receive path (bgp_notify_receive) already correctly uses bgp_notify.length * 3 as the size limit for the same formatting logic. This fix makes the send path consistent with the receive path.

While strlcat/strlcpy are safe functions that truncate rather than overflow, the truncated output made NOTIFICATION debugging unreliable, potentially hiding critical protocol error details from operators during fault diagnosis.