### PR TITLE
pimd: fix elected BSR not updating when priority changes

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -2086,8 +2086,16 @@ static void pim_cand_bsr_trigger(struct bsm_scope *scope, bool verbose)
 		return;
 	}
 
-	if (!pim_addr_cmp(scope->current_bsr, scope->bsr_addrsel.run_addr))
+	if (!pim_addr_cmp(scope->current_bsr, scope->bsr_addrsel.run_addr)) {
+		/* We are the current BSR. If our priority changed, update and
+		 * regenerate BSM immediately.
+		 */
+		if (scope->state == BSR_ELECTED && scope->current_bsr_prio != scope->cand_bsr_prio) {
+			scope->current_bsr_prio = scope->cand_bsr_prio;
+			pim_bsm_generate(scope);
+		}
 		return;
+	}
 
 	pim_cand_bsr_pending(scope);
 }

--- a/tests/topotests/pim_cand_rp_bsr/test_pim_cand_rp_bsr.py
+++ b/tests/topotests/pim_cand_rp_bsr/test_pim_cand_rp_bsr.py
@@ -347,6 +347,55 @@ def test_pim_bsr_priority_modify(request):
     assert result is None, assertmsg
 
 
+def test_pim_elected_bsr_priority_change(request):
+    "Test elected BSR can change its own priority"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    r2 = tgen.gears["r2"]
+
+    # r2 is already BSR_ELECTED with priority 250 from test_pim_bsr_priority_modify.
+    # Raise its priority and verify the change takes effect immediately.
+    step("Raise elected BSR r2's priority to 255")
+    r2.vtysh_cmd(
+        """
+        configure
+          router pim
+            bsr candidate-bsr priority 255
+        """
+    )
+
+    step("Verify r2's BSR priority is updated to 255")
+    expected = {
+        "bsr": "10.0.0.2",
+        "priority": 255,
+        "state": "BSR_ELECTED",
+    }
+
+    test_func = partial(topotest.router_json_cmp, r2, "show ip pim bsr json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+
+    assertmsg = "r2: elected BSR priority change did not take effect"
+    assert result is None, assertmsg
+
+    step("Verify r1 receives BSM with updated priority 255")
+    r1 = tgen.gears["r1"]
+    expected = {
+        "bsr": "10.0.0.2",
+        "priority": 255,
+    }
+
+    test_func = partial(topotest.router_json_cmp, r1, "show ip pim bsr json", expected)
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=1)
+
+    assertmsg = "r1: did not receive BSM with updated priority from r2"
+    assert result is None, assertmsg
+
+
 def test_pim_bsr_election_fallback_r2(request):
     "Test PIM BSR Election Backup"
     tgen = get_topogen()
@@ -378,10 +427,10 @@ def test_pim_bsr_election_fallback_r2(request):
     assert result is None, assertmsg
 
     r2 = tgen.gears["r2"]
-    # r2 became BSR earlier after its priority was raised to 250
+    # r2 became BSR earlier after its priority was raised to 255
     expected = {
         "bsr": "10.0.0.2",
-        "priority": 250,
+        "priority": 255,
         "state": "BSR_ELECTED",
     }
 


### PR DESCRIPTION
When the elected BSR changes its own priority, the change was silently
ignored. This happened because pim_cand_bsr_trigger() returned early
when current_bsr matched our own address, without checking if the
priority had changed.

Fix by updating current_bsr_prio and regenerating BSM immediately when
the elected BSR's priority changes.