### PR TITLE
topotests: support ExaBGP 5.x and update the in-tree installs to 5.0.9

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -46,7 +46,7 @@ Installing Topotest Requirements
    python3 -m pip install 'scapy>=2.4.5'
    python3 -m pip install 'libyang<4'
    python3 -m pip install pyyaml xmltodict
-   python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
+   python3 -m pip install git+https://github.com/Exa-Networks/exabgp@5d36bc40253235a913664599ac5cf85bc7adb996 # ExaBGP 5.0.9
    useradd -d /var/run/exabgp/ -s /bin/false exabgp
 
 The version of protobuf package that is installed on your system will determine

--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -107,7 +107,7 @@ RUN for i in $(seq 1 ${APT_RETRIES}); do \
     python3 -m pip install 'scapy>=2.4.5' && \
     python3 -m pip install pyyaml && \
     python3 -m pip install xmltodict && \
-    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
+    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@5d36bc40253235a913664599ac5cf85bc7adb996 # ExaBGP 5.0.9
 
 # LTTng tracing dependencies (conditional)
 RUN if [ "$ENABLE_LTTNG" = "true" ]; then \

--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -83,7 +83,7 @@ RUN apt update -y && apt upgrade -y && \
     python3 -m pip install 'pytest>=6.2.4' 'pytest-xdist>=2.3.0' && \
     python3 -m pip install 'scapy>=2.4.5' && \
     python3 -m pip install xmltodict && \
-    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
+    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@5d36bc40253235a913664599ac5cf85bc7adb996 # ExaBGP 5.0.9
 
 # Install FRR built packages
 RUN mkdir -p /etc/apt/keyrings && \

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -81,21 +81,21 @@ def is_string(value):
 
 
 def get_exabgp_cmd(commander=None):
-    """Return the command to use for ExaBGP version >= 4.2.11"""
+    """Return the command to use for ExaBGP version >= 5.0.0"""
 
     if commander is None:
         commander = Commander("exabgp", logger=logging.getLogger("exabgp"))
 
     def exacmd_version_ok(exacmd):
-        logger.debug("checking %s for exabgp version >= 4.2.11", exacmd)
-        _, stdout, _ = commander.cmd_status(exacmd + " --version", warn=False)
+        logger.debug("checking %s for exabgp version >= 5.0.0", exacmd)
+        _, stdout, _ = commander.cmd_status(exacmd + " version", warn=False)
         m = re.search(r"ExaBGP\s*:\s*((\d+)\.(\d+)(?:\.(\d+))?)", stdout)
         if not m:
             return False
         version = m.group(1)
-        if topotest.version_cmp(version, "4.2.11") < 0:
+        if topotest.version_cmp(version, "5.0.0") < 0:
             logging.debug(
-                "found exabgp version < 4.2.11 in %s will keep looking", exacmd
+                "found exabgp version < 5.0.0 in %s will keep looking", exacmd
             )
             return False
         logger.info("Using ExaBGP version %s in %s", version, exacmd)
@@ -1331,7 +1331,7 @@ class TopoExaBGP(TopoHost):
         * Run ExaBGP with env file `env_file` and configuration peer*/exabgp.cfg
         """
         exacmd = self.tgen.get_exabgp_cmd()
-        assert exacmd, "Can't find a usable ExaBGP (must be version >= 4.2.11)"
+        assert exacmd, "Can't find a usable ExaBGP (must be version >= 5.0.0)"
 
         self.run("mkdir -p /etc/exabgp")
         self.run("chmod 755 /etc/exabgp")
@@ -1342,10 +1342,6 @@ class TopoExaBGP(TopoHost):
         self.run("chmod 644 /etc/exabgp/*")
         self.run("chmod a+x /etc/exabgp/*.py")
         self.run("chown -R exabgp:exabgp /etc/exabgp")
-        self.run("[ -p /var/run/exabgp.in ] || mkfifo /var/run/exabgp.in")
-        self.run("[ -p /var/run/exabgp.out ] || mkfifo /var/run/exabgp.out")
-        self.run("chown exabgp:exabgp /var/run/exabgp.{in,out}")
-        self.run("chmod 600 /var/run/exabgp.{in,out}")
 
         log_dir = os.path.join(self.logdir, self.name)
         self.run("chmod 777 {}".format(log_dir))
@@ -1354,10 +1350,15 @@ class TopoExaBGP(TopoHost):
 
         env_cmd = "env exabgp.log.level=INFO "
         env_cmd += "exabgp.log.destination={} ".format(log_file)
+        env_cmd += "EXABGP_ENVFILE=/etc/exabgp/exabgp.env "
 
-        output = self.run(
-            env_cmd + exacmd + " -e /etc/exabgp/exabgp.env /etc/exabgp/exabgp.cfg "
+        # Without the stdio redirect the daemonized exabgp keeps the
+        # launch pipe open and self.run() blocks forever.
+        invocation = (
+            exacmd + " server /etc/exabgp/exabgp.cfg </dev/null >/dev/null 2>&1"
         )
+
+        output = self.run(env_cmd + invocation)
         if output is None or len(output) == 0:
             output = "<none>"
 
@@ -1530,7 +1531,7 @@ def diagnose_env_linux(rundir):
         logger.info("LDPd tests will not run (missing mpls-iptunnel kernel module)")
 
     if not get_exabgp_cmd():
-        logger.warning("Failed to find exabgp >= 4.2.11")
+        logger.warning("Failed to find exabgp >= 5.0.0")
 
     logger.removeHandler(fhandler)
     fhandler.close()


### PR DESCRIPTION
The topotests only support ExaBGP 4.2, but its branch no longer receives new features; newer address families such as BGP-MUP (#22311) need ExaBGP 5.x.

This PR switches TopoExaBGP to ExaBGP 5.x: probe and launch via the 5.x subcommands, and update the in-tree installs (tests/topotests/Dockerfile, docker/ubuntu-ci/Dockerfile, doc/developer/topotests.rst) to the 5.0.9 release. The NetDEF CI agents provision their own ExaBGP separately and need updating too: see #22320.

None of the 5.x breaking changes affect the in-tree tests: all exabgp.env files use encoder=text, no test drives BGP-LS through exabgp, and the prefix-sid tests announce the attribute as raw bytes.

Verified bgp_prefix_sid, bgp_vrf_md5_peering and bgp_peer_shut via tests/topotests/docker/frr-topotests.sh with ExaBGP 5.0.9.

Updated to target ExaBGP 5.x only, per @donaldsharp and @mjstapp. The original dual-version description is kept below for reference.

<details>
<summary>Original description (dual 4.x/5.x support)</summary>

The topotests only support ExaBGP 4.2, but its branch no longer receives new features; newer address families such as BGP-MUP (#22311) need ExaBGP 5.x.

This PR makes TopoExaBGP.start detect the installed ExaBGP version and use the matching launch form (the 4.x behavior is unchanged), and updates the in-tree installs (tests/topotests/Dockerfile, docker/ubuntu-ci/Dockerfile, doc/developer/topotests.rst) from 4.2.21 to the 5.0.9 release. The NetDEF CI agents provision their own ExaBGP separately and can switch independently: see #22320.

None of the 5.x breaking changes affect the in-tree tests: all exabgp.env files use encoder=text, no test drives BGP-LS through exabgp, and the prefix-sid tests announce the attribute as raw bytes.

Verified bgp_prefix_sid, bgp_vrf_md5_peering and bgp_peer_shut via tests/topotests/docker/frr-topotests.sh with both 4.2.21 and 5.0.9: 5 passed each. As a side effect this fixes a hang when running the topotests that way with any exabgp >= 4.2: frr-topotests.sh runs pytest as the container's PID 1, and exabgp's daemonise() refuses to detach from a PID 1 parent. No standard setup hits this today -- the published topotests image still ships ExaBGP 3.4.17, which the version probe rejects fail-fast, and the docker/ubuntu-ci flow runs with --init -- but a locally built topotests image (4.2.21) reproduces it. See the first commit message for details.

</details>
