### PR TITLE
tools: Use the topotest log directory instead of /tmp

### DIFF
--- a/tests/topotests/bgp_bmp/test_bgp_bmp_3.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_3.py
@@ -103,9 +103,10 @@ ip link set r1import-eth2 master vrf1
 
     bmp_reset_seq(bmp_seq_context)
     if DEBUG_PCAP:
-        tgen.gears["r1import"].run("rm /tmp/bmp.pcap")
+        pcap_file = os.path.join(tgen.logdir, "r1import/bmp.pcap")
+        tgen.gears["r1import"].run("rm {}".format(pcap_file))
         tgen.gears["r1import"].run(
-            "tcpdump -nni r1import-eth0 -s 0 -w /tmp/bmp.pcap &", stdout=None
+            "tcpdump -nni r1import-eth0 -s 0 -w {} &".format(pcap_file), stdout=None
         )
 
     for rname, router in tgen.routers().items():

--- a/tests/topotests/ospf_rfc4222_dscp/test_ospf_rfc4222_dscp.py
+++ b/tests/topotests/ospf_rfc4222_dscp/test_ospf_rfc4222_dscp.py
@@ -13,11 +13,12 @@
 #
 
 import sys
+import os
 import pytest
 import json
 
 from lib.topogen import Topogen, get_topogen, TopoRouter, topotest
-
+from lib.topolog import logger
 
 def _build_topo(tgen):
     "Simple R1-R2 topology"
@@ -222,7 +223,9 @@ interface r1-eth0
 
     # Give OSPF a moment to send some control traffic
     # Flood: add 200 loopbacks on r1 and redistribute connected
-    pcap = "/tmp/r1-ospf-dscp.pcap"
+    pcap = os.path.join(tgen.logdir, "r1-ospf-dscp.pcap")
+    logger.info("PCAP DIR: {}".format(pcap))
+
     _capture_ospf_pcap(r1, "r1-eth0", pcap)
     topotest.sleep(2, "Setup packet capture")
     r1.vtysh_cmd("conf t\nrouter ospf\n redistribute connected\n exit")


### PR DESCRIPTION
Found a couple of places that were logging directly into /tmp instead of the log directory for the test.  Let's move them over.