### PR TITLE
ospfd, bgpd, ripd, isisd: replay routes to zebra after reconnect

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3300,6 +3300,8 @@ static void bgp_encode_pbr_iptable_match(struct stream *s,
 static void bgp_zebra_connected(struct zclient *zclient)
 {
 	struct bgp *bgp;
+	afi_t afi;
+	safi_t safi;
 
 	zclient_num_connects++; /* increment even if not responding */
 
@@ -3315,6 +3317,17 @@ static void bgp_zebra_connected(struct zclient *zclient)
 		return;
 
 	bgp_zebra_instance_register(bgp);
+
+	/* A restarted zebra has lost any previously installed BGP routes, and a
+	 * stable BGP RIB will not re-select unchanged best paths on its own.
+	 * Replay the selected routes so zebra and the kernel FIB are rebuilt.
+	 */
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (!bgp_fibupd_safi(safi))
+			continue;
+
+		bgp_zebra_announce_table(bgp, afi, safi);
+	}
 
 	/* Retry the deferred suppress-fib-pending configuration */
 	bgp_zebra_suppress_fib_pending_config_retry();

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -863,3 +863,18 @@ void isis_route_switchover_nexthop(struct isis_area *area, struct route_table *t
 		route_unlock_node(rnode);
 	}
 }
+
+void isis_route_table_clear_synced(struct route_table *table)
+{
+	struct route_node *rnode;
+	struct isis_route_info *rinfo;
+
+	if (!table)
+		return;
+
+	for (rnode = route_top(table); rnode; rnode = srcdest_route_next(rnode)) {
+		rinfo = rnode->info;
+		if (rinfo)
+			UNSET_FLAG(rinfo->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED);
+	}
+}

--- a/isisd/isis_route.h
+++ b/isisd/isis_route.h
@@ -81,4 +81,9 @@ struct isis_route_table_info *isis_route_table_info_alloc(uint8_t algorithm);
 void isis_route_table_info_free(void *info);
 uint8_t isis_route_table_algorithm(const struct route_table *table);
 
+/* Clear ISIS_ROUTE_FLAG_ZEBRA_SYNCED on all routes so they are reinstalled on
+ * the next verify (e.g. after a zebra reconnect).
+ */
+void isis_route_table_clear_synced(struct route_table *table);
+
 #endif /* _ZEBRA_ISIS_ROUTE_H */

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -802,12 +802,44 @@ void isis_zebra_vrf_deregister(struct isis *isis)
 
 static void isis_zebra_connected(struct zclient *zclient)
 {
+	struct isis *isis;
+	struct isis_area *area;
+
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 	zclient_register_opaque(zclient, LDP_RLFA_LABELS);
 	zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
 	zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER, VRF_DEFAULT);
 	isis_srv6_locators_request();
+
+	/*
+	 * A (re)connected zebra has none of the routes we previously
+	 * installed, and routes computed while zebra was down were never
+	 * sent (yet may have been marked synced). Clear the zebra-synced
+	 * state on every area's routes and reschedule SPF so all routes are
+	 * reinstalled into the new zebra.
+	 */
+	frr_each (isis_instance_list, &im->isis, isis) {
+		frr_each (isis_area_list, &isis->area_list, area) {
+			for (int tree = 0; tree < SPFTREE_COUNT; tree++) {
+				for (int level = 0; level < ISIS_LEVELS; level++) {
+					struct isis_spftree *spftree;
+
+					spftree = area->spftree[tree][level];
+					if (!spftree)
+						continue;
+
+					isis_route_table_clear_synced(spftree->route_table);
+					isis_route_table_clear_synced(spftree->route_table_backup);
+				}
+			}
+
+			if (area->is_type & IS_LEVEL_1)
+				isis_spf_schedule(area, IS_LEVEL_1);
+			if (area->is_type & IS_LEVEL_2)
+				isis_spf_schedule(area, IS_LEVEL_2);
+		}
+	}
 }
 
 /**

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2276,7 +2276,7 @@ static void ospf_table_reinstall_routes(struct ospf *ospf,
 	}
 }
 
-static void ospf_reinstall_routes(struct ospf *ospf)
+void ospf_reinstall_routes(struct ospf *ospf)
 {
 	ospf_table_reinstall_routes(ospf, ospf->new_table);
 	ospf_table_reinstall_routes(ospf, ospf->new_external_route);

--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -38,6 +38,7 @@ extern void ospf_vty_init(void);
 extern void ospf_vty_show_init(void);
 extern void ospf_vty_clear_init(void);
 extern int str2area_id(const char *str, struct in_addr *area_id, int *area_id_fmt);
+extern void ospf_reinstall_routes(struct ospf *ospf);
 
 /* unit tests */
 void show_ip_ospf_database_summary(struct vty *vty, struct ospf *ospf, int self,

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -39,6 +39,7 @@
 #include "ospfd/ospf_te.h"
 #include "ospfd/ospf_sr.h"
 #include "ospfd/ospf_ldp_sync.h"
+#include "ospfd/ospf_vty.h"
 
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_EXTERNAL, "OSPF External route table");
 DEFINE_MTYPE_STATIC(OSPFD, OSPF_REDISTRIBUTE, "OSPF Redistriute");
@@ -2123,8 +2124,13 @@ static void ospf_zebra_connected(struct zclient *zclient)
 
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 
-	/* Activate graceful restart if configured. */
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
+		/* Replay existing OSPF routes to the (re)connected Zebra so a
+		 * restarted Zebra rebuilds its OSPF RIB state.
+		 */
+		ospf_reinstall_routes(ospf);
+
+		/* Activate graceful restart if configured. */
 		if (!ospf->gr_info.restart_support)
 			continue;
 		(void)ospf_zebra_gr_enable(ospf, ospf->gr_info.grace_period);

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -24,8 +24,8 @@
 struct zclient *ripd_zclient = NULL;
 
 /* Send ECMP routes to zebra. */
-static void rip_zebra_ipv4_send(struct rip *rip, struct route_node *rp,
-				uint8_t cmd)
+static void rip_zebra_ipv4_send(struct rip *rip, struct route_node *rp, uint8_t cmd,
+				bool count_change)
 {
 	struct rip_info_list_head *list = rp->info;
 	struct zapi_route api;
@@ -89,19 +89,45 @@ static void rip_zebra_ipv4_send(struct rip *rip, struct route_node *rp,
 					   : "Delete from zebra", &rp->p);
 	}
 
-	rip->counters.route_changes++;
+	if (count_change)
+		rip->counters.route_changes++;
 }
 
 /* Add/update ECMP routes to zebra. */
 void rip_zebra_ipv4_add(struct rip *rip, struct route_node *rp)
 {
-	rip_zebra_ipv4_send(rip, rp, ZEBRA_ROUTE_ADD);
+	rip_zebra_ipv4_send(rip, rp, ZEBRA_ROUTE_ADD, true);
 }
 
 /* Delete ECMP routes from zebra. */
 void rip_zebra_ipv4_delete(struct rip *rip, struct route_node *rp)
 {
-	rip_zebra_ipv4_send(rip, rp, ZEBRA_ROUTE_DELETE);
+	rip_zebra_ipv4_send(rip, rp, ZEBRA_ROUTE_DELETE, true);
+}
+
+static void rip_zebra_ipv4_replay(struct rip *rip)
+{
+	struct route_node *rp;
+	struct rip_info *rinfo;
+	struct rip_info_list_head *list;
+
+	for (rp = route_top(rip->table); rp; rp = route_next(rp)) {
+		list = rp->info;
+		if (!list || rip_info_list_count(list) == 0)
+			continue;
+
+		rinfo = rip_info_list_first(list);
+		if (!rip_route_rte(rinfo))
+			continue;
+
+		if (rinfo->metric == RIP_METRIC_INFINITY)
+			continue;
+
+		if (!CHECK_FLAG(rinfo->flags, RIP_RTF_FIB))
+			continue;
+
+		rip_zebra_ipv4_send(rip, rp, ZEBRA_ROUTE_ADD, false);
+	}
 }
 
 /* Zebra route add and delete treatment. */
@@ -221,8 +247,19 @@ void rip_zebra_vrf_deregister(struct vrf *vrf)
 
 static void rip_zebra_connected(struct zclient *zclient)
 {
+	struct rip *rip;
+
 	zclient_send_reg_requests(zclient, VRF_DEFAULT);
 	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER, VRF_DEFAULT);
+
+	RB_FOREACH (rip, rip_instance_head, &rip_instances) {
+		if (!rip->enabled || !rip->vrf)
+			continue;
+
+		rip_redistribute_enable(rip);
+		rip_zebra_vrf_register(rip->vrf);
+		rip_zebra_ipv4_replay(rip);
+	}
 }
 
 zclient_handler *const rip_handlers[] = {

--- a/tests/topotests/zebra_reconnect_route_replay/r1/bgpd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r1/bgpd.conf
@@ -1,0 +1,9 @@
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.2 remote-as 65002
+ address-family ipv4 unicast
+  network 10.0.4.0/24
+  neighbor 10.0.0.2 activate
+ exit-address-family
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r1/isisd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r1/isisd.conf
@@ -1,0 +1,12 @@
+!
+interface r1-eth0
+ ip router isis 1
+!
+interface r1-eth3
+ ip router isis 1
+ isis passive
+!
+router isis 1
+ net 49.0001.0000.0000.0001.00
+ is-type level-2-only
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r1/ospfd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r1/ospfd.conf
@@ -1,0 +1,7 @@
+!
+router ospf
+ ospf router-id 1.1.1.1
+ network 10.0.0.0/24 area 0
+ network 10.0.1.0/24 area 0
+ passive-interface r1-eth1
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r1/ripd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r1/ripd.conf
@@ -1,0 +1,8 @@
+!
+router rip
+ version 2
+ network 10.0.0.0/24
+ network 10.0.2.0/24
+ passive-interface r1-eth2
+ timers basic 5 30 60
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r1/zebra.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r1/zebra.conf
@@ -1,0 +1,19 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+interface r1-eth1
+ ip address 10.0.1.1/24
+!
+interface r1-eth2
+ ip address 10.0.2.1/24
+!
+interface r1-eth3
+ ip address 10.0.3.1/24
+!
+ip route 10.0.4.0/24 Null0
+!
+ip forwarding
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r2/bgpd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r2/bgpd.conf
@@ -1,0 +1,8 @@
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.1 remote-as 65001
+ address-family ipv4 unicast
+  neighbor 10.0.0.1 activate
+ exit-address-family
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r2/isisd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r2/isisd.conf
@@ -1,0 +1,8 @@
+!
+interface r2-eth0
+ ip router isis 1
+!
+router isis 1
+ net 49.0001.0000.0000.0002.00
+ is-type level-2-only
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r2/ospfd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r2/ospfd.conf
@@ -1,0 +1,5 @@
+!
+router ospf
+ ospf router-id 2.2.2.2
+ network 10.0.0.0/24 area 0
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r2/ripd.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r2/ripd.conf
@@ -1,0 +1,6 @@
+!
+router rip
+ version 2
+ network 10.0.0.0/24
+ timers basic 5 30 60
+!

--- a/tests/topotests/zebra_reconnect_route_replay/r2/zebra.conf
+++ b/tests/topotests/zebra_reconnect_route_replay/r2/zebra.conf
@@ -1,0 +1,8 @@
+!
+hostname r2
+!
+interface r2-eth0
+ ip address 10.0.0.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/zebra_reconnect_route_replay/test_zebra_reconnect_route_replay.py
+++ b/tests/topotests/zebra_reconnect_route_replay/test_zebra_reconnect_route_replay.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_zebra_reconnect_route_replay.py
+#
+# Copyright (c) 2026 by
+# Evelyn0828
+#
+
+"""
+test_zebra_reconnect_route_replay.py: when zebra restarts while a routing
+daemon keeps running, the daemon must replay its already computed/selected
+routes to zebra on reconnect, so they are reinstalled without waiting for a
+topology change.
+
+r1 originates one distinct prefix into each of OSPF, RIP, IS-IS and BGP and
+advertises them to r2 over a shared link:
+
+    [ r1 ] --- r1-eth0 --- sw0 --- r2-eth0 --- [ r2 ]
+
+    r1 stubs:  OSPF 10.0.1.0/24, RIP 10.0.2.0/24, IS-IS 10.0.3.0/24
+    r1 BGP network: 10.0.4.0/24
+
+After r2 has installed all four, only zebra is restarted on r2 (the protocol
+daemons keep running). The test verifies every prefix is reinstalled in r2's
+RIB after zebra comes back, which only happens if each daemon replays its
+routes on the zebra reconnect.
+"""
+
+import os
+import sys
+import pytest
+from functools import partial
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import kill_router_daemons, start_router_daemons
+
+pytestmark = [
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+    pytest.mark.ripd,
+    pytest.mark.isisd,
+]
+
+# prefix -> protocol that should install it on r2
+PREFIXES = {
+    "10.0.1.0/24": "ospf",
+    "10.0.2.0/24": "rip",
+    "10.0.3.0/24": "isis",
+    "10.0.4.0/24": "bgp",
+}
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    # Shared link carrying every protocol adjacency.
+    sw0 = tgen.add_switch("sw0")
+    sw0.add_link(tgen.gears["r1"])
+    sw0.add_link(tgen.gears["r2"])
+
+    # r1 stub interfaces, one per IGP prefix (r1-eth1/2/3).
+    for i in range(1, 4):
+        sw = tgen.add_switch("sw{}".format(i))
+        sw.add_link(tgen.gears["r1"])
+
+
+def setup_module(module):
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    daemons = [
+        (TopoRouter.RD_ZEBRA, "zebra.conf"),
+        (TopoRouter.RD_OSPF, "ospfd.conf"),
+        (TopoRouter.RD_RIP, "ripd.conf"),
+        (TopoRouter.RD_ISIS, "isisd.conf"),
+        (TopoRouter.RD_BGP, "bgpd.conf"),
+    ]
+    for rname, router in tgen.routers().items():
+        for daemon, fname in daemons:
+            router.load_config(daemon, os.path.join(CWD, "{}/{}".format(rname, fname)))
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _route_installed(router, prefix, proto):
+    """Return None when prefix is installed on router via proto with a nexthop."""
+    output = router.vtysh_cmd("show ip route {} json".format(prefix), isjson=True)
+    if not output or prefix not in output:
+        return "{} missing from {} RIB".format(prefix, router.name)
+    for entry in output[prefix]:
+        if entry.get("protocol") != proto:
+            continue
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("ip") and nh.get("active"):
+                return None
+    return "{} on {} not installed via {}".format(prefix, router.name, proto)
+
+
+def _all_routes_installed(router):
+    for prefix, proto in PREFIXES.items():
+        err = _route_installed(router, prefix, proto)
+        if err:
+            return err
+    return None
+
+
+def test_converge():
+    "All four prefixes must be installed on r2 via their protocols."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+    _, result = topotest.run_and_expect(
+        partial(_all_routes_installed, r2), None, count=120, wait=1
+    )
+    assert result is None, "r2 did not install all prefixes initially: {}".format(result)
+    logger.info("r2 initial routes:\n{}".format(r2.vtysh_cmd("show ip route")))
+
+
+def test_zebra_reconnect_replays_routes():
+    "After only zebra restarts on r2, every protocol must replay its routes."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    # Make sure we start from a fully converged state.
+    _, result = topotest.run_and_expect(
+        partial(_all_routes_installed, r2), None, count=120, wait=1
+    )
+    assert result is None, "preconditions not met: {}".format(result)
+
+    logger.info("Restarting only zebra on r2 (protocol daemons keep running)")
+    kill_router_daemons(tgen, "r2", ["zebra"])
+    start_router_daemons(tgen, "r2", ["zebra"])
+
+    # On reconnect each daemon must replay its routes; they should reappear
+    # without waiting for a topology change.
+    _, result = topotest.run_and_expect(
+        partial(_all_routes_installed, r2), None, count=60, wait=1
+    )
+    assert result is None, "r2 did not get routes replayed after zebra restart: {}".format(
+        result
+    )
+    logger.info("r2 routes after zebra restart:\n{}".format(r2.vtysh_cmd("show ip route")))
+
+
+def test_shutdown_check_stderr():
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        pytest.skip("Skipping test for Stderr output and memory leaks")
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for router in tgen.routers().values():
+        router.stop()
+        for daemon in ["zebra", "ospfd", "ripd", "isisd", "bgpd"]:
+            log = tgen.net[router.name].getStdErr(daemon)
+            if log:
+                logger.error("{} {} StdErr Log:\n{}".format(router.name, daemon, log))
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
ospf6d already reinstalls its routes when zebra reconnects (commit `c39faf280a`, "ospf6d: reinstall routes after zebra reconnect"). ospfd, bgpd, ripd and isisd don't — so after a zebra restart their routes stay in the daemon RIB but silently vanish from zebra and the kernel FIB, with the control plane still looking healthy, until something forces a recompute or the routes time out.

This brings the other daemons in line with ospf6d, reusing each one's existing reinstall path — one commit per protocol:

- **ospfd** — call `ospf_reinstall_routes()` from `ospf_zebra_connected()` (direct analogue of ospf6d). Closes #22363
- **bgpd** — replay selected routes via `bgp_zebra_announce_table()`. Closes #22362
- **ripd** — re-register redistribution + non-default VRFs and re-send routes for every instance. Closes #22364, Closes #22367
- **isisd** — clear the zebra-synced flag on each area's SPF route tables and reschedule SPF (also covers a route learned while the zclient was down, which was wrongly marked synced). Closes #22359