### PR TITLE
zebra: remove unused snprintf

### DIFF
--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1055,7 +1055,6 @@ struct zebra_evpn *zebra_evpn_add(vni_t vni)
 	/* Create hash table for MAC */
 	zevpn->mac_table = zebra_mac_db_create(buffer);
 
-	snprintf(buffer, sizeof(buffer), "Zebra EVPN Neighbor Table vni: %u", vni);
 	/* Create hash table for neighbors */
 	zebra_neigh_db_init(zevpn->neigh_table);
 


### PR DESCRIPTION
Commit aa300791cac4e ("zebra: convert `zebra_neigh` hashes to typesafe") replaced a call to zebra_neigh_db_create() by zebra_neigh_db_init(). As a result, the last `snprintf` becomes useless. Let's remove it.