### PR TITLE
bgpd: skip peers not activated for AFI/SAFI in bgp_gr_check_all_eors()

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1492,6 +1492,19 @@ static bool bgp_gr_check_all_eors(struct bgp *bgp, afi_t afi, safi_t safi,
 			continue;
 
 		if (!CHECK_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_EOR_RECEIVED)) {
+			/*
+			 * Skip peers that do not have this AFI/SAFI
+			 * configured/activated; they cannot have negotiated
+			 * the AF nor send an EOR for it, so waiting for one
+			 * would block GR fast-cancel indefinitely.
+			 */
+			if (!peer->afc[afi][safi]) {
+				if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
+					zlog_debug(".... Ignoring EOR from %s. %s is not configured",
+						   peer->host, get_afi_safi_str(afi, safi, false));
+				continue;
+			}
+
 			if (!bgp->gr_multihop_peer_exists) {
 				/*
 				 * This instance doesn't have a mix of directly
@@ -1506,13 +1519,6 @@ static bool bgp_gr_check_all_eors(struct bgp *bgp, afi_t afi, safi_t safi,
 					 peer->host, 1);
 
 				return false;
-			}
-
-			if (!peer->afc[afi][safi]) {
-				if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-					zlog_debug(".... Ignoring EOR from %s. %s is not configured",
-						   peer->host, get_afi_safi_str(afi, safi, false));
-				continue;
 			}
 
 			/*


### PR DESCRIPTION
bgp_gr_check_all_eors() walks every peer in bgp->peer and -- for any peer with PEER_STATUS_GR_WAIT_EOR set but no PEER_STATUS_EOR_RECEIVED -- splits into two code paths based on bgp->gr_multihop_peer_exists.

An existing !afc check filtered out peers that do not have this AFI/SAFI configured/activated, but it sat after the no-multihop-mix branch's early 'return false' -- so it was only ever reached when gr_multihop_peer_exists was true. The no-multihop-mix branch instead returned false on the first peer that lacked EOR_RECEIVED -- including peers that have no activated AF at all and are therefore physically incapable of ever sending an EOR for the AFI/SAFI in question.

In topologies where the BGP config defines neighbors that are never 'activate'd under any address family, this caused bgp_gr_check_all_eors() to return FALSE on every incoming EOR receipt, permanently blocking the GR fast-cancel path and forcing the deferral to always run to the select-defer-time safety-timer expiry.

Move the !afc check above the branch split so both branches see it; the post-split copy becomes unreachable and is removed.

