### PR TITLE
ospfd: fix wrong/inactive next-hop interface for inter-area routes via virtual link

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -436,6 +436,29 @@ struct ospf_interface *ospf_if_lookup_by_lsa_pos(struct ospf_area *area,
 	return NULL;
 }
 
+/*
+ * Look up the (non virtual-link) interface owning the given ifindex.
+ *
+ * Used to resolve the egress interface for a nexthop whose lsa_pos is not
+ * meaningful in the area being populated, e.g. a virtual-link nexthop whose
+ * position was resolved in the transit area.  Unlike lsa_pos, ifindex is not
+ * area-relative, so this lookup spans the whole instance.
+ */
+struct ospf_interface *ospf_if_lookup_by_ifindex(struct ospf *ospf,
+						 ifindex_t ifindex)
+{
+	struct listnode *node;
+	struct ospf_interface *oi;
+
+	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi)) {
+		if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
+			continue;
+		if (oi->ifp && oi->ifp->ifindex == ifindex)
+			return oi;
+	}
+	return NULL;
+}
+
 struct ospf_interface *ospf_if_lookup_by_local_addr(struct ospf *ospf,
 						    struct interface *ifp,
 						    struct in_addr address)
@@ -1175,6 +1198,7 @@ static int ospf_vl_set_params(struct ospf_area *area,
 	for (ALL_LIST_ELEMENTS_RO(v->parents, node, vp)) {
 		vl_data->nexthop.lsa_pos = vp->nexthop->lsa_pos;
 		vl_data->nexthop.router = vp->nexthop->router;
+		vl_data->nexthop.ifindex = 0;
 
 		/*
 		 * Only deal with interface data when the local
@@ -1183,6 +1207,16 @@ static int ospf_vl_set_params(struct ospf_area *area,
 		if (!area->spf_dry_run) {
 			oi = ospf_if_lookup_by_lsa_pos(
 				area, vl_data->nexthop.lsa_pos);
+
+			/*
+			 * Record the egress interface resolved here, in the
+			 * transit area where lsa_pos is valid.  The backbone
+			 * route calculation inherits this nexthop but its
+			 * lsa_pos is meaningless against the backbone's own
+			 * interfaces, so it relies on this ifindex instead.
+			 */
+			if (oi)
+				vl_data->nexthop.ifindex = oi->ifp->ifindex;
 
 			if (!IPV4_ADDR_SAME(&voi->address->u.prefix4,
 					    &oi->address->u.prefix4))

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -552,6 +552,29 @@ struct ospf_interface *ospf_if_lookup_by_lsa_pos(struct ospf_area *area,
 	return NULL;
 }
 
+/*
+ * Look up the (non virtual-link) interface owning the given ifindex.
+ *
+ * Used to resolve the egress interface for a nexthop whose lsa_pos is not
+ * meaningful in the area being populated, e.g. a virtual-link nexthop whose
+ * position was resolved in the transit area.  Unlike lsa_pos, ifindex is not
+ * area-relative, so this lookup spans the whole instance.
+ */
+struct ospf_interface *ospf_if_lookup_by_ifindex(struct ospf *ospf,
+						 ifindex_t ifindex)
+{
+	struct listnode *node;
+	struct ospf_interface *oi;
+
+	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi)) {
+		if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
+			continue;
+		if (oi->ifp && oi->ifp->ifindex == ifindex)
+			return oi;
+	}
+	return NULL;
+}
+
 struct ospf_interface *ospf_if_lookup_by_local_addr(struct ospf *ospf,
 						    struct interface *ifp,
 						    struct in_addr address)
@@ -1355,6 +1378,7 @@ static int ospf_vl_set_params(struct ospf_area *area,
 	for (ALL_LIST_ELEMENTS_RO(v->parents, node, vp)) {
 		vl_data->nexthop.lsa_pos = vp->nexthop->lsa_pos;
 		vl_data->nexthop.router = vp->nexthop->router;
+		vl_data->nexthop.ifindex = 0;
 
 		/*
 		 * Only deal with interface data when the local
@@ -1363,6 +1387,16 @@ static int ospf_vl_set_params(struct ospf_area *area,
 		if (!area->spf_dry_run) {
 			oi = ospf_if_lookup_by_lsa_pos(
 				area, vl_data->nexthop.lsa_pos);
+
+			/*
+			 * Record the egress interface resolved here, in the
+			 * transit area where lsa_pos is valid.  The backbone
+			 * route calculation inherits this nexthop but its
+			 * lsa_pos is meaningless against the backbone's own
+			 * interfaces, so it relies on this ifindex instead.
+			 */
+			if (oi)
+				vl_data->nexthop.ifindex = oi->ifp->ifindex;
 
 			if (!IPV4_ADDR_SAME(&voi->address->u.prefix4,
 					    &oi->address->u.prefix4))

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -334,6 +334,8 @@ extern int ospf_if_down(struct ospf_interface *oi);
 extern int ospf_if_is_up(struct ospf_interface *oi);
 extern struct ospf_interface *ospf_if_lookup_by_lsa_pos(struct ospf_area *area,
 							int lsa_pos);
+extern struct ospf_interface *ospf_if_lookup_by_ifindex(struct ospf *ospf,
+							ifindex_t ifindex);
 extern struct ospf_interface *
 ospf_if_lookup_by_local_addr(struct ospf *ospf, struct interface *ifp,
 			     struct in_addr addr);

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -417,6 +417,8 @@ extern int ospf_if_down(struct ospf_interface *oi);
 extern int ospf_if_is_up(struct ospf_interface *oi);
 extern struct ospf_interface *ospf_if_lookup_by_lsa_pos(struct ospf_area *area,
 							int lsa_pos);
+extern struct ospf_interface *ospf_if_lookup_by_ifindex(struct ospf *ospf,
+							ifindex_t ifindex);
 extern struct ospf_interface *
 ospf_if_lookup_by_local_addr(struct ospf *ospf, struct interface *ifp,
 			     struct in_addr addr);

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -872,8 +872,20 @@ void ospf_route_copy_nexthops_from_vertex(struct ospf_area *area,
 		 * Only deal with interface data when we
 		 * don't do a dry run
 		 */
-		if (!area->spf_dry_run)
-			oi = ospf_if_lookup_by_lsa_pos(area, nexthop->lsa_pos);
+		if (!area->spf_dry_run) {
+			/*
+			 * A virtual-link nexthop carries the egress interface
+			 * resolved in the transit area; its lsa_pos is not
+			 * meaningful in the area being populated (e.g. the
+			 * backbone), so resolve by ifindex when one is set.
+			 */
+			if (nexthop->ifindex)
+				oi = ospf_if_lookup_by_ifindex(area->ospf,
+							       nexthop->ifindex);
+			else
+				oi = ospf_if_lookup_by_lsa_pos(
+					area, nexthop->lsa_pos);
+		}
 
 		if ((oi && !ospf_path_exist(to->paths, nexthop->router, oi))
 		    || area->spf_dry_run) {

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -879,8 +879,20 @@ void ospf_route_copy_nexthops_from_vertex(struct ospf_area *area,
 		 * Only deal with interface data when we
 		 * don't do a dry run
 		 */
-		if (!area->spf_dry_run)
-			oi = ospf_if_lookup_by_lsa_pos(area, nexthop->lsa_pos);
+		if (!area->spf_dry_run) {
+			/*
+			 * A virtual-link nexthop carries the egress interface
+			 * resolved in the transit area; its lsa_pos is not
+			 * meaningful in the area being populated (e.g. the
+			 * backbone), so resolve by ifindex when one is set.
+			 */
+			if (nexthop->ifindex)
+				oi = ospf_if_lookup_by_ifindex(area->ospf,
+							       nexthop->ifindex);
+			else
+				oi = ospf_if_lookup_by_lsa_pos(
+					area, nexthop->lsa_pos);
+		}
 
 		if ((oi && !ospf_path_exist(to->paths, nexthop->router, oi))
 		    || area->spf_dry_run) {

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1004,6 +1004,13 @@ static unsigned int ospf_nexthop_calculation(struct ospf_area *area,
 					nh = vertex_nexthop_new();
 					nh->router = vl_data->nexthop.router;
 					nh->lsa_pos = vl_data->nexthop.lsa_pos;
+					/*
+					 * lsa_pos above is relative to the
+					 * transit area and cannot be resolved
+					 * against the backbone, so carry the
+					 * egress interface resolved there.
+					 */
+					nh->ifindex = vl_data->nexthop.ifindex;
 
 					/*
 					 * Since v is the root the nexthop and

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1005,6 +1005,13 @@ static unsigned int ospf_nexthop_calculation(struct ospf_area *area,
 					nh = vertex_nexthop_new();
 					nh->router = vl_data->nexthop.router;
 					nh->lsa_pos = vl_data->nexthop.lsa_pos;
+					/*
+					 * lsa_pos above is relative to the
+					 * transit area and cannot be resolved
+					 * against the backbone, so carry the
+					 * egress interface resolved there.
+					 */
+					nh->ifindex = vl_data->nexthop.ifindex;
 
 					/*
 					 * Since v is the root the nexthop and

--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -35,6 +35,10 @@ struct vertex {
 struct vertex_nexthop {
 	struct in_addr router;     /* router address to send to */
 	int lsa_pos; /* LSA position for resolving the interface */
+	ifindex_t ifindex; /* resolved egress interface, for nexthops whose
+			    * lsa_pos is not valid in the area being populated
+			    * (e.g. a virtual-link nexthop, whose position is
+			    * relative to the transit area); 0 when unset. */
 };
 
 struct vertex_parent {

--- a/tests/topotests/ospf_vlink_nexthop/r1/frr.conf
+++ b/tests/topotests/ospf_vlink_nexthop/r1/frr.conf
@@ -1,0 +1,10 @@
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+router ospf
+ ospf router-id 1.1.1.1
+ network 10.0.1.0/24 area 0
+!

--- a/tests/topotests/ospf_vlink_nexthop/r2/frr.conf
+++ b/tests/topotests/ospf_vlink_nexthop/r2/frr.conf
@@ -1,0 +1,20 @@
+!
+! r2 is an ABR between area 0 (toward r1) and the transit area 10 (toward r3).
+! The area 10 virtual link is intentionally NOT configured here; the test adds
+! it at runtime so the backbone interface holds the colliding LSA position.
+!
+interface r2-eth0
+ ip address 10.0.1.2/24
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+interface r2-eth1
+ ip address 10.0.2.1/24
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+router ospf
+ ospf router-id 2.2.2.2
+ network 10.0.1.0/24 area 0
+ network 10.0.2.0/24 area 10
+!

--- a/tests/topotests/ospf_vlink_nexthop/r3/frr.conf
+++ b/tests/topotests/ospf_vlink_nexthop/r3/frr.conf
@@ -1,0 +1,26 @@
+!
+! r3 is an ABR between area 10 and area 20; it reaches the backbone only
+! through the area 10 virtual link (added at runtime by the test).
+!
+interface r3-eth0
+ ip address 10.0.2.2/24
+ ip ospf hello-interval 2
+ ip ospf dead-interval 10
+!
+interface r3-eth1
+ ip address 192.168.21.1/24
+!
+interface r3-eth2
+ ip address 192.168.22.1/24
+!
+router ospf
+ ospf router-id 3.3.3.3
+ ! Configuring a virtual link on a non-ABR is rejected. With the default
+ ! (cisco) ABR type r3 is not an ABR until it is attached to the backbone,
+ ! which it only gets through this very virtual link. Use the RFC 2328
+ ! definition so r3 counts as an ABR with two active areas.
+ ospf abr-type standard
+ network 10.0.2.0/24 area 10
+ network 192.168.21.0/24 area 20
+ network 192.168.22.0/24 area 20
+!

--- a/tests/topotests/ospf_vlink_nexthop/test_ospf_vlink_nexthop.py
+++ b/tests/topotests/ospf_vlink_nexthop/test_ospf_vlink_nexthop.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+test_ospf_vlink_nexthop.py: Regression test for inter-area routes installed
+with a wrong/inactive next-hop interface in an OSPF virtual-link environment.
+
+Topology (inter-router links use the default broadcast network type):
+
+                area 0            area 10
+   +----+   10.0.1.0/24   +----+   10.0.2.0/24   +----+   area 20
+   | r1 |----------------| r2 |----------------| r3 |---- 192.168.21.0/24
+   +----+ eth0      eth0 +----+ eth1      eth0 +----+ eth1
+   1.1.1.1            2.2.2.2                3.3.3.3 eth2  192.168.22.0/24
+
+ * r2 is an ABR between the backbone (area 0) and the transit area (area 10).
+ * r3 is an ABR between area 10 and area 20; it reaches the backbone only
+   through an area 10 virtual link to r2.
+
+The virtual link is configured at RUNTIME (vtysh), after the physical
+adjacencies are full. This mirrors how the issue is hit in practice (an
+operator configures the virtual link on a running system) and is required to
+reproduce it: the wrong next-hop only occurs when the real backbone interface
+occupies the first link position(s) of the backbone router-LSA, i.e. when the
+VLINK pseudo interface is created after the backbone interface. With the
+virtual link in the boot configuration the VLINK interface grabs position 0
+instead and the stale position resolves to the (harmless) VLINK interface.
+
+Mechanism: the virtual-link next-hop carries an LSA position that is relative
+to the *transit* area (area 10, r2-eth1 = position 0), but the backbone
+router-route to r3 resolves that position against the *backbone* router-LSA,
+where position 0 is the unrelated backbone interface (r2-eth0, toward r1). The
+bogus next-hop is then inherited by every inter-area route via r3 and shows up
+as e.g.:
+
+  192.168.21.0/24 [110/x] via 10.0.2.2, r2-eth1
+                          via 10.0.2.2, r2-eth0 inactive   <-- must NOT appear
+
+This test fails on an unfixed daemon and passes once the next-hop interface is
+resolved correctly.
+"""
+
+import os
+import sys
+from functools import partial
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.ospfd]
+
+# Networks advertised from area 20 behind r3.
+AREA20_PREFIXES = ["192.168.21.0/24", "192.168.22.0/24"]
+
+# Interface on r2 that legitimately reaches r3 (transit area 10).
+GOOD_IF = "r2-eth1"
+# Backbone interface on r2 (toward r1); r3's transit address is NOT on it.
+BAD_IF = "r2-eth0"
+
+
+def build_topo(tgen):
+    "Build function"
+
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    # area 0: r1 <-> r2
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # area 10 (transit): r2 <-> r3
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+
+    # area 20 downlinks on r3
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r3"])
+
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _expect_neighbor_full(router, neighbor):
+    "Wait until OSPFv2 neighbor `neighbor` is Full on `router`."
+    tgen = get_topogen()
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show ip ospf neighbor json",
+        {"neighbors": {neighbor: [{"converged": "Full"}]}},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+    assert result is None, '"{}" OSPF neighbor {} not Full'.format(router, neighbor)
+
+
+def test_ospf_convergence():
+    "Wait for the physical adjacencies to come up."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for OSPF adjacencies to converge")
+    _expect_neighbor_full("r1", "2.2.2.2")
+    _expect_neighbor_full("r2", "1.1.1.1")
+    _expect_neighbor_full("r2", "3.3.3.3")
+    _expect_neighbor_full("r3", "2.2.2.2")
+
+
+def test_ospf_vlink_configure_runtime():
+    """
+    Configure the virtual link at runtime, after the physical adjacencies and
+    router-LSAs exist (see module docstring for why this ordering is essential
+    to reproduce the bug).
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("configuring the area 10 virtual link via vtysh")
+    tgen.gears["r2"].vtysh_cmd(
+        "configure terminal\nrouter ospf\narea 10 virtual-link 3.3.3.3"
+    )
+    tgen.gears["r3"].vtysh_cmd(
+        "configure terminal\nrouter ospf\narea 10 virtual-link 2.2.2.2"
+    )
+
+
+def _check_route_nexthops(rname, prefix):
+    """
+    Return None if `prefix` on `rname` is installed with at least one active
+    next-hop via GOOD_IF and no next-hop at all via BAD_IF; otherwise return a
+    diagnostic string (so it can be driven by run_and_expect()).
+    """
+    tgen = get_topogen()
+    output = tgen.gears[rname].vtysh_cmd(
+        "show ip route {} json".format(prefix), isjson=True
+    )
+
+    entries = output.get(prefix)
+    if not entries:
+        return "{}: route {} is not installed yet".format(rname, prefix)
+
+    # Use the OSPF entry (there is only one in this topology).
+    entry = entries[0]
+    nexthops = entry.get("nexthops", [])
+
+    bogus = [nh for nh in nexthops if nh.get("interfaceName") == BAD_IF]
+    if bogus:
+        return "{}: route {} has a bogus next-hop via {} (bug present): {}".format(
+            rname, prefix, BAD_IF, bogus
+        )
+
+    good = [
+        nh
+        for nh in nexthops
+        if nh.get("interfaceName") == GOOD_IF and nh.get("active")
+    ]
+    if not good:
+        return "{}: route {} has no active next-hop via {}".format(
+            rname, prefix, GOOD_IF
+        )
+
+    return None
+
+
+def test_ospf_vlink_route_nexthop():
+    "Inter-area routes via the virtual link must not carry a bogus next-hop."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    for prefix in AREA20_PREFIXES:
+        test_func = partial(_check_route_nexthops, "r2", prefix)
+        _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+        assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
### Problem

In an OSPF virtual-link topology, inter-area routes whose next-hop is the far
end of the virtual link (and the networks behind it) are installed with an
extra next-hop that has the correct gateway but a wrong outgoing interface,
which zebra then marks inactive. Reproduced on the 10.6.1 release:

```
r2# show ip route 192.168.21.0/24
Routing entry for 192.168.21.0/24
  Known via "ospf", distance 110, metric 20, best
    10.0.2.2, via r2-eth0 inactive, weight 1   <-- bogus, backbone interface
  * 10.0.2.2, via r2-eth1, weight 1
```

The OSPF router routing table shows where it comes from — the backbone
router-route to the virtual-link endpoint resolves to the wrong interface:

```
R    3.3.3.3    [10] area: 0.0.0.10, ABR
                via 10.0.2.2, r2-eth1          <-- correct (transit area)
                [10] area: 0.0.0.0, ABR
                via 10.0.2.2, r2-eth0          <-- wrong (backbone lookup)
```

### Topology

```
        area 0            area 10              area 20
 r1 ---------------- r2 ---------------- r3 ----+---- 192.168.21.0/24
 1.1.1.1  10.0.1/24   2.2.2.2  10.0.2/24  3.3.3.3     +-- 192.168.22.0/24
```

r2 is an ABR (backbone + transit area 10). r3 reaches the backbone only via an
`area 10 virtual-link` to r2. Default broadcast networks.

### Root cause

`struct vertex_nexthop` identifies the egress interface only by `lsa_pos`, an
index into one area's router-LSA links — i.e. it is *area-relative*. The
virtual-link next-hop's `lsa_pos` is computed in the transit area
(`ospf_vl_set_params()`), but the backbone router-route to the ABR is built by
`ospf_intra_add_router()` → `ospf_route_copy_nexthops_from_vertex()` with
`area == backbone`, so `ospf_if_lookup_by_lsa_pos()` interprets the
transit-area position against the *backbone* router-LSA and selects whatever
interface occupies that position there.

This collides whenever the real backbone interface holds the colliding LSA
position — notably when the virtual link is configured at runtime, after the
interfaces (the usual operational order): the VLINK pseudo interface is then
created last and the backbone interface keeps position 0. The bogus path
survives de-duplication (different ifindex) and is inherited by every
inter-area route through that ABR.

Note this is not limited to setups needing `abr-type standard` on the far
end: in the canonical virtual-link use case — repairing a partitioned
backbone — both endpoints own backbone interfaces, are ABRs under the default
abr-type, and hit this with no special configuration.

### Fix (Update)

Resolve the virtual-link egress interface once, in the transit area where
`lsa_pos` is valid (`ospf_vl_set_params()`), record its `ifindex` on the
next-hop (`struct vertex_nexthop`), and have the consumer
(`ospf_route_copy_nexthops_from_vertex()`) use that `ifindex` directly via the
new `ospf_if_lookup_by_ifindex()` helper. `ifindex` is not area-relative, so it
is correct regardless of which area's table is being populated, and it
disambiguates correctly when multiple interfaces share a subnet.

`ifindex` stays 0 for non virtual-link next-hops, so they keep resolving via
`lsa_pos` - the change is a no-op for them, and the other
`ospf_if_lookup_by_lsa_pos()` callers (where `lsa_pos` and the area always
match by construction) are left untouched.

### Testing

* New topotest `ospf_vlink_nexthop` (3 routers; the virtual link is configured
  at runtime via vtysh, which is required to reproduce — see the module
  docstring). On 10.6.1 and master it fails before this change with
  `bogus next-hop via r2-eth0 (bug present)` and passes after it
  (`3 passed`).
* r3 uses `ospf abr-type standard` in the test because configuring a virtual
  link on a non-ABR is rejected, and with the default abr-type a router with
  two non-backbone areas is not an ABR until the virtual link itself attaches
  it to the backbone.
* Existing `ospf_topo1` suite: 11 passed, unchanged.