### PR TITLE
ospf6d: fix loopback interface cost

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -892,7 +892,7 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *event)
 	struct ospf6_intra_prefix_lsa *intra_prefix_lsa;
 	struct ospf6_interface *oi;
 	struct ospf6_neighbor *on;
-	struct ospf6_route *route;
+	struct ospf6_route *route, *alt_route;
 	struct ospf6_prefix *op;
 	struct listnode *i, *j;
 	int full_count = 0;
@@ -981,8 +981,16 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *event)
 		     route = ospf6_route_best_next(route)) {
 			if (IS_OSPF6_DEBUG_ORIGINATE(INTRA_PREFIX))
 				zlog_debug("    include %pFX", &route->prefix);
-			ospf6_route_add(ospf6_route_copy(route),
-					route_advertise);
+
+			/* same prefix on different interfaces */
+			alt_route = ospf6_route_lookup(&route->prefix, route_advertise);
+			if (alt_route) {
+				if (ospf6_route_cmp(alt_route, route) > 0) {
+					ospf6_route_remove(alt_route, route_advertise);
+					ospf6_route_add(ospf6_route_copy(route), route_advertise);
+				}
+			} else
+				ospf6_route_add(ospf6_route_copy(route), route_advertise);
 		}
 	}
 


### PR DESCRIPTION
followin creation order we saw the following routes for the same configuration:

dut-vm running config# show ipv6-routes
l3vrf       protocol    summary     table       to          uid
vrf
dut-vm running config# show ipv6-routes
Codes: K - kernel route, C - connected, S - static, R - RIPng,
       O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table, 6 - 6PE, p - SRTE,
       > - selected route, * - FIB route, r - rejected, b - backup

L3VRF default:
O   2001:db8:bb::1/128 [110/10] is directly connected, loop0, weight 1, 00:06:56
C * 2001:db8:bb::1/128 is directly connected, r1r2-2, 00:06:57
C * 2001:db8:bb::1/128 is directly connected, r1r2-1, 00:06:57
C>* 2001:db8:bb::1/128 is directly connected, loop0, 00:07:07
O>* 2001:db8:bb::2/128 [110/20] via fe80::dced:2ff:fe75:75ed, r1r2-1, weight 1, 00:06:50
  *                             via fe80::dced:3ff:fe91:55fd, r1r2-2, weight 1, 00:06:50
C * fe80::/64 is directly connected, r1r2-1, 00:06:56
C * fe80::/64 is directly connected, r1r2-2, 00:06:56
C>* fe80::/64 is directly connected, loop0, 00:07:07
C * fe80::/64 is directly connected, fptun0, 18:25:52
C * fe80::/64 is directly connected, ens3, 18:26:00
C>* fec0::/64 is directly connected, ens3, 18:26:00

and

dut-vm# show ipv6 route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
       t - Table-Direct, p - SR-TE,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

O   2001:db8:bb::1/128 [110/0] is directly connected, loop0, weight 1, 00:00:24
L * 2001:db8:bb::1/128 is directly connected, loop0, 00:00:24
C * 2001:db8:bb::1/128 is directly connected, loop0, 00:00:24
L * 2001:db8:bb::1/128 is directly connected, r1r2-1, 00:00:31
C * 2001:db8:bb::1/128 is directly connected, r1r2-1, 00:00:31
L * 2001:db8:bb::1/128 is directly connected, r1r2-2, 00:00:32
C>* 2001:db8:bb::1/128 is directly connected, r1r2-2, 00:00:32
O>* 2001:db8:bb::2/128 [110/20] via fe80::dced:2ff:fe75:75ed, r1r2-1, weight 1,
00:00:26
  *                             via fe80::dced:3ff:fe91:55fd, r1r2-2, weight 1,
00:00:26
C>* fe80::/64 is directly connected, loop0, 00:00:24
C * fe80::/64 is directly connected, r1r2-2, 00:00:31
C * fe80::/64 is directly connected, r1r2-1, 00:00:31
C * fe80::/64 is directly connected, fptun0, 16:48:31
C * fe80::/64 is directly connected, ens3, 16:48:39
C>* fec0::/64 is directly connected, ens3, 16:48:39
L>* fec0::dcad:deff:fe01:203/128 is directly connected, ens3, 16:48:39

and we see also two different intra LSA(see metric of 10.0.0.1

wrong case

dut-vm# show ipv6 ospf6 database intra-prefix
*                detail           internal         linkstate-id
adv-router       dump             json             self-originated
dut-vm# show ipv6 ospf6 database intra-prefix detail

        Area Scoped Link State Database (Area 0.0.0.0)

Age:  943 Type: Intra-Prefix
Link State ID: 0.0.0.0
Advertising Router: 10.0.0.1
LS Sequence Number: 0x8000000e
CheckSum: 0x901d Length: 52
Duration: 00:15:42
     Number of Prefix: 1
     Reference: Router Id: 0.0.0.0 Adv: 10.0.0.1
     Prefix Options: --|--|--|--|--
     Prefix: 2001:db8:bb::1/128
     Metric: 10

Age:  949 Type: Intra-Prefix
Link State ID: 0.0.0.0
Advertising Router: 10.0.0.2
LS Sequence Number: 0x800000f7
CheckSum: 0xe6d9 Length: 52
Duration: 00:15:42
     Number of Prefix: 1
     Reference: Router Id: 0.0.0.0 Adv: 10.0.0.2
     Prefix Options: --|--|--|--|--
     Prefix: 2001:db8:bb::2/128
     Metric: 10

correct case

dut-vm# show ipv6 ospf6 database intra-prefix detail

        Area Scoped Link State Database (Area 0.0.0.0)

Age:  142 Type: Intra-Prefix
Link State ID: 0.0.0.0
Advertising Router: 10.0.0.1
LS Sequence Number: 0x80000015
CheckSum: 0xcde2 Length: 52
Duration: 00:02:22
     Number of Prefix: 1
     Reference: Router Id: 0.0.0.0 Adv: 10.0.0.1
     Prefix Options: --|--|--|--|--
     Prefix: 2001:db8:bb::1/128
     Metric: 0

Age:  149 Type: Intra-Prefix
Link State ID: 0.0.0.0
Advertising Router: 10.0.0.2
LS Sequence Number: 0x800000fb
CheckSum: 0xdedd Length: 52
Duration: 00:02:23
     Number of Prefix: 1
     Reference: Router Id: 0.0.0.0 Adv: 10.0.0.2
     Prefix Options: --|--|--|--|--
     Prefix: 2001:db8:bb::2/128
     Metric: 10

When adding an intra-area prefix LSA in ospf6_intra_prefix_lsa_add(), the path cost for loopback interfaces needs to be explicitly handled.

This patch introduces a check using if_is_loopback(ifp) to determine if the associated interface is a loopback. If it is, the route's path cost is properly forced to 0 before the nexthop interface is added.

Signed-off-by: Francois Dumontet francois.dumontet@6wind.com