### PR TITLE
pceplib: Fix formatstring to be platform-independent o 32/64 bit

### DIFF
--- a/pceplib/test/pcep_msg_tlvs_test.c
+++ b/pceplib/test/pcep_msg_tlvs_test.c
@@ -564,7 +564,7 @@ void test_pcep_tlv_create_srpag_cp_pref(void)
 	pcep_encode_tlv(&tlv->header, versioning, tlv_buf);
 	CU_ASSERT_EQUAL(tlv->header.type,
 			(PCEP_OBJ_TLV_TYPE_SRPOLICY_CPATH_PREFERENCE));
-	printf(" encoded length vs sizeof pref (%d) vs (%ld)\n",
+	printf(" encoded length vs sizeof pref (%d) vs (%zu)\n",
 	       tlv->header.encoded_tlv_length, sizeof(preference_default));
 	CU_ASSERT_EQUAL(tlv->header.encoded_tlv_length,
 			sizeof(preference_default));


### PR DESCRIPTION
Use %zu instead %ld for string formatting to make it independent on 32/64 bit pointer lengths

Fixes build on 32bit platforms with newer compilers which currently fail:
```
pceplib/test/pcep_msg_tlvs_test.c:567:59: error: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘unsigned int’ [-Werror=format=]
  567 |         printf(" encoded length vs sizeof pref (%d) vs (%ld)\n",
      |                                                         ~~^
      |                                                           |
      |                                                           long int
      |                                                         %d
  568 |                tlv->header.encoded_tlv_length, sizeof(preference_default));
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                unsigned int
cc1: all warnings being treated as errors
```