### PR TITLE
bgpd: accept extended-size BGP messages on receive (RFC 8654)

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2291,6 +2291,9 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 	/* Reset capabilities. */
 	peer->cap = 0;
 
+	/* Capabilities are gone: revert the message-size limit to standard. */
+	bgp_peer_set_max_packet_size(peer);
+
 	/* Resetting neighbor role to the default value */
 	peer->remote_role = ROLE_UNDEFINED;
 
@@ -2655,6 +2658,9 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 
 	/* Clear peer capability flag. */
 	peer->cap = 0;
+
+	/* Capabilities are gone: revert the message-size limit to standard. */
+	bgp_peer_set_max_packet_size(peer);
 
 	if (peergroup_flag_check(peer, PEER_FLAG_RPKI_STRICT) &&
 	    !bgp_rpki_cache_connected(peer->bgp)) {

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -40,6 +40,36 @@ static bool validate_header(struct peer_connection *connection);
 #define BGP_IO_FATAL_ERR (1 << 1) /* some kind of fatal TCP error */
 #define BGP_IO_WORK_FULL_ERR (1 << 2) /* No room in work buffer */
 
+/*
+ * Maximum size of a BGP message we are willing to *receive*, by message type.
+ *
+ * RFC 8654 makes the message-size limit asymmetric: a speaker that has
+ * advertised the Extended Message capability MUST be able to receive messages
+ * of up to 65535 octets; whether the *peer* advertised the capability governs
+ * only what we are allowed to *send*.  FRR advertises the capability
+ * unconditionally (see bgp_open_capability()), so on receive we must accept
+ * extended-size messages.  OPEN and KEEPALIVE are never extended (RFC 8654),
+ * so they stay capped at the standard size.
+ *
+ * This deliberately does NOT use peer->max_packet_size: that field is the
+ * negotiated *send* limit (set to the extended size only when the capability
+ * was both advertised and received, and computed once while parsing the peer's
+ * OPEN).  Reusing it on the receive path wrongly rejects valid extended
+ * messages whenever that value is left at the standard size on this
+ * connection -- notably a passively accepted connection, whose own OPEN is
+ * sent (from bgp_fsm_open()) only after the peer's OPEN has been parsed; the
+ * value is then preserved across connection-collision resolution -- dropping
+ * every >4096 message with NOTIFICATION Message Header Error / Bad Message
+ * Length.
+ */
+static uint16_t bgp_rx_max_packet_size(uint8_t type)
+{
+	if (type == BGP_MSG_OPEN || type == BGP_MSG_KEEPALIVE)
+		return BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
+
+	return BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE;
+}
+
 /* Thread external API ----------------------------------------------------- */
 
 void bgp_writes_on(struct peer_connection *connection)
@@ -178,6 +208,8 @@ static int read_ibuf_work(struct peer_connection *connection)
 	struct ringbuf *ibw = connection->ibuf_work;
 	/* packet size as given by header */
 	uint16_t pktsize = 0;
+	/* packet type as given by header */
+	uint8_t pkttype = 0;
 	struct stream *pkt;
 
 	/* ============================================== */
@@ -199,8 +231,12 @@ static int read_ibuf_work(struct peer_connection *connection)
 
 	pktsize = ntohs(pktsize);
 
+	/* retrieve packet type for the receive-side size limit */
+	ringbuf_peek(ibw, BGP_MARKER_SIZE + sizeof(pktsize), &pkttype,
+		     sizeof(pkttype));
+
 	/* if this fails we are seriously screwed */
-	if (pktsize > connection->peer->max_packet_size)
+	if (pktsize > bgp_rx_max_packet_size(pkttype))
 		return -EBADMSG;
 
 	/*
@@ -626,7 +662,7 @@ static bool validate_header(struct peer_connection *connection)
 	}
 
 	/* Minimum packet length check. */
-	if ((size < BGP_HEADER_SIZE) || (size > peer->max_packet_size)
+	if ((size < BGP_HEADER_SIZE) || (size > bgp_rx_max_packet_size(type))
 	    || (type == BGP_MSG_OPEN && size < BGP_MSG_OPEN_MIN_SIZE)
 	    || (type == BGP_MSG_UPDATE && size < BGP_MSG_UPDATE_MIN_SIZE)
 	    || (type == BGP_MSG_NOTIFY && size < BGP_MSG_NOTIFY_MIN_SIZE)

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -40,36 +40,6 @@ static bool validate_header(struct peer_connection *connection);
 #define BGP_IO_FATAL_ERR (1 << 1) /* some kind of fatal TCP error */
 #define BGP_IO_WORK_FULL_ERR (1 << 2) /* No room in work buffer */
 
-/*
- * Maximum size of a BGP message we are willing to *receive*, by message type.
- *
- * RFC 8654 makes the message-size limit asymmetric: a speaker that has
- * advertised the Extended Message capability MUST be able to receive messages
- * of up to 65535 octets; whether the *peer* advertised the capability governs
- * only what we are allowed to *send*.  FRR advertises the capability
- * unconditionally (see bgp_open_capability()), so on receive we must accept
- * extended-size messages.  OPEN and KEEPALIVE are never extended (RFC 8654),
- * so they stay capped at the standard size.
- *
- * This deliberately does NOT use peer->max_packet_size: that field is the
- * negotiated *send* limit (set to the extended size only when the capability
- * was both advertised and received, and computed once while parsing the peer's
- * OPEN).  Reusing it on the receive path wrongly rejects valid extended
- * messages whenever that value is left at the standard size on this
- * connection -- notably a passively accepted connection, whose own OPEN is
- * sent (from bgp_fsm_open()) only after the peer's OPEN has been parsed; the
- * value is then preserved across connection-collision resolution -- dropping
- * every >4096 message with NOTIFICATION Message Header Error / Bad Message
- * Length.
- */
-static uint16_t bgp_rx_max_packet_size(uint8_t type)
-{
-	if (type == BGP_MSG_OPEN || type == BGP_MSG_KEEPALIVE)
-		return BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
-
-	return BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE;
-}
-
 /* Thread external API ----------------------------------------------------- */
 
 void bgp_writes_on(struct peer_connection *connection)
@@ -208,8 +178,6 @@ static int read_ibuf_work(struct peer_connection *connection)
 	struct ringbuf *ibw = connection->ibuf_work;
 	/* packet size as given by header */
 	uint16_t pktsize = 0;
-	/* packet type as given by header */
-	uint8_t pkttype = 0;
 	struct stream *pkt;
 
 	/* ============================================== */
@@ -231,12 +199,8 @@ static int read_ibuf_work(struct peer_connection *connection)
 
 	pktsize = ntohs(pktsize);
 
-	/* retrieve packet type for the receive-side size limit */
-	ringbuf_peek(ibw, BGP_MARKER_SIZE + sizeof(pktsize), &pkttype,
-		     sizeof(pkttype));
-
 	/* if this fails we are seriously screwed */
-	if (pktsize > bgp_rx_max_packet_size(pkttype))
+	if (pktsize > connection->peer->max_packet_size)
 		return -EBADMSG;
 
 	/*
@@ -662,7 +626,7 @@ static bool validate_header(struct peer_connection *connection)
 	}
 
 	/* Minimum packet length check. */
-	if ((size < BGP_HEADER_SIZE) || (size > bgp_rx_max_packet_size(type))
+	if ((size < BGP_HEADER_SIZE) || (size > peer->max_packet_size)
 	    || (type == BGP_MSG_OPEN && size < BGP_MSG_OPEN_MIN_SIZE)
 	    || (type == BGP_MSG_UPDATE && size < BGP_MSG_UPDATE_MIN_SIZE)
 	    || (type == BGP_MSG_NOTIFY && size < BGP_MSG_NOTIFY_MIN_SIZE)

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1415,6 +1415,30 @@ end:
 	return as4;
 }
 
+/*
+ * (Re)compute the maximum BGP message size for this peer from the negotiated
+ * Extended Message capability (RFC 8654).  The extended size (65535) is used
+ * only when we have advertised the capability *and* received it from the peer;
+ * otherwise the standard size (4096) applies.
+ *
+ * This must be recomputed whenever either half of that condition can change:
+ * when we parse the peer's OPEN (sets the RCV flag) and when we build our own
+ * OPEN (sets the ADV flag).  On a passively accepted connection our OPEN is
+ * sent only after the peer's OPEN has already been parsed, so computing this
+ * solely at OPEN-parse time would leave it at the standard size -- and the
+ * stale value is then carried across connection-collision resolution by
+ * peer_xfer_conn() -- even though both speakers support the capability.  It is
+ * reset to the standard size when the peer's capabilities are cleared on
+ * connection reset.
+ */
+void bgp_peer_set_max_packet_size(struct peer *peer)
+{
+	peer->max_packet_size = (CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV) &&
+				 CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_ADV))
+					? BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
+					: BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
+}
+
 /**
  * Parse open option.
  *
@@ -1530,11 +1554,7 @@ int bgp_open_option_parse(struct peer_connection *connection, uint16_t length, i
 	}
 
 	/* Extended Message Support */
-	peer->max_packet_size =
-		(CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV)
-		 && CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_ADV))
-			? BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
-			: BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
+	bgp_peer_set_max_packet_size(peer);
 
 	/* Check that roles are corresponding to each other */
 	if (bgp_role_violation(connection))
@@ -1907,6 +1927,12 @@ uint16_t bgp_open_capability(struct stream *s, struct peer_connection *connectio
 
 	/* Extended Message Support */
 	SET_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_ADV);
+	/*
+	 * We have now advertised the capability; refresh the receive/send size
+	 * limit so a passively accepted connection (whose OPEN is built only
+	 * after the peer's OPEN was parsed) is not left at the standard size.
+	 */
+	bgp_peer_set_max_packet_size(peer);
 	stream_putc(s, BGP_OPEN_OPT_CAP);
 	ext_opt_params ? stream_putw(s, CAPABILITY_CODE_EXT_MESSAGE_LEN + 2)
 		       : stream_putc(s, CAPABILITY_CODE_EXT_MESSAGE_LEN + 2);

--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -106,6 +106,7 @@ struct graceful_restart_af {
 
 extern int bgp_open_option_parse(struct peer_connection *connection, uint16_t length,
 				 int *mp_capability);
+extern void bgp_peer_set_max_packet_size(struct peer *peer);
 extern uint16_t bgp_open_capability(struct stream *s, struct peer_connection *connection,
 				    bool ext_opt_params);
 extern void bgp_capability_vty_out(struct vty *vty, struct peer *peer,

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1793,6 +1793,20 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 	uint8_t notify_data_remote_id[4];
 	uint8_t notify_data_holdtime[2];
 
+	/*
+	 * RFC 8654: the Extended Message capability never applies to OPEN.
+	 * An OPEN larger than the standard maximum (4096) is malformed and is
+	 * rejected here regardless of any extended size already negotiated on
+	 * this session, so the receive-path guard in bgp_io.c stays type-blind.
+	 */
+	if (size > BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE - BGP_HEADER_SIZE) {
+		flog_err(EC_BGP_PKT_OPEN,
+			 "%s: OPEN message size (%u bytes) exceeds the standard maximum",
+			 peer->host, (unsigned int)(size + BGP_HEADER_SIZE));
+		bgp_notify_send(connection, BGP_NOTIFY_HEADER_ERR, BGP_NOTIFY_HEADER_BAD_MESLEN);
+		return BGP_Stop;
+	}
+
 	/* Parse open packet. */
 	if (STREAM_READABLE(connection->curr) < BGP_OPEN_BODY_MIN_SIZE) {
 		flog_err(EC_BGP_PKT_OPEN, "%s: OPEN message too short (%zu bytes, need %u)",
@@ -2228,6 +2242,19 @@ static int bgp_open_receive(struct peer_connection *connection, bgp_size_t size)
 static int bgp_keepalive_receive(struct peer_connection *connection, bgp_size_t size)
 {
 	struct peer *peer = connection->peer;
+
+	/*
+	 * RFC 8654: the Extended Message capability never applies to KEEPALIVE,
+	 * which stays capped at the standard maximum (4096) even after an
+	 * extended size has been negotiated for this session.
+	 */
+	if (size > BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE - BGP_HEADER_SIZE) {
+		flog_err(EC_BGP_KEEP_RCV,
+			 "%s: KEEPALIVE message size (%u bytes) exceeds the standard maximum",
+			 peer->host, (unsigned int)(size + BGP_HEADER_SIZE));
+		bgp_notify_send(connection, BGP_NOTIFY_HEADER_ERR, BGP_NOTIFY_HEADER_BAD_MESLEN);
+		return BGP_Stop;
+	}
 
 	if (bgp_debug_keepalive(peer))
 		zlog_debug("%s KEEPALIVE rcvd", peer->host);


### PR DESCRIPTION
The receive path (validate_header() / read_ibuf_work() in bgp_io.c) caps an incoming message at peer->max_packet_size and, when exceeded, drops it with NOTIFICATION Message Header Error / Bad Message Length.

peer->max_packet_size is the *negotiated send* limit: it is set to the extended size (65535) only when the Extended Message capability (RFC 8654) was both advertised and received, it is computed once while parsing the peer's OPEN (bgp_open_option_parse()), and it is never refreshed.  If that value is left at the standard size (4096) on a connection -- e.g. our OPEN had not been built yet when the peer's OPEN was parsed, a state then preserved across collision resolution by peer_xfer_conn() -- it sticks for the life of the session.

RFC 8654 makes the limit asymmetric: a speaker that has advertised the capability MUST be able to *receive* messages up to 65535 octets; the peer's advertisement governs only what we may *send*.  FRR advertises the capability unconditionally, so the receive limit must allow extended-size messages regardless of peer->max_packet_size.  Two FRR speakers that both advertised and received the capability could therefore still tear each other down in a loop once one packed an UPDATE larger than 4096 octets (observed with a 7795-octet add-path UPDATE: NOTIFICATION data 0x1E73).

Use a dedicated, type-aware receive limit: the extended size for every message except OPEN and KEEPALIVE (which RFC 8654 never extends), independent of peer->max_packet_size which remains the send/update-group sizing field.