### PR TITLE
bgpd: register ENCAP and LINK_STATE in attr_flags_values table

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -76,6 +76,7 @@ static const struct message attr_str[] = {
 	{BGP_ATTR_IPV6_EXT_COMMUNITIES, "IPV6_EXT_COMMUNITIES"},
 	{BGP_ATTR_AIGP, "AIGP"},
 	{BGP_ATTR_NHC, "Next Hop Dependent Characteristics"},
+	{BGP_ATTR_LINK_STATE, "BGP-LS Attribute"},
 	{0}};
 
 static const struct message attr_flag_str[] = {
@@ -1935,6 +1936,7 @@ bgp_attr_malformed(struct bgp_attr_parser_args *args, uint8_t subcode,
 	case BGP_ATTR_CLUSTER_LIST:
 	case BGP_ATTR_PMSI_TUNNEL:
 	case BGP_ATTR_ENCAP:
+	case BGP_ATTR_LINK_STATE:
 	case BGP_ATTR_OTC:
 		return BGP_ATTR_PARSE_WITHDRAW;
 	case BGP_ATTR_MP_REACH_NLRI:
@@ -2024,6 +2026,8 @@ const uint8_t attr_flags_values[] = {
 		BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
 	[BGP_ATTR_AIGP] = BGP_ATTR_FLAG_OPTIONAL,
 	[BGP_ATTR_NHC] = BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
+	[BGP_ATTR_ENCAP] = BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
+	[BGP_ATTR_LINK_STATE] = BGP_ATTR_FLAG_OPTIONAL,
 };
 static const size_t attr_flags_values_max = array_size(attr_flags_values) - 1;
 

--- a/tests/topotests/bgp_attr_flag_validation/exabgp.env
+++ b/tests/topotests/bgp_attr_flag_validation/exabgp.env
@@ -1,0 +1,52 @@
+[exabgp.api]
+encoder = text
+highres = false
+respawn = false
+socket = ''
+
+[exabgp.bgp]
+openwait = 60
+
+[exabgp.cache]
+attributes = true
+nexthops = true
+
+[exabgp.daemon]
+daemonize = true
+pid = '/var/run/exabgp/exabgp.pid'
+user = 'exabgp'
+
+[exabgp.log]
+all = false
+configuration = true
+daemon = true
+destination = '/var/log/exabgp.log'
+enable = true
+level = INFO
+message = false
+network = true
+packets = false
+parser = false
+processes = true
+reactor = true
+rib = false
+routes = false
+short = false
+timers = false
+
+[exabgp.pdb]
+enable = false
+
+[exabgp.profile]
+enable = false
+file = ''
+
+[exabgp.reactor]
+speed = 1.0
+
+[exabgp.tcp]
+acl = false
+bind = ''
+delay = 0
+once = false
+port = 179

--- a/tests/topotests/bgp_attr_flag_validation/peer1/exa-send.py
+++ b/tests/topotests/bgp_attr_flag_validation/peer1/exa-send.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: ISC
+#
+# exa-send.py: Dynamic route announcement for BGP attribute flag validation test
+#
+# Phase 1: announce clean routes (no custom attrs) -> should be accepted
+# Phase 2: withdraw clean routes, announce with WRONG flag bits -> treat-as-withdraw
+
+from sys import stdout
+from time import sleep
+
+# Wait for BGP session to establish
+sleep(5)
+
+# Phase 1: Announce clean routes with only mandatory attributes (origin, as-path).
+# These should be accepted and appear in the RIB.
+stdout.write("announce route 192.168.1.1/32 next-hop 10.0.0.2 origin igp as-path [ 65001 ]\n")
+stdout.flush()
+stdout.write("announce route 192.168.2.1/32 next-hop 10.0.0.2 origin igp as-path [ 65001 ]\n")
+stdout.flush()
+
+# Wait for routes to be processed and verified by the test
+sleep(8)
+
+# Phase 2: Withdraw the clean routes
+stdout.write("withdraw route 192.168.1.1/32 next-hop 10.0.0.2 origin igp as-path [ 65001 ]\n")
+stdout.write("withdraw route 192.168.2.1/32 next-hop 10.0.0.2 origin igp as-path [ 65001 ]\n")
+stdout.flush()
+
+sleep(2)
+
+# Re-announce with WRONG flag bits on optional attributes.
+# The flag validation (bgp_attr_flag_invalid) runs before value parsing,
+# so the attribute value encoding doesn't matter — wrong flags are caught first.
+
+# Route 1: ENCAP (type 23) with WRONG flags 0x40 (Transitive only).
+# Correct is 0xC0 (Optional + Transitive). Valid value: type=7(VXLAN), sub-TLV len=0
+stdout.write("announce route 192.168.1.1/32 next-hop 10.0.0.2 origin igp as-path [ 65001 ] attribute [0x17 0x40 0x00070000]\n")
+stdout.flush()
+
+# Route 2: LINK_STATE (type 29) with WRONG flags 0x40 (Transitive bit set).
+# Correct is 0x80 (Optional only). Valid value: TLV type=1024(node-flags), len=1, val=0x00
+stdout.write("announce route 192.168.2.1/32 next-hop 10.0.0.2 origin igp as-path [ 65001 ] attribute [0x1d 0x40 0x0400000100]\n")
+stdout.flush()
+
+# Keep ExaBGP running
+while True:
+    sleep(1)

--- a/tests/topotests/bgp_attr_flag_validation/peer1/exabgp.cfg
+++ b/tests/topotests/bgp_attr_flag_validation/peer1/exabgp.cfg
@@ -1,0 +1,13 @@
+process announce-routes {
+    run /etc/exabgp/exa-send.py;
+    encoder text;
+}
+
+neighbor 10.0.0.1 {
+    router-id 10.0.0.2;
+    local-address 10.0.0.2;
+    local-as 65001;
+    peer-as 65000;
+    capability {graceful-restart;}
+    api {processes [ announce-routes ];}
+}

--- a/tests/topotests/bgp_attr_flag_validation/r1/frr.conf
+++ b/tests/topotests/bgp_attr_flag_validation/r1/frr.conf
@@ -1,0 +1,12 @@
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+ip forwarding
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.2 remote-as external
+ neighbor 10.0.0.2 timers 3 10
+ neighbor 10.0.0.2 timers connect 1
+!

--- a/tests/topotests/bgp_attr_flag_validation/test_bgp_attr_flag_validation.py
+++ b/tests/topotests/bgp_attr_flag_validation/test_bgp_attr_flag_validation.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+Test that BGP validates attribute flag bits (Optional / Transitive / Partial)
+and rejects routes with incorrect flags using treat-as-withdraw.
+
+Per RFC 7606, malformed well-known and core optional attributes trigger
+"treat-as-withdraw": the route is not installed in the RIB, but the BGP
+session stays up.
+
+Validates the fix in bgpd/bgp_attr.c that registers ENCAP (type 23) and
+LINK_STATE (type 29) in attr_flags_values[].
+
+Test flow:
+1. ExaBGP announces routes with CORRECT flags
+2. Verify routes are accepted and in RIB
+3. ExaBGP withdraws correct routes and announces with WRONG flags
+4. Verify routes are treated-as-withdraw (not in RIB)
+5. Verify BGP session stays up
+"""
+
+import os
+import sys
+import json
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    r1 = tgen.add_router("r1")
+    peer1 = tgen.add_exabgp_peer("peer1", ip="10.0.0.2", defaultRoute="via 10.0.0.1")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(r1)
+    switch.add_link(peer1)
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router = tgen.gears["r1"]
+    router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+    router.start()
+
+    peer = tgen.gears["peer1"]
+    peer.start(os.path.join(CWD, "peer1"), os.path.join(CWD, "exabgp.env"))
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_attr_flag_validation():
+    """
+    Test BGP attribute flag validation with dynamic route announcement.
+
+    Phase 1: Announce routes with correct flags - should be accepted
+    Phase 2: Announce routes with wrong flags - should be treat-as-withdraw
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Wait for BGP session to establish
+    def _bgp_converge():
+        output = json.loads(
+            r1.vtysh_cmd("show bgp neighbors 10.0.0.2 json")
+        )
+        expected = {
+            "10.0.0.2": {"bgpState": "Established"}
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "BGP session with peer1 not established"
+
+    # Phase 1: Verify routes with CORRECT flags are accepted
+    # exa-send.py announces these first, then after 8 seconds sends wrong flags
+    prefixes = ["192.168.1.1/32", "192.168.2.1/32"]
+
+    def _bgp_routes_accepted():
+        output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast json"))
+        routes = output.get("routes", {})
+        for p in prefixes:
+            if p not in routes:
+                return "prefix {} not in RIB".format(p)
+        return None
+
+    test_func = functools.partial(_bgp_routes_accepted)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=0.5)
+    assert result is None, (
+        "Routes with correct flags not accepted. Detail: {}".format(result)
+    )
+
+    # Phase 2: After exa-send.py withdraws correct routes and announces wrong flags,
+    # verify routes are treat-as-withdraw (not in RIB)
+    def _bgp_routes_withdrawn():
+        output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast json"))
+        routes = output.get("routes", {})
+        for p in prefixes:
+            if p in routes:
+                return "prefix {} still in RIB".format(p)
+        return None
+
+    test_func = functools.partial(_bgp_routes_withdrawn)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "Routes with malformed flags still in RIB. "
+        "Expected treat-as-withdraw. Detail: {}".format(result)
+    )
+
+    # Final check: BGP session still up
+    output = json.loads(r1.vtysh_cmd("show bgp neighbors 10.0.0.2 json"))
+    state = output.get("10.0.0.2", {}).get("bgpState")
+    assert state == "Established", (
+        "BGP session torn down (state={}), expected treat-as-withdraw".format(state)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
The attr_flags_values array was missing entries for BGP_ATTR_ENCAP (type 23) and BGP_ATTR_LINK_STATE (type 29). Without a registered entry, bgp_attr_flag_invalid() returns false early and skips all flag validation for these attributes, allowing malformed UPDATE messages with incorrect Optional/Transitive bits to be silently accepted instead of generating a NOTIFICATION.

Add:
  - BGP_ATTR_ENCAP: Optional + Transitive (RFC 5512)
  - BGP_ATTR_LINK_STATE: Optional (RFC 7752 Section 3.3.1, RFC 9552 Section 4)