### PR TITLE
bgpd: replay selected routes to zebra after reconnect

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3300,6 +3300,8 @@ static void bgp_encode_pbr_iptable_match(struct stream *s,
 static void bgp_zebra_connected(struct zclient *zclient)
 {
 	struct bgp *bgp;
+	afi_t afi;
+	safi_t safi;
 
 	zclient_num_connects++; /* increment even if not responding */
 
@@ -3315,6 +3317,17 @@ static void bgp_zebra_connected(struct zclient *zclient)
 		return;
 
 	bgp_zebra_instance_register(bgp);
+
+	/* A restarted zebra has lost any previously installed BGP routes, and a
+	 * stable BGP RIB will not re-select unchanged best paths on its own.
+	 * Replay the selected routes so zebra and the kernel FIB are rebuilt.
+	 */
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (!bgp_fibupd_safi(safi))
+			continue;
+
+		bgp_zebra_announce_table(bgp, afi, safi);
+	}
 
 	/* Retry the deferred suppress-fib-pending configuration */
 	bgp_zebra_suppress_fib_pending_config_retry();


### PR DESCRIPTION
When zebra restarts while `bgpd` keeps running, the BGP-to-zebra reconnect callback re-registers the instance but does not replay the selected BGP routes. A stable BGP RIB does not re-select unchanged best paths, so the routes remain in the BGP RIB but disappear from zebra and the kernel FIB.

This replays the selected routes for the default BGP instance from `bgp_zebra_connected()` via the existing `bgp_zebra_announce_table()`, so a restarted zebra rebuilds its BGP RIB state.

Closes #22362