### PR TITLE
ospfd: replay routes to zebra after reconnect

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2276,7 +2276,7 @@ static void ospf_table_reinstall_routes(struct ospf *ospf,
 	}
 }
 
-static void ospf_reinstall_routes(struct ospf *ospf)
+void ospf_reinstall_routes(struct ospf *ospf)
 {
 	ospf_table_reinstall_routes(ospf, ospf->new_table);
 	ospf_table_reinstall_routes(ospf, ospf->new_external_route);

--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -38,6 +38,7 @@ extern void ospf_vty_init(void);
 extern void ospf_vty_show_init(void);
 extern void ospf_vty_clear_init(void);
 extern int str2area_id(const char *str, struct in_addr *area_id, int *area_id_fmt);
+extern void ospf_reinstall_routes(struct ospf *ospf);
 
 /* unit tests */
 void show_ip_ospf_database_summary(struct vty *vty, struct ospf *ospf, int self,

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -39,6 +39,7 @@
 #include "ospfd/ospf_te.h"
 #include "ospfd/ospf_sr.h"
 #include "ospfd/ospf_ldp_sync.h"
+#include "ospfd/ospf_vty.h"
 
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_EXTERNAL, "OSPF External route table");
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_REDISTRIBUTE, "OSPF Redistriute");
@@ -2123,8 +2124,13 @@ static void ospf_zebra_connected(struct zclient *zclient)
 
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 
-	/* Activate graceful restart if configured. */
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
+		/* Replay existing OSPF routes to the (re)connected Zebra so a
+		 * restarted Zebra rebuilds its OSPF RIB state.
+		 */
+		ospf_reinstall_routes(ospf);
+
+		/* Activate graceful restart if configured. */
 		if (!ospf->gr_info.restart_support)
 			continue;
 		(void)ospf_zebra_gr_enable(ospf, ospf->gr_info.grace_period);


### PR DESCRIPTION
When zebra restarts while `ospfd` keeps running, the OSPF-to-zebra reconnect callback re-registers the client but does not replay existing OSPF routes. Because a same-state SPF run does not re-send unchanged routes, already computed routes stay in the OSPF table but disappear from zebra and the kernel FIB.

This calls the existing `ospf_reinstall_routes()` helper from `ospf_zebra_connected()` for every OSPF instance, so a restarted zebra rebuilds its OSPF RIB state.

Closes #22363