### PR TITLE
lib, zebra: proper PtP peer prefixes across ZAPI

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -997,31 +997,31 @@ unsigned int connected_count_by_family(struct interface *ifp, int family)
 	return cnt;
 }
 
-struct connected *connected_lookup_prefix_exact(struct interface *ifp,
-						const struct prefix *p)
+struct connected *connected_lookup_prefix_exact(struct interface *ifp, const struct prefix *p,
+						const struct prefix *dest)
 {
 	struct connected *ifc;
 
 	frr_each (if_connected, ifp->connected, ifc) {
-		if (prefix_same(ifc->address, p))
+		if (!prefix_same(ifc->address, p))
+			continue;
+		if (!ifc->destination && !dest)
+			return ifc;
+		if (ifc->destination && dest && prefix_same(ifc->destination, dest))
 			return ifc;
 	}
 	return NULL;
 }
 
-struct connected *connected_delete_by_prefix(struct interface *ifp,
-					     struct prefix *p)
+struct connected *connected_delete_by_prefix(struct interface *ifp, const struct prefix *p,
+					     const struct prefix *dest)
 {
 	struct connected *ifc;
 
-	/* In case of same prefix come, replace it with new one. */
-	frr_each_safe (if_connected, ifp->connected, ifc) {
-		if (prefix_same(ifc->address, p)) {
-			if_connected_del(ifp->connected, ifc);
-			return ifc;
-		}
-	}
-	return NULL;
+	ifc = connected_lookup_prefix_exact(ifp, p, dest);
+	if (ifc)
+		if_connected_del(ifp->connected, ifc);
+	return ifc;
 }
 
 /* Find the address on our side that will be used when packets
@@ -1044,9 +1044,8 @@ struct connected *connected_lookup_prefix(struct interface *ifp,
 	return match;
 }
 
-struct connected *connected_add_by_prefix(struct interface *ifp,
-					  struct prefix *p,
-					  struct prefix *destination)
+struct connected *connected_add_by_prefix(struct interface *ifp, const struct prefix *p,
+					  const struct prefix *destination)
 {
 	struct connected *ifc;
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -621,15 +621,15 @@ extern ifindex_t ifname2ifindex(const char *ifname, vrf_id_t vrf_id);
 /* Connected address functions. */
 extern struct connected *connected_new(void);
 extern void connected_free(struct connected **connected);
-extern struct connected *connected_add_by_prefix(struct interface *ifp,
-						 struct prefix *p,
-						 struct prefix *dest);
-extern struct connected *connected_delete_by_prefix(struct interface *ifp,
-						    struct prefix *p);
+extern struct connected *connected_add_by_prefix(struct interface *ifp, const struct prefix *p,
+						 const struct prefix *dest);
+extern struct connected *connected_delete_by_prefix(struct interface *ifp, const struct prefix *p,
+						    const struct prefix *dest);
 extern struct connected *connected_lookup_prefix(struct interface *ifp,
 						 const struct prefix *p);
 extern struct connected *connected_lookup_prefix_exact(struct interface *ifp,
-						       const struct prefix *p);
+						       const struct prefix *p,
+						       const struct prefix *dest);
 extern bool if_has_connected_with_family(struct interface *ifp, int family);
 extern unsigned int connected_count_by_family(struct interface *ifp, int family);
 extern struct nbr_connected *nbr_connected_new(void);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3240,26 +3240,20 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 
 	if (zclient_stream_get_prefix(s, &p) != 0)
 		goto stream_failure;
-
-	/* Fetch destination address. */
-	STREAM_GET(&d.u.prefix, s, plen);
+	if (zclient_stream_get_prefix(s, &d) != 0)
+		goto stream_failure;
 
 	/* N.B. NULL destination pointers are encoded as all zeroes */
-	dp = memconstant(&d.u.prefix, 0, plen) ? NULL : &d;
+	dp = (d.prefixlen == 0) && memconstant(&d.u.prefix, 0, plen) ? NULL : &d;
 
 	if (type == ZEBRA_INTERFACE_ADDRESS_ADD) {
-		ifc = connected_lookup_prefix_exact(ifp, &p);
-		if (!ifc) {
-			/* N.B. NULL destination pointers are encoded as all
-			 * zeroes */
+		ifc = connected_lookup_prefix_exact(ifp, &p, dp);
+		if (!ifc)
 			ifc = connected_add_by_prefix(ifp, &p, dp);
-		}
+
 		if (ifc) {
 			ifc->flags = ifc_flags;
-			if (ifc->destination)
-				ifc->destination->prefixlen =
-					ifc->address->prefixlen;
-			else if (CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
+			if (!ifc->destination && CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
 				/* carp interfaces on OpenBSD with 0.0.0.0/0 as
 				 * "peer" */
 				flog_err(
@@ -3271,7 +3265,7 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 		}
 	} else {
 		assert(type == ZEBRA_INTERFACE_ADDRESS_DELETE);
-		ifc = connected_delete_by_prefix(ifp, &p);
+		ifc = connected_delete_by_prefix(ifp, &p, dp);
 	}
 
 	return ifc;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3185,11 +3185,13 @@ size_t zebra_interface_link_params_write(struct stream *s,
  * :               :
  * |               |
  * +-+-+-+-+-+-+-+-+
- * |    addr_len   |  len of addr. E.g., addr_len = 4 for ipv4 addrs.
+ * |   addr_plen   |  prefixlen of addr.
  * +-+-+-+-+-+-+-+-+
- * |     daddr..   |
+ * |    daddr..    |  (zeroes if no destination/peer prefix)
  * :               :
  * |               |
+ * +-+-+-+-+-+-+-+-+
+ * |   daddr_plen  |  prefixlen of daddr.
  * +-+-+-+-+-+-+-+-+
  */
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -420,7 +420,7 @@ extern int zclient_bfd_session_update(ZAPI_CALLBACK_ARGS);
 #define ZAPI_MESSAGE_SRTE 0x0200
 #define ZAPI_MESSAGE_OPAQUE 0x0400
 
-#define ZSERV_VERSION 6
+#define ZSERV_VERSION 7
 /* Zserv protocol message header */
 struct zmsghdr {
 	uint16_t length;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -309,10 +309,11 @@ int zsend_interface_address(int cmd, struct zserv *client,
 
 	/* Destination. */
 	p = ifc->destination;
-	if (p)
+	if (p) {
 		stream_put(s, &p->u.prefix, blen);
-	else
-		stream_put(s, NULL, blen);
+		stream_putc(s, p->prefixlen);
+	} else
+		stream_put(s, NULL, blen + 1);
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));


### PR DESCRIPTION
We were (1) losing the peer prefix length, (2) couldn't support the same
address with more than one peer prefix (which to be fair will probably
break protocols), and (3) were possibly deleting the wrong thing, since
that lookup was without the peer prefix.

Straighten all of this out, properly carry peer prefix across ZAPI.

---
more comprehensive fix for the first commit in #22129. The 2nd and 3rd commit from that PR are still needed.

Haven't really tested this, let's see if it blows up in CI.