### PR TITLE
mgmtd: fix startup race: retry running DS lock for VTY  implicit commit

### DIFF
--- a/lib/vty.h
+++ b/lib/vty.h
@@ -231,6 +231,9 @@ struct vty {
 	uintptr_t mgmt_req_pending_data;
 	bool mgmt_locked_candidate_ds;
 	bool mgmt_locked_running_ds;
+	/* Retry state when running DS lock is contended during implicit commit. */
+	struct event *mgmt_running_lock_retry_ev;
+	uint mgmt_running_lock_retry_count;
 	/* Incremental write/flush limit and current accumulator. When
 	 * producing large outputs, we try to avoid buffering the entire
 	 * output, sending incremental output periodically

--- a/mgmtd/mgmt_vty_frontend.c
+++ b/mgmtd/mgmt_vty_frontend.c
@@ -387,6 +387,51 @@ static void vty_mgmt_handle_lock_ds_reply(struct mgmt_fe_client *client, uintptr
 	}
 }
 
+/* ---------------------------------------------------------------- */
+/* Running DS lock retry for implicit commits (startup race fix).   */
+/*                                                                  */
+/* When mgmtd sends initial config to a connecting backend, it      */
+/* holds the running DS lock briefly. Rather than silently dropping */
+/* the commit, we retry every 50 ms until the lock is available.    */
+/* ---------------------------------------------------------------- */
+
+#define MGMT_RUNNING_LOCK_RETRY_MS    50  /* interval between retries */
+#define MGMT_RUNNING_LOCK_MAX_RETRIES 200 /* 200 × 50 ms = 10 s */
+
+static void vty_mgmt_running_lock_retry(struct event *event)
+{
+	struct vty *vty = EVENT_ARG(event);
+
+	assert(vty->mgmt_req_pending_cmd &&
+	       !strcmp(vty->mgmt_req_pending_cmd, "RUNNING_DS_LOCK_RETRY"));
+
+	/*
+	 * Candidate edits were already applied before scheduling retry.
+	 * Candidate lock is held. Only need to acquire running lock and commit.
+	 */
+	if (vty_mgmt_lock_running_inline(vty) == 0) {
+		/* Running lock acquired — commit the pending candidate changes. */
+		if (vty_mgmt_send_commit_config(vty, false, false, true) < 0) {
+			vty_mgmt_unlock_running_inline(vty);
+			vty_mgmt_unlock_candidate_inline(vty);
+			vty_mgmt_resume_response(vty, CMD_WARNING_CONFIG_FAILED);
+		}
+		/* Success: pending_cmd is now "MESSAGE_COMMCFG_REQ"; reply will resume. */
+		return;
+	}
+
+	if (++vty->mgmt_running_lock_retry_count < MGMT_RUNNING_LOCK_MAX_RETRIES) {
+		event_add_timer_msec(mm->master, vty_mgmt_running_lock_retry, vty,
+				     MGMT_RUNNING_LOCK_RETRY_MS, &vty->mgmt_running_lock_retry_ev);
+		return;
+	}
+
+	/* Exhausted retries — give up. Unlock candidate held since initial call. */
+	vty_mgmt_unlock_candidate_inline(vty);
+	vty_out(vty, "%% could not lock running DS (timed out)\n");
+	vty_mgmt_resume_response(vty, CMD_WARNING_CONFIG_FAILED);
+}
+
 /* ------------------------------------------------ */
 /* "Send" Config Data -- actually just edits inline */
 /* ------------------------------------------------ */
@@ -402,9 +447,26 @@ int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base, bool impl
 			vty_out(vty, "%% could not lock candidate DS\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		} else if (vty_mgmt_lock_running_inline(vty)) {
-			vty_out(vty, "%% could not lock running DS\n");
-			vty_mgmt_unlock_candidate_inline(vty);
-			return CMD_WARNING_CONFIG_FAILED;
+			/*
+			 * Running DS is locked (mgmtd may be sending initial
+			 * config to a backend). Apply candidate edit now while
+			 * cfg_changes values are still live, keep candidate
+			 * locked, and retry only lock+commit.
+			 */
+			nb_candidate_edit_config_changes(vty->candidate_config, vty->cfg_changes,
+							 vty->num_cfg_changes, xpath_base, false,
+							 err_buf, sizeof(err_buf), &error);
+			if (error) {
+				vty_out(vty, "%% Couldn't apply changes: %s", err_buf);
+				vty_mgmt_unlock_candidate_inline(vty);
+				return CMD_WARNING_CONFIG_FAILED;
+			}
+			vty->mgmt_running_lock_retry_count = 0;
+			vty->mgmt_req_pending_cmd = "RUNNING_DS_LOCK_RETRY";
+			event_add_timer_msec(mm->master, vty_mgmt_running_lock_retry, vty,
+					     MGMT_RUNNING_LOCK_RETRY_MS,
+					     &vty->mgmt_running_lock_retry_ev);
+			return CMD_SUCCESS;
 		}
 	}
 
@@ -684,6 +746,11 @@ static void vty_new_mgmt(struct vty *new)
 
 static void vty_close_mgmt(struct vty *vty)
 {
+	if (vty->mgmt_running_lock_retry_ev) {
+		event_cancel(&vty->mgmt_running_lock_retry_ev);
+		vty->mgmt_req_pending_cmd = NULL;
+	}
+
 	if (!mgmt_fe_client || !vty->mgmt_client_id)
 		return;
 

--- a/tests/topotests/mgmt_startup_race/r1/frr.conf
+++ b/tests/topotests/mgmt_startup_race/r1/frr.conf
@@ -1,0 +1,7 @@
+log timestamp precision 3
+log file frr.log
+!
+interface r1-eth0
+  ip address 101.0.0.1/24
+exit
+!

--- a/tests/topotests/mgmt_startup_race/test_startup_race.py
+++ b/tests/topotests/mgmt_startup_race/test_startup_race.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+"""
+Test for startup race: CLI commands vs mgmtd sending initial config.
+
+When staticd connects to mgmtd, mgmtd sends the initial config to staticd
+while holding the running DS lock. CLI commands arriving during this
+window fail to acquire the lock. Without the fix, these commands were
+silently dropped.
+
+This race condition is scale-related: mgmtd must hold the lock long
+enough for CLI commands to arrive. The route count (INIT_ROUTE_COUNT)
+may need adjustment on different systems.
+
+This test delays starting staticd until after mgmtd is running and the
+config is loaded. If staticd were started together with mgmtd, a much
+higher route count would be needed to trigger the race, since mgmtd
+would start sending config before CLI commands could be sent.
+
+This test reproduces the race:
+1. Load N routes into mgmtd config (more routes = longer lock hold time)
+2. Start staticd after mgmtd (mgmtd sends config, holds running DS lock)
+3. Immediately send CLI route commands (race with config send)
+4. Verify ALL routes are present (config + CLI-added)
+
+Without the fix, CLI-added routes are dropped with "could not lock running DS".
+With the fix, CLI commits retry until the lock is released.
+
+To verify the race was triggered, check mgmtd.log for lock failure:
+    grep "Lock.*failed" /tmp/topotests/mgmt_startup_race.../r1/mgmtd.log
+    -> "Locking for DS 1 failed, Err: 'Lock already taken...'"
+This confirms the CLI command hit the lock held while mgmtd was sending
+config to staticd, and the fix's retry logic handled it.
+"""
+
+import json
+import logging
+import os
+import shutil
+import time
+
+import pytest
+from lib.common_config import retry, step
+from lib.topogen import Topogen, TopoRouter
+from munet.base import Timeout
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+# Routes in initial config - more routes means mgmtd holds the running
+# DS lock longer while sending config, increasing the race window.
+INIT_ROUTE_COUNT = 300
+
+# Routes to add via CLI during race window, with non-default distance to verify
+# the value isn't corrupted by UAF (distance is a stack local in the CLI handler)
+CLI_ROUTES = [
+    "192.168.1.0/24",
+    "192.168.2.0/24",
+    "192.168.3.0/24",
+    "192.168.4.0/24",
+    "192.168.5.0/24",
+]
+CLI_ROUTE_DISTANCE = 55
+
+# Delay (ms) after starting staticd to let mgmtd grab the lock first
+RACE_DELAY_MS = 50
+
+
+def generate_conf_with_routes(srcpath, dstpath, count):
+    """Copy source config and append generated routes."""
+    shutil.copy(srcpath, dstpath)
+    with open(dstpath, "a", encoding="ascii") as f:
+        for i in range(count):
+            x = i // 256
+            y = i % 256
+            f.write(f"ip route 10.{x}.{y}.0/24 101.0.0.2\n")
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    """Setup/Teardown the environment and provide tgen argument to tests"""
+
+    topodef = {
+        "s1": ("r1",),
+    }
+
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+
+    # Generate config with routes, then load it.
+    router = tgen.gears["r1"]
+    srcconf = os.path.join(CWD, "{}/frr.conf".format("r1"))
+    dstconf = os.path.join(router.gearlogdir, "frr.conf")
+    generate_conf_with_routes(srcconf, dstconf, INIT_ROUTE_COUNT)
+    router.load_frr_config(dstconf)
+
+    # Disable staticd - start it manually to control timing and trigger
+    # the race condition.
+    router.net.daemons["staticd"] = 0
+
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+@retry(retry_timeout=120)
+def check_route_count(router, expected):
+    """Wait for expected number of static routes in zebra."""
+    output = json.loads(router.vtysh_cmd("show ip route static json"))
+    count = len(output)
+    assert count >= expected, f"Expected {expected} routes, got {count}"
+    return count
+
+
+@retry(retry_timeout=30)
+def check_route_present(router, prefix, expected_distance=None):
+    """Check if a route is present in zebra with expected distance."""
+    output = json.loads(router.vtysh_cmd(f"show ip route {prefix} json"))
+    assert prefix in output, f"Route {prefix} not found"
+    if expected_distance is not None:
+        route_info = output[prefix][0]
+        actual_distance = route_info.get("distance")
+        assert actual_distance == expected_distance, (
+            f"Route {prefix} distance mismatch: expected {expected_distance}, "
+            f"got {actual_distance}"
+        )
+
+
+def test_startup_race(tgen):
+    """Test that CLI routes are not dropped during init push race."""
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.routers()["r1"]
+
+    step("Verify no static routes present before staticd starts")
+    output = json.loads(r1.vtysh_cmd("show ip route static json"))
+    assert len(output) == 0, f"Expected 0 routes, got {len(output)}"
+
+    step(f"Starting staticd (will push {INIT_ROUTE_COUNT} routes)")
+    t = Timeout(0)
+    r1.startDaemons(["staticd"])
+
+    # Let mgmtd grab the running DS lock first
+    time.sleep(RACE_DELAY_MS / 1000.0)
+
+    step("Adding CLI routes (racing with config send)")
+    for prefix in CLI_ROUTES:
+        r1.net.cmd_nostatus(
+            f"vtysh -c 'config t' -c 'ip route {prefix} 101.0.0.2 {CLI_ROUTE_DISTANCE}'"
+        )
+    logging.info("CLI routes sent after %ss", t.elapsed())
+
+    step("Waiting for all routes to be installed")
+    expected = INIT_ROUTE_COUNT + len(CLI_ROUTES)
+    actual = check_route_count(r1, expected)
+    logging.info("All %d routes installed after %ss", actual, t.elapsed())
+
+    step("Verifying CLI-added routes are present with correct distance")
+    for prefix in CLI_ROUTES:
+        check_route_present(r1, prefix, expected_distance=CLI_ROUTE_DISTANCE)
+    logging.info("All %d CLI routes present with distance %d", len(CLI_ROUTES), CLI_ROUTE_DISTANCE)


### PR DESCRIPTION
When a backend daemon (e.g., staticd) connects to mgmtd, mgmtd sends it
the initial config while holding the running DS lock. If a VTY session
attempts an implicit commit during this window, it fails with a lock
error.

Add a retry mechanism for implicit commits that encounter a running DS
lock failure:
- Apply the candidate edit immediately (while cfg_changes values are
  still live on the stack)
- Keep the candidate lock held across the retry window
- Schedule a retry timer (50ms intervals, up to 200 retries = 10s max)
- On retry, acquire running lock and commit (no cfg_changes replay)
- Clear pending state on success or after max retries