### PR TITLE
pimd: run Assert for dense mode wrong-interface handling

### DIFF
--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -24,6 +24,7 @@
 #include "pim_assert.h"
 #include "pim_zebra.h"
 #include "pim_ifchannel.h"
+#include "pim_dm.h"
 
 static int assert_action_a3(struct pim_ifchannel *ch);
 static void assert_action_a2(struct pim_ifchannel *ch,
@@ -36,6 +37,7 @@ void pim_ifassert_winner_set(struct pim_ifchannel *ch,
 			     struct pim_assert_metric winner_metric)
 {
 	struct pim_interface *pim_ifp = ch->interface->info;
+	enum pim_ifassert_state old_state = ch->ifassert_state;
 	int winner_changed = !!pim_addr_cmp(ch->ifassert_winner, winner);
 	int metric_changed = !pim_assert_metric_match(
 		&ch->ifassert_winner_metric, &winner_metric);
@@ -85,6 +87,12 @@ void pim_ifassert_winner_set(struct pim_ifchannel *ch,
 		pim_ifchannel_update_could_assert(ch);
 		pim_ifchannel_update_assert_tracking_desired(ch);
 	}
+
+	/* Dense mode manages its OIL directly (not via the SM olist), so the
+	 * Assert loser/winner OIF transitions have to be applied here.
+	 */
+	if (old_state != new_state)
+		pim_dm_assert_state_changed(ch, new_state);
 }
 
 static void on_trace(const char *label, struct interface *ifp, pim_addr src)

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -23,6 +23,10 @@
 #include "pim_igmp.h"
 #include "pim_join.h"
 #include "pim_util.h"
+#include "pim_ifchannel.h"
+#include "pim_assert.h"
+#include "pim_macro.h"
+#include "if.h"
 
 static void pim_dm_range_reevaluate(struct pim_instance *pim)
 {
@@ -127,8 +131,68 @@ void pim_dm_graft_send(struct pim_rpf rpf, struct pim_upstream *up)
 	list_delete_all_node(&groups);
 }
 
-/* Send a prune immediately to all neighbors on a interface.
- * Used when a packet is received on the wrong interface.
+static void pim_dm_assert_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up)
+{
+	struct pim_ifchannel *ch, *throwaway;
+
+	pim_ifchannel_find(ifp, &sg, &ch, &throwaway);
+	if (!ch)
+		ch = pim_ifchannel_add(ifp, &sg, 0, 0);
+
+	if (ch->upstream != up) {
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG ifchannel upstream mismatch on %s", __func__,
+				   &sg, ifp->name);
+		return;
+	}
+
+	pim_ifchannel_update_could_assert(ch);
+
+	/* CouldAssert(S,G,I) must be true to initiate Assert (RFC 3973 4.6.4) */
+	if (!PIM_IF_FLAG_TEST_COULD_ASSERT(ch->flags)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: (S,G)=%s CouldAssert false on %s, skipping assert",
+				   __func__, ch->sg_str, ifp->name);
+		return;
+	}
+
+	if (ch->ifassert_state != PIM_IFASSERT_NOINFO) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: (S,G)=%s assert state %d on %s, skipping assert_action_a1",
+				   __func__, ch->sg_str, ch->ifassert_state, ifp->name);
+		return;
+	}
+
+	if (assert_action_a1(ch)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: (S,G)=%s assert_action_a1 failure on %s", __func__,
+				   ch->sg_str, ifp->name);
+	}
+}
+
+void pim_dm_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up)
+{
+	if (!up || !up->rpf.source_nexthop.interface)
+		return;
+
+	if (up->rpf.source_nexthop.interface->ifindex == ifp->ifindex)
+		return;
+
+	if (if_is_pointopoint(ifp)) {
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: Dense Mode WRONGVIF on P2P %s, immediate prune (S,G)=%pSG",
+				   __func__, ifp->name, &sg);
+		pim_dm_prune_wrongif(ifp, sg, up);
+	} else {
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: Dense Mode WRONGVIF on LAN %s, starting Assert (S,G)=%pSG",
+				   __func__, ifp->name, &sg);
+		pim_dm_assert_wrongif(ifp, sg, up);
+	}
+}
+
+/* Send a prune immediately to all neighbors on an interface.
+ * Used for wrong-interface traffic on P2P links and at the FHR.
  */
 void pim_dm_prune_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up)
 {
@@ -160,6 +224,73 @@ void pim_dm_prune_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstr
 			pim_dm_prune_send(rpf, up, 0);
 		}
 		prune_limit_timer_start(up);
+	}
+}
+
+/* React to an Assert state change on a dense-mode (S,G) interface.
+ *
+ * RFC 3973 4.6: the Assert loser must stop forwarding the duplicate onto the
+ * shared LAN. If it also has no downstream receivers on that interface, it
+ * prunes toward the Assert winner so the winner can drop the OIF and the tree
+ * can converge. When the Assert is cancelled (back to NoInfo) the interface is
+ * re-added so normal dense flooding resumes.
+ */
+void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_state new_state)
+{
+	struct interface *ifp = ch->interface;
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_upstream *up = ch->upstream;
+
+	if (!pim_ifp || !up || !up->channel_oil)
+		return;
+
+	if (!pim_iface_grp_dm(pim_ifp, ch->sg.grp))
+		return;
+
+	/* Only downstream (non-RPF) interfaces are forwarding OIFs here. While
+	 * RPF is unresolved (transiently NULL during reconvergence) we cannot
+	 * tell whether ifp is the RPF interface, so skip the OIL update.
+	 */
+	if (!up->rpf.source_nexthop.interface || up->rpf.source_nexthop.interface == ifp)
+		return;
+
+	if (new_state == PIM_IFASSERT_I_AM_LOSER) {
+		/* Defer to the Assert winner: stop forwarding the duplicate
+		 * back onto this LAN.
+		 */
+		if (oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+			oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+			pim_upstream_mroute_update(up->channel_oil, __func__);
+		}
+
+		/* With no local receivers on this interface, ask the winner to
+		 * stop forwarding the duplicate to us so its OIF clears too.
+		 */
+		if (!pim_gm_has_igmp_join(ifp, ch->sg.grp)) {
+			struct pim_rpf rpf;
+
+			rpf.source_nexthop.interface = ifp;
+			rpf.source_nexthop.mrib_nexthop_addr = ch->ifassert_winner;
+			if (PIM_DEBUG_PIM_J_P)
+				zlog_debug("%s: (S,G)=%s Assert loser on %s, pruning winner %pPA",
+					   __func__, ch->sg_str, ifp->name, &ch->ifassert_winner);
+			pim_dm_prune_send(rpf, up, 0);
+		}
+	} else if (new_state == PIM_IFASSERT_NOINFO) {
+		/* Assert cancelled: resume dense flooding on this interface if
+		 * it still has neighbors or local receivers and is not pruned,
+		 * either on this interface (ch->flags) or for the whole (S,G)
+		 * upstream (up->flags). Re-adding an OIF while the upstream is
+		 * globally pruned would install an OIF that never sees traffic;
+		 * mirror the up->flags guard used in pim_dm_prune_iff_on_timer().
+		 */
+		if ((pim_ifp->pim_neighbor_list->count || pim_gm_has_igmp_join(ifp, ch->sg.grp)) &&
+		    !PIM_UPSTREAM_DM_TEST_PRUNE(ch->flags) &&
+		    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) &&
+		    !oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+			oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
+			pim_upstream_mroute_update(up->channel_oil, __func__);
+		}
 	}
 }
 
@@ -323,6 +454,7 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 				break;
 			}
 		}
+
 		if (!sg_connected) {
 			PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
 			pim_dm_prune_send(up->rpf, up, 0);
@@ -347,12 +479,16 @@ void pim_dm_prune_iff_on_timer(struct event *t)
 	struct pim_upstream *up;
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
+	bool lost_assert;
 
 	ch = EVENT_ARG(t);
 
 	ifp = ch->interface;
 	pim_ifp = ifp->info;
 	up = pim_upstream_find(pim_ifp->pim, &ch->sg);
+
+	/* Save assert state before pim_ifchannel_delete() may free ch. */
+	lost_assert = pim_macro_ch_lost_assert(ch);
 
 	PIM_UPSTREAM_DM_UNSET_PRUNE(ch->flags);
 	if (ch->flags == 0)
@@ -361,7 +497,8 @@ void pim_dm_prune_iff_on_timer(struct event *t)
 	if (!up)
 		return;
 	pim_upstream_keep_alive_timer_start(up, pim_ifp->pim->keep_alive_time);
-	if (up->channel_oil && up->channel_oil->installed) {
+	if (up->channel_oil && up->channel_oil->installed &&
+	    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) && !lost_assert) {
 		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 	}

--- a/pimd/pim_dm.h
+++ b/pimd/pim_dm.h
@@ -23,7 +23,9 @@ struct pim_dm {
 
 void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode);
 void pim_dm_graft_send(struct pim_rpf rpf, struct pim_upstream *up);
+void pim_dm_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up);
 void pim_dm_prune_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up);
+void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_state new_state);
 void pim_dm_prune_send(struct pim_rpf rpf, struct pim_upstream *up, bool is_join);
 bool pim_dm_check_gm_group_list(struct interface *ifp);
 bool pim_gm_has_igmp_join(struct interface *ifp, pim_addr group_addr);

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -610,6 +610,18 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 	else
 		PIM_IF_FLAG_UNSET_COULD_ASSERT(ch->flags);
 
+	/*
+	 * my_assert_metric() depends on the CouldAssert(S,G,I) flag, but the
+	 * metric above was evaluated before that flag was set, so it defaulted
+	 * to the infinite metric. Dense-mode ifchannels are frequently created
+	 * with RPF already resolved (CouldAssert true at creation), and the
+	 * flag is set directly here without going through
+	 * pim_ifchannel_update_could_assert(), so a later update sees no change
+	 * and never refreshes the metric. Recompute it now that the flag is
+	 * known so the first Assert we send carries the real metric.
+	 */
+	ch->ifassert_my_metric = pim_macro_ch_my_assert_metric_eval(ch);
+
 	if (pim_macro_assert_tracking_desired_eval(ch))
 		PIM_IF_FLAG_SET_ASSERT_TRACKING_DESIRED(ch->flags);
 	else

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -17,6 +17,7 @@
 #include "pim_iface.h"
 #include "pim_ifchannel.h"
 #include "pim_rp.h"
+#include "pim_dm.h"
 
 /*
   DownstreamJPState(S,G,I) is the per-interface state machine for
@@ -218,11 +219,22 @@ int pim_macro_chisin_joins_or_include(const struct pim_ifchannel *ch)
 int pim_macro_ch_could_assert_eval(const struct pim_ifchannel *ch)
 {
 	struct interface *ifp;
+	struct pim_interface *pim_ifp;
 
 	ifp = ch->interface;
 	if (!ifp) {
 		zlog_warn("%s: (S,G)=%s: null interface", __func__, ch->sg_str);
 		return 0; /* false */
+	}
+
+	pim_ifp = ifp->info;
+	if (pim_ifp && pim_iface_grp_dm(pim_ifp, ch->sg.grp)) {
+		/* RFC 3973 4.6.4: CouldAssert(S,G,I) = (RPF_interface(S) != I).
+		 * Require a resolved RPF interface so a transiently unresolved
+		 * RPF (NULL) does not make every interface assert-eligible.
+		 */
+		return ch->upstream->rpf.source_nexthop.interface != NULL &&
+		       ch->upstream->rpf.source_nexthop.interface != ifp;
 	}
 
 	/* SPTbit(S,G) == true */

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -323,9 +323,9 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 		if (!up->rpf.source_nexthop.interface ||
 		    up->rpf.source_nexthop.interface->ifindex != ifp->ifindex) {
 			if (PIM_DEBUG_PIM_J_P)
-				zlog_debug("%s: Dense Mode WRONGVIF, sending immediate prune upstream (s,g)=%pSG intf=%s",
-					   __func__, &sg, ifp->name);
-			pim_dm_prune_wrongif(ifp, sg, up);
+				zlog_debug("%s: Dense Mode WRONGVIF on %s for (S,G)=%pSG",
+					   __func__, ifp->name, &sg);
+			pim_dm_wrongif(ifp, sg, up);
 			return 0;
 		}
 
@@ -336,6 +336,8 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 		}
 
 		FOR_ALL_INTERFACES (pim_ifp->pim->vrf, ifp2) {
+			struct pim_ifchannel *ch_flood, *ch_flood_rpt;
+
 			pim_ifp2 = ifp2->info;
 
 			/* Make sure the interface has PIM enabled and is not the current interface and is a dense type mode */
@@ -346,6 +348,13 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 			/* Flood if has neighbors or IGMP join */
 			if (pim_ifp2->pim_neighbor_list->count ||
 			    pim_gm_has_igmp_join(ifp2, sg.grp)) {
+				pim_ifchannel_find(ifp2, &sg, &ch_flood, &ch_flood_rpt);
+				if (ch_flood) {
+					if (PIM_UPSTREAM_DM_TEST_PRUNE(ch_flood->flags))
+						continue;
+					if (pim_macro_ch_lost_assert(ch_flood))
+						continue;
+				}
 				oil_if_set(up->channel_oil, pim_ifp2->mroute_vif_index, 1);
 				update_oil = true;
 			}
@@ -827,10 +836,18 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 		return -3;
 
 	if (pim_iface_grp_dm(pim_ifp, sg.grp)) {
+		struct pim_upstream *up = pim_upstream_find(pim_ifp->pim, &sg);
+
+		if (!up) {
+			if (PIM_DEBUG_MROUTE)
+				zlog_debug("%s: Dense Mode WRONGVIF on %s for (S,G)=%pSG, no upstream",
+					   __func__, ifp->name, &sg);
+			return 0;
+		}
 		if (PIM_DEBUG_PIM_J_P)
-			zlog_debug("%s: Dense Mode WRONGVIF, sending immediate prune upstream (s,g)=%pSG intf=%s",
-				   __func__, &sg, ifp->name);
-		pim_dm_prune_wrongif(ifp, sg, ch->upstream);
+			zlog_debug("%s: Dense Mode WRONGVIF on %s for (S,G)=%pSG", __func__,
+				   ifp->name, &sg);
+		pim_dm_wrongif(ifp, sg, up);
 		return 0;
 	}
 
@@ -904,17 +921,18 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
 
 	isdense = pim_iface_grp_dm(pim_ifp, sg.grp);
 
-	/*
-	 * I believe the wrvifwhole message should also trigger PIM assert messaging
-	 * but I don't see any of that here, only in wrongvif.
-	 * If we need to add assert handling here, then dense mode will still need that.
-	 * Otherwise, right now it looks like this function only
-	 * handles register and register stops, so skip it if the group is in dense mode.
-	 */
 	if (isdense) {
-		if (PIM_DEBUG_MROUTE)
-			zlog_debug("WRVIFWHOLE (S,G)=%pSG dense mode group, skipping register handling",
-				   &sg);
+		up = pim_upstream_find(pim, &sg);
+		if (!up) {
+			if (PIM_DEBUG_MROUTE)
+				zlog_debug("WRVIFWHOLE (S,G)=%pSG dense mode, no upstream", &sg);
+			return 0;
+		}
+
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: Dense Mode WRVIFWHOLE on %s for (S,G)=%pSG", __func__,
+				   ifp->name, &sg);
+		pim_dm_wrongif(ifp, sg, up);
 		return 0;
 	}
 

--- a/tests/topotests/pim_dense/test_pim_dense.py
+++ b/tests/topotests/pim_dense/test_pim_dense.py
@@ -318,6 +318,26 @@ def check_mroute_oil(tgen, router, src, group, iif, oil):
     return None
 
 
+def check_mroute_iif(tgen, router, src, group, iif):
+    """Return None once (S,G) is installed on router with the expected iif.
+
+    Unlike check_mroute_oil(), this does not constrain the OIL; it only confirms
+    the entry exists and resolves RPF to the given incoming interface.
+    """
+    entry = mroute_entry(tgen, router, src, group)
+    if not entry:
+        return "No mroute for ({},{}) on {}".format(src, group, router)
+    if entry.get("installed", 0) == 0:
+        return "mroute ({},{}) not installed on {}".format(src, group, router)
+    if isinstance(iif, str):
+        iif = [iif]
+    if entry.get("iif") not in iif:
+        return "Unexpected iif on {}: {} (expected {})".format(
+            router, entry.get("iif"), iif
+        )
+    return None
+
+
 def _join_entries_for_group(iface_data, group):
     """Return join entry dict for group, tolerating /32 suffix in JSON keys."""
     if group in iface_data:
@@ -1212,6 +1232,94 @@ def test_pim_dense_state_refresh_relay(request):
     stop_all_hosts()
 
 
+def verify_pim_assert_entry(
+    tgen, router, iface, src, group, states=("WINNER", "LOSER")
+):
+    """Return None once (S,G) has active Assert state on iface.
+
+    Dense-mode wrong-interface handling on multi-access links should enter
+    the Assert FSM instead of sending an immediate prune.
+    """
+    output = tgen.gears[router].vtysh_cmd("show ip pim assert")
+    for line in output.splitlines():
+        if iface not in line or src not in line or group not in line:
+            continue
+        for state in states:
+            if state in line:
+                return None
+    return "no Assert state for ({},{}) on {} {}".format(src, group, router, iface)
+
+
+def verify_pim_assert_winner(tgen, router, iface, src, group, winner):
+    """Return None once (S,G) on iface has elected a specific Assert winner.
+
+    Confirms the LAN ran the Assert election (rather than an immediate prune)
+    and that the expected forwarder won the duplicate-traffic arbitration.
+    """
+    output = tgen.gears[router].vtysh_cmd("show ip pim assert")
+    for line in output.splitlines():
+        if iface not in line or src not in line or group not in line:
+            continue
+        if winner in line.split():
+            return None
+    return "no Assert winner {} for ({},{}) on {} {}".format(
+        winner, src, group, router, iface
+    )
+
+
+def test_pim_dense_wrongif_assert(request):
+    """Verify dense-mode WRONGVIF on a multi-access LAN runs Assert, not a prune.
+
+    r3 reaches the source via r3-eth0 (toward r2), but r1 also floods (S,G)
+    directly onto the shared r1<->r3 link (r1-eth2 -> r3-eth3). That duplicate
+    arrives on r3-eth3, which is not r3's RPF interface, so the kernel raises a
+    WRONGVIF/WRVIFWHOLE upcall for r3-eth3. Because the link is multi-access,
+    pim_dm_wrongif() must run the Assert FSM rather than an immediate prune, and
+    r3 must lose the election to the directly connected first-hop router r1
+    (10.1.3.1). A receiver behind r3 keeps the (S,G) tree (and thus r1's Assert)
+    active so the loser state is stable.
+    """
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    stop_all_hosts()
+
+    step("Start dense traffic and a receiver behind r3 to keep the tree active")
+    result = app_helper.run_traffic("h1", DENSE_GROUP, bind_intf="h1-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    result = app_helper.run_join("h6", DENSE_GROUP, join_intf="h6-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify r3 has (S,G) state with RPF on r3-eth0 (not the r1<->r3 link)")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_iif, tgen, "r3", SRC, DENSE_GROUP, "r3-eth0"),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify WRONGVIF on r3-eth3 entered the Assert FSM (not an immediate prune)")
+    test_func = functools.partial(
+        verify_pim_assert_entry, tgen, "r3", "r3-eth3", SRC, DENSE_GROUP
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=45, wait=2)
+    assert result is None, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify r3 lost the LAN Assert to the first-hop router r1 (10.1.3.1)")
+    test_func = functools.partial(
+        verify_pim_assert_winner, tgen, "r3", "r3-eth3", SRC, DENSE_GROUP, "10.1.3.1"
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=2)
+    assert result is None, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    stop_all_hosts()
+
+
 def test_pim_sparse_non_rp_upstream_cleanup(request):
     """Verify non-RP sparse upstream cleans up after the last receiver leaves."""
     tgen = get_topogen()
@@ -1265,6 +1373,13 @@ def test_pim_dense_to_sparse_on_rp_add(request):
 
     routers = ["r1", "r2", "r3", "r4", "r5", "r6"]
 
+    # Use a dedicated dense group that no other test touches so r1 builds a
+    # brand-new dense (S,G) for this test. Reusing the shared DENSE_GROUP makes
+    # this test depend on whatever pruned/grafted (S,G) state earlier tests left
+    # behind (kept alive by the keepalive timer), which is not a stable starting
+    # point for exercising the DM->SM transition.
+    group = "239.7.7.7"
+
     step("Reset dynamic RP mapping for dense test group")
     for rname in routers:
         tgen.gears[rname].vtysh_cmd(
@@ -1275,34 +1390,50 @@ def test_pim_dense_to_sparse_on_rp_add(request):
             """
         )
 
-    step("Ensure only source traffic is active for transition check")
-    app_helper.stop_host("h4")
-    app_helper.stop_host("h5")
-    app_helper.stop_host("h6")
-    app_helper.stop_host("h1")
-    result = app_helper.run_traffic("h1", DENSE_GROUP, bind_intf="h1-eth0")
+    step("Bring up the downstream receiver before the source")
+    stop_all_hosts()
+    result = app_helper.run_join("h4", group, join_intf="h4-eth0")
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
-    step("Add downstream receiver before RP add")
-    result = app_helper.run_join("h4", DENSE_GROUP, join_intf="h4-eth0")
+    # Make sure r4 has registered the local membership before the source starts,
+    # so the very first dense flood is never pruned on the r1->r2->r4 branch.
+    def _r4_has_membership():
+        out = tgen.gears["r4"].vtysh_cmd("show ip pim upstream json", isjson=True)
+        if group in out:
+            return None
+        return "r4 has no upstream state for {} yet".format(group)
+
+    _, result = topotest.run_and_expect(_r4_has_membership, None, count=15, wait=2)
+    assert result is None, "Receiver not ready on r4: {}".format(result)
+
+    step("Start the dense source traffic")
+    result = app_helper.run_traffic("h1", group, bind_intf="h1-eth0")
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
-    step("Verify dense (S,G) exists before RP add")
+    step("Verify dense (S,G) is flooding toward r2 before RP add")
 
     def _r1_dense_before_rp():
-        output = tgen.gears["r1"].vtysh_cmd("show ip pim upstream json", isjson=True)
-        group = output.get(DENSE_GROUP, {})
-        if "10.100.0.2" not in group:
-            return "No upstream for 10.100.0.2,{}".format(DENSE_GROUP)
-
-        result = verify_mroutes(
-            tgen, "r1", "10.100.0.2", DENSE_GROUP, "r1-eth1", "r1-eth0"
-        )
-        if result is not True:
-            return result
+        entry = mroute_entry(tgen, "r1", SRC, group)
+        if not entry:
+            return "No mroute for ({},{}) on r1".format(SRC, group)
+        if entry.get("installed", 0) == 0:
+            return "mroute ({},{}) not installed on r1".format(SRC, group)
+        if entry.get("iif") != "r1-eth1":
+            return "Unexpected iif on r1 before RP add: {}".format(entry.get("iif"))
+        flags = entry.get("flags", "")
+        if "S" in flags:
+            return "Unexpected sparse (S) flag on r1 before RP add, got {!r}".format(
+                flags
+            )
+        if "D" not in flags:
+            return "Expected dense (D) flag on r1 before RP add, got {!r}".format(flags)
+        if "r1-eth0" not in mroute_oil_names(entry):
+            return "Expected dense flood OIF r1-eth0 on r1, got {}".format(
+                mroute_oil_names(entry)
+            )
         return None
 
-    _, result = topotest.run_and_expect(_r1_dense_before_rp, None, count=30, wait=1)
+    _, result = topotest.run_and_expect(_r1_dense_before_rp, None, count=30, wait=2)
     assert result is None, "Dense upstream not present before RP add: {}".format(result)
 
     step("Add RP mapping for dense group range")
@@ -1319,11 +1450,11 @@ def test_pim_dense_to_sparse_on_rp_add(request):
 
     def _r1_upstream_sparse():
         output = tgen.gears["r1"].vtysh_cmd(
-            "show ip pim upstream 10.100.0.2 {} json".format(DENSE_GROUP), isjson=True
+            "show ip pim upstream {} {} json".format(SRC, group), isjson=True
         )
-        upstream = output.get(DENSE_GROUP, {}).get("10.100.0.2", {})
+        upstream = output.get(group, {}).get(SRC, {})
         if not upstream:
-            return "No upstream for 10.100.0.2,{}".format(DENSE_GROUP)
+            return "No upstream for {},{}".format(SRC, group)
         if not upstream.get("firstHopRouter"):
             return "Expected FHR upstream on r1 after RP add"
         if upstream.get("rpfAddress") != "10.0.2.1":
@@ -1331,11 +1462,9 @@ def test_pim_dense_to_sparse_on_rp_add(request):
                 upstream.get("rpfAddress")
             )
 
-        mroute = mroute_entry(tgen, "r1", "10.100.0.2", DENSE_GROUP)
+        mroute = mroute_entry(tgen, "r1", SRC, group)
         if not mroute:
-            return "No mroute for (10.100.0.2,{}) on r1 after RP add".format(
-                DENSE_GROUP
-            )
+            return "No mroute for ({},{}) on r1 after RP add".format(SRC, group)
         if mroute.get("iif") != "r1-eth1":
             return "Unexpected IIF on r1 after RP add: {}".format(mroute.get("iif"))
 
@@ -1364,7 +1493,7 @@ def test_pim_dense_to_sparse_on_rp_add(request):
     step("Verify r1 no longer uses dense-mode OIL toward r2")
 
     def _r1_not_dense_oil():
-        mroute = mroute_entry(tgen, "r1", "10.100.0.2", DENSE_GROUP)
+        mroute = mroute_entry(tgen, "r1", SRC, group)
         if not mroute:
             return "No mroute on r1 after RP add"
         oil = mroute_oil_names(mroute)
@@ -1384,6 +1513,8 @@ def test_pim_dense_to_sparse_on_rp_add(request):
                 no rp 10.0.2.1 239.0.0.0/8
             """
         )
+
+    stop_all_hosts()
 
 
 def test_memory_leak():


### PR DESCRIPTION
When a dense-mode (S,G) packet arrives on a non-RPF interface, we previously sent an immediate prune to all neighbors on that interface for both point-to-point and multi-access links, and skipped WRVIFWHOLE entirely. On a shared LAN with multiple forwarders this prunes active branches instead of electing a single forwarder.

Run the Assert FSM on multi-access interfaces (RFC 3973 4.6) while keeping the immediate prune on point-to-point links. WRONGVIF (NOCACHE and wrongvif upcalls) and WRVIFWHOLE now dispatch through pim_dm_wrongif(). CouldAssert(S,G,I) for dense groups is the simplified RFC 3973 form (RPF_interface(S) != I).

Note: when the upstream RPF interface is not yet resolved, wrong-interface handling is now skipped rather than sending a prune with unknown RPF.