### PR TITLE
doc, docker: Add dependency on cunit1 for pceplib

### DIFF
--- a/doc/developer/building-frr-for-debian13.rst
+++ b/doc/developer/building-frr-for-debian13.rst
@@ -32,6 +32,13 @@ For gRPC support the following packages are required:
       libprotobuf-dev protobuf-compiler-grpc
 
 
+For pceplib testing the following packages are required:
+
+::
+
+  sudo apt-get install libcunit1-dev
+
+
 Get FRR, compile it and install it (from Git)
 ---------------------------------------------
 

--- a/doc/developer/building-frr-for-ubuntu2x04.rst
+++ b/doc/developer/building-frr-for-ubuntu2x04.rst
@@ -30,6 +30,16 @@ installed.
    sudo apt-get install libgrpc++-dev protobuf-compiler-grpc
 
 
+PCEPLIB
+^^^^^^^
+
+If you are building/working on pceplib then you must install cunit
+
+.. code-block:: console
+
+   sudo apt-get install libcunit1-dev
+
+
 Config Rollbacks
 ^^^^^^^^^^^^^^^^
 

--- a/doc/developer/pceplib.rst
+++ b/doc/developer/pceplib.rst
@@ -316,7 +316,8 @@ Testing
 The Unit Tests for an individual library are executed with the ``make check``
 command. The Unit Test binary will be written to the project ``build`` directory.
 All Unit Tests are executed with Valgrind, and any memory issues reported by
-Valgrind will cause the Unit Test to fail.
+Valgrind will cause the Unit Test to fail.  This testing will not work without
+installing the cunit development library.
 
 
 PCEPlib PCC API

--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -77,6 +77,7 @@ RUN for i in $(seq 1 ${APT_RETRIES}); do \
         kmod \
         iproute2 \
         iputils-ping \
+        libcunit1-dev \
         liblua5.3-dev \
         libssl-dev \
         lua5.3 \


### PR DESCRIPTION
If you want `make check` to work to test pceplib than the cunit1 development libraries need to be installed as well. Document this some more.