### PR TITLE
babeld: retract routes denied by an outbound filter change

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -24,6 +24,7 @@ Copyright 2011 by Matthieu Boutier and Juliusz Chroboczek
 #include "babel_interface.h"
 #include "neighbour.h"
 #include "route.h"
+#include "xroute.h"
 #include "message.h"
 #include "resend.h"
 #include "babel_filter.h"
@@ -536,6 +537,10 @@ static void babel_distribute_update(struct distribute_ctx *ctx __attribute__((__
 	babel_interface_nfo *babel_ifp;
 	int type;
 	int family;
+	struct xroute_stream *xroutes;
+	struct xroute *xroute;
+	struct route_stream *routes;
+	struct babel_route *route;
 
 	if (!dist->ifname)
 		return;
@@ -557,6 +562,42 @@ static void babel_distribute_update(struct distribute_ctx *ctx __attribute__((__
 		else
 			babel_ifp->prefix[type] = NULL;
 	}
+
+	/* The outbound filter may now deny prefixes that were previously
+	 * advertised on this interface. Walk the locally originated xroutes and
+	 * the installed (transit) routes and explicitly retract the ones that
+	 * are no longer permitted, otherwise neighbors keep the stale route
+	 * until it times out. Newly permitted prefixes are re-advertised by the
+	 * update below.
+	 */
+	xroutes = xroute_stream();
+	if (xroutes) {
+		while (1) {
+			xroute = xroute_stream_next(xroutes);
+			if (xroute == NULL)
+				break;
+			if (output_filter(NULL, xroute->prefix, xroute->plen, ifp->ifindex) >=
+			    INFINITY)
+				send_retraction(ifp, myid, myseqno, xroute->prefix, xroute->plen);
+		}
+		xroute_stream_done(xroutes);
+	}
+
+	routes = route_stream(1);
+	if (routes) {
+		while (1) {
+			route = route_stream_next(routes);
+			if (route == NULL)
+				break;
+			if (output_filter(route->src->id, route->src->prefix, route->src->plen,
+					  ifp->ifindex) >= INFINITY)
+				send_retraction(ifp, route->src->id, route->seqno,
+						route->src->prefix, route->src->plen);
+		}
+		route_stream_done(routes);
+	}
+
+	send_update(ifp, 0, NULL, 0);
 }
 
 static void babel_distribute_update_interface(struct interface *ifp)

--- a/babeld/message.c
+++ b/babeld/message.c
@@ -1362,8 +1362,16 @@ static void really_send_update(struct interface *ifp, const unsigned char *id,
 		return;
 
 	add_metric = output_filter(id, prefix, plen, ifp->ifindex);
-	if (add_metric >= INFINITY)
-		return;
+	if (add_metric >= INFINITY) {
+		/* The outbound filter denies this prefix. Still let an explicit
+		 * retraction (metric infinity) through, so a route that was
+		 * advertised before the filter started denying it is withdrawn
+		 * instead of lingering at neighbors until it times out.
+		 */
+		if (metric < INFINITY)
+			return;
+		add_metric = 0;
+	}
 
 	metric = MIN(metric + add_metric, INFINITY);
 	/* Worst case */
@@ -1694,6 +1702,16 @@ void send_update_resend(struct interface *ifp, const unsigned char *prefix, unsi
 
 	send_update(ifp, 1, prefix, plen);
 	record_resend(RESEND_UPDATE, prefix, plen, 0, NULL, NULL, resend_delay);
+}
+
+void send_retraction(struct interface *ifp, const unsigned char *id, unsigned short seqno,
+		     const unsigned char *prefix, unsigned char plen)
+{
+	if (!if_up(ifp))
+		return;
+
+	really_send_update(ifp, id, prefix, plen, seqno, INFINITY, NULL, -1);
+	schedule_flush_now(ifp);
 }
 
 void send_wildcard_retraction(struct interface *ifp)

--- a/babeld/message.h
+++ b/babeld/message.h
@@ -56,6 +56,8 @@ void flush_unicast(int dofree);
 void send_update(struct interface *ifp, int urgent, const unsigned char *prefix,
 		 unsigned char plen);
 void send_update_resend(struct interface *ifp, const unsigned char *prefix, unsigned char plen);
+void send_retraction(struct interface *ifp, const unsigned char *id, unsigned short seqno,
+		     const unsigned char *prefix, unsigned char plen);
 void send_wildcard_retraction(struct interface *ifp);
 void update_myseqno(void);
 void send_self_update(struct interface *ifp);

--- a/tests/topotests/babel_distribute_list_retract/r1/babeld.conf
+++ b/tests/topotests/babel_distribute_list_retract/r1/babeld.conf
@@ -1,0 +1,12 @@
+!
+interface r1-eth0
+  babel wired
+  babel hello-interval 1000
+  babel update-interval 20000
+!
+router babel
+ network r1-eth0
+ redistribute ipv4 connected
+!
+line vty
+!

--- a/tests/topotests/babel_distribute_list_retract/r1/zebra.conf
+++ b/tests/topotests/babel_distribute_list_retract/r1/zebra.conf
@@ -1,0 +1,17 @@
+!
+hostname r1
+!
+interface r1-eth0
+ description babel link to r2
+ ip address 10.0.0.1/24
+ no link-detect
+!
+interface r1-eth1
+ description stub - originated prefix
+ ip address 10.1.1.1/24
+ no link-detect
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/babel_distribute_list_retract/r2/babeld.conf
+++ b/tests/topotests/babel_distribute_list_retract/r2/babeld.conf
@@ -1,0 +1,12 @@
+!
+interface r2-eth0
+  babel wired
+  babel hello-interval 1000
+  babel update-interval 20000
+!
+router babel
+ network r2-eth0
+ redistribute ipv4 connected
+!
+line vty
+!

--- a/tests/topotests/babel_distribute_list_retract/r2/zebra.conf
+++ b/tests/topotests/babel_distribute_list_retract/r2/zebra.conf
@@ -1,0 +1,12 @@
+!
+hostname r2
+!
+interface r2-eth0
+ description babel link to r1
+ ip address 10.0.0.2/24
+ no link-detect
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/babel_distribute_list_retract/test_babel_distribute_list_retract.py
+++ b/tests/topotests/babel_distribute_list_retract/test_babel_distribute_list_retract.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_babel_distribute_list_retract.py
+#
+# Copyright (c) 2026 by
+# Evelyn0828
+#
+
+"""
+test_babel_distribute_list_retract.py: Babel must retract a previously
+advertised route when an outbound distribute-list change starts denying it,
+instead of leaving the stale route reachable on the neighbor until it times
+out.
+
+Topology:
+
+    r1-eth1 (stub 10.1.1.0/24)
+       |
+    [ r1 ] --- r1-eth0 --- sw1 --- r2-eth0 --- [ r2 ]
+
+r1 originates 10.1.1.0/24 (redistribute connected) and advertises it to r2 over
+Babel. The test then applies an outbound distribute-list on r1's Babel interface
+denying 10.1.1.0/24 and verifies r2 stops forwarding to it promptly (Babel sends
+an explicit metric-infinity retraction, so the route is withdrawn / turned into
+an unreachable route well before its natural hold time of several update
+intervals). Finally it removes the filter and verifies the route is
+re-advertised and reachable again.
+"""
+
+import os
+import sys
+import pytest
+from functools import partial
+
+pytestmark = [pytest.mark.babeld]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+PREFIX = "10.1.1.0/24"
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    # Babel link: r1-eth0 <-> r2-eth0
+    sw1 = tgen.add_switch("sw1")
+    sw1.add_link(tgen.gears["r1"])
+    sw1.add_link(tgen.gears["r2"])
+
+    # Stub on r1 carrying the originated prefix: r1-eth1
+    sw2 = tgen.add_switch("sw2")
+    sw2.add_link(tgen.gears["r1"])
+
+
+def setup_module(module):
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BABEL, os.path.join(CWD, "{}/babeld.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _forwarding_nexthops(router):
+    """Return the list of active forwarding nexthops for PREFIX on router.
+
+    A retracted/unreachable route stays in the RIB with a reject ("unreachable")
+    nexthop and no gateway, so it is not counted here.
+    """
+    output = router.vtysh_cmd("show ip route {} json".format(PREFIX), isjson=True)
+    if not output or PREFIX not in output:
+        return []
+    fwd = []
+    for entry in output[PREFIX]:
+        if entry.get("protocol") != "babel":
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("unreachable") or nh.get("reject") or nh.get("blackhole"):
+                continue
+            if nh.get("ip"):
+                fwd.append(nh)
+    return fwd
+
+
+def _prefix_reachable(router):
+    "Return None when PREFIX is installed via babel with a forwarding nexthop."
+    if _forwarding_nexthops(router):
+        return None
+    return "{} is not reachable via babel on {}".format(PREFIX, router.name)
+
+
+def _prefix_retracted(router):
+    "Return None when PREFIX is gone or has no forwarding nexthop left."
+    if not _forwarding_nexthops(router):
+        return None
+    return "{} still has a forwarding nexthop on {}".format(PREFIX, router.name)
+
+
+def test_converge_protocols():
+    "Wait for Babel adjacency between r1 and r2."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ["r1", "r2"]:
+        router = tgen.gears[rname]
+
+        def check_convergence(router=router):
+            output = router.vtysh_cmd("show babel neighbor")
+            if "Neighbour" not in output:
+                return "{} has no babel neighbor yet".format(router.name)
+            return None
+
+        _, result = topotest.run_and_expect(check_convergence, None, count=60, wait=1)
+        assert result is None, "{} failed to establish babel neighbor".format(rname)
+
+
+def test_route_learned():
+    "r2 must learn 10.1.1.0/24 from r1 via Babel as a reachable route."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+    _, result = topotest.run_and_expect(
+        partial(_prefix_reachable, r2), None, count=60, wait=1
+    )
+    assert result is None, "r2 did not learn a reachable {} via babel".format(PREFIX)
+
+
+def test_outbound_filter_retracts_route():
+    "Denying 10.1.1.0/24 outbound on r1 must retract it from r2 promptly."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Make sure r2 really has it before we deny it.
+    _, result = topotest.run_and_expect(
+        partial(_prefix_reachable, r2), None, count=60, wait=1
+    )
+    assert result is None, "r2 never had a reachable {} to retract".format(PREFIX)
+
+    logger.info("Applying outbound distribute-list denying {} on r1-eth0".format(PREFIX))
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "ip prefix-list DENY10 seq 5 deny {}\n".format(PREFIX)
+        + "ip prefix-list DENY10 seq 10 permit any\n"
+        "router babel\n"
+        "distribute-list prefix DENY10 out r1-eth0\n"
+    )
+
+    # The Babel update-interval is 20s, so the route's natural hold time is well
+    # over a minute; the explicit retraction makes r2 drop the forwarding path
+    # within this much shorter window.
+    _, result = topotest.run_and_expect(
+        partial(_prefix_retracted, r2), None, count=30, wait=1
+    )
+    assert result is None, "r2 did not retract {} after outbound deny".format(PREFIX)
+
+
+def test_route_readvertised_when_filter_removed():
+    "Removing the outbound deny must re-advertise 10.1.1.0/24 to r2."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    logger.info("Removing outbound distribute-list on r1-eth0")
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        "router babel\n"
+        "no distribute-list prefix DENY10 out r1-eth0\n"
+    )
+
+    _, result = topotest.run_and_expect(
+        partial(_prefix_reachable, r2), None, count=60, wait=1
+    )
+    assert result is None, "r2 did not relearn a reachable {} after filter removal".format(
+        PREFIX
+    )
+
+
+def test_shutdown_check_stderr():
+    if os.environ.get("TOPOTESTS_CHECK_STDERR") is None:
+        pytest.skip("Skipping test for Stderr output and memory leaks")
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for router in tgen.routers().values():
+        router.stop()
+        for daemon in ["babeld", "zebra"]:
+            log = tgen.net[router.name].getStdErr(daemon)
+            if log:
+                logger.error("{} {} StdErr Log:\n{}".format(router.name, daemon, log))
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
When an outbound `distribute-list` / prefix-list is changed to deny a prefix that babeld had already advertised, babeld simply stops including the route in updates. The local xroute is not removed, so no retraction is generated and neighbors keep the stale route (in Babel, zebra and the kernel FIB) until it times out.

On top of that, `really_send_update()` applied the outbound filter to retractions as well, so even an explicit metric-infinity withdrawal for a denied prefix was suppressed — a filtered prefix could never be withdrawn.

This:
- lets metric-infinity retractions through the outbound filter, and
- when an interface's outbound filter is updated, walks the local xroutes and sends a retraction for any prefix the new filter denies (newly permitted prefixes are re-advertised by the normal update).

Closes #22366