### PR TITLE
lib: fix admin_group memory leak in link state attribute parse failure

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1432,6 +1432,7 @@ stream_failure:
 	/* Clean memory allocation */
 	if (attr->srlgs != NULL)
 		XFREE(MTYPE_LS_DB, attr->srlgs);
+	admin_group_term(&attr->ext_admin_group);
 	XFREE(MTYPE_LS_DB, attr);
 	return NULL;
 


### PR DESCRIPTION
ls_parse_attributes() calls admin_group_init(&attr->ext_admin_group) at function entry (line 1280) to allocate a bitfield bitmap via bf_init(), which internally calls qcalloc() to allocate heap memory.

When any subsequent STREAM_GET/STREAM_GETL macro detects insufficient data in the stream, control jumps to the stream_failure label. The error path frees attr->srlgs and the attr struct itself, but does not call admin_group_term() to release the bitmap memory allocated by admin_group_init(). This leaks memory on every failed parse.