### PR TITLE
bfdd: fix stack buffer overflow in bp_raw_sbfd_red_send()

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -2885,6 +2885,11 @@ static int bp_raw_sbfd_red_send(int sd, uint8_t *data, size_t datalen, uint16_t 
 	struct sockaddr_in6 dst_sin6 = { 0 };
 	char buf_addr[INET6_ADDRSTRLEN] = { 0 };
 
+	if (seg_num > SRV6_MAX_SEGS) {
+		zlog_err("%s: seg_num %u exceeds SRV6_MAX_SEGS", __func__, seg_num);
+		return -1;
+	}
+
 	memset(sendbuf, 0, sizeof(sendbuf));
 	int total_len = 0;
 
@@ -2940,6 +2945,11 @@ static int bp_raw_sbfd_red_send(int sd, uint8_t *data, size_t datalen, uint16_t 
 	}
 
 	/* BFD payload*/
+	if ((size_t)total_len + datalen > sizeof(sendbuf)) {
+		zlog_err("%s: packet too large (%d + %zu > %zu)",
+			 __func__, total_len, datalen, sizeof(sendbuf));
+		return -1;
+	}
 	payload = (uint8_t *)(sendbuf + total_len);
 	memcpy(payload, data, datalen);
 	total_len += datalen;


### PR DESCRIPTION
bp_raw_sbfd_red_send() constructs a raw SRv6-encapsulated BFD packet in a stack-allocated 1024-byte buffer (sendbuf[BUF_SIZ]). The Segment Routing Header (SRH) grows by 16 bytes per segment, and seg_num is a uint8_t parameter (max 255) supplied from the caller without prior validation.

Before this fix, a crafted or misconfigured seg_num value (e.g. 64) would cause the SRH alone to consume ~1064 bytes, exceeding the buffer. The subsequent memcpy() of the BFD payload then writes past the end of sendbuf, corrupting the stack frame — potentially the saved frame pointer, return address, or adjacent local variables.
