### PR TITLE
zebra: fix memory leaks

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2265,14 +2265,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	}
 	ret = rib_add_multipath_nhe(afi, api.safi, &api.prefix, src_p, re, n, false, true);
 
-	/*
-	 * rib_add_multipath_nhe only fails in a couple spots
-	 * and in those spots we have not freed memory
-	 */
-	if (ret == -1) {
+	if (ret == -1)
 		client->error_cnt++;
-		zebra_rib_route_entry_free(re);
-	}
 
 	/* At this point, these allocations are not needed: 're' has been
 	 * retained or freed, and if 're' still exists, it is using

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -2045,12 +2045,17 @@ static int zfpm_init(struct event_loop *master)
 
 static int zfpm_fini(void)
 {
+	struct fpm_mac_info_t *mac;
+
 	zfpm_write_off();
 	zfpm_read_off();
 	zfpm_connect_off();
 	zfpm_conn_down_off();
 
 	zfpm_stop_stats_timer();
+
+	while ((mac = TAILQ_FIRST(&zfpm_g->mac_q)) != NULL)
+		zfpm_mac_info_del(mac);
 
 	hook_unregister(rib_update, zfpm_trigger_update);
 	hook_unregister(zebra_rmac_update, zfpm_trigger_rmac_update);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2588,8 +2588,8 @@ static void rib_re_nhg_free(struct route_entry *re)
 	if (re->nhe && re->nhe_id) {
 		assert(re->nhe->id == re->nhe_id);
 		route_entry_update_nhe(re, NULL);
-	} else if (re->nhe && re->nhe->nhg.nexthop)
-		nexthops_free(re->nhe->nhg.nexthop);
+	} else if (re->nhe)
+		zebra_nhg_free(re->nhe);
 
 	/*
 	 * Clean up nhe_received if it wasn't already cleared by

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4463,10 +4463,11 @@ void zebra_rib_route_entry_free(struct route_entry *re)
  * Internal route-add implementation; there are a couple of different public
  * signatures. Callers in this path are responsible for the memory they
  * allocate: if they allocate a nexthop_group or backup nexthop info, they
- * must free those objects. If this returns < 0, an error has occurred and the
- * route_entry 're' has not been captured; the caller should free that also.
+ * must free those objects. On mq_add_handler() failure (-1), this function
+ * frees re (and re_nhe) via early_route_memory_free(); callers must not
+ * free re after -1.
  *
- * -1 -> error
+ * -1 -> error (re already freed on enqueue failure)
  *  0 -> Add
  *  1 -> update
  */
@@ -4475,6 +4476,7 @@ int rib_add_multipath_nhe(afi_t afi, safi_t safi, struct prefix *p, struct prefi
 			  bool replace)
 {
 	struct zebra_early_route *ere;
+	int ret;
 
 	if (!re)
 		return -1;
@@ -4493,7 +4495,11 @@ int rib_add_multipath_nhe(afi_t afi, safi_t safi, struct prefix *p, struct prefi
 	ere->startup = startup;
 	ere->replace = replace;
 
-	return mq_add_handler(ere, rib_meta_queue_early_route_add);
+	ret = mq_add_handler(ere, rib_meta_queue_early_route_add);
+	if (ret == -1)
+		early_route_memory_free(ere);
+
+	return ret;
 }
 
 /*
@@ -4581,10 +4587,6 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p, struct prefix_ip
 
 	ret = rib_add_multipath_nhe(afi, safi, p, src_p, re, n, startup, replace);
 
-	/* In error cases, free the route also */
-	if (ret < 0)
-		zebra_rib_route_entry_free(re);
-
 	return ret;
 }
 
@@ -4619,7 +4621,8 @@ void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 	ere->deletion = true;
 	ere->fromkernel = fromkernel;
 
-	mq_add_handler(ere, rib_meta_queue_early_route_add);
+	if (mq_add_handler(ere, rib_meta_queue_early_route_add) == -1)
+		early_route_memory_free(ere);
 }
 
 


### PR DESCRIPTION
## Summary

Fix zebra memory leaks on RIB NHG teardown, early-route enqueue ownership,
and FPM shutdown.

- Free unhashed NHG entries with `zebra_nhg_free()` in `rib_re_nhg_free`
- Use `early_route_memory_free()` on early-route `mq_add_handler()` failure
  and remove duplicate `route_entry` frees in callers (avoids double-free)
- Drain the FPM MAC queue in `zfpm_fini`

## Commits

1. **`zebra: fix unhashed NHG leak in rib_re_nhg_free`**

   When tearing down a route entry whose nexthop group is not hashed
   (`nhe_id == 0`), `rib_re_nhg_free()` called `nexthops_free()` on the
   nexthop chain only, leaving the `nhg_hash_entry` wrapper (timer,
   backup info, dependency tree) allocated. Switch to `zebra_nhg_free()`
   so the full unhashed NHG object is released.

2. **`zebra: free early route wrapper on enqueue failure`**

   `rib_add_multipath_nhe()` and `rib_delete()` wrap work in a
   `zebra_early_route` and hand it to `mq_add_handler()`. On failure,
   the wrapper, `route_entry`, and attached NHE must be freed via
   `early_route_memory_free()`. Callers in `rib_add_multipath` and
   `zapi_msg.c` had redundant `zebra_rib_route_entry_free(re)` calls
   that would double-free once the callee owns cleanup; those are
   removed and the ownership contract is documented in a comment.

3. **`zebra: drain FPM MAC queue on module fini`**

   `zfpm_fini()` unregistered hooks and stopped timers but did not drain
   `mac_q`, so pending `fpm_mac_info_t` entries could leak if zebra
   exited without a normal FPM teardown path. Walk the queue and call
   `zfpm_mac_info_del()` on each entry before hook unregister.

## Test plan

Topotests run with `TOPOTESTS_CHECK_MEMLEAK=1` and `--memleaks`:

```
Suite: fpm_testing_topo1 Tests: 4 Pass: 4 Fail: 0 Error: 0 Skip: 0 Time: 65.96s
Suite: zebra_metaq Tests: 1 Pass: 1 Fail: 0 Error: 0 Skip: 0 Time: 31.04s
Suite: zebra_netlink Tests: 1 Pass: 1 Fail: 0 Error: 0 Skip: 0 Time: 23.61s
Suite: zebra_nhg_check Tests: 4 Pass: 4 Fail: 0 Error: 0 Skip: 0 Time: 173.55s
Suite: zebra_received_nhe_kept Tests: 5 Pass: 5 Fail: 0 Error: 0 Skip: 0 Time: 26.87s
Suite: zebra_rib Tests: 12 Pass: 12 Fail: 0 Error: 0 Skip: 0 Time: 57.95s
Suite: zebra_rnh_testing Tests: 2 Pass: 2 Fail: 0 Error: 0 Skip: 0 Time: 25.13s
TOTAL: 29 Pass, 0 Fail, 0 Skip (404.11s)
```

- [x] 7 zebra topotest suites with memleak checking (29/29 pass;
      both `zebra_rib::test_memory_leak` cases PASSED, not SKIPPED)