### PR TITLE
bgpd: allocate ibuf_work on demand to reduce memory usage

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2272,8 +2272,10 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 		if (connection->obuf)
 			stream_fifo_clean(connection->obuf);
 
-		if (connection->ibuf_work)
-			ringbuf_wipe(connection->ibuf_work);
+		if (connection->ibuf_work) {
+			ringbuf_del(connection->ibuf_work);
+			connection->ibuf_work = NULL;
+		}
 
 		if (connection->curr) {
 			stream_free(connection->curr);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -38,7 +38,6 @@ static bool validate_header(struct peer_connection *connection);
 /* generic i/o status codes */
 #define BGP_IO_TRANS_ERR (1 << 0) /* EAGAIN or similar occurred */
 #define BGP_IO_FATAL_ERR (1 << 1) /* some kind of fatal TCP error */
-#define BGP_IO_WORK_FULL_ERR (1 << 2) /* No room in work buffer */
 
 /* Thread external API ----------------------------------------------------- */
 
@@ -51,7 +50,6 @@ void bgp_writes_on(struct peer_connection *connection)
 	assert(connection->status != Deleted);
 	assert(connection->obuf);
 	assert(connection->ibuf);
-	assert(connection->ibuf_work);
 	assert(!connection->t_connect_check_r);
 	assert(!connection->t_connect_check_w);
 	assert(connection->fd);
@@ -92,7 +90,6 @@ void bgp_reads_on(struct peer_connection *connection)
 	assert(connection->status != Deleted);
 	assert(connection->ibuf);
 	assert(connection->fd);
-	assert(connection->ibuf_work);
 	assert(connection->obuf);
 	assert(!connection->t_connect_check_r);
 	assert(!connection->t_connect_check_w);
@@ -173,14 +170,16 @@ static void bgp_process_writes(struct event *event)
 
 static int read_ibuf_work(struct peer_connection *connection)
 {
-	/* static buffer for transferring packets */
 	/* shorter alias to peer's input buffer */
 	struct ringbuf *ibw = connection->ibuf_work;
 	/* packet size as given by header */
 	uint16_t pktsize = 0;
 	struct stream *pkt;
 
-	/* ============================================== */
+	/* ibuf_work is allocated on demand; nothing to do if not present */
+	if (!ibw)
+		return 0;
+
 	frr_with_mutex (&connection->io_mtx) {
 		if (connection->ibuf->count >= bm->inq_limit)
 			return -ENOMEM;
@@ -305,8 +304,17 @@ done:
 	/* handle invalid header */
 	if (fatal) {
 		/* wipe buffer just in case someone screwed up */
-		ringbuf_wipe(connection->ibuf_work);
+		if (connection->ibuf_work) {
+			ringbuf_del(connection->ibuf_work);
+			connection->ibuf_work = NULL;
+		}
 		return;
+	}
+
+	/* Free ibuf_work if empty - it will be reallocated on demand */
+	if (connection->ibuf_work && ringbuf_remain(connection->ibuf_work) == 0) {
+		ringbuf_del(connection->ibuf_work);
+		connection->ibuf_work = NULL;
 	}
 
 	if (ret != -ENOMEM)
@@ -525,12 +533,13 @@ static uint16_t bgp_read(struct peer_connection *connection, int *code_p)
 	size_t ibuf_work_space; /* space we can read into the work buf */
 	uint16_t status = 0;
 
-	ibuf_work_space = ringbuf_space(connection->ibuf_work);
+	if (connection->ibuf_work)
+		ibuf_work_space = ringbuf_space(connection->ibuf_work);
+	else
+		ibuf_work_space = BGP_IBUF_WORK_SIZE;
 
-	if (ibuf_work_space == 0) {
-		SET_FLAG(status, BGP_IO_WORK_FULL_ERR);
-		return status;
-	}
+	if (ibuf_work_space == 0)
+		return 0;
 
 	readsize = MIN(ibuf_work_space, sizeof(ibuf_scratch));
 
@@ -569,6 +578,10 @@ static uint16_t bgp_read(struct peer_connection *connection, int *code_p)
 
 		SET_FLAG(status, BGP_IO_FATAL_ERR);
 	} else {
+		/* Allocate ibuf_work on demand to hold partial packets */
+		if (!connection->ibuf_work)
+			connection->ibuf_work = ringbuf_new(BGP_IBUF_WORK_SIZE);
+
 		assert(ringbuf_put(connection->ibuf_work, ibuf_scratch,
 				   nbytes) == (size_t)nbytes);
 	}

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1383,19 +1383,10 @@ struct peer_connection *bgp_peer_connection_new(struct peer *peer, const union s
 	connection->obuf = stream_fifo_new();
 	pthread_mutex_init(&connection->io_mtx, NULL);
 
-	/* We use a larger buffer for peer->obuf_work in the event that:
-	 * - We RX a BGP_UPDATE where the attributes alone are just
-	 *   under BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE.
-	 * - The user configures an outbound route-map that does many as-path
-	 *   prepends or adds many communities. At most they can have
-	 *   CMD_ARGC_MAX args in a route-map so there is a finite limit on how
-	 *   large they can make the attributes.
-	 *
-	 * Having a buffer with BGP_MAX_PACKET_SIZE_OVERFLOW allows us to avoid
-	 * bounds checking for every single attribute as we construct an
-	 * UPDATE.
+	/* ibuf_work is allocated on demand in bgp_read() when needed to hold
+	 * partial packets, and freed when drained. This saves ~98KB per peer
+	 * when idle or receiving complete packets.
 	 */
-	connection->ibuf_work = ringbuf_new(BGP_IBUF_WORK_SIZE);
 
 	connection->status = Idle;
 	connection->ostatus = Idle;


### PR DESCRIPTION
Previously, ibuf_work (~98KB ringbuf) was allocated when the peer connection was created and persisted for the lifetime of the peer. For 2000 peers, this consumed ~196MB even when peers were idle (i.e., without UPDATEs).

Change ibuf_work to on-demand allocation:
- Allocate in bgp_read() only when data is received
- Free in bgp_process_reads() when the buffer is drained
- Free in bgp_stop() when the session goes down

Since ibuf_work only needs to hold partial packets across reads, this saves ~98KB per peer for idle connections or peers receiving complete packets.