### PR TITLE
bgpd: validate MP_UNREACH_NLRI withdraw_len against stream bounds

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3077,6 +3077,13 @@ int bgp_mp_unreach_parse(struct bgp_attr_parser_args *args,
 
 	withdraw_len = length - BGP_MP_UNREACH_MIN_SIZE;
 
+	if (withdraw_len > STREAM_READABLE(s)) {
+		flog_err(EC_BGP_ATTR_LEN,
+			 "%s: MP_UNREACH_NLRI withdraw length %u exceeds readable stream %zu",
+			 peer->host, withdraw_len, STREAM_READABLE(s));
+		return BGP_ATTR_PARSE_ERROR_NOTIFYPLS;
+	}
+
 	mp_withdraw->afi = afi;
 	mp_withdraw->safi = safi;
 	mp_withdraw->nlri = stream_pnt(s);


### PR DESCRIPTION
bgp_mp_unreach_parse() computes withdraw_len = length - BGP_MP_UNREACH_MIN_SIZE and immediately sets mp_withdraw->nlri to stream_pnt(s) followed by stream_forward_getp(s, withdraw_len), without re-validating that withdraw_len does not exceed STREAM_READABLE(s).

The outer attribute-length check validates against the full stream at entry, but if any intermediate consumer has advanced the stream pointer, the remaining readable bytes may be fewer than withdraw_len. This leads to mp_withdraw->nlri pointing past the valid stream region, and subsequent NLRI parsing reading beyond the buffer — a heap out-of-bounds read.

The symmetric function bgp_mp_reach_parse() already performs this re-validation (nlri_len > STREAM_READABLE(s)) but the unreach path was missing it.

Add the same STREAM_READABLE check before setting the NLRI pointer, returning BGP_ATTR_PARSE_ERROR_NOTIFYPLS so the caller sends a NOTIFICATION to the peer.