### PR TITLE
ospfd: flush translated Type-5 LSAs when no longer an NSSA translator

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -2037,11 +2037,16 @@ void ospf_abr_nssa_task(struct ospf *ospf) /* called only if any_nssa */
 	if (IS_DEBUG_OSPF_NSSA)
 		zlog_debug("Check for NSSA-ABR Tasks():");
 
-	if (!IS_OSPF_ABR(ospf))
+	if (!IS_OSPF_ABR(ospf) || !ospf->anyNSSA) {
+		/* We can no longer act as an NSSA translator -- either we are
+		 * no longer an ABR, or the last NSSA area was removed. Flush any
+		 * Type-5 LSAs we previously translated; otherwise they linger in
+		 * the global LSDB as stale self-originated translated LSAs.
+		 */
+		ospf_abr_unapprove_translates(ospf);
+		ospf_abr_remove_unapproved_translates(ospf);
 		return;
-
-	if (!ospf->anyNSSA)
-		return;
+	}
 
 	/* Each area must confirm TranslatorRole */
 	if (IS_DEBUG_OSPF_NSSA)


### PR DESCRIPTION
When an OSPF NSSA ABR has translated a Type-7 LSA into a Type-5 and then stops being an ABR (e.g. loses its backbone connection), `ospf_abr_nssa_task()` returned early at the `!IS_OSPF_ABR(ospf)` check, skipping the translated-LSA cleanup. The old self-originated translated Type-5 LSA was never unapproved or flushed, so it lingered in the global LSDB and downstream backbone routers kept the stale Type-5 LSA and the corresponding route.

When the router is no longer an ABR, unapprove and remove the previously translated Type-5 LSAs (`ospf_abr_unapprove_translates()` + `ospf_abr_remove_unapproved_translates()`, which only touch `OSPF_LSA_LOCAL_XLT` LSAs) so they are flushed throughout the AS.

Closes #21949