### PR TITLE
ospfd: correctly compute size of router LSA links

### DIFF
--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -297,7 +297,7 @@ static void ospf_router_lsa_dump(struct stream *s, uint16_t length)
 	char buf[BUFSIZ];
 	struct router_lsa *rl;
 	struct router_link *rlnk;
-	int i, len, sum;
+	int i;
 
 	rl = (struct router_lsa *)stream_pnt(s);
 
@@ -306,15 +306,15 @@ static void ospf_router_lsa_dump(struct stream *s, uint16_t length)
 		   ospf_router_lsa_flags_dump(rl->flags, buf, BUFSIZ));
 	zlog_debug("    # links %d", ntohs(rl->links));
 
-	len = length - OSPF_LSA_HEADER_SIZE - 4;
 	rlnk = &rl->link[0];
-	sum = 0;
-	for (i = 0; sum < len && rlnk; sum += 12, rlnk = &rl->link[++i]) {
+	for (i = 0; i < ntohs(rl->links); i++) {
 		zlog_debug("    Link ID %pI4", &rlnk->link_id);
 		zlog_debug("    Link Data %pI4", &rlnk->link_data);
 		zlog_debug("    Type %d", (uint8_t)rlnk->type);
 		zlog_debug("    TOS %d", (uint8_t)rlnk->tos);
 		zlog_debug("    metric %d", ntohs(rlnk->metric));
+
+		rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
 	}
 }
 

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -308,17 +308,26 @@ void ospf_gr_restart_enter(struct ospf *ospf,
 }
 
 /* Check if a Router-LSA contains a given link. */
-static bool ospf_router_lsa_contains_adj(struct ospf_lsa *lsa,
-					 struct in_addr *id)
+static bool ospf_router_lsa_contains_adj(const struct ospf_lsa *lsa,
+					 const struct in_addr *id)
 {
-	struct router_lsa *rl;
+	const struct router_lsa *rl;
+	const struct router_link *rlnk;
+	const struct in_addr *link_id;
+	int i;
 
 	rl = (struct router_lsa *)lsa->data;
-	for (int i = 0; i < ntohs(rl->links); i++) {
-		struct in_addr *link_id = &rl->link[i].link_id;
 
-		if (rl->link[i].type != LSA_LINK_TYPE_POINTOPOINT)
+	for (i = 0; i < ntohs(rl->links); i++) {
+		if (i == 0)
+			rlnk = &(rl->link[0]);
+		else
+			rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
+
+		if (rlnk->type != LSA_LINK_TYPE_POINTOPOINT)
 			continue;
+
+		link_id = &rlnk->link_id;
 
 		if (IPV4_ADDR_SAME(id, link_id))
 			return true;
@@ -327,19 +336,29 @@ static bool ospf_router_lsa_contains_adj(struct ospf_lsa *lsa,
 	return false;
 }
 
-static bool ospf_gr_check_router_lsa_consistency(struct ospf *ospf,
-						 struct ospf_area *area,
-						 struct ospf_lsa *lsa)
+static bool ospf_gr_check_router_lsa_consistency(struct ospf *ospf, struct ospf_area *area,
+						 const struct ospf_lsa *lsa)
 {
+	const struct ospf_lsa *lsa_self;
+	const struct ospf_lsa *lsa_adj;
+	const struct router_lsa *rl;
+	const struct router_link *rlnk;
+	const struct in_addr *link_id;
+	int i;
+
 	if (CHECK_FLAG(lsa->flags, OSPF_LSA_SELF)) {
-		struct ospf_lsa *lsa_self = lsa;
-		struct router_lsa *rl = (struct router_lsa *)lsa->data;
+		lsa_self = lsa;
+		rl = (struct router_lsa *)lsa->data;
 
-		for (int i = 0; i < ntohs(rl->links); i++) {
-			struct in_addr *link_id = &rl->link[i].link_id;
-			struct ospf_lsa *lsa_adj;
+		for (i = 0; i < ntohs(rl->links); i++) {
+			if (i == 0)
+				rlnk = &(rl->link[0]);
+			else
+				rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
 
-			if (rl->link[i].type != LSA_LINK_TYPE_POINTOPOINT)
+			link_id = &rlnk->link_id;
+
+			if (rlnk->type != LSA_LINK_TYPE_POINTOPOINT)
 				continue;
 
 			lsa_adj = ospf_lsa_lookup_by_id(area, OSPF_ROUTER_LSA,
@@ -352,8 +371,6 @@ static bool ospf_gr_check_router_lsa_consistency(struct ospf *ospf,
 				return false;
 		}
 	} else {
-		struct ospf_lsa *lsa_self;
-
 		lsa_self = ospf_lsa_lookup_by_id(area, OSPF_ROUTER_LSA,
 						 ospf->router_id);
 		if (!lsa_self
@@ -396,8 +413,8 @@ void ospf_gr_check_lsdb_consistency(struct ospf *ospf, struct ospf_area *area)
 }
 
 /* Lookup neighbor by address in a given OSPF area. */
-static struct ospf_neighbor *
-ospf_area_nbr_lookup_by_addr(struct ospf_area *area, struct in_addr *addr)
+static struct ospf_neighbor *ospf_area_nbr_lookup_by_addr(struct ospf_area *area,
+							  const struct in_addr *addr)
 {
 	struct ospf_interface *oi;
 	struct ospf_neighbor *nbr;
@@ -413,8 +430,8 @@ ospf_area_nbr_lookup_by_addr(struct ospf_area *area, struct in_addr *addr)
 }
 
 /* Lookup neighbor by Router ID in a given OSPF area. */
-static struct ospf_neighbor *
-ospf_area_nbr_lookup_by_routerid(struct ospf_area *area, struct in_addr *id)
+static struct ospf_neighbor *ospf_area_nbr_lookup_by_routerid(struct ospf_area *area,
+							      const struct in_addr *id)
 {
 	struct ospf_interface *oi;
 	struct ospf_neighbor *nbr;
@@ -430,8 +447,7 @@ ospf_area_nbr_lookup_by_routerid(struct ospf_area *area, struct in_addr *id)
 }
 
 /* Check if there's a fully formed adjacency with the given neighbor ID. */
-static bool ospf_gr_check_adj_id(struct ospf_area *area,
-				 struct in_addr *nbr_id)
+static bool ospf_gr_check_adj_id(struct ospf_area *area, const struct in_addr *nbr_id)
 {
 	struct ospf_neighbor *nbr;
 
@@ -447,7 +463,7 @@ static bool ospf_gr_check_adj_id(struct ospf_area *area,
 }
 
 static bool ospf_gr_check_adjs_lsa_transit(struct ospf_area *area,
-					   struct in_addr *link_id)
+					   const struct in_addr *link_id)
 {
 	struct ospf *ospf = area->ospf;
 	struct ospf_interface *oi;
@@ -501,14 +517,22 @@ static bool ospf_gr_check_adjs_lsa_transit(struct ospf_area *area,
 	return true;
 }
 
-static bool ospf_gr_check_adjs_lsa(struct ospf_area *area, struct ospf_lsa *lsa)
+static bool ospf_gr_check_adjs_lsa(struct ospf_area *area, const struct ospf_lsa *lsa)
 {
-	struct router_lsa *rl = (struct router_lsa *)lsa->data;
+	const struct router_lsa *rl = (struct router_lsa *)lsa->data;
+	const struct router_link *rlnk;
+	const struct in_addr *link_id;
+	int i;
 
-	for (int i = 0; i < ntohs(rl->links); i++) {
-		struct in_addr *link_id = &rl->link[i].link_id;
+	for (i = 0; i < ntohs(rl->links); i++) {
+		if (i == 0)
+			rlnk = &(rl->link[0]);
+		else
+			rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
 
-		switch (rl->link[i].type) {
+		link_id = &rlnk->link_id;
+
+		switch (rlnk->type) {
 		case LSA_LINK_TYPE_POINTOPOINT:
 			if (!ospf_gr_check_adj_id(area, link_id))
 				return false;

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1160,9 +1160,11 @@ static int ospf_vl_set_params(struct ospf_area *area,
 	struct ospf_interface *voi;
 	struct listnode *node;
 	struct vertex_parent *vp = NULL;
-	unsigned int i;
+	int i;
 	struct router_lsa *rl;
 	struct ospf_interface *oi;
+	const struct router_link *rlnk;
+	bool found_p;
 
 	voi = vl_data->vl_oi;
 
@@ -1196,24 +1198,42 @@ static int ospf_vl_set_params(struct ospf_area *area,
 	}
 
 	rl = (struct router_lsa *)v->lsa;
+	rlnk = NULL;
 
 	/* use SPF determined backlink index in struct vertex
 	 * for virtual link destination address
 	 */
 	if (vp && vp->backlink >= 0) {
-		if (!IPV4_ADDR_SAME(&vl_data->peer_addr,
-				    &rl->link[vp->backlink].link_data))
-			changed = 1;
-		vl_data->peer_addr = rl->link[vp->backlink].link_data;
-	} else {
+		/* Note that the links may have a variable-length area, so we cannot
+		 * just index into an array.
+		 */
+		for (i = 0; i < ntohs(rl->links); i++) {
+			if (i == 0)
+				rlnk = &(rl->link[0]);
+			else
+				rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
+
+			if (i == vp->backlink)
+				break;
+		}
+	}
+
+	if (rlnk == NULL) {
 		/* This is highly odd, there is no backlink index
 		 * there should be due to the ospf_spf_has_link() check
-		 * in SPF. Lets warn and try pick a link anyway.
+		 * in SPF. Lets warn and try to pick a link anyway.
 		 */
 		zlog_info("ospf_vl_set_params: No backlink for %s!",
 			  vl_data->vl_oi->ifp->name);
+
+		found_p = false;
 		for (i = 0; i < ntohs(rl->links); i++) {
-			switch (rl->link[i].type) {
+			if (i == 0)
+				rlnk = &(rl->link[0]);
+			else
+				rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
+
+			switch (rlnk->type) {
 			case LSA_LINK_TYPE_VIRTUALLINK:
 				if (IS_DEBUG_OSPF_EVENT)
 					zlog_debug(
@@ -1221,12 +1241,22 @@ static int ospf_vl_set_params(struct ospf_area *area,
 				fallthrough;
 			case LSA_LINK_TYPE_TRANSIT:
 			case LSA_LINK_TYPE_POINTOPOINT:
-				if (!IPV4_ADDR_SAME(&vl_data->peer_addr,
-						    &rl->link[i].link_data))
-					changed = 1;
-				vl_data->peer_addr = rl->link[i].link_data;
+				found_p = true;
+				break;
 			}
+
+			if (found_p)
+				break;
 		}
+
+		if (!found_p)
+			rlnk = NULL;
+	}
+
+	if (rlnk) {
+		if (!IPV4_ADDR_SAME(&vl_data->peer_addr, &rlnk->link_data))
+			changed = 1;
+		vl_data->peer_addr = rlnk->link_data;
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -167,6 +167,14 @@ struct router_lsa {
 	} link[1];
 };
 
+/* Next link after 'l' in a router_lsa */
+#define OSPF_ROUTER_LINK_NEXT(l)                                               \
+	((void *)((uint8_t *)(l) + OSPF_ROUTER_LSA_LINK_SIZE + ((l)->tos * 4)))
+
+/* Len of router_lsa_link 'l', including variable part */
+#define OSPF_ROUTER_LSA_LINK_LEN(l)                                            \
+	(OSPF_ROUTER_LSA_LINK_SIZE + ((l)->m[0].tos_count * 4))
+
 /* OSPF Network-LSAs structure. */
 #define OSPF_NETWORK_LSA_MIN_SIZE                  8U /* w/1 router-ID */
 struct network_lsa {

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -331,7 +331,7 @@ int ospf_nbr_count_opaque_capable(struct ospf_interface *oi)
  * with virtual link and PointToPoint neighbours
  */
 struct ospf_neighbor *ospf_nbr_lookup_by_addr(struct route_table *nbrs,
-					      struct in_addr *addr)
+					      const struct in_addr *addr)
 {
 	struct prefix p;
 	struct route_node *rn;
@@ -360,7 +360,7 @@ struct ospf_neighbor *ospf_nbr_lookup_by_addr(struct route_table *nbrs,
 }
 
 struct ospf_neighbor *ospf_nbr_lookup_by_routerid(struct route_table *nbrs,
-						  struct in_addr *id)
+						  const struct in_addr *id)
 {
 	struct route_node *rn;
 	struct ospf_neighbor *nbr;

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -103,8 +103,8 @@ extern struct ospf_neighbor *ospf_qnbr_get(struct ospf_interface *oi, struct in_
 extern struct ospf_neighbor *ospf_nbr_lookup(struct ospf_interface *oi, struct ip *iph,
 					     struct ospf_header *ospfh);
 extern struct ospf_neighbor *ospf_nbr_lookup_by_addr(struct route_table *nbrs,
-						     struct in_addr *addr);
+						     const struct in_addr *addr);
 extern struct ospf_neighbor *ospf_nbr_lookup_by_routerid(struct route_table *nbrs,
-							 struct in_addr *id);
+							 const struct in_addr *id);
 extern void ospf_renegotiate_optional_capabilities(struct ospf *top);
 #endif /* _ZEBRA_OSPF_NEIGHBOR_H */

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2462,15 +2462,14 @@ static unsigned ospf_router_lsa_links_examin(struct router_lsa_link *link,
 	unsigned counted_links = 0, thislinklen;
 
 	while (linkbytes >= OSPF_ROUTER_LSA_LINK_SIZE) {
-		thislinklen =
-			OSPF_ROUTER_LSA_LINK_SIZE + 4 * link->m[0].tos_count;
+		thislinklen = OSPF_ROUTER_LSA_LINK_LEN(link);
 		if (thislinklen > linkbytes) {
 			if (IS_DEBUG_OSPF_PACKET(0, RECV))
 				zlog_debug("%s: length error in link block #%u",
 					   __func__, counted_links);
 			return MSG_NG;
 		}
-		link = (struct router_lsa_link *)((caddr_t)link + thislinklen);
+		link = (struct router_lsa_link *)((uint8_t *)link + thislinklen);
 		linkbytes -= thislinklen;
 		counted_links++;
 	}

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -558,6 +558,7 @@ static int ospf_lsa_has_link(struct lsa_header *w, struct lsa_header *v)
 	unsigned int i, length;
 	struct router_lsa *rl;
 	struct network_lsa *nl;
+	struct router_link *rlnk;
 
 	/* In case of W is Network LSA. */
 	if (w->type == OSPF_NETWORK_LSA) {
@@ -577,37 +578,35 @@ static int ospf_lsa_has_link(struct lsa_header *w, struct lsa_header *v)
 	if (w->type == OSPF_ROUTER_LSA) {
 		rl = (struct router_lsa *)w;
 
-		length = ntohs(w->length);
+		rlnk = &(rl->link[0]);
 
-		for (i = 0; i < ntohs(rl->links)
-			    && length >= sizeof(struct router_lsa);
-		     i++, length -= 12) {
-			switch (rl->link[i].type) {
+		for (i = 0; i < ntohs(rl->links); i++) {
+			switch (rlnk->type) {
 			case LSA_LINK_TYPE_POINTOPOINT:
 			case LSA_LINK_TYPE_VIRTUALLINK:
 				/* Router LSA ID. */
-				if (v->type == OSPF_ROUTER_LSA
-				    && IPV4_ADDR_SAME(&rl->link[i].link_id,
-						      &v->id)) {
+				if (v->type == OSPF_ROUTER_LSA &&
+				    IPV4_ADDR_SAME(&rlnk->link_id, &v->id))
 					return i;
-				}
 				break;
 			case LSA_LINK_TYPE_TRANSIT:
 				/* Network LSA ID. */
-				if (v->type == OSPF_NETWORK_LSA
-				    && IPV4_ADDR_SAME(&rl->link[i].link_id,
-						      &v->id)) {
+				if (v->type == OSPF_NETWORK_LSA &&
+				    IPV4_ADDR_SAME(&rlnk->link_id, &v->id))
 					return i;
-				}
 				break;
 			case LSA_LINK_TYPE_STUB:
 				/* Stub can't lead anywhere, carry on */
-				continue;
+				break;
 			default:
 				break;
 			}
+
+			/* Advance router_link pointer */
+			rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
 		}
 	}
+
 	return -1;
 }
 

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1873,10 +1873,11 @@ static void ospf_te_delete_subnet(struct ls_ted *ted, struct in_addr addr)
  */
 static int ospf_te_parse_router_lsa(struct ls_ted *ted, struct ospf_lsa *lsa)
 {
-	struct router_lsa *rl;
+	const struct router_lsa *rl;
+	const struct router_link *rlnk;
 	enum ls_node_type type;
 	struct ls_vertex *vertex;
-	int len, links;
+	int i, len, links;
 
 	/* Sanity Check */
 	if (!ted || !lsa || !lsa->data)
@@ -1920,34 +1921,41 @@ static int ospf_te_parse_router_lsa(struct ls_ted *ted, struct ospf_lsa *lsa)
 	/* Then, process Link Information */
 	len = lsa->size - OSPF_LSA_HEADER_SIZE - OSPF_ROUTER_LSA_MIN_SIZE;
 	links = ntohs(rl->links);
-	for (int i = 0; i < links && len > 0; len -= 12, i++) {
+	for (i = 0; i < links && len > 0; i++) {
 		struct prefix p;
 		uint32_t metric;
 
-		switch (rl->link[i].type) {
+		if (i == 0)
+			rlnk = &(rl->link[0]);
+		else
+			rlnk = OSPF_ROUTER_LINK_NEXT(rlnk);
+
+		switch (rlnk->type) {
 		case LSA_LINK_TYPE_POINTOPOINT:
-			ospf_te_update_link(ted, vertex, rl->link[i].link_data,
-					    ntohs(rl->link[i].metric));
+			ospf_te_update_link(ted, vertex, rlnk->link_data,
+					    ntohs(rlnk->metric));
 			/* Add corresponding subnet */
 			p.family = AF_INET;
 			p.prefixlen = IPV4_MAX_BITLEN;
-			p.u.prefix4 = rl->link[i].link_data;
-			metric = ntohs(rl->link[i].metric);
+			p.u.prefix4 = rlnk->link_data;
+			metric = ntohs(rlnk->metric);
 			ospf_te_update_subnet(ted, vertex, &p, metric);
 			break;
 		case LSA_LINK_TYPE_STUB:
 			/* Keep only /32 prefix */
-			p.prefixlen = ip_masklen(rl->link[i].link_data);
+			p.prefixlen = ip_masklen(rlnk->link_data);
 			if (p.prefixlen == IPV4_MAX_BITLEN) {
 				p.family = AF_INET;
-				p.u.prefix4 = rl->link[i].link_id;
-				metric = ntohs(rl->link[i].metric);
+				p.u.prefix4 = rlnk->link_id;
+				metric = ntohs(rlnk->metric);
 				ospf_te_update_subnet(ted, vertex, &p, metric);
 			}
 			break;
 		default:
 			break;
 		}
+
+		len -= (OSPF_ROUTER_LSA_LINK_SIZE + (rlnk->tos * 4));
 	}
 
 	return 0;


### PR DESCRIPTION
The router-LSA can contain a series of link objects; those objects' sizes can vary, based on the presence or absence of TOS information. When iterating through the links in an LSA, use the correct size in computing the number of octets to advance. I've added a macro that will capture that computation, and found the places that need to be fixed (I hope).

Ospf actually has two slightly different structs that represent the link portion of the LSA, and that adds to the confusion. I haven't tried to do anything about that here.
