### PR TITLE
Implement RFC7981 Appendix A

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1053,6 +1053,8 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 	int level = lsp->level;
 	struct listnode *node;
 	struct isis_lsp *frag;
+	uint32_t router_id = 0;
+	bool router_capability_authorized = false;
 
 	lsp_clear_data(lsp);
 	for (ALL_LIST_ELEMENTS_RO(lsp->lspu.frags, node, frag))
@@ -1119,7 +1121,28 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 	}
 
 	/* Add Router Capability TLV. */
-	if (area->isis->router_id != 0) {
+	if (area->newmetric && IS_MPLS_TE(area->mta) && area->mta->router_id.s_addr != INADDR_ANY) {
+		/* RFC7981: The Router ID SHOULD be identical to the value advertised
+		 * in the Traffic Engineering Router ID TLV (134)
+		 */
+		router_id = area->mta->router_id.s_addr;
+		router_capability_authorized = true;
+	} else if (area->isis->router_id != 0) {
+		/* RFC7981: If no Traffic Engineering Router ID is assigned, the Router ID
+		 * SHOULD be identical to an IP Interface Address [RFC1195]
+		 * advertised by the originating IS.
+		 */
+		router_id = area->isis->router_id;
+		router_capability_authorized = true;
+	} else if (area->newmetric && IS_MPLS_TE(area->mta) &&
+		   !IN6_IS_ADDR_UNSPECIFIED(&area->mta->router_id_ipv6))
+		/* RFC7981: If the originating node does not support IPv4, then the
+		 * reserved value 0.0.0.0 MUST be used in the Router ID field,
+		 * and the IPv6 TE Router ID sub-TLV [RFC5316] MUST be present in the TLV.
+		 */
+		router_capability_authorized = true;
+
+	if (router_capability_authorized) {
 		struct isis_router_cap *rcap;
 #ifndef FABRICD
 		struct isis_router_cap_fad *rcap_fad;
@@ -1128,7 +1151,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 
 		rcap = isis_tlvs_init_router_capability(lsp->tlvs);
 
-		rcap->router_id.s_addr = area->isis->router_id;
+		rcap->router_id.s_addr = router_id;
 
 #ifndef FABRICD
 		/* Set flex-algo definitions */
@@ -1246,24 +1269,31 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 	 * into LSP. TE router ID will be the same if MPLS-TE
 	 * is not activate or MPLS-TE router-id not specified
 	 */
-	if (area->isis->router_id != 0) {
-		struct in_addr id = {.s_addr = area->isis->router_id};
-		lsp_debug("ISIS (%s): Adding router ID %pI4 as IPv4 tlv.",
-			  area->area_tag, &id);
-		isis_tlvs_add_ipv4_address(lsp->tlvs, &id);
+	if (router_capability_authorized) {
+		if (area->isis->router_id != 0) {
+			lsp_debug("ISIS (%s): Adding router ID %pI4 as IPv4 tlv.", area->area_tag,
+				  (struct in_addr *)&router_id);
+			isis_tlvs_add_ipv4_address(lsp->tlvs, (struct in_addr *)&router_id);
+		}
 
 		/* If new style TLV's are in use, add TE router ID TLV
 		 * Check if MPLS-TE is activate and mpls-te router-id set
 		 * otherwise add exactly same data as for IPv4 address
 		 */
 		if (area->newmetric) {
-			if (IS_MPLS_TE(area->mta)
-			    && area->mta->router_id.s_addr != INADDR_ANY)
-				id.s_addr = area->mta->router_id.s_addr;
-			lsp_debug(
-				"ISIS (%s): Adding router ID also as TE router ID tlv.",
-				area->area_tag);
-			isis_tlvs_set_te_router_id(lsp->tlvs, &id);
+			if (IS_MPLS_TE(area->mta) && router_id != 0 &&
+			    area->isis->router_id == router_id &&
+			    area->mta->router_id.s_addr != INADDR_ANY)
+				/* RFC7981: The Router ID SHOULD be identical to the value advertised
+				 * in the Traffic Engineering Router ID TLV (134)
+				 * update router-id of the TE
+				 */
+				router_id = area->mta->router_id.s_addr;
+			if (router_id != 0) {
+				lsp_debug("ISIS (%s): Adding router ID as TE router ID %pI4 tlv.",
+					  area->area_tag, (struct in_addr *)&router_id);
+				isis_tlvs_set_te_router_id(lsp->tlvs, (struct in_addr *)&router_id);
+			}
 		}
 	} else {
 		lsp_debug("ISIS (%s): Router ID is unset. Not adding tlv.",

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -83,11 +83,18 @@ struct isis_sr_block *isis_sr_find_srgb(struct lspdb_head *lspdb, const uint8_t 
 	struct isis_lsp *lsp;
 
 	lsp = isis_root_system_lsp(lspdb, sysid);
-	if (!lsp)
+	if (!lsp) {
+		sr_debug("%s: LSP not found for node %pSY", __func__, sysid);
 		return NULL;
-
-	if (!lsp->tlvs->router_cap || lsp->tlvs->router_cap->srgb.range_size == 0)
+	}
+	if (!lsp->tlvs->router_cap || lsp->tlvs->router_cap->srgb.range_size == 0) {
+		if (lsp->tlvs->router_cap)
+			sr_debug("%s: Router capability found with SRGB range size of 0 for node %pSY",
+				 __func__, sysid);
+		else
+			sr_debug("%s: No Router capability found for node %pSY", __func__, sysid);
 		return NULL;
+	}
 
 	return &lsp->tlvs->router_cap->srgb;
 }
@@ -169,16 +176,21 @@ mpls_label_t sr_prefix_out_label(struct lspdb_head *lspdb, int family, struct is
 
 	/* Check that SID index falls inside the SRGB */
 	nh_srgb = isis_sr_find_srgb(lspdb, nh_sysid);
-	if (!nh_srgb)
+	if (!nh_srgb) {
+		zlog_warn("%s(): no SRGB received for %pSY", __func__, nh_sysid);
 		return MPLS_INVALID_LABEL;
+	}
 
 	/*
 	 * Check if the nexthop can handle SR-MPLS encapsulated IPv4 or
 	 * IPv6 packets.
 	 */
 	if ((family == AF_INET && !IS_SR_IPV4(nh_srgb)) ||
-	    (family == AF_INET6 && !IS_SR_IPV6(nh_srgb)))
+	    (family == AF_INET6 && !IS_SR_IPV6(nh_srgb))) {
+		zlog_warn("%s(): SRGB received for %pSY, but IPv%d disabled", __func__, nh_sysid,
+			  family == AF_INET ? 4 : 6);
 		return MPLS_INVALID_LABEL;
+	}
 
 	if (psid->value >= nh_srgb->range_size) {
 		flog_warn(EC_ISIS_SID_OVERFLOW, "%s: SID index %u falls outside remote SRGB range",


### PR DESCRIPTION
Handle the case where an unset router-id prevents from sending IS-IS SRGB information.
With this appendix, it is now possible to use TE router-id IPv4 or TE router-id IPv6 as identifier.
Consequently, the LSP generation will send the router capability TLV with the SRGB information.
