### PR TITLE
ospf6d: reject undersized LSAs in ospf6_lsupdate_recv

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -215,11 +215,11 @@ void ospf6_lsupdate_print(struct ospf6_header *oh, int action)
 	     && action == OSPF6_ACTION_RECV)
 	    || (IS_OSPF6_DEBUG_MESSAGE(oh->type, SEND)
 		&& action == OSPF6_ACTION_SEND)) {
-		for (p = (char *)((caddr_t)lsupdate +
-				  sizeof(struct ospf6_lsupdate));
-		     p < OSPF6_MESSAGE_END(oh) &&
-		     p + ospf6_lsa_size((struct ospf6_lsa_header *)p) <=
-			     OSPF6_MESSAGE_END(oh);
+		for (p = (char *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
+		     p + sizeof(struct ospf6_lsa_header) <= OSPF6_MESSAGE_END(oh) &&
+		     ospf6_lsa_size((struct ospf6_lsa_header *)p) >=
+			     sizeof(struct ospf6_lsa_header) &&
+		     p + ospf6_lsa_size((struct ospf6_lsa_header *)p) <= OSPF6_MESSAGE_END(oh);
 		     p += ospf6_lsa_size((struct ospf6_lsa_header *)p)) {
 			ospf6_lsa_header_print_raw(
 				(struct ospf6_lsa_header *)p);
@@ -1647,9 +1647,9 @@ static void ospf6_lsupdate_recv(struct in6_addr *src, struct in6_addr *dst,
 
 	/* Process LSAs */
 	for (p = (char *)((caddr_t)lsupdate + sizeof(struct ospf6_lsupdate));
-	     p < OSPF6_MESSAGE_END(oh) &&
-	     p + ospf6_lsa_size((struct ospf6_lsa_header *)p) <=
-		     OSPF6_MESSAGE_END(oh);
+	     p + sizeof(struct ospf6_lsa_header) <= OSPF6_MESSAGE_END(oh) &&
+	     ospf6_lsa_size((struct ospf6_lsa_header *)p) >= sizeof(struct ospf6_lsa_header) &&
+	     p + ospf6_lsa_size((struct ospf6_lsa_header *)p) <= OSPF6_MESSAGE_END(oh);
 	     p += ospf6_lsa_size((struct ospf6_lsa_header *)p)) {
 		ospf6_receive_lsa(on, (struct ospf6_lsa_header *)p);
 	}


### PR DESCRIPTION
### Summary
ospf6_lsupdate_recv walks the LSAs in a received Link State Update by stepping p forward by ospf6_lsa_size(), which is ntohs(header->length) straight off the wire. The walk only checks that each LSA fits inside the message, not that its claimed length covers a full LSA header, so a neighbor in Exchange, Loading or Full can send an LS Update whose LSA length field is below 20. ospf6_receive_lsa then passes it to ospf6_lsa_create, which mallocs that many bytes and copies them, and ospf6_lsa_checksum_valid reads the length field at offset 18 of that short copy and runs fletcher_checksum over ntohs(length) - 2 bytes, which underflows to about 65534 for a length of 0 or 1.

Before, any LSA length that fit the remaining message was processed, so a 1-byte LSA produced a 1-byte allocation that was then read well past its end. After, the walk also requires ospf6_lsa_size() to be at least the size of the LSA header before the LSA is handed on, the same fixed-size bound the database-description, request and ack walks in this file already rely on. Keeping the bound in the walk means one malformed length stops parsing instead of every downstream consumer carrying its own guard; the tradeoff is that a truncated LSA ends processing of the rest of the update, matching the existing too-long check.

### Related Issue
N/A

### Components
ospf6d