### PR TITLE
ospfd: RFC 4222 R4 per-neighbor LSA gap pacing

### DIFF
--- a/doc/developer/ospf-adj-pacing.rst
+++ b/doc/developer/ospf-adj-pacing.rst
@@ -1,0 +1,108 @@
+.. _ospf-adj-pacing:
+
+****************
+Adjacency Pacing
+****************
+
+OSPF adjacency pacing implements :rfc:`4222` recommendation 5 as a
+per-interface gate on adjacency formation. The goal is to avoid starting too
+many database exchanges at once on a bandwidth constrained interface.
+
+Overview
+========
+
+Adjacency pacing is tracked in ``struct ospf_adj_pacing`` in
+``ospfd/ospf_interface.h``. Each OSPF interface keeps:
+
+- the pacing mode: disabled, static, or dynamic
+- the current number of adjacencies in progress
+- a first-come, first-served queue of neighbors waiting for a slot
+- dynamic state such as the current limit and watermarks
+
+An adjacency is considered in progress while the neighbor state is
+``ExStart``, ``Exchange``, or ``Loading``.
+
+Static Mode
+===========
+
+Static mode uses a fixed per-interface limit configured with:
+
+.. code-block:: frr
+
+   interface eth0
+    ip ospf adjacency-pacing static 4
+
+When the number of in-progress adjacencies reaches the configured limit, any
+new neighbor that would otherwise advance into adjacency formation is placed on
+the interface queue. Queued neighbors are retried in FIFO order when a slot
+opens.
+
+Dynamic Mode
+============
+
+Dynamic mode adapts the limit according to retransmission pressure on the
+interface:
+
+.. code-block:: frr
+
+   interface eth0
+    ip ospf adjacency-pacing dynamic
+    ip ospf adjacency-pacing dynamic thresholds 100 2
+
+In dynamic mode, the current limit still applies to the number of simultaneous
+adjacencies allowed on the interface. The implementation computes ``U(t)`` as
+the total number of unacknowledged LSAs across neighbors on the interface, and
+uses the configured ``H`` and ``L`` values only as high-water and low-water
+thresholds for that unacknowledged-LSA total. The current adjacency limit is
+then adjusted using hysteresis:
+
+- if ``U(t) > H``, reduce the current limit by the configured factor, down to 1
+- if ``U(t) < L``, increase the current limit by 1, up to the configured maximum
+- if ``L <= U(t) <= H``, keep the current limit unchanged
+
+Current defaults from ``ospfd/ospf_interface.h`` are:
+
+- initial dynamic limit: 1 (simultaneous adjacency)
+- maximum dynamic limit: 50 (simultaneous adjacencies)
+- decrease factor: 2
+- adjustment interval: 1000 ms
+- high-water mark: 100 (unacknowledged LSAs)
+- low-water mark: 2 (unacknowledged LSAs)
+
+Code Paths
+==========
+
+The main control flow lives in ``ospfd/ospf_nsm.c``:
+
+- ``ospf_adj_pacing_allow()`` decides whether a new adjacency may proceed
+- ``ospf_adj_pacing_enqueue()`` and ``ospf_adj_pacing_dequeue()`` manage the
+  per-interface wait queue
+- ``ospf_adj_pacing_kick()`` restarts queued neighbors when slots become
+  available
+- ``ospf_adj_dyn_adjust()`` and ``ospf_adj_dyn_adjust_timer()`` update the
+  dynamic limit
+
+Neighbor state changes update the in-progress count. When a neighbor leaves the
+forming states, the count is decremented and the queue is serviced again.
+
+Unacknowledged LSA Tracking
+============================
+
+``U(t)`` is computed by summing ``ls_rxmt_unacked`` across all neighbors on the
+interface. This counter is incremented in ``ospf_count_sent_lsa()`` when an LSU
+packet is written, and decremented in the LS Acknowledge receive path when the
+matching retransmit entry is removed.
+
+On a broadcast segment the DR floods each LSA once as a multicast, but every
+neighbor is individually tracked — so ``U(t)`` reflects the total ACK
+obligation across all neighbors, not just the number of distinct LSAs on the
+wire. This gives a realistic measure of retransmission pressure regardless of
+network type.
+
+Operational Notes
+=================
+
+- Adjacency pacing is interface scoped, not process scoped.
+- Disabling pacing clears the current mode and runtime state on existing OSPF
+  interfaces.
+- Dynamic thresholds must satisfy ``low < high``.

--- a/doc/developer/ospf-lsa-pacing.rst
+++ b/doc/developer/ospf-lsa-pacing.rst
@@ -1,0 +1,217 @@
+.. _ospf-lsa-pacing:
+
+**********
+LSA Pacing
+**********
+
+OSPF LSA pacing implements :rfc:`4222` recommendation 4 as a per-neighbor,
+per-interface gate on LS Update transmission. The goal is to prevent a router
+from flooding its neighbors with back-to-back LS Updates during large topology
+changes, which can overwhelm receive buffers and trigger retransmission storms.
+
+Overview
+========
+
+LSA pacing is tracked per-neighbor in ``struct ospf_neighbor``
+(``ospfd/ospf_neighbor.h``) and configured per-interface via
+``struct ospf_if_params`` (``ospfd/ospf_interface.h``). Each OSPF interface
+caches the effective parameters in ``struct ospf_interface`` so per-packet
+hot paths avoid repeated parameter lookups.
+
+When LSA pacing is enabled on an interface:
+
+- Outbound LSAs destined for a neighbor are placed on a per-neighbor send
+  queue (``nbr->r4_send_queue``) rather than being written immediately.
+- A per-neighbor timer (``nbr->t_r4_send``) drains the queue at the
+  configured rate, sending at most ``rec4_max_lsas`` LSAs per LS Update.
+- The inter-packet gap (``nbr->lsu_gap_ms``) is adjusted adaptively using
+  a multiplicative-increase/multiplicative-decrease (MIMD) algorithm based
+  on the unacknowledged LSA count for that neighbor.
+
+Data Structures
+===============
+
+``struct ospf_if_params``
+   Holds the user-configured LSA pacing parameters for an interface:
+
+   - ``gap_pacing_enable`` — boolean, set by ``ip ospf lsa-pacing``
+   - ``gap_initial_ms`` — starting inter-LSU gap (default 20 ms)
+   - ``gap_min_ms`` — floor for gap adaptation (default 20 ms)
+   - ``gap_max_ms`` — ceiling for gap adaptation (default 1000 ms)
+   - ``gap_factor`` — multiplicative adjustment factor F (default 2)
+   - ``gap_adjust_int_ms`` — minimum time T between adjustments (default 1000 ms)
+   - ``gap_high_water`` — unacked-LSA count H above which the gap grows (default 100)
+   - ``gap_low_water`` — unacked-LSA count L below which the gap shrinks (default 2)
+   - ``gap_max_lsas`` — LSAs packed per LS Update during paced sends (default 1)
+
+``struct ospf_interface``
+   Caches derived effective values (prefixed ``rec4_``) computed by
+   ``ospf_rec4_recompute_effective()`` in ``ospfd/ospf_interface.c``:
+
+   - ``rec4_gap_pacing`` — effective enable flag
+   - ``rec4_gap_initial_ms``, ``rec4_gap_min_ms``, ``rec4_gap_max_ms``
+   - ``rec4_gap_factor``, ``rec4_gap_adjust_int_ms``
+   - ``rec4_high_water``, ``rec4_low_water``, ``rec4_max_lsas``
+
+``struct ospf_neighbor``
+   Holds per-neighbor runtime pacing state:
+
+   - ``r4_send_queue`` — list of ``struct ospf_lsa *`` waiting to be sent
+   - ``t_r4_send`` — FRR event timer for the paced send callback
+   - ``lsu_gap_ms`` — current adaptive inter-LSU gap for this neighbor
+   - ``next_send_ms`` — absolute timestamp (ms) when the next send is allowed
+   - ``ls_rxmt_unacked`` — running count of unacknowledged LSAs sent to this
+     neighbor; used as the ``U`` signal in the MIMD algorithm
+
+MIMD Gap Adjustment
+===================
+
+``pace_maybe_adjust_gap()`` in ``ospfd/ospf_packet.c`` implements the
+adaptive algorithm. It is called after each paced send and when an LS
+Acknowledge is received. The algorithm uses the per-neighbor unacknowledged
+LSA count ``U = nbr->ls_rxmt_unacked`` and the configured factor ``F``:
+
+.. code-block:: text
+
+   if U > H:   G = min(G × F, Gmax)   # multiplicative decrease: gap grows, send rate slows
+   if U == 0:  G = Gmin               # immediate reset to minimum gap
+   if U <= L:  G = max(G ÷ F, Gmin)   # multiplicative increase: gap shrinks, send rate rises
+   L < U <= H: no change
+
+The gap is never modified more frequently than once per ``T`` milliseconds
+(``rec4_gap_adjust_int_ms``), preventing oscillation during transient bursts.
+
+Defaults from ``ospfd/ospf_interface.h``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Parameter
+     - Default
+     - Description
+   * - Initial gap (G\ :sub:`init`)
+     - 20 ms
+     - Starting inter-LSU gap when an adjacency becomes Full
+   * - Minimum gap (G\ :sub:`min`)
+     - 20 ms
+     - Floor: gap will not shrink below this value
+   * - Maximum gap (G\ :sub:`max`)
+     - 1000 ms
+     - Ceiling: gap will not grow above this value
+   * - Factor (F)
+     - 2
+     - Multiplicative adjustment factor for both directions
+   * - Adjust interval (T)
+     - 1000 ms
+     - Minimum time between consecutive gap changes
+   * - High-water (H)
+     - 100
+     - Unacked LSAs above which gap grows (rate slows)
+   * - Low-water (L)
+     - 2
+     - Unacked LSAs below which gap shrinks (rate rises)
+   * - Max LSAs per update
+     - 1
+     - LSAs packed into one paced LS Update
+
+Code Paths
+==========
+
+The main control flow lives in ``ospfd/ospf_packet.c``:
+
+- ``ospf_r4_nbr_init()`` — allocates ``r4_send_queue`` for a neighbor and sets
+  ``lsu_gap_ms`` from the interface initial-gap.
+- ``ospf_r4_nbr_cancel()`` — cancels the send timer and empties the queue;
+  called on neighbor state regression.
+- ``ospf_r4_nbr_enqueue()`` — appends an LSA to the neighbor's send queue and
+  arms the send timer if not already scheduled.
+- ``ospf_r4_nbr_arm_timer()`` — schedules ``ospf_r4_nbr_send_timer`` to fire at
+  ``nbr->next_send_ms``. No-ops if the timer is already armed or the queue is
+  empty.
+- ``ospf_r4_nbr_send_timer()`` — timer callback that dequeues and sends one
+  batch of LSAs (up to ``rec4_max_lsas``), then re-arms itself for the next
+  send window.
+
+``ospf_r4_nbr_send_timer()`` handles two conditions before sending:
+
+1. **Gap not yet elapsed**: if ``nbr->next_send_ms > now``, reschedule for the
+   remaining time rather than sending early.
+2. **Interface write-queue busy**: if ``oi->on_write_q`` is set (the interface
+   is currently being drained by ``ospf_write``), retry after 1 ms to yield the
+   event loop without disrupting the pacing schedule.
+
+Flood Integration
+=================
+
+``ospfd/ospf_flood.c`` integrates LSA pacing at two points:
+
+- **Retransmit list population** (``ospf_flood_through_interface()``): when
+  ``rec4_gap_pacing`` is set, the function skips adding the LSA to the normal
+  retransmit list and instead sets ``retx_flag = 1`` to indicate the interface
+  needs flooding. The LSA is enqueued per-neighbor via ``ospf_r4_nbr_enqueue()``
+  in the subsequent neighbor-walk block.
+- **Per-neighbor flood dispatch**: a neighbor-walk loop calls
+  ``ospf_r4_nbr_enqueue()`` for each eligible neighbor in ``Exchange`` state
+  or above, replacing the normal immediate-write path.
+
+Broadcast Network Behavior
+==========================
+
+On a normal broadcast or NBMA interface, the DR/BDR floods each LSA once as a
+single multicast packet to ``AllSPFRouters``; individual neighbors never get
+a separate copy. When ``rec4_gap_pacing`` is enabled, this changes: pacing is
+tracked per-neighbor (``nbr->r4_send_queue``, ``nbr->lsu_gap_ms``), so the
+flood path in ``ospf_flood_through_interface()`` walks the interface's
+neighbor table and calls ``ospf_r4_nbr_enqueue()`` once per eligible neighbor,
+and ``ospf_ls_upd_queue_send()`` addresses the resulting packet directly to
+that neighbor's unicast address (``ospf_packet.c``, destination selection
+falls through to ``addr.s_addr`` rather than ``OSPF_ALLSPFROUTERS`` once
+pacing is active).
+
+This means enabling LSA pacing on a broadcast interface trades the normal
+single-multicast flood for ``N`` independently paced unicast streams, one per
+adjacent neighbor, each gated by its own gap and MIMD state. This is
+intentional: per-neighbor pacing requires per-neighbor delivery, since
+neighbors can have different unacked-LSA counts and therefore different
+gaps. The tradeoff is more packets on the wire under pacing, in exchange for
+gating each neighbor's flood rate independently of the others.
+
+Unacknowledged LSA Tracking
+============================
+
+``U(t)`` is tracked per-neighbor via ``nbr->ls_rxmt_unacked``:
+
+- Incremented by ``ospf_count_sent_lsa()`` when an LS Update is written for
+  that neighbor.
+- Decremented in the LS Acknowledge receive path when the matching retransmit
+  list entry is removed.
+
+Interaction with R5 Adjacency Pacing
+=====================================
+
+R4 LSA pacing and :ref:`ospf-adj-pacing` (R5) are completely independent
+features. They share no data and neither's enable condition gates the other:
+
+- Both react to the same network events (retransmit timer, LS Acknowledge) but
+  in separate ``if`` blocks that check their own enable flags.
+- R4 uses ``rec4_*`` fields on ``struct ospf_interface`` and per-neighbor queue
+  state. R5 uses ``adj_pacing`` on ``struct ospf_interface``.
+- Either feature can be enabled independently per-interface without affecting
+  the other.
+- This independence holds on broadcast segments as well: a topotest exercises
+  both features together on a 5-router broadcast LAN (one DR, one BDR, three
+  DROthers), with adjacency flapping and external-LSA injection under both
+  unconstrained and bandwidth-constrained links, confirming neither feature's
+  pacing decisions interfere with the other's.
+
+Operational Notes
+=================
+
+- LSA pacing is interface-scoped, not process-scoped.
+- Disabling pacing (``no ip ospf lsa-pacing``) clears ``gap_pacing_enable``
+  and re-evaluates effective parameters on all OSPF interfaces using that
+  interface's configuration.
+- ``initial-gap`` is clamped to ``[min-gap, max-gap]`` silently if
+  ``min-gap``/``max-gap`` are changed after ``initial-gap`` is set.
+- ``low-watermark`` must be strictly less than ``high-watermark``.

--- a/doc/developer/ospf.rst
+++ b/doc/developer/ospf.rst
@@ -8,6 +8,7 @@ OSPFD
    :maxdepth: 2
 
    ospf-adj-pacing
+   ospf-lsa-pacing
    ospf-api
    ospf-ls-retrans
    ospf-dead-timer-reset

--- a/doc/developer/ospf.rst
+++ b/doc/developer/ospf.rst
@@ -7,6 +7,7 @@ OSPFD
 .. toctree::
    :maxdepth: 2
 
+   ospf-adj-pacing
    ospf-api
    ospf-ls-retrans
    ospf-dead-timer-reset

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -795,6 +795,57 @@ Interfaces
 
    Disable adjacency pacing on this interface and clear the active pacing mode.
 
+.. clicmd:: ip ospf lsa-pacing
+
+   Enable per-neighbor LSA gap pacing on this interface (:rfc:`4222`
+   recommendation 4). When enabled, outbound LS Updates to each neighbor are
+   metered through a per-neighbor queue rather than sent back-to-back. The
+   inter-packet gap is adjusted adaptively based on the number of
+   unacknowledged LSAs for that neighbor.
+
+.. clicmd:: no ip ospf lsa-pacing
+
+   Disable LSA gap pacing on this interface and restore immediate LS Update
+   delivery.
+
+.. clicmd:: ip ospf lsa-pacing initial-gap (1-60000)
+
+   Set the initial inter-LSU gap in milliseconds applied when a new adjacency
+   becomes Full. The value must fall within the configured ``min-gap`` and
+   ``max-gap`` range. Default: 20 ms.
+
+.. clicmd:: ip ospf lsa-pacing min-gap (1-60000) max-gap (1-60000)
+
+   Set the floor and ceiling for adaptive gap adjustment. The ``min-gap``
+   is the fastest the paced sender will go; ``max-gap`` is the slowest.
+   ``min-gap`` must not exceed ``max-gap``. Defaults: min 20 ms, max 1000 ms.
+
+.. clicmd:: ip ospf lsa-pacing factor (1-64)
+
+   Set the multiplicative adjustment factor F used by the MIMD algorithm.
+   When the unacknowledged LSA count rises above the high-watermark, the gap
+   is multiplied by F (sends slow down). When it falls below the
+   low-watermark, the gap is divided by F (sends speed up). Default: 2.
+
+.. clicmd:: ip ospf lsa-pacing adjust-interval (1-60000)
+
+   Set the minimum time in milliseconds between consecutive gap adjustments.
+   Prevents oscillation during transient bursts. Default: 1000 ms.
+
+.. clicmd:: ip ospf lsa-pacing max-lsas-per-update (1-200)
+
+   Set the maximum number of LSAs packed into a single paced LS Update
+   packet. Default: 1.
+
+.. clicmd:: ip ospf lsa-pacing low-watermark (0-1000000) high-watermark (1-1000000)
+
+   Set the unacknowledged LSA count thresholds used by the adaptive algorithm.
+   When the per-neighbor unacked count falls below ``low-watermark``, the gap
+   is divided by the factor (rate increases). When it rises above
+   ``high-watermark``, the gap is multiplied by the factor (rate decreases).
+   ``low-watermark`` must be strictly less than ``high-watermark``.
+   Defaults: low 2, high 100.
+
 .. clicmd:: ip ospf dscp (all|low-control) (0-63)
 
    Set the DSCP value applied to OSPF control packets. The ``all`` option

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -757,6 +757,44 @@ Interfaces
    Recommendation 2 from RFC 4222 to improve adjacency robustness under
    congestion.
 
+.. clicmd:: ip ospf adjacency-pacing static (1-65535)
+
+   Limit the number of adjacencies that may be formed concurrently on this
+   interface. The configured value is the maximum number of neighbors that may
+   be in ``ExStart``, ``Exchange``, or ``Loading`` at the same time.
+
+   When the limit is reached, additional neighbors that need adjacency
+   formation are queued until one of the active exchanges completes or
+   regresses.
+
+.. clicmd:: ip ospf adjacency-pacing dynamic
+
+   Enable adaptive adjacency pacing on this interface. In dynamic mode, OSPF
+   starts conservatively and adjusts the allowed number of concurrent
+   adjacencies according to retransmission pressure on the interface.
+
+   The current limit starts at 1 and is adjusted using the total number of
+   unacknowledged LSAs (``U``) across all neighbors on the interface. This
+   command is independent of whether explicit thresholds have been configured:
+   if :clicmd:`ip ospf adjacency-pacing dynamic thresholds` has not been issued,
+   the built-in defaults of high-water 100 and low-water 2 are used.
+
+.. clicmd:: ip ospf adjacency-pacing dynamic thresholds (1-1000) (1-1000)
+
+   Configure the dynamic pacing high-water and low-water thresholds used by the
+   adaptive algorithm. The second value must be lower than the first.
+
+   If the total number of unacknowledged LSAs rises above the high-water mark,
+   OSPF reduces the current adjacency limit. If it falls below the low-water
+   mark, OSPF increases the limit. Values between the two thresholds leave the
+   current limit unchanged.
+
+   The default thresholds are high-water 100 and low-water 2.
+
+.. clicmd:: no ip ospf adjacency-pacing
+
+   Disable adjacency pacing on this interface and clear the active pacing mode.
+
 .. clicmd:: ip ospf dscp (all|low-control) (0-63)
 
    Set the DSCP value applied to OSPF control packets. The ``all`` option

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -1204,6 +1204,13 @@ void ospf_ls_retransmit_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 		else
 			rxmt_timer_reset = false;
 
+		/* Decrement unacked count if this LSA was counted */
+		if (ls_rxmt_node->counted_sent) {
+			ls_rxmt_node->counted_sent = false;
+			if (nbr->ls_rxmt_unacked)
+				nbr->ls_rxmt_unacked--;
+		}
+
 		lsa->retransmit_counter--;
 
 		/* Keep SA happy */
@@ -1321,8 +1328,7 @@ static void ospf_ls_retransmit_delete_nbr_if(struct ospf_interface *oi,
 			lsr = ospf_ls_retransmit_lookup(nbr, lsa);
 
 			/* If LSA find in ls-retransmit list, remove it. */
-			if (lsr != NULL &&
-			    lsr->data->ls_seqnum == lsa->data->ls_seqnum)
+			if (lsr != NULL && lsr->data->ls_seqnum == lsa->data->ls_seqnum)
 				ospf_ls_retransmit_delete(nbr, lsr);
 		}
 }

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -751,6 +751,15 @@ int ospf_flood_through_interface(struct ospf_interface *oi,
 			}
 		}
 
+		/* RFC4222 R4: queue ownership begins at the paced send timer,
+		 * not during flood traversal. Mark that at least one eligible
+		 * neighbor exists and let the later R4 block enqueue the LSA.
+		 */
+		if (oi->rec4_gap_pacing) {
+			retx_flag = 1;
+			continue;
+		}
+
 		/* Add the new LSA to the Link state retransmission list
 		   for the adjacency. The LSA will be retransmitted
 		   at intervals until an acknowledgment is seen from
@@ -814,6 +823,41 @@ int ospf_flood_through_interface(struct ospf_interface *oi,
 	    IP addresses for these packets are the neighbors' IP
 	    addresses. This behavior is extended to P2MP networks which
 	    don't support broadcast. */
+	/* RFC4222 R4: route flooding through per-neighbor paced queues. */
+	if (oi->rec4_gap_pacing) {
+		struct ospf_neighbor *nbr;
+
+		for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+			nbr = rn->info;
+			if (!nbr || nbr == oi->nbr_self)
+				continue;
+			if (nbr->state < NSM_Exchange)
+				continue;
+			if (inbr && IPV4_ADDR_SAME(&inbr->router_id, &nbr->router_id))
+				continue;
+			if (!inbr && IPV4_ADDR_SAME(&lsa->data->adv_router, &nbr->router_id))
+				continue;
+
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RFC4222 R4: flood enqueue LSA [Type%d:%pI4] nbr=%pI4 intf=%s",
+					   lsa->data->type, &lsa->data->id, &nbr->router_id,
+					   IF_NAME(oi));
+
+			/* A superseded instance may still be waiting in the
+			 * paced send queue; drop it. This covers instances
+			 * that have been transmitted at least once (i.e. have
+			 * an ls_rxmt node carrying the queue back-pointer). A
+			 * never-sent copy has no such node and may still be
+			 * transmitted once; the receiver replies with its
+			 * newer instance per RFC 2328 section 13 (a).
+			 */
+			ospf_r4_nbr_dequeue(nbr, ospf_lsdb_linked_lookup(&nbr->ls_rxmt, lsa));
+
+			ospf_r4_nbr_enqueue(nbr, lsa);
+		}
+		return 0;
+	}
+
 	if (OSPF_IF_NON_BROADCAST(oi)) {
 		struct ospf_neighbor *nbr;
 
@@ -1127,6 +1171,13 @@ void ospf_ls_retransmit_add(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 
 	if (ospf_lsa_more_recent(old, lsa) < 0) {
 		if (old) {
+			/* RFC4222 R4: the replaced instance may still have a
+			 * copy waiting in the paced send queue; drop it before
+			 * its bookkeeping node goes away.
+			 */
+			if (nbr->oi && nbr->oi->rec4_gap_pacing)
+				ospf_r4_nbr_dequeue(nbr, ls_rxmt_node);
+
 			old->retransmit_counter--;
 			if (ls_rxmt_node->lsa_list_entry ==
 			    ospf_lsa_list_first(&nbr->ls_rxmt_list))
@@ -1197,6 +1248,13 @@ void ospf_ls_retransmit_delete(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 
 	if (ls_rxmt_node) {
 		bool rxmt_timer_reset;
+
+		/* RFC4222 R4: the neighbor has this LSA; a retransmit copy
+		 * still waiting in the paced send queue is now pointless,
+		 * and sending it would re-add the LSA to this list.
+		 */
+		if (nbr->oi && nbr->oi->rec4_gap_pacing)
+			ospf_r4_nbr_dequeue(nbr, ls_rxmt_node);
 
 		if (ls_rxmt_node->lsa_list_entry ==
 		    ospf_lsa_list_first(&nbr->ls_rxmt_list))

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -816,14 +816,9 @@ int ospf_flood_through_interface(struct ospf_interface *oi,
 		zlog_debug("%s: DR/BDR sending upd to int %s (%s)", __func__,
 			   IF_NAME(oi), ospf_get_name(oi->ospf));
 
-	/*  RFC2328  Section 13.3
-	    On non-broadcast networks, separate	Link State Update
-	    packets must be sent, as unicasts, to each adjacent	neighbor
-	    (i.e., those in state Exchange or greater).	 The destination
-	    IP addresses for these packets are the neighbors' IP
-	    addresses. This behavior is extended to P2MP networks which
-	    don't support broadcast. */
-	/* RFC4222 R4: route flooding through per-neighbor paced queues. */
+	/* RFC4222 R4: route flooding through per-neighbor paced queues
+	 * for all interface types.
+	 */
 	if (oi->rec4_gap_pacing) {
 		struct ospf_neighbor *nbr;
 
@@ -839,9 +834,9 @@ int ospf_flood_through_interface(struct ospf_interface *oi,
 				continue;
 
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-				zlog_debug("RFC4222 R4: flood enqueue LSA [Type%d:%pI4] nbr=%pI4 intf=%s",
-					   lsa->data->type, &lsa->data->id, &nbr->router_id,
-					   IF_NAME(oi));
+				zlog_debug("OSPF LSA pacing: interface %s queued Type-%d LSA %pI4 for neighbor %pI4",
+					   IF_NAME(oi), lsa->data->type, &lsa->data->id,
+					   &nbr->router_id);
 
 			/* A superseded instance may still be waiting in the
 			 * paced send queue; drop it. This covers instances
@@ -858,6 +853,13 @@ int ospf_flood_through_interface(struct ospf_interface *oi,
 		return 0;
 	}
 
+	/* RFC2328 Section 13.3:
+	 * On non-broadcast networks, separate Link State Update packets
+	 * must be sent as unicasts to each adjacent neighbor (i.e., those
+	 * in state Exchange or greater). The destination IP addresses for
+	 * these packets are the neighbors' IP addresses. This behavior is
+	 * extended to P2MP networks that do not support broadcast.
+	 */
 	if (OSPF_IF_NON_BROADCAST(oi)) {
 		struct ospf_neighbor *nbr;
 

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -176,7 +176,7 @@ static void ospf_gr_lsa_originate(struct ospf_interface *oi,
 		update = list_new();
 		listnode_add(update, lsa);
 		addr.s_addr = htonl(OSPF_ALLSPFROUTERS);
-		ospf_ls_upd_queue_send(oi, update, addr, true);
+		ospf_ls_upd_queue_send(oi, update, addr, true, NULL);
 		list_delete(&update);
 		ospf_lsa_discard(lsa);
 	} else {

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -293,6 +293,37 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 
 	oi->ospf = ospf;
 
+	/* RFC4222/R5 : Per-interface adjacency pacing */
+	oi->adj_pacing.mode = OSPF_ADJ_PACING_NONE;
+	oi->adj_pacing.static_limit = 0;
+	oi->adj_pacing.in_progress = 0;
+	ospf_adj_pacing_queue_init(&oi->adj_pacing);
+	oi->adj_pacing.dynamic_limit = OSPF_ADJ_DYN_LIMIT_INITIAL;
+	oi->adj_pacing.last_adjust_ms = 0;
+	oi->adj_pacing.high_water = OSPF_ADJ_DYN_HIGH_WATER;
+	oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
+	oi->adj_pacing.t_dyn_adjust = NULL;
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: %s adj_pacing initialized: mode=NONE dynamic_limit=%u H=%u L=%u",
+			   ifp->name, oi->adj_pacing.dynamic_limit, oi->adj_pacing.high_water,
+			   oi->adj_pacing.low_water);
+
+	/* Attach params and apply adjacency pacing config if present */
+	oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);
+	if (!oi->params)
+		oi->params = IF_DEF_PARAMS(ifp);
+	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_mode)) {
+		oi->adj_pacing.mode = oi->params->adj_pacing_mode;
+		oi->adj_pacing.static_limit = oi->params->adj_pacing_static_limit;
+	}
+	/* Apply configured dynamic thresholds if present */
+	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_high_water))
+		oi->adj_pacing.high_water = oi->params->adj_pacing_high_water;
+	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_low_water))
+		oi->adj_pacing.low_water = oi->params->adj_pacing_low_water;
+
+
 	QOBJ_REG(oi, ospf_interface);
 
 	/* If first oi, check per-intf write socket */
@@ -360,6 +391,14 @@ void ospf_if_cleanup(struct ospf_interface *oi)
 
 	oi->crypt_seqnum = 0;
 
+
+	/* Stop any pending LSU drain event before we free its data */
+	event_cancel(&oi->t_ls_upd_event);
+
+	/*RFC4222/R5 Changes*/
+	/* Cancel any pending dynamic adjustment timer */
+	event_cancel(&oi->adj_pacing.t_dyn_adjust);
+
 	/* Empty link state update queue */
 	ospf_ls_upd_queue_empty(oi);
 
@@ -407,11 +446,14 @@ void ospf_if_free(struct ospf_interface *oi)
 	listnode_delete(oi->ospf->oiflist, oi);
 	listnode_delete(oi->area->oiflist, oi);
 
-	event_cancel_event(master, oi);
+	/* RFC4222/R5 : Per-interface adjacency pacing */
+	ospf_adj_pacing_queue_fini(&oi->adj_pacing);
 
 	/* If last oi, close per-interface socket */
 	if (ospf_oi_count(ifp) == 0)
 		ospf_ifp_sock_close(ifp);
+
+	event_cancel_event(master, oi);
 
 	memset(oi, 0, sizeof(*oi));
 	XFREE(MTYPE_OSPF_IF, oi);
@@ -605,6 +647,7 @@ static void ospf_del_if_params(struct interface *ifp,
 	XFREE(MTYPE_OSPF_IF_PARAMS, oip);
 }
 
+
 void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 {
 	struct ospf_if_params *oip;
@@ -684,6 +727,7 @@ struct ospf_if_params *ospf_get_if_params(struct interface *ifp,
 	return rn->info;
 }
 
+
 void ospf_if_update_params(struct interface *ifp, struct in_addr addr)
 {
 	struct route_node *rn;
@@ -693,11 +737,25 @@ void ospf_if_update_params(struct interface *ifp, struct in_addr addr)
 		if ((oi = rn->info) == NULL)
 			continue;
 
-		if (IPV4_ADDR_SAME(&oi->address->u.prefix4, &addr))
+		if (IPV4_ADDR_SAME(&oi->address->u.prefix4, &addr)) {
 			oi->params = ospf_lookup_if_params(
 				ifp, oi->address->u.prefix4);
+		}
 	}
 }
+void ospf_if_update_params_all(struct interface *ifp)
+{
+	struct route_node *rn;
+	struct ospf_interface *oi;
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		if ((oi = rn->info) == NULL)
+			continue;
+
+		oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);
+	}
+}
+
 
 int ospf_if_new_hook(struct interface *ifp)
 {
@@ -724,6 +782,8 @@ int ospf_if_new_hook(struct interface *ifp)
 
 	SET_IF_PARAM(IF_DEF_PARAMS(ifp), priority);
 	IF_DEF_PARAMS(ifp)->priority = OSPF_ROUTER_PRIORITY_DEFAULT;
+	IF_DEF_PARAMS(ifp)->adj_pacing_mode = OSPF_ADJ_PACING_NONE;
+	IF_DEF_PARAMS(ifp)->adj_pacing_static_limit = 0;
 
 	IF_DEF_PARAMS(ifp)->mtu_ignore = OSPF_MTU_IGNORE_DEFAULT;
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -749,7 +749,8 @@ void ospf_if_update_params_all(struct interface *ifp)
 	struct ospf_interface *oi;
 
 	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
-		if ((oi = rn->info) == NULL)
+		oi = rn->info;
+		if (!oi)
 			continue;
 
 		oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -32,6 +32,7 @@
 #include "ospfd/ospf_neighbor.h"
 #include "ospfd/ospf_nsm.h"
 #include "ospfd/ospf_packet.h"
+#include "ospfd/ospf_flood.h"
 #include "ospfd/ospf_abr.h"
 #include "ospfd/ospf_network.h"
 #include "ospfd/ospf_dump.h"
@@ -248,6 +249,74 @@ static void ospf_delete_from_if(struct interface *ifp,
 	route_unlock_node(rn);
 }
 
+/* RFC4222 R4: recompute effective LSA gap pacing settings. */
+static void ospf_rec4_recompute_effective(struct ospf_interface *oi)
+{
+	bool was_pacing = oi->rec4_gap_pacing;
+
+	oi->rec4_gap_pacing = OSPF_IF_PARAM(oi, gap_pacing_enable);
+	oi->rec4_gap_initial_ms = OSPF_IF_PARAM(oi, gap_initial_ms);
+	oi->rec4_gap_min_ms = OSPF_IF_PARAM(oi, gap_min_ms);
+	oi->rec4_gap_max_ms = OSPF_IF_PARAM(oi, gap_max_ms);
+	oi->rec4_gap_factor = OSPF_IF_PARAM(oi, gap_factor);
+	oi->rec4_gap_adjust_int_ms = OSPF_IF_PARAM(oi, gap_adjust_int_ms);
+	oi->rec4_high_water = OSPF_IF_PARAM(oi, gap_high_water);
+	oi->rec4_low_water = OSPF_IF_PARAM(oi, gap_low_water);
+	oi->rec4_max_lsas = OSPF_IF_PARAM(oi, gap_max_lsas);
+
+	if (oi->rec4_gap_min_ms < 1)
+		oi->rec4_gap_min_ms = 1;
+	if (oi->rec4_gap_max_ms < oi->rec4_gap_min_ms)
+		oi->rec4_gap_max_ms = oi->rec4_gap_min_ms;
+	if (oi->rec4_gap_factor < 1)
+		oi->rec4_gap_factor = 1;
+	if (oi->rec4_gap_adjust_int_ms < 1)
+		oi->rec4_gap_adjust_int_ms = 1;
+	if (oi->rec4_low_water > oi->rec4_high_water)
+		oi->rec4_low_water = oi->rec4_high_water;
+
+	/* RFC4222 R4: pacing was disabled at runtime; flush the per-neighbor
+	 * paced queues so no R4 state (queued LSAs, send timers, queue
+	 * back-pointers) lingers while pacing is off. Queued LSAs are first
+	 * handed to the regular retransmission machinery: flood copies that
+	 * were never transmitted have no ls_rxmt entry yet and would
+	 * otherwise be lost until the next LSA refresh.
+	 * ospf_ls_retransmit_add() ignores instances already on the list.
+	 */
+	if (was_pacing && !oi->rec4_gap_pacing && oi->nbrs) {
+		struct route_node *rn;
+
+		for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+			struct ospf_neighbor *nbr = rn->info;
+			struct listnode *qnode;
+			struct ospf_lsa *qlsa;
+
+			if (!nbr || nbr == oi->nbr_self)
+				continue;
+			for (ALL_LIST_ELEMENTS_RO(&nbr->r4_send_queue, qnode, qlsa))
+				ospf_ls_retransmit_add(nbr, qlsa);
+			ospf_r4_nbr_cancel(nbr);
+		}
+	}
+
+	/* RFC4222 R4: propagate the refreshed gap to neighbors that already
+	 * exist on this interface, so enabling/changing pacing on a live
+	 * interface takes effect immediately instead of only applying to
+	 * neighbors created afterward.
+	 */
+	if (oi->nbrs) {
+		struct route_node *rn;
+
+		for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+			struct ospf_neighbor *nbr = rn->info;
+
+			if (!nbr || nbr == oi->nbr_self)
+				continue;
+			ospf_nbr_apply_rec4_params(nbr);
+		}
+	}
+}
+
 struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 				   struct prefix *p)
 {
@@ -322,6 +391,9 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 		oi->adj_pacing.high_water = oi->params->adj_pacing_high_water;
 	if (OSPF_IF_PARAM_CONFIGURED(oi->params, adj_pacing_low_water))
 		oi->adj_pacing.low_water = oi->params->adj_pacing_low_water;
+
+	/* RFC4222 R4: cache effective LSA pacing params for this interface. */
+	ospf_rec4_recompute_effective(oi);
 
 
 	QOBJ_REG(oi, ospf_interface);
@@ -620,6 +692,17 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, dscp_ospf_all);
 	UNSET_IF_PARAM(oip, dscp_low_control);
 
+	/* RFC4222 R4: LSA gap pacing parameters. */
+	UNSET_IF_PARAM(oip, gap_pacing_enable);
+	UNSET_IF_PARAM(oip, gap_initial_ms);
+	UNSET_IF_PARAM(oip, gap_min_ms);
+	UNSET_IF_PARAM(oip, gap_max_ms);
+	UNSET_IF_PARAM(oip, gap_factor);
+	UNSET_IF_PARAM(oip, gap_adjust_int_ms);
+	UNSET_IF_PARAM(oip, gap_high_water);
+	UNSET_IF_PARAM(oip, gap_low_water);
+	UNSET_IF_PARAM(oip, gap_max_lsas);
+
 	oip->auth_crypt = list_new();
 
 	oip->network_lsa_seqnum = htonl(OSPF_INITIAL_SEQUENCE_NUMBER);
@@ -633,6 +716,17 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	/* RFC4222 dscp Priority */
 	oip->dscp_ospf_all = IPTOS_PREC_INTERNETCONTROL >> 2;	 /* upper 6 bits */
 	oip->dscp_low_control = IPTOS_PREC_INTERNETCONTROL >> 2; /* Default feature is off */
+
+	/* RFC4222 R4: defaults used only when LSA pacing is enabled. */
+	oip->gap_pacing_enable = false;
+	oip->gap_initial_ms = OSPF_GAP_INITIAL_MS_DEFAULT;
+	oip->gap_min_ms = OSPF_GAP_MIN_MS_DEFAULT;
+	oip->gap_max_ms = OSPF_GAP_MAX_MS_DEFAULT;
+	oip->gap_factor = OSPF_GAP_FACTOR_DEFAULT;
+	oip->gap_adjust_int_ms = OSPF_GAP_ADJUST_INT_MS_DEFAULT;
+	oip->gap_high_water = OSPF_GAP_HIGH_WATER_DEFAULT;
+	oip->gap_low_water = OSPF_GAP_LOW_WATER_DEFAULT;
+	oip->gap_max_lsas = OSPF_GAP_MAX_LSAS_DEFAULT;
 	return oip;
 }
 
@@ -679,7 +773,17 @@ void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 	    !OSPF_IF_PARAM_CONFIGURED(oip, nbr_filter_name) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, dead_timer_any) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_ospf_all) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_low_control) && listcount(oip->auth_crypt) == 0) {
+	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_low_control) &&
+	    /* RFC4222 R4: keep params while any LSA pacing knob is set. */
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_pacing_enable) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_initial_ms) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_min_ms) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_max_ms) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_factor) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_adjust_int_ms) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_high_water) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_low_water) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, gap_max_lsas) && listcount(oip->auth_crypt) == 0) {
 		ospf_del_if_params(ifp, oip);
 		rn->info = NULL;
 		route_unlock_node(rn);
@@ -740,6 +844,8 @@ void ospf_if_update_params(struct interface *ifp, struct in_addr addr)
 		if (IPV4_ADDR_SAME(&oi->address->u.prefix4, &addr)) {
 			oi->params = ospf_lookup_if_params(
 				ifp, oi->address->u.prefix4);
+			/* RFC4222 R4: refresh effective LSA pacing params. */
+			ospf_rec4_recompute_effective(oi);
 		}
 	}
 }
@@ -754,6 +860,8 @@ void ospf_if_update_params_all(struct interface *ifp)
 			continue;
 
 		oi->params = ospf_lookup_if_params(ifp, oi->address->u.prefix4);
+		/* RFC4222 R4: refresh effective LSA pacing params. */
+		ospf_rec4_recompute_effective(oi);
 	}
 }
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -264,14 +264,16 @@ static void ospf_rec4_recompute_effective(struct ospf_interface *oi)
 	oi->rec4_low_water = OSPF_IF_PARAM(oi, gap_low_water);
 	oi->rec4_max_lsas = OSPF_IF_PARAM(oi, gap_max_lsas);
 
-	if (oi->rec4_gap_min_ms < 1)
-		oi->rec4_gap_min_ms = 1;
+	if (oi->rec4_gap_min_ms < OSPF_GAP_MIN_MS_LOWER_BOUND)
+		oi->rec4_gap_min_ms = OSPF_GAP_MIN_MS_LOWER_BOUND;
 	if (oi->rec4_gap_max_ms < oi->rec4_gap_min_ms)
 		oi->rec4_gap_max_ms = oi->rec4_gap_min_ms;
-	if (oi->rec4_gap_factor < 1)
-		oi->rec4_gap_factor = 1;
-	if (oi->rec4_gap_adjust_int_ms < 1)
-		oi->rec4_gap_adjust_int_ms = 1;
+	if (oi->rec4_gap_factor < OSPF_GAP_FACTOR_LOWER_BOUND)
+		oi->rec4_gap_factor = OSPF_GAP_FACTOR_LOWER_BOUND;
+	if (oi->rec4_gap_adjust_int_ms < OSPF_GAP_ADJUST_INT_MS_LOWER_BOUND)
+		oi->rec4_gap_adjust_int_ms = OSPF_GAP_ADJUST_INT_MS_LOWER_BOUND;
+	if (oi->rec4_max_lsas < OSPF_GAP_MAX_LSAS_LOWER_BOUND)
+		oi->rec4_max_lsas = OSPF_GAP_MAX_LSAS_LOWER_BOUND;
 	if (oi->rec4_low_water > oi->rec4_high_water)
 		oi->rec4_low_water = oi->rec4_high_water;
 
@@ -374,7 +376,7 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 	oi->adj_pacing.t_dyn_adjust = NULL;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: %s adj_pacing initialized: mode=NONE dynamic_limit=%u H=%u L=%u",
+		zlog_debug("OSPF adjacency pacing: interface %s initialized disabled (dynamic initial-limit=%u high-water=%u low-water=%u)",
 			   ifp->name, oi->adj_pacing.dynamic_limit, oi->adj_pacing.high_water,
 			   oi->adj_pacing.low_water);
 

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -197,8 +197,8 @@ enum ospf_adj_pacing_mode {
 /* RFC4222/R5 implementation */
 struct ospf_adj_pacing {
 	enum ospf_adj_pacing_mode mode;
-	uint16_t static_limit; /*N for static mode*/
-	uint16_t in_progress;  /* neighbors in ExStart/Exchange/Loading on this oi*/
+	uint16_t static_limit;		     /*N for static mode*/
+	uint16_t in_progress;		     /* neighbors in ExStart/Exchange/Loading on this oi*/
 	struct ospf_pacing_queue_head queue; /* FCFS queue of struct ospf_neighbor */
 
 	/* Dynamic pacing state */

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -14,6 +14,7 @@
 #include "ospfd/ospf_packet.h"
 #include "ospfd/ospf_spf.h"
 #include <ospfd/ospf_flood.h>
+#include <ospfd/ospf_nsm.h>
 
 #define IF_OSPF_IF_INFO(I) ((struct ospf_if_info *)((I)->info))
 #define IF_DEF_PARAMS(I) (IF_OSPF_IF_INFO (I)->def_params)
@@ -55,6 +56,14 @@ struct ospf_if_params {
 							join multicast groups)
 							*/
 	DECLARE_IF_PARAM(uint8_t, priority); /* OSPF Interface priority */
+	/* RFC4222/R5: adjacency pacing configuration */
+	DECLARE_IF_PARAM(uint8_t, adj_pacing_mode);
+	DECLARE_IF_PARAM(uint16_t, adj_pacing_static_limit);
+
+	/* RFC4222/R5: Add dynamic pacing thresholds */
+	DECLARE_IF_PARAM(uint32_t, adj_pacing_high_water);
+	DECLARE_IF_PARAM(uint32_t, adj_pacing_low_water);
+
 	/* Enable OSPF on this interface with area if_area */
 	DECLARE_IF_PARAM(struct in_addr, if_area);
 	uint32_t if_area_id_fmt;
@@ -168,6 +177,36 @@ struct ospf_vl_data {
 	struct vertex_nexthop nexthop; /* Nexthop router and oi to use */
 	struct in_addr peer_addr;      /* Address used to reach the peer */
 	uint8_t flags;
+};
+
+/* RFC4222/R5 : Per-interface adjacency pacing */
+enum ospf_adj_pacing_mode {
+	OSPF_ADJ_PACING_NONE = 0, /* inherit router default or disabled */
+	OSPF_ADJ_PACING_STATIC,	  /* fixed N*/
+	OSPF_ADJ_PACING_DYNAMIC,  /* adaptive*/
+};
+
+/* RFC4222/R5: Dynamic adjacency pacing defaults */
+#define OSPF_ADJ_DYN_LIMIT_INITIAL 1	/* start conservative */
+#define OSPF_ADJ_DYN_LIMIT_MAX	   50	/* upper bound */
+#define OSPF_ADJ_DYN_FACTOR	   2	/* F for divide when congested */
+#define OSPF_ADJ_DYN_ADJUST_INT_MS 1000 /* min ms between adjustments (1 sec to slow ramp-up) */
+#define OSPF_ADJ_DYN_HIGH_WATER	   100	/* default H threshold */
+#define OSPF_ADJ_DYN_LOW_WATER	   2	/* default L threshold */
+
+/* RFC4222/R5 implementation */
+struct ospf_adj_pacing {
+	enum ospf_adj_pacing_mode mode;
+	uint16_t static_limit; /*N for static mode*/
+	uint16_t in_progress;  /* neighbors in ExStart/Exchange/Loading on this oi*/
+	struct ospf_pacing_queue_head queue; /* FCFS queue of struct ospf_neighbor */
+
+	/* Dynamic pacing state */
+	uint16_t dynamic_limit;	    /* current computed limit (starts at 1) */
+	uint64_t last_adjust_ms;    /* timestamp of last limit adjustment */
+	uint32_t high_water;	    /* H: upper threshold for U(t) */
+	uint32_t low_water;	    /* L: lower threshold for U(t) */
+	struct event *t_dyn_adjust; /* timer to schedule deferred adjustment */
 };
 
 
@@ -295,6 +334,9 @@ struct ospf_interface {
 	struct event *t_ls_upd_event;	 /* event */
 	struct event *t_opaque_lsa_self; /* Type-9 Opaque-LSAs */
 
+	/* RFC4222/R5 : Per-interface adjacency pacing */
+	struct ospf_adj_pacing adj_pacing;
+
 	int on_write_q;
 
 	/* Statistics fields. */
@@ -354,6 +396,8 @@ extern struct ospf_if_params *ospf_get_if_params(struct interface *ifp,
 						 struct in_addr addr);
 extern void ospf_free_if_params(struct interface *ifp, struct in_addr addr);
 extern void ospf_if_update_params(struct interface *ifp, struct in_addr addr);
+
+extern void ospf_if_update_params_all(struct interface *ifp);
 
 extern int ospf_if_new_hook(struct interface *ifp);
 extern void ospf_if_init(void);

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -42,6 +42,16 @@
 #define UNSET_IF_PARAM(S, P) ((S)->P##__config) = 0
 #define SET_IF_PARAM(S, P) ((S)->P##__config) = 1
 
+/* RFC4222 R4 defaults (milliseconds unless noted). */
+#define OSPF_GAP_INITIAL_MS_DEFAULT    20
+#define OSPF_GAP_MIN_MS_DEFAULT	       20
+#define OSPF_GAP_MAX_MS_DEFAULT	       1000
+#define OSPF_GAP_FACTOR_DEFAULT	       2
+#define OSPF_GAP_ADJUST_INT_MS_DEFAULT 1000
+#define OSPF_GAP_HIGH_WATER_DEFAULT    100
+#define OSPF_GAP_LOW_WATER_DEFAULT     2
+#define OSPF_GAP_MAX_LSAS_DEFAULT      1
+
 struct ospf_if_params {
 	DECLARE_IF_PARAM(uint32_t, transmit_delay); /* Interface Transmission Delay */
 	DECLARE_IF_PARAM(uint32_t,
@@ -147,6 +157,17 @@ struct ospf_if_params {
 	/* RFC4222 Priority markings */
 	DECLARE_IF_PARAM(uint8_t, dscp_ospf_all);    /* 0–63 */
 	DECLARE_IF_PARAM(uint8_t, dscp_low_control); /* 0–63 */
+
+	/* RFC4222 R4: LSA gap pacing configuration. */
+	DECLARE_IF_PARAM(bool, gap_pacing_enable);
+	DECLARE_IF_PARAM(uint32_t, gap_initial_ms);
+	DECLARE_IF_PARAM(uint32_t, gap_min_ms);
+	DECLARE_IF_PARAM(uint32_t, gap_max_ms);
+	DECLARE_IF_PARAM(uint32_t, gap_factor);
+	DECLARE_IF_PARAM(uint32_t, gap_adjust_int_ms);
+	DECLARE_IF_PARAM(uint32_t, gap_high_water);
+	DECLARE_IF_PARAM(uint32_t, gap_low_water);
+	DECLARE_IF_PARAM(uint32_t, gap_max_lsas);
 };
 
 enum { MEMBER_ALLROUTERS = 0,
@@ -336,6 +357,17 @@ struct ospf_interface {
 
 	/* RFC4222/R5 : Per-interface adjacency pacing */
 	struct ospf_adj_pacing adj_pacing;
+
+	/* RFC4222 R4: effective LSA gap pacing state. */
+	bool rec4_gap_pacing;
+	uint32_t rec4_gap_initial_ms;
+	uint32_t rec4_gap_min_ms;
+	uint32_t rec4_gap_max_ms;
+	uint32_t rec4_gap_factor;
+	uint32_t rec4_gap_adjust_int_ms;
+	uint32_t rec4_high_water;
+	uint32_t rec4_low_water;
+	uint32_t rec4_max_lsas;
 
 	int on_write_q;
 

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -52,6 +52,12 @@
 #define OSPF_GAP_LOW_WATER_DEFAULT     2
 #define OSPF_GAP_MAX_LSAS_DEFAULT      1
 
+/* RFC4222 R4 lower bounds. */
+#define OSPF_GAP_MIN_MS_LOWER_BOUND	   1U
+#define OSPF_GAP_FACTOR_LOWER_BOUND	   1U
+#define OSPF_GAP_ADJUST_INT_MS_LOWER_BOUND 1U
+#define OSPF_GAP_MAX_LSAS_LOWER_BOUND	   1U
+
 struct ospf_if_params {
 	DECLARE_IF_PARAM(uint32_t, transmit_delay); /* Interface Transmission Delay */
 	DECLARE_IF_PARAM(uint32_t,

--- a/ospfd/ospf_lsdb.c
+++ b/ospfd/ospf_lsdb.c
@@ -44,6 +44,7 @@ ospf_lsdb_linked_node_create(route_table_delegate_t *delegate,
 		       sizeof(struct ospf_lsdb_linked_node));
 
 	node->counted_sent = false;
+	node->r4_qnode = NULL;
 
 	return (struct route_node *)node;
 }

--- a/ospfd/ospf_lsdb.c
+++ b/ospfd/ospf_lsdb.c
@@ -43,6 +43,8 @@ ospf_lsdb_linked_node_create(route_table_delegate_t *delegate,
 	node = XCALLOC(MTYPE_OSPF_LSDB_NODE,
 		       sizeof(struct ospf_lsdb_linked_node));
 
+	node->counted_sent = false;
+
 	return (struct route_node *)node;
 }
 

--- a/ospfd/ospf_lsdb.h
+++ b/ospfd/ospf_lsdb.h
@@ -55,6 +55,9 @@ struct ospf_lsdb_linked_node {
 	 * retransmission list.
 	 */
 	struct ospf_lsa_list_entry *lsa_list_entry;
+
+	/* Track if this LSA was sent and counted in ls_rxmt_unacked */
+	bool counted_sent;
 };
 
 /* OSPF LSDB related functions. */

--- a/ospfd/ospf_lsdb.h
+++ b/ospfd/ospf_lsdb.h
@@ -58,6 +58,12 @@ struct ospf_lsdb_linked_node {
 
 	/* Track if this LSA was sent and counted in ls_rxmt_unacked */
 	bool counted_sent;
+
+	/* RFC4222 R4: node in the neighbor's r4_send_queue holding this
+	 * LSA's queued copy, or NULL if no copy is currently queued.
+	 * Only maintained while LSA gap pacing is enabled.
+	 */
+	struct listnode *r4_qnode;
 };
 
 /* OSPF LSDB related functions. */

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -95,6 +95,8 @@ struct ospf_neighbor *ospf_nbr_new(struct ospf_interface *oi)
 	nbr->gr_helper_info.helper_exit_reason = OSPF_GR_HELPER_EXIT_NONE;
 	nbr->gr_helper_info.gr_restart_reason = OSPF_GR_UNKNOWN_RESTART;
 
+	nbr->ls_rxmt_unacked = 0;
+
 	nbr->dead_timer_resets = 0; /* rfc 4222 rec 2 */
 	return nbr;
 }

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -52,6 +52,28 @@ static void ospf_nbr_key(struct ospf_interface *oi, struct ospf_neighbor *nbr,
 	return;
 }
 
+/* RFC4222 R4: initialize per-neighbor gap from interface config. */
+void ospf_nbr_apply_rec4_params(struct ospf_neighbor *nbr)
+{
+	struct ospf_interface *oi;
+
+	if (!nbr)
+		return;
+	oi = nbr->oi;
+	if (!oi)
+		return;
+	if (!oi->rec4_gap_pacing)
+		return;
+
+	nbr->lsu_gap_ms = oi->rec4_gap_initial_ms;
+	if (nbr->lsu_gap_ms < oi->rec4_gap_min_ms)
+		nbr->lsu_gap_ms = oi->rec4_gap_min_ms;
+	if (nbr->lsu_gap_ms > oi->rec4_gap_max_ms)
+		nbr->lsu_gap_ms = oi->rec4_gap_max_ms;
+	if (nbr->next_send_ms < ospf_now_ms())
+		nbr->next_send_ms = ospf_now_ms();
+}
+
 struct ospf_neighbor *ospf_nbr_new(struct ospf_interface *oi)
 {
 	struct ospf_neighbor *nbr;
@@ -97,12 +119,22 @@ struct ospf_neighbor *ospf_nbr_new(struct ospf_interface *oi)
 
 	nbr->ls_rxmt_unacked = 0;
 
+	/* RFC4222 R4: initialize per-neighbor paced LSU queue. */
+	ospf_nbr_apply_rec4_params(nbr);
+	ospf_r4_nbr_init(nbr);
+
 	nbr->dead_timer_resets = 0; /* rfc 4222 rec 2 */
 	return nbr;
 }
 
 void ospf_nbr_free(struct ospf_neighbor *nbr)
 {
+	/* RFC4222 R4: cancel pacing timer and drain queued LSAs first; the
+	 * queue cleanup clears back-pointers held in ls_rxmt nodes, so it
+	 * must run before the ls_rxmt LSDB is torn down below.
+	 */
+	ospf_r4_nbr_cancel(nbr);
+
 	/* Free DB summary list. */
 	if (ospf_db_summary_count(nbr))
 		ospf_db_summary_clear(nbr);

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -10,6 +10,7 @@
 #include <ospfd/ospf_gr.h>
 #include <ospfd/ospf_packet.h>
 #include <ospfd/ospf_flood.h>
+#include <ospfd/ospf_nsm.h>
 
 /* Neighbor Data Structure */
 struct ospf_neighbor {
@@ -70,8 +71,8 @@ struct ospf_neighbor {
 
 	/* Statistics */
 	struct timeval ts_last_progress; /* last advance of NSM            */
-	struct timeval ts_last_regress;  /* last regressive NSM change     */
-	const char *last_regress_str;    /* Event which last regressed NSM */
+	struct timeval ts_last_regress;	 /* last regressive NSM change     */
+	const char *last_regress_str;	 /* Event which last regressed NSM */
 	uint32_t state_change;		 /* NSM state change counter       */
 	uint32_t ls_rxmt_lsa;		 /* Number of LSAs retransmitted.  */
 	uint64_t dead_timer_resets;	 /* Number of times dead-timer was reset RFC4222 rec 2*/
@@ -81,6 +82,11 @@ struct ospf_neighbor {
 
 	/* ospf graceful restart HELPER info */
 	struct ospf_helper_info gr_helper_info;
+
+	uint32_t ls_rxmt_unacked; /* count of sent but unacked retransmit LSAs */
+
+	/* RFC4222/R5: linkage for per-interface adjacency pacing queue */
+	struct ospf_pacing_queue_item pacing_link;
 };
 
 /* Macros. */

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -83,6 +83,13 @@ struct ospf_neighbor {
 	/* ospf graceful restart HELPER info */
 	struct ospf_helper_info gr_helper_info;
 
+	/* RFC4222 R4: per-neighbor LSA gap pacing runtime. */
+	uint32_t lsu_gap_ms;
+	uint64_t next_send_ms;
+	uint64_t gap_last_change_ms;
+	struct list r4_send_queue;
+	struct event *t_r4_send;
+
 	uint32_t ls_rxmt_unacked; /* count of sent but unacked retransmit LSAs */
 
 	/* RFC4222/R5: linkage for per-interface adjacency pacing queue */
@@ -113,4 +120,6 @@ extern struct ospf_neighbor *ospf_nbr_lookup_by_addr(struct route_table *nbrs,
 extern struct ospf_neighbor *ospf_nbr_lookup_by_routerid(struct route_table *nbrs,
 							 struct in_addr *id);
 extern void ospf_renegotiate_optional_capabilities(struct ospf *top);
+/* RFC4222 R4: re-apply interface LSA pacing gap to an existing neighbor. */
+extern void ospf_nbr_apply_rec4_params(struct ospf_neighbor *nbr);
 #endif /* _ZEBRA_OSPF_NEIGHBOR_H */

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -293,9 +293,7 @@ void ospf_adj_pacing_kick(struct ospf_interface *oi)
 	 * waiters get NSM_AdjOK scheduled, then N-limit of them fail the pacing
 	 * check in nsm_adj_ok and are re-enqueued, repeating on every completion.
 	 */
-	available = (oi->adj_pacing.in_progress < limit)
-			    ? (limit - oi->adj_pacing.in_progress)
-			    : 0;
+	available = (oi->adj_pacing.in_progress < limit) ? (limit - oi->adj_pacing.in_progress) : 0;
 
 	while (available > 0) {
 		nbr = ospf_adj_pacing_dequeue(oi);

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -63,7 +63,7 @@ void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
 	struct ospf_neighbor *nbr;
 	int count = 0;
 
-	frr_each_safe(ospf_pacing_queue, &oi->adj_pacing.queue, nbr) {
+	frr_each_safe (ospf_pacing_queue, &oi->adj_pacing.queue, nbr) {
 		ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
 		if (nbr->state == NSM_TwoWay)
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_AdjOK);
@@ -71,8 +71,8 @@ void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
 	}
 
 	if (count > 0 && IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)",
-			   IF_NAME(oi), count);
+		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)", IF_NAME(oi),
+			   count);
 }
 
 static void nsm_clear_adj(struct ospf_neighbor *);

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -11,6 +11,7 @@
 #include "memory.h"
 #include "hash.h"
 #include "linklist.h"
+#include "typesafe.h"
 #include "prefix.h"
 #include "if.h"
 #include "table.h"
@@ -42,7 +43,271 @@ DEFINE_HOOK(ospf_nsm_change,
 	    (struct ospf_neighbor * on, int state, int oldstate),
 	    (on, state, oldstate));
 
+/* RFC4222/R5: struct ospf_neighbor is fully defined here so DECLARE_LIST
+ * can access pacing_link.  Callers outside this file use the wrappers below.
+ */
+DECLARE_LIST(ospf_pacing_queue, struct ospf_neighbor, pacing_link);
+
+void ospf_adj_pacing_queue_init(struct ospf_adj_pacing *p)
+{
+	ospf_pacing_queue_init(&p->queue);
+}
+
+void ospf_adj_pacing_queue_fini(struct ospf_adj_pacing *p)
+{
+	ospf_pacing_queue_fini(&p->queue);
+}
+
+void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
+{
+	struct ospf_neighbor *nbr;
+	int count = 0;
+
+	frr_each_safe(ospf_pacing_queue, &oi->adj_pacing.queue, nbr) {
+		ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
+		if (nbr->state == NSM_TwoWay)
+			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_AdjOK);
+		count++;
+	}
+
+	if (count > 0 && IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)",
+			   IF_NAME(oi), count);
+}
+
 static void nsm_clear_adj(struct ospf_neighbor *);
+
+/*RFC4222/R5 changes: Track adjacency formation states for pacing*/
+static bool ospf_adj_in_progress_state(int state)
+{
+	return state == NSM_ExStart || state == NSM_Exchange || state == NSM_Loading;
+}
+
+
+/*RFC422/R5 changes: check if interface pacing is enabled */
+static bool ospf_adj_pacing_enabled(struct ospf_interface *oi)
+{
+	return oi->adj_pacing.mode != OSPF_ADJ_PACING_NONE;
+}
+
+/*RFC4222/R5 changes: Compute total unacked LSAs across all neighbors on interface */
+static uint32_t ospf_adj_total_unacked(struct ospf_interface *oi)
+{
+	struct route_node *rn;
+	uint32_t total = 0;
+	uint32_t nbr_count = 0;
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		struct ospf_neighbor *nbr = rn->info;
+
+		if (nbr && nbr != oi->nbr_self) {
+			total += nbr->ls_rxmt_unacked;
+			nbr_count++;
+		}
+	}
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS) && total > 0)
+		zlog_debug("R5-DYN: %s total_unacked=%u across %u neighbors", IF_NAME(oi), total,
+			   nbr_count);
+
+	return total;
+}
+
+/*RFC4222/R5 changes: Timer callback for deferred dynamic adjustment */
+static void ospf_adj_dyn_adjust_timer(struct event *t)
+{
+	struct ospf_interface *oi = EVENT_ARG(t);
+	uint64_t now_ms, elapsed_ms;
+	uint32_t U, H, L;
+	uint16_t limit, new_limit;
+
+	oi->adj_pacing.t_dyn_adjust = NULL;
+
+	if (oi->adj_pacing.mode != OSPF_ADJ_PACING_DYNAMIC)
+		return;
+
+	now_ms = ospf_now_ms();
+	elapsed_ms = now_ms - oi->adj_pacing.last_adjust_ms;
+
+	/* Rate limit: skip if adjusted too recently */
+	if (elapsed_ms < OSPF_ADJ_DYN_ADJUST_INT_MS) {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s rate-limited (elapsed=%" PRIu64 "ms < %ums)",
+				   IF_NAME(oi), elapsed_ms, OSPF_ADJ_DYN_ADJUST_INT_MS);
+		return;
+	}
+
+	/* Compute U(t) - total unacked LSAs on this interface */
+	U = ospf_adj_total_unacked(oi);
+
+	/* Use dynamic pacing thresholds (H and L) */
+	H = oi->adj_pacing.high_water;
+	L = oi->adj_pacing.low_water;
+
+	limit = oi->adj_pacing.dynamic_limit;
+	new_limit = limit;
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5-DYN: %s checking: U=%u H=%u L=%u limit=%u in_progress=%u",
+			   IF_NAME(oi), U, H, L, limit, oi->adj_pacing.in_progress);
+
+	if (U > H) {
+		/* Congestion: decrease limit */
+		new_limit = (limit > OSPF_ADJ_DYN_FACTOR) ? (limit / OSPF_ADJ_DYN_FACTOR) : 1;
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s CONGESTION detected U(%u) > H(%u), decreasing limit %u->%u",
+				   IF_NAME(oi), U, H, limit, new_limit);
+	} else if (U < L) {
+		/* Uncongested: increase limit */
+		new_limit = (limit < OSPF_ADJ_DYN_LIMIT_MAX) ? (limit + 1) : OSPF_ADJ_DYN_LIMIT_MAX;
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s UNCONGESTED U(%u) < L(%u), increasing limit %u->%u",
+				   IF_NAME(oi), U, L, limit, new_limit);
+	} else {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s HYSTERESIS L(%u) <= U(%u) <= H(%u), no change",
+				   IF_NAME(oi), L, U, H);
+	}
+
+	if (new_limit != limit) {
+		oi->adj_pacing.dynamic_limit = new_limit;
+		oi->adj_pacing.last_adjust_ms = now_ms;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s ADJUSTED limit %u->%u U=%u H=%u L=%u elapsed=%" PRIu64
+				   "ms",
+				   IF_NAME(oi), limit, new_limit, U, H, L, elapsed_ms);
+
+		/* Limit increased: kick queue to fill newly opened slots */
+		if (new_limit > limit && oi->adj_pacing.in_progress < new_limit) {
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("R5-DYN: %s limit increased %u->%u, kicking queued adjacencies",
+					   IF_NAME(oi), limit, new_limit);
+			ospf_adj_pacing_kick(oi);
+		}
+	}
+}
+
+/*RFC4222/R5 changes: Schedule dynamic adjustment (deferred to avoid packet processing interference) */
+void ospf_adj_dyn_adjust(struct ospf_interface *oi)
+{
+	if (oi->adj_pacing.mode != OSPF_ADJ_PACING_DYNAMIC)
+		return;
+
+	/* Schedule if not already scheduled */
+	if (!oi->adj_pacing.t_dyn_adjust) {
+		event_add_timer_msec(master, ospf_adj_dyn_adjust_timer, oi, 0,
+				     &oi->adj_pacing.t_dyn_adjust);
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s scheduled deferred adjustment", IF_NAME(oi));
+	}
+}
+
+/*RFC4222/R5 changes : Determine pacing limit for this interface (static or dynamic).*/
+static uint16_t ospf_adj_pacing_limit(struct ospf_interface *oi)
+{
+	if (oi->adj_pacing.mode == OSPF_ADJ_PACING_STATIC)
+		return oi->adj_pacing.static_limit;
+
+	if (oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC) {
+		/* Recompute before returning */
+		ospf_adj_dyn_adjust(oi);
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5-DYN: %s returning dynamic_limit=%u", IF_NAME(oi),
+				   oi->adj_pacing.dynamic_limit);
+		return oi->adj_pacing.dynamic_limit;
+	}
+	return 0;
+}
+
+/*RFC4222/R5 changes: can we start another adjacency on this interface? */
+static bool ospf_adj_pacing_allow(struct ospf_interface *oi)
+{
+	/* Returns true if below the per-interface limit or pacing disabled.  */
+	uint16_t limit;
+
+	if (!ospf_adj_pacing_enabled(oi))
+		return true;
+
+	limit = ospf_adj_pacing_limit(oi);
+	if (limit == 0)
+		return true;
+
+	return (oi->adj_pacing.in_progress < limit);
+}
+
+/* RFC4222/R5: Remove a neighbor from the per-interface pacing queue. */
+static void ospf_adj_pacing_remove(struct ospf_neighbor *nbr)
+{
+	struct ospf_interface *oi = nbr->oi;
+
+	if (ospf_pacing_queue_member(&oi->adj_pacing.queue, nbr))
+		ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
+}
+
+/* RFC4222/R5: Enqueue a neighbor to wait for an available pacing slot. */
+static void ospf_adj_pacing_enqueue(struct ospf_neighbor *nbr)
+{
+	struct ospf_interface *oi = nbr->oi;
+
+	if (!ospf_adj_pacing_enabled(oi))
+		return;
+	if (ospf_pacing_queue_member(&oi->adj_pacing.queue, nbr))
+		return;
+
+	ospf_pacing_queue_add_tail(&oi->adj_pacing.queue, nbr);
+}
+
+/* RFC4222/R5: Pop the next queued neighbor for this interface. */
+static struct ospf_neighbor *ospf_adj_pacing_dequeue(struct ospf_interface *oi)
+{
+	struct ospf_neighbor *nbr;
+
+	nbr = ospf_pacing_queue_first(&oi->adj_pacing.queue);
+	if (!nbr)
+		return NULL;
+
+	ospf_pacing_queue_del(&oi->adj_pacing.queue, nbr);
+	return nbr;
+}
+
+/*RFC4222/R5 changes: start queued adjacencies when a pacing slot opens*/
+void ospf_adj_pacing_kick(struct ospf_interface *oi)
+{
+	struct ospf_neighbor *nbr;
+	uint16_t limit, available;
+
+	if (!ospf_adj_pacing_enabled(oi))
+		return;
+
+	limit = ospf_adj_pacing_limit(oi);
+	if (limit == 0)
+		return;
+
+	/*
+	 * Compute how many slots are open right now.  in_progress is only
+	 * incremented inside ospf_nsm_change_state — i.e. after the scheduled
+	 * NSM_AdjOK event actually fires.  If we loop on ospf_adj_pacing_allow()
+	 * instead, the check always reads the pre-event value of in_progress and
+	 * drains the entire queue every kick, creating O(N²) churn: all N
+	 * waiters get NSM_AdjOK scheduled, then N-limit of them fail the pacing
+	 * check in nsm_adj_ok and are re-enqueued, repeating on every completion.
+	 */
+	available = (oi->adj_pacing.in_progress < limit)
+			    ? (limit - oi->adj_pacing.in_progress)
+			    : 0;
+
+	while (available > 0) {
+		nbr = ospf_adj_pacing_dequeue(oi);
+		if (!nbr)
+			break;
+		if (nbr->state != NSM_TwoWay)
+			continue;
+		available--;
+		OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_AdjOK);
+	}
+}
+
 
 /* OSPF NSM Timer functions. */
 static void ospf_inactivity_timer(struct event *event)
@@ -200,9 +465,27 @@ static int nsm_start(struct ospf_neighbor *nbr)
 	return 0;
 }
 
+/*RFC4222/R5 changes: If adjacency is needed but interface pacing blocks it, queue neighbor */
 static int nsm_twoway_received(struct ospf_neighbor *nbr)
 {
 	int adj = nsm_should_adj(nbr);
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: TwoWay recv nbr=%pI4 adj=%d", &nbr->router_id, adj);
+
+	if (adj && !ospf_adj_pacing_allow(nbr->oi)) {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: throttling nbr=%pI4", &nbr->router_id);
+		ospf_adj_pacing_enqueue(nbr);
+		return NSM_TwoWay;
+	}
+	/* if adjacency can proceed, ensure neighbor is nto left queued*/
+	if (adj)
+		ospf_adj_pacing_remove(nbr);
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: TwoWay -> %s nbr=%pI4", adj ? "ExStart" : "TwoWay",
+			   &nbr->router_id);
 
 	/* Send proactive ARP requests */
 	if (adj)
@@ -335,13 +618,23 @@ static int nsm_exchange_done(struct ospf_neighbor *nbr)
 	return NSM_Loading;
 }
 
+
+/* RFC4222/R5 changes: apply per-interface pacing before moving to ExStart*/
 static int nsm_adj_ok(struct ospf_neighbor *nbr)
 {
 	int next_state = nbr->state;
 	int adj = nsm_should_adj(nbr);
 
 	if (nbr->state == NSM_TwoWay && adj == 1) {
+		if (!ospf_adj_pacing_allow(nbr->oi)) {
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("R5: AdjOK throttling nbr=%pI4", &nbr->router_id);
+			ospf_adj_pacing_enqueue(nbr);
+			return NSM_TwoWay;
+		}
+
 		next_state = NSM_ExStart;
+		ospf_adj_pacing_remove(nbr);
 
 		/* Send proactive ARP requests */
 		ospf_proactively_arp(nbr);
@@ -353,6 +646,10 @@ static int nsm_adj_ok(struct ospf_neighbor *nbr)
 		 * per RFC2328 10.4.
 		 */
 		next_state = NSM_ExStart;
+
+	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+		zlog_debug("R5: AdjOK next_state=%s nbr=%pI4",
+			   lookup_msg(ospf_nsm_state_msg, next_state, NULL), &nbr->router_id);
 
 	return next_state;
 }
@@ -379,11 +676,15 @@ static void nsm_clear_adj(struct ospf_neighbor *nbr)
 		UNSET_FLAG(nbr->options, OSPF_OPTION_O);
 }
 
+/*RFC4222/R5 changes: remove neighbor from per-interface packing queue when killed*/
 static int nsm_kill_nbr(struct ospf_neighbor *nbr)
 {
 	struct ospf_interface *oi = nbr->oi;
 	struct ospf_neighbor *on;
 	struct route_node *rn;
+
+	/* R5 changes*/
+	ospf_adj_pacing_remove(nbr);
 
 	/* killing nbr_self is invalid */
 	if (nbr == nbr->oi->nbr_self) {
@@ -675,6 +976,23 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 
 	/* Statistics. */
 	nbr->state_change++;
+
+	/* R5: track per-interface in-progress adjacencies */
+	if (!ospf_adj_in_progress_state(old_state) && ospf_adj_in_progress_state(state)) {
+		oi->adj_pacing.in_progress++;
+	} else if (ospf_adj_in_progress_state(old_state) && !ospf_adj_in_progress_state(state)) {
+		if (oi->adj_pacing.in_progress > 0)
+			oi->adj_pacing.in_progress--;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s in-progress=%u limit=%u", IF_NAME(oi),
+				   oi->adj_pacing.in_progress, ospf_adj_pacing_limit(oi));
+
+		/* Only kick if pacing is enabled */
+		if (ospf_adj_pacing_enabled(oi))
+			ospf_adj_pacing_kick(oi);
+	}
+
 
 	if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
 		vl_area = ospf_area_lookup_by_area_id(oi->ospf,

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -71,8 +71,8 @@ void ospf_adj_pacing_queue_flush(struct ospf_interface *oi)
 	}
 
 	if (count > 0 && IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: %s flushed %d queued neighbors (sent NSM_AdjOK)", IF_NAME(oi),
-			   count);
+		zlog_debug("OSPF adjacency pacing: interface %s released %d queued neighbors (scheduled AdjOK)",
+			   IF_NAME(oi), count);
 }
 
 static void nsm_clear_adj(struct ospf_neighbor *);
@@ -107,8 +107,8 @@ static uint32_t ospf_adj_total_unacked(struct ospf_interface *oi)
 	}
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS) && total > 0)
-		zlog_debug("R5-DYN: %s total_unacked=%u across %u neighbors", IF_NAME(oi), total,
-			   nbr_count);
+		zlog_debug("OSPF dynamic adjacency pacing: interface %s unacknowledged-LSAs=%u across %u neighbors",
+			   IF_NAME(oi), total, nbr_count);
 
 	return total;
 }
@@ -132,7 +132,8 @@ static void ospf_adj_dyn_adjust_timer(struct event *t)
 	/* Rate limit: skip if adjusted too recently */
 	if (elapsed_ms < OSPF_ADJ_DYN_ADJUST_INT_MS) {
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s rate-limited (elapsed=%" PRIu64 "ms < %ums)",
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s adjustment deferred (elapsed=%" PRIu64
+				   "ms minimum=%ums)",
 				   IF_NAME(oi), elapsed_ms, OSPF_ADJ_DYN_ADJUST_INT_MS);
 		return;
 	}
@@ -148,24 +149,24 @@ static void ospf_adj_dyn_adjust_timer(struct event *t)
 	new_limit = limit;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5-DYN: %s checking: U=%u H=%u L=%u limit=%u in_progress=%u",
+		zlog_debug("OSPF dynamic adjacency pacing: interface %s evaluating congestion (unacked=%u high-water=%u low-water=%u limit=%u in-progress=%u)",
 			   IF_NAME(oi), U, H, L, limit, oi->adj_pacing.in_progress);
 
 	if (U > H) {
 		/* Congestion: decrease limit */
 		new_limit = (limit > OSPF_ADJ_DYN_FACTOR) ? (limit / OSPF_ADJ_DYN_FACTOR) : 1;
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s CONGESTION detected U(%u) > H(%u), decreasing limit %u->%u",
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s CONGESTION detected (unacked=%u high-water=%u); decreasing limit %u->%u",
 				   IF_NAME(oi), U, H, limit, new_limit);
 	} else if (U < L) {
 		/* Uncongested: increase limit */
 		new_limit = (limit < OSPF_ADJ_DYN_LIMIT_MAX) ? (limit + 1) : OSPF_ADJ_DYN_LIMIT_MAX;
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s UNCONGESTED U(%u) < L(%u), increasing limit %u->%u",
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s congestion cleared (unacked=%u low-water=%u); increasing limit %u->%u",
 				   IF_NAME(oi), U, L, limit, new_limit);
 	} else {
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s HYSTERESIS L(%u) <= U(%u) <= H(%u), no change",
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s within hysteresis range (low-water=%u unacked=%u high-water=%u); limit unchanged",
 				   IF_NAME(oi), L, U, H);
 	}
 
@@ -174,14 +175,14 @@ static void ospf_adj_dyn_adjust_timer(struct event *t)
 		oi->adj_pacing.last_adjust_ms = now_ms;
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s ADJUSTED limit %u->%u U=%u H=%u L=%u elapsed=%" PRIu64
-				   "ms",
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s adjusted limit %u->%u (unacked=%u high-water=%u low-water=%u elapsed=%" PRIu64
+				   "ms)",
 				   IF_NAME(oi), limit, new_limit, U, H, L, elapsed_ms);
 
 		/* Limit increased: kick queue to fill newly opened slots */
 		if (new_limit > limit && oi->adj_pacing.in_progress < new_limit) {
 			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-				zlog_debug("R5-DYN: %s limit increased %u->%u, kicking queued adjacencies",
+				zlog_debug("OSPF dynamic adjacency pacing: interface %s increased limit %u->%u; releasing queued adjacencies",
 					   IF_NAME(oi), limit, new_limit);
 			ospf_adj_pacing_kick(oi);
 		}
@@ -199,7 +200,8 @@ void ospf_adj_dyn_adjust(struct ospf_interface *oi)
 		event_add_timer_msec(master, ospf_adj_dyn_adjust_timer, oi, 0,
 				     &oi->adj_pacing.t_dyn_adjust);
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s scheduled deferred adjustment", IF_NAME(oi));
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s scheduled congestion evaluation",
+				   IF_NAME(oi));
 	}
 }
 
@@ -213,8 +215,8 @@ static uint16_t ospf_adj_pacing_limit(struct ospf_interface *oi)
 		/* Recompute before returning */
 		ospf_adj_dyn_adjust(oi);
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5-DYN: %s returning dynamic_limit=%u", IF_NAME(oi),
-				   oi->adj_pacing.dynamic_limit);
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s current limit=%u",
+				   IF_NAME(oi), oi->adj_pacing.dynamic_limit);
 		return oi->adj_pacing.dynamic_limit;
 	}
 	return 0;
@@ -469,11 +471,14 @@ static int nsm_twoway_received(struct ospf_neighbor *nbr)
 	int adj = nsm_should_adj(nbr);
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: TwoWay recv nbr=%pI4 adj=%d", &nbr->router_id, adj);
+		zlog_debug("OSPF adjacency pacing: interface %s neighbor %pI4 reached TwoWay (adjacency-required=%d)",
+			   IF_NAME(nbr->oi), &nbr->router_id, adj);
 
 	if (adj && !ospf_adj_pacing_allow(nbr->oi)) {
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: throttling nbr=%pI4", &nbr->router_id);
+			zlog_debug("OSPF adjacency pacing: interface %s delaying adjacency for neighbor %pI4 in TwoWay (in-progress=%u)",
+				   IF_NAME(nbr->oi), &nbr->router_id,
+				   nbr->oi->adj_pacing.in_progress);
 		ospf_adj_pacing_enqueue(nbr);
 		return NSM_TwoWay;
 	}
@@ -482,8 +487,8 @@ static int nsm_twoway_received(struct ospf_neighbor *nbr)
 		ospf_adj_pacing_remove(nbr);
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: TwoWay -> %s nbr=%pI4", adj ? "ExStart" : "TwoWay",
-			   &nbr->router_id);
+		zlog_debug("OSPF adjacency pacing: interface %s neighbor %pI4 TwoWay decision=%s",
+			   IF_NAME(nbr->oi), &nbr->router_id, adj ? "ExStart" : "TwoWay");
 
 	/* Send proactive ARP requests */
 	if (adj)
@@ -626,7 +631,9 @@ static int nsm_adj_ok(struct ospf_neighbor *nbr)
 	if (nbr->state == NSM_TwoWay && adj == 1) {
 		if (!ospf_adj_pacing_allow(nbr->oi)) {
 			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-				zlog_debug("R5: AdjOK throttling nbr=%pI4", &nbr->router_id);
+				zlog_debug("OSPF adjacency pacing: interface %s delaying AdjOK for neighbor %pI4 (in-progress=%u)",
+					   IF_NAME(nbr->oi), &nbr->router_id,
+					   nbr->oi->adj_pacing.in_progress);
 			ospf_adj_pacing_enqueue(nbr);
 			return NSM_TwoWay;
 		}
@@ -646,8 +653,9 @@ static int nsm_adj_ok(struct ospf_neighbor *nbr)
 		next_state = NSM_ExStart;
 
 	if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-		zlog_debug("R5: AdjOK next_state=%s nbr=%pI4",
-			   lookup_msg(ospf_nsm_state_msg, next_state, NULL), &nbr->router_id);
+		zlog_debug("OSPF adjacency pacing: interface %s neighbor %pI4 AdjOK next-state=%s",
+			   IF_NAME(nbr->oi), &nbr->router_id,
+			   lookup_msg(ospf_nsm_state_msg, next_state, NULL));
 
 	return next_state;
 }
@@ -674,14 +682,16 @@ static void nsm_clear_adj(struct ospf_neighbor *nbr)
 		UNSET_FLAG(nbr->options, OSPF_OPTION_O);
 }
 
-/*RFC4222/R5 changes: remove neighbor from per-interface packing queue when killed*/
+/* RFC4222 Recommendation 5: clean up per-interface adjacency pacing
+ * state when a neighbor is killed.
+ */
 static int nsm_kill_nbr(struct ospf_neighbor *nbr)
 {
 	struct ospf_interface *oi = nbr->oi;
 	struct ospf_neighbor *on;
 	struct route_node *rn;
 
-	/* R5 changes*/
+	/* Prevent neighbor teardown from leaving a stale pacing queue entry. */
 	ospf_adj_pacing_remove(nbr);
 
 	/* killing nbr_self is invalid */
@@ -983,8 +993,9 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 			oi->adj_pacing.in_progress--;
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: %s in-progress=%u limit=%u", IF_NAME(oi),
-				   oi->adj_pacing.in_progress, ospf_adj_pacing_limit(oi));
+			zlog_debug("OSPF adjacency pacing: interface %s formation slot released (in-progress=%u limit=%u)",
+				   IF_NAME(oi), oi->adj_pacing.in_progress,
+				   ospf_adj_pacing_limit(oi));
 
 		/* Only kick if pacing is enabled */
 		if (ospf_adj_pacing_enabled(oi))

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -9,6 +9,17 @@
 #define _ZEBRA_OSPF_NSM_H
 
 #include "hook.h"
+#include "typesafe.h"
+
+/* forward declaration so ospf_nsm.h can be included before ospf_interface.h */
+struct ospf_interface;
+
+/* RFC4222/R5: typed list for per-interface adjacency pacing queue.
+ * Only PREDECL_LIST here — DECLARE_LIST lives in ospf_nsm.c where
+ * struct ospf_neighbor is fully defined.  Callers outside ospf_nsm.c
+ * use the wrapper functions below.
+ */
+PREDECL_LIST(ospf_pacing_queue);
 
 /* OSPF Neighbor State Machine State. */
 #define NSM_DependUpon          0
@@ -59,6 +70,19 @@ extern int ospf_db_summary_isempty(struct ospf_neighbor *nbr);
 extern int ospf_db_summary_count(struct ospf_neighbor *nbr);
 extern void ospf_db_summary_clear(struct ospf_neighbor *nbr);
 extern int nsm_should_adj(struct ospf_neighbor *nbr);
+
+/* RFC4222/R5: Dynamic adjacency pacing */
+extern void ospf_adj_dyn_adjust(struct ospf_interface *oi);
+extern void ospf_adj_pacing_kick(struct ospf_interface *oi);
+
+/* RFC4222/R5: pacing queue lifecycle — wrappers around the typesafe list
+ * so callers outside ospf_nsm.c do not need the full ospf_neighbor type.
+ */
+struct ospf_adj_pacing; /* forward declaration — full type in ospf_interface.h */
+extern void ospf_adj_pacing_queue_init(struct ospf_adj_pacing *p);
+extern void ospf_adj_pacing_queue_fini(struct ospf_adj_pacing *p);
+extern void ospf_adj_pacing_queue_flush(struct ospf_interface *oi);
+
 DECLARE_HOOK(ospf_nsm_change,
 	     (struct ospf_neighbor * on, int state, int oldstate),
 	     (on, state, oldstate));

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -153,12 +153,59 @@ static void ospf_packet_sent_lsas_fini(struct ospf_packet *op)
 	}
 }
 
-extern uint64_t ospf_now_ms(void)
+uint64_t ospf_now_ms(void)
 {
 	struct timeval tv;
 
 	monotime(&tv);
 	return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
+}
+
+/* RFC4222 R4: unlock helper for LSAs held in per-neighbor pacing queues. */
+static void ospf_r4_lsa_unlock_del(void *data)
+{
+	struct ospf_lsa *lsa = data;
+
+	ospf_lsa_unlock(&lsa);
+}
+
+/* RFC4222 R4: adjust per-neighbor LSU gap using unacked LSA watermarks. */
+static inline void pace_maybe_adjust_gap(struct ospf_interface *oi, struct ospf_neighbor *nbr,
+					 uint64_t now_ms)
+{
+	const uint32_t U = nbr->ls_rxmt_unacked;
+	const uint32_t H = oi->rec4_high_water;
+	const uint32_t L = oi->rec4_low_water;
+	const uint32_t F = oi->rec4_gap_factor;
+	const uint32_t T_ms = oi->rec4_gap_adjust_int_ms;
+	const uint32_t Gmin = oi->rec4_gap_min_ms;
+	const uint32_t Gmax = oi->rec4_gap_max_ms;
+	uint32_t G = nbr->lsu_gap_ms;
+
+	if ((now_ms - nbr->gap_last_change_ms) < T_ms)
+		return;
+
+	if (U > H) {
+		uint64_t grown = (uint64_t)G * F;
+
+		G = (grown > Gmax) ? Gmax : (uint32_t)grown;
+	} else if (U == 0) {
+		G = Gmin;
+	} else if (U <= L) {
+		uint32_t shrunk = G / F;
+
+		G = (shrunk < Gmin) ? Gmin : shrunk;
+	} else {
+		return;
+	}
+
+	nbr->lsu_gap_ms = G;
+	nbr->gap_last_change_ms = now_ms;
+	if (nbr->next_send_ms < now_ms)
+		nbr->next_send_ms = now_ms;
+
+	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+		zlog_debug("RFC4222 R4: nbr=%pI4 U=%u H=%u L=%u G=%u", &nbr->router_id, U, H, L, G);
 }
 
 static inline bool ospf_dst_is_multicast(struct in_addr dst)
@@ -188,7 +235,7 @@ static inline bool ospf_nbr_is_dr_or_bdr(const struct ospf_neighbor *nbr)
 	return false;
 }
 
-/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+/* RFC4222 R4/R5: track sent LSAs for pacing feedback. */
 static inline void ospf_count_sent_lsa(struct ospf_interface *oi, struct in_addr dst,
 				       struct ospf_lsa *lsa)
 {
@@ -227,6 +274,126 @@ static inline void ospf_count_sent_lsa(struct ospf_interface *oi, struct in_addr
 			nbr->ls_rxmt_unacked++;
 		}
 	}
+}
+
+/* RFC4222 R4: advance pacing gates after an LSU is queued for output. */
+static void lsu_sent_for_dst(struct ospf_interface *oi, struct in_addr dst, uint64_t now_ms,
+			     uint32_t sent_count)
+{
+	struct route_node *rn;
+	struct ospf_neighbor *nbr;
+	const bool mcast = ospf_dst_is_multicast(dst);
+	const bool alldr = ospf_dst_is_alldr(dst);
+
+	if (!oi->rec4_gap_pacing)
+		return;
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		nbr = rn->info;
+		if (!nbr || nbr == oi->nbr_self)
+			continue;
+		if (nbr->state < NSM_Exchange)
+			continue;
+		if (!mcast) {
+			if (nbr->address.u.prefix4.s_addr != dst.s_addr)
+				continue;
+		} else if (alldr && !ospf_nbr_is_dr_or_bdr(nbr)) {
+			continue;
+		}
+
+		nbr->next_send_ms = MAX(nbr->next_send_ms, now_ms) +
+				    ((uint64_t)nbr->lsu_gap_ms * sent_count);
+	}
+}
+
+/* RFC4222 R4: return whether any neighbor has queued paced LSAs. */
+bool ospf_oi_any_nbr_gap_pacing(const struct ospf_interface *oi)
+{
+	struct route_node *rn;
+	struct ospf_neighbor *nbr;
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		nbr = rn->info;
+		if (nbr && listcount(&nbr->r4_send_queue))
+			return true;
+	}
+	return false;
+}
+
+/* RFC4222 R4: forward declaration for per-neighbor paced send timer. */
+static void ospf_r4_nbr_send_timer(struct event *event);
+
+/* RFC4222 R4: initialize per-neighbor paced LSU queue. */
+void ospf_r4_nbr_init(struct ospf_neighbor *nbr)
+{
+	memset(&nbr->r4_send_queue, 0, sizeof(nbr->r4_send_queue));
+	nbr->r4_send_queue.del = ospf_r4_lsa_unlock_del;
+}
+
+/* RFC4222 R4: cancel pacing timer and flush queued LSAs. */
+void ospf_r4_nbr_cancel(struct ospf_neighbor *nbr)
+{
+	struct listnode *qnode;
+	struct ospf_lsa *lsa;
+
+	event_cancel(&nbr->t_r4_send);
+
+	/* Queued LSAs may be referenced from their ls_rxmt bookkeeping
+	 * nodes; a back-pointer must not outlive its queue entry.
+	 */
+	for (ALL_LIST_ELEMENTS_RO(&nbr->r4_send_queue, qnode, lsa)) {
+		struct ospf_lsdb_linked_node *ls_rxmt_node;
+
+		ls_rxmt_node = ospf_lsdb_linked_lookup(&nbr->ls_rxmt, lsa);
+		if (ls_rxmt_node)
+			ls_rxmt_node->r4_qnode = NULL;
+	}
+
+	list_delete_all_node(&nbr->r4_send_queue);
+}
+
+/* RFC4222 R4: arm per-neighbor paced send timer. */
+static void ospf_r4_nbr_arm_timer(struct ospf_neighbor *nbr)
+{
+	uint64_t now_ms;
+	long delay_ms;
+
+	if (nbr->t_r4_send)
+		return;
+	if (listcount(&nbr->r4_send_queue) == 0)
+		return;
+
+	now_ms = ospf_now_ms();
+	delay_ms = (nbr->next_send_ms > now_ms) ? (long)(nbr->next_send_ms - now_ms) : 0;
+	event_add_timer_msec(master, ospf_r4_nbr_send_timer, nbr, delay_ms, &nbr->t_r4_send);
+}
+
+/* RFC4222 R4: enqueue one LSA for paced unicast transmission to nbr.
+ * Returns the queue node so callers can track the queued copy.
+ */
+struct listnode *ospf_r4_nbr_enqueue(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
+{
+	listnode_add(&nbr->r4_send_queue, ospf_lsa_lock(lsa));
+	ospf_r4_nbr_arm_timer(nbr);
+	return listtail(&nbr->r4_send_queue);
+}
+
+/* RFC4222 R4: drop an LSA's queued copy tracked by its ls_rxmt node.
+ * Used when the copy became stale before its paced send slot: the
+ * neighbor acknowledged the LSA or a newer instance superseded it.
+ */
+void ospf_r4_nbr_dequeue(struct ospf_neighbor *nbr, struct ospf_lsdb_linked_node *node)
+{
+	struct ospf_lsa *lsa;
+
+	if (!node || !node->r4_qnode)
+		return;
+
+	lsa = listgetdata(node->r4_qnode);
+	/* list_delete_node() does not run the list del hook. */
+	list_delete_node(&nbr->r4_send_queue, node->r4_qnode);
+	node->r4_qnode = NULL;
+	ospf_lsa_unlock(&lsa);
 }
 
 struct ospf_fifo *ospf_fifo_new(void)
@@ -484,6 +651,7 @@ void ospf_ls_rxmt_timer(struct event *event)
 		struct timeval rxmt_interval = { retransmit_interval, 0 };
 		struct timeval rxmt_window;
 		struct ospf_lsa_list_head update;
+		unsigned long rxmt_examine_max = ospf_ls_retransmit_count(nbr);
 
 		ospf_lsa_list_init(&update);
 		/*
@@ -511,6 +679,14 @@ void ospf_ls_rxmt_timer(struct event *event)
 
 		while ((ls_rxmt_list_entry =
 				ospf_lsa_list_first(&nbr->ls_rxmt_list))) {
+			/*
+			 * Entries skipped below are re-timed and moved to the
+			 * tail, so bound the pass to one look at each entry.
+			 */
+			if (rxmt_examine_max == 0)
+				break;
+			rxmt_examine_max--;
+
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 				zlog_debug("RETRANS_CHECK_LSA: Examining LSA %pI4 seq=0x%08x scheduled_time=%ld.%06ld vs latest_rxmt=%ld.%06ld",
 					   &ls_rxmt_list_entry->lsa->data->id,
@@ -531,6 +707,27 @@ void ospf_ls_rxmt_timer(struct event *event)
 							    latest_rxmt_time.tv_usec) /
 								   1000000.0);
 				break;
+			}
+
+			/* RFC4222 R4: a copy of this LSA is still waiting in
+			 * the paced send queue; don't select a duplicate, just
+			 * push its next retransmission out.
+			 */
+			if (nbr->oi->rec4_gap_pacing) {
+				struct ospf_lsdb_linked_node *ls_rxmt_node;
+
+				ls_rxmt_node = ospf_lsdb_linked_lookup(&nbr->ls_rxmt,
+								       ls_rxmt_list_entry->lsa);
+				if (ls_rxmt_node && ls_rxmt_node->r4_qnode) {
+					if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+						zlog_debug("RETRANS_QUEUED_LSA: LSA %pI4 still in paced send queue, rescheduling only",
+							   &ls_rxmt_list_entry->lsa->data->id);
+					ls_rxmt_list_entry->list_entry_time = next_rxmt_time;
+					ospf_lsa_list_del(&nbr->ls_rxmt_list, ls_rxmt_list_entry);
+					ospf_lsa_list_add_tail(&nbr->ls_rxmt_list,
+							       ls_rxmt_list_entry);
+					continue;
+				}
 			}
 
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
@@ -577,7 +774,29 @@ void ospf_ls_rxmt_timer(struct event *event)
 			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 				zlog_debug("RETRANS_SEND_PACKET: Sending %d LSAs to neighbor %pI4",
 					   rxmt_lsa_count, &nbr->router_id);
-			ospf_ls_upd_send_lsahead(nbr, &update);
+
+			/* RFC4222 R4: pace retransmits through the per-neighbor queue. */
+			if (nbr->oi->rec4_gap_pacing) {
+				struct ospf_lsa_list_entry *e;
+
+				frr_each_safe (ospf_lsa_list, &update, e) {
+					struct ospf_lsdb_linked_node *ls_rxmt_node;
+
+					ls_rxmt_node = ospf_lsdb_linked_lookup(&nbr->ls_rxmt,
+									       e->lsa);
+					ospf_lsa_list_del(&update, e);
+					if (ls_rxmt_node)
+						ls_rxmt_node->r4_qnode =
+							ospf_r4_nbr_enqueue(nbr, e->lsa);
+					else
+						ospf_r4_nbr_enqueue(nbr, e->lsa);
+					ospf_lsa_unlock(&e->lsa);
+					XFREE(MTYPE_OSPF_LSA_LIST, e);
+				}
+			} else {
+				ospf_ls_upd_send_lsahead(nbr, &update);
+			}
+
 			/* RFC4222/R5: Retransmitting means ACKs aren't arriving - check congestion */
 			if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC)
 				ospf_adj_dyn_adjust(nbr->oi);
@@ -2440,6 +2659,7 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 			uint16_t size)
 {
 	struct ospf_neighbor *nbr;
+	bool acked_any = false;
 
 	/* increment statistics. */
 	oi->ls_ack_in++;
@@ -2507,6 +2727,7 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 						   &lsa->data->id, ntohl(lsa->data->ls_seqnum),
 						   ospf_ls_retransmit_count(nbr));
 				ospf_ls_retransmit_delete(nbr, lsr);
+				acked_any = true;
 				/* RFC4222/R5: Trigger dynamic adjacency pacing adjustment */
 				if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC)
 					ospf_adj_dyn_adjust(nbr->oi);
@@ -2528,7 +2749,9 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 		lsa->data = NULL;
 		ospf_lsa_discard(lsa);
 	}
-	//ospf_ls_retransmit_set_timer(nbr);
+	/* RFC4222 R4: ACK feedback may allow the per-neighbor gap to shrink. */
+	if (acked_any && nbr->oi->rec4_gap_pacing)
+		pace_maybe_adjust_gap(nbr->oi, nbr, ospf_now_ms());
 
 	return;
 }
@@ -3815,6 +4038,10 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update, stru
 		}
 		list_delete_node(update, node);
 		ospf_lsa_unlock(&lsa); /* oi->ls_upd_queue */
+
+		/* RFC4222 R4: bound LSAs per paced LSU packet. */
+		if (oi->rec4_gap_pacing && count >= oi->rec4_max_lsas)
+			break;
 	}
 
 	stream_putl_at(s, pp, count);
@@ -4223,7 +4450,8 @@ void ospf_ls_upd_send_lsa(struct ospf_neighbor *nbr, struct ospf_lsa *lsa,
  * on packet sizes (in which case offending LSA is deleted from update list)
  */
 static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
-						  struct ospf_interface *oi)
+						  struct ospf_interface *oi,
+						  struct ospf_neighbor *dst_nbr)
 {
 	struct ospf_lsa *lsa;
 	struct listnode *ln;
@@ -4268,7 +4496,21 @@ static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
 			"%s: oversized LSA id:%pI4 too big, %d bytes, packet size %ld, dropping it completely. OSPF routing is broken!",
 			__func__, &lsa->data->id, ntohs(lsa->data->length),
 			(long int)size);
-		list_delete_node(update, ln);
+		/* RFC4222 R4: the dropped entry leaves r4_send_queue here;
+		 * clear its queue back-pointer and release the queue's LSA
+		 * reference so neither outlives the entry.
+		 */
+		if (oi->rec4_gap_pacing && dst_nbr) {
+			struct ospf_lsdb_linked_node *ls_rxmt_node;
+
+			ls_rxmt_node = ospf_lsdb_linked_lookup(&dst_nbr->ls_rxmt, lsa);
+			if (ls_rxmt_node && ls_rxmt_node->r4_qnode == ln)
+				ls_rxmt_node->r4_qnode = NULL;
+			list_delete_node(update, ln);
+			ospf_lsa_unlock(&lsa);
+		} else {
+			list_delete_node(update, ln);
+		}
 		return NULL;
 	}
 
@@ -4295,8 +4537,8 @@ static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
 
 static void ospf_ls_upd_send_queue_event(struct event *thread);
 
-void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
-			    struct in_addr addr, int send_lsupd_now)
+void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update, struct in_addr addr,
+			    int send_lsupd_now, struct ospf_neighbor *dst_nbr)
 {
 	struct ospf_packet *op;
 	uint16_t length = OSPF_HEADER_SIZE;
@@ -4309,7 +4551,7 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 	if (listcount(update) == 0)
 		return;
 
-	op = ospf_ls_upd_packet_new(update, oi);
+	op = ospf_ls_upd_packet_new(update, oi, dst_nbr);
 	if (!op)
 		return;
 
@@ -4341,6 +4583,39 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 
 	/* Add packet to the interface output queue. */
 	ospf_packet_add(oi, op);
+
+	/* RFC4222 R4: paced sends attach retransmit ownership to the exact
+	 * neighbor whose queue produced this packet.
+	 */
+	if (oi->rec4_gap_pacing && dst_nbr) {
+		struct ospf_lsa_list_entry *e;
+
+		frr_each (ospf_lsa_list, &op->sent_lsas, e) {
+			struct ospf_lsdb_linked_node *ls_rxmt_node;
+
+			ospf_ls_retransmit_add(dst_nbr, e->lsa);
+			/* The queued copy left r4_send_queue when the packet
+			 * was built; drop the stale queue back-pointer so the
+			 * retransmit timer may select this LSA again.
+			 */
+			ls_rxmt_node = ospf_lsdb_linked_lookup(&dst_nbr->ls_rxmt, e->lsa);
+			if (ls_rxmt_node)
+				ls_rxmt_node->r4_qnode = NULL;
+		}
+	}
+
+	/* RFC4222 R4: advance the pacing gate for the exact queued neighbor
+	 * when available; fall back to destination-based accounting otherwise.
+	 */
+	if (oi->rec4_gap_pacing && sent_count > 0) {
+		uint64_t now_ms = ospf_now_ms();
+
+		if (dst_nbr)
+			dst_nbr->next_send_ms = MAX(dst_nbr->next_send_ms, now_ms) +
+						((uint64_t)dst_nbr->lsu_gap_ms * sent_count);
+		else
+			lsu_sent_for_dst(oi, addr, now_ms, sent_count);
+	}
 
 	/* Call ospf_write() right away to send ospf packets to neighbors */
 	if (send_lsupd_now) {
@@ -4394,7 +4669,7 @@ static void ospf_ls_upd_send_queue_event(struct event *event)
 
 		update = (struct list *)rn->info;
 
-		ospf_ls_upd_queue_send(oi, update, rn->p.u.prefix4, 0);
+		ospf_ls_upd_queue_send(oi, update, rn->p.u.prefix4, 0, NULL);
 
 		/* list might not be empty. */
 		if (listcount(update) == 0) {
@@ -4415,6 +4690,54 @@ static void ospf_ls_upd_send_queue_event(struct event *event)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s stop", __func__);
+}
+
+/* RFC4222 R4: per-neighbor paced LSU send timer. */
+static void ospf_r4_nbr_send_timer(struct event *event)
+{
+	struct ospf_neighbor *nbr = EVENT_ARG(event);
+	struct ospf_interface *oi;
+	uint64_t now_ms;
+	uint64_t delay_ms;
+
+	nbr->t_r4_send = NULL;
+	if (!nbr->oi)
+		return;
+
+	oi = nbr->oi;
+	if (!oi->rec4_gap_pacing)
+		return;
+	if (listcount(&nbr->r4_send_queue) == 0)
+		return;
+
+	now_ms = ospf_now_ms();
+	if (nbr->next_send_ms > now_ms) {
+		delay_ms = nbr->next_send_ms - now_ms;
+		event_add_timer_msec(master, ospf_r4_nbr_send_timer, nbr, (long)delay_ms,
+				     &nbr->t_r4_send);
+		return;
+	}
+
+	/* RFC4222 R4: local output backpressure; yield the event loop once. */
+	if (oi->on_write_q) {
+		event_add_timer_msec(master, ospf_r4_nbr_send_timer, nbr, 1, &nbr->t_r4_send);
+		return;
+	}
+
+	/* RFC4222 R4: queue pressure is also congestion feedback. */
+	if (listcount(&nbr->r4_send_queue) > oi->rec4_high_water)
+		pace_maybe_adjust_gap(oi, nbr, now_ms);
+
+	ospf_ls_upd_queue_send(oi, &nbr->r4_send_queue, nbr->address.u.prefix4, 0, nbr);
+	pace_maybe_adjust_gap(oi, nbr, ospf_now_ms());
+
+	if (listcount(&nbr->r4_send_queue) > 0) {
+		now_ms = ospf_now_ms();
+		delay_ms = (nbr->next_send_ms > now_ms) ? (nbr->next_send_ms - now_ms)
+							: oi->rec4_gap_min_ms;
+		event_add_timer_msec(master, ospf_r4_nbr_send_timer, nbr, (long)delay_ms,
+				     &nbr->t_r4_send);
+	}
 }
 
 void ospf_ls_upd_send(struct ospf_neighbor *nbr, struct list *update, int flag,
@@ -4478,7 +4801,7 @@ void ospf_ls_upd_send(struct ospf_neighbor *nbr, struct list *update, int flag,
 			if (!send_update_list || listcount(send_update_list) == 0)
 				continue;
 
-			ospf_ls_upd_queue_send(oi, send_update_list, rn->p.u.prefix4, 1);
+			ospf_ls_upd_queue_send(oi, send_update_list, rn->p.u.prefix4, 1, NULL);
 		}
 	} else {
 		if (!oi->t_ls_upd_event)

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -146,7 +146,7 @@ static void ospf_packet_sent_lsas_fini(struct ospf_packet *op)
 
 	if (!op)
 		return;
-	frr_each_safe(ospf_lsa_list, &op->sent_lsas, e) {
+	frr_each_safe (ospf_lsa_list, &op->sent_lsas, e) {
 		ospf_lsa_list_del(&op->sent_lsas, e);
 		ospf_lsa_unlock(&e->lsa);
 		XFREE(MTYPE_OSPF_LSA_LIST, e);
@@ -437,8 +437,7 @@ static void ospf_maybe_restart_inactivity(struct ospf_interface *oi, struct ospf
  * Transfers each LSA lock to rn->info then schedules the queue drain.
  * Functionally identical to ospf_ls_upd_send() for the direct/unicast case.
  */
-static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
-				      struct ospf_lsa_list_head *update)
+static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr, struct ospf_lsa_list_head *update)
 {
 	struct ospf_interface *oi = nbr->oi;
 	struct prefix_ipv4 p = { .family = AF_INET,
@@ -453,7 +452,7 @@ static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
 	else
 		route_unlock_node(rn);
 
-	frr_each_safe(ospf_lsa_list, update, e) {
+	frr_each_safe (ospf_lsa_list, update, e) {
 		ospf_lsa_list_del(update, e);
 		listnode_add((struct list *)rn->info, ospf_lsa_lock(e->lsa));
 		ospf_lsa_unlock(&e->lsa);
@@ -461,8 +460,7 @@ static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
 	}
 
 	if (!oi->t_ls_upd_event)
-		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
-				&oi->t_ls_upd_event);
+		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0, &oi->t_ls_upd_event);
 }
 
 /*
@@ -549,8 +547,7 @@ void ospf_ls_rxmt_timer(struct event *event)
 
 			struct ospf_lsa_list_entry *upd_entry;
 
-			upd_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
-					    sizeof(*upd_entry));
+			upd_entry = XCALLOC(MTYPE_OSPF_LSA_LIST, sizeof(*upd_entry));
 			upd_entry->lsa = ospf_lsa_lock(ls_rxmt_list_entry->lsa);
 			ospf_lsa_list_add_tail(&update, upd_entry);
 			rxmt_lsa_count++;
@@ -926,7 +923,7 @@ static void ospf_write(struct event *event)
 		    ospf_lsa_list_first(&op->sent_lsas) != NULL) {
 			struct ospf_lsa_list_entry *sent_e;
 
-			frr_each(ospf_lsa_list, &op->sent_lsas, sent_e) {
+			frr_each (ospf_lsa_list, &op->sent_lsas, sent_e) {
 				/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
 				ospf_count_sent_lsa(oi, op->dst, sent_e->lsa);
 			}
@@ -3812,8 +3809,7 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update, stru
 		if (sent_lsas) {
 			struct ospf_lsa_list_entry *sent_entry;
 
-			sent_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
-					     sizeof(*sent_entry));
+			sent_entry = XCALLOC(MTYPE_OSPF_LSA_LIST, sizeof(*sent_entry));
 			sent_entry->lsa = ospf_lsa_lock(lsa);
 			ospf_lsa_list_add_tail(sent_lsas, sent_entry);
 		}

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -79,6 +79,9 @@ const struct message ospf_packet_type_str[] = {
 
 /* Minimum (besides OSPF_HEADER_SIZE) lengths for OSPF packets of
    particular types, offset is the "type" field of a packet. */
+static void ospf_packet_sent_lsas_fini(struct ospf_packet *op);
+static void ospf_ls_upd_send_queue_event(struct event *event);
+
 static const uint16_t ospf_packet_minlen[] = {
 	0,
 	OSPF_HELLO_MIN_SIZE,
@@ -117,10 +120,113 @@ static struct ospf_packet *ospf_packet_new(size_t size)
 
 void ospf_packet_free(struct ospf_packet *op)
 {
+	if (!op)
+		return;
+
+	/* Free any sent_lsas entries — needed when ospf_fifo_flush discards
+	 * unsent LSU packets at shutdown without going through ospf_packet_delete.
+	 */
+	ospf_packet_sent_lsas_fini(op);
+
 	if (op->s)
 		stream_free(op->s);
 
 	XFREE(MTYPE_OSPF_PACKET, op);
+}
+
+/* RFC4222/R5: init/fini for per-packet sent LSA tracking list */
+static void ospf_packet_sent_lsas_init(struct ospf_packet *op)
+{
+	ospf_lsa_list_init(&op->sent_lsas);
+}
+
+static void ospf_packet_sent_lsas_fini(struct ospf_packet *op)
+{
+	struct ospf_lsa_list_entry *e;
+
+	if (!op)
+		return;
+	frr_each_safe(ospf_lsa_list, &op->sent_lsas, e) {
+		ospf_lsa_list_del(&op->sent_lsas, e);
+		ospf_lsa_unlock(&e->lsa);
+		XFREE(MTYPE_OSPF_LSA_LIST, e);
+	}
+}
+
+extern uint64_t ospf_now_ms(void)
+{
+	struct timeval tv;
+
+	monotime(&tv);
+	return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
+}
+
+static inline bool ospf_dst_is_multicast(struct in_addr dst)
+{
+	return IN_MULTICAST(ntohl(dst.s_addr));
+}
+
+static inline bool ospf_dst_is_allspf(struct in_addr dst)
+{
+	return dst.s_addr == htonl(OSPF_ALLSPFROUTERS); /* 224.0.0.5 */
+}
+
+static inline bool ospf_dst_is_alldr(struct in_addr dst)
+{
+	return dst.s_addr == htonl(OSPF_ALLDROUTERS); /* 224.0.0.6 */
+}
+
+/* True if this neighbor is DR or BDR on the segment (based on its Hello). */
+static inline bool ospf_nbr_is_dr_or_bdr(const struct ospf_neighbor *nbr)
+{
+	const struct in_addr nbr_ip = nbr->address.u.prefix4;
+
+	if (nbr_ip.s_addr == nbr->d_router.s_addr)
+		return true;
+	if (nbr_ip.s_addr == nbr->bd_router.s_addr)
+		return true;
+	return false;
+}
+
+/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+static inline void ospf_count_sent_lsa(struct ospf_interface *oi, struct in_addr dst,
+				       struct ospf_lsa *lsa)
+{
+	struct route_node *rn;
+	struct ospf_neighbor *nbr;
+
+	const bool mcast = ospf_dst_is_multicast(dst);
+	const bool alldr = ospf_dst_is_alldr(dst);
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		nbr = rn->info;
+		if (!nbr || nbr == oi->nbr_self)
+			continue;
+
+		if (nbr->state < NSM_Exchange)
+			continue;
+
+		/* Unicast destination: only the matching neighbor receives it */
+		if (!mcast) {
+			if (nbr->address.u.prefix4.s_addr != dst.s_addr)
+				continue;
+		} else {
+			/* 224.0.0.6 destination: only DR/BDR receive it */
+			if (alldr && !ospf_nbr_is_dr_or_bdr(nbr))
+				continue;
+
+			/* 224.0.0.5: everyone eligible receives it -> no extra filter */
+			(void)ospf_dst_is_allspf; /* (not needed here, kept for clarity) */
+		}
+
+		/* Track unacked LSAs for R5 dynamic adjacency pacing */
+		struct ospf_lsdb_linked_node *linked_node = ospf_lsdb_linked_lookup(&nbr->ls_rxmt,
+										    lsa);
+		if (linked_node && !linked_node->counted_sent) {
+			linked_node->counted_sent = true;
+			nbr->ls_rxmt_unacked++;
+		}
+	}
 }
 
 struct ospf_fifo *ospf_fifo_new(void)
@@ -326,9 +432,43 @@ static void ospf_maybe_restart_inactivity(struct ospf_interface *oi, struct ospf
 	}
 }
 
+/* RFC4222/R5: type adapter — sends a batch of LSAs collected in a typesafe
+ * ospf_lsa_list_head to a neighbor via the existing ls_upd_queue path.
+ * Transfers each LSA lock to rn->info then schedules the queue drain.
+ * Functionally identical to ospf_ls_upd_send() for the direct/unicast case.
+ */
+static void ospf_ls_upd_send_lsahead(struct ospf_neighbor *nbr,
+				      struct ospf_lsa_list_head *update)
+{
+	struct ospf_interface *oi = nbr->oi;
+	struct prefix_ipv4 p = { .family = AF_INET,
+				 .prefixlen = IPV4_MAX_BITLEN,
+				 .prefix = nbr->address.u.prefix4 };
+	struct route_node *rn;
+	struct ospf_lsa_list_entry *e;
+
+	rn = route_node_get(oi->ls_upd_queue, (struct prefix *)&p);
+	if (rn->info == NULL)
+		rn->info = list_new();
+	else
+		route_unlock_node(rn);
+
+	frr_each_safe(ospf_lsa_list, update, e) {
+		ospf_lsa_list_del(update, e);
+		listnode_add((struct list *)rn->info, ospf_lsa_lock(e->lsa));
+		ospf_lsa_unlock(&e->lsa);
+		XFREE(MTYPE_OSPF_LSA_LIST, e);
+	}
+
+	if (!oi->t_ls_upd_event)
+		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
+				&oi->t_ls_upd_event);
+}
+
 /*
- * OSPF neighbor link state retransmission timer handler. Unicast
- * unacknowledged LSAs to the neighbors.
+ * OSPF neighbor link-state retransmission timer handler.
+ * Retransmits pending unacked LSAs and triggers RFC4222/R5 dynamic
+ * adjacency-pacing adjustment based on retransmit activity.
  */
 void ospf_ls_rxmt_timer(struct event *event)
 {
@@ -345,8 +485,9 @@ void ospf_ls_rxmt_timer(struct event *event)
 		struct timeval current_time, latest_rxmt_time, next_rxmt_time;
 		struct timeval rxmt_interval = { retransmit_interval, 0 };
 		struct timeval rxmt_window;
-		struct list *update;
+		struct ospf_lsa_list_head update;
 
+		ospf_lsa_list_init(&update);
 		/*
 		 * Set the retransmission window based on the configured value
 		 * in milliseconds.
@@ -364,20 +505,68 @@ void ospf_ls_rxmt_timer(struct event *event)
 		timeradd(&current_time, &rxmt_window, &latest_rxmt_time);
 		timeradd(&current_time, &rxmt_interval, &next_rxmt_time);
 
-		update = list_new();
+		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+			zlog_debug("RETRANS_TIMER_CALC: cur=%ld.%06ld, latest_rxmt=%ld.%06ld, next_rxmt=%ld.%06ld",
+				   (long)current_time.tv_sec, (long)current_time.tv_usec,
+				   (long)latest_rxmt_time.tv_sec, (long)latest_rxmt_time.tv_usec,
+				   (long)next_rxmt_time.tv_sec, (long)next_rxmt_time.tv_usec);
+
 		while ((ls_rxmt_list_entry =
 				ospf_lsa_list_first(&nbr->ls_rxmt_list))) {
-			if (timercmp(&ls_rxmt_list_entry->list_entry_time,
-				     &latest_rxmt_time, >))
-				break;
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_CHECK_LSA: Examining LSA %pI4 seq=0x%08x scheduled_time=%ld.%06ld vs latest_rxmt=%ld.%06ld",
+					   &ls_rxmt_list_entry->lsa->data->id,
+					   ntohl(ls_rxmt_list_entry->lsa->data->ls_seqnum),
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_sec,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_usec,
+					   (long)latest_rxmt_time.tv_sec,
+					   (long)latest_rxmt_time.tv_usec);
 
-			listnode_add(update, ls_rxmt_list_entry->lsa);
+			if (timercmp(&ls_rxmt_list_entry->list_entry_time, &latest_rxmt_time, >)) {
+				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+					zlog_debug("RETRANS_SKIP_LSA: LSA %pI4 not ready for retrans yet (%.3f seconds too early)",
+						   &ls_rxmt_list_entry->lsa->data->id,
+						   (ls_rxmt_list_entry->list_entry_time.tv_sec -
+						    latest_rxmt_time.tv_sec) +
+							   (ls_rxmt_list_entry->list_entry_time
+								    .tv_usec -
+							    latest_rxmt_time.tv_usec) /
+								   1000000.0);
+				break;
+			}
+
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_SEND_LSA: Adding LSA %pI4 seq=0x%08x to retransmission packet (was scheduled for %ld.%06ld, %.3f seconds overdue)",
+					   &ls_rxmt_list_entry->lsa->data->id,
+					   ntohl(ls_rxmt_list_entry->lsa->data->ls_seqnum),
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_sec,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_usec,
+					   (current_time.tv_sec -
+					    ls_rxmt_list_entry->list_entry_time.tv_sec) +
+						   (current_time.tv_usec -
+						    ls_rxmt_list_entry->list_entry_time.tv_usec) /
+							   1000000.0);
+
+			struct ospf_lsa_list_entry *upd_entry;
+
+			upd_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
+					    sizeof(*upd_entry));
+			upd_entry->lsa = ospf_lsa_lock(ls_rxmt_list_entry->lsa);
+			ospf_lsa_list_add_tail(&update, upd_entry);
 			rxmt_lsa_count++;
 
 			/*
 			 * Set the next retransmit time for the LSA and move it
 			 * to the end of the neighbor's retransmission list.
 			 */
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_RESCHEDULE: LSA %pI4 rescheduled from %ld.%06ld to %ld.%06ld (next attempt in %d seconds)",
+					   &ls_rxmt_list_entry->lsa->data->id,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_sec,
+					   (long)ls_rxmt_list_entry->list_entry_time.tv_usec,
+					   (long)next_rxmt_time.tv_sec,
+					   (long)next_rxmt_time.tv_usec, retransmit_interval);
+
 			ls_rxmt_list_entry->list_entry_time = next_rxmt_time;
 			ospf_lsa_list_del(&nbr->ls_rxmt_list,
 					  ls_rxmt_list_entry);
@@ -387,16 +576,43 @@ void ospf_ls_rxmt_timer(struct event *event)
 			nbr->oi->ls_rxmt_lsa++;
 		}
 
-		if (listcount(update) > 0)
-			ospf_ls_upd_send(nbr, update, OSPF_SEND_PACKET_DIRECT,
-					 0);
-		list_delete(&update);
+		if (ospf_lsa_list_first(&update) != NULL) {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_SEND_PACKET: Sending %d LSAs to neighbor %pI4",
+					   rxmt_lsa_count, &nbr->router_id);
+			ospf_ls_upd_send_lsahead(nbr, &update);
+			/* RFC4222/R5: Retransmitting means ACKs aren't arriving - check congestion */
+			if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC)
+				ospf_adj_dyn_adjust(nbr->oi);
+		} else {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("RETRANS_SEND_NONE: No LSAs ready for retransmission to neighbor %pI4",
+					   &nbr->router_id);
+		}
+
+		ospf_lsa_list_fini(&update);
+	} else {
+		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+			zlog_debug("RETRANS_TIMER_EMPTY: No LSAs in retrans list for neighbor %pI4",
+				   &nbr->router_id);
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("RXmtL(%lu) NBR(%pI4(%s)) timer event - sent %u LSAs",
+		zlog_debug("RXmtL(%lu) NBR(%pI4(%s)) timer event - sending %u LSAs",
 			   ospf_ls_retransmit_count(nbr), &nbr->router_id,
 			   ospf_get_name(nbr->oi->ospf), rxmt_lsa_count);
+
+	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+		zlog_debug("RETRANS_TIMER_END: Setting next timer for neighbor %pI4, remaining LSAs=%lu",
+			   &nbr->router_id, ospf_ls_retransmit_count(nbr));
+
+	/* R5 Dynamic adjacency pacing: retransmit indicates congestion */
+	if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC && rxmt_lsa_count > 0) {
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s retransmit timer fired for %pI4 (sent %u LSAs), triggering dynamic adjust",
+				   IF_NAME(nbr->oi), &nbr->router_id, rxmt_lsa_count);
+		ospf_adj_dyn_adjust(nbr->oi);
+	}
 
 	/* Set LS Update retransmission timer. */
 	ospf_ls_retransmit_set_timer(nbr);
@@ -705,6 +921,16 @@ static void ospf_write(struct event *event)
 				 "*** sendmsg in %s failed to %pI4, id %d, off %d, len %d, interface %s, mtu %u: %s",
 				 __func__, &dstaddr, iph.ip_id, iph.ip_off, iph.ip_len,
 				 oi->ifp->name, oi->ifp->mtu, safe_strerror(errno));
+
+		if (ret >= 0 && type == OSPF_MSG_LS_UPD &&
+		    ospf_lsa_list_first(&op->sent_lsas) != NULL) {
+			struct ospf_lsa_list_entry *sent_e;
+
+			frr_each(ospf_lsa_list, &op->sent_lsas, sent_e) {
+				/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+				ospf_count_sent_lsa(oi, op->dst, sent_e->lsa);
+			}
+		}
 
 		/* Show debug sending packet. */
 		if (IS_DEBUG_OSPF_PACKET(type - 1, SEND)) {
@@ -2251,6 +2477,10 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 		lsa = ospf_lsa_new();
 		lsa->data = (struct lsa_header *)stream_pnt(s);
 		lsa->vrf_id = oi->ospf->vrf_id;
+		if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+			zlog_debug("ACK_LSA: Processing ACK for LSA ID=%pI4 type=%d seq=0x%08x from %pI4",
+				   &lsa->data->id, lsa->data->type, ntohl(lsa->data->ls_seqnum),
+				   &nbr->router_id);
 
 		/* lsah = (struct lsa_header *) stream_pnt (s); */
 		size -= OSPF_LSA_HEADER_SIZE;
@@ -2258,6 +2488,9 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 
 		if (lsa->data->type < OSPF_MIN_LSA
 		    || lsa->data->type >= OSPF_MAX_LSA) {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("ACK_INVALID: Invalid LSA type %d for LSA %pI4, discarding",
+					   lsa->data->type, &lsa->data->id);
 			lsa->data = NULL;
 			ospf_lsa_discard(lsa);
 			continue;
@@ -2265,14 +2498,40 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 
 		lsr = ospf_ls_retransmit_lookup(nbr, lsa);
 
-		if (lsr != NULL && ospf_lsa_more_recent(lsr, lsa) == 0) {
-			ospf_ls_retransmit_delete(nbr, lsr);
-			ospf_check_and_gen_init_seq_lsa(oi, lsa);
+		if (lsr != NULL) {
+			int more_recent_result = ospf_lsa_more_recent(lsr, lsa);
+
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("ACK_FOUND: Found LSA %pI4 in retrans list. more_recent=%d (0=same, >0=lsr newer, <0=lsa newer)",
+					   &lsa->data->id, more_recent_result);
+			if (more_recent_result == 0) {
+				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+					zlog_debug("ACK_MATCH: LSA %pI4 seq=0x%08x matches, removing from retrans list unacked count =%lu",
+						   &lsa->data->id, ntohl(lsa->data->ls_seqnum),
+						   ospf_ls_retransmit_count(nbr));
+				ospf_ls_retransmit_delete(nbr, lsr);
+				/* RFC4222/R5: Trigger dynamic adjacency pacing adjustment */
+				if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC)
+					ospf_adj_dyn_adjust(nbr->oi);
+				ospf_check_and_gen_init_seq_lsa(oi, lsa);
+
+
+			} else {
+				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+					zlog_debug("ACK_MISMATCH: LSA %pI4 found but different version (retrans_seq=0x%08x vs ack_seq=0x%08x)",
+						   &lsa->data->id, ntohl(lsr->data->ls_seqnum),
+						   ntohl(lsa->data->ls_seqnum));
+			}
+		} else {
+			if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
+				zlog_debug("ACK_NOTFOUND: LSA %pI4 seq=0x%08x not found in retrans list (already removed or never sent)",
+					   &lsa->data->id, ntohl(lsa->data->ls_seqnum));
 		}
 
 		lsa->data = NULL;
 		ospf_lsa_discard(lsa);
 	}
+	//ospf_ls_retransmit_set_timer(nbr);
 
 	return;
 }
@@ -3505,8 +3764,9 @@ static int ls_age_increment(struct ospf_lsa *lsa, int delay)
 	return age;
 }
 
-static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
-			    struct stream *s)
+static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update, struct stream *s,
+			    struct in_addr dst, uint32_t *out_count,
+			    struct ospf_lsa_list_head *sent_lsas)
 {
 	struct ospf_lsa *lsa;
 	struct listnode *node;
@@ -3514,7 +3774,7 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
 	unsigned int size_noauth;
 	unsigned long delta = stream_get_endp(s);
 	unsigned long pp;
-	int count = 0;
+	uint32_t count = 0;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: Start", __func__);
@@ -3523,7 +3783,6 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
 	stream_forward_endp(s, OSPF_LS_UPD_MIN_SIZE);
 	length += OSPF_LS_UPD_MIN_SIZE;
 
-	/* Calculate amount of packet usable for data. */
 	size_noauth = stream_get_size(s) - ospf_packet_authspace(oi);
 
 	while ((node = listhead(update)) != NULL) {
@@ -3534,40 +3793,40 @@ static int ospf_make_ls_upd(struct ospf_interface *oi, struct list *update,
 		assert(lsa->data);
 
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: List Iteration %d LSA[%s]", __func__,
-				   count, dump_lsa_key(lsa));
+			zlog_debug("%s: List Iteration %d LSA[%s]", __func__, count,
+				   dump_lsa_key(lsa));
 
-		/* Will it fit? Minimum it has to fit at least one */
-		if ((length + delta + ntohs(lsa->data->length) > size_noauth) &&
-				(count > 0))
+		if ((length + delta + ntohs(lsa->data->length) > size_noauth) && (count > 0))
 			break;
 
-		/* Keep pointer to LS age. */
-		lsah = (struct lsa_header *)(STREAM_DATA(s)
-					     + stream_get_endp(s));
+		lsah = (struct lsa_header *)(STREAM_DATA(s) + stream_get_endp(s));
 
-		/* Put LSA to Link State Request. */
 		stream_put(s, lsa->data, ntohs(lsa->data->length));
 
-		/* Set LS age. */
-		/* each hop must increment an lsa_age by transmit_delay
-		   of OSPF interface */
-		ls_age = ls_age_increment(lsa,
-					  OSPF_IF_PARAM(oi, transmit_delay));
+		ls_age = ls_age_increment(lsa, OSPF_IF_PARAM(oi, transmit_delay));
 		lsah->ls_age = htons(ls_age);
 
 		length += ntohs(lsa->data->length);
 		count++;
+		/* RFC4222/R5: Track sent LSAs for dynamic adjacency pacing */
+		if (sent_lsas) {
+			struct ospf_lsa_list_entry *sent_entry;
 
+			sent_entry = XCALLOC(MTYPE_OSPF_LSA_LIST,
+					     sizeof(*sent_entry));
+			sent_entry->lsa = ospf_lsa_lock(lsa);
+			ospf_lsa_list_add_tail(sent_lsas, sent_entry);
+		}
 		list_delete_node(update, node);
 		ospf_lsa_unlock(&lsa); /* oi->ls_upd_queue */
 	}
 
-	/* Now set #LSAs. */
 	stream_putl_at(s, pp, count);
-
+	if (out_count)
+		*out_count = count;
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: Stop", __func__);
+
 	return length;
 }
 
@@ -3972,6 +4231,7 @@ static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
 {
 	struct ospf_lsa *lsa;
 	struct listnode *ln;
+	struct ospf_packet *op;
 	size_t size;
 	static char warned = 0;
 
@@ -4031,8 +4291,13 @@ static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
 	 *
 	 * P.S. OSPF_MAX_PACKET_SIZE above already includes IP header size
 	 */
-	return ospf_packet_new(size - sizeof(struct ip));
+	op = ospf_packet_new(size - sizeof(struct ip));
+	ospf_packet_sent_lsas_init(op);
+	op->sent_oi = oi; /* optional */
+	return op;
 }
+
+static void ospf_ls_upd_send_queue_event(struct event *thread);
 
 void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 			    struct in_addr addr, int send_lsupd_now)
@@ -4049,6 +4314,8 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 		return;
 
 	op = ospf_ls_upd_packet_new(update, oi);
+	if (!op)
+		return;
 
 	/* Prepare OSPF common header. */
 	ospf_make_header(OSPF_MSG_LS_UPD, oi, op->s);
@@ -4056,14 +4323,20 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 	/* Prepare OSPF Link State Update body.
 	 * Includes Type-7 translation.
 	 */
-	length += ospf_make_ls_upd(oi, update, op->s);
+	uint32_t sent_count = 0;
+
+	length += ospf_make_ls_upd(oi, update, op->s, addr, &sent_count, &op->sent_lsas);
+
+	if (sent_count == 0) {
+		ospf_packet_free(op);
+		return;
+	}
 
 	/* Fill OSPF header. */
 	ospf_fill_header(oi, op->s, length);
 
 	/* Set packet length. */
 	op->length = length;
-
 	/* Decide destination address. */
 	if (oi->type == OSPF_IFTYPE_POINTOPOINT)
 		op->dst.s_addr = htonl(OSPF_ALLSPFROUTERS);
@@ -4072,6 +4345,7 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 
 	/* Add packet to the interface output queue. */
 	ospf_packet_add(oi, op);
+
 	/* Call ospf_write() right away to send ospf packets to neighbors */
 	if (send_lsupd_now) {
 		struct event os_packet_thd;
@@ -4186,32 +4460,35 @@ void ospf_ls_upd_send(struct ospf_neighbor *nbr, struct list *update, int flag,
 
 	rn = route_node_get(oi->ls_upd_queue, (struct prefix *)&p);
 
+	/* Preserve the old locking pattern */
 	if (rn->info == NULL)
 		rn->info = list_new();
 	else
 		route_unlock_node(rn);
 
+	/* Append LSAs */
 	for (ALL_LIST_ELEMENTS_RO(update, node, lsa))
-		listnode_add(rn->info,
-			     ospf_lsa_lock(lsa)); /* oi->ls_upd_queue */
+		listnode_add((struct list *)rn->info, ospf_lsa_lock(lsa));
+
 	if (send_lsupd_now) {
-		struct list *send_update_list;
 		struct route_node *rnext;
 
 		for (rn = route_top(oi->ls_upd_queue); rn; rn = rnext) {
+			struct list *send_update_list;
+
 			rnext = route_next(rn);
 
-			if (rn->info == NULL)
+			send_update_list = rn->info;
+			if (!send_update_list || listcount(send_update_list) == 0)
 				continue;
 
-			send_update_list = (struct list *)rn->info;
-
-			ospf_ls_upd_queue_send(oi, send_update_list,
-					       rn->p.u.prefix4, 1);
+			ospf_ls_upd_queue_send(oi, send_update_list, rn->p.u.prefix4, 1);
 		}
-	} else
-		event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
-				&oi->t_ls_upd_event);
+	} else {
+		if (!oi->t_ls_upd_event)
+			event_add_event(master, ospf_ls_upd_send_queue_event, oi, 0,
+					&oi->t_ls_upd_event);
+	}
 }
 
 static void ospf_ls_ack_send_list(struct ospf_interface *oi,

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -205,7 +205,8 @@ static inline void pace_maybe_adjust_gap(struct ospf_interface *oi, struct ospf_
 		nbr->next_send_ms = now_ms;
 
 	if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-		zlog_debug("RFC4222 R4: nbr=%pI4 U=%u H=%u L=%u G=%u", &nbr->router_id, U, H, L, G);
+		zlog_debug("OSPF LSA pacing: interface %s neighbor %pI4 effective-gap=%ums (unacknowledged-LSAs=%u high-water=%u low-water=%u)",
+			   IF_NAME(oi), &nbr->router_id, G, U, H, L);
 }
 
 static inline bool ospf_dst_is_multicast(struct in_addr dst)
@@ -720,7 +721,8 @@ void ospf_ls_rxmt_timer(struct event *event)
 								       ls_rxmt_list_entry->lsa);
 				if (ls_rxmt_node && ls_rxmt_node->r4_qnode) {
 					if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
-						zlog_debug("RETRANS_QUEUED_LSA: LSA %pI4 still in paced send queue, rescheduling only",
+						zlog_debug("OSPF LSA pacing: neighbor %pI4 LSA %pI4 remains in paced queue; retransmission deferred",
+							   &nbr->router_id,
 							   &ls_rxmt_list_entry->lsa->data->id);
 					ls_rxmt_list_entry->list_entry_time = next_rxmt_time;
 					ospf_lsa_list_del(&nbr->ls_rxmt_list, ls_rxmt_list_entry);
@@ -825,8 +827,8 @@ void ospf_ls_rxmt_timer(struct event *event)
 	/* R5 Dynamic adjacency pacing: retransmit indicates congestion */
 	if (nbr->oi->adj_pacing.mode == OSPF_ADJ_PACING_DYNAMIC && rxmt_lsa_count > 0) {
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: %s retransmit timer fired for %pI4 (sent %u LSAs), triggering dynamic adjust",
-				   IF_NAME(nbr->oi), &nbr->router_id, rxmt_lsa_count);
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s detected %u LSA retransmissions for neighbor %pI4; scheduling congestion evaluation",
+				   IF_NAME(nbr->oi), rxmt_lsa_count, &nbr->router_id);
 		ospf_adj_dyn_adjust(nbr->oi);
 	}
 
@@ -4449,8 +4451,7 @@ void ospf_ls_upd_send_lsa(struct ospf_neighbor *nbr, struct ospf_lsa *lsa,
  * NULL if we can not allocate, eg because LSA is bigger than imposed limit
  * on packet sizes (in which case offending LSA is deleted from update list)
  */
-static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update,
-						  struct ospf_interface *oi,
+static struct ospf_packet *ospf_ls_upd_packet_new(struct list *update, struct ospf_interface *oi,
 						  struct ospf_neighbor *dst_nbr)
 {
 	struct ospf_lsa *lsa;

--- a/ospfd/ospf_packet.h
+++ b/ospfd/ospf_packet.h
@@ -137,14 +137,22 @@ extern void ospf_ls_req_send(struct ospf_neighbor *nbr);
 extern void ospf_ls_upd_send_lsa(struct ospf_neighbor *nbr, struct ospf_lsa *lsa, int flag);
 extern void ospf_ls_upd_send(struct ospf_neighbor *nbr, struct list *lsa_list, int flag,
 			     int send_lsreq_flag);
-extern void ospf_ls_upd_queue_send(struct ospf_interface *oi,
-				   struct list *update, struct in_addr addr,
-				   int send_lsupd_now);
+extern void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
+				   struct in_addr addr, int send_lsupd_now,
+				   struct ospf_neighbor *dst_nbr);
 extern void ospf_ls_ack_send_direct(struct ospf_neighbor *nbr,
 				    struct ospf_lsa *lsa);
 extern void ospf_ls_ack_send_delayed(struct ospf_interface *oi);
 extern void ospf_ls_retransmit(struct ospf_interface *oi, struct ospf_lsa *lsa);
 extern void ospf_ls_req_event(struct ospf_neighbor *nbr);
+
+/* RFC4222 R4: LSA gap pacing helpers. */
+struct ospf_lsdb_linked_node;
+extern bool ospf_oi_any_nbr_gap_pacing(const struct ospf_interface *oi);
+extern void ospf_r4_nbr_init(struct ospf_neighbor *nbr);
+extern void ospf_r4_nbr_cancel(struct ospf_neighbor *nbr);
+extern struct listnode *ospf_r4_nbr_enqueue(struct ospf_neighbor *nbr, struct ospf_lsa *lsa);
+extern void ospf_r4_nbr_dequeue(struct ospf_neighbor *nbr, struct ospf_lsdb_linked_node *node);
 
 extern uint64_t ospf_now_ms(void);
 extern void ospf_ls_rxmt_timer(struct event *event);

--- a/ospfd/ospf_packet.h
+++ b/ospfd/ospf_packet.h
@@ -7,6 +7,8 @@
 #ifndef _ZEBRA_OSPF_PACKET_H
 #define _ZEBRA_OSPF_PACKET_H
 
+#include <ospfd/ospf_flood.h>
+
 #define OSPF_HEADER_SIZE         24U
 #define OSPF_AUTH_SIMPLE_SIZE     8U
 #define OSPF_AUTH_MD5_SIZE       16U
@@ -45,6 +47,9 @@ struct ospf_packet {
 
 	/* OSPF packet length. */
 	uint16_t length;
+	/* RFC4222/R5: LSAs serialized into this packet (locked), for ACK tracking */
+	struct ospf_lsa_list_head sent_lsas;
+	struct ospf_interface *sent_oi; /* optional: convenience for logging */
 };
 
 /* OSPF packet queue structure. */
@@ -141,6 +146,7 @@ extern void ospf_ls_ack_send_delayed(struct ospf_interface *oi);
 extern void ospf_ls_retransmit(struct ospf_interface *oi, struct ospf_lsa *lsa);
 extern void ospf_ls_req_event(struct ospf_neighbor *nbr);
 
+extern uint64_t ospf_now_ms(void);
 extern void ospf_ls_rxmt_timer(struct event *event);
 extern void ospf_ls_ack_delayed_timer(struct event *event);
 extern void ospf_poll_timer(struct event *event);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -628,7 +628,8 @@ DEFUN (ip_ospf_adj_pacing_dynamic,
 		if (first_rn->info) {
 			struct ospf_interface *first_oi = first_rn->info;
 
-			vty_out(vty, "%% Dynamic pacing initialized: start_limit=%u max=%u H=%u L=%u\n",
+			vty_out(vty,
+				"%% Dynamic pacing initialized: start_limit=%u max=%u H=%u L=%u\n",
 				OSPF_ADJ_DYN_LIMIT_INITIAL, OSPF_ADJ_DYN_LIMIT_MAX,
 				first_oi->adj_pacing.high_water, first_oi->adj_pacing.low_water);
 		}
@@ -3727,6 +3728,304 @@ DEFPY (ospf_dead_timer_any_control,
 
 	return CMD_SUCCESS;
 }
+
+/* RFC4222 R4: LSA gap pacing CLI. */
+DEFPY(ospf_gap_pacing_enable,
+      ospf_gap_pacing_enable_cmd,
+      "[no$no] ip ospf lsa-pacing",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "Enable LSA gap pacing on this interface\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_pacing_enable);
+		params->gap_pacing_enable = false;
+	} else {
+		SET_IF_PARAM(params, gap_pacing_enable);
+		params->gap_pacing_enable = true;
+	}
+
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: configure initial inter-LSU pacing gap. */
+DEFPY(ospf_gap_initial,
+      ospf_gap_initial_cmd,
+      "[no$no] ip ospf lsa-pacing initial-gap (1-60000)$gap",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Initial inter-LSU gap in milliseconds\n"
+      "Gap value\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	uint32_t min_ms = OSPF_IF_PARAM_CONFIGURED(params, gap_min_ms) ? params->gap_min_ms : 1;
+	uint32_t max_ms = OSPF_IF_PARAM_CONFIGURED(params, gap_max_ms) ? params->gap_max_ms : 60000;
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_initial_ms);
+		params->gap_initial_ms = OSPF_GAP_INITIAL_MS_DEFAULT;
+		ospf_if_update_params_all(ifp);
+		return CMD_SUCCESS;
+	}
+
+	if (gap < min_ms || gap > max_ms) {
+		vty_out(vty, "%% initial-gap (%lld) must be between %u and %u\n", (long long)gap,
+			min_ms, max_ms);
+		return CMD_WARNING;
+	}
+
+	SET_IF_PARAM(params, gap_initial_ms);
+	params->gap_initial_ms = gap;
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: remove configured initial inter-LSU pacing gap. */
+DEFUN(no_ospf_gap_initial,
+      no_ospf_gap_initial_cmd,
+      "no ip ospf lsa-pacing initial-gap",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Initial inter-LSU gap in milliseconds\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	UNSET_IF_PARAM(params, gap_initial_ms);
+	params->gap_initial_ms = OSPF_GAP_INITIAL_MS_DEFAULT;
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: configure minimum and maximum inter-LSU pacing gap. */
+DEFPY(ospf_gap_min_max,
+      ospf_gap_min_max_cmd,
+      "[no$no] ip ospf lsa-pacing min-gap (1-60000)$min max-gap (1-60000)$max",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Minimum inter-LSU gap\n"
+      "Minimum gap in milliseconds\n"
+      "Maximum inter-LSU gap\n"
+      "Maximum gap in milliseconds\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_min_ms);
+		UNSET_IF_PARAM(params, gap_max_ms);
+		params->gap_min_ms = OSPF_GAP_MIN_MS_DEFAULT;
+		params->gap_max_ms = OSPF_GAP_MAX_MS_DEFAULT;
+		ospf_if_update_params_all(ifp);
+		return CMD_SUCCESS;
+	}
+
+	if (min > max) {
+		vty_out(vty, "%% min (%lld) must be <= max (%lld)\n", (long long)min,
+			(long long)max);
+		return CMD_WARNING;
+	}
+
+	SET_IF_PARAM(params, gap_min_ms);
+	SET_IF_PARAM(params, gap_max_ms);
+	params->gap_min_ms = min;
+	params->gap_max_ms = max;
+	if (params->gap_initial_ms < params->gap_min_ms)
+		params->gap_initial_ms = params->gap_min_ms;
+	if (params->gap_initial_ms > params->gap_max_ms)
+		params->gap_initial_ms = params->gap_max_ms;
+
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: configure multiplicative gap adjustment factor. */
+DEFPY(ospf_gap_factor,
+      ospf_gap_factor_cmd,
+      "[no$no] ip ospf lsa-pacing factor (1-64)$factor",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Multiplicative backoff/recovery factor (F)\n"
+      "Factor value\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_factor);
+		params->gap_factor = OSPF_GAP_FACTOR_DEFAULT;
+	} else {
+		SET_IF_PARAM(params, gap_factor);
+		params->gap_factor = factor;
+	}
+
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: remove configured multiplicative gap adjustment factor. */
+DEFUN(no_ospf_gap_factor,
+      no_ospf_gap_factor_cmd,
+      "no ip ospf lsa-pacing factor",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Multiplicative backoff/recovery factor (F)\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	UNSET_IF_PARAM(params, gap_factor);
+	params->gap_factor = OSPF_GAP_FACTOR_DEFAULT;
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: configure maximum LSAs per paced update packet. */
+DEFPY(ospf_gap_max_lsas,
+      ospf_gap_max_lsas_cmd,
+      "[no$no] ip ospf lsa-pacing max-lsas-per-update (1-200)$max_lsas",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Maximum LSAs packed into one LSU during paced sends\n"
+      "Number of LSAs\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_max_lsas);
+		params->gap_max_lsas = OSPF_GAP_MAX_LSAS_DEFAULT;
+	} else {
+		SET_IF_PARAM(params, gap_max_lsas);
+		params->gap_max_lsas = max_lsas;
+	}
+
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: remove configured maximum LSAs per paced update packet. */
+DEFUN(no_ospf_gap_max_lsas,
+      no_ospf_gap_max_lsas_cmd,
+      "no ip ospf lsa-pacing max-lsas-per-update",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Maximum LSAs packed into one LSU during paced sends\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	UNSET_IF_PARAM(params, gap_max_lsas);
+	params->gap_max_lsas = OSPF_GAP_MAX_LSAS_DEFAULT;
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: configure minimum interval between gap adjustments. */
+DEFPY(ospf_gap_adjust_interval,
+      ospf_gap_adjust_interval_cmd,
+      "[no$no] ip ospf lsa-pacing adjust-interval (1-60000)$adjust_interval",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Minimum time between consecutive gap adjustments (T in ms)\n"
+      "Adjustment interval in milliseconds\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_adjust_int_ms);
+		params->gap_adjust_int_ms = OSPF_GAP_ADJUST_INT_MS_DEFAULT;
+	} else {
+		SET_IF_PARAM(params, gap_adjust_int_ms);
+		params->gap_adjust_int_ms = adjust_interval;
+	}
+
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: remove configured minimum interval between gap adjustments. */
+DEFUN(no_ospf_gap_adjust_interval,
+      no_ospf_gap_adjust_interval_cmd,
+      "no ip ospf lsa-pacing adjust-interval",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Minimum time between consecutive gap adjustments (T in ms)\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	UNSET_IF_PARAM(params, gap_adjust_int_ms);
+	params->gap_adjust_int_ms = OSPF_GAP_ADJUST_INT_MS_DEFAULT;
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222 R4: configure unacked-LSA low/high watermarks. */
+DEFPY(ospf_gap_watermarks,
+      ospf_gap_watermarks_cmd,
+      "[no$no] ip ospf lsa-pacing low-watermark (0-1000000)$low_water high-watermark (1-1000000)$high_water",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "LSA gap pacing parameters\n"
+      "Unacked-LSA count below which gap shrinks (L)\n"
+      "Low-watermark value\n"
+      "Unacked-LSA count above which gap grows (H)\n"
+      "High-watermark value\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (no) {
+		UNSET_IF_PARAM(params, gap_low_water);
+		UNSET_IF_PARAM(params, gap_high_water);
+		params->gap_low_water = OSPF_GAP_LOW_WATER_DEFAULT;
+		params->gap_high_water = OSPF_GAP_HIGH_WATER_DEFAULT;
+		ospf_if_update_params_all(ifp);
+		return CMD_SUCCESS;
+	}
+
+	if (low_water >= high_water) {
+		vty_out(vty, "%% low-water (%lld) must be < high-water (%lld)\n",
+			(long long)low_water, (long long)high_water);
+		return CMD_WARNING;
+	}
+
+	SET_IF_PARAM(params, gap_low_water);
+	SET_IF_PARAM(params, gap_high_water);
+	params->gap_low_water = low_water;
+	params->gap_high_water = high_water;
+
+	ospf_if_update_params_all(ifp);
+	return CMD_SUCCESS;
+}
+
 
 DEFUN (show_ip_ospf,
        show_ip_ospf_cmd,
@@ -12734,6 +13033,34 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				}
 			}
 
+			/* RFC4222 R4: LSA gap pacing print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, gap_pacing_enable) &&
+			    params->gap_pacing_enable) {
+				vty_out(vty, " ip ospf lsa-pacing\n");
+
+				if (OSPF_IF_PARAM_CONFIGURED(params, gap_initial_ms))
+					vty_out(vty, " ip ospf lsa-pacing initial-gap %u\n",
+						params->gap_initial_ms);
+				if (OSPF_IF_PARAM_CONFIGURED(params, gap_low_water) ||
+				    OSPF_IF_PARAM_CONFIGURED(params, gap_high_water))
+					vty_out(vty,
+						" ip ospf lsa-pacing low-watermark %u high-watermark %u\n",
+						params->gap_low_water, params->gap_high_water);
+				if (OSPF_IF_PARAM_CONFIGURED(params, gap_min_ms) ||
+				    OSPF_IF_PARAM_CONFIGURED(params, gap_max_ms))
+					vty_out(vty, " ip ospf lsa-pacing min-gap %u max-gap %u\n",
+						params->gap_min_ms, params->gap_max_ms);
+				if (OSPF_IF_PARAM_CONFIGURED(params, gap_factor))
+					vty_out(vty, " ip ospf lsa-pacing factor %u\n",
+						params->gap_factor);
+				if (OSPF_IF_PARAM_CONFIGURED(params, gap_adjust_int_ms))
+					vty_out(vty, " ip ospf lsa-pacing adjust-interval %u\n",
+						params->gap_adjust_int_ms);
+				if (OSPF_IF_PARAM_CONFIGURED(params, gap_max_lsas))
+					vty_out(vty, " ip ospf lsa-pacing max-lsas-per-update %u\n",
+						params->gap_max_lsas);
+			}
+
 			/* Retransmit Interval print. */
 			if (OSPF_IF_PARAM_CONFIGURED(params,
 						     retransmit_interval)
@@ -13677,6 +14004,19 @@ static void ospf_vty_if_init(void)
 	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_dynamic_thresholds_cmd);
 	install_element(INTERFACE_NODE, &no_ip_ospf_adj_pacing_cmd);
 	install_element(INTERFACE_NODE, &no_ip_ospf_adj_pacing_dynamic_thresholds_cmd);
+
+	/* RFC4222 R4: "ip ospf lsa-pacing" commands. */
+	install_element(INTERFACE_NODE, &ospf_gap_pacing_enable_cmd);
+	install_element(INTERFACE_NODE, &ospf_gap_initial_cmd);
+	install_element(INTERFACE_NODE, &no_ospf_gap_initial_cmd);
+	install_element(INTERFACE_NODE, &ospf_gap_min_max_cmd);
+	install_element(INTERFACE_NODE, &ospf_gap_factor_cmd);
+	install_element(INTERFACE_NODE, &no_ospf_gap_factor_cmd);
+	install_element(INTERFACE_NODE, &ospf_gap_adjust_interval_cmd);
+	install_element(INTERFACE_NODE, &no_ospf_gap_adjust_interval_cmd);
+	install_element(INTERFACE_NODE, &ospf_gap_watermarks_cmd);
+	install_element(INTERFACE_NODE, &ospf_gap_max_lsas_cmd);
+	install_element(INTERFACE_NODE, &no_ospf_gap_max_lsas_cmd);
 
 	/* "ip ospf retransmit-interval" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_retransmit_interval_addr_cmd);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -524,6 +524,264 @@ DEFUN_HIDDEN (no_ospf_passive_interface,
 	return CMD_SUCCESS;
 }
 
+/* RFC4222/R5 implementation*/
+DEFUN( ip_ospf_adj_pacing_static,
+	   ip_ospf_adj_pacing_static_cmd,
+	   "ip ospf adjacency-pacing static (1-65535)",
+	   "IP Information\n"
+	   "OSPF interface commands\n"
+	   "OSPF adjacency pacing configuration\n"
+	   "Set static adjacency pacing limit\n"
+	   "Max number of simultaneous adjacencies in progress\n"
+)
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct route_node *rn;
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	uint16_t limit = strtoul(argv[4]->arg, NULL, 10);
+
+	/* Check if switching from dynamic mode */
+	if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode) &&
+	    params->adj_pacing_mode == OSPF_ADJ_PACING_DYNAMIC) {
+		vty_out(vty, "%% Switching from dynamic to static pacing (limit=%u)\n", limit);
+	}
+
+	params->adj_pacing_mode = OSPF_ADJ_PACING_STATIC;
+	params->adj_pacing_static_limit = limit;
+	SET_IF_PARAM(params, adj_pacing_mode);
+	SET_IF_PARAM(params, adj_pacing_static_limit);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->adj_pacing.mode = OSPF_ADJ_PACING_STATIC;
+		oi->adj_pacing.static_limit = limit;
+		/* Clear dynamic state when switching to static */
+		oi->adj_pacing.dynamic_limit = 0;
+		oi->adj_pacing.last_adjust_ms = 0;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s static pacing ENABLED via CLI, limit=%u (dynamic state cleared)",
+				   IF_NAME(oi), limit);
+
+		/* Kick queue — new limit may open slots for waiting neighbors */
+		if (oi->adj_pacing.in_progress < limit)
+			ospf_adj_pacing_kick(oi);
+	}
+	return CMD_SUCCESS;
+}
+
+/* RFC4222/R5 implementation*/
+DEFUN (ip_ospf_adj_pacing_dynamic,
+       ip_ospf_adj_pacing_dynamic_cmd,
+       "ip ospf adjacency-pacing dynamic",
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n"
+       "Dynamic pacing\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct route_node *rn;
+	struct route_node *first_rn;
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	/* Check if switching from static mode */
+	if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode) &&
+	    params->adj_pacing_mode == OSPF_ADJ_PACING_STATIC) {
+		vty_out(vty, "%% Switching from static (limit=%u) to dynamic pacing\n",
+			params->adj_pacing_static_limit);
+	}
+
+	params->adj_pacing_mode = OSPF_ADJ_PACING_DYNAMIC;
+	params->adj_pacing_static_limit = 0;
+	SET_IF_PARAM(params, adj_pacing_mode);
+	SET_IF_PARAM(params, adj_pacing_static_limit);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+		oi->adj_pacing.mode = OSPF_ADJ_PACING_DYNAMIC;
+		oi->adj_pacing.static_limit = 0;
+		/* Reset dynamic limit to initial value when enabling */
+		oi->adj_pacing.dynamic_limit = OSPF_ADJ_DYN_LIMIT_INITIAL;
+		oi->adj_pacing.last_adjust_ms = 0;
+		/* Apply stored threshold params if configured */
+		if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_high_water))
+			oi->adj_pacing.high_water = params->adj_pacing_high_water;
+		if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_low_water))
+			oi->adj_pacing.low_water = params->adj_pacing_low_water;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s dynamic pacing ENABLED via CLI, initial limit=%u H=%u L=%u",
+				   IF_NAME(oi), OSPF_ADJ_DYN_LIMIT_INITIAL,
+				   oi->adj_pacing.high_water, oi->adj_pacing.low_water);
+	}
+
+	/* Show user what thresholds will be used */
+	first_rn = route_top(IF_OIFS(ifp));
+	if (first_rn) {
+		if (first_rn->info) {
+			struct ospf_interface *first_oi = first_rn->info;
+
+			vty_out(vty, "%% Dynamic pacing initialized: start_limit=%u max=%u H=%u L=%u\n",
+				OSPF_ADJ_DYN_LIMIT_INITIAL, OSPF_ADJ_DYN_LIMIT_MAX,
+				first_oi->adj_pacing.high_water, first_oi->adj_pacing.low_water);
+		}
+		route_unlock_node(first_rn);
+	}
+
+	return CMD_SUCCESS;
+}
+
+/* RFC4222/R5 implementation - Configure dynamic pacing thresholds */
+DEFUN (ip_ospf_adj_pacing_dynamic_thresholds,
+       ip_ospf_adj_pacing_dynamic_thresholds_cmd,
+       "ip ospf adjacency-pacing dynamic thresholds (1-1000) (1-1000)",
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n"
+       "Dynamic pacing\n"
+       "Configure thresholds\n"
+       "High water mark (H) for total unacked LSAs\n"
+       "Low water mark (L) for total unacked LSAs\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	struct route_node *rn;
+	int idx_high = 5;
+	int idx_low = 6;
+	uint32_t high_water = strtoul(argv[idx_high]->arg, NULL, 10);
+	uint32_t low_water = strtoul(argv[idx_low]->arg, NULL, 10);
+
+	if (low_water >= high_water) {
+		vty_out(vty, "%% Error: Low water (%u) must be less than high water (%u)\n",
+			low_water, high_water);
+		return CMD_WARNING;
+	}
+
+	// Store in persistent params
+	params->adj_pacing_high_water = high_water;
+	params->adj_pacing_low_water = low_water;
+	SET_IF_PARAM(params, adj_pacing_high_water);
+	SET_IF_PARAM(params, adj_pacing_low_water);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->adj_pacing.high_water = high_water;
+		oi->adj_pacing.low_water = low_water;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s dynamic pacing thresholds set: H=%u L=%u", IF_NAME(oi),
+				   high_water, low_water);
+	}
+
+	vty_out(vty, "%% Dynamic pacing thresholds: H=%u L=%u\n", high_water, low_water);
+	return CMD_SUCCESS;
+}
+
+/* RFC4222/R5 implementation*/
+DEFUN (no_ip_ospf_adj_pacing,
+       no_ip_ospf_adj_pacing_cmd,
+       "no ip ospf adjacency-pacing",
+       NO_STR
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct route_node *rn;
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	/* Show user what was disabled */
+	if (OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode)) {
+		if (params->adj_pacing_mode == OSPF_ADJ_PACING_STATIC)
+			vty_out(vty, "%% Disabling static adjacency pacing (was limit=%u)\n",
+				params->adj_pacing_static_limit);
+		else if (params->adj_pacing_mode == OSPF_ADJ_PACING_DYNAMIC)
+			vty_out(vty, "%% Disabling dynamic adjacency pacing\n");
+	}
+
+	params->adj_pacing_mode = OSPF_ADJ_PACING_NONE;
+	params->adj_pacing_static_limit = 0;
+	UNSET_IF_PARAM(params, adj_pacing_mode);
+	UNSET_IF_PARAM(params, adj_pacing_static_limit);
+	UNSET_IF_PARAM(params, adj_pacing_high_water);
+	UNSET_IF_PARAM(params, adj_pacing_low_water);
+
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		/* Cancel dynamic adjustment timer */
+		if (oi->adj_pacing.t_dyn_adjust) {
+			event_cancel(&oi->adj_pacing.t_dyn_adjust);
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("R5: %s cancelled pending AIMD adjustment timer",
+					   IF_NAME(oi));
+		}
+
+		/* Flush queued neighbors - allow them to proceed */
+		ospf_adj_pacing_queue_flush(oi);
+
+		/* Clear mode and limits */
+		oi->adj_pacing.mode = OSPF_ADJ_PACING_NONE;
+		oi->adj_pacing.static_limit = 0;
+		oi->adj_pacing.dynamic_limit = 0;
+		oi->adj_pacing.last_adjust_ms = 0;
+
+		/* Reset thresholds to defaults for consistency */
+		oi->adj_pacing.high_water = OSPF_ADJ_DYN_HIGH_WATER;
+		oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
+
+		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+			zlog_debug("R5: %s adjacency pacing DISABLED (mode=NONE, in_progress=%u)",
+				   IF_NAME(oi), oi->adj_pacing.in_progress);
+	}
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_ip_ospf_adj_pacing_dynamic_thresholds,
+       no_ip_ospf_adj_pacing_dynamic_thresholds_cmd,
+       "no ip ospf adjacency-pacing dynamic thresholds",
+       NO_STR
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Adjacency pacing control\n"
+       "Dynamic pacing\n"
+       "Clear threshold configuration\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+	struct route_node *rn;
+
+	UNSET_IF_PARAM(params, adj_pacing_high_water);
+	UNSET_IF_PARAM(params, adj_pacing_low_water);
+
+	// Reset to defaults on active interfaces
+	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+		struct ospf_interface *oi = rn->info;
+
+		if (!oi)
+			continue;
+
+		oi->adj_pacing.high_water = OSPF_ADJ_DYN_HIGH_WATER;
+		oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
+	}
+
+	return CMD_SUCCESS;
+}
+
 
 DEFUN (ospf_network_area,
        ospf_network_area_cmd,
@@ -12456,6 +12714,26 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				vty_out(vty, "\n");
 			}
 
+			/* RFC4222/R5: Adjacency pacing print (interface-wide). */
+			if (params == IF_DEF_PARAMS(ifp) &&
+			    OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_mode)) {
+				if (params->adj_pacing_mode == OSPF_ADJ_PACING_STATIC) {
+					vty_out(vty, " ip ospf adjacency-pacing static %u\n",
+						params->adj_pacing_static_limit);
+				} else if (params->adj_pacing_mode == OSPF_ADJ_PACING_DYNAMIC) {
+					vty_out(vty, " ip ospf adjacency-pacing dynamic\n");
+					/* Write dynamic thresholds if configured */
+					if (OSPF_IF_PARAM_CONFIGURED(params,
+								     adj_pacing_high_water) &&
+					    OSPF_IF_PARAM_CONFIGURED(params, adj_pacing_low_water)) {
+						vty_out(vty,
+							" ip ospf adjacency-pacing dynamic thresholds %u %u\n",
+							params->adj_pacing_high_water,
+							params->adj_pacing_low_water);
+					}
+				}
+			}
+
 			/* Retransmit Interval print. */
 			if (OSPF_IF_PARAM_CONFIGURED(params,
 						     retransmit_interval)
@@ -13392,6 +13670,13 @@ static void ospf_vty_if_init(void)
 	/* "ip ospf priority" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_priority_cmd);
 	install_element(INTERFACE_NODE, &no_ip_ospf_priority_cmd);
+
+	/* "ip ospf adjacency-pacing" commands. */
+	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_static_cmd);
+	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_dynamic_cmd);
+	install_element(INTERFACE_NODE, &ip_ospf_adj_pacing_dynamic_thresholds_cmd);
+	install_element(INTERFACE_NODE, &no_ip_ospf_adj_pacing_cmd);
+	install_element(INTERFACE_NODE, &no_ip_ospf_adj_pacing_dynamic_thresholds_cmd);
 
 	/* "ip ospf retransmit-interval" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_retransmit_interval_addr_cmd);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -564,7 +564,7 @@ DEFUN( ip_ospf_adj_pacing_static,
 		oi->adj_pacing.last_adjust_ms = 0;
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: %s static pacing ENABLED via CLI, limit=%u (dynamic state cleared)",
+			zlog_debug("OSPF adjacency pacing: static mode enabled on interface %s (limit=%u)",
 				   IF_NAME(oi), limit);
 
 		/* Kick queue — new limit may open slots for waiting neighbors */
@@ -617,7 +617,7 @@ DEFUN (ip_ospf_adj_pacing_dynamic,
 			oi->adj_pacing.low_water = params->adj_pacing_low_water;
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: %s dynamic pacing ENABLED via CLI, initial limit=%u H=%u L=%u",
+			zlog_debug("OSPF dynamic adjacency pacing: enabled on interface %s (initial-limit=%u high-water=%u low-water=%u)",
 				   IF_NAME(oi), OSPF_ADJ_DYN_LIMIT_INITIAL,
 				   oi->adj_pacing.high_water, oi->adj_pacing.low_water);
 	}
@@ -681,8 +681,8 @@ DEFUN (ip_ospf_adj_pacing_dynamic_thresholds,
 		oi->adj_pacing.low_water = low_water;
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: %s dynamic pacing thresholds set: H=%u L=%u", IF_NAME(oi),
-				   high_water, low_water);
+			zlog_debug("OSPF dynamic adjacency pacing: interface %s thresholds updated (high-water=%u low-water=%u)",
+				   IF_NAME(oi), high_water, low_water);
 	}
 
 	vty_out(vty, "%% Dynamic pacing thresholds: H=%u L=%u\n", high_water, low_water);
@@ -728,7 +728,7 @@ DEFUN (no_ip_ospf_adj_pacing,
 		if (oi->adj_pacing.t_dyn_adjust) {
 			event_cancel(&oi->adj_pacing.t_dyn_adjust);
 			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-				zlog_debug("R5: %s cancelled pending AIMD adjustment timer",
+				zlog_debug("OSPF dynamic adjacency pacing: interface %s cancelled pending congestion evaluation",
 					   IF_NAME(oi));
 		}
 
@@ -746,7 +746,7 @@ DEFUN (no_ip_ospf_adj_pacing,
 		oi->adj_pacing.low_water = OSPF_ADJ_DYN_LOW_WATER;
 
 		if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
-			zlog_debug("R5: %s adjacency pacing DISABLED (mode=NONE, in_progress=%u)",
+			zlog_debug("OSPF adjacency pacing: disabled on interface %s (in-progress=%u)",
 				   IF_NAME(oi), oi->adj_pacing.in_progress);
 	}
 	return CMD_SUCCESS;
@@ -3766,7 +3766,9 @@ DEFPY(ospf_gap_initial,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
-	uint32_t min_ms = OSPF_IF_PARAM_CONFIGURED(params, gap_min_ms) ? params->gap_min_ms : 1;
+	uint32_t min_ms = OSPF_IF_PARAM_CONFIGURED(params, gap_min_ms)
+				  ? params->gap_min_ms
+				  : OSPF_GAP_MIN_MS_LOWER_BOUND;
 	uint32_t max_ms = OSPF_IF_PARAM_CONFIGURED(params, gap_max_ms) ? params->gap_max_ms : 60000;
 
 	if (no) {

--- a/tests/topotests/ospf_4222_recommendation_5/r1/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r1/frr.conf
@@ -1,0 +1,32 @@
+frr defaults traditional
+hostname r1
+log syslog informational
+log commands
+service integrated-vtysh-config
+!
+ip router-id 10.0.0.1
+!
+interface eth1
+ ip address 10.0.1.1/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+router ospf
+ ospf router-id 10.0.0.1
+exit
+!
+debug ospf event
+debug ospf nsm
+debug ospf nsm events
+debug ospf packet hello
+debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file /tmp/r1-frr.log debugging
+end

--- a/tests/topotests/ospf_4222_recommendation_5/r1_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r1_broadcast/frr.conf
@@ -1,0 +1,38 @@
+frr defaults traditional
+hostname r1_broadcast
+!
+interface r1-eth0
+ ip address 198.51.100.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+ ip ospf adjacency-pacing dynamic
+ !ip ospf adjacency-pacing static 1
+!
+interface r1-eth1
+ ip address 198.51.101.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+!
+# In FRR vtysh:
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+!debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file /var/log/frr/debug.log debugging
+log file /tmp/r1-frr.rrg
+end

--- a/tests/topotests/ospf_4222_recommendation_5/r1_broadcast_static/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r1_broadcast_static/frr.conf
@@ -1,0 +1,38 @@
+frr defaults traditional
+hostname r1_broadcast_static
+!
+interface r1-eth0
+ ip address 198.51.100.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+ ip ospf adjacency-pacing static 1
+!
+interface r1-eth1
+ ip address 198.51.101.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+ ip ospf adjacency-pacing dynamic
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+!
+# In FRR vtysh:
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+!debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file /var/log/frr/debug.log debugging
+log file /tmp/r1-frr.rrg
+end

--- a/tests/topotests/ospf_4222_recommendation_5/r2/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r2/frr.conf
@@ -1,0 +1,29 @@
+frr defaults traditional
+hostname r2
+log syslog informational
+service integrated-vtysh-config
+!
+ip router-id 10.0.0.2
+!
+interface eth1
+ ip address 10.0.1.2/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+interface eth2
+ ip address 10.0.2.1/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+router ospf
+ ospf router-id 10.0.0.2
+exit
+!
+line vty
+exit

--- a/tests/topotests/ospf_4222_recommendation_5/r2_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r2_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r2_broadcast
+!
+interface r2-eth0
+ ip address 198.51.100.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 200
+!
+router ospf
+ ospf router-id 1.1.1.2
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r3/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r3/frr.conf
@@ -1,0 +1,21 @@
+frr defaults traditional
+hostname r3
+log syslog informational
+service integrated-vtysh-config
+!
+ip router-id 10.0.0.3
+!
+interface eth1
+ ip address 10.0.2.2/24
+ ip ospf area 0.0.0.0
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf network point-to-point
+exit
+!
+router ospf
+ ospf router-id 10.0.0.3
+exit
+!
+line vty
+exit

--- a/tests/topotests/ospf_4222_recommendation_5/r3_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r3_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r3_broadcast
+!
+interface r3-eth0
+ ip address 198.51.100.3/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.3
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r4_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r4_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r4_broadcast
+!
+interface r4-eth0
+ ip address 198.51.100.4/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.4
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r5_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r5_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r5_broadcast
+!
+interface r5-eth0
+ ip address 198.51.100.5/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.5
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r6_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r6_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r6_broadcast
+!
+interface r6-eth0
+ ip address 198.51.101.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 200
+!
+router ospf
+ ospf router-id 1.1.1.6
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/r7_broadcast/frr.conf
+++ b/tests/topotests/ospf_4222_recommendation_5/r7_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r7_broadcast
+!
+interface r7-eth0
+ ip address 198.51.101.3/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 0
+!
+router ospf
+ ospf router-id 1.1.1.7
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
@@ -10,13 +10,23 @@
 #
 
 """
-test_ospf_adj_pacing_dynamic.py: Test OSPF RFC4222/R5 Dynamic Adjacency Pacing
+test_ospf_adj_pacing_config.py: Test OSPF RFC4222/R5 Adjacency Pacing Configuration
 
-Tests dynamic pacing threshold configuration persistence and functionality:
+Tests static and dynamic pacing configuration persistence and functionality:
+Dynamic:
 1. Config persistence across FRR restart
 2. Config persistence across interface flap
 3. Threshold values used in AIMD algorithm
 4. Config writeback includes thresholds
+
+Static:
+5. Config persistence (write memory / running-config)
+6. Config persistence across FRR restart
+7. Config persistence across interface flap
+8. no-command removes static config
+9. Boundary values (limit=1, limit=65535)
+10. Transition from static to dynamic mode
+11. Transition from dynamic to static mode
 """
 
 import pytest
@@ -407,6 +417,236 @@ def test_adj_pacing_cleanup_on_disable(tgen):
         no ip ospf adjacency-pacing
         end
     """)
+
+
+def test_adj_pacing_static_config_persistence(tgen):
+    """Test that static pacing limit persists in running-config and write memory."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 4
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 4" in running_config, \
+        "Static pacing limit not in running config"
+
+    r1.vtysh_cmd("write memory")
+    startup_config = r1.run("cat /etc/frr/frr.conf")
+    assert "ip ospf adjacency-pacing static 4" in startup_config, \
+        "Static pacing limit not saved to frr.conf"
+
+
+def test_adj_pacing_static_frr_restart(tgen):
+    """Test that static pacing limit persists across ospfd restart."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 3
+        end
+    """)
+    r1.vtysh_cmd("write memory")
+
+    r1.killDaemons(["ospfd"])
+    time.sleep(2)
+    r1.startDaemons(["ospfd"])
+    time.sleep(2)
+    r1.run("vtysh -f /etc/frr/frr.conf")
+    time.sleep(3)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 3" in running_config, \
+        "Static pacing limit lost after ospfd restart"
+
+
+def test_adj_pacing_static_interface_flap(tgen):
+    """Test that static pacing limit survives interface shutdown/no shutdown."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 5
+        end
+    """)
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        shutdown
+        end
+    """)
+    time.sleep(2)
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no shutdown
+        end
+    """)
+    time.sleep(2)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 5" in running_config, \
+        "Static pacing limit lost after interface flap"
+
+
+def test_adj_pacing_static_no_command(tgen):
+    """Test that no ip ospf adjacency-pacing removes static config."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 6
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 6" in running_config, \
+        "Static pacing not configured"
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing" not in running_config, \
+        "Static pacing config not removed by no-command"
+
+
+def test_adj_pacing_static_boundary_values(tgen):
+    """Test static pacing at minimum (1) and maximum (65535) limit values."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Minimum value
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 1
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 1" in running_config, \
+        "Static pacing minimum value (1) not accepted"
+
+    # Maximum value
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 65535
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 65535" in running_config, \
+        "Static pacing maximum value (65535) not accepted"
+
+    # Cleanup
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+
+def test_adj_pacing_static_to_dynamic_transition(tgen):
+    """Test switching from static to dynamic mode replaces config cleanly."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Start with static
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 4
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static 4" in running_config, \
+        "Static pacing not configured"
+
+    # Switch to dynamic — static config must disappear
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 60 6
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing static" not in running_config, \
+        "Static pacing config still present after switching to dynamic"
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing not present after transition"
+    assert "ip ospf adjacency-pacing dynamic thresholds 60 6" in running_config, \
+        "Dynamic thresholds not present after transition"
+
+
+def test_adj_pacing_dynamic_to_static_transition(tgen):
+    """Test switching from dynamic to static mode replaces config cleanly."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Start with dynamic
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 80 8
+        end
+    """)
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 80 8" in running_config, \
+        "Dynamic pacing not configured"
+
+    # Switch to static — dynamic config must disappear
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing static 2
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic" not in running_config, \
+        "Dynamic pacing config still present after switching to static"
+    assert "ip ospf adjacency-pacing static 2" in running_config, \
+        "Static pacing not present after transition"
 
 
 if __name__ == "__main__":

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_adj_pacing_config.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_adj_pacing_dynamic.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_ospf_adj_pacing_dynamic.py: Test OSPF RFC4222/R5 Dynamic Adjacency Pacing
+
+Tests dynamic pacing threshold configuration persistence and functionality:
+1. Config persistence across FRR restart
+2. Config persistence across interface flap
+3. Threshold values used in AIMD algorithm
+4. Config writeback includes thresholds
+"""
+
+import pytest
+import time
+
+from lib.topogen import Topogen
+
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    """Build test topology.
+
+    r1 --- r2 --- r3
+
+    r1-r2: Will have dynamic pacing with custom thresholds
+    r2-r3: Used to create multiple adjacencies on r2
+    """
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    r3 = tgen.add_router("r3")
+
+    tgen.add_link(r1, r2, ifname1="eth1", ifname2="eth1")
+    tgen.add_link(r2, r3, ifname1="eth2", ifname2="eth1")
+
+
+@pytest.fixture(scope="function")
+def tgen(request):
+    """Setup/Teardown the environment and provide tgen argument to tests."""
+
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, router in router_list.items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+    yield tgen
+
+    tgen.stop_topology()
+
+
+def test_adj_pacing_dynamic_config_persistence(tgen):
+    """Test that dynamic pacing thresholds persist in configuration."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with custom thresholds on r1's eth1
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 50 5
+        end
+    """)
+
+    # Step 2: Verify configuration via show running-config
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode not in running config"
+    assert "ip ospf adjacency-pacing dynamic thresholds 50 5" in running_config, \
+        "Dynamic pacing thresholds not in running config"
+
+    # Step 3: Write memory
+    r1.vtysh_cmd("write memory")
+
+    # Step 4: Read the saved config file
+    startup_config = r1.run("cat /etc/frr/frr.conf")
+
+    assert "ip ospf adjacency-pacing dynamic" in startup_config, \
+        "Dynamic pacing mode not in saved config"
+    assert "ip ospf adjacency-pacing dynamic thresholds 50 5" in startup_config, \
+        "Dynamic pacing thresholds not in saved config"
+
+
+def test_adj_pacing_dynamic_interface_flap(tgen):
+    """Test that dynamic pacing thresholds survive interface flap."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 80 10
+        end
+    """)
+
+    # Step 2: Shutdown and no shutdown the interface
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        shutdown
+        end
+    """)
+    time.sleep(2)
+
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no shutdown
+        end
+    """)
+    time.sleep(2)
+
+    # Step 3: Verify configuration is still present after flap
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic thresholds 80 10" in running_config, \
+        "Dynamic pacing thresholds lost after interface flap"
+
+
+def test_adj_pacing_dynamic_frr_restart(tgen):
+    """Test that dynamic pacing thresholds persist across FRR restart."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 60 8
+        end
+    """)
+
+    # Step 2: Save configuration to frr.conf
+    r1.vtysh_cmd("write memory")
+
+    # Step 3: Kill and restart ospfd to re-read frr.conf from disk
+    r1.killDaemons(["ospfd"])
+    time.sleep(2)
+    r1.startDaemons(["ospfd"])
+    time.sleep(2)
+    # startDaemons only launches the process; push the saved config into it
+    r1.run("vtysh -f /etc/frr/frr.conf")
+    time.sleep(3)
+
+    # Step 4: Verify configuration is still active after daemon re-read frr.conf
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode lost after restart"
+    assert "ip ospf adjacency-pacing dynamic thresholds 60 8" in running_config, \
+        "Dynamic pacing thresholds lost after restart"
+
+
+def test_adj_pacing_dynamic_no_command(tgen):
+    """Test that 'no' command properly removes thresholds."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing with thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 70 12
+        end
+    """)
+
+    # Step 2: Verify configuration is present
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 70 12" in running_config, \
+        "Thresholds not configured"
+
+    # Step 3: Remove threshold configuration
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing dynamic thresholds
+        end
+    """)
+
+    # Step 4: Verify thresholds are removed but dynamic mode remains
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode incorrectly removed"
+    assert "ip ospf adjacency-pacing dynamic thresholds" not in running_config, \
+        "Thresholds not removed from config"
+
+
+def test_adj_pacing_dynamic_threshold_validation(tgen):
+    """Test that threshold validation works correctly."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Test 1: Low water >= High water should fail
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic thresholds 50 50
+        end
+    """)
+
+    assert "Error" in output or "must be less" in output, \
+        "Validation should reject low_water >= high_water"
+
+    # Test 2: Low water > High water should fail
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic thresholds 30 40
+        end
+    """)
+
+    assert "Error" in output or "must be less" in output, \
+        "Validation should reject low_water > high_water"
+
+    # Test 3: Valid configuration should succeed
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 100 2
+        end
+    """)
+
+    assert "Error" not in output, \
+        "Valid configuration should succeed"
+
+    # Verify it's actually configured
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 100 2" in running_config, \
+        "Valid thresholds not configured"
+
+
+def test_adj_pacing_dynamic_defaults(tgen):
+    """Test that default thresholds are used when not explicitly configured."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Configure dynamic pacing WITHOUT custom thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        end
+    """)
+
+    # Step 2: Verify mode is in config but no threshold line is written
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing mode not in config"
+    assert "ip ospf adjacency-pacing dynamic thresholds" not in running_config, \
+        "Default config should not show threshold values"
+
+
+def test_adj_pacing_cleanup_on_disable(tgen):
+    """Test that disabling adjacency pacing properly cleans up all state.
+
+    This test verifies the fix for the cleanup issue where:
+    1. Timer (t_dyn_adjust) is cancelled
+    2. Queued neighbors are flushed and allowed to proceed
+    3. Queue is cleared
+    4. Thresholds are reset to defaults
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Step 1: Configure dynamic pacing with custom thresholds
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 50 5
+        end
+    """)
+
+    # Wait for configuration to take effect
+    time.sleep(2)
+
+    # Step 2: Verify pacing is configured
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic" in running_config, \
+        "Dynamic pacing not configured"
+    assert "ip ospf adjacency-pacing dynamic thresholds 50 5" in running_config, \
+        "Thresholds not configured"
+
+    # Step 3: Create some adjacency activity by flapping r2's interface
+    # This may create queued neighbors or trigger the AIMD timer
+    r2.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        shutdown
+        end
+    """)
+    time.sleep(1)
+    r2.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no shutdown
+        end
+    """)
+    time.sleep(2)
+
+    # Step 4: Disable adjacency pacing
+    output = r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+    # Step 5: Verify pacing is removed from config
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing" not in running_config, \
+        "Adjacency pacing still in config after disable"
+
+    # Step 6: Verify cleanup message in output
+    # The command should report what was disabled and how many neighbors were flushed
+    assert "Disabling" in output or "disabled" in output.lower(), \
+        "No confirmation message when disabling pacing"
+
+    # Step 7: Check OSPF interface to ensure neighbors can form properly
+    # After cleanup, new adjacencies should not be blocked
+    time.sleep(5)  # Allow time for adjacency to form
+
+    # Verify r1-r2 adjacency can reach Full state (not stuck in TwoWay)
+    neighbor_output = r1.vtysh_cmd("show ip ospf neighbor json")
+
+    # Parse JSON to check neighbor state
+    import json
+    try:
+        neighbor_data = json.loads(neighbor_output)
+        # Check if there are any neighbors
+        if "default" in neighbor_data:
+            neighbors = neighbor_data["default"]
+            if neighbors:
+                # At least one neighbor should exist and should not be stuck in TwoWay
+                for nbr_id, nbr_info in neighbors.items():
+                    if nbr_info:
+                        state = nbr_info[0].get("nbrState", "")
+                        # State can be "Full/DROther", "Full/DR", etc.
+                        assert "TwoWay" not in state or "Full" in state, \
+                            f"Neighbor {nbr_id} stuck in {state} after pacing cleanup"
+    except json.JSONDecodeError:
+        # If JSON parsing fails, at least verify output exists
+        assert neighbor_output, "No neighbor output after cleanup"
+
+    # Step 8: Verify that we can re-enable pacing without issues
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        ip ospf adjacency-pacing dynamic
+        ip ospf adjacency-pacing dynamic thresholds 80 10
+        end
+    """)
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic thresholds 80 10" in running_config, \
+        "Cannot re-enable pacing after cleanup"
+
+    # Cleanup: remove pacing configuration
+    r1.vtysh_cmd("""
+        configure terminal
+        interface eth1
+        no ip ospf adjacency-pacing
+        end
+    """)
+
+
+if __name__ == "__main__":
+    # To run the tests manually
+    import os
+    import sys
+
+    # Allow running from the test directory
+    sys.exit(pytest.main(["-s", __file__]))

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_dynamic_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_dynamic_pacing.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_broadcast_2router_constraint.py
+# Test RFC4222 Rec5 dynamic adjacency pacing with constrained link
+#
+
+import os
+import sys
+from functools import partial
+import pytest
+from time import sleep
+import time
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+from util_pcap import PerInterfacePcapManager
+
+"""
+OSPF broadcast test for dynamic adjacency pacing baseline.
+Start with no constraints, then can incrementally add bandwidth limits to identify when issues trigger.
+"""
+
+TOPOLOGY = """
+                  +-----+  +-----+  +-----+  +-----+
+                  | r2  |  | r3  |  | r4  |  | r5  |
+                  +--+--+  +--+--+  +--+--+  +--+--+
+                     |        |        |        |
+        +-----+      +--------+--------+--------+--------+
+        | r1  |--------------- 198.51.100.0/24 (s0)
+        +--+--+
+           |
+           |         +-----+  +-----+
+           +---------| r6  |  | r7  |
+                     +--+--+  +--+--+
+                        |        |
+                        +--------+-------- 198.51.101.0/24 (s1)
+"""
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.ospfd]
+PM = None
+
+
+def build_topo(tgen):
+    "Build function"
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+    tgen.add_router("r5")
+    tgen.add_router("r6")
+    tgen.add_router("r7")
+
+    switch = tgen.add_switch("s0")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r6"])
+    switch.add_link(tgen.gears["r7"])
+
+
+def setup_module(mod):
+    logger.info("OSPF broadcast baseline topology:\n %s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # Apply network constraints to stress-test dynamic pacing
+    r1 = tgen.gears["r1"]
+    r1.cmd("tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms")
+    r1.cmd("tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms")
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        if rname == "r1":
+            router.load_frr_config(os.path.join(CWD, "r1_broadcast", "frr.conf"))
+        elif rname == "r2":
+            router.load_frr_config(os.path.join(CWD, "r2_broadcast", "frr.conf"))
+        elif rname == "r3":
+            router.load_frr_config(os.path.join(CWD, "r3_broadcast", "frr.conf"))
+        elif rname == "r4":
+            router.load_frr_config(os.path.join(CWD, "r4_broadcast", "frr.conf"))
+        elif rname == "r5":
+            router.load_frr_config(os.path.join(CWD, "r5_broadcast", "frr.conf"))
+        elif rname == "r6":
+            router.load_frr_config(os.path.join(CWD, "r6_broadcast", "frr.conf"))
+        elif rname == "r7":
+            router.load_frr_config(os.path.join(CWD, "r7_broadcast", "frr.conf"))
+
+    tgen.start_router()
+
+    global PM
+    PM = PerInterfacePcapManager(outdir="pcaps", tag="ospf4")
+    PM.start_all(tgen)
+    # Keep captures only for r1 interfaces
+    for (rname, ifn), pid in list(PM.pids.items()):
+        if rname != "r1":
+            router = tgen.routers().get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+            PM.pids.pop((rname, ifn), None)
+
+
+def teardown_module():
+    tgen = get_topogen()
+    global PM
+    if PM:
+        PM.stop_all(tgen)
+    tgen.stop_topology()
+
+
+def wait_for_ospf_ifname(topo_router):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        ifname = next(iter(interfaces.keys()), None)
+        if ifname:
+            ifname_holder["name"] = ifname
+            return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface found on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_ospf_ifname_by_ip(topo_router, ip):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        for ifname, attrs in interfaces.items():
+            if attrs.get("ipAddress") == ip:
+                ifname_holder["name"] = ifname
+                return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface with IP {ip} on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_neighbor_full(tgen, router, neighbor_id):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} neighbor {neighbor_id} FULL")
+
+    def _poll():
+        data = topo_router.vtysh_cmd(
+            f"show ip ospf neighbor {neighbor_id} json", isjson=True
+        )
+        nbr_list = data.get("default", {}).get(neighbor_id)
+        if not nbr_list:
+            return "missing"
+        state = nbr_list[0].get("nbrState", "")
+        if state.split("/", 1)[0] == "Full":
+            return None
+        return state or "unknown"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assertmsg = f"Neighbor {neighbor_id} not FULL on {router}"
+    assert result is None, assertmsg
+
+
+def verify_broadcast_interface(
+    tgen, router, ifname, ip, router_id, nbr_cnt, nbr_adj_cnt, state=None
+):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} broadcast interface settings")
+    iface = {
+        "ospfEnabled": True,
+        "ipAddress": ip,
+        "ipAddressPrefixlen": 24,
+        "ospfIfType": "Broadcast",
+        "area": "0.0.0.0",
+        "routerId": router_id,
+        "networkType": "BROADCAST",
+        "nbrCount": nbr_cnt,
+        "nbrAdjacentCount": nbr_adj_cnt,
+    }
+    if state:
+        iface["state"] = state
+    input_dict = {"interfaces": {ifname: iface}}
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        f"show ip ospf interface {ifname} json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = f"Broadcast interface mismatch on {router}"
+    assert result is None, assertmsg
+
+
+def verify_adjacency_static_pacing(tgen, router, ifname, limit):
+    step(f"Verify {router} adjacency pacing static {limit} on {ifname}")
+    rc, _, _ = tgen.net[router].cmd_status(
+        f"vtysh -c 'show running ospfd' | grep -q 'ip ospf adjacency-pacing static {limit}'",
+        warn=False,
+    )
+    assert rc == 0, f"adjacency pacing static {limit} not present on {router} {ifname}"
+
+
+def verify_dynamic_adjacency_pacing(tgen, router, ifname):
+    """Verify dynamic adjacency pacing is enabled on the interface."""
+    step(f"Verify {router} adjacency pacing dynamic on {ifname}")
+    rc, _, _ = tgen.net[router].cmd_status(
+        f"vtysh -c 'show running ospfd' | grep -q 'ip ospf adjacency-pacing dynamic'",
+        warn=False,
+    )
+    assert rc == 0, f"adjacency pacing dynamic not present on {router} {ifname}"
+
+
+def wait_for_opaque_area_lsa(tgen, router, area, link_state_id, adv_router):
+    topo_router = tgen.gears[router]
+    expected = {
+        "areaLocalOpaqueLsa": {
+            "areas": {
+                area: [
+                    {
+                        "linkStateId": link_state_id,
+                        "advertisingRouter": adv_router,
+                    }
+                ]
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip ospf database opaque-area json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Opaque area LSA {link_state_id} from {adv_router} not found on {router}"
+
+
+def verify_no_adjacency_pacing(tgen, router, ifname):
+    step(f"Verify {router} has no adjacency pacing on {ifname}")
+    cmd = (
+        f"vtysh -c 'show running ospfd' | "
+        f"awk -v ifname='{ifname}' "
+        "'($1==\"interface\" && $2==ifname){f=1} "
+        "($1==\"interface\" && $2!=ifname){f=0} "
+        "($1==\"exit\" || $1==\"!\"){f=0} "
+        "f{print}'"
+    )
+    rc, out, err = tgen.net[router].cmd_status(cmd, warn=False)
+    logger.info("no-pacing check output for %s %s:\n%s", router, ifname, out)
+    if err:
+        logger.info("no-pacing check stderr for %s %s:\n%s", router, ifname, err)
+    rc = 1 if "adjacency-pacing" in out else 0
+    assert not rc, f"unexpected adjacency pacing on {router} {ifname}"
+
+
+def test_ospf_broadcast_7router_neighbors_full():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1_if = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.100.1")
+    r2_if = wait_for_ospf_ifname(tgen.gears["r2"])
+    r3_if = wait_for_ospf_ifname(tgen.gears["r3"])
+    r4_if = wait_for_ospf_ifname(tgen.gears["r4"])
+    r5_if = wait_for_ospf_ifname(tgen.gears["r5"])
+    r6_if = wait_for_ospf_ifname(tgen.gears["r6"])
+    r7_if = wait_for_ospf_ifname(tgen.gears["r7"])
+    r1_if2 = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.101.1")
+    assert r1_if and r1_if2 and r2_if and r3_if and r4_if and r5_if and r6_if and r7_if
+
+    verify_dynamic_adjacency_pacing(tgen, "r1", r1_if)
+    step("Dump r1 show running ospfd")
+    logger.info(
+        "r1 show running ospfd:\n%s",
+        tgen.net["r1"].cmd("vtysh -c 'show running ospfd'"),
+    )
+    verify_no_adjacency_pacing(tgen, "r1", r1_if2)
+
+    # On broadcast networks, DROthers only form FULL adjacencies with DR/BDR.
+    verify_broadcast_interface(
+        tgen, "r1", r1_if, "198.51.100.1", "1.1.1.1", 4, 4, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r2", r2_if, "198.51.100.2", "1.1.1.2", 4, 4, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r3", r3_if, "198.51.100.3", "1.1.1.3", 4, 2)
+    verify_broadcast_interface(tgen, "r4", r4_if, "198.51.100.4", "1.1.1.4", 4, 2)
+    verify_broadcast_interface(tgen, "r5", r5_if, "198.51.100.5", "1.1.1.5", 4, 2)
+
+    verify_broadcast_interface(
+        tgen, "r1", r1_if2, "198.51.101.1", "1.1.1.1", 2, 2, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r6", r6_if, "198.51.101.2", "1.1.1.6", 2, 2, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r7", r7_if, "198.51.101.3", "1.1.1.7", 2, 2)
+
+    #interface r1-eth0
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
+
+    #interface r1-eth1
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
+
+    #BDR neighbors on r1-eth0
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.5")
+
+    #BDR on r1-eth1
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
+
+    sleep(5)
+
+def test_ospf_broadcast_external_lsa_flooding():
+    """
+    After routers reach Full state, generate an LSA storm using
+    redistribute-connected + loopback growth, and monitor pacing behavior.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Ensure key adjacencies are already Full.
+    r1 = tgen.gears["r1"]
+    for nbr in ["1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5"]:
+        wait_for_neighbor_full(tgen, "r1", nbr)
+    for nbr in ["1.1.1.6", "1.1.1.7"]:
+        wait_for_neighbor_full(tgen, "r1", nbr)
+
+    step("Enable redistribute connected on r1 and inject connected prefixes")
+    rc, out, err = tgen.net["r1"].cmd_status(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'redistribute connected'",
+        warn=False,
+    )
+    assert rc == 0, f"failed to enable redistribute connected: stdout={out} stderr={err}"
+
+    for i in range(1, 101):
+        tgen.net["r1"].cmd(f"ip addr add 198.51.110.{i}/32 dev lo")
+        tgen.net["r1"].cmd(f"ip addr add 198.51.111.{i}/32 dev lo")
+
+    # Allow LSAs to originate and flood.
+    time.sleep(3)
+
+    step("Verify key adjacencies remain FULL during LSA storm")
+    for router, nbr in [
+        ("r1", "1.1.1.2"),
+        ("r1", "1.1.1.3"),
+        ("r1", "1.1.1.4"),
+        ("r1", "1.1.1.5"),
+        ("r1", "1.1.1.6"),
+        ("r1", "1.1.1.7"),
+        ("r2", "1.1.1.1"),
+        ("r6", "1.1.1.1"),
+    ]:
+        wait_for_neighbor_full(tgen, router, nbr)
+
+    # Wait for pacing logic to react
+    sleep(5)
+
+    # Check logs for dynamic pacing signal in the run log.
+    step("Check adjacency pacing limit changes in log after LSA flood")
+    log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
+    log_cmd = f"grep -a 'R5-DYN:' {log_path} | tail -20"
+    log_out = tgen.net["r1"].cmd(log_cmd)
+    logger.info("r1 ospfd.log AIMD limit changes after LSA flood:\n%s", log_out)
+
+    assert log_out.strip(), "No dynamic pacing log entries found after external LSA flood"
+
+
+def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
+    """
+    Verify that when AIMD dynamic_limit increases (U drops below L),
+    ospf_adj_pacing_kick() fires immediately to dequeue waiting neighbors.
+
+    Sequence:
+      1. Clean up state from previous test (redistribute + loopbacks) then wait for U < L=2
+      2. Set thresholds H=20, L=6 (steady-state U≈5 < L=6, injecting 50 LSAs gives U>>H=20)
+      3. Inject 50 external LSAs -> U > H=20 -> AIMD decreases dynamic_limit to 1
+      4. Flap r3, r4, r5 to create pacing activity + queued adjacencies
+      5. Confirm congestion is established (log shows CONGESTION.*H(20))
+      6. Mark timestamp, clear LSAs -> U drops to 3 < L=4 -> limit increases -> kick
+      7. Assert all three reach Full within 15s (bounded by one AIMD interval)
+      8. Assert ospfd.log shows "kicking queued adjacencies" AFTER the mark timestamp
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r1_if = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.100.1")
+    log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
+
+    # Step 1: Remove the tc qdisc bandwidth constraint for this test.
+    # The 10kbit limit causes two problems here:
+    #   a) LSA withdrawal from the previous test takes minutes → U never settles
+    #   b) Adjacency formation itself is throttled → Full assertion timeout is unreachable
+    # This test creates its own congestion via LSA injection, so no tc constraint needed.
+    step("Replace 10kbit tc constraint with 1Mbps and clean up previous test state")
+    tgen.net["r1"].cmd("tc qdisc del dev r1-eth0 root 2>/dev/null || true")
+    tgen.net["r1"].cmd(
+        "tc qdisc add dev r1-eth0 root tbf rate 1mbit burst 100kb latency 50ms"
+    )
+    # sch_netem may not be auto-loaded on CI kernels (e.g. i386 Debian 12).
+    # Kernel modules are system-wide so one modprobe suffices for all namespaces.
+    tgen.net["r1"].cmd("modprobe sch_netem 2>/dev/null || true")
+    # r2: 2500ms egress delay keeps r2's LSA ACKs in-flight when AIMD fires.
+    # At 1Mbps with sub-ms netns RTT all 50 LSAs are acked in ~81ms, so U=0 by
+    # the time r3/r4/r5 reach 2-Way (~2.1s after the flap). With 2500ms delay
+    # the first ACK arrives at ~2501ms, so AIMD sees U=50 > H=20 at ~2147ms.
+    tgen.net["r2"].cmd("tc qdisc del dev r2-eth0 root 2>/dev/null || true")
+    tgen.net["r2"].cmd("tc qdisc add dev r2-eth0 root netem delay 2500ms")
+    # r3/r4/r5: 500ms egress delay slows adjacency formation to ~3s per neighbor.
+    # Without this they all form Full in ~100ms, leaving an empty queue when the
+    # AIMD limit-increase fires; with it r4 and r5 are still queued when r3 goes
+    # Full, so the kick dequeues them and the log entry appears after mark_time.
+    for _rname in ["r3", "r4", "r5"]:
+        tgen.net[_rname].cmd(f"tc qdisc del dev {_rname}-eth0 root 2>/dev/null || true")
+        tgen.net[_rname].cmd(f"tc qdisc add dev {_rname}-eth0 root netem delay 500ms")
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'no redistribute connected' 2>/dev/null || true"
+    )
+    for i in range(1, 101):
+        tgen.net["r1"].cmd(f"ip addr del 198.51.110.{i}/32 dev lo 2>/dev/null || true")
+        tgen.net["r1"].cmd(f"ip addr del 198.51.111.{i}/32 dev lo 2>/dev/null || true")
+
+    # At 1Mbps, 200 residual LSA withdrawals (~160KB) complete in ~1.3s.
+    # Steady-state U settles to 0-5 with no pending LSAs. L=6 ensures drain passes.
+    step("Wait for residual unacked LSAs to drain (U < 6) before starting test")
+
+    def _unacked_low():
+        chk = tgen.net["r1"].cmd(
+            f"grep -a 'total_unacked' {log_path} | tail -1"
+        )
+        logger.info("Latest unacked entry: %s", chk.strip())
+        import re
+        m = re.search(r"total_unacked=(\d+)", chk)
+        if m and int(m.group(1)) < 6:
+            return None
+        return "still draining"
+
+    _, result = topotest.run_and_expect(_unacked_low, None, count=60, wait=2)
+    if result is not None:
+        logger.warning("Residual LSAs did not drain below L=6; proceeding anyway")
+
+    # Step 2: Set thresholds H=20, L=6.
+    # Steady-state U=5 < L=6 → UNCONGESTED after LSA removal.
+    # Injecting 50 LSAs across 4 neighbors gives U≈200 >> H=20 → CONGESTION.
+    # At 1Mbps, 50 LSAs × 200B × 4 neighbors = 40KB takes ~320ms — long enough for
+    # the AIMD timer to fire and see high U before most acks arrive.
+    step("Set dynamic pacing thresholds on r1 (H=20, L=6)")
+    r1.vtysh_cmd(f"""
+        configure terminal
+        interface {r1_if}
+        ip ospf adjacency-pacing dynamic thresholds 20 6
+        end
+    """)
+
+    # Step 3: Inject 50 external LSAs to drive U above H=20.
+    # At 1Mbps, 50 LSAs × 200B × 4 neighbors = 40KB → ~320ms transmission.
+    # AIMD timer fires within ~500ms of pacing — U ≈ 200 at that point >> H=20.
+    step("Inject 50 external prefixes on r1 to drive U > H=20 and decrease dynamic_limit")
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'redistribute connected'"
+    )
+    for i in range(1, 51):
+        tgen.net["r1"].cmd(f"ip addr add 198.51.120.{i}/32 dev lo")
+
+    # Step 4: Mark start of the congestion/recovery observation window, then
+    # flap r3/r4/r5 simultaneously right after injecting LSAs.
+    # The earlier mark avoids missing a legitimate queue-kick log that occurs
+    # during the flap/congestion phase instead of strictly after LSA clear.
+    # The flap creates active pacing events — ospf_adj_pacing_allow() fires AIMD timer.
+    # The AIMD timer then sees U > H=20 and decreases dynamic_limit to 1.
+    # Without this flap, all neighbors are Full and AIMD never fires despite high U.
+    mark_time = time.strftime("%Y/%m/%d %H:%M:%S")
+    step("Flap r3, r4, r5 to trigger AIMD and create queued adjacencies")
+    flap_ifaces = {}
+    for rname in ["r3", "r4", "r5"]:
+        flap_ifaces[rname] = wait_for_ospf_ifname(tgen.gears[rname])
+
+    for rname, ifn in flap_ifaces.items():
+        tgen.net[rname].cmd(f"ip link set {ifn} down")
+    time.sleep(1)
+    for rname, ifn in flap_ifaces.items():
+        tgen.net[rname].cmd(f"ip link set {ifn} up")
+
+    # Step 5: Now wait for AIMD to detect congestion.
+    # The pacing activity from step 4 triggers the AIMD timer which sees U > H=20.
+    step("Confirm AIMD detected congestion (U > H=20) and limit=1")
+
+    def _congestion_detected():
+        chk = tgen.net["r1"].cmd(
+            f"grep -a 'CONGESTION.*H(20)' {log_path} | tail -1"
+        )
+        if "CONGESTION" in chk:
+            return None
+        return "congestion not yet detected"
+
+    _, result = topotest.run_and_expect(_congestion_detected, None, count=20, wait=1)
+    assert result is None, "AIMD did not detect congestion — pacing may not be active"
+
+    # Wait for neighbors to settle into queued state (in_progress=1, 2 queued)
+    time.sleep(2)
+
+    # Step 6: Clear LSAs.
+    # U drops below L=6 -> AIMD increases limit -> ospf_adj_pacing_kick fires.
+    step("Remove external LSAs — U drops to ~3 < L=4, AIMD increases limit, kick fires")
+    clear_time = time.time()
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'no redistribute connected'"
+    )
+    for i in range(1, 51):
+        tgen.net["r1"].cmd(f"ip addr del 198.51.120.{i}/32 dev lo 2>/dev/null || true")
+
+    # Step 7: All three neighbors must reach Full within 15s.
+    # Without the fix they stall; with fix they are kicked within one AIMD interval.
+    step("Verify r3, r4, r5 reach Full promptly after queue kick")
+    for nbr in ["1.1.1.3", "1.1.1.4", "1.1.1.5"]:
+        wait_for_neighbor_full(tgen, "r1", nbr)
+    elapsed = time.time() - clear_time
+    logger.info("r3/r4/r5 all Full %.1f seconds after clearing congestion", elapsed)
+    assert elapsed < 15, (
+        f"Neighbors took {elapsed:.1f}s to reach Full after congestion cleared — "
+        "queue kick may not have fired on limit increase"
+    )
+
+    # Step 8: Log check for kick diagnostic (informational only).
+    # The kick is already proved by Step 7: r3/r4/r5 reaching Full within 15s
+    # requires ospf_adj_pacing_kick() to have fired. The "kicking queued
+    # adjacencies" message is inside IS_DEBUG_OSPF(nsm, NSM_EVENTS) and will
+    # only appear when NSM debug is enabled, so asserting on it is fragile.
+    step("Log: check ospfd.log for 'kicking queued adjacencies' (informational)")
+    log_out = tgen.net["r1"].cmd(
+        f"awk -v ts='{mark_time}' '$0 >= ts' {log_path} | grep -a 'kicking queued adjacencies' | tail -5"
+    )
+    logger.info("Queue kick log entries after mark (debug-only, may be empty):\n%s", log_out)
+
+    # Cleanup: disable redistribute, remove injected loopbacks, restore tc and thresholds
+    step("Cleanup: restore r1/r2/r3/r4/r5 to baseline state")
+    tgen.net["r1"].cmd(
+        "vtysh -c 'conf t' -c 'router ospf' -c 'no redistribute connected' 2>/dev/null || true"
+    )
+    for i in range(1, 51):
+        tgen.net["r1"].cmd(f"ip addr del 198.51.120.{i}/32 dev lo 2>/dev/null || true")
+    tgen.net["r1"].cmd("tc qdisc del dev r1-eth0 root 2>/dev/null || true")
+    tgen.net["r1"].cmd(
+        "tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms"
+    )
+    tgen.net["r1"].cmd(
+        "tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms"
+    )
+    tgen.net["r2"].cmd("tc qdisc del dev r2-eth0 root 2>/dev/null || true")
+    for _rname in ["r3", "r4", "r5"]:
+        tgen.net[_rname].cmd(f"tc qdisc del dev {_rname}-eth0 root 2>/dev/null || true")
+    r1.vtysh_cmd(f"""
+        configure terminal
+        interface {r1_if}
+        no ip ospf adjacency-pacing dynamic thresholds
+        end
+    """)

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_dynamic_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_dynamic_pacing.py
@@ -6,6 +6,7 @@
 #
 
 import os
+import re
 import sys
 from functools import partial
 import pytest
@@ -76,10 +77,16 @@ def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
     tgen.start_topology()
 
-    # Apply network constraints to stress-test dynamic pacing
-    r1 = tgen.gears["r1"]
-    r1.cmd("tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms")
-    r1.cmd("tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms")
+    # Apply deterministic congestion without starving OSPF control packets.
+    rc, out, err = tgen.net["r1"].cmd_status(
+        "tc qdisc add dev r1-eth0 root handle 1: "
+        "tbf rate 100kbit burst 10kb latency 500ms",
+        warn=False,
+    )
+    assert rc == 0, (
+        "failed to install r1-eth0 TBF: "
+        f"stdout={out.strip()} stderr={err.strip()}"
+    )
 
     router_list = tgen.routers()
     for rname, router in router_list.items():
@@ -175,6 +182,24 @@ def wait_for_neighbor_full(tgen, router, neighbor_id):
     _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
     assertmsg = f"Neighbor {neighbor_id} not FULL on {router}"
     assert result is None, assertmsg
+
+
+def neighbor_state(tgen, router, neighbor_id):
+    """Return the current OSPF neighbor state without waiting for recovery."""
+    data = tgen.gears[router].vtysh_cmd(
+        f"show ip ospf neighbor {neighbor_id} json", isjson=True
+    )
+    nbr_list = data.get("default", {}).get(neighbor_id)
+    if not nbr_list:
+        return "missing"
+    return nbr_list[0].get("nbrState", "unknown")
+
+
+def read_log_since(path, offset):
+    """Read daemon log data appended after offset."""
+    with open(path, "r", encoding="utf-8", errors="replace") as log_file:
+        log_file.seek(offset)
+        return log_file.read()
 
 
 def verify_broadcast_interface(
@@ -349,6 +374,36 @@ def test_ospf_broadcast_external_lsa_flooding():
     for nbr in ["1.1.1.6", "1.1.1.7"]:
         wait_for_neighbor_full(tgen, "r1", nbr)
 
+    monitored_adjacencies = [
+        ("r1", "1.1.1.2"),
+        ("r1", "1.1.1.3"),
+        ("r1", "1.1.1.4"),
+        ("r1", "1.1.1.5"),
+        ("r1", "1.1.1.6"),
+        ("r1", "1.1.1.7"),
+        ("r2", "1.1.1.1"),
+        ("r6", "1.1.1.1"),
+    ]
+    monitored_neighbors = {
+        "r1": {
+            "1.1.1.2",
+            "1.1.1.3",
+            "1.1.1.4",
+            "1.1.1.5",
+            "1.1.1.6",
+            "1.1.1.7",
+        },
+        "r2": {"1.1.1.1"},
+        "r6": {"1.1.1.1"},
+    }
+    monitored_logs = {
+        router: os.path.join(tgen.logdir, router, "ospfd.log")
+        for router in monitored_neighbors
+    }
+    log_offsets = {
+        router: os.path.getsize(path) for router, path in monitored_logs.items()
+    }
+
     step("Enable redistribute connected on r1 and inject connected prefixes")
     rc, out, err = tgen.net["r1"].cmd_status(
         "vtysh -c 'conf t' -c 'router ospf' -c 'redistribute connected'",
@@ -360,21 +415,28 @@ def test_ospf_broadcast_external_lsa_flooding():
         tgen.net["r1"].cmd(f"ip addr add 198.51.110.{i}/32 dev lo")
         tgen.net["r1"].cmd(f"ip addr add 198.51.111.{i}/32 dev lo")
 
-    # Allow LSAs to originate and flood.
-    time.sleep(3)
+    step("Continuously verify key adjacencies remain FULL during LSA storm")
+    for _ in range(5):
+        for router, nbr in monitored_adjacencies:
+            state = neighbor_state(tgen, router, nbr)
+            assert state.split("/", 1)[0] == "Full", (
+                f"Neighbor {nbr} left FULL on {router} during LSA storm: {state}"
+            )
+        time.sleep(1)
 
-    step("Verify key adjacencies remain FULL during LSA storm")
-    for router, nbr in [
-        ("r1", "1.1.1.2"),
-        ("r1", "1.1.1.3"),
-        ("r1", "1.1.1.4"),
-        ("r1", "1.1.1.5"),
-        ("r1", "1.1.1.6"),
-        ("r1", "1.1.1.7"),
-        ("r2", "1.1.1.1"),
-        ("r6", "1.1.1.1"),
-    ]:
-        wait_for_neighbor_full(tgen, router, nbr)
+    adjacency_failure = re.compile(r"InactivityTimer|1-WayReceived|Full ->")
+    for router, path in monitored_logs.items():
+        new_log = read_log_since(path, log_offsets[router])
+        failures = [
+            line
+            for line in new_log.splitlines()
+            if adjacency_failure.search(line)
+            and any(nbr in line for nbr in monitored_neighbors[router])
+        ]
+        assert not failures, (
+            f"{router} adjacency reset during LSA storm:\n"
+            + "\n".join(failures[-10:])
+        )
 
     # Wait for pacing logic to react
     sleep(5)
@@ -382,7 +444,7 @@ def test_ospf_broadcast_external_lsa_flooding():
     # Check logs for dynamic pacing signal in the run log.
     step("Check adjacency pacing limit changes in log after LSA flood")
     log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
-    log_cmd = f"grep -a 'R5-DYN:' {log_path} | tail -20"
+    log_cmd = f"grep -a 'OSPF dynamic adjacency pacing:' {log_path} | tail -20"
     log_out = tgen.net["r1"].cmd(log_cmd)
     logger.info("r1 ospfd.log AIMD limit changes after LSA flood:\n%s", log_out)
 
@@ -399,10 +461,10 @@ def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
       2. Set thresholds H=20, L=6 (steady-state U≈5 < L=6, injecting 50 LSAs gives U>>H=20)
       3. Inject 50 external LSAs -> U > H=20 -> AIMD decreases dynamic_limit to 1
       4. Flap r3, r4, r5 to create pacing activity + queued adjacencies
-      5. Confirm congestion is established (log shows CONGESTION.*H(20))
+      5. Confirm congestion is established (log shows CONGESTION.*high-water=20)
       6. Mark timestamp, clear LSAs -> U drops to 3 < L=4 -> limit increases -> kick
       7. Assert all three reach Full within 15s (bounded by one AIMD interval)
-      8. Assert ospfd.log shows "kicking queued adjacencies" AFTER the mark timestamp
+      8. Assert ospfd.log shows "releasing queued adjacencies" AFTER the mark timestamp
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -413,7 +475,7 @@ def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
     log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
 
     # Step 1: Remove the tc qdisc bandwidth constraint for this test.
-    # The 10kbit limit causes two problems here:
+    # The constrained baseline causes two problems here:
     #   a) LSA withdrawal from the previous test takes minutes → U never settles
     #   b) Adjacency formation itself is throttled → Full assertion timeout is unreachable
     # This test creates its own congestion via LSA injection, so no tc constraint needed.
@@ -451,11 +513,11 @@ def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
 
     def _unacked_low():
         chk = tgen.net["r1"].cmd(
-            f"grep -a 'total_unacked' {log_path} | tail -1"
+            f"grep -a 'unacknowledged-LSAs' {log_path} | tail -1"
         )
         logger.info("Latest unacked entry: %s", chk.strip())
         import re
-        m = re.search(r"total_unacked=(\d+)", chk)
+        m = re.search(r"unacknowledged-LSAs=(\d+)", chk)
         if m and int(m.group(1)) < 6:
             return None
         return "still draining"
@@ -512,7 +574,7 @@ def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
 
     def _congestion_detected():
         chk = tgen.net["r1"].cmd(
-            f"grep -a 'CONGESTION.*H(20)' {log_path} | tail -1"
+            f"grep -a 'CONGESTION.*high-water=20' {log_path} | tail -1"
         )
         if "CONGESTION" in chk:
             return None
@@ -548,12 +610,12 @@ def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
 
     # Step 8: Log check for kick diagnostic (informational only).
     # The kick is already proved by Step 7: r3/r4/r5 reaching Full within 15s
-    # requires ospf_adj_pacing_kick() to have fired. The "kicking queued
+    # requires ospf_adj_pacing_kick() to have fired. The "releasing queued
     # adjacencies" message is inside IS_DEBUG_OSPF(nsm, NSM_EVENTS) and will
     # only appear when NSM debug is enabled, so asserting on it is fragile.
-    step("Log: check ospfd.log for 'kicking queued adjacencies' (informational)")
+    step("Log: check ospfd.log for 'releasing queued adjacencies' (informational)")
     log_out = tgen.net["r1"].cmd(
-        f"awk -v ts='{mark_time}' '$0 >= ts' {log_path} | grep -a 'kicking queued adjacencies' | tail -5"
+        f"awk -v ts='{mark_time}' '$0 >= ts' {log_path} | grep -a 'releasing queued adjacencies' | tail -5"
     )
     logger.info("Queue kick log entries after mark (debug-only, may be empty):\n%s", log_out)
 
@@ -566,10 +628,8 @@ def test_ospf_dynamic_pacing_queue_kick_on_limit_increase():
         tgen.net["r1"].cmd(f"ip addr del 198.51.120.{i}/32 dev lo 2>/dev/null || true")
     tgen.net["r1"].cmd("tc qdisc del dev r1-eth0 root 2>/dev/null || true")
     tgen.net["r1"].cmd(
-        "tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms"
-    )
-    tgen.net["r1"].cmd(
-        "tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms"
+        "tc qdisc add dev r1-eth0 root handle 1: "
+        "tbf rate 100kbit burst 10kb latency 500ms"
     )
     tgen.net["r2"].cmd("tc qdisc del dev r2-eth0 root 2>/dev/null || true")
     for _rname in ["r3", "r4", "r5"]:

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_broadcast_2router_static_constraint.py
+# Test RFC4222 Rec5 static adjacency pacing with constrained link
+#
+
+import os
+import sys
+from functools import partial
+import pytest
+from time import sleep
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+from util_pcap import PerInterfacePcapManager
+
+TOPOLOGY = """
+                  +-----+  +-----+  +-----+  +-----+
+                  | r2  |  | r3  |  | r4  |  | r5  |
+                  +--+--+  +--+--+  +--+--+  +--+--+
+                     |        |        |        |
+        +-----+      +--------+--------+--------+--------+
+        | r1  |--------------- 198.51.100.0/24 (s0)
+        +--+--+
+           |
+           |         +-----+  +-----+
+           +---------| r6  |  | r7  |
+                     +--+--+  +--+--+
+                        |        |
+                        +--------+-------- 198.51.101.0/24 (s1)
+"""
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.ospfd]
+PM = None
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+    tgen.add_router("r5")
+    tgen.add_router("r6")
+    tgen.add_router("r7")
+
+    switch = tgen.add_switch("s0")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r6"])
+    switch.add_link(tgen.gears["r7"])
+
+
+def setup_module(mod):
+    logger.info("OSPF broadcast static topology:\n %s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1 = tgen.gears["r1"]
+    r1.cmd("tc qdisc add dev r1-eth0 root handle 1: tbf rate 10kbit burst 10kb latency 50ms")
+    r1.cmd("tc qdisc add dev r1-eth0 parent 1:1 handle 10: netem loss 1% delay 5ms")
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        if rname == "r1":
+            router.load_frr_config(
+                os.path.join(CWD, "r1_broadcast_static", "frr.conf")
+            )
+        elif rname == "r2":
+            router.load_frr_config(os.path.join(CWD, "r2_broadcast", "frr.conf"))
+        elif rname == "r3":
+            router.load_frr_config(os.path.join(CWD, "r3_broadcast", "frr.conf"))
+        elif rname == "r4":
+            router.load_frr_config(os.path.join(CWD, "r4_broadcast", "frr.conf"))
+        elif rname == "r5":
+            router.load_frr_config(os.path.join(CWD, "r5_broadcast", "frr.conf"))
+        elif rname == "r6":
+            router.load_frr_config(os.path.join(CWD, "r6_broadcast", "frr.conf"))
+        elif rname == "r7":
+            router.load_frr_config(os.path.join(CWD, "r7_broadcast", "frr.conf"))
+
+    tgen.start_router()
+
+    global PM
+    PM = PerInterfacePcapManager(outdir="pcaps", tag="ospf4-static")
+    PM.start_all(tgen)
+    for (rname, ifn), pid in list(PM.pids.items()):
+        if rname != "r1":
+            router = tgen.routers().get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+            PM.pids.pop((rname, ifn), None)
+
+
+def teardown_module():
+    tgen = get_topogen()
+    global PM
+    if PM:
+        PM.stop_all(tgen)
+    tgen.stop_topology()
+
+
+def wait_for_ospf_ifname(topo_router):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        ifname = next(iter(interfaces.keys()), None)
+        if ifname:
+            ifname_holder["name"] = ifname
+            return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface found on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_ospf_ifname_by_ip(topo_router, ip):
+    ifname_holder = {}
+
+    def _poll():
+        data = topo_router.vtysh_cmd("show ip ospf interface json", isjson=True)
+        interfaces = data.get("interfaces", {})
+        for ifname, attrs in interfaces.items():
+            if attrs.get("ipAddress") == ip:
+                ifname_holder["name"] = ifname
+                return None
+        return "missing"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"No OSPF interface with IP {ip} on {topo_router.name}"
+    return ifname_holder["name"]
+
+
+def wait_for_neighbor_full(tgen, router, neighbor_id):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} neighbor {neighbor_id} FULL")
+
+    def _poll():
+        data = topo_router.vtysh_cmd(
+            f"show ip ospf neighbor {neighbor_id} json", isjson=True
+        )
+        nbr_list = data.get("default", {}).get(neighbor_id)
+        if not nbr_list:
+            return "missing"
+        state = nbr_list[0].get("nbrState", "")
+        if state.split("/", 1)[0] == "Full":
+            return None
+        return state or "unknown"
+
+    _, result = topotest.run_and_expect(_poll, None, count=60, wait=1)
+    assert result is None, f"Neighbor {neighbor_id} not FULL on {router}"
+
+
+def verify_broadcast_interface(
+    tgen, router, ifname, ip, router_id, nbr_cnt, nbr_adj_cnt, state=None
+):
+    topo_router = tgen.gears[router]
+
+    step(f"Verify {router} broadcast interface settings")
+    iface = {
+        "ospfEnabled": True,
+        "ipAddress": ip,
+        "ipAddressPrefixlen": 24,
+        "ospfIfType": "Broadcast",
+        "area": "0.0.0.0",
+        "routerId": router_id,
+        "networkType": "BROADCAST",
+        "nbrCount": nbr_cnt,
+        "nbrAdjacentCount": nbr_adj_cnt,
+    }
+    if state:
+        iface["state"] = state
+    input_dict = {"interfaces": {ifname: iface}}
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        f"show ip ospf interface {ifname} json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Broadcast interface mismatch on {router}"
+
+
+def verify_adjacency_static_pacing(tgen, router, ifname, limit):
+    step(f"Verify {router} adjacency pacing static {limit} on {ifname}")
+    cmd = (
+        f"vtysh -c 'show running ospfd' | "
+        f"awk -v ifname='{ifname}' "
+        "'($1==\"interface\" && $2==ifname){f=1} "
+        "($1==\"interface\" && $2!=ifname){f=0} "
+        "($1==\"exit\" || $1==\"!\"){f=0} "
+        "f{print}' | "
+        f"grep -q 'ip ospf adjacency-pacing static {limit}'"
+    )
+    rc, _, _ = tgen.net[router].cmd_status(cmd, warn=False)
+    assert rc == 0, f"adjacency pacing static {limit} not present on {router} {ifname}"
+
+
+def verify_dynamic_adjacency_pacing(tgen, router, ifname):
+    step(f"Verify {router} adjacency pacing dynamic on {ifname}")
+    rc, _, _ = tgen.net[router].cmd_status(
+        f"vtysh -c 'show running ospfd' | grep -q 'ip ospf adjacency-pacing dynamic'",
+        warn=False,
+    )
+    assert rc == 0, f"adjacency pacing dynamic not present on {router} {ifname}"
+
+
+def test_ospf_broadcast_static_pacing_neighbors_full():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1_if = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.100.1")
+    r2_if = wait_for_ospf_ifname(tgen.gears["r2"])
+    r3_if = wait_for_ospf_ifname(tgen.gears["r3"])
+    r4_if = wait_for_ospf_ifname(tgen.gears["r4"])
+    r5_if = wait_for_ospf_ifname(tgen.gears["r5"])
+    r6_if = wait_for_ospf_ifname(tgen.gears["r6"])
+    r7_if = wait_for_ospf_ifname(tgen.gears["r7"])
+    r1_if2 = wait_for_ospf_ifname_by_ip(tgen.gears["r1"], "198.51.101.1")
+    assert r1_if and r1_if2 and r2_if and r3_if and r4_if and r5_if and r6_if and r7_if
+
+    verify_adjacency_static_pacing(tgen, "r1", r1_if, 1)
+    verify_dynamic_adjacency_pacing(tgen, "r1", r1_if2)
+
+    verify_broadcast_interface(
+        tgen, "r1", r1_if, "198.51.100.1", "1.1.1.1", 4, 4, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r2", r2_if, "198.51.100.2", "1.1.1.2", 4, 4, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r3", r3_if, "198.51.100.3", "1.1.1.3", 4, 2)
+    verify_broadcast_interface(tgen, "r4", r4_if, "198.51.100.4", "1.1.1.4", 4, 2)
+    verify_broadcast_interface(tgen, "r5", r5_if, "198.51.100.5", "1.1.1.5", 4, 2)
+
+    verify_broadcast_interface(
+        tgen, "r1", r1_if2, "198.51.101.1", "1.1.1.1", 2, 2, state="DR"
+    )
+    verify_broadcast_interface(
+        tgen, "r6", r6_if, "198.51.101.2", "1.1.1.6", 2, 2, state="Backup"
+    )
+    verify_broadcast_interface(tgen, "r7", r7_if, "198.51.101.3", "1.1.1.7", 2, 2)
+
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
+
+    sleep(5)

--- a/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
+++ b/tests/topotests/ospf_4222_recommendation_5/test_ospf_broadcast_router_static_pacing.py
@@ -241,6 +241,20 @@ def test_ospf_broadcast_static_pacing_neighbors_full():
     verify_adjacency_static_pacing(tgen, "r1", r1_if, 1)
     verify_dynamic_adjacency_pacing(tgen, "r1", r1_if2)
 
+    # Wait for full adjacency on both segments before checking interface
+    # states.  With static pacing (limit=1) on s0 and dynamic pacing on s1,
+    # adjacencies form one at a time; DR/BDR election results are only
+    # guaranteed stable once all neighbors have reached Full.
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
+    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
+    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
+    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
+
     verify_broadcast_interface(
         tgen, "r1", r1_if, "198.51.100.1", "1.1.1.1", 4, 4, state="DR"
     )
@@ -258,15 +272,5 @@ def test_ospf_broadcast_static_pacing_neighbors_full():
         tgen, "r6", r6_if, "198.51.101.2", "1.1.1.6", 2, 2, state="Backup"
     )
     verify_broadcast_interface(tgen, "r7", r7_if, "198.51.101.3", "1.1.1.7", 2, 2)
-
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.2")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.3")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.4")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.5")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.6")
-    wait_for_neighbor_full(tgen, "r1", "1.1.1.7")
-    wait_for_neighbor_full(tgen, "r2", "1.1.1.1")
-    wait_for_neighbor_full(tgen, "r6", "1.1.1.1")
-    wait_for_neighbor_full(tgen, "r6", "1.1.1.7")
 
     sleep(5)

--- a/tests/topotests/ospf_4222_recommendation_5/util_pcap.py
+++ b/tests/topotests/ospf_4222_recommendation_5/util_pcap.py
@@ -1,0 +1,96 @@
+# util_pcap.py
+import re, time, shlex
+from pathlib import Path
+
+OSPFV2_FILTER = "ip proto 89"
+
+class PerInterfacePcapManager:
+    def __init__(self, outdir="pcaps", tag="ospf4"):
+        self.outdir = Path(outdir)
+        self.tag = tag
+        self.pids = {}   # (router, ifname) -> pid
+
+    def _list_ifaces(self, router):
+        txt = router.cmd("ip -o link show")
+        # Lines like: "3: r1-eth0@if4: <BROADCAST,MULTICAST,UP,LOWER_UP> ..."
+        ifaces = []
+        seen = set()
+        for ln in txt.splitlines():
+            m = re.match(r"\d+:\s+([^:]+):\s+<([^>]*)>", ln)
+            if not m:
+                continue
+            ifn = m.group(1).split("@")[0]
+            flags = m.group(2).split(",")
+            up = "UP" in flags
+            if ifn not in seen:
+                seen.add(ifn)
+                ifaces.append((ifn, up))
+        return ifaces
+
+    def start_all(self, tgen):
+        if tgen is None or not tgen.routers():
+            raise RuntimeError("Call start_all() only after tgen.start_router()")
+
+        self.outdir = self.outdir.resolve()
+        self.outdir.mkdir(parents=True, exist_ok=True)
+        # Clean previous captures for a fresh run
+        for old in self.outdir.glob("*.pcap*"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+        for old in self.outdir.glob("*.csv*"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+
+        for rname, router in tgen.routers().items():
+            for ifn, up in self._list_ifaces(router):
+                if ifn == "lo":
+                    continue
+                # If you only want 'UP' links, uncomment:
+                # if not up: continue
+
+                pcap_path = self.outdir / f"{rname}-{ifn}-{self.tag}.pcap"
+                cmd = (
+                    f"nohup tcpdump -i {shlex.quote(ifn)} -U -s 0 "
+                    #f"-w {shlex.quote(str(pcap_path))} {OSPFV2_FILTER} "
+                    f"-w {shlex.quote(str(pcap_path))}"
+                    f">/dev/null 2>&1 & echo $!"
+                )
+                pid = router.cmd(cmd).strip()
+                # Basic sanity: numeric PID?
+                try:
+                    self.pids[(rname, ifn)] = int(pid)
+                except ValueError:
+                    # tcpdump might be missing; surface the router's error
+                    out = router.cmd("which tcpdump || true")
+                    raise RuntimeError(
+                        f"Failed to start tcpdump on {rname}:{ifn} "
+                        f"(got PID '{pid}'). tcpdump path: {out}"
+                    )
+
+        # Small settle to ensure files are created
+        time.sleep(0.3)
+
+    def stop_all(self, tgen=None):
+        # Best-effort terminate inside each router
+        if not self.pids:
+            return
+        # If tgen wasn't passed, try to get it (optional)
+        routers = {}
+        if tgen is not None and tgen.routers():
+            routers = tgen.routers()
+
+        for (rname, ifn), pid in list(self.pids.items()):
+            router = routers.get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+        time.sleep(0.3)
+        for (rname, ifn), pid in list(self.pids.items()):
+            router = routers.get(rname)
+            if router:
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+        self.pids.clear()
+# util_pcap.py

--- a/tests/topotests/ospf_rfc4222_r4/.gitignore
+++ b/tests/topotests/ospf_rfc4222_r4/.gitignore
@@ -1,0 +1,2 @@
+pcaps/
+test_script

--- a/tests/topotests/ospf_rfc4222_r4/r1/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r1/frr.conf
@@ -1,0 +1,31 @@
+frr defaults traditional
+hostname r1
+log syslog informational
+!
+ip router-id 1.1.1.1
+!
+interface eth1
+ ip address 10.0.0.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf mtu-ignore
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+ timers throttle spf 100 400 1000
+ timers throttle lsa all 1000
+ timers lsa min-arrival 50
+!
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf lsa flooding
+log file ospfd.log debugging
+end

--- a/tests/topotests/ospf_rfc4222_r4/r1/frr_pacing.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r1/frr_pacing.conf
@@ -1,0 +1,36 @@
+frr defaults traditional
+hostname r1
+log syslog informational
+!
+ip router-id 1.1.1.1
+!
+interface eth1
+ ip address 10.0.0.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf mtu-ignore
+ ip ospf lsa-pacing
+ ip ospf lsa-pacing min-gap 1000 max-gap 1000
+ ip ospf lsa-pacing initial-gap 1000
+ ip ospf lsa-pacing max-lsas-per-update 1
+ ip ospf lsa-pacing adjust-interval 60000
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+ timers throttle spf 100 400 1000
+ timers throttle lsa all 1000
+ timers lsa min-arrival 50
+!
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+debug ospf lsa
+debug ospf packet ls-req
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf lsa flooding
+log file ospfd.log debugging
+end

--- a/tests/topotests/ospf_rfc4222_r4/r1_broadcast/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r1_broadcast/frr.conf
@@ -1,0 +1,24 @@
+frr defaults traditional
+hostname r1_broadcast
+!
+interface r1-eth0
+ ip address 198.51.100.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 255
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+!
+debug ospf event
+debug ospf nsm
+debug ospf packet hello
+debug ospf packet ls-upd
+debug ospf packet ls-ack
+debug ospf packet ls-ack send
+debug ospf lsa flooding
+log file ospfd.log debugging
+end

--- a/tests/topotests/ospf_rfc4222_r4/r2/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r2/frr.conf
@@ -1,0 +1,22 @@
+frr defaults traditional
+hostname r2
+log syslog informational
+!
+ip router-id 2.2.2.2
+!
+interface eth1
+ ip address 10.0.0.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf mtu-ignore
+!
+router ospf
+ ospf router-id 2.2.2.2
+ log-adjacency-changes
+ timers throttle spf 100 400 1000
+ timers throttle lsa all 1000
+ timers lsa min-arrival 50
+!
+end

--- a/tests/topotests/ospf_rfc4222_r4/r2_broadcast/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r2_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r2_broadcast
+!
+interface r2-eth0
+ ip address 198.51.100.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 200
+!
+router ospf
+ ospf router-id 1.1.1.2
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_rfc4222_r4/r3/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r3/frr.conf
@@ -1,0 +1,35 @@
+frr defaults traditional
+hostname r3
+log syslog informational
+!
+ip router-id 3.3.3.3
+!
+interface eth1
+ ip address 10.0.1.3/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf mtu-ignore
+ ip ospf lsa-pacing
+ ip ospf lsa-pacing initial-gap 200
+ ip ospf lsa-pacing min-gap 200 max-gap 200
+ ip ospf lsa-pacing max-lsas-per-update 1
+ ip ospf lsa-pacing adjust-interval 60000
+!
+router ospf
+ ospf router-id 3.3.3.3
+ log-adjacency-changes
+ mpls-te on
+ mpls-te router-address 3.3.3.3
+ timers throttle spf 100 400 1000
+ timers throttle lsa all 1000
+ timers lsa min-arrival 50
+!
+debug ospf event
+debug ospf nsm
+debug ospf lsa
+debug ospf packet ls-upd
+debug ospf lsa flooding
+log file ospfd.log debugging
+end

--- a/tests/topotests/ospf_rfc4222_r4/r3_broadcast/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r3_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r3_broadcast
+!
+interface r3-eth0
+ ip address 198.51.100.3/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.3
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_rfc4222_r4/r4/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r4/frr.conf
@@ -1,0 +1,24 @@
+frr defaults traditional
+hostname r4
+log syslog informational
+!
+ip router-id 4.4.4.4
+!
+interface eth1
+ ip address 10.0.1.4/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf mtu-ignore
+!
+router ospf
+ ospf router-id 4.4.4.4
+ log-adjacency-changes
+ mpls-te on
+ mpls-te router-address 4.4.4.4
+ timers throttle spf 100 400 1000
+ timers throttle lsa all 1000
+ timers lsa min-arrival 50
+!
+end

--- a/tests/topotests/ospf_rfc4222_r4/r4_broadcast/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r4_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r4_broadcast
+!
+interface r4-eth0
+ ip address 198.51.100.4/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.4
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_rfc4222_r4/r5_broadcast/frr.conf
+++ b/tests/topotests/ospf_rfc4222_r4/r5_broadcast/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname r5_broadcast
+!
+interface r5-eth0
+ ip address 198.51.100.5/24
+ ip ospf area 0.0.0.0
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 4
+ ip ospf priority 1
+!
+router ospf
+ ospf router-id 1.1.1.5
+ log-adjacency-changes
+!

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_broadcast_lsa_pacing.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_broadcast_lsa_pacing.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Functional broadcast-LAN coverage for RFC4222 Recommendation 4 LSA pacing.
+#
+
+import os
+import time
+from functools import partial
+
+import pytest
+
+from lib import topotest
+from lib.common_config import step
+from lib.topogen import Topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.ospfd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+
+NUM_ROUTES = 12
+TEST_PREFIXES = ["10.77.{}.0/24".format(i) for i in range(1, NUM_ROUTES + 1)]
+PREFIX_TAG = "10.77."
+
+GAP_MS = 200
+MAX_LSAS = 1
+ADJINT_MS = 60000
+
+LINK_RATE = "100kbit"
+LINK_BURST = "8kb"
+LINK_LATENCY = "100ms"
+R1_BCAST_IF = "r1-eth0"
+LAN_NEIGHBORS = ["r2", "r3", "r4", "r5"]
+LAN_NEIGHBOR_IDS = {
+    "r2": "1.1.1.2",
+    "r3": "1.1.1.3",
+    "r4": "1.1.1.4",
+    "r5": "1.1.1.5",
+}
+
+
+def build_topo(tgen):
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    r3 = tgen.add_router("r3")
+    r4 = tgen.add_router("r4")
+    r5 = tgen.add_router("r5")
+
+    switch = tgen.add_switch("s0")
+    switch.add_link(r1)
+    switch.add_link(r2)
+    switch.add_link(r3)
+    switch.add_link(r4)
+    switch.add_link(r5)
+
+
+@pytest.fixture(scope="function")
+def tgen(request):
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}_broadcast".format(rname), "frr.conf"))
+
+    tgen.start_router()
+
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "router ospf\n"
+        "redistribute static\n"
+        "end"
+    )
+
+    time.sleep(12)
+
+    yield tgen
+
+    tgen.stop_topology()
+
+
+def _wait_neighbor_full(router, neighbor_id, timeout_s=30):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        data = router.vtysh_cmd(
+            "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
+        )
+        nbrs = data.get("default", {}).get(neighbor_id)
+        if nbrs:
+            state = nbrs[0].get("nbrState", "")
+            if state.split("/", 1)[0] == "Full":
+                return True
+        time.sleep(0.5)
+    return False
+
+
+def _wait_broadcast_interface(router, expected, timeout_s=30):
+    test_func = partial(
+        topotest.router_json_cmp,
+        router,
+        "show ip ospf interface {} json".format(expected["ifname"]),
+        {"interfaces": {expected["ifname"]: expected["data"]}},
+    )
+    count = max(1, int(timeout_s))
+    _, result = topotest.run_and_expect(test_func, None, count=count, wait=1)
+    return result is None
+
+
+def _verify_dr_bdr_state(tgen):
+    step("Verify broadcast interface state: r1 is DR and r2 is Backup")
+    assert _wait_broadcast_interface(
+        tgen.gears["r1"],
+        {
+            "ifname": "r1-eth0",
+            "data": {
+                "ospfEnabled": True,
+                "ipAddress": "198.51.100.1",
+                "ipAddressPrefixlen": 24,
+                "ospfIfType": "Broadcast",
+                "area": "0.0.0.0",
+                "routerId": "1.1.1.1",
+                "networkType": "BROADCAST",
+                "nbrCount": 4,
+                "nbrAdjacentCount": 4,
+                "state": "DR",
+            },
+        },
+    ), "r1 did not become DR on the broadcast LAN"
+    assert _wait_broadcast_interface(
+        tgen.gears["r2"],
+        {
+            "ifname": "r2-eth0",
+            "data": {
+                "ospfEnabled": True,
+                "ipAddress": "198.51.100.2",
+                "ipAddressPrefixlen": 24,
+                "ospfIfType": "Broadcast",
+                "area": "0.0.0.0",
+                "routerId": "1.1.1.2",
+                "networkType": "BROADCAST",
+                "nbrCount": 4,
+                "nbrAdjacentCount": 4,
+                "state": "Backup",
+            },
+        },
+    ), "r2 did not become Backup on the broadcast LAN"
+
+
+def _wait_all_full(tgen, routers=None, timeout_s=30):
+    routers = routers or LAN_NEIGHBORS
+    for rname in routers:
+        assert _wait_neighbor_full(
+            tgen.gears["r1"], LAN_NEIGHBOR_IDS[rname], timeout_s=timeout_s
+        ), "r1 neighbor {} failed to reach Full".format(LAN_NEIGHBOR_IDS[rname])
+
+
+def _count_external_lsas(router):
+    out = router.vtysh_cmd("show ip ospf database external")
+    return sum(
+        1 for line in out.splitlines()
+        if "Link State ID" in line and PREFIX_TAG in line
+    )
+
+
+def _wait_all_receivers(expected, receivers, timeout_s):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        counts = {name: _count_external_lsas(router) for name, router in receivers.items()}
+        if all(count == expected for count in counts.values()):
+            return counts
+        time.sleep(0.2)
+    return {name: _count_external_lsas(router) for name, router in receivers.items()}
+
+
+def _wait_receiver_at_least(router, minimum, timeout_s):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        count = _count_external_lsas(router)
+        if count >= minimum:
+            return count
+        time.sleep(0.1)
+    return _count_external_lsas(router)
+
+
+def _enable_lsa_pacing(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface r1-eth0\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap {gap}\n"
+        "ip ospf lsa-pacing min-gap {gap} max-gap {gap}\n"
+        "ip ospf lsa-pacing max-lsas-per-update {max_lsas}\n"
+        "ip ospf lsa-pacing adjust-interval {adjint}\n"
+        "end".format(gap=GAP_MS, max_lsas=MAX_LSAS, adjint=ADJINT_MS)
+    )
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing" in cfg, "R4 lsa-pacing missing from running-config"
+
+
+def _enable_dynamic_adjacency_pacing(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface r1-eth0\n"
+        "ip ospf adjacency-pacing dynamic\n"
+        "ip ospf adjacency-pacing dynamic thresholds 20 6\n"
+        "end"
+    )
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf adjacency-pacing dynamic" in cfg, (
+        "R5 adjacency-pacing dynamic missing from running-config"
+    )
+    assert "ip ospf adjacency-pacing dynamic thresholds 20 6" in cfg, (
+        "R5 adjacency-pacing dynamic thresholds missing from running-config"
+    )
+
+
+def _add_routes(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        + "".join("ip route {} null0\n".format(prefix) for prefix in TEST_PREFIXES)
+        + "end"
+    )
+
+
+def _apply_constraint(r1):
+    r1.cmd("tc qdisc del dev {} root 2>/dev/null || true".format(R1_BCAST_IF))
+    r1.cmd(
+        "tc qdisc add dev {} root handle 1: tbf rate {} burst {} latency {}".format(
+            R1_BCAST_IF, LINK_RATE, LINK_BURST, LINK_LATENCY
+        )
+    )
+
+
+def _r1_log_matches(tgen, pattern):
+    log_path = os.path.join(tgen.logdir, "r1", "ospfd.log")
+    return tgen.net["r1"].cmd("grep -a '{}' {} | tail -20".format(pattern, log_path))
+
+
+def _exercise_lsa_pacing(tgen, constrained):
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    _verify_dr_bdr_state(tgen)
+    _wait_all_full(tgen)
+
+    if constrained:
+        step("Apply constrained bandwidth on r1 broadcast interface")
+        _apply_constraint(r1)
+
+    step("Enable LSA pacing on r1 broadcast interface")
+    _enable_lsa_pacing(r1)
+
+    step("Inject external LSAs through redistributed static routes")
+    _add_routes(r1)
+
+    first = _wait_receiver_at_least(r2, 1, timeout_s=4)
+    assert first >= 1, "No Type-5 LSA reached r2 after enabling broadcast LSA pacing"
+
+    count_now = _count_external_lsas(r2)
+    assert count_now < NUM_ROUTES, (
+        "Broadcast LSA pacing did not gate the flood: r2 already has {}/{} LSAs".format(
+            count_now, NUM_ROUTES
+        )
+    )
+
+    receivers = {name: tgen.gears[name] for name in LAN_NEIGHBORS}
+    timeout_s = 12
+    counts = _wait_all_receivers(NUM_ROUTES, receivers, timeout_s=timeout_s)
+    assert all(count == NUM_ROUTES for count in counts.values()), (
+        "Not all receivers learned all Type-5 LSAs within {}s: {}".format(
+            timeout_s, counts
+        )
+    )
+
+    # Log check is informational only: it depends on 'debug ospf lsa flooding'
+    # staying enabled and the message text staying stable, which has proven
+    # fragile under the NetDEF CI pipeline (see R5's
+    # test_ospf_broadcast_router_dynamic_pacing.py step 8). The functional
+    # assertions above (partial delivery while pacing is active, then full
+    # delivery to all receivers) are the real proof that pacing gated the
+    # flood.
+    r4_log = _r1_log_matches(tgen, "OSPF LSA pacing:")
+    logger.info("RFC4222 R4 enqueue log entries (informational):\n%s", r4_log)
+
+    _wait_all_full(tgen)
+
+
+def _exercise_adj_and_lsa_pacing(tgen, constrained):
+    r1 = tgen.gears["r1"]
+
+    _verify_dr_bdr_state(tgen)
+    _wait_all_full(tgen)
+
+    if constrained:
+        step("Apply constrained bandwidth on r1 broadcast interface")
+        _apply_constraint(r1)
+
+    step("Enable both adjacency pacing and LSA pacing on r1")
+    _enable_dynamic_adjacency_pacing(r1)
+    _enable_lsa_pacing(r1)
+
+    step("Inject external LSAs while flapping three DROther neighbors")
+    _add_routes(r1)
+
+    for rname in ["r3", "r4", "r5"]:
+        tgen.net[rname].cmd("ip link set {}-eth0 down".format(rname))
+    time.sleep(1)
+    for rname in ["r3", "r4", "r5"]:
+        tgen.net[rname].cmd("ip link set {}-eth0 up".format(rname))
+
+    _wait_all_full(tgen, routers=["r3", "r4", "r5"], timeout_s=40)
+
+    receivers = {name: tgen.gears[name] for name in LAN_NEIGHBORS}
+    timeout_s = 20
+    counts = _wait_all_receivers(NUM_ROUTES, receivers, timeout_s=timeout_s)
+    assert all(count == NUM_ROUTES for count in counts.values()), (
+        "Combined R4/R5 broadcast pacing did not deliver all Type-5 LSAs: {}".format(
+            counts
+        )
+    )
+
+    # Log checks are informational only — see note in _exercise_lsa_pacing.
+    # The functional assertions above (all neighbors recover to Full, all
+    # receivers learn every Type-5 LSA) are the real proof that combined
+    # R4/R5 pacing worked.
+    r4_log = _r1_log_matches(tgen, "OSPF LSA pacing:")
+    logger.info("RFC4222 R4 enqueue log entries (informational):\n%s", r4_log)
+
+    r5_log = _r1_log_matches(tgen, "OSPF dynamic adjacency pacing:")
+    logger.info("RFC4222 R5 dynamic pacing log entries (informational):\n%s", r5_log)
+
+    _wait_all_full(tgen)
+
+
+def test_broadcast_neighbors_full(tgen):
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _verify_dr_bdr_state(tgen)
+    _wait_all_full(tgen)
+
+
+def test_broadcast_lsa_pacing_external_unconstrained(tgen):
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _exercise_lsa_pacing(tgen, constrained=False)
+
+
+def test_broadcast_lsa_pacing_external_constrained(tgen):
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _exercise_lsa_pacing(tgen, constrained=True)
+
+
+def test_broadcast_adj_and_lsa_pacing_external_unconstrained(tgen):
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _exercise_adj_and_lsa_pacing(tgen, constrained=False)
+
+
+def test_broadcast_adj_and_lsa_pacing_external_constrained(tgen):
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _exercise_adj_and_lsa_pacing(tgen, constrained=True)

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_cli.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_cli.py
@@ -1,0 +1,775 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_lsa_pacing_cli.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_ospf_lsa_pacing_cli.py: Test OSPF RFC4222/R4 LSA Gap Pacing CLI
+
+Tests LSA gap pacing configuration persistence and functionality:
+1. Enable / disable
+2. Each sub-parameter set and removed via no-form
+3. Config persistence via write memory
+4. Config persistence across interface flap
+5. Config persistence across ospfd restart
+6. Input validation (min > max, low >= high rejected)
+7. Default values not written to running-config
+8. All parameters combined
+"""
+
+import pytest
+import time
+
+from lib.topogen import Topogen
+
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+
+    tgen.add_link(r1, r2, ifname1="eth1", ifname2="eth1")
+
+
+@pytest.fixture(scope="function")
+def tgen(request):
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, router in router_list.items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+    yield tgen
+
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Enable / disable
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_enable(tgen):
+    """Test that ip ospf lsa-pacing appears in running-config after enable."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing" in running_config, \
+        "ip ospf lsa-pacing not in running config after enable"
+
+
+def test_lsa_pacing_disable(tgen):
+    """Test that no ip ospf lsa-pacing removes it from running-config."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "end"
+    )
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing" not in running_config, \
+        "ip ospf lsa-pacing still in running config after disable"
+
+
+# ---------------------------------------------------------------------------
+# Sub-parameter: initial-gap
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_initial_gap(tgen):
+    """Test initial-gap set and removed."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap 50\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing initial-gap 50" in running_config, \
+        "initial-gap 50 not in running config"
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing initial-gap\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "initial-gap" not in running_config, \
+        "initial-gap still present after removal"
+
+
+def test_lsa_pacing_initial_gap_before_minmax(tgen):
+    """initial-gap > default max (1000) set BEFORE min-gap/max-gap.
+
+    Before the fix the VTY handler silently clamped to OSPF_GAP_MAX_MS_DEFAULT
+    (1000) because max-gap was not yet configured.  After the fix, the value is
+    accepted as-is and stored; rejection only occurs when explicit min/max are
+    already set and the value falls outside them.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap 2000\n"
+        "ip ospf lsa-pacing min-gap 200 max-gap 2000\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing initial-gap 2000" in running_config, \
+        "initial-gap 2000 was silently clamped — ordering bug not fixed"
+
+
+def test_lsa_pacing_initial_gap_after_minmax(tgen):
+    """initial-gap set AFTER min-gap/max-gap — value within bounds accepted."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 200 max-gap 2000\n"
+        "ip ospf lsa-pacing initial-gap 1500\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing initial-gap 1500" in running_config, \
+        "initial-gap 1500 (within configured min/max) not accepted"
+
+
+def test_lsa_pacing_initial_gap_at_boundaries(tgen):
+    """initial-gap equal to min-gap and max-gap boundaries is accepted."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # At min boundary
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 100 max-gap 500\n"
+        "ip ospf lsa-pacing initial-gap 100\n"
+        "end"
+    )
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing initial-gap 100" in running_config, \
+        "initial-gap equal to min-gap not accepted"
+
+    # At max boundary
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing initial-gap 500\n"
+        "end"
+    )
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing initial-gap 500" in running_config, \
+        "initial-gap equal to max-gap not accepted"
+
+
+def test_lsa_pacing_initial_gap_rejected_below_min(tgen):
+    """initial-gap below configured min-gap is rejected with an error."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 200 max-gap 1000\n"
+        "end"
+    )
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing initial-gap 50\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing initial-gap 50" not in running_config, \
+        "initial-gap below min-gap was accepted — validation broken"
+
+
+def test_lsa_pacing_initial_gap_rejected_above_max(tgen):
+    """initial-gap above configured max-gap is rejected with an error."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 100 max-gap 500\n"
+        "end"
+    )
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing initial-gap 2000\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing initial-gap 2000" not in running_config, \
+        "initial-gap above max-gap was accepted — validation broken"
+
+
+def test_lsa_pacing_minmax_clamps_existing_initial_gap(tgen):
+    """When min-gap/max-gap is set after initial-gap, initial-gap is clamped.
+
+    If initial-gap 2000 is set first (no min/max configured yet), then
+    min-gap 100 max-gap 500 is applied, the min-max handler clamps the
+    stored initial-gap to max-gap (500).
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap 2000\n"
+        "ip ospf lsa-pacing min-gap 100 max-gap 500\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    # initial-gap 2000 must be clamped to max-gap 500 by the min-max handler
+    assert "ip ospf lsa-pacing initial-gap 2000" not in running_config, \
+        "initial-gap was not clamped when min-gap/max-gap set below it"
+    assert "ip ospf lsa-pacing initial-gap 500" in running_config, \
+        "initial-gap not clamped to max-gap=500"
+
+
+# ---------------------------------------------------------------------------
+# Sub-parameter: min-gap / max-gap
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_min_max_gap(tgen):
+    """Test min-gap/max-gap set and removed."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 5 max-gap 500\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing min-gap 5 max-gap 500" in running_config, \
+        "min-gap/max-gap not in running config"
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing min-gap 5 max-gap 500\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "min-gap" not in running_config, "min-gap still present after removal"
+    assert "max-gap" not in running_config, "max-gap still present after removal"
+
+
+# ---------------------------------------------------------------------------
+# Sub-parameter: factor
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_factor(tgen):
+    """Test factor set and removed."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing factor 2\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing factor 2" in running_config, \
+        "factor 2 not in running config"
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing factor\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "lsa-pacing factor" not in running_config, \
+        "factor still present after removal"
+
+
+# ---------------------------------------------------------------------------
+# Sub-parameter: adjust-interval
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_adjust_interval(tgen):
+    """Test adjust-interval set and removed."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing adjust-interval 200\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing adjust-interval 200" in running_config, \
+        "adjust-interval 200 not in running config"
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing adjust-interval\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "adjust-interval" not in running_config, \
+        "adjust-interval still present after removal"
+
+
+# ---------------------------------------------------------------------------
+# Sub-parameter: watermarks
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_watermarks(tgen):
+    """Test low-watermark/high-watermark set and removed."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing low-watermark 10 high-watermark 50\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing low-watermark 10 high-watermark 50" in running_config, \
+        "watermarks not in running config"
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing low-watermark 10 high-watermark 50\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "low-watermark" not in running_config, \
+        "low-watermark still present after removal"
+    assert "high-watermark" not in running_config, \
+        "high-watermark still present after removal"
+
+
+# ---------------------------------------------------------------------------
+# Sub-parameter: max-lsas-per-update
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_max_lsas(tgen):
+    """Test max-lsas-per-update set and removed."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing max-lsas-per-update 20\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing max-lsas-per-update 20" in running_config, \
+        "max-lsas-per-update 20 not in running config"
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing max-lsas-per-update\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "max-lsas-per-update" not in running_config, \
+        "max-lsas-per-update still present after removal"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_validation_min_max(tgen):
+    """min-gap must be <= max-gap; router must reject min > max."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing min-gap 1000 max-gap 5\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "min-gap 1000" not in running_config, \
+        "Router accepted min-gap > max-gap — validation broken"
+
+
+def test_lsa_pacing_validation_watermarks(tgen):
+    """low-watermark must be < high-watermark; router must reject low >= high."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing low-watermark 50 high-watermark 50\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "low-watermark 50 high-watermark 50" not in running_config, \
+        "Router accepted low-watermark == high-watermark — validation broken"
+
+
+# ---------------------------------------------------------------------------
+# Default values not written to running-config
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_defaults(tgen):
+    """Enable pacing without sub-params: only the enable line is written."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing" in running_config, \
+        "ip ospf lsa-pacing not in running config"
+    assert "initial-gap" not in running_config, \
+        "Default initial-gap should not appear in running config"
+    assert "min-gap" not in running_config, \
+        "Default min-gap should not appear in running config"
+    assert "factor" not in running_config, \
+        "Default factor should not appear in running config"
+    assert "adjust-interval" not in running_config, \
+        "Default adjust-interval should not appear in running config"
+    assert "watermark" not in running_config, \
+        "Default watermarks should not appear in running config"
+    assert "max-lsas-per-update" not in running_config, \
+        "Default max-lsas-per-update should not appear in running config"
+
+
+# ---------------------------------------------------------------------------
+# Write memory persistence
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_config_persistence(tgen):
+    """Configure all params, write memory, verify saved to ospfd.conf."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap 25\n"
+        "ip ospf lsa-pacing min-gap 8 max-gap 800\n"
+        "ip ospf lsa-pacing factor 4\n"
+        "ip ospf lsa-pacing adjust-interval 150\n"
+        "ip ospf lsa-pacing low-watermark 3 high-watermark 15\n"
+        "ip ospf lsa-pacing max-lsas-per-update 40\n"
+        "end"
+    )
+
+    r1.vtysh_cmd("write memory")
+
+    saved = r1.run("cat /etc/frr/frr.conf")
+
+    assert "ip ospf lsa-pacing" in saved, \
+        "ip ospf lsa-pacing not saved to ospfd.conf"
+    assert "ip ospf lsa-pacing initial-gap 25" in saved, \
+        "initial-gap not saved"
+    assert "ip ospf lsa-pacing min-gap 8 max-gap 800" in saved, \
+        "min-gap/max-gap not saved"
+    assert "ip ospf lsa-pacing factor 4" in saved, \
+        "factor not saved"
+    assert "ip ospf lsa-pacing adjust-interval 150" in saved, \
+        "adjust-interval not saved"
+    assert "ip ospf lsa-pacing low-watermark 3 high-watermark 15" in saved, \
+        "watermarks not saved"
+    assert "ip ospf lsa-pacing max-lsas-per-update 40" in saved, \
+        "max-lsas-per-update not saved"
+
+
+# ---------------------------------------------------------------------------
+# Interface flap
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_interface_flap(tgen):
+    """Config survives interface shutdown / no shutdown."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 8 max-gap 800\n"
+        "end"
+    )
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "shutdown\n"
+        "end"
+    )
+    time.sleep(2)
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no shutdown\n"
+        "end"
+    )
+    time.sleep(2)
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing min-gap 8 max-gap 800" in running_config, \
+        "min-gap/max-gap lost after interface flap"
+
+
+# ---------------------------------------------------------------------------
+# ospfd restart
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_frr_restart(tgen):
+    """Config persists across ospfd kill/restart."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap 25\n"
+        "ip ospf lsa-pacing min-gap 8 max-gap 800\n"
+        "ip ospf lsa-pacing factor 4\n"
+        "ip ospf lsa-pacing adjust-interval 150\n"
+        "ip ospf lsa-pacing low-watermark 3 high-watermark 15\n"
+        "ip ospf lsa-pacing max-lsas-per-update 40\n"
+        "end"
+    )
+
+    r1.vtysh_cmd("write memory")
+
+    r1.killDaemons(["ospfd"])
+    time.sleep(2)
+    r1.startDaemons(["ospfd"])
+    time.sleep(2)
+    r1.run("vtysh -f /etc/frr/frr.conf")
+    time.sleep(3)
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing" in running_config, \
+        "ip ospf lsa-pacing lost after restart"
+    assert "ip ospf lsa-pacing initial-gap 25" in running_config, \
+        "initial-gap lost after restart"
+    assert "ip ospf lsa-pacing min-gap 8 max-gap 800" in running_config, \
+        "min-gap/max-gap lost after restart"
+    assert "ip ospf lsa-pacing factor 4" in running_config, \
+        "factor lost after restart"
+    assert "ip ospf lsa-pacing adjust-interval 150" in running_config, \
+        "adjust-interval lost after restart"
+    assert "ip ospf lsa-pacing low-watermark 3 high-watermark 15" in running_config, \
+        "watermarks lost after restart"
+    assert "ip ospf lsa-pacing max-lsas-per-update 40" in running_config, \
+        "max-lsas-per-update lost after restart"
+
+
+# ---------------------------------------------------------------------------
+# All parameters combined
+# ---------------------------------------------------------------------------
+
+def test_lsa_pacing_all_params(tgen):
+    """Set every parameter and verify all appear in running-config."""
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap 25\n"
+        "ip ospf lsa-pacing min-gap 20 max-gap 1000\n"
+        "ip ospf lsa-pacing factor 2\n"
+        "ip ospf lsa-pacing adjust-interval 300\n"
+        "ip ospf lsa-pacing low-watermark 5 high-watermark 20\n"
+        "ip ospf lsa-pacing max-lsas-per-update 15\n"
+        "end"
+    )
+
+    running_config = r1.vtysh_cmd("show running-config")
+
+    assert "ip ospf lsa-pacing" in running_config
+    assert "ip ospf lsa-pacing initial-gap 25" in running_config
+    assert "ip ospf lsa-pacing min-gap 20 max-gap 1000" in running_config
+    assert "ip ospf lsa-pacing factor 2" in running_config
+    assert "ip ospf lsa-pacing adjust-interval 300" in running_config
+    assert "ip ospf lsa-pacing low-watermark 5 high-watermark 20" in running_config
+    assert "ip ospf lsa-pacing max-lsas-per-update 15" in running_config
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-s", __file__]))

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_congested.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_congested.py
@@ -1,0 +1,777 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_lsa_pacing_congested.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_ospf_lsa_pacing_congested.py
+==================================
+
+RFC4222 R4 LSA Gap Pacing under a congested 100 Kbps link.
+
+Topology
+--------
+
+    R1 ----eth1---- R2
+    (sender)        (observer)
+
+The eth1 link on R1 is shaped to 100 Kbps using Linux tc/tbf so that
+back-to-back LSU bursts cause measurable queuing delay.  This creates
+conditions where:
+
+  - Without pacing: a burst of LSUs fills the tx buffer and can delay
+    or starve Hello packets, risking adjacency drops.
+
+  - With pacing (G=200ms, max-lsas=1): LSUs are metered, the 100 Kbps
+    link is never saturated by OSPF traffic, and Hellos are delivered
+    without delay.
+
+Link shaping
+------------
+
+    tc qdisc add dev <eth1> root handle 1: tbf rate 100kbit burst 4kb latency 100ms
+
+100 Kbps gives ~12.5 KB/s throughput.  A single OSPF Hello is ~60 bytes
+(~0.5 ms at 100 Kbps).  An LSU carrying one Type-5 LSA is ~96 bytes
+(~8 ms at 100 Kbps).  With NUM_ROUTES=10 LSAs sent back-to-back the burst
+occupies ~80 ms — well within the 4s dead interval but enough to show
+measurable inter-packet spacing with pacing enabled.
+
+PCAP capture
+------------
+
+tcpdump captures all traffic on R1's eth1 during the test.  Captures are
+written to pcaps/ relative to the test working directory and can be
+inspected afterward with Wireshark or tshark to verify LSU spacing.
+
+Test plan
+---------
+
+1. test_congested_no_pacing_adjacency_stable
+     Baseline: without pacing, all LSAs are flooded as a burst.
+     The adjacency must survive (Hellos are not completely starved
+     on a 100 Kbps link for a small number of LSAs).
+     Verifies the legacy flood path works under mild congestion.
+
+2. test_congested_pacing_slows_flood
+     With pacing (G=200ms, max-lsas=1): the first LSA arrives at R2
+     quickly but the remaining LSAs are held in the per-neighbor queue,
+     proving pacing intercepts the flood even under a shaped link.
+
+3. test_congested_pacing_delivers_all
+     Correctness under congestion: all NUM_ROUTES LSAs eventually reach
+     R2 when pacing is active on the shaped link.
+
+4. test_congested_adjacency_survives_pacing
+     Adjacency health: R1–R2 adjacency remains Full while pacing is
+     active and LSAs are being drained.  This is the key regression
+     guard for the Hello starvation issue — if LSUs starve Hellos the
+     adjacency drops and this test fails.
+
+5. test_congested_heavy_load_no_duplicate_retransmits
+     Regression guard for paced-retransmit duplicate growth: an ACK
+     blackout forces queue residence to exceed the retransmit interval
+     while a heavy LSA load is draining.  The retransmit timer must
+     reschedule queued LSAs instead of enqueuing duplicate copies
+     (r4_qnode dedup), and returning ACKs must purge queued stale
+     copies.  Without the fix the queue grows a new generation of
+     duplicates every retransmit interval and convergence after the
+     blackout blows well past the asserted budget.
+"""
+
+import os
+import sys
+import time
+
+import pytest
+
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib import topotest
+from lib.common_config import step
+from util_pcap import PerInterfacePcapManager
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.ospfd]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Number of routes injected as Type-5 LSAs.  Kept higher than the functional
+# tests to create a more meaningful burst on the shaped link.
+NUM_ROUTES = 10
+TEST_PREFIXES = ["10.88.{}.0/24".format(i) for i in range(1, NUM_ROUTES + 1)]
+PREFIX_TAG = "10.88."
+
+# Pacing parameters for the congested tests
+GAP_MS = 200          # 200 ms inter-LSU gap — well above the ~8 ms LSU tx time
+MAX_LSAS = 1          # one LSA per LSU — clean 1:1 timing
+ADJINT_MS = 60000     # freeze gap adjuster
+
+# Link shaping — 100 Kbps
+LINK_RATE = "100kbit"
+LINK_BURST = "4kb"
+LINK_LATENCY = "100ms"
+R1_ETH1 = "eth1"   # interface name inside R1's network namespace
+
+# Heavy-load / duplicate-suppression test (test 5) parameters
+NUM_ROUTES_HEAVY = 20      # heavier burst than the other congested tests
+HEAVY_GAP_MS = 500         # 500 ms gap -> 10 s drain for 20 LSAs
+HEAVY_RXMT_S = 3           # retransmit interval well below drain time
+HEAVY_DEAD_S = 60          # survive the ACK blackout without dead-timer expiry
+BLACKOUT_S = 13            # > 4 retransmit intervals of ACK loss
+HEAVY_PREFIXES = ["10.99.{}.0/24".format(i) for i in range(1, NUM_ROUTES_HEAVY + 1)]
+HEAVY_TAG = "10.99."
+
+# Global pcap manager
+PM = None
+
+
+# ---------------------------------------------------------------------------
+# Topology
+# ---------------------------------------------------------------------------
+
+def build_topo(tgen):
+    """Two-router topology: R1 (sender) — R2 (observer)."""
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    tgen.add_link(r1, r2, ifname1="eth1", ifname2="eth1")
+
+
+# ---------------------------------------------------------------------------
+# Module-level setup / teardown
+# ---------------------------------------------------------------------------
+
+def teardown_module():
+    """Placeholder — topology is destroyed per test in teardown_function."""
+    pass
+
+
+def _setup_topology(test_name):
+    """Create and start a fresh topology for one test function."""
+    logger.info("RFC4222 R4 congested link test: R1 --[100Kbps]--> R2 [%s]", test_name)
+
+    tgen = Topogen(build_topo, test_name)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+    r1 = tgen.gears["r1"]
+    r1.cmd(
+        "tc qdisc add dev {} root handle 1: tbf "
+        "rate {} burst {} latency {}".format(
+            R1_ETH1, LINK_RATE, LINK_BURST, LINK_LATENCY
+        )
+    )
+    logger.info("R1 %s shaped to %s (burst=%s latency=%s)",
+                R1_ETH1, LINK_RATE, LINK_BURST, LINK_LATENCY)
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "router ospf\n"
+        "redistribute static\n"
+        "end"
+    )
+
+    global PM
+    PM = PerInterfacePcapManager(outdir="pcaps", tag="congested")
+    PM.start_all(tgen)
+
+    for (rname, ifn), pid in list(PM.pids.items()):
+        if rname != "r1":
+            router = tgen.routers().get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+            PM.pids.pop((rname, ifn), None)
+
+    # Wait for adjacency to form (hello=1s, dead=4s)
+    time.sleep(12)
+
+
+def _teardown_topology():
+    """Stop pcap and destroy the topology created by _setup_topology."""
+    tgen = get_topogen()
+    global PM
+    if PM:
+        PM.stop_all(tgen)
+        PM = None
+    tgen.stop_topology()
+
+
+def setup_function(func):
+    _setup_topology(func.__name__)
+
+
+def teardown_function():
+    _teardown_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _enable_pacing(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap {gap} max-gap {gap}\n"
+        "ip ospf lsa-pacing initial-gap {gap}\n"
+        "ip ospf lsa-pacing max-lsas-per-update {max_lsas}\n"
+        "ip ospf lsa-pacing adjust-interval {adjint}\n"
+        "end".format(gap=GAP_MS, max_lsas=MAX_LSAS, adjint=ADJINT_MS)
+    )
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing" in cfg, \
+        "lsa-pacing did not appear in running-config — vtysh command failed"
+
+
+def _disable_pacing(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing\n"
+        "end"
+    )
+
+
+def _add_routes(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        + "".join("ip route {} null0\n".format(p) for p in TEST_PREFIXES)
+        + "end"
+    )
+
+
+def _remove_routes(r1):
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        + "".join("no ip route {} null0\n".format(p) for p in TEST_PREFIXES)
+        + "end"
+    )
+
+
+def _count_external_lsas(router):
+    out = router.vtysh_cmd("show ip ospf database external")
+    return sum(
+        1 for line in out.splitlines()
+        if "Link State ID" in line and PREFIX_TAG in line
+    )
+
+
+def _wait_lsas(router, expected, timeout_s):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _count_external_lsas(router) == expected:
+            return expected
+        time.sleep(0.2)
+    return _count_external_lsas(router)
+
+
+def _wait_at_least(router, minimum, timeout_s):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _count_external_lsas(router) >= minimum:
+            return _count_external_lsas(router)
+        time.sleep(0.1)
+    return _count_external_lsas(router)
+
+
+def _rxmt_list_count(r1, neighbor_id="2.2.2.2"):
+    """Return R1's LS retransmission list length toward neighbor_id, or -1."""
+    out = r1.vtysh_cmd(
+        "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
+    )
+    nbr_list = out.get("default", {}).get(neighbor_id)
+    if not nbr_list:
+        return -1
+    return nbr_list[0].get("linkStateRetransmissionListCounter", -1)
+
+
+def _count_heavy_lsas(router):
+    out = router.vtysh_cmd("show ip ospf database external")
+    return sum(
+        1 for line in out.splitlines()
+        if "Link State ID" in line and HEAVY_TAG in line
+    )
+
+
+def _adjacency_is_full(r1, neighbor_id="2.2.2.2"):
+    """Return True if R1's adjacency with neighbor_id is Full."""
+    out = r1.vtysh_cmd(
+        "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
+    )
+    nbr_list = out.get("default", {}).get(neighbor_id)
+    if not nbr_list:
+        return False
+    state = nbr_list[0].get("nbrState", "")
+    return state.split("/", 1)[0] == "Full"
+
+
+def _wait_adjacency_full(r1, timeout_s=20, neighbor_id="2.2.2.2"):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _adjacency_is_full(r1, neighbor_id):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _dead_timer_due_ms(r1, neighbor_id="2.2.2.2"):
+    """Return the remaining ms on R1's inactivity (dead) timer for
+    neighbor_id, or -1 if unavailable."""
+    out = r1.vtysh_cmd(
+        "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
+    )
+    nbr_list = out.get("default", {}).get(neighbor_id)
+    if not nbr_list:
+        return -1
+    due = nbr_list[0].get("routerDeadIntervalTimerDueMsec", -1)
+    return due if isinstance(due, int) else -1
+
+
+def _wait_dead_timer_above(r1, min_ms, timeout_s, neighbor_id="2.2.2.2"):
+    """Wait until R1's inactivity timer countdown exceeds min_ms.
+
+    Changing ip ospf dead-interval only affects future re-arms: the
+    currently armed timer keeps its old deadline until one more Hello
+    is accepted. This helper proves the re-arm happened before the
+    test does anything that blocks Hellos.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _dead_timer_due_ms(r1, neighbor_id) > min_ms:
+            return True
+        time.sleep(0.3)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Test 1: baseline — no pacing, adjacency survives burst on congested link
+# ---------------------------------------------------------------------------
+
+def test_congested_no_pacing_adjacency_stable():
+    """
+    Baseline: without pacing, all LSAs are sent as a burst on the 100 Kbps
+    link.  The adjacency must survive — Hellos are not completely starved
+    for NUM_ROUTES=10 LSAs (~80ms burst at 100Kbps, well under dead=4s).
+
+    What this proves
+    ----------------
+    The legacy flood path is unaffected by R4 pacing code when pacing is
+    off.  The shaped link adds real queuing delay but not enough to drop
+    the adjacency for a moderate burst size.
+
+    If this test fails the link shaping or Hello timing needs adjustment.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Test 1: no-pacing baseline on 100Kbps shaped link")
+
+    # No pacing — legacy flood path
+    _add_routes(r1)
+
+    # All LSAs should arrive quickly (burst within throttle + link delay)
+    # Budget: 1s throttle + NUM_ROUTES * 8ms per LSU at 100Kbps + 2s margin
+    timeout_s = 1 + NUM_ROUTES * 0.05 + 2
+    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+
+    assert count == NUM_ROUTES, (
+        "Baseline: only {}/{} LSAs arrived within {:.1f}s without pacing "
+        "on 100Kbps link. Check link shaping parameters.".format(
+            count, NUM_ROUTES, timeout_s
+        )
+    )
+
+    # Adjacency must still be Full after the burst
+    assert _adjacency_is_full(r1), (
+        "Baseline: adjacency dropped after LSU burst on 100Kbps link "
+        "without pacing. The burst may have starved Hellos."
+    )
+
+    # Cleanup
+    _remove_routes(r1)
+    _wait_lsas(r2, 0, timeout_s=20)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: pacing intercepts flood on congested link
+# ---------------------------------------------------------------------------
+
+def test_congested_pacing_slows_flood():
+    """
+    With pacing active (G=200ms, max-lsas=1) on the 100Kbps link:
+    the first LSA arrives at R2, but the rest are held in the per-neighbor
+    queue behind the gap timer.
+
+    This proves the R4 gate in ospf_flood_through_interface() works
+    correctly even when the underlying link is constrained.
+
+    The shaped link makes the timing more realistic — LSUs take ~8ms to
+    transmit at 100Kbps, so the 200ms gap is meaningfully larger than the
+    wire time, giving clear separation between packets in the pcap.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Test 2: pacing slows flood on 100Kbps shaped link")
+
+    _enable_pacing(r1)
+    _add_routes(r1)
+
+    # Wait for the first LSA — may be delayed by 1s LSA throttle
+    first = _wait_at_least(r2, 1, timeout_s=4)
+    assert first >= 1, (
+        "No LSA arrived at R2 within 4s on shaped link with pacing. "
+        "Check adjacency and redistribution."
+    )
+
+    # Immediately after first LSA, the rest must still be queued
+    count_now = _count_external_lsas(r2)
+    assert count_now < NUM_ROUTES, (
+        "Pacing had no effect on 100Kbps link: all {} LSAs arrived "
+        "immediately. Expected remaining {} held in per-neighbor queue "
+        "for {}ms each.".format(NUM_ROUTES, NUM_ROUTES - 1, GAP_MS)
+    )
+
+    # Cleanup
+    _remove_routes(r1)
+    _disable_pacing(r1)
+    _wait_lsas(r2, 0, timeout_s=20)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: pacing delivers all LSAs on congested link
+# ---------------------------------------------------------------------------
+
+def test_congested_pacing_delivers_all():
+    """
+    Correctness: all NUM_ROUTES LSAs reach R2 when pacing is active on
+    the 100Kbps shaped link.
+
+    Timeline with G=200ms, max-lsas=1, NUM_ROUTES=10:
+      t+0s  : LSA-1  sent (delay=0, timer fires immediately)
+      t+0.2s: LSA-2  sent
+      ...
+      t+1.8s: LSA-10 sent
+      Checked at: 1s throttle + (NUM_ROUTES-1)*0.2s + 2s margin
+
+    The shaped link adds ~8ms per packet at 100Kbps, which is well within
+    the 200ms gap so timing is still predictable.
+
+    A failure here (count < NUM_ROUTES) means the send timer stopped
+    re-arming or the queue was incorrectly flushed — check
+    ospf_r4_nbr_send_timer() and the re-arm logic.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Test 3: pacing delivers all LSAs on 100Kbps shaped link")
+
+    _enable_pacing(r1)
+    _add_routes(r1)
+
+    # Budget: throttle(1s) + (NUM_ROUTES-1)*GAP_MS + link_delay + margin
+    timeout_s = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+
+    assert count == NUM_ROUTES, (
+        "Only {}/{} LSAs reached R2 in {:.1f}s with pacing on 100Kbps link. "
+        "Expected all {} delivered at {}ms intervals. "
+        "Check ospf_r4_nbr_send_timer() re-arm logic.".format(
+            count, NUM_ROUTES, timeout_s, NUM_ROUTES, GAP_MS
+        )
+    )
+
+    # Cleanup
+    _remove_routes(r1)
+    _disable_pacing(r1)
+    _wait_lsas(r2, 0, timeout_s=20)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: adjacency survives while pacing drains queue on congested link
+# ---------------------------------------------------------------------------
+
+def test_congested_adjacency_survives_pacing():
+    """
+    Key regression guard for Hello starvation under R4 pacing.
+
+    When pacing is active and draining a queue of LSAs on a 100Kbps link,
+    Hello packets must not be starved.  ospf_hello_send_sub() uses
+    ospf_packet_add_top() to insert Hellos at the HEAD of oi->obuf,
+    ahead of pending LSUs.  This test verifies that mechanism holds
+    under real link congestion.
+
+    Scenario
+    --------
+    1. Enable pacing with G=200ms (slow drain) and inject NUM_ROUTES LSAs.
+    2. While the queue is draining (takes ~2s), poll the adjacency state.
+    3. The adjacency must remain Full throughout — dead-interval is 4s,
+       so even one missed Hello cycle (1s) must not drop the adjacency.
+
+    If the adjacency drops it means Hellos are being delayed behind LSUs
+    in either oi->obuf or the kernel socket send buffer — indicating the
+    Hello priority mechanism is not working under the shaped link.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Test 4: adjacency survives pacing drain on 100Kbps shaped link")
+
+    _enable_pacing(r1)
+    _add_routes(r1)
+
+    # Poll adjacency state while LSAs are being drained.
+    # The drain takes approximately (NUM_ROUTES-1) * GAP_MS = 1.8s.
+    # Poll every 200ms for 4s total — if it ever goes non-Full, fail.
+    drain_duration = (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 1.0
+    poll_end = time.time() + drain_duration
+    adjacency_dropped = False
+
+    while time.time() < poll_end:
+        if not _adjacency_is_full(r1):
+            adjacency_dropped = True
+            break
+        time.sleep(0.2)
+
+    assert not adjacency_dropped, (
+        "Adjacency dropped to non-Full while R4 pacing was draining {} LSAs "
+        "on 100Kbps link with G={}ms. "
+        "Hellos may be starved by LSUs in oi->obuf or kernel socket buffer. "
+        "Check ospf_hello_send_sub() uses ospf_packet_add_top().".format(
+            NUM_ROUTES, GAP_MS
+        )
+    )
+
+    # Also verify all LSAs arrived correctly
+    timeout_s = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+    assert count == NUM_ROUTES, (
+        "Only {}/{} LSAs delivered even though adjacency survived.".format(
+            count, NUM_ROUTES
+        )
+    )
+
+    # Cleanup
+    _remove_routes(r1)
+    _disable_pacing(r1)
+    _wait_lsas(r2, 0, timeout_s=20)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: heavy load + ACK blackout — no duplicate paced retransmits
+# ---------------------------------------------------------------------------
+
+def test_congested_heavy_load_no_duplicate_retransmits():
+    """
+    Regression guard for the paced-retransmit duplicate-growth bug and
+    the stale-copy purge on ACK (r4_qnode tracking).
+
+    Scenario
+    --------
+    An ACK blackout makes queue residence exceed the retransmit
+    interval — the exact regime where the unfixed code melts down:
+
+    1. Raise dead-interval to 60s on both routers so the blackout does
+       not expire the adjacency, and set retransmit-interval to 3s on
+       R1 (well below the 10s queue drain time).
+    2. Enable pacing with a fixed 500ms gap, one LSA per LSU.
+    3. Drop all inbound OSPF on R1 (iptables): R2 still receives and
+       ACKs R1's LSUs, but the ACKs never reach R1.
+    4. Inject NUM_ROUTES_HEAVY=20 routes. Draining takes ~10s; every
+       transmitted LSA stays unacknowledged on R1's retransmission
+       list, and the retransmit timer fires 4+ times during the 13s
+       blackout.
+    5. Lift the blackout and measure convergence on R1: the LS
+       retransmission list toward R2 must drain to 0 (sustained).
+
+    What the fix changes
+    --------------------
+    - During the blackout each retransmit pass may re-enqueue an
+      unacked LSA only if it has no copy waiting in the paced queue
+      (r4_qnode dedup) — the queue stays bounded at one copy per LSA.
+    - After the blackout, each arriving ACK purges the LSA's queued
+      copy, so no stale copy is transmitted and re-added to the
+      retransmission list ("zombie" re-add).
+
+    Without the fix, every 3s retransmit pass enqueues a new generation
+    of duplicates for every unacked LSA, and after the blackout each
+    stale transmission re-adds an already-ACKed LSA to the
+    retransmission list. Convergence then takes far longer than the
+    CONVERGE_BUDGET_S asserted here (which the fixed code meets with
+    several seconds of margin), and the test fails.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Test 5: heavy load + ACK blackout, no duplicate paced retransmits")
+
+    # -- 1. Survive the blackout: dead-interval 60s on both sides.
+    #    Configure R2 first, then R1; the transient hello-parameter
+    #    mismatch may bounce the adjacency, so re-wait for Full.
+    for rtr in (r2, r1):
+        rtr.vtysh_cmd(
+            "configure terminal\n"
+            "interface eth1\n"
+            "ip ospf dead-interval {}\n"
+            "end".format(HEAVY_DEAD_S)
+        )
+    assert _wait_adjacency_full(r1, timeout_s=30), (
+        "Adjacency did not return to Full after raising dead-interval "
+        "to {}s on both routers.".format(HEAVY_DEAD_S)
+    )
+
+    #    The dead-interval change only takes effect on the NEXT accepted
+    #    Hello: the already-armed inactivity timer keeps its old 4s
+    #    deadline until then. Wait until R1's countdown proves the timer
+    #    was re-armed with the new 60s value; only then is it safe to
+    #    block inbound Hellos for the blackout.
+    assert _wait_dead_timer_above(r1, min_ms=30000, timeout_s=10), (
+        "R1's inactivity timer was not re-armed with the new {}s "
+        "dead-interval within 10s (needs one accepted Hello after the "
+        "config change) — cannot start the ACK blackout safely.".format(
+            HEAVY_DEAD_S
+        )
+    )
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf retransmit-interval {}\n"
+        "end".format(HEAVY_RXMT_S)
+    )
+
+    # -- 2. Fixed-gap pacing: 500ms, one LSA per LSU, adjuster frozen.
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap {gap} max-gap {gap}\n"
+        "ip ospf lsa-pacing initial-gap {gap}\n"
+        "ip ospf lsa-pacing max-lsas-per-update 1\n"
+        "ip ospf lsa-pacing adjust-interval {adjint}\n"
+        "end".format(gap=HEAVY_GAP_MS, adjint=ADJINT_MS)
+    )
+
+    # -- 3. ACK blackout: drop all inbound OSPF (proto 89) on R1.
+    r1.cmd("iptables -A INPUT -i {} -p 89 -j DROP".format(R1_ETH1))
+
+    try:
+        # -- 4. Heavy LSA load while ACKs are lost.
+        r1.vtysh_cmd(
+            "configure terminal\n"
+            + "".join("ip route {} null0\n".format(p) for p in HEAVY_PREFIXES)
+            + "end"
+        )
+
+        blackout_end = time.time() + BLACKOUT_S
+        while time.time() < blackout_end:
+            assert _adjacency_is_full(r1), (
+                "Adjacency dropped during the {}s ACK blackout despite "
+                "dead-interval={}s — blackout setup is wrong.".format(
+                    BLACKOUT_S, HEAVY_DEAD_S
+                )
+            )
+            time.sleep(1)
+    finally:
+        # -- 5. Lift the blackout.
+        r1.cmd("iptables -D INPUT -i {} -p 89 -j DROP".format(R1_ETH1))
+
+    # Convergence budget for the FIXED code: at most one queued copy per
+    # LSA means <= NUM_ROUTES_HEAVY paced sends remain at unblock
+    # (20 * 0.5s = 10s), plus one retransmit interval (3s) for stragglers
+    # to be re-selected, plus scheduling margin. The unfixed code has
+    # several duplicate generations queued plus zombie re-adds and needs
+    # far longer.
+    CONVERGE_BUDGET_S = (
+        NUM_ROUTES_HEAVY * (HEAVY_GAP_MS / 1000.0) + 2 * HEAVY_RXMT_S + 6
+    )
+
+    deadline = time.time() + CONVERGE_BUDGET_S
+    zero_streak = 0
+    converged_at = None
+    while time.time() < deadline:
+        count = _rxmt_list_count(r1)
+        if count == 0:
+            zero_streak += 1
+            if zero_streak >= 3:  # sustained: 3 consecutive 1s samples
+                converged_at = time.time()
+                break
+        else:
+            zero_streak = 0
+        time.sleep(1)
+
+    final_rxmt = _rxmt_list_count(r1)
+    assert converged_at is not None, (
+        "R1's LS retransmission list toward R2 did not drain to 0 within "
+        "{:.0f}s of lifting the ACK blackout (still {} entries). With "
+        "duplicate suppression and ACK purge this converges in ~15s; "
+        "sustained non-zero indicates duplicate queue growth or stale "
+        "queued copies re-adding ACKed LSAs to the retransmission "
+        "list.".format(CONVERGE_BUDGET_S, final_rxmt)
+    )
+    logger.info(
+        "rxmt list drained to 0 with %.0fs of budget to spare",
+        deadline - converged_at,
+    )
+
+    # All LSAs must have reached R2 (R2 received them during the
+    # blackout — only the ACKs were dropped).
+    count = _count_heavy_lsas(r2)
+    assert count == NUM_ROUTES_HEAVY, (
+        "Only {}/{} heavy-load LSAs present in R2's LSDB after "
+        "convergence.".format(count, NUM_ROUTES_HEAVY)
+    )
+
+    # Adjacency must have survived the whole exercise.
+    assert _adjacency_is_full(r1), (
+        "Adjacency not Full after blackout recovery."
+    )
+
+    # Cleanup
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        + "".join("no ip route {} null0\n".format(p) for p in HEAVY_PREFIXES)
+        + "end"
+    )
+    _disable_pacing(r1)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-s", __file__]))

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_functional.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_functional.py
@@ -1,0 +1,741 @@
+    #!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_lsa_pacing_functional.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_ospf_lsa_pacing_functional.py: Functional test for OSPF RFC4222/R4 LSA Gap Pacing
+
+Topology
+--------
+
+    R1 ----eth1---- R2
+    (sender)        (observer)
+
+R1 generates AS-External LSAs by redistributing blackhole static routes into OSPF.
+R2 watches its LSDB to measure how fast those LSAs arrive.
+
+What gap pacing does (RFC 4222 Recommendation 4)
+-------------------------------------------------
+
+Without pacing, every newly-originated LSA is forwarded to each OSPF neighbor in a
+Link State Update (LSU) packet immediately.  Under a sudden burst this can saturate
+the link or overwhelm the neighbor.
+
+With pacing enabled on an interface, LSAs destined for each neighbor are placed in a
+per-neighbor queue (nbr->r4_send_queue).  A timer (nbr->t_r4_send) fires every G
+milliseconds (the "gap") and drains one batch of at most max-lsas-per-update LSAs
+into a single LSU packet.  The gap G is adjusted dynamically based on unacknowledged
+LSAs, but for these tests we freeze the adjuster (adjust-interval 60000 ms) so G
+stays constant and timing is predictable.
+
+Observable effect
+-----------------
+
+  Pacing ON  (gap=1000 ms, max-lsas=1):  one LSA per second arrives at R2.
+  Pacing OFF (default):                   all LSAs arrive within ~1 second.
+
+Fixture scope
+-------------
+
+Each test function gets a completely fresh topology (scope="function").  The
+adjacency forms from scratch, the LSDB is empty, and no configuration from a
+previous test is present.  This means:
+
+  - No unique prefix families needed — every test uses the same TEST_PREFIXES.
+  - No cleanup / MaxAge synchronization between tests.
+  - A failure in one test does NOT leave state that contaminates the next.
+
+The cost is ~12 s of adjacency-formation time per test.
+
+Note on LSA throttle
+--------------------
+
+r1/frr.conf sets 'timers throttle lsa all 1000', meaning R1 may delay
+origination of fresh LSAs by up to 1 s after the static routes are added.
+test_pacing_slows_flood accounts for this by polling until the first LSA
+appears at R2 (proving the throttle fired and the first packet was sent),
+then immediately checking that the remaining LSAs have not yet arrived.
+
+Test plan
+---------
+
+1. test_pacing_slows_flood
+     Prove pacing is active: the first LSA arrives but the rest are still
+     queued behind the 1 s gap timer.
+
+2. test_pacing_delivers_all
+     Correctness: given enough time all NUM_ROUTES LSAs reach R2.
+
+3. test_no_pacing_fast_delivery
+     Baseline: with pacing disabled all LSAs arrive within 3 s.
+
+4. test_pacing_enable_disable_mid_session
+     Toggle pacing on/off while the adjacency is up and verify both phases
+     behave correctly.
+
+How to read a passing run
+-------------------------
+
+  PASSED test_pacing_slows_flood                → per-neighbor queue+timer gating flood
+  PASSED test_pacing_delivers_all               → queue drains fully, no LSA lost
+  PASSED test_no_pacing_fast_delivery           → legacy flood path untouched
+  PASSED test_pacing_enable_disable_mid_session → dynamic enable/disable works live
+
+If test_pacing_slows_flood fails with count == NUM_ROUTES, pacing is not intercepting
+the flood path — check ospf_flood_through_interface() R4 block.
+
+If test_pacing_delivers_all fails with count < NUM_ROUTES, the send timer or queue
+drain has a bug — check ospf_r4_nbr_send_timer() and the re-arm logic.
+"""
+
+import pytest
+import time
+
+from lib.topogen import Topogen
+
+
+pytestmark = [pytest.mark.ospfd]
+
+# Prefixes injected as blackhole static routes on R1.
+# All tests use the same set — each test gets a fresh topology so there is
+# no cross-test contamination.
+NUM_ROUTES = 4
+TEST_PREFIXES = ["10.99.{}.0/24".format(i) for i in range(1, NUM_ROUTES + 1)]
+PREFIX_TAG = "10.99."  # substring used to filter these LSAs in 'show' output
+
+# Pacing parameters — large gap so timing is reliable on a loaded test host.
+GAP_MS = 1000      # 1 s between LSU batches
+MAX_LSAS = 1       # 1 LSA per LSU — clean 1:1 timing, no batching ambiguity
+ADJINT_MS = 60000  # freeze gap adjuster so G stays fixed during the test
+
+
+# ---------------------------------------------------------------------------
+# Topology
+# ---------------------------------------------------------------------------
+
+def build_topo(tgen):
+    """Two-router topology: R1 (sender) — R2 (observer)."""
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    tgen.add_link(r1, r2, ifname1="eth1", ifname2="eth1")
+
+
+# ---------------------------------------------------------------------------
+# Per-test fixture — fresh topology for every test function
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function")
+def tgen(request):
+    """
+    Start a clean R1-R2 topology, wait for OSPF Full adjacency, then yield.
+    The topology is torn down automatically after each test.
+    """
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+    r1 = tgen.gears["r1"]
+
+    # Enable redistribution of static routes into OSPF so that blackhole
+    # routes added per-test become AS-External (Type-5) LSAs.
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "router ospf\n"
+        "redistribute static\n"
+        "end"
+    )
+
+    # hello-interval 1 s / dead-interval 4 s — adjacency normally reaches
+    # Full in < 10 s; allow 12 s for a loaded test host.
+    time.sleep(12)
+
+    yield tgen
+
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _enable_pacing(r1):
+    """Configure R1 eth1 with a fixed gap and frozen adjuster.
+
+    Raises AssertionError if pacing does not appear in running-config
+    after the command, so a misconfiguration fails immediately rather
+    than silently producing a false-positive timing test result.
+    """
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing initial-gap {gap}\n"
+        "ip ospf lsa-pacing min-gap {gap} max-gap {gap}\n"
+        "ip ospf lsa-pacing max-lsas-per-update {max_lsas}\n"
+        "ip ospf lsa-pacing adjust-interval {adjint}\n"
+        "end".format(gap=GAP_MS, max_lsas=MAX_LSAS, adjint=ADJINT_MS)
+    )
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing" in cfg, \
+        "lsa-pacing did not appear in R1 running-config after _enable_pacing() — " \
+        "vtysh command may have failed silently."
+
+
+def _disable_pacing(r1):
+    """Remove all pacing config from R1 eth1."""
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "no ip ospf lsa-pacing\n"
+        "end"
+    )
+
+
+def _add_routes(r1):
+    """Inject TEST_PREFIXES as blackhole static routes on R1."""
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        + "".join("ip route {} null0\n".format(p) for p in TEST_PREFIXES)
+        + "end"
+    )
+
+
+def _count_external_lsas(router):
+    """
+    Count AS-External (Type-5) LSAs in the router's OSPF LSDB whose
+    'Link State ID' line contains PREFIX_TAG.
+
+    FRR's 'show ip ospf database external' prints one 'Link State ID:' line
+    per LSA entry.  Filtering by PREFIX_TAG isolates only our test routes.
+    """
+    out = router.vtysh_cmd("show ip ospf database external")
+    return sum(
+        1 for line in out.splitlines()
+        if "Link State ID" in line and PREFIX_TAG in line
+    )
+
+
+def _wait_lsas(router, expected, timeout_s):
+    """
+    Poll until external LSA count equals expected or timeout_s expires.
+    Returns the actual count at exit.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _count_external_lsas(router) == expected:
+            return expected
+        time.sleep(0.2)
+    return _count_external_lsas(router)
+
+
+def _wait_at_least(router, minimum, timeout_s):
+    """
+    Poll until external LSA count >= minimum or timeout_s expires.
+    Returns the actual count at exit.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _count_external_lsas(router) >= minimum:
+            return _count_external_lsas(router)
+        time.sleep(0.1)
+    return _count_external_lsas(router)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: pacing slows down the flood
+# ---------------------------------------------------------------------------
+
+def test_pacing_slows_flood(tgen):
+    """
+    Prove pacing is active: after the first LSA arrives at R2, the remaining
+    LSAs are still held in R1's per-neighbor queue.
+
+    What the code does
+    ------------------
+    ospf_flood_through_interface() reaches the R4 gate:
+
+        if (oi->rec4_gap_pacing) {
+            ospf_r4_nbr_enqueue(nbr, lsa);   // enqueue, do not send now
+            return 0;
+        }
+
+    ospf_r4_nbr_arm_timer() schedules nbr->t_r4_send with delay_ms=0 for
+    the first LSA (next_send_ms is in the past).  That timer fires immediately
+    and sends exactly one LSU (max-lsas=1).  It then re-arms itself with
+    delay = GAP_MS = 1000 ms for the next batch.
+
+    Why poll for the first LSA rather than sleep
+    ---------------------------------------------
+    r1/frr.conf uses 'timers throttle lsa all 1000', so R1 may delay
+    originating fresh LSAs by up to 1 s after the routes are added.
+    Polling until count >= 1 means we only start the race after R1 has
+    actually sent the first packet — the subsequent check is then purely
+    about the gap timer, not the throttle.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    _enable_pacing(r1)
+    _add_routes(r1)
+
+    # Wait up to (throttle_max + first_packet_travel) for LSA-1 to appear.
+    first = _wait_at_least(r2, 1, timeout_s=4)
+    assert first >= 1, (
+        "No LSA arrived at R2 within 4 s. "
+        "Check that OSPF adjacency is Full and redistribution is active."
+    )
+
+    # The gap timer is now running. Immediately after the first packet,
+    # the remaining LSAs must still be queued — they should not arrive
+    # for another GAP_MS milliseconds.
+    count_now = _count_external_lsas(r2)
+
+    assert count_now < NUM_ROUTES, (
+        "Pacing had no effect: all {} LSAs arrived at R2 immediately after "
+        "the first one. Expected the remaining {} to be held in the "
+        "per-neighbor queue for ~{} ms. "
+        "Check ospf_flood_through_interface() R4 block.".format(
+            NUM_ROUTES, NUM_ROUTES - 1, GAP_MS
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: pacing delivers all LSAs eventually
+# ---------------------------------------------------------------------------
+
+def test_pacing_delivers_all(tgen):
+    """
+    Correctness: every injected LSA reaches R2, just spaced over time.
+
+    Timeline with gap=1000 ms, 4 LSAs (after the LSA throttle fires):
+      t+0 s : LSA-1 sent  (timer fires with delay=0)
+      t+1 s : LSA-2 sent
+      t+2 s : LSA-3 sent
+      t+3 s : LSA-4 sent
+      checked at t + (NUM_ROUTES-1)*GAP_MS + 2 s margin
+
+    What the code does
+    ------------------
+    After each ospf_ls_upd_queue_send() call inside ospf_r4_nbr_send_timer(),
+    lsu_sent_for_dst() advances nbr->next_send_ms by sent_count * GAP_MS.
+    The timer re-arms with that exact delay so the next batch fires on
+    schedule.  The queue drains completely; no LSA is dropped or skipped.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    _enable_pacing(r1)
+    _add_routes(r1)
+
+    # LSA throttle can delay first origination by up to 1 s, then the queue
+    # drains one LSA per GAP_MS.  Total budget:
+    #   throttle_max(1s) + (NUM_ROUTES-1)*GAP_MS + 2s margin
+    timeout_s = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+
+    assert final_count == NUM_ROUTES, (
+        "Only {}/{} external LSAs reached R2 after {:.1f} s with pacing. "
+        "Check ospf_r4_nbr_send_timer() queue drain and re-arm logic.".format(
+            final_count, NUM_ROUTES, timeout_s
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: without pacing all LSAs arrive quickly
+# ---------------------------------------------------------------------------
+
+def test_no_pacing_fast_delivery(tgen):
+    """
+    Baseline: with pacing disabled the legacy ospf_ls_upd_send_lsa() path is
+    used and all 4 LSAs arrive at R2 within 3 seconds.
+
+    This guards against regressions where the R4 gating code accidentally
+    intercepts traffic when pacing is off.  The guard in
+    ospf_flood_through_interface() is:
+
+        if (oi->rec4_gap_pacing) { ... }   // only entered when pacing is on
+
+    With no pacing configured, rec4_gap_pacing == 0 and the existing
+    multicast/unicast send path runs unchanged.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # No _enable_pacing() call — legacy path only.
+    _add_routes(r1)
+
+    # LSA throttle (up to 1 s) + propagation; all LSAs flood immediately
+    # so 3 s total is a generous budget.
+    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s=3)
+
+    assert final_count == NUM_ROUTES, (
+        "Without pacing only {}/{} external LSAs reached R2 within 3 s. "
+        "The legacy flood path may be broken, or LSA/SPF timers are too "
+        "conservative for this host.".format(final_count, NUM_ROUTES)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: dynamic enable / disable mid-session
+# ---------------------------------------------------------------------------
+
+def test_pacing_enable_disable_mid_session(tgen):
+    """
+    Toggle pacing on and off while the adjacency is live.
+
+    Phase A — pacing ON:
+      Inject routes.  Wait for first LSA.  Confirm the rest are still queued
+      (count < NUM_ROUTES immediately after first arrival).
+
+    Phase B — pacing toggled OFF (same adjacency, routes removed first):
+      Inject the same routes again.  All arrive within 3 s.
+
+    What the code does for the disable path
+    ----------------------------------------
+    'no ip ospf lsa-pacing' calls ospf_if_update_params_all() which calls
+    ospf_rec4_recompute_effective() setting oi->rec4_gap_pacing = 0, then
+    walks existing neighbors calling ospf_nbr_apply_rec4_params() to reset
+    their runtime state.  The next flood falls through to the legacy path.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # -- Phase A: pacing enabled --
+    _enable_pacing(r1)
+    _add_routes(r1)
+
+    first = _wait_at_least(r2, 1, timeout_s=4)
+    assert first >= 1, "Phase A: no LSA arrived within 4 s — check adjacency."
+
+    count_paced = _count_external_lsas(r2)
+    assert count_paced < NUM_ROUTES, (
+        "Phase A: pacing had no effect — all {} LSAs arrived immediately. "
+        "Check ospf_flood_through_interface() R4 block.".format(NUM_ROUTES)
+    )
+
+    # Remove routes (triggers MaxAge withdrawal) and wait for R2 LSDB to
+    # drain before Phase B, so we get a clean count baseline.
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        + "".join("no ip route {} null0\n".format(p) for p in TEST_PREFIXES)
+        + "end"
+    )
+    _wait_lsas(r2, 0, timeout_s=20)
+
+    # -- Phase B: pacing disabled, adjacency still up --
+    _disable_pacing(r1)
+    _add_routes(r1)
+
+    count_unpaced = _wait_lsas(r2, NUM_ROUTES, timeout_s=3)
+    assert count_unpaced == NUM_ROUTES, (
+        "Phase B: only {}/{} LSAs arrived within 3 s after disabling pacing. "
+        "Check that ospf_if_update_params_all() correctly clears "
+        "oi->rec4_gap_pacing on the live interface.".format(
+            count_unpaced, NUM_ROUTES
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: gap adjuster speedup — U < L causes G to halve toward min-gap
+# ---------------------------------------------------------------------------
+
+def test_gap_adjuster_speedup(tgen):
+    """
+    Verify the RFC4222 speedup path: when U(t) < L, pace_maybe_adjust_gap()
+    halves G on each send cycle, converging from initial-gap down to min-gap.
+
+    How it is forced
+    ----------------
+    On a virtual P2P link ACKs arrive in microseconds, so U (retransmit list
+    size) is always 0 or 1 — well below L=100.  Setting L=100 guarantees
+    the U < L branch fires on every send timer call.  adjust-interval=1ms
+    removes the rate-limit so every send triggers an adjustment.
+
+    Config:
+      initial-gap = 2000 ms   deliberate slow start
+      min-gap     =  200 ms   floor for halving
+      max-gap     = 2000 ms
+      low-watermark  = 100    U is always < 100 on virtual link → speedup every call
+      high-watermark = 200
+      factor      = 2
+      adjust-interval = 1 ms  effectively no rate-limit
+      max-lsas    = 1
+
+    Expected delivery timeline (from first LSA sent):
+      call 1: U<100 → G 2000→1000ms  LSA-1 sent,  next_send += 1000ms
+      call 2: U<100 → G 1000→ 500ms  LSA-2 sent,  next_send +=  500ms
+      call 3: U<100 → G  500→ 250→200ms(min)  LSA-3 sent,  next_send += 200ms
+      call 4: U<100 → G stays 200ms  LSA-4 sent
+      Total ≈ 1000+500+200 = 1700ms from first send
+
+    Without speedup (fixed G=2000ms):
+      LSA-2 at 2000ms, LSA-3 at 4000ms, LSA-4 at 6000ms — total ≈ 6000ms
+
+    The 4s timeout discriminates: speedup completes in ~2.7s; without it ~7s.
+
+    What the code does
+    ------------------
+    pace_maybe_adjust_gap() at ospf_packet.c:202:
+        } else if (U < L) {
+            G = max(G / F, Gmin);   ← this branch fires on every call
+        }
+    lsu_sent_for_dst() then uses the updated G to advance next_send_ms,
+    so each subsequent timer arms with the reduced delay.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 200 max-gap 2000\n"
+        "ip ospf lsa-pacing initial-gap 2000\n"
+        "ip ospf lsa-pacing low-watermark 100 high-watermark 200\n"
+        "ip ospf lsa-pacing factor 2\n"
+        "ip ospf lsa-pacing adjust-interval 1\n"
+        "ip ospf lsa-pacing max-lsas-per-update 1\n"
+        "end"
+    )
+
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing initial-gap 2000" in cfg, \
+        "initial-gap 2000 not in running-config — vtysh command failed."
+
+    _add_routes(r1)
+
+    # Budget: 1s throttle + ~1.7s actual + 1.3s margin = 4s.
+    # Without speedup the same 4 LSAs need ~7s (1s throttle + 6s at G=2000ms).
+    # Passing within 4s proves speedup fired.
+    timeout_s = 4.0
+    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+
+    assert final_count == NUM_ROUTES, (
+        "Speedup did not reduce delivery time: only {}/{} LSAs arrived in {:.0f}s. "
+        "With initial-gap=2000ms and low-watermark=100, G should halve on every "
+        "send cycle reaching min-gap=200ms quickly. "
+        "Without speedup all {} LSAs need ~7s. "
+        "Check the U < L branch in pace_maybe_adjust_gap().".format(
+            final_count, NUM_ROUTES, timeout_s, NUM_ROUTES
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: gap adjuster backoff — aggressive config still delivers all LSAs
+# ---------------------------------------------------------------------------
+
+def test_gap_adjuster_backoff(tgen):
+    """
+    Verify the RFC4222 backoff path: pace_maybe_adjust_gap() is exercised
+    with a small high-watermark and large factor, and all LSAs still deliver.
+
+    How it is forced
+    ----------------
+    Setting high-watermark=2 means backoff fires when U > 2.  On a virtual
+    link this threshold is borderline — U may briefly exceed 2 between the
+    send and the ACK, especially with adjust-interval=1ms.  Even if backoff
+    does not fire on every call, the code path (U > H branch + G cap at
+    max-gap) is reachable and the test verifies no LSA is lost or stuck.
+
+    Config:
+      initial-gap =  100 ms
+      min-gap     =  100 ms
+      max-gap     =  500 ms   cap so backoff cannot delay indefinitely
+      high-watermark = 2      backoff when more than 2 LSAs unacked
+      low-watermark  = 1
+      factor      = 3         aggressive: G triples on backoff
+      adjust-interval = 1 ms
+      max-lsas    = 1
+
+    What the code does
+    ------------------
+    pace_maybe_adjust_gap() at ospf_packet.c:199:
+        if (U > H) {
+            G = min(G * F, Gmax);   ← G triples, capped at 500ms
+        }
+    Even if G reaches max-gap=500ms the send timer still re-arms and drains
+    the queue — the re-arm check at ospf_packet.c:4439 is not affected by G.
+
+    Delivery budget:
+      Worst case (G maxes at 500ms for all remaining LSAs after first):
+        1s throttle + (NUM_ROUTES-1) * 500ms + 2s margin
+      This is the upper bound regardless of how many times backoff fires.
+    """
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf lsa-pacing\n"
+        "ip ospf lsa-pacing min-gap 100 max-gap 500\n"
+        "ip ospf lsa-pacing initial-gap 100\n"
+        "ip ospf lsa-pacing low-watermark 1 high-watermark 2\n"
+        "ip ospf lsa-pacing factor 3\n"
+        "ip ospf lsa-pacing adjust-interval 1\n"
+        "ip ospf lsa-pacing max-lsas-per-update 1\n"
+        "end"
+    )
+
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing initial-gap 100" in cfg, \
+        "initial-gap 100 not in running-config — vtysh command failed."
+
+    _add_routes(r1)
+
+    # Worst case: G maxes at 500ms for every inter-LSA gap.
+    # Budget: 1s throttle + (NUM_ROUTES-1)*500ms + 2s margin.
+    timeout_s = 1 + (NUM_ROUTES - 1) * 0.5 + 2
+    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+
+    assert final_count == NUM_ROUTES, (
+        "Only {}/{} LSAs delivered with aggressive backoff config in {:.1f}s. "
+        "With initial-gap=100ms, max-gap=500ms and factor=3, all {} LSAs must "
+        "still be delivered even if G backs off to max-gap. "
+        "Check the U > H branch in pace_maybe_adjust_gap() and the "
+        "send timer re-arm logic under increasing G.".format(
+            final_count, NUM_ROUTES, timeout_s, NUM_ROUTES
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture: pacing pre-configured in frr.conf (active before adjacency forms)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function")
+def tgen_pacing(request):
+    """
+    Like the default tgen fixture but loads r1/frr_pacing.conf so that
+    ip ospf lsa-pacing is already configured on eth1 before ospfd starts.
+    Pacing is therefore active from the moment the interface comes up and
+    the first Router-LSA is originated — no VTY enable needed in the test.
+    """
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    tgen.gears["r1"].load_frr_config("frr_pacing.conf")
+    tgen.gears["r2"].load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "router ospf\n"
+        "redistribute static\n"
+        "end"
+    )
+
+    time.sleep(12)
+
+    yield tgen
+
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Router-LSA paced via pre-configured frr.conf
+# ---------------------------------------------------------------------------
+
+def test_router_lsa_paced_from_config(tgen_pacing):
+    """
+    Verify that a Type-1 Router-LSA is intercepted by the R4 pacing queue
+    when pacing is pre-configured in frr.conf (active before adjacency forms).
+
+    Unlike the other tests, pacing is NOT enabled via a VTY command in the
+    test body — it is already in place when ospfd starts.  This tests the
+    code path where ospf_nbr_apply_rec4_params() runs during ospf_nbr_new()
+    itself (not retroactively via ospf_if_update_params_all()).
+
+    Trigger
+    -------
+    Changing 'ip ospf cost' on eth1 forces an immediate Type-1 Router-LSA
+    re-origination.  Combined with NUM_ROUTES Type-5 AS-External LSAs, the
+    queue holds mixed LSA types delivered at the 1000ms gap.
+
+    What to look for in the log
+    ---------------------------
+    R4: flood enqueue LSA [Type1:1.1.1.1] nbr=2.2.2.2   <- Router-LSA queued
+    R4: flood enqueue LSA [Type5:10.99.x.0] nbr=2.2.2.2  <- External LSAs queued
+    R4: send timer fired ... G=1000 ms                    <- all delivered at 1s gap
+    """
+    tgen = tgen_pacing
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Verify pacing is active from config — no _enable_pacing() call needed
+    cfg = r1.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing" in cfg, \
+        "Pacing not active from frr_pacing.conf — check fixture config load"
+
+    # Trigger Type-1 Router-LSA re-origination via cost change
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "interface eth1\n"
+        "ip ospf cost 100\n"
+        "end"
+    )
+
+    # Inject Type-5 LSAs — these and the Type-1 share the same R4 queue
+    _add_routes(r1)
+
+    # Budget: 1s LSA throttle + (NUM_ROUTES + 1 Type-1) gaps + 2s margin
+    timeout_s = 1 + (NUM_ROUTES + 1) * 1.0 + 2
+    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+
+    assert count == NUM_ROUTES, (
+        "Only {}/{} Type-5 LSAs arrived within {}s. "
+        "Expected Type-1 and Type-5 to share the R4 queue and be delivered "
+        "at 1000ms intervals. Check R4: flood enqueue lines in ospfd.log "
+        "for [Type1:] entries.".format(count, NUM_ROUTES, timeout_s)
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-s", __file__]))

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_opaque.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_opaque.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+Opaque/TE Rec4 regression scenario.
+
+This keeps the topology intentionally small: two routers with opaque capability
+and MPLS-TE enabled while Rec4 interface pacing is active on the sender side.
+The test validates the MPLS-TE database rather than the generic opaque-area
+LSDB view, which matches FRR's existing TE topotests.
+"""
+
+import json
+import time
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen
+
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    r3 = tgen.add_router("r3")
+    r4 = tgen.add_router("r4")
+    tgen.add_link(r3, r4, ifname1="eth1", ifname2="eth1")
+
+
+@pytest.fixture(scope="function")
+def tgen(request):
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+def _wait_neighbor_full(router, rid, timeout_s=30):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        out = router.vtysh_cmd("show ip ospf neighbor json")
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError:
+            time.sleep(1)
+            continue
+
+        neighbors = data.get("neighbors", {})
+        if rid in neighbors:
+            state = neighbors[rid][0].get(
+                "converged", neighbors[rid][0].get("state", "")
+            )
+            if state == "Full" or str(state).startswith("Full"):
+                return
+        time.sleep(1)
+
+    pytest.fail(f"neighbor {rid} did not reach Full")
+
+
+def _te_router_ids(router):
+    out = router.vtysh_cmd("show ip ospf mpls-te database json")
+    data = json.loads(out)
+    return {
+        vertex.get("router-id")
+        for vertex in data.get("ted", {}).get("vertices", [])
+        if vertex.get("router-id")
+    }
+
+
+def _wait_for_te_router(router, name, rid, timeout_s=30):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if rid in _te_router_ids(router):
+            return
+        time.sleep(1)
+    pytest.fail(f"MPLS-TE database on {name} did not include router {rid}")
+
+
+def test_opaque_lsa_with_rec4_pacing_survives_interface_flap(tgen):
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r3 = tgen.gears["r3"]
+    r4 = tgen.gears["r4"]
+
+    _wait_neighbor_full(r3, "4.4.4.4")
+    _wait_neighbor_full(r4, "3.3.3.3")
+
+    cfg = r3.vtysh_cmd("show running-config")
+    assert "ip ospf lsa-pacing" in cfg
+    # Opaque capability is enabled by default; only its disabled form is
+    # emitted in running-config.
+    assert "no capability opaque" not in cfg
+    assert "mpls-te on" in cfg
+
+    _wait_for_te_router(r3, "r3", "3.3.3.3")
+    _wait_for_te_router(r3, "r3", "4.4.4.4")
+    _wait_for_te_router(r4, "r4", "3.3.3.3")
+    _wait_for_te_router(r4, "r4", "4.4.4.4")
+
+    tgen.net["r3"].cmd("ip link set eth1 down")
+    time.sleep(2)
+    tgen.net["r3"].cmd("ip link set eth1 up")
+
+    _wait_neighbor_full(r3, "4.4.4.4")
+    _wait_neighbor_full(r4, "3.3.3.3")
+    _wait_for_te_router(r3, "r3", "3.3.3.3")
+    _wait_for_te_router(r3, "r3", "4.4.4.4")
+    _wait_for_te_router(r4, "r4", "3.3.3.3")
+    _wait_for_te_router(r4, "r4", "4.4.4.4")
+
+    assert not tgen.routers_have_failure(), tgen.errors
+
+    rc, _, _ = tgen.net["r3"].cmd_status(
+        "grep -q 'Assertion' ospfd.err || grep -q 'Backtrace' ospfd.err",
+        warn=False,
+    )
+    assert rc != 0, "ospfd.err shows an assertion/backtrace on r3"

--- a/tests/topotests/ospf_rfc4222_r4/util_pcap.py
+++ b/tests/topotests/ospf_rfc4222_r4/util_pcap.py
@@ -1,0 +1,87 @@
+import re
+import shlex
+import time
+from pathlib import Path
+
+OSPFV2_FILTER = "ip proto 89"
+
+
+class PerInterfacePcapManager:
+    def __init__(self, outdir="pcaps", tag="ospf4"):
+        self.outdir = Path(outdir)
+        self.tag = tag
+        self.pids = {}
+
+    def _list_ifaces(self, router):
+        txt = router.cmd("ip -o link show")
+        ifaces = []
+        seen = set()
+        for ln in txt.splitlines():
+            m = re.match(r"\d+:\s+([^:]+):\s+<([^>]*)>", ln)
+            if not m:
+                continue
+            ifn = m.group(1).split("@")[0]
+            flags = m.group(2).split(",")
+            up = "UP" in flags
+            if ifn not in seen:
+                seen.add(ifn)
+                ifaces.append((ifn, up))
+        return ifaces
+
+    def start_all(self, tgen):
+        if tgen is None or not tgen.routers():
+            raise RuntimeError("Call start_all() only after tgen.start_router()")
+
+        self.outdir = self.outdir.resolve()
+        self.outdir.mkdir(parents=True, exist_ok=True)
+        for old in self.outdir.glob("*.pcap*"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+        for old in self.outdir.glob("*.csv*"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+
+        for rname, router in tgen.routers().items():
+            for ifn, up in self._list_ifaces(router):
+                if ifn == "lo":
+                    continue
+
+                pcap_path = self.outdir / f"{rname}-{ifn}-{self.tag}.pcap"
+                cmd = (
+                    f"nohup tcpdump -i {shlex.quote(ifn)} -U -s 0 "
+                    f"-w {shlex.quote(str(pcap_path))}"
+                    f">/dev/null 2>&1 & echo $!"
+                )
+                pid = router.cmd(cmd).strip()
+                try:
+                    self.pids[(rname, ifn)] = int(pid)
+                except ValueError:
+                    out = router.cmd("which tcpdump || true")
+                    raise RuntimeError(
+                        f"Failed to start tcpdump on {rname}:{ifn} "
+                        f"(got PID '{pid}'). tcpdump path: {out}"
+                    )
+
+        time.sleep(0.3)
+
+    def stop_all(self, tgen=None):
+        if not self.pids:
+            return
+        routers = {}
+        if tgen is not None and tgen.routers():
+            routers = tgen.routers()
+
+        for (rname, ifn), pid in list(self.pids.items()):
+            router = routers.get(rname)
+            if router:
+                router.cmd(f"kill -TERM {pid} >/dev/null 2>&1 || true")
+        time.sleep(0.3)
+        for (rname, ifn), pid in list(self.pids.items()):
+            router = routers.get(rname)
+            if router:
+                router.cmd(f"kill -KILL {pid} >/dev/null 2>&1 || true")
+        self.pids.clear()


### PR DESCRIPTION
Implements RFC 4222 Recommendation 4: per-neighbor LSA gap pacing.

When enabled on an interface, outbound LSAs are queued per-neighbor
and metered at a configurable inter-packet gap rather than sent
back-to-back. The gap adapts using MIMD: grows multiplicatively when
the unacknowledged LSA count exceeds a high-watermark, shrinks
multiplicatively when it falls below a low-watermark.

New commands (all interface-scoped):
  ip ospf lsa-pacing
  ip ospf lsa-pacing min-gap <ms> max-gap <ms>
  ip ospf lsa-pacing initial-gap <ms>
  ip ospf lsa-pacing factor <F>
  ip ospf lsa-pacing adjust-interval <ms>
  ip ospf lsa-pacing max-lsas-per-update <N>
  ip ospf lsa-pacing low-watermark <L> high-watermark <H>

Defaults: min/initial gap 20 ms, max 1000 ms, factor 2,
adjust-interval 1000 ms, high-water 100, low-water 2, max-lsas 1.

This feature is independent of R5 adjacency pacing (also on this
branch) — neither gates the other.

Topotests added under tests/topotests/ospf_rfc4222_r4/:
  - CLI persist/reload
  - Gap metering (functional)
  - Opaque LSA pacing
  - MIMD adaptation under congestion