### PR TITLE
pceplib: add length validation for pcep obj decoders

### DIFF
--- a/pceplib/pcep_msg_objects_encoding.c
+++ b/pceplib/pcep_msg_objects_encoding.c
@@ -1079,6 +1079,9 @@ common_object_create(struct pcep_object_header *hdr, uint16_t new_obj_length)
 struct pcep_object_header *pcep_decode_obj_open(struct pcep_object_header *hdr,
 						const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_open *obj =
 		(struct pcep_object_open *)common_object_create(
 			hdr, sizeof(struct pcep_object_open));
@@ -1094,6 +1097,9 @@ struct pcep_object_header *pcep_decode_obj_open(struct pcep_object_header *hdr,
 struct pcep_object_header *pcep_decode_obj_rp(struct pcep_object_header *hdr,
 					      const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4 + 4))
+		return NULL;
+
 	struct pcep_object_rp *obj =
 		(struct pcep_object_rp *)common_object_create(
 			hdr, sizeof(struct pcep_object_rp));
@@ -1111,6 +1117,9 @@ struct pcep_object_header *pcep_decode_obj_rp(struct pcep_object_header *hdr,
 struct pcep_object_header *
 pcep_decode_obj_notify(struct pcep_object_header *hdr, const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_notify *obj =
 		(struct pcep_object_notify *)common_object_create(
 			hdr, sizeof(struct pcep_object_notify));
@@ -1124,6 +1133,9 @@ pcep_decode_obj_notify(struct pcep_object_header *hdr, const uint8_t *obj_buf)
 struct pcep_object_header *
 pcep_decode_obj_nopath(struct pcep_object_header *hdr, const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_nopath *obj =
 		(struct pcep_object_nopath *)common_object_create(
 			hdr, sizeof(struct pcep_object_nopath));
@@ -1142,6 +1154,9 @@ pcep_decode_obj_association(struct pcep_object_header *hdr,
 	uint32_t *uint32_ptr = (uint32_t *)obj_buf;
 
 	if (hdr->object_type == PCEP_OBJ_TYPE_ASSOCIATION_IPV4) {
+		if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 8 + 4))
+			return NULL;
+
 		struct pcep_object_association_ipv4 *obj =
 			(struct pcep_object_association_ipv4 *)
 				common_object_create(
@@ -1155,6 +1170,9 @@ pcep_decode_obj_association(struct pcep_object_header *hdr,
 
 		return (struct pcep_object_header *)obj;
 	} else if (hdr->object_type == PCEP_OBJ_TYPE_ENDPOINT_IPV6) {
+		if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 8 + 16))
+			return NULL;
+
 		struct pcep_object_association_ipv6 *obj =
 			(struct pcep_object_association_ipv6 *)
 				common_object_create(
@@ -1179,6 +1197,9 @@ pcep_decode_obj_endpoints(struct pcep_object_header *hdr,
 	uint32_t *uint32_ptr = (uint32_t *)obj_buf;
 
 	if (hdr->object_type == PCEP_OBJ_TYPE_ENDPOINT_IPV4) {
+		if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4 + 4))
+			return NULL;
+
 		struct pcep_object_endpoints_ipv4 *obj =
 			(struct pcep_object_endpoints_ipv4 *)
 				common_object_create(
@@ -1190,6 +1211,9 @@ pcep_decode_obj_endpoints(struct pcep_object_header *hdr,
 
 		return (struct pcep_object_header *)obj;
 	} else if (hdr->object_type == PCEP_OBJ_TYPE_ENDPOINT_IPV6) {
+		if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 16 + 16))
+			return NULL;
+
 		struct pcep_object_endpoints_ipv6 *obj =
 			(struct pcep_object_endpoints_ipv6 *)
 				common_object_create(
@@ -1210,6 +1234,9 @@ struct pcep_object_header *
 pcep_decode_obj_bandwidth(struct pcep_object_header *hdr,
 			  const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_bandwidth *obj =
 		(struct pcep_object_bandwidth *)common_object_create(
 			hdr, sizeof(struct pcep_object_bandwidth));
@@ -1225,6 +1252,9 @@ pcep_decode_obj_bandwidth(struct pcep_object_header *hdr,
 struct pcep_object_header *
 pcep_decode_obj_metric(struct pcep_object_header *hdr, const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 8))
+		return NULL;
+
 	struct pcep_object_metric *obj =
 		(struct pcep_object_metric *)common_object_create(
 			hdr, sizeof(struct pcep_object_metric));
@@ -1242,6 +1272,9 @@ pcep_decode_obj_metric(struct pcep_object_header *hdr, const uint8_t *obj_buf)
 struct pcep_object_header *pcep_decode_obj_lspa(struct pcep_object_header *hdr,
 						const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 12 + 4))
+		return NULL;
+
 	struct pcep_object_lspa *obj =
 		(struct pcep_object_lspa *)common_object_create(
 			hdr, sizeof(struct pcep_object_lspa));
@@ -1260,6 +1293,9 @@ struct pcep_object_header *pcep_decode_obj_lspa(struct pcep_object_header *hdr,
 struct pcep_object_header *pcep_decode_obj_svec(struct pcep_object_header *hdr,
 						const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_svec *obj =
 		(struct pcep_object_svec *)common_object_create(
 			hdr, sizeof(struct pcep_object_svec));
@@ -1288,6 +1324,9 @@ struct pcep_object_header *pcep_decode_obj_svec(struct pcep_object_header *hdr,
 struct pcep_object_header *pcep_decode_obj_error(struct pcep_object_header *hdr,
 						 const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_error *obj =
 		(struct pcep_object_error *)common_object_create(
 			hdr, sizeof(struct pcep_object_error));
@@ -1301,6 +1340,9 @@ struct pcep_object_header *pcep_decode_obj_error(struct pcep_object_header *hdr,
 struct pcep_object_header *pcep_decode_obj_close(struct pcep_object_header *hdr,
 						 const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_close *obj =
 		(struct pcep_object_close *)common_object_create(
 			hdr, sizeof(struct pcep_object_close));
@@ -1313,6 +1355,9 @@ struct pcep_object_header *pcep_decode_obj_close(struct pcep_object_header *hdr,
 struct pcep_object_header *pcep_decode_obj_srp(struct pcep_object_header *hdr,
 					       const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4 + 4))
+		return NULL;
+
 	struct pcep_object_srp *obj =
 		(struct pcep_object_srp *)common_object_create(
 			hdr, sizeof(struct pcep_object_srp));
@@ -1326,6 +1371,9 @@ struct pcep_object_header *pcep_decode_obj_srp(struct pcep_object_header *hdr,
 struct pcep_object_header *pcep_decode_obj_lsp(struct pcep_object_header *hdr,
 					       const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_lsp *obj =
 		(struct pcep_object_lsp *)common_object_create(
 			hdr, sizeof(struct pcep_object_lsp));
@@ -1345,18 +1393,26 @@ struct pcep_object_header *
 pcep_decode_obj_vendor_info(struct pcep_object_header *hdr,
 			    const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 8))
+		return NULL;
+
 	struct pcep_object_vendor_info *obj =
 		(struct pcep_object_vendor_info *)common_object_create(
 			hdr, sizeof(struct pcep_object_vendor_info));
 
 	obj->enterprise_number = ntohl(*((uint32_t *)(obj_buf)));
 	obj->enterprise_specific_info = ntohl(*((uint32_t *)(obj_buf + 4)));
-	if (obj->enterprise_number == ENTERPRISE_NUMBER_CISCO
-	    && obj->enterprise_specific_info == ENTERPRISE_COLOR_CISCO)
-		obj->enterprise_specific_info1 =
-			ntohl(*((uint32_t *)(obj_buf + 8)));
-	else
+	if (obj->enterprise_number == ENTERPRISE_NUMBER_CISCO &&
+	    obj->enterprise_specific_info == ENTERPRISE_COLOR_CISCO) {
+		if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 8 + 4)) {
+			pcep_obj_free_object((struct pcep_object_header *)obj);
+			return NULL;
+		}
+
+		obj->enterprise_specific_info1 = ntohl(*((uint32_t *)(obj_buf + 8)));
+	} else {
 		obj->enterprise_specific_info1 = 0;
+	}
 
 	return (struct pcep_object_header *)obj;
 }
@@ -1365,6 +1421,9 @@ struct pcep_object_header *
 pcep_decode_obj_inter_layer(struct pcep_object_header *hdr,
 			    const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_inter_layer *obj =
 		(struct pcep_object_inter_layer *)common_object_create(
 			hdr, sizeof(struct pcep_object_inter_layer));
@@ -1379,6 +1438,9 @@ struct pcep_object_header *
 pcep_decode_obj_switch_layer(struct pcep_object_header *hdr,
 			     const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 4))
+		return NULL;
+
 	struct pcep_object_switch_layer *obj =
 		(struct pcep_object_switch_layer *)common_object_create(
 			hdr, sizeof(struct pcep_object_switch_layer));
@@ -1407,6 +1469,9 @@ struct pcep_object_header *
 pcep_decode_obj_req_adap_cap(struct pcep_object_header *hdr,
 			     const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 2))
+		return NULL;
+
 	struct pcep_object_req_adap_cap *obj =
 		(struct pcep_object_req_adap_cap *)common_object_create(
 			hdr, sizeof(struct pcep_object_req_adap_cap));
@@ -1421,6 +1486,9 @@ struct pcep_object_header *
 pcep_decode_obj_server_ind(struct pcep_object_header *hdr,
 			   const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 2))
+		return NULL;
+
 	struct pcep_object_server_indication *obj =
 		(struct pcep_object_server_indication *)common_object_create(
 			hdr, sizeof(struct pcep_object_server_indication));
@@ -1435,6 +1503,9 @@ struct pcep_object_header *
 pcep_decode_obj_objective_function(struct pcep_object_header *hdr,
 				   const uint8_t *obj_buf)
 {
+	if (hdr->encoded_object_length < (OBJECT_HEADER_LENGTH + 2))
+		return NULL;
+
 	struct pcep_object_objective_function *obj =
 		(struct pcep_object_objective_function *)common_object_create(
 			hdr, sizeof(struct pcep_object_objective_function));

--- a/pceplib/pcep_msg_objects_encoding.c
+++ b/pceplib/pcep_msg_objects_encoding.c
@@ -1141,7 +1141,7 @@ pcep_decode_obj_nopath(struct pcep_object_header *hdr, const uint8_t *obj_buf)
 			hdr, sizeof(struct pcep_object_nopath));
 
 	obj->ni = (obj_buf[0] >> 1);
-	obj->flag_c = (obj_buf[0] & OBJECT_NOPATH_FLAG_C);
+	obj->flag_c = (obj_buf[1] & OBJECT_NOPATH_FLAG_C);
 
 	return (struct pcep_object_header *)obj;
 }


### PR DESCRIPTION
For pcep object decoder functions, validate the number of octets present after the header before de-referencing any bytes. The top-level validation only ensures that the header is present.
Also noticed that the decoder for the NOPATH object was slightly wrong, and fixed it.
