### PR TITLE
ospf6d: log KillNbr adjacency changes on interface down

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -967,7 +967,7 @@ void neighbor_change(struct event *event)
 void interface_down(struct event *event)
 {
 	struct ospf6_interface *oi;
-	struct listnode *node, *nnode;
+	struct listnode *node;
 	struct ospf6_neighbor *on;
 	struct ospf6 *ospf6;
 
@@ -995,10 +995,10 @@ void interface_down(struct event *event)
 			ospf6_gr_helper_exit(nbr, OSPF6_GR_HELPER_TOPO_CHG);
 	}
 
-	for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on))
-		ospf6_neighbor_delete(on);
-
-	list_delete_all_node(oi->neighbor_list);
+	while ((node = listhead(oi->neighbor_list)) != NULL) {
+		on = listgetdata(node);
+		ospf6_neighbor_kill(on);
+	}
 
 	/* When interface state is reset, also reset information about
 	 * DR election, as it is no longer valid. */

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -60,7 +60,7 @@ const char *const ospf6_neighbor_state_str[] = {
 const char *const ospf6_neighbor_event_str[] = {
 	"NoEvent",	"HelloReceived", "2-WayReceived",   "NegotiationDone",
 	"ExchangeDone", "LoadingDone",	 "AdjOK?",	    "SeqNumberMismatch",
-	"BadLSReq",	"1-WayReceived", "InactivityTimer",
+	"BadLSReq",	"1-WayReceived", "KillNbr",	    "InactivityTimer",
 };
 
 int ospf6_neighbor_cmp(void *va, void *vb)
@@ -596,6 +596,26 @@ void oneway_received(struct event *event)
 	event_cancel(&on->thread_adj_ok);
 }
 
+static void ospf6_neighbor_remove(struct ospf6_neighbor *on, int event)
+{
+	on->drouter = on->prev_drouter = 0;
+	on->bdrouter = on->prev_bdrouter = 0;
+
+	ospf6_neighbor_state_change(OSPF6_NEIGHBOR_DOWN, on, event);
+	event_add_event(master, neighbor_change, on->ospf6_if, 0, NULL);
+
+	listnode_delete(on->ospf6_if->neighbor_list, on);
+	ospf6_neighbor_delete(on);
+}
+
+void ospf6_neighbor_kill(struct ospf6_neighbor *on)
+{
+	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
+		zlog_debug("Neighbor Event %s: *KillNbr*", on->name);
+
+	ospf6_neighbor_remove(on, OSPF6_NEIGHBOR_EVENT_KILL_NBR);
+}
+
 void inactivity_timer(struct event *event)
 {
 	struct ospf6_neighbor *on;
@@ -606,21 +626,9 @@ void inactivity_timer(struct event *event)
 	if (IS_OSPF6_DEBUG_NEIGHBOR(EVENT))
 		zlog_debug("Neighbor Event %s: *InactivityTimer*", on->name);
 
-	on->drouter = on->prev_drouter = 0;
-	on->bdrouter = on->prev_bdrouter = 0;
-
-	if (!OSPF6_GR_IS_ACTIVE_HELPER(on)) {
-		on->drouter = on->prev_drouter = 0;
-		on->bdrouter = on->prev_bdrouter = 0;
-
-		ospf6_neighbor_state_change(OSPF6_NEIGHBOR_DOWN, on,
-					    OSPF6_NEIGHBOR_EVENT_INACTIVITY_TIMER);
-		event_add_event(master, neighbor_change, on->ospf6_if, 0, NULL);
-
-		listnode_delete(on->ospf6_if->neighbor_list, on);
-		ospf6_neighbor_delete(on);
-
-	} else {
+	if (!OSPF6_GR_IS_ACTIVE_HELPER(on))
+		ospf6_neighbor_remove(on, OSPF6_NEIGHBOR_EVENT_INACTIVITY_TIMER);
+	else {
 		if (IS_DEBUG_OSPF6_GR)
 			zlog_debug("%s, Acting as HELPER for this neighbour, So restart the dead timer.",
 				   __PRETTY_FUNCTION__);

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -171,8 +171,9 @@ struct ospf6_neighbor {
 #define OSPF6_NEIGHBOR_EVENT_SEQNUMBER_MISMATCH   7
 #define OSPF6_NEIGHBOR_EVENT_BAD_LSREQ            8
 #define OSPF6_NEIGHBOR_EVENT_ONEWAY_RCVD          9
-#define OSPF6_NEIGHBOR_EVENT_INACTIVITY_TIMER    10
-#define OSPF6_NEIGHBOR_EVENT_MAX_EVENT           11
+#define OSPF6_NEIGHBOR_EVENT_KILL_NBR            10
+#define OSPF6_NEIGHBOR_EVENT_INACTIVITY_TIMER    11
+#define OSPF6_NEIGHBOR_EVENT_MAX_EVENT           12
 
 extern const char *const ospf6_neighbor_event_str[];
 
@@ -199,6 +200,7 @@ struct ospf6_neighbor *ospf6_area_neighbor_lookup(struct ospf6_area *area,
 struct ospf6_neighbor *ospf6_neighbor_create(uint32_t router_id,
 					     struct ospf6_interface *oi);
 void ospf6_neighbor_delete(struct ospf6_neighbor *on);
+void ospf6_neighbor_kill(struct ospf6_neighbor *on);
 
 void ospf6_neighbor_lladdr_set(struct ospf6_neighbor *on,
 			       const struct in6_addr *addr);


### PR DESCRIPTION
When an interface is shut down, ospf6d deleted neighbors without transitioning through the neighbor state machine, so log-adjacency-changes never emitted the KillNbr message that ospfd already logs. Add a KillNbr event and use it from interface_down, matching OSPFv2 behavior.

Fixes #22452