### PR TITLE
bgpd: fixes for NH and aggregator attribute parsing (backport #22200)

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2214,7 +2214,8 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 	if (peer->discard_attrs[args->type] || peer->withdraw_attrs[args->type])
 		goto aggregator_ignore;
 
-	if (CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV))
+	if (CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV) &&
+	    CHECK_FLAG(peer->cap, PEER_CAP_AS4_ADV))
 		aggregator_as = stream_getl(peer->curr);
 	else
 		aggregator_as = stream_getw(peer->curr);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2063,19 +2063,10 @@ enum bgp_attr_parse_ret bgp_attr_nexthop_valid(struct peer *peer,
 	struct bgp *bgp = peer->bgp;
 
 	if (ipv4_martian(&attr->nexthop) && !bgp->allow_martian) {
-		uint8_t data[7]; /* type(2) + length(1) + nhop(4) */
-
 		flog_err(EC_BGP_ATTR_MARTIAN_NH, "Martian nexthop %pI4",
 			 &attr->nexthop);
-		data[0] = BGP_ATTR_FLAG_TRANS;
-		data[1] = BGP_ATTR_NEXT_HOP;
-		data[2] = BGP_ATTR_NHLEN_IPV4;
-		memcpy(&data[3], &attr->nexthop.s_addr, BGP_ATTR_NHLEN_IPV4);
-		bgp_notify_send_with_data(peer->connection,
-					  BGP_NOTIFY_UPDATE_ERR,
-					  BGP_NOTIFY_UPDATE_INVAL_NEXT_HOP,
-					  data, 7);
-		return BGP_ATTR_PARSE_ERROR;
+
+		return BGP_ATTR_PARSE_WITHDRAW;
 	}
 
 	return BGP_ATTR_PARSE_PROCEED;
@@ -4447,7 +4438,7 @@ enum bgp_attr_parse_ret bgp_attr_parse(struct peer *peer, struct attr *attr,
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP))
 	    && !CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) {
 		if (bgp_attr_nexthop_valid(peer, attr) < 0) {
-			ret = BGP_ATTR_PARSE_ERROR;
+			ret = BGP_ATTR_PARSE_WITHDRAW;
 			goto done;
 		}
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2464,17 +2464,6 @@ static int bgp_update_receive(struct peer_connection *connection,
 		nlris[NLRI_UPDATE].nlri = stream_pnt(s);
 		nlris[NLRI_UPDATE].length = update_len;
 		stream_forward_getp(s, update_len);
-
-		if (CHECK_FLAG(attr.flag, ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) {
-			/*
-			 * We skipped nexthop attribute validation earlier so
-			 * validate the nexthop now.
-			 */
-			if (bgp_attr_nexthop_valid(peer, &attr) < 0) {
-				bgp_attr_unintern_sub(&attr);
-				return BGP_Stop;
-			}
-		}
 	}
 
 	if (BGP_DEBUG(update, UPDATE_IN) && BGP_DEBUG(update, UPDATE_DETAIL))


### PR DESCRIPTION
Only validate nexthop attr if it was present; invalid attr should be treated as WITHDRAW, not a session teardown.

Only use 32-bit AS in the aggregator attribute when both sides have negotiated the capability. The "wanted" length check in the attr parser used that logic, but the actual stream read did not.

These were F-083, F-084, and F-085 in the 2026_05_27 batch of reports.

This is a manual backport of pull request https://github.com/FRRouting/frr/pull/22200 done by [Mergify](https://mergify.com).