### PR TITLE
bgpd: fix unaligned pointer cast in bgp_attr_cluster_list()

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2777,13 +2777,18 @@ bgp_attr_cluster_list(struct bgp_attr_parser_args *args)
 	if (peer->discard_attrs[args->type] || peer->withdraw_attrs[args->type])
 		goto cluster_list_ignore;
 
-	bgp_attr_set_cluster(attr, cluster_parse((struct in_addr *)stream_pnt(connection->curr),
-						 length));
+	struct in_addr *cluster_buf = XMALLOC(MTYPE_TMP, length);
 
-	/* XXX: Fix cluster_parse to use stream API and then remove this */
-	stream_forward_getp(connection->curr, length);
+	STREAM_GET(cluster_buf, connection->curr, length);
+	bgp_attr_set_cluster(attr, cluster_parse(cluster_buf, length));
+	XFREE(MTYPE_TMP, cluster_buf);
 
 	return BGP_ATTR_PARSE_PROCEED;
+
+stream_failure:
+	XFREE(MTYPE_TMP, cluster_buf);
+	return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
+				  args->total);
 
 cluster_list_ignore:
 	stream_forward_getp(connection->curr, length);


### PR DESCRIPTION
When parsing the BGP CLUSTER_LIST attribute, the raw stream buffer pointer is directly cast to (struct in_addr *) via stream_pnt():

    cluster_parse((struct in_addr *)stream_pnt(peer->curr), length)

struct in_addr requires 4-byte alignment. The stream buffer pointer, however, depends on the cumulative length of preceding BGP attributes in the UPDATE message. If that cumulative length is not a multiple of 4, stream_pnt() returns an unaligned address.


Fix this by allocating a properly aligned temporary buffer with XMALLOC(), copying the stream data into it with stream_get() (which handles the stream pointer advancement safely), passing the aligned buffer to cluster_parse(), and freeing the temporary buffer.