### PR TITLE
ripd: poison redistributed routes on route-map change

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2271,8 +2271,20 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 					zlog_debug(
 						"%pFX is filtered by route-map",
 						p);
-				continue;
-			}
+				/* If this route was advertised under the
+				 * previous policy and is now denied, poison it
+				 * once so neighbors withdraw it instead of
+				 * keeping it until timeout. Otherwise it was
+				 * never advertised, so just skip it.
+				 */
+				if (!CHECK_FLAG(rinfo->flags, RIP_RTF_POLICY_ADVERTISED))
+					continue;
+
+				UNSET_FLAG(rinfo->flags, RIP_RTF_POLICY_ADVERTISED);
+				rinfo->metric_out = RIP_METRIC_INFINITY;
+				rinfo->metric_set = 1;
+			} else
+				SET_FLAG(rinfo->flags, RIP_RTF_POLICY_ADVERTISED);
 		}
 
 		/* When route-map does not set metric. */

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -252,6 +252,10 @@ struct rip_info {
 /* Flags of RIP route. */
 #define RIP_RTF_FIB      1
 #define RIP_RTF_CHANGED  2
+/* Route was permitted by its redistribute route-map at the last update, i.e.
+ * it has been advertised to neighbors under the current policy.
+ */
+#define RIP_RTF_POLICY_ADVERTISED 4
 	uint8_t flags;
 
 	/* Garbage collect timer - not copied by rip_info_cpy() */


### PR DESCRIPTION
When a RIP redistribution route-map is changed, routes advertised under the previous policy need to be withdrawn if the new policy denies them. Mark existing redistributed routes on route-map changes and let the triggered update send metric 16 for denied entries instead of skipping them.

CLOSES #22360