### PR TITLE
tests: Fix zebra_graceful_restart topotest

### DIFF
--- a/tests/topotests/zebra_graceful_restart/r1/frr.conf
+++ b/tests/topotests/zebra_graceful_restart/r1/frr.conf
@@ -14,15 +14,6 @@ interface r1-eth1
 interface r1-eth2
  ip address 192.168.3.1/24
 !
-nexthop-group twonhg
- nexthop 192.168.1.2 r1-eth0
- nexthop 192.168.2.2 r1-eth1
-!
-nexthop-group threenhg
- nexthop 192.168.1.2 r1-eth0
- nexthop 192.168.2.2 r1-eth1
- nexthop 192.168.3.2 r1-eth2
-!
 ip route 10.3.0.0/24 192.168.1.12
 ip route 10.3.0.0/24 192.168.2.22
 !

--- a/tests/topotests/zebra_graceful_restart/test_zebra_gr.py
+++ b/tests/topotests/zebra_graceful_restart/test_zebra_gr.py
@@ -111,9 +111,34 @@ def test_zebra_gr_kernel_read_and_sweep():
     r1 = tgen.gears["r1"]
 
     # ---- Phase 1: Install routes via sharpd ----
+    step("Verify the 3 connected routes are present before creating nexthop groups")
+    connected_prefixes = ["192.168.1.0/24", "192.168.2.0/24", "192.168.3.0/24"]
+
+    def _check_connected_routes():
+        output = json.loads(r1.vtysh_cmd("show ip route connected json"))
+        for pfx in connected_prefixes:
+            if pfx not in output:
+                return "connected route {} not present yet".format(pfx)
+        return None
+
+    _, result = topotest.run_and_expect(_check_connected_routes, None, count=30, wait=1)
+    assert result is None, "Connected routes not present: {}".format(result)
+
+    step("Create nexthop groups now that connected routes are resolvable")
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "nexthop-group twonhg\n"
+        "nexthop 192.168.1.2 r1-eth0\n"
+        "nexthop 192.168.2.2 r1-eth1\n"
+        "exit\n"
+        "nexthop-group threenhg\n"
+        "nexthop 192.168.1.2 r1-eth0\n"
+        "nexthop 192.168.2.2 r1-eth1\n"
+        "nexthop 192.168.3.2 r1-eth2\n"
+        "exit\n"
+    )
 
     step("Verify sharpd nexthop groups are installed in zebra RIB")
-
     def _check_sharp_nhgs_installed():
         output = r1.vtysh_cmd("show nexthop-group rib sharp json", isjson=True)
         if not output or "default" not in output:


### PR DESCRIPTION
I am seeing failures of this topotest with the nexthop groups defined in the frr.conf not being actually installed. The sharpd proceses is attempting to install them before zebra is ready to process them.  Modify the test code to install the nexthop groups after it ensures the connected routes are there.