### PR TITLE
bgpd: reduce ibuf_scratch size to match ibuf_work

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -504,7 +504,7 @@ done : {
 	return status;
 }
 
-uint8_t ibuf_scratch[BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE * BGP_READ_PACKET_MAX];
+uint8_t ibuf_scratch[BGP_IBUF_WORK_SIZE];
 /*
  * Reads a chunk of data from peer->connection.fd into
  * peer->connection.ibuf_work.

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1395,8 +1395,7 @@ struct peer_connection *bgp_peer_connection_new(struct peer *peer, const union s
 	 * bounds checking for every single attribute as we construct an
 	 * UPDATE.
 	 */
-	connection->ibuf_work =
-		ringbuf_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE / 2);
+	connection->ibuf_work = ringbuf_new(BGP_IBUF_WORK_SIZE);
 
 	connection->status = Idle;
 	connection->ostatus = Idle;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1304,6 +1304,7 @@ enum bgp_peer_sub_sort {
 #define BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE 65535
 #define BGP_MAX_PACKET_SIZE BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
 #define BGP_MAX_PACKET_SIZE_OVERFLOW          1024
+#define BGP_IBUF_WORK_SIZE			(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE / 2)
 
 /*
  * Trigger delay for bgp_announce_route().


### PR DESCRIPTION
Commit 2e172f01145 reduced ibuf_work ringbuf size from 650KB to ~98KB (1.5x max packet size), but left ibuf_scratch at the old 650KB size.

Since bgp_read() uses MIN(ibuf_work_space, sizeof(ibuf_scratch)) to determine read size, the extra ~550KB in ibuf_scratch is never used.

Reduce ibuf_scratch to match ibuf_work, saving ~550KB of BSS. Define BGP_IBUF_WORK_SIZE macro to keep the two in sync.