### PR TITLE
build, *: followup fixes for frr-format plugin & uint64_t print

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,9 @@
 ## Process this file with automake to produce Makefile.in.
 
-#AUTODERP# ifeq (0,$(MAKELEVEL))
+#AUTODERP# ifneq ($(FPLUGIN_DONE),1)
 FPLUGIN := $(shell CC="$(CC)" top_srcdir="$(top_srcdir)" top_builddir="$(top_builddir)" "$(top_srcdir)/tools/gcc-plugins/autobuild.sh" )
 # with the "all"/"all-am" target split, make always runs twice - save the extra check
-AM_MAKEFLAGS := $(AM_MAKEFLAGS) FPLUGIN="$(FPLUGIN)"
+AM_MAKEFLAGS := $(AM_MAKEFLAGS) FPLUGIN="$(FPLUGIN)" FPLUGIN_DONE=1
 #AUTODERP# endif
 
 AUTOMAKE_OPTIONS = subdir-objects 1.12

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3325,12 +3325,12 @@ DEFPY(show_bmp,
 				peer_uptime(bmp->t_up.tv_sec, uptime,
 					    sizeof(uptime), false, NULL);
 
-				ttable_add_row(tt, "%s|%s|%Lu|%Lu|%Lu|%Lu|%zu|%zu",
-					       bmp->remote, uptime,
-					       bmp->cnt_update,
-					       bmp->cnt_mirror,
-					       bmp->cnt_mirror_overruns,
-					       total, q, kq);
+				ttable_add_row(tt,
+					       "%s|%s|%" PRIu64 "|%" PRIu64 "|%" PRIu64 "|%" PRIu64
+					       "|%zu|%zu",
+					       bmp->remote, uptime, bmp->cnt_update,
+					       bmp->cnt_mirror, bmp->cnt_mirror_overruns, total, q,
+					       kq);
 			}
 			out = ttable_dump(tt, "\n");
 			vty_out(vty, "%s", out);

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -386,7 +386,11 @@ extern "C" {
 /* frr-format plugin is C-only for now, so no point in doing these shenanigans
  * for C++...  (also they can break some C++ stuff...)
  */
-#ifndef __cplusplus
+#ifdef __cplusplus
+/* do nothing */
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+/* do nothing - "%w64u" will be used & should match the original defs */
+#else
 /* these should be typedefs, but might also be #define */
 #ifdef uint64_t
 #undef uint64_t
@@ -418,7 +422,7 @@ _Static_assert(sizeof(_uint64_t) == 8 && sizeof(_int64_t) == 8,
 #endif /* !__cplusplus */
 #endif /* !_FRR_ATTRIBUTE_PRINTFRR */
 
-#if __STDC_VERSION__ >= 202311L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 /* whohoo, we can start moving towards getting rid of these, since
  * __STDC_VERSION__ >= 202311L also implies printf supports it
  *

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -91,7 +91,7 @@ mgmt_be_find_txn_by_id(struct mgmt_be_client *client_ctx, uint64_t txn_id,
 	if (client_ctx->config_txn && client_ctx->config_txn->txn_id == txn_id)
 		return client_ctx->config_txn;
 	if (warn)
-		log_err_be_client("client %s unkonwn txn-id: %Lu", client_ctx->name, txn_id);
+		log_err_be_client("client %s unkonwn txn-id: %" PRIu64, client_ctx->name, txn_id);
 	return NULL;
 }
 
@@ -116,7 +116,7 @@ mgmt_be_txn_create(struct mgmt_be_client *client_ctx, uint64_t txn_id)
 	 */
 	txn->candidate_config = nb_config_dup(client_ctx->running_config);
 	if (!txn->candidate_config) {
-		log_err_be_client("Failed to create candidate config for txn-id: %Lu", txn_id);
+		log_err_be_client("Failed to create candidate config for txn-id: %" PRIu64, txn_id);
 		XFREE(MTYPE_MGMTD_BE_TXN, txn);
 		return NULL;
 	}
@@ -320,7 +320,7 @@ static int mgmt_be_send_cfg_reply(struct mgmt_be_client *client_ctx, uint64_t tx
 	msg->code = MGMT_MSG_CODE_CFG_REPLY;
 	msg->refer_id = txn_id;
 
-	debug_be_client("Sending CFG_REPLY txn-id: %Lu", txn_id);
+	debug_be_client("Sending CFG_REPLY txn-id: %" PRIu64, txn_id);
 
 	ret = be_client_send_native_msg(client_ctx, msg, mgmt_msg_native_get_msg_len(msg), false);
 	mgmt_msg_native_free_msg(msg);
@@ -432,14 +432,15 @@ static bool mgmt_be_txn_cfg_prepare(struct mgmt_be_client *client_ctx, uint64_t 
 	nb_ctx.user = (void *)client_ctx->user_data;
 	err_buf[0] = 0;
 
-	debug_be_client("Creating new txn-id %Lu", txn_id);
+	debug_be_client("Creating new txn-id %" PRIu64, txn_id);
 
 	/*
 	 * First validate there's no other config txn right now. Eventually we
 	 * may want to support multiple CFG_REQ prioer to a CFG_APPLY.
 	 */
 	if (client_ctx->config_txn) {
-		log_err_be_client("Cannot prepare cfg for txn-id: %Lu, another txn-id: %Lu was in progress",
+		log_err_be_client("Cannot prepare cfg for txn-id: %" PRIu64
+				  ", another txn-id: %" PRIu64 " was in progress",
 				  txn_id, client_ctx->config_txn->txn_id);
 		return true;
 	}
@@ -447,7 +448,7 @@ static bool mgmt_be_txn_cfg_prepare(struct mgmt_be_client *client_ctx, uint64_t 
 	/* Create a txn to track the config changes for later apply */
 	txn = mgmt_be_txn_create(client_ctx, txn_id);
 	if (!txn) {
-		log_err_be_client("Failed to create txn for txn_id: %Lu", txn_id);
+		log_err_be_client("Failed to create txn for txn_id: %" PRIu64, txn_id);
 		return true;
 	}
 
@@ -526,7 +527,8 @@ static bool mgmt_be_txn_cfg_prepare(struct mgmt_be_client *client_ctx, uint64_t 
 	disconnect = !!mgmt_be_send_cfg_reply(client_ctx, txn->txn_id, !error,
 					      error ? err_buf : NULL);
 
-	debug_be_client("Avg-nb-edit-duration %Lu uSec, nb-prep-duration %lu (avg: %Lu) uSec, batch size %u",
+	debug_be_client("Avg-nb-edit-duration %" PRIu64
+			" uSec, nb-prep-duration %lu (avg: %" PRIu64 ") uSec, batch size %u",
 			client_ctx->avg_edit_nb_cfg_tm, prep_nb_cfg_tm,
 			client_ctx->avg_prep_nb_cfg_tm, (uint32_t)num_processed);
 done:
@@ -547,7 +549,7 @@ static void be_client_handle_cfg(struct mgmt_be_client *client, uint64_t txn_id,
 	struct mgmt_msg_cfg_req *msg = msgbuf;
 	const char **config = NULL;
 
-	debug_be_client("Got CFG_REQ txn-id: %Lu", txn_id);
+	debug_be_client("Got CFG_REQ txn-id: %" PRIu64, txn_id);
 
 	config = mgmt_msg_native_strings_decode(msg, msg_len, msg->config);
 	if (darr_len(config) == 0) {
@@ -626,7 +628,7 @@ static bool mgmt_be_txn_proc_cfgapply(struct mgmt_be_txn_ctx *txn)
 	disconnect = !!mgmt_be_send_apply_reply(client_ctx, txn->txn_id,
 						err_buf[0] ? err_buf : NULL);
 
-	debug_be_client("Nb-apply-duration %lu (avg: %Lu) uSec", apply_nb_cfg_tm,
+	debug_be_client("Nb-apply-duration %lu (avg: %" PRIu64 ") uSec", apply_nb_cfg_tm,
 			client_ctx->avg_apply_nb_cfg_tm);
 
 	mgmt_be_txn_delete(txn);
@@ -638,12 +640,13 @@ static void be_client_handle_cfg_apply(struct mgmt_be_client *client, uint64_t t
 {
 	struct mgmt_be_txn_ctx *txn = NULL;
 
-	debug_be_client("Got CFG_APPLY_REQ for client %s txn-id %Lu", client->name, txn_id);
+	debug_be_client("Got CFG_APPLY_REQ for client %s txn-id %" PRIu64, client->name, txn_id);
 
 	if (client->config_txn && client->config_txn->txn_id == txn_id)
 		txn = client->config_txn;
 	else
-		log_err_be_client("client %s unkonwn config txn-id: %Lu", client->name, txn_id);
+		log_err_be_client("client %s unkonwn config txn-id: %" PRIu64, client->name,
+				  txn_id);
 
 	if (!txn || mgmt_be_txn_proc_cfgapply(txn))
 		msg_conn_disconnect(&client->client.conn, true);
@@ -657,13 +660,13 @@ static void be_client_handle_txn_req(struct mgmt_be_client *client, uint64_t txn
 {
 	struct mgmt_msg_txn_req *msg = msgbuf;
 
-	debug_be_client("Got TXN_DELETE txn-id: %Lu", txn_id);
+	debug_be_client("Got TXN_DELETE txn-id: %" PRIu64, txn_id);
 	if (msg->create) {
-		log_err_be_client("Unsupported TXN_REQ create for txn-id: %Lu", txn_id);
+		log_err_be_client("Unsupported TXN_REQ create for txn-id: %" PRIu64, txn_id);
 		goto failed;
 	}
 	if (!client->config_txn || client->config_txn->txn_id != txn_id) {
-		debug_be_client("Ignoring TXN_DELETE of removed (or never present) txn-id: %Lu",
+		debug_be_client("Ignoring TXN_DELETE of removed (or never present) txn-id: %" PRIu64,
 				txn_id);
 		return;
 	}
@@ -700,7 +703,8 @@ static enum nb_error be_client_send_tree_data_batch(const struct lyd_node *tree,
 	}
 	if (ret != NB_OK) {
 		if (be_client_send_error(client, args->txn_id, args->req_id, false, -EINVAL,
-					 "BE client %s txn-id %Lu error fetching oper state %d",
+					 "BE client %s txn-id %" PRIu64
+					 " error fetching oper state %d",
 					 client->name, args->txn_id, ret))
 			ret = NB_ERR;
 		else

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -125,7 +125,7 @@ static int fe_client_push_sent_msg(struct mgmt_fe_client *client, struct mgmt_ms
 	if (msg->refer_id) {
 		session = mgmt_fe_find_session_by_session_id(client, msg->refer_id);
 		if (!session) {
-			log_err_fe_client("No session for sent msg with session-id %Lu",
+			log_err_fe_client("No session for sent msg with session-id %" PRIu64,
 					  msg->refer_id);
 			mgmt_msg_native_free_msg(msg);
 			return -1;
@@ -133,11 +133,13 @@ static int fe_client_push_sent_msg(struct mgmt_fe_client *client, struct mgmt_ms
 	}
 
 	if (session) {
-		debug_fe_client("Push sent message refer-id %Lu req-id %Lu for session-id %Lu of client %s",
+		debug_fe_client("Push sent message refer-id %" PRIu64 " req-id %" PRIu64
+				" for session-id %" PRIu64 " of client %s",
 				msg->refer_id, msg->req_id, session->session_id, client->name);
 		darr_push(session->sent_msgs, msg);
 	} else {
-		debug_fe_client("Push sent message refer-id %Lu req-id %Lu for client %s",
+		debug_fe_client("Push sent message refer-id %" PRIu64 " req-id %" PRIu64
+				" for client %s",
 				msg->refer_id, msg->req_id, client->name);
 		darr_push(client->sent_msgs, msg);
 	}
@@ -161,7 +163,7 @@ static struct mgmt_msg_header *fe_client_pop_sent_msg(struct mgmt_fe_client *cli
 	if (session_id) {
 		session = mgmt_fe_find_session_by_session_id(client, session_id);
 		if (!session) {
-			log_err_fe_client("No session for sent msg with session-id %Lu",
+			log_err_fe_client("No session for sent msg with session-id %" PRIu64,
 					  session_id);
 			return NULL;
 		}
@@ -176,12 +178,14 @@ static struct mgmt_msg_header *fe_client_pop_sent_msg(struct mgmt_fe_client *cli
 		msg = (*sent_msgsp)[i];
 		if (msg->req_id == req_id) {
 			darr_remove(*sent_msgsp, i);
-			debug_fe_client("Popping sent message for client %s session-id %Lu req-id %Lu",
+			debug_fe_client("Popping sent message for client %s session-id %" PRIu64
+					" req-id %" PRIu64,
 					client->name, session_id, req_id);
 			return msg;
 		}
 	}
-	debug_fe_client("No sent message found for client %s session-id %Lu req-id %Lu",
+	debug_fe_client("No sent message found for client %s session-id %" PRIu64
+			" req-id %" PRIu64,
 			client->name, session_id, req_id);
 	return NULL;
 }
@@ -200,11 +204,11 @@ static struct mgmt_msg_header *fe_client_pop_sess_req_msg(struct mgmt_fe_client 
 		if (msg->req_id != req_id)
 			continue;
 		if (msg->code != MGMT_MSG_CODE_SESSION_REQ) {
-			log_err_fe_client("non-session-req sent msg found for client %s req-id %Lu",
+			log_err_fe_client("non-session-req sent msg found for client %s req-id %" PRIu64,
 					  client->name, req_id);
 			return NULL;
 		}
-		debug_fe_client("Popping sent session_req message for client %s req-id %Lu",
+		debug_fe_client("Popping sent session_req message for client %s req-id %" PRIu64,
 				client->name, req_id);
 		darr_remove(client->sent_msgs, i);
 		return msg;
@@ -223,13 +227,14 @@ static int mgmt_fe_send_session_req(struct mgmt_fe_client *client,
 	msg->code = MGMT_MSG_CODE_SESSION_REQ;
 	msg->req_id = session->client_id;
 	if (create) {
-		debug_fe_client("Sending SESSION_REQ create message for client-id %Lu",
+		debug_fe_client("Sending SESSION_REQ create message for client-id %" PRIu64,
 				session->client_id);
 		/* we need to queue before sending short-circuit so it's there when replied to */
 		darr_push(client->sent_msgs, (struct mgmt_msg_header *)msg);
 	} else {
 		msg->refer_id = session->session_id;
-		debug_fe_client("Sending SESSION_REQ destroy message for session-id: %Lu client-id %Lu",
+		debug_fe_client("Sending SESSION_REQ destroy message for session-id: %" PRIu64
+				" client-id %" PRIu64,
 				msg->refer_id, msg->req_id);
 		/* we need to queue before sending short-circuit so it's there when replied to */
 		darr_push(session->sent_msgs, (struct mgmt_msg_header *)msg);
@@ -287,7 +292,8 @@ int mgmt_fe_send_commit_req(struct mgmt_fe_client *client, uint64_t session_id, 
 		msg->action = MGMT_MSG_COMMIT_APPLY;
 	msg->unlock = unlock;
 
-	debug_fe_client("Sending COMMIT message for src: %s dst: %s session-id %Lu action: %s unlock: %d",
+	debug_fe_client("Sending COMMIT message for src: %s dst: %s session-id %" PRIu64
+			" action: %s unlock: %d",
 			dsid2name(src_ds_id), dsid2name(dest_ds_id), session_id,
 			msg->action == MGMT_MSG_COMMIT_VALIDATE ? "validate"
 			: msg->action == MGMT_MSG_COMMIT_ABORT	? "abort"
@@ -469,19 +475,20 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 			orig_msg = fe_client_pop_sent_msg(client, msg->refer_id, msg->req_id,
 							  &session);
 
-		debug_fe_client("Got SESSION_REPLY (%s) for client-id %Lu with session-id: %Lu",
+		debug_fe_client("Got SESSION_REPLY (%s) for client-id %" PRIu64
+				" with session-id: %" PRIu64,
 				session_reply->created ? "create" : "destroy", msg->req_id,
 				msg->refer_id);
 		if (session_reply->created) {
 			session = mgmt_fe_find_session_by_client_id(client, msg->req_id);
 			if (!session) {
-				log_err_fe_client("Session create failed for client-id %Lu",
+				log_err_fe_client("Session create failed for client-id %" PRIu64,
 						  msg->req_id);
 				goto done;
 			}
 			session->session_id = msg->refer_id;
 		} else {
-			debug_fe_client("Got SESSION_REPLY (destroy) for session-id %Lu",
+			debug_fe_client("Got SESSION_REPLY (destroy) for session-id %" PRIu64,
 					session_reply->refer_id);
 			session = mgmt_fe_find_session_by_session_id(client, msg->refer_id);
 		}
@@ -497,8 +504,8 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 		assert(msg->code == MGMT_MSG_CODE_ERROR &&
 		       orig_msg->code == MGMT_MSG_CODE_SESSION_REQ);
 
-		debug_fe_client("Error handling session-req client-id %Lu req-id %Lu", msg->req_id,
-				msg->req_id);
+		debug_fe_client("Error handling session-req client-id %" PRIu64 " req-id %" PRIu64,
+				msg->req_id, msg->req_id);
 
 		if (msg->refer_id)
 			session = mgmt_fe_find_session_by_session_id(client, msg->refer_id);
@@ -522,7 +529,7 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 	orig_msg = fe_client_pop_sent_msg(client, msg->refer_id, msg->req_id, &session);
 	orig_code = orig_msg ? orig_msg->code : MGMT_MSG_CODE_ERROR;
 	if (!session || !session->client) {
-		log_err_fe_client("No session for received native msg session-id %Lu",
+		log_err_fe_client("No session for received native msg session-id %" PRIu64,
 				  msg->refer_id);
 		goto done;
 	}
@@ -581,7 +588,8 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 generic_error_handler:
 			err_msg = (typeof(err_msg))msg;
 			if (!orig_msg)
-				log_err_fe_client("No saved message for session-id %Lu req-id %Lu",
+				log_err_fe_client("No saved message for session-id %" PRIu64
+						  " req-id %" PRIu64,
 						  msg->refer_id, msg->req_id);
 			if (session->client->cbs.error_notify)
 				session->client->cbs.error_notify(client, client->user_data,
@@ -590,7 +598,8 @@ generic_error_handler:
 								  err_msg->error, err_msg->errstr);
 			break;
 		default:
-			log_err_fe_client("Unhandled original message code %u for session-id %Lu req-id %Lu",
+			log_err_fe_client("Unhandled original message code %u for session-id %" PRIu64
+					  " req-id %" PRIu64,
 					  orig_code, msg->refer_id, msg->req_id);
 			assert(!"Unhandled error for original message code");
 			break;

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -389,13 +389,13 @@ int mgmt_be_adapter_send(struct mgmt_be_client_adapter *adapter, void *_msg)
 	uint64_t txn_id = msg->refer_id;
 	int ret;
 
-	_dbg("Sending %s to '%s' txn-id: %Lu", mgmt_msg_code_name(msg->code), adapter->name,
+	_dbg("Sending %s to '%s' txn-id: %" PRIu64, mgmt_msg_code_name(msg->code), adapter->name,
 	     txn_id);
 
 	ret = mgmt_msg_native_send_msg(adapter->conn, msg, false);
 	if (ret)
-		_log_err("Failed sending %s to '%s' txn-id: %Lu", mgmt_msg_code_name(msg->code),
-			 adapter->name, txn_id);
+		_log_err("Failed sending %s to '%s' txn-id: %" PRIu64,
+			 mgmt_msg_code_name(msg->code), adapter->name, txn_id);
 	return ret;
 }
 
@@ -525,7 +525,7 @@ static void be_adapter_process_msg(uint8_t version, uint8_t *data, size_t msg_le
 	 * function.
 	 */
 
-	_dbg("Got %s from '%s' txn-id %Lu", mgmt_msg_code_name(msg->code), adapter->name,
+	_dbg("Got %s from '%s' txn-id %" PRIu64, mgmt_msg_code_name(msg->code), adapter->name,
 	     msg->refer_id);
 
 	assert(adapter->id != MGMTD_BE_CLIENT_ID_MAX || msg->code == MGMT_MSG_CODE_SUBSCRIBE);
@@ -599,10 +599,10 @@ void mgmt_be_adapter_status_write(struct vty *vty)
 		vty_out(vty, "  Client: \t\t\t%s\n", adapter->name);
 		vty_out(vty, "    Conn-FD: \t\t\t%d\n", adapter->conn->fd);
 		vty_out(vty, "    Client-Id: \t\t\t%d\n", adapter->id);
-		vty_out(vty, "    Msg-Recvd: \t\t\t%Lu\n", adapter->conn->mstate.nrxm);
-		vty_out(vty, "    Bytes-Recvd: \t\t%Lu\n", adapter->conn->mstate.nrxb);
-		vty_out(vty, "    Msg-Sent: \t\t\t%Lu\n", adapter->conn->mstate.ntxm);
-		vty_out(vty, "    Bytes-Sent: \t\t%Lu\n", adapter->conn->mstate.ntxb);
+		vty_out(vty, "    Msg-Recvd: \t\t\t%" PRIu64 "\n", adapter->conn->mstate.nrxm);
+		vty_out(vty, "    Bytes-Recvd: \t\t%" PRIu64 "\n", adapter->conn->mstate.nrxb);
+		vty_out(vty, "    Msg-Sent: \t\t\t%" PRIu64 "\n", adapter->conn->mstate.ntxm);
+		vty_out(vty, "    Bytes-Sent: \t\t%" PRIu64 "\n", adapter->conn->mstate.ntxb);
 		count++;
 	}
 	vty_out(vty, "  Total: %u\n", count);

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -242,16 +242,18 @@ int mgmt_ds_lock(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id)
 	assert(ds_ctx);
 
 	if (ds_ctx->locked) {
-		_log_err("LOCK already taken on DS:%s by session-id %Lu (requesting session-id %Lu)",
+		_log_err("LOCK already taken on DS:%s by session-id %" PRIu64
+			 " (requesting session-id %" PRIu64 ")",
 			 mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id, session_id);
 		return -EBUSY;
 	}
 	if (ds_ctx->txn_locked) {
-		_log_err("LOCK already taken on DS:%s by session-less txn-id %Lu (requesting session-id %Lu)",
+		_log_err("LOCK already taken on DS:%s by session-less txn-id %" PRIu64
+			 " (requesting session-id %" PRIu64 ")",
 			 mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->txn_locked, session_id);
 		return -EBUSY;
 	}
-	_dbg("LOCK on DS:%s for session-id %Lu", mgmt_ds_id2name(ds_ctx->ds_id), session_id);
+	_dbg("LOCK on DS:%s for session-id %" PRIu64, mgmt_ds_id2name(ds_ctx->ds_id), session_id);
 
 	ds_ctx->locked = true;
 	ds_ctx->vty_session_id = session_id;
@@ -262,20 +264,20 @@ void mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id)
 {
 	assert(ds_ctx);
 	if (!ds_ctx->locked)
-		_log_err("unlock on unlocked in DS:%s last session-id %Lu",
+		_log_err("unlock on unlocked in DS:%s last session-id %" PRIu64,
 			 mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id);
 	else {
 		assert(ds_ctx->vty_session_id == session_id);
-		_dbg("releasing lock on DS:%s for session-id %Lu", mgmt_ds_id2name(ds_ctx->ds_id),
-		     ds_ctx->vty_session_id);
+		_dbg("releasing lock on DS:%s for session-id %" PRIu64,
+		     mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id);
 	}
 
 	ds_ctx->locked = 0;
 	ds_ctx->vty_session_id = MGMTD_SESSION_ID_NONE;
 
 	if (ds_ctx->txn_locked)
-		_dbg("TXN-LOCK remains on DS:%s for txn-id %Lu", mgmt_ds_id2name(ds_ctx->ds_id),
-		     ds_ctx->txn_locked);
+		_dbg("TXN-LOCK remains on DS:%s for txn-id %" PRIu64,
+		     mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->txn_locked);
 }
 
 bool mgmt_ds_is_txn_locked(struct mgmt_ds_ctx *ds_ctx, uint64_t *txn_id)
@@ -292,17 +294,18 @@ uint64_t mgmt_ds_txn_lock(struct mgmt_ds_ctx *ds_ctx, uint64_t txn_id)
 	assert(ds_ctx);
 
 	if (ds_ctx->txn_locked && ds_ctx->txn_locked != txn_id) {
-		_log_err("TXN-LOCK txn lock held on DS:%s by txn-id: %Lu not txn-id: %Lu",
+		_log_err("TXN-LOCK txn lock held on DS:%s by txn-id: %" PRIu64
+			 " not txn-id: %" PRIu64,
 			 mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->txn_locked, txn_id);
 		return ds_ctx->txn_locked;
 	}
 	if (ds_ctx->txn_locked == txn_id) {
-		_log_warn("TXN-LOCK double lock on DS:%s txn-id: %Lu",
+		_log_warn("TXN-LOCK double lock on DS:%s txn-id: %" PRIu64,
 			  mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->txn_locked);
 		return 0;
 	}
-	_dbg("TXN-LOCK on DS:%s session-id: %Lu txn-id: %Lu", mgmt_ds_id2name(ds_ctx->ds_id),
-	     ds_ctx->vty_session_id, txn_id);
+	_dbg("TXN-LOCK on DS:%s session-id: %" PRIu64 " txn-id: %" PRIu64,
+	     mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id, txn_id);
 	ds_ctx->txn_locked = txn_id;
 	return 0;
 }
@@ -311,16 +314,18 @@ void mgmt_ds_txn_unlock(struct mgmt_ds_ctx *ds_ctx, uint64_t txn_id)
 {
 	assert(ds_ctx);
 	if (ds_ctx->txn_locked && ds_ctx->txn_locked != txn_id) {
-		_log_err("TXN-UNLOCK: txn lock held on DS:%s by session-id: %Lu txn-id: %Lu not txn-id: %Lu",
+		_log_err("TXN-UNLOCK: txn lock held on DS:%s by session-id: %" PRIu64
+			 " txn-id: %" PRIu64 " not txn-id: %" PRIu64,
 			 mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id,
 			 ds_ctx->txn_locked, txn_id);
 		return;
 	}
 	if (!ds_ctx->txn_locked)
-		_log_warn("TXN-UNLOCK of unlocked on DS:%s session-id: %Lu txn-id: %Lu",
+		_log_warn("TXN-UNLOCK of unlocked on DS:%s session-id: %" PRIu64
+			  " txn-id: %" PRIu64,
 			  mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id, txn_id);
 	else
-		_dbg("TXN-UNLOCK on DS:%s session-id: %Lu txn-id: %Lu",
+		_dbg("TXN-UNLOCK on DS:%s session-id: %" PRIu64 " txn-id: %" PRIu64,
 		     mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id, txn_id);
 	ds_ctx->txn_locked = 0;
 }
@@ -599,7 +604,7 @@ void mgmt_ds_status_write_one(struct vty *vty, struct mgmt_ds_ctx *ds_ctx)
 	vty_out(vty, "    DS-Hndl: \t\t\t%p\n", ds_ctx);
 	vty_out(vty, "    Config: \t\t\t%s\n",
 		ds_ctx->config_ds ? "True" : "False");
-	vty_out(vty, "    Locked: \t\t\t%s Session-ID: %Lu Txn-ID: %Lu\n",
+	vty_out(vty, "    Locked: \t\t\t%s Session-ID: %" PRIu64 " Txn-ID: %" PRIu64 "\n",
 		locked ? "True" : "False", session_id, txn_id);
 }
 

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -215,13 +215,13 @@ static void ns_string_add_session(uint64_t req_id, const char **selectors, uint6
 		clients |= ns_string_add_string(*sp, darr_strlen(*sp), session_id, &all_clients);
 
 	if (!(all_clients | upd_clients)) {
-		_dbg("No backends publishing data for selectors '%pSAd' for session-id: %Lu",
+		_dbg("No backends publishing data for selectors '%pSAd' for session-id: %" PRIu64,
 		     selectors, session_id);
 		return;
 	}
 	if (!(clients | upd_clients))
-		_dbg("No backends to update for selectors: '%pSAd' for session-id: %Lu", selectors,
-		     session_id);
+		_dbg("No backends to update for selectors: '%pSAd' for session-id: %" PRIu64,
+		     selectors, session_id);
 	else
 		/*
 		 * Send a message to set the selectors on the changed clients,
@@ -235,7 +235,7 @@ static void ns_string_add_session(uint64_t req_id, const char **selectors, uint6
 	if (!all_clients || !selectors)
 		return;
 
-	_dbg("Creating new data-push for session-id: %Lu", session_id);
+	_dbg("Creating new data-push for session-id: %" PRIu64, session_id);
 
 	/* Send a second message requesting a full state dump for the session */
 	mgmt_txn_send_notify_selectors(req_id, session_id, all_clients, false, selectors);
@@ -703,14 +703,15 @@ static void fe_session_send_commit_reply(struct mgmt_fe_session_ctx *session, ui
 	if (info && info[0])
 		mgmt_msg_native_add_str(msg, info);
 
-	_dbg("Sending commit-reply session-id %Lu on %s req-id %Lu source-ds: %s target-ds: %s action: %u unlock: %d",
+	_dbg("Sending commit-reply session-id %" PRIu64 " on %s req-id %" PRIu64
+	     " source-ds: %s target-ds: %s action: %u unlock: %d",
 	     session->session_id, session->adapter->name, req_id, mgmt_ds_id2name(source),
 	     mgmt_ds_id2name(target), action, unlock);
 
 	ret = fe_adapter_send_msg(session->adapter, msg, mgmt_msg_native_get_msg_len(msg), false);
 	mgmt_msg_native_free_msg(msg);
 	if (ret) {
-		_log_err("Failed to send COMMIT_REPLY to session-id %Lu", session->session_id);
+		_log_err("Failed to send COMMIT_REPLY to session-id %" PRIu64, session->session_id);
 		msg_conn_disconnect(session->adapter->conn, false);
 	}
 }
@@ -773,12 +774,13 @@ int mgmt_fe_send_commit_cfg_reply(uint64_t session_id, uint64_t txn_id, enum mgm
 		fe_session_send_commit_reply(session, req_id, src_ds_id, dst_ds_id, action, unlock,
 					     error_if_any);
 	else {
-		ret = fe_session_send_error(
-			session, req_id, false, mgmt_result_to_error(result),
-			"commit failed session-id %Lu on %s req-id %Lu source-ds: %s target-ds: %s validate-only: %u: reason: '%s'",
-			session->session_id, session->adapter->name, req_id,
-			mgmt_ds_id2name(src_ds_id), mgmt_ds_id2name(dst_ds_id), validate_only,
-			error_if_any ?: "");
+		ret = fe_session_send_error(session, req_id, false, mgmt_result_to_error(result),
+					    "commit failed session-id %" PRIu64
+					    " on %s req-id %" PRIu64
+					    " source-ds: %s target-ds: %s validate-only: %u: reason: '%s'",
+					    session->session_id, session->adapter->name, req_id,
+					    mgmt_ds_id2name(src_ds_id), mgmt_ds_id2name(dst_ds_id),
+					    validate_only, error_if_any ?: "");
 	}
 
 	assert(session->cfg_txn_id == txn_id);
@@ -794,7 +796,8 @@ static void fe_session_handle_commit(struct mgmt_fe_session_ctx *session, void *
 	struct mgmt_ds_ctx *src_ds_ctx, *dst_ds_ctx;
 	uint64_t txn_id;
 
-	_dbg("Got COMMIT for source-ds: %s target-ds: %s action: %s on session-id %Lu from '%s'",
+	_dbg("Got COMMIT for source-ds: %s target-ds: %s action: %s on session-id %" PRIu64
+	     " from '%s'",
 	     mgmt_ds_id2name(msg->source), mgmt_ds_id2name(msg->target),
 	     msg->action == MGMT_MSG_COMMIT_VALIDATE ? "validate"
 	     : msg->action == MGMT_MSG_COMMIT_ABORT  ? "abort"
@@ -818,7 +821,7 @@ static void fe_session_handle_commit(struct mgmt_fe_session_ctx *session, void *
 	if (mgmt_ds_is_txn_locked(src_ds_ctx, &txn_id) ||
 	    mgmt_ds_is_txn_locked(dst_ds_ctx, &txn_id)) {
 		fe_session_send_error(session, msg->req_id, false, EBUSY,
-				      "source/target datastore is locked by another transaction txn-id: %Lu",
+				      "source/target datastore is locked by another transaction txn-id: %" PRIu64,
 				      txn_id);
 		return;
 	}
@@ -826,7 +829,7 @@ static void fe_session_handle_commit(struct mgmt_fe_session_ctx *session, void *
 	/* User must always have lock on source */
 	if (!session->ds_locked[msg->source]) {
 		fe_session_send_error(session, msg->req_id, false, EBUSY,
-				      "source not locked by session-id: %Lu on '%s'",
+				      "source not locked by session-id: %" PRIu64 " on '%s'",
 				      session->session_id, session->adapter->name);
 		return;
 	}
@@ -834,7 +837,8 @@ static void fe_session_handle_commit(struct mgmt_fe_session_ctx *session, void *
 	/* For apply/abort user must also have lock on target */
 	if (msg->action != MGMT_MSG_COMMIT_VALIDATE && !session->ds_locked[msg->target]) {
 		fe_session_send_error(session, msg->req_id, false, EBUSY,
-				      "target not locked for apply/abort by session-id: %Lu on '%s'",
+				      "target not locked for apply/abort by session-id: %" PRIu64
+				      " on '%s'",
 				      session->session_id, session->adapter->name);
 		return;
 	}
@@ -853,12 +857,13 @@ static void fe_session_handle_commit(struct mgmt_fe_session_ctx *session, void *
 		session->cfg_txn_id = mgmt_create_txn(session->session_id, MGMTD_TXN_TYPE_CONFIG);
 		if (session->cfg_txn_id == MGMTD_SESSION_ID_NONE) {
 			fe_session_send_error(session, msg->req_id, false, ENOMEM,
-					      "failed to create config transaction for session-id: %Lu on '%s'",
+					      "failed to create config transaction for session-id: %" PRIu64
+					      " on '%s'",
 					      session->session_id, session->adapter->name);
 			return;
 		}
-		_dbg("created config txn-id: %Lu for session-id %Lu on '%s'", session->cfg_txn_id,
-		     session->session_id, session->adapter->name);
+		_dbg("created config txn-id: %" PRIu64 " for session-id %" PRIu64 " on '%s'",
+		     session->cfg_txn_id, session->session_id, session->adapter->name);
 	}
 
 	/*
@@ -888,7 +893,8 @@ static int fe_session_send_lock_reply(struct mgmt_fe_session_ctx *session, uint6
 	msg->datastore = datastore;
 	msg->lock = lock;
 
-	_dbg("Sending lock-reply from adapter %s on session-id %Lu req-id %Lu datastore %u lock %u scok %u",
+	_dbg("Sending lock-reply from adapter %s on session-id %" PRIu64 " req-id %" PRIu64
+	     " datastore %u lock %u scok %u",
 	     session->adapter->name, session->session_id, req_id, datastore, lock,
 	     short_circuit_ok);
 
@@ -910,7 +916,7 @@ static void fe_session_handle_lock(struct mgmt_fe_session_ctx *session, void *_m
 	bool lock = msg->lock;
 	int ret;
 
-	_dbg("Got %sLOCK for DS:%s for session-id %Lu from '%s'", msg->lock ? "" : "UN",
+	_dbg("Got %sLOCK for DS:%s for session-id %" PRIu64 " from '%s'", msg->lock ? "" : "UN",
 	     mgmt_ds_id2name(datastore), msg->refer_id, session->adapter->name);
 
 	if (datastore != MGMTD_DS_CANDIDATE && datastore != MGMTD_DS_RUNNING) {
@@ -925,15 +931,17 @@ static void fe_session_handle_lock(struct mgmt_fe_session_ctx *session, void *_m
 	if (lock && mgmt_ds_is_locked(ds_ctx, &lock_session, &txn_id) &&
 	    lock_session != session->session_id) {
 		fe_session_send_error(session, msg->req_id, short_circuit_ok, EBUSY,
-				      "Lock already taken on datastore %s by session: %Lu txn-id: %Lu",
+				      "Lock already taken on datastore %s by session: %" PRIu64
+				      " txn-id: %" PRIu64,
 				      mgmt_ds_id2name(datastore), lock_session, txn_id);
 		return;
 	} else if (lock) {
 		ret = mgmt_fe_session_write_lock_ds(datastore, ds_ctx, session);
 		if (ret) {
-			fe_session_send_error(session, msg->req_id, short_circuit_ok, EBUSY,
-					      "Unexpected error %d trying to lock datastore by session-id: %Lu",
-					      ret, session->session_id);
+			fe_session_send_error(
+				session, msg->req_id, short_circuit_ok, EBUSY,
+				"Unexpected error %d trying to lock datastore by session-id: %" PRIu64,
+				ret, session->session_id);
 			return;
 		}
 	} else {
@@ -944,7 +952,7 @@ static void fe_session_handle_lock(struct mgmt_fe_session_ctx *session, void *_m
 	if (fe_session_send_lock_reply(session, msg->req_id, msg->datastore, msg->lock,
 				       short_circuit_ok)) {
 		assert(!short_circuit_ok);
-		_log_err("Failed to send LOCK_REPLY to session-id %Lu", session->session_id);
+		_log_err("Failed to send LOCK_REPLY to session-id %" PRIu64, session->session_id);
 		msg_conn_disconnect(session->adapter->conn, false);
 	}
 }
@@ -1308,7 +1316,7 @@ static void fe_session_handle_edit(struct mgmt_fe_session_ctx *session, void *_m
 	if (commit &&
 	    (mgmt_ds_is_txn_locked(can_ds, &txn_id) || mgmt_ds_is_txn_locked(run_ds, &txn_id))) {
 		fe_session_send_error(session, msg->req_id, false, -EBUSY,
-				      "datastores are locked by another transaction txn-id: %Lu",
+				      "datastores are locked by another transaction txn-id: %" PRIu64,
 				      txn_id);
 		return;
 	}
@@ -1353,8 +1361,9 @@ static void fe_session_handle_edit(struct mgmt_fe_session_ctx *session, void *_m
 	if (ret && ret == NB_ERR_NO_CHANGES)
 		ret = NB_OK;
 	else if (ret)
-		_dbg("Edit failed for txn-id %Lu req-id %Lu: %s: restoring candidate", txn_id,
-		     msg->req_id, errstr[0] ? errstr : "unknown reason");
+		_dbg("Edit failed for txn-id %" PRIu64 " req-id %" PRIu64
+		     ": %s: restoring candidate",
+		     txn_id, msg->req_id, errstr[0] ? errstr : "unknown reason");
 	else if (commit) {
 		/* Get a TXN for the commit */
 		txn_id = mgmt_create_txn(session->session_id, MGMTD_TXN_TYPE_CONFIG);
@@ -1364,7 +1373,7 @@ static void fe_session_handle_edit(struct mgmt_fe_session_ctx *session, void *_m
 		}
 		session->cfg_txn_id = txn_id;
 
-		_dbg("Created new config txn-id: %Lu for session-id: %Lu", txn_id,
+		_dbg("Created new config txn-id: %" PRIu64 " for session-id: %" PRIu64, txn_id,
 		     session->session_id);
 
 		/* And this is modifying the running */
@@ -1476,7 +1485,7 @@ static void fe_session_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	}
 
 	if (*xpaths && DEBUG_MODE_CHECK(&mgmt_debug_fe, DEBUG_MODE_ALL)) {
-		_dbg("Update %s selectors '%pSAd' (replace: %d mode-data: %u) for session-id: %Lu",
+		_dbg("Update %s selectors '%pSAd' (replace: %d mode-data: %u) for session-id: %" PRIu64,
 		     is_periodic ? "PERIODIC" : "ON-CHANGE", *xpaths, msg->replace,
 		     session->periodic_interval, session->session_id);
 	}
@@ -1652,7 +1661,8 @@ static int fe_adapter_send_session_reply(struct mgmt_fe_client_adapter *adapter,
 	msg->code = MGMT_MSG_CODE_SESSION_REPLY;
 	msg->created = created;
 
-	_dbg("Sending session-reply from adapter %s to session-id %Lu req-id %Lu created %u scok %u",
+	_dbg("Sending session-reply from adapter %s to session-id %" PRIu64 " req-id %" PRIu64
+	     " created %u scok %u",
 	     adapter->name, session_id, req_id, created, scok);
 
 	ret = fe_adapter_send_msg(adapter, msg, mgmt_msg_native_get_msg_len(msg), scok);
@@ -1672,7 +1682,8 @@ static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter
 	bool scok = adapter->conn->is_short_circuit;
 	uint64_t client_id;
 
-	_dbg("Got session-req is create %u req-id %Lu for refer-id %Lu notify-fmt %u from '%s'",
+	_dbg("Got session-req is create %u req-id %" PRIu64 " for refer-id %" PRIu64
+	     " notify-fmt %u from '%s'",
 	     msg->refer_id == 0, msg->req_id, msg->refer_id, msg->notify_format, adapter->name);
 
 	/*
@@ -1710,7 +1721,7 @@ static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter
 	if (msg_len > sizeof(*msg)) {
 		if (!MGMT_MSG_VALIDATE_NUL_TERM(msg, msg_len)) {
 			fe_adapter_conn_send_error(adapter->conn, 0, msg->req_id, scok, EINVAL,
-						   "Corrupt session-req msg from client-id: %Lu",
+						   "Corrupt session-req msg from client-id: %" PRIu64,
 						   client_id);
 			return;
 		}
@@ -1762,8 +1773,8 @@ static void fe_adapter_process_msg(uint8_t version, uint8_t *data, size_t msg_le
 	 */
 
 	if (msg->code == MGMT_MSG_CODE_SESSION_REQ) {
-		_dbg("adapter %s: session-id %Lu received SESSION_REQ message", adapter->name,
-		     msg->refer_id);
+		_dbg("adapter %s: session-id %" PRIu64 " received SESSION_REQ message",
+		     adapter->name, msg->refer_id);
 		fe_adapter_handle_session_req(adapter, msg, msg_len);
 		return;
 	}
@@ -1782,7 +1793,7 @@ static void fe_adapter_process_msg(uint8_t version, uint8_t *data, size_t msg_le
 
 	switch (msg->code) {
 	case MGMT_MSG_CODE_COMMIT:
-		_dbg("adapter %s: session-id %Lu received COMMIT message", adapter->name,
+		_dbg("adapter %s: session-id %" PRIu64 " received COMMIT message", adapter->name,
 		     msg->refer_id);
 		fe_session_handle_commit(session, msg, msg_len);
 		break;
@@ -1792,7 +1803,7 @@ static void fe_adapter_process_msg(uint8_t version, uint8_t *data, size_t msg_le
 		fe_session_handle_edit(session, msg, msg_len);
 		break;
 	case MGMT_MSG_CODE_LOCK:
-		_dbg("adapter %s: session-id %Lu received LOCK message", adapter->name,
+		_dbg("adapter %s: session-id %" PRIu64 " received LOCK message", adapter->name,
 		     msg->refer_id);
 		fe_session_handle_lock(session, msg, msg_len);
 		break;
@@ -1964,7 +1975,8 @@ void mgmt_fe_adapter_send_notify(uint from_id, struct mgmt_msg_notify_data *msg,
 	if (msg->refer_id != MGMTD_SESSION_ID_NONE) {
 		conn = _get_notify_conn(msg->refer_id, &format);
 		if (!conn) {
-			_dbg("No session or client (id: %Lu) exists to send notify 'get' data to: %s",
+			_dbg("No session or client (id: %" PRIu64
+			     ") exists to send notify 'get' data to: %s",
 			     msg->refer_id, notif);
 			return;
 		}
@@ -1978,7 +1990,7 @@ void mgmt_fe_adapter_send_notify(uint from_id, struct mgmt_msg_notify_data *msg,
 	darr_foreach_i (session_ids, i) {
 		conn = _get_notify_conn(session_ids[i], &format);
 		if (!conn) {
-			_log_err("No session or client (id: %Lu) exists to send notify: %s",
+			_log_err("No session or client (id: %" PRIu64 ") exists to send notify: %s",
 				 session_ids[i], notif);
 			continue;
 		}

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -98,8 +98,8 @@ struct txn_req *txn_req_alloc(struct mgmt_txn *txn, uint64_t req_id, enum txn_re
 	TAILQ_INSERT_TAIL(&txn->reqs, txn_req, link);
 	TXN_INCREF(txn);
 
-	_dbg("Added %s txn-req req-id: %Lu txn-id: %Lu session-id: %Lu", txn_req_names[req_type],
-	     req_id, txn->txn_id, txn->session_id);
+	_dbg("Added %s txn-req req-id: %" PRIu64 " txn-id: %" PRIu64 " session-id: %" PRIu64,
+	     txn_req_names[req_type], req_id, txn->txn_id, txn->session_id);
 
 	return txn_req;
 }
@@ -128,8 +128,8 @@ void txn_req_free(struct txn_req *txn_req)
 	uint64_t txn_id = txn->txn_id;
 
 	/* prevent recursion */
-	_dbg("Deleting %s txn-req req-id: %Lu txn-id: %Lu", txn_req_names[txn_req->req_type],
-	     txn_req->req_id, txn_id);
+	_dbg("Deleting %s txn-req req-id: %" PRIu64 " txn-id: %" PRIu64,
+	     txn_req_names[txn_req->req_type], txn_req->req_id, txn_id);
 
 	switch (txn_req->req_type) {
 	case TXN_REQ_TYPE_COMMIT:
@@ -148,7 +148,7 @@ void txn_req_free(struct txn_req *txn_req)
 	}
 
 	TAILQ_REMOVE(&txn->reqs, txn_req, link);
-	_dbg("Removed req-id: %Lu from request-list", txn_req->req_id);
+	_dbg("Removed req-id: %" PRIu64 " from request-list", txn_req->req_id);
 
 	darr_free(txn_req->err_info);
 	TXN_DECREF(txn_req->txn);
@@ -188,7 +188,8 @@ static void txn_get_tree_data_done(struct txn_req_get_tree *get_tree)
 					       get_tree->result_type, get_tree->wd_options, result,
 					       get_tree->partial_error, false);
 	else {
-		_log_err("Error sending the results of GET-TREE for txn-id %Lu req_id %Lu to requested type %u",
+		_log_err("Error sending the results of GET-TREE for txn-id %" PRIu64
+			 " req_id %" PRIu64 " to requested type %u",
 			 txn->txn_id, req_id, get_tree->result_type);
 
 		(void)mgmt_fe_adapter_txn_error(txn->txn_id, req_id, false,
@@ -379,7 +380,7 @@ state:
 		err = lyd_merge_siblings(&get_tree->client_results, *ylib, LYD_MERGE_DESTRUCT);
 		*ylib = NULL;
 		if (err) {
-			_log_err("Error merging yang-library result for txn-id: %Lu", txn_id);
+			_log_err("Error merging yang-library result for txn-id: %" PRIu64, txn_id);
 			return NB_ERR;
 		}
 	}
@@ -489,15 +490,15 @@ void mgmt_txn_handle_rpc_reply(struct mgmt_be_client_adapter *adapter,
 	LY_ERR err = LY_SUCCESS;
 
 	if (!txn) {
-		_log_err("RPC reply from %s for a missing txn-id %Lu", adapter->name, txn_id);
+		_log_err("RPC reply from %s for a missing txn-id %" PRIu64, adapter->name, txn_id);
 		return;
 	}
 
 	/* Find the request. */
 	txn_req = txn_txn_req(txn, req_id);
 	if (!txn_req || txn_req->req_type != TXN_REQ_TYPE_RPC) {
-		_log_err("RPC reply from %s for txn-id %Lu missing req_id %Lu", adapter->name,
-			 txn_id, req_id);
+		_log_err("RPC reply from %s for txn-id %" PRIu64 " missing req_id %" PRIu64,
+			 adapter->name, txn_id, req_id);
 		return;
 	}
 	rpc = as_rpc(txn_req);
@@ -656,7 +657,7 @@ void mgmt_txn_handle_error_reply(struct mgmt_be_client_adapter *adapter, uint64_
 
 	txn = txn_lookup(txn_id);
 	if (!txn) {
-		_log_err("Error reply from %s cannot find txn-id %Lu", adapter->name, txn_id);
+		_log_err("Error reply from %s cannot find txn-id %" PRIu64, adapter->name, txn_id);
 		return;
 	}
 
@@ -669,12 +670,13 @@ void mgmt_txn_handle_error_reply(struct mgmt_be_client_adapter *adapter, uint64_
 			break;
 	}
 	if (!txn_req) {
-		_log_err("Error reply from %s for txn-id %Lu cannot find req_id %Lu",
+		_log_err("Error reply from %s for txn-id %" PRIu64 " cannot find req_id %" PRIu64,
 			 adapter->name, txn_id, req_id);
 		return;
 	}
 
-	_log_err("Error reply from %s for txn-id %Lu req_id %Lu", adapter->name, txn_id, req_id);
+	_log_err("Error reply from %s for txn-id %" PRIu64 " req_id %" PRIu64, adapter->name,
+		 txn_id, req_id);
 
 	switch (txn_req->req_type) {
 	case TXN_REQ_TYPE_COMMIT:
@@ -728,7 +730,7 @@ uint64_t mgmt_txn_get_session_id(uint64_t txn_id)
 static void txn_incref(struct mgmt_txn *txn, const char *file, int line)
 {
 	txn->refcount++;
-	_dbg("TXN-INCREF %s txn-id: %Lu refcnt: %d file: %s line: %d)",
+	_dbg("TXN-INCREF %s txn-id: %" PRIu64 " refcnt: %d file: %s line: %d)",
 	     mgmt_txn_type2str(txn->type), txn->txn_id, txn->refcount, file, line);
 }
 
@@ -737,7 +739,7 @@ void txn_decref(struct mgmt_txn *txn, const char *file, int line)
 	assert(txn && txn->refcount);
 
 	txn->refcount--;
-	_dbg("TXN-DECREF %s txn-id: %Lu refcnt: %d file: %s line: %d",
+	_dbg("TXN-DECREF %s txn-id: %" PRIu64 " refcnt: %d file: %s line: %d",
 	     mgmt_txn_type2str(txn->type), txn->txn_id, txn->refcount, file, line);
 	if (!txn->refcount) {
 		if (txn->type == MGMTD_TXN_TYPE_CONFIG)
@@ -746,8 +748,8 @@ void txn_decref(struct mgmt_txn *txn, const char *file, int line)
 		hash_release(txn_id_tab, txn);
 		TAILQ_REMOVE(&txn_txns, txn, link);
 
-		_dbg("Deleted %s txn-id: %Lu session-id: %Lu", mgmt_txn_type2str(txn->type),
-		     txn->txn_id, txn->session_id);
+		_dbg("Deleted %s txn-id: %" PRIu64 " session-id: %" PRIu64,
+		     mgmt_txn_type2str(txn->type), txn->txn_id, txn->session_id);
 
 		XFREE(MTYPE_MGMTD_TXN, txn);
 	}

--- a/mgmtd/mgmt_txn_cfg.c
+++ b/mgmtd/mgmt_txn_cfg.c
@@ -122,7 +122,7 @@ void txn_cfg_cleanup(struct txn_req *txn_req)
 	uint64_t txn_id = txn_req->txn->txn_id;
 	uint64_t clients;
 
-	_dbg("Deleting COMMITCFG req-id: %Lu txn-id: %Lu", txn_req->req_id, txn_id);
+	_dbg("Deleting COMMITCFG req-id: %" PRIu64 " txn-id: %" PRIu64, txn_req->req_id, txn_id);
 
 	XFREE(MTYPE_MGMTD_TXN_REQ, ccreq->edit);
 	darr_free(ccreq->info_msgs);
@@ -165,7 +165,7 @@ void txn_cfg_cleanup(struct txn_req *txn_req)
 		ccreq->clients_wait = 0;
 		ccreq->clients = 0;
 		FOREACH_BE_ADAPTER_BITS (id, adapter, clients) {
-			_dbg("Disconnect client: %s for txn-id: %Lu resync required",
+			_dbg("Disconnect client: %s for txn-id: %" PRIu64 " resync required",
 			     adapter->name, txn_id);
 			msg_conn_disconnect(adapter->conn, false);
 		}
@@ -178,7 +178,8 @@ void txn_cfg_cleanup(struct txn_req *txn_req)
 		FOREACH_BE_ADAPTER_BITS (id, adapter, clients) {
 			if (!txn_cfg_send_txn_delete(adapter, txn_id))
 				continue;
-			_dbg("Disconnect client: %s for txn-id: %Lu failed to send CFG_ABORT",
+			_dbg("Disconnect client: %s for txn-id: %" PRIu64
+			     " failed to send CFG_ABORT",
 			     adapter->name, txn_id);
 			msg_conn_disconnect(adapter->conn, false);
 		}
@@ -341,7 +342,7 @@ static int txn_cfg_make_and_send_cfg_req(struct txn_req_commit *ccreq,
 			if (DEBUG_MODE_CHECK(&mgmt_debug_txn, DEBUG_MODE_ALL)) {
 				darr_ensure_i(num_cfg_data, id);
 				num_cfg_data[id]++;
-				_dbg(" -- %s item: %Lu", adapter->name, num_cfg_data[id]);
+				_dbg(" -- %s item: %" PRIu64, adapter->name, num_cfg_data[id]);
 			}
 
 			batch_items++;
@@ -398,8 +399,8 @@ static int txn_cfg_make_and_send_cfg_req(struct txn_req_commit *ccreq,
 		darr_ensure_i(cfg_actions, id); /* required for clang SA NULL ptr check */
 		darr_push(cfg_actions[id], 0);
 		mgmt_msg_native_add_str(cfg_msgs[id], cfg_actions[id]);
-		_dbg("Finished CFG_REQ for '%s' txn-id: %Lu with actions: %s", adapter->name,
-		     txn_req->txn->txn_id, cfg_actions[id]);
+		_dbg("Finished CFG_REQ for '%s' txn-id: %" PRIu64 " with actions: %s",
+		     adapter->name, txn_req->txn->txn_id, cfg_actions[id]);
 
 		if (mgmt_be_adapter_send(adapter, cfg_msgs[id])) {
 			/* remove this client and reset the connection */
@@ -413,7 +414,7 @@ static int txn_cfg_make_and_send_cfg_req(struct txn_req_commit *ccreq,
 
 	if (ccreq->clients) {
 		/* set a timeout for hearing back from the backend clients */
-		_dbg("Set timeout (%us) for txn-id: %Lu backend client CFG_REPLYs",
+		_dbg("Set timeout (%us) for txn-id: %" PRIu64 " backend client CFG_REPLYs",
 		     MGMTD_TXN_CFG_COMMIT_MAX_DELAY_SEC, txn_req->txn->txn_id);
 		event_add_timer(mm->master, txn_cfg_timeout, txn_req,
 				MGMTD_TXN_CFG_COMMIT_MAX_DELAY_SEC, &txn_req->timeout);
@@ -482,7 +483,7 @@ static void txn_cfg_send_cfg_apply(struct txn_req_commit *ccreq)
 	mgmt_msg_native_free_msg(msg);
 
 	if (!ccreq->clients_wait) {
-		_dbg("No backends to wait for on CFG_APPLY for txn-id: %Lu", txn_id);
+		_dbg("No backends to wait for on CFG_APPLY for txn-id: %" PRIu64, txn_id);
 		txn_cfg_adapter_acked(ccreq, NULL);
 	}
 }
@@ -574,7 +575,7 @@ static void txn_finish_commit(struct txn_req_commit *ccreq, enum mgmt_result res
 						      &ccreq->edit, result, error_if_any);
 	}
 	if (ret)
-		_log_err("Failed sending config reply for txn-id: %Lu session-id: %Lu",
+		_log_err("Failed sending config reply for txn-id: %" PRIu64 " session-id: %" PRIu64,
 			 txn->txn_id, txn->session_id);
 
 	ccreq->cmt_stats = NULL;
@@ -607,8 +608,8 @@ static void txn_cfg_next_phase(struct txn_req_commit *ccreq)
 		break;
 	}
 
-	_dbg("CONFIG-STATE-MACHINE txn-id: %Lu transition to state: %s", txn_req->txn->txn_id,
-	     mgmt_commit_phase_name[ccreq->phase]);
+	_dbg("CONFIG-STATE-MACHINE txn-id: %" PRIu64 " transition to state: %s",
+	     txn_req->txn->txn_id, mgmt_commit_phase_name[ccreq->phase]);
 
 	switch (ccreq->phase) {
 	case MGMTD_COMMIT_PHASE_APPLY_CFG:
@@ -630,7 +631,7 @@ static void txn_cfg_adapter_acked(struct txn_req_commit *ccreq,
 {
 	struct txn_req *txn_req = &ccreq->req;
 
-	_dbg("CONFIG-STATE-MACHINE txn-id: %Lu in state: %s", txn_req->txn->txn_id,
+	_dbg("CONFIG-STATE-MACHINE txn-id: %" PRIu64 " in state: %s", txn_req->txn->txn_id,
 	     mgmt_commit_phase_name[ccreq->phase]);
 
 	if (adapter) {
@@ -643,7 +644,8 @@ static void txn_cfg_adapter_acked(struct txn_req_commit *ccreq,
 	}
 
 	if (ccreq->clients_wait) {
-		_dbg("CONFIG-STATE-MACHINE txn-id: %Lu still waiting on clients: 0x%Lx",
+		_dbg("CONFIG-STATE-MACHINE txn-id: %" PRIu64
+		     " still waiting on clients: 0x%" PRIx64,
 		     txn_req->txn->txn_id, ccreq->clients_wait);
 		return;
 	}
@@ -666,12 +668,14 @@ static void txn_cfg_timeout(struct event *event)
 	 * phase we return an error and abort the commit.
 	 */
 	if (ccreq->phase < MGMTD_COMMIT_PHASE_APPLY_CFG) {
-		_log_err("Backend timeout validating txn-id: %Lu waiting: 0x%Lx aborting commit",
+		_log_err("Backend timeout validating txn-id: %" PRIu64 " waiting: 0x%" PRIx64
+			 " aborting commit",
 			 txn_req->txn->txn_id, ccreq->clients_wait);
 		txn_finish_commit(ccreq, MGMTD_INTERNAL_ERROR,
 				  "Some backend clients taking too long to validate the changes.");
 	} else {
-		_log_warn("Backend timeout applying txn-id: %Lu waiting: 0x%Lx, applying commit",
+		_log_warn("Backend timeout applying txn-id: %" PRIu64 " waiting: 0x%" PRIx64
+			  ", applying commit",
 			  txn_req->txn->txn_id, ccreq->clients_wait);
 		txn_finish_commit(ccreq, MGMTD_SUCCESS,
 				  "Some backend clients taking too long to apply the changes.");
@@ -710,24 +714,27 @@ txn_cfg_ensure_msg(uint64_t txn_id, struct mgmt_be_client_adapter *adapter, cons
 	struct txn_req_commit *ccreq;
 
 	if (!txn) {
-		_log_err("%s reply from '%s' for txn-id: %Lu no TXN, resetting connection", tag,
-			 adapter->name, txn_id);
+		_log_err("%s reply from '%s' for txn-id: %" PRIu64 " no TXN, resetting connection",
+			 tag, adapter->name, txn_id);
 		return NULL;
 	}
 	if (txn->type != MGMTD_TXN_TYPE_CONFIG) {
-		_log_err("%s reply from '%s' for txn-id: %Lu failed wrong txn TYPE %u, resetting connection",
+		_log_err("%s reply from '%s' for txn-id: %" PRIu64
+			 " failed wrong txn TYPE %u, resetting connection",
 			 tag, adapter->name, txn_id, txn->type);
 		return NULL;
 	}
 	ccreq = txn_txn_req_commit(txn);
 	if (!ccreq) {
-		_log_err("%s reply from '%s' for txn-id: %Lu failed no COMMITCFG_REQ, resetting connection",
+		_log_err("%s reply from '%s' for txn-id: %" PRIu64
+			 " failed no COMMITCFG_REQ, resetting connection",
 			 tag, adapter->name, txn_id);
 		return NULL;
 	}
 	/* make sure we are part of this config commit */
 	if (!IS_IDBIT_SET(ccreq->clients, adapter->id)) {
-		_log_err("%s reply from '%s' for txn-id %Lu not participating, resetting connection",
+		_log_err("%s reply from '%s' for txn-id %" PRIu64
+			 " not participating, resetting connection",
 			 tag, adapter->name, txn_id);
 		return NULL;
 	}
@@ -748,7 +755,8 @@ static void txn_cfg_handle_cfg_reply(struct txn_req_commit *ccreq, bool success,
 	struct txn_req *txn_req = as_txn_req(ccreq);
 
 	if (!IS_IDBIT_SET(ccreq->clients_wait, adapter->id)) {
-		_log_warn("CFG_REPLY from '%s' but not waiting for it txn-id: %Lu, resetting conn",
+		_log_warn("CFG_REPLY from '%s' but not waiting for it txn-id: %" PRIu64
+			  ", resetting conn",
 			  adapter->name, txn_req->txn->txn_id);
 		msg_conn_disconnect(adapter->conn, false);
 		return;

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -6294,14 +6294,13 @@ sub process {
 		while ($line =~ /(?:^|")([X\t]*)(?:"|$)/g) {
 			my $string = substr($rawline, $-[1], $+[1] - $-[1]);
 			$string =~ s/%%/__/g;
-                        # check for %L
-                        # OK in FRR
-                        # if ($show_L && $string =~ /%[\*\d\.\$]*L([diouxX])/) {
-                        #       WARN("PRINTF_L",
-                        #            "\%L$1 is non-standard C, use %ll$1\n" . $herecurr);
-                        #       $show_L = 0;
-                        # }
-                        # check for %Z
+			# check for %L
+			if ($show_L && $string =~ /%[\*\d\.\$]*L([diouxX])/) {
+				WARN("PRINTF_L",
+				     "\%L$1 is non-standard C, use %ll$1\n" . $herecurr);
+				$show_L = 0;
+			}
+			# check for %Z
 			if ($show_Z && $string =~ /%[\*\d\.\$]*Z([diouxX])/) {
 				WARN("PRINTF_Z",
 				     "%Z$1 is non-standard C, use %z$1\n" . $herecurr);

--- a/tools/gcc-plugins/autobuild.sh
+++ b/tools/gcc-plugins/autobuild.sh
@@ -82,9 +82,13 @@ else
 	srcdir="${top_srcdir%/}/tools/gcc-plugins"
 fi
 
+# silence warnings if file not found, but try anyway
+exec 4>&2
+test -e "$(g++-${shortver} -print-file-name=plugin)/include/gcc-plugin.h" || exec 4>/dev/null
+
 mkdir -p "$outdir"
 test -e "$outdir/Makefile" \
 	|| ln -s "${srcdir}/Makefile" "$outdir/Makefile"
-make VPATH="${srcdir}" CC=gcc-${shortver} CXX=g++-${shortver} VERSUFFIX="$infohash" -C "$outdir" \
+make VPATH="${srcdir}" CC=gcc-${shortver} CXX=g++-${shortver} VERSUFFIX="$infohash" -s -C "$outdir" 2>&4 \
 	|| strongfail "build for gcc ${fullver} failed"
 ok "enabled (gcc-${fullver}, freshly built)"


### PR DESCRIPTION
* make the GCC plugin check work when building from a subdirectory
* silence GCC plugin build warnings if `gcc-plugin.h` isn't found
* stop messing with `uint64_t` if we're building on ISO C23, it's no longer necessary
* remove uses of `%Lu` from the codebase, it now causes warnings and was never really correct to begin with; `%w64u` is what it'll be but that's not supported on all of our platforms yet
* revert allowing `%Lu` in `checkpatch`