### PR TITLE
mgmtd: release datastore lock before sending commit reply

### DIFF
--- a/mgmtd/mgmt_txn_cfg.c
+++ b/mgmtd/mgmt_txn_cfg.c
@@ -542,6 +542,18 @@ static void txn_finish_commit(struct txn_req_commit *ccreq, enum mgmt_result res
 		mgmt_ds_copy_dss(ccreq->src_ds_ctx, ccreq->dst_ds_ctx, false);
 
 	/*
+	 * Release transaction datastore locks before sending replies to
+	 * front-end clients. Commit replies resume the VTY session immediately
+	 * (short-circuit) and a new CLI command can try to lock running before
+	 * txn_req_free() would otherwise clear txn_lock.
+	 */
+	if (ccreq->txn_lock) {
+		mgmt_ds_txn_unlock(ccreq->src_ds_ctx, txn->txn_id);
+		mgmt_ds_txn_unlock(ccreq->dst_ds_ctx, txn->txn_id);
+		ccreq->txn_lock = false;
+	}
+
+	/*
 	 * For internal txns do lock cleanup, for front-end session send replies.
 	 */
 	if (ccreq->init) {


### PR DESCRIPTION
Per-command commits released the running lock too late, after the commit reply already resumed the VTY session. The next CLI command could then race to lock running and fail with "could not lock running DS". Release the lock before replying, fixing an occasional mgmt_notif.test_ds_notify test failure.

fixes failures like [this](https://github.com/FRRouting/frr/actions/runs/27709421321/job/81968095241?pr=22398#step:5:1) and [this](https://github.com/FRRouting/frr/actions/runs/27592262741/job/81576230933?pr=22375)