### PR TITLE
bgpd: fix VNC export-zebra route-map use count leak

### DIFF
--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2111,12 +2111,11 @@ void vnc_routemap_update(struct bgp *bgp, const char *unused)
 					rfg->routemap_export_bgp);
 		}
 		if (rfg->routemap_export_zebra_name) {
-			old = rfg->routemap_export_bgp;
-			rfg->routemap_export_bgp = route_map_lookup_by_name(
-				rfg->routemap_export_zebra_name);
+			old = rfg->routemap_export_zebra;
+			rfg->routemap_export_zebra =
+				route_map_lookup_by_name(rfg->routemap_export_zebra_name);
 			if (!old)
-				route_map_counter_increment(
-					rfg->routemap_export_bgp);
+				route_map_counter_increment(rfg->routemap_export_zebra);
 		}
 		for (i = 0; i < ZEBRA_ROUTE_MAX; ++i) {
 			if (rfg->routemap_redist_name[i]) {
@@ -2146,11 +2145,11 @@ void vnc_routemap_update(struct bgp *bgp, const char *unused)
 			route_map_counter_increment(hc->routemap_export_bgp);
 	}
 	if (hc->routemap_export_zebra_name) {
-		old  = hc->routemap_export_bgp;
-		hc->routemap_export_bgp = route_map_lookup_by_name(
-			hc->routemap_export_zebra_name);
+		old = hc->routemap_export_zebra;
+		hc->routemap_export_zebra =
+			route_map_lookup_by_name(hc->routemap_export_zebra_name);
 		if (!old)
-			route_map_counter_increment(hc->routemap_export_bgp);
+			route_map_counter_increment(hc->routemap_export_zebra);
 	}
 	for (i = 0; i < ZEBRA_ROUTE_MAX; ++i) {
 		if (hc->routemap_redist_name[i]) {


### PR DESCRIPTION
`vnc_routemap_update()` handles the export-zebra route-map name but stores the looked-up route-map in the export-bgp field and increments the export-bgp counter. When the export-zebra route-map is later removed, only the export-zebra reference is decremented, so the route-map keeps a stale use count and `show route-map-unused` never lists it even though the running config no longer references it.

This assigns and counts the export-zebra route-map on its own field in both the NVE group and RH config update paths.

Closes #22365