### PR TITLE
pimd: fix NOCACHE forwarding for non-connected sources and static mroute upcalls

### DIFF
--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -70,8 +70,8 @@ void pim_ifassert_winner_set(struct pim_ifchannel *ch,
 		if (winner_changed) {
 			old_rpf.source_nexthop.interface =
 				ch->upstream->rpf.source_nexthop.interface;
-			rpf_result = pim_rpf_update(pim_ifp->pim, ch->upstream,
-						    &old_rpf, __func__);
+			rpf_result = pim_rpf_update(pim_ifp->pim, ch->upstream, &old_rpf, NULL,
+						    __func__);
 			if (rpf_result == PIM_RPF_CHANGED ||
 			    (rpf_result == PIM_RPF_FAILURE &&
 			     old_rpf.source_nexthop.interface))

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3023,7 +3023,7 @@ int pim_show_nexthop_lookup_cmd_helper(const char *vrf, struct vty *vty,
 	pim_addr_to_prefix(&grp, group);
 	memset(&nexthop, 0, sizeof(nexthop));
 
-	if (!pim_nht_lookup_ecmp(v->info, &nexthop, vif_source, &grp, false)) {
+	if (!pim_nht_lookup_ecmp(v->info, &nexthop, vif_source, &grp, false, NULL)) {
 		vty_out(vty, "(%pPAs, %pPA) --- Nexthop Lookup failed, no usable routes returned.\n",
 			&source, &group);
 		return CMD_SUCCESS;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -179,6 +179,58 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 static const char *const gmmsgtype2str[GMMSG_WRVIFWHOLE + 1] = {
 	"<unknown_upcall?>", "NOCACHE", "WRONGVIF", "WHOLEPKT", "WRVIFWHOLE"};
 
+/*
+ * RFC 4601 section 4.2: on NOCACHE, forward using existing (S,G) state when
+ * iif == RPF_interface(S) and local receivers exist.  Register encapsulation
+ * requires DirectlyConnected(S) at the DR and is handled elsewhere.
+ */
+static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgaddr *sg)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_instance *pim = pim_ifp->pim;
+	struct pim_upstream *up;
+
+	up = pim_upstream_find(pim, sg);
+	if (!up)
+		return;
+
+	if (!up->rpf.source_nexthop.interface ||
+	    up->rpf.source_nexthop.interface->ifindex != ifp->ifindex) {
+		if (PIM_DEBUG_MROUTE_DETAIL)
+			zlog_debug("%s: %pSG NOCACHE on %s, RPF interface is %s", __func__, sg,
+				   ifp->name,
+				   up->rpf.source_nexthop.interface ? up->rpf.source_nexthop
+									      .interface->name
+								    : "(none)");
+		return;
+	}
+
+	pim_upstream_inherited_olist_decide(pim, up);
+	if (pim_upstream_empty_inherited_olist(up)) {
+		if (PIM_DEBUG_MROUTE_DETAIL)
+			zlog_debug("%s: %pSG NOCACHE on %s, no local receivers", __func__, sg,
+				   ifp->name);
+		return;
+	}
+
+	if (up->sptbit != PIM_UPSTREAM_SPTBIT_TRUE)
+		pim_upstream_set_sptbit(up, ifp);
+
+	PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
+	up->channel_oil->cc.pktcnt++;
+
+	if (up->rpf.source_nexthop.interface && *oil_incoming_vif(up->channel_oil) >= MAXVIFS)
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+
+	pim_upstream_update_join_desired(pim, up);
+
+	if (pim_upstream_kat_start_ok(up))
+		pim_upstream_keep_alive_timer_start(up, pim->keep_alive_time);
+
+	if (!up->channel_oil->installed)
+		pim_upstream_mroute_add(up->channel_oil, __func__);
+}
+
 int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 {
 	struct pim_interface *pim_ifp = ifp->info;
@@ -386,15 +438,12 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 
 	/* All further processing is for SSM or SM with an RP only */
 
-
-	/*
-	 * If we've received a multicast packet that isn't connected to us
-	 */
 	if (!pim_if_connected_to_source(ifp, msg->msg_im_src)) {
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
 				"%s: incoming packet to %pSG from non-connected source",
 				ifp->name, &sg);
+		pim_mroute_nocache_forward_existing(ifp, &sg);
 		return 0;
 	}
 

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -20,6 +20,7 @@
 
 #include "pimd.h"
 #include "pim_rpf.h"
+#include "pim_zebra.h"
 #include "pim_mroute.h"
 #include "pim_oil.h"
 #include "pim_str.h"
@@ -41,6 +42,7 @@
 #include "pim_state_refresh.h"
 #include "pim_util.h"
 #include "pim_nht.h"
+#include "pim_static.h"
 #include "pim_upstream.h"
 
 static void mroute_read_on(struct pim_instance *pim);
@@ -189,20 +191,46 @@ static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgadd
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_instance *pim = pim_ifp->pim;
 	struct pim_upstream *up;
+	struct pim_nexthop rpf_nh;
+	struct prefix grp;
+	struct pim_rpf old;
 
 	up = pim_upstream_find(pim, sg);
 	if (!up)
 		return;
 
-	if (!up->rpf.source_nexthop.interface ||
-	    up->rpf.source_nexthop.interface->ifindex != ifp->ifindex) {
+	memset(&rpf_nh, 0, sizeof(rpf_nh));
+	pim_addr_to_prefix(&grp, sg->grp);
+
+	/*
+	 * Live RPF lookup honors MRIB static routes (ip mroute PREFIX NEXTHOP)
+	 * instead of stale upstream RPF cached from URIB-only resolution.
+	 */
+	if (!pim_nht_lookup_ecmp(pim, &rpf_nh, sg->src, &grp, false)) {
+		if (PIM_DEBUG_MROUTE_DETAIL)
+			zlog_debug("%s: %pSG NOCACHE on %s, no RPF route to source", __func__, sg,
+				   ifp->name);
+		return;
+	}
+
+	if (!rpf_nh.interface || rpf_nh.interface->ifindex != ifp->ifindex) {
 		if (PIM_DEBUG_MROUTE_DETAIL)
 			zlog_debug("%s: %pSG NOCACHE on %s, RPF interface is %s", __func__, sg,
-				   ifp->name,
-				   up->rpf.source_nexthop.interface ? up->rpf.source_nexthop
-									      .interface->name
-								    : "(none)");
+				   ifp->name, rpf_nh.interface ? rpf_nh.interface->name : "(none)");
 		return;
+	}
+
+	if (up->rpf.source_nexthop.interface != rpf_nh.interface ||
+	    pim_addr_cmp(up->rpf.source_nexthop.mrib_nexthop_addr, rpf_nh.mrib_nexthop_addr)) {
+		enum pim_rpf_result rpf_result;
+
+		memset(&old, 0, sizeof(old));
+		rpf_result = pim_rpf_update(pim, up, &old, __func__);
+		if (rpf_result == PIM_RPF_CHANGED)
+			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+		if (rpf_result == PIM_RPF_CHANGED ||
+		    (rpf_result == PIM_RPF_FAILURE && old.source_nexthop.interface))
+			pim_zebra_upstream_rpf_changed(pim, up, &old);
 	}
 
 	pim_upstream_inherited_olist_decide(pim, up);
@@ -219,9 +247,6 @@ static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgadd
 	PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
 	up->channel_oil->cc.pktcnt++;
 
-	if (up->rpf.source_nexthop.interface && *oil_incoming_vif(up->channel_oil) >= MAXVIFS)
-		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
-
 	pim_upstream_update_join_desired(pim, up);
 
 	if (pim_upstream_kat_start_ok(up))
@@ -229,6 +254,8 @@ static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgadd
 
 	if (!up->channel_oil->installed)
 		pim_upstream_mroute_add(up->channel_oil, __func__);
+	else
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 }
 
 int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
@@ -257,6 +284,13 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 				&sg);
 		return 0;
 	}
+
+	/*
+	 * "ip mroute OIF GROUP [SOURCE]" on this interface (ingress/IIF).
+	 * Static MFC overrides PIM dense/sparse NOCACHE handling.
+	 */
+	if (pim_static_nocache_resolve(pim_ifp->pim, ifp, &sg) != 1)
+		return 0;
 
 	if (!pim_is_grp_ssm(pim_ifp->pim, sg.grp)) {
 		/* for ASM, check that we have enough information (i.e. path
@@ -835,6 +869,9 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 				__func__, &sg, ifp->name);
 		return -2;
 	}
+
+	if (pim_static_nocache_resolve(pim_ifp->pim, ifp, &sg) != 1)
+		return 0;
 
 	pim_ifchannel_find(ifp, &sg, &ch, &throwaway);
 	if (ch) {

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -205,8 +205,10 @@ static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgadd
 	/*
 	 * Live RPF lookup honors MRIB static routes (ip mroute PREFIX NEXTHOP)
 	 * instead of stale upstream RPF cached from URIB-only resolution.
+	 * Prefer the kernel ingress interface when it is a valid nexthop (e.g.
+	 * tunnel vs underlying WAN with duplicate addressing).
 	 */
-	if (!pim_nht_lookup_ecmp(pim, &rpf_nh, sg->src, &grp, false)) {
+	if (!pim_nht_lookup_ecmp(pim, &rpf_nh, sg->src, &grp, false, ifp)) {
 		if (PIM_DEBUG_MROUTE_DETAIL)
 			zlog_debug("%s: %pSG NOCACHE on %s, no RPF route to source", __func__, sg,
 				   ifp->name);
@@ -225,9 +227,7 @@ static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgadd
 		enum pim_rpf_result rpf_result;
 
 		memset(&old, 0, sizeof(old));
-		rpf_result = pim_rpf_update(pim, up, &old, __func__);
-		if (rpf_result == PIM_RPF_CHANGED)
-			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+		rpf_result = pim_rpf_update(pim, up, &old, ifp, __func__);
 		if (rpf_result == PIM_RPF_CHANGED ||
 		    (rpf_result == PIM_RPF_FAILURE && old.source_nexthop.interface))
 			pim_zebra_upstream_rpf_changed(pim, up, &old);
@@ -252,10 +252,7 @@ static void pim_mroute_nocache_forward_existing(struct interface *ifp, pim_sgadd
 	if (pim_upstream_kat_start_ok(up))
 		pim_upstream_keep_alive_timer_start(up, pim->keep_alive_time);
 
-	if (!up->channel_oil->installed)
-		pim_upstream_mroute_add(up->channel_oil, __func__);
-	else
-		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+	pim_upstream_mroute_add(up->channel_oil, __func__);
 }
 
 int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -929,7 +929,7 @@ static void pim_update_rp_nh(struct pim_instance *pim,
 		ifp = rp_info->rp.source_nexthop.interface;
 		// Compute PIM RPF using cached nexthop
 		if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, rp_info->rp.rpf_addr,
-					 &rp_info->group, true))
+					 &rp_info->group, true, NULL))
 			pim_nht_rp_del(rp_info);
 
 		/*
@@ -953,7 +953,7 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 	struct pim_rpf old;
 
 	old.source_nexthop.interface = up->rpf.source_nexthop.interface;
-	rpf_result = pim_rpf_update(pim, up, &old, __func__);
+	rpf_result = pim_rpf_update(pim, up, &old, NULL, __func__);
 
 	/* update kernel multicast forwarding cache (MFC); if the
 	 * RPF nbr is now unreachable the MFC has already been updated
@@ -1059,9 +1059,88 @@ static uint32_t pim_compute_ecmp_hash(struct prefix *src, struct prefix *grp)
 	return hash_val;
 }
 
+static bool pim_nht_nexthop_accept(struct pim_instance *pim, struct interface *ifp, pim_addr src,
+				   bool neighbor_needed, pim_addr *nh_gate,
+				   struct pim_neighbor **nbr_out)
+{
+	struct pim_interface *pim_ifp;
+	struct pim_neighbor *nbr = NULL;
+
+	if (!ifp)
+		return false;
+
+	pim_ifp = ifp->info;
+	if (!pim_ifp || !pim_ifp->pim_enable)
+		return false;
+
+	if (neighbor_needed && !pim_if_connected_to_source(ifp, src)) {
+		if (pim_addr_is_any(*nh_gate)) {
+			struct pim_neighbor *fresh_nbr = pim_neighbor_find_if(ifp);
+
+			if (fresh_nbr)
+				*nh_gate = fresh_nbr->source_addr;
+		}
+
+		nbr = pim_neighbor_find(ifp, *nh_gate, true);
+		if (!nbr && !if_is_loopback(ifp))
+			return false;
+	}
+
+	if (nbr_out)
+		*nbr_out = nbr;
+	return true;
+}
+
+static void pim_nht_nexthop_assign(struct pim_nexthop *nexthop, pim_addr src,
+				   struct interface *ifp, pim_addr nh_gate, uint32_t distance,
+				   uint32_t metric, struct pim_neighbor *nbr)
+{
+	nexthop->interface = ifp;
+	nexthop->mrib_nexthop_addr = nh_gate;
+	nexthop->mrib_metric_preference = distance;
+	nexthop->mrib_route_metric = metric;
+	nexthop->last_lookup = src;
+	nexthop->last_lookup_time = pim_time_monotonic_usec();
+	nexthop->nbr = nbr;
+}
+
+static bool pim_nht_nexthop_prefer_ingress(struct pim_instance *pim, struct pim_nexthop *nexthop,
+					   pim_addr src, bool neighbor_needed,
+					   struct interface *ingress_ifp,
+					   struct zclient_next_hop_args *args, int num_ifindex)
+{
+	int i;
+
+	if (!ingress_ifp)
+		return false;
+
+	for (i = 0; i < num_ifindex; i++) {
+		struct interface *ifp;
+		pim_addr nh_gate = args->next_hops[i].nexthop_addr;
+		struct pim_neighbor *nbr = NULL;
+
+		if (args->next_hops[i].ifindex != ingress_ifp->ifindex)
+			continue;
+
+		ifp = if_lookup_by_index(args->next_hops[i].ifindex, pim->vrf->vrf_id);
+		if (!pim_nht_nexthop_accept(pim, ifp, src, neighbor_needed, &nh_gate, &nbr))
+			continue;
+
+		pim_nht_nexthop_assign(nexthop, src, ifp, nh_gate,
+				       args->next_hops[i].protocol_distance,
+				       args->next_hops[i].route_metric, nbr);
+		if (PIM_DEBUG_PIM_NHT)
+			zlog_debug("%s: prefer ingress %s for %pPA(%s)", __func__, ifp->name, &src,
+				   pim->vrf->name);
+		return true;
+	}
+
+	return false;
+}
+
 static bool pim_ecmp_nexthop_search(struct pim_instance *pim, struct pim_nexthop_cache *pnc,
 				    struct pim_nexthop *nexthop, pim_addr src, struct prefix *grp,
-				    bool neighbor_needed)
+				    bool neighbor_needed, struct interface *ingress_ifp)
 {
 	struct nexthop *nh_node = NULL;
 	uint32_t hash_val = 0;
@@ -1083,6 +1162,40 @@ static bool pim_ecmp_nexthop_search(struct pim_instance *pim, struct pim_nexthop
 	nh_addr = nexthop->mrib_nexthop_addr;
 	grp_addr = pim_addr_from_prefix(grp);
 	rib = pim_pnc_get_rib(pim, pnc, group);
+
+	if (ingress_ifp) {
+		for (nh_node = rib->nexthop; nh_node; nh_node = nh_node->next) {
+			struct interface *ifp;
+			struct pim_neighbor *nbr = NULL;
+#if PIM_IPV == 4
+			pim_addr nh_gate = nh_node->gate.ipv4;
+#else
+			pim_addr nh_gate = nh_node->gate.ipv6;
+#endif
+
+			if (nh_node->ifindex != ingress_ifp->ifindex)
+				continue;
+
+			ifp = if_lookup_by_index(nh_node->ifindex, pim->vrf->vrf_id);
+			if (!pim_nht_nexthop_accept(pim, ifp, src, neighbor_needed, &nh_gate, &nbr))
+				continue;
+
+#if PIM_IPV == 4
+			if (pim_addr_cmp(nh_node->gate.ipv4, nh_gate))
+				nh_node->gate.ipv4 = nh_gate;
+#else
+			if (pim_addr_cmp(nh_node->gate.ipv6, nh_gate))
+				nh_node->gate.ipv6 = nh_gate;
+#endif
+
+			pim_nht_nexthop_assign(nexthop, src, ifp, nh_gate, rib->distance,
+					       rib->metric, nbr);
+			if (PIM_DEBUG_PIM_NHT)
+				zlog_debug("%s: prefer ingress %s for %pPA(%s)", __func__,
+					   ifp->name, &src, pim->vrf->name);
+			return true;
+		}
+	}
 
 	/* Current Nexthop is VALID, check to stay on the current path. */
 	if (nexthop->interface && nexthop->interface->info &&
@@ -1277,7 +1390,7 @@ static bool pim_ecmp_nexthop_search(struct pim_instance *pim, struct pim_nexthop
 }
 
 bool pim_nht_lookup_ecmp(struct pim_instance *pim, struct pim_nexthop *nexthop, pim_addr src,
-			 struct prefix *grp, bool neighbor_needed)
+			 struct prefix *grp, bool neighbor_needed, struct interface *ingress_ifp)
 {
 	struct pim_nexthop_cache *pnc;
 	int num_ifindex;
@@ -1306,7 +1419,8 @@ bool pim_nht_lookup_ecmp(struct pim_instance *pim, struct pim_nexthop *nexthop, 
 	pnc = pim_nexthop_cache_find(pim, src);
 	if (pnc) {
 		if (pim_nht_pnc_has_answer(pim, pnc, group))
-			return pim_ecmp_nexthop_search(pim, pnc, nexthop, src, grp, neighbor_needed);
+			return pim_ecmp_nexthop_search(pim, pnc, nexthop, src, grp,
+						       neighbor_needed, ingress_ifp);
 	}
 
 	num_ifindex = zclient_lookup_nexthop(&args, PIM_NEXTHOP_LOOKUP_MAX);
@@ -1316,6 +1430,10 @@ bool pim_nht_lookup_ecmp(struct pim_instance *pim, struct pim_nexthop *nexthop, 
 				  __func__, &src, pim->vrf->name);
 		return false;
 	}
+
+	if (pim_nht_nexthop_prefer_ingress(pim, nexthop, src, neighbor_needed, ingress_ifp, &args,
+					   num_ifindex))
+		return true;
 
 	/* Count the number of neighbors for ECMP computation */
 	for (i = 0; i < num_ifindex; i++) {
@@ -1613,7 +1731,7 @@ int pim_nht_lookup_ecmp_if_vif_index(struct pim_instance *pim, pim_addr src, str
 	ifindex_t ifindex;
 
 	memset(&nhop, 0, sizeof(nhop));
-	if (!pim_nht_lookup_ecmp(pim, &nhop, src, grp, true)) {
+	if (!pim_nht_lookup_ecmp(pim, &nhop, src, grp, true, NULL)) {
 		if (PIM_DEBUG_PIM_NHT)
 			zlog_debug("%s: could not find nexthop ifindex for address %pPA(%s)",
 				   __func__, &src, pim->vrf->name);

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -123,10 +123,12 @@ void pim_nht_upstream_if_update(struct pim_instance *pim, struct interface *ifp)
  * Tries to find in cache first and does a synchronous lookup if not found in the cache.
  * If neighbor_needed is true, then nexthop is only considered valid if it's to a pim
  * neighbor.
- * Providing the group only effects the ECMP decision, if enabled
+ * Providing the group only effects the ECMP decision, if enabled.
+ * When ingress_ifp is non-NULL and listed among valid nexthops, it is
+ * preferred over the default first-fit / ECMP selection.
  */
 bool pim_nht_lookup_ecmp(struct pim_instance *pim, struct pim_nexthop *nexthop, pim_addr src,
-			 struct prefix *grp, bool neighbor_needed);
+			 struct prefix *grp, bool neighbor_needed, struct interface *ingress_ifp);
 
 /* Very similar to pim_nht_lookup_ecmp, but does not check the nht cache and only does
  * a synchronous lookup. No ECMP decision is made.

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -440,7 +440,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 
 	old_rpf.source_nexthop.interface = up->rpf.source_nexthop.interface;
 
-	rpf_result = pim_rpf_update(pim, up, &old_rpf, __func__);
+	rpf_result = pim_rpf_update(pim, up, &old_rpf, NULL, __func__);
 	if (rpf_result == PIM_RPF_FAILURE && up->channel_oil)
 		pim_mroute_del(up->channel_oil, __func__);
 
@@ -586,7 +586,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 			pim_nht_find_or_track(pim, nht_p, NULL, rp_all, NULL);
 
 			if (!pim_nht_lookup_ecmp(pim, &rp_all->rp.source_nexthop, nht_p,
-						 &rp_all->group, true))
+						 &rp_all->group, true, NULL))
 				return PIM_RP_NO_PATH;
 			return PIM_SUCCESS;
 		}
@@ -682,7 +682,8 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 		zlog_debug("%s: NHT Register RP addr %pPA grp %pFX with Zebra ",
 			   __func__, &nht_p, &rp_info->group);
 	pim_nht_find_or_track(pim, nht_p, NULL, rp_info, NULL);
-	if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, nht_p, &rp_info->group, true))
+	if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, nht_p, &rp_info->group, true,
+				 NULL))
 		return PIM_RP_NO_PATH;
 
 	return PIM_SUCCESS;
@@ -954,7 +955,8 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 			   __func__, &nht_p, &rp_info->group);
 
 	pim_nht_find_or_track(pim, nht_p, NULL, rp_info, NULL);
-	if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, nht_p, &rp_info->group, true)) {
+	if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, nht_p, &rp_info->group, true,
+				 NULL)) {
 		route_unlock_node(rn);
 		return PIM_RP_NO_PATH;
 	}
@@ -982,7 +984,7 @@ void pim_rp_setup(struct pim_instance *pim)
 
 		pim_nht_find_or_track(pim, nht_p, NULL, rp_info, NULL);
 		if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, nht_p, &rp_info->group,
-					 true)) {
+					 true, NULL)) {
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug("%s: unable to lookup nexthop for rp %pPA", __func__,
 					   &rp_info->rp.rpf_addr);
@@ -1133,7 +1135,7 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group)
 		pim_nht_find_or_track(pim, nht_p, NULL, rp_info, NULL);
 		pim_rpf_set_refresh_time(pim);
 		if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, nht_p, &rp_info->group,
-					 true))
+					 true, NULL))
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug("%s: unable to lookup nexthop for rp %pPA", __func__,
 					   &rp_info->rp.rpf_addr);
@@ -1522,7 +1524,7 @@ void pim_embedded_rp_new(struct pim_instance *pim, const pim_addr *group, const 
 
 	pim_nht_find_or_track(pim, rp_info->rp.rpf_addr, NULL, rp_info, NULL);
 	if (!pim_nht_lookup_ecmp(pim, &rp_info->rp.source_nexthop, rp_info->rp.rpf_addr,
-				 &rp_info->group, 1)) {
+				 &rp_info->group, 1, NULL)) {
 		if (PIM_DEBUG_PIM_NHT_RP)
 			zlog_debug("%s: Embedded RP %pPA learned but no next hop", __func__,
 				   &rp_info->rp.rpf_addr);

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -73,9 +73,9 @@ static void pim_rpf_cost_change(struct pim_instance *pim,
 		pim_mlag_up_local_add(pim, up);
 }
 
-enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
-		struct pim_upstream *up, struct pim_rpf *old,
-		const char *caller)
+enum pim_rpf_result pim_rpf_update(struct pim_instance *pim, struct pim_upstream *up,
+				   struct pim_rpf *old, struct interface *ingress_ifp,
+				   const char *caller)
 {
 	struct pim_rpf *rpf = &up->rpf;
 	struct pim_rpf saved;
@@ -109,7 +109,7 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 		neigh_needed = false;
 
 	pim_nht_find_or_track(pim, up->upstream_addr, up, NULL, NULL);
-	if (!pim_nht_lookup_ecmp(pim, &rpf->source_nexthop, src, &grp, neigh_needed)) {
+	if (!pim_nht_lookup_ecmp(pim, &rpf->source_nexthop, src, &grp, neigh_needed, ingress_ifp)) {
 		/* Route is Deleted in Zebra, reset the stored NH data */
 		pim_upstream_rpf_clear(pim, up);
 		pim_rpf_cost_change(pim, up, saved_mrib_route_metric);

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -53,9 +53,9 @@ enum pim_rpf_lookup_mode {
 			      /* on equal value, MRIB wins for last 2 */
 };
 
-enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
-				   struct pim_upstream *up,
-				   struct pim_rpf *old, const char *caller);
+enum pim_rpf_result pim_rpf_update(struct pim_instance *pim, struct pim_upstream *up,
+				   struct pim_rpf *old, struct interface *ingress_ifp,
+				   const char *caller);
 void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up);
 int pim_rpf_addr_is_inaddr_any(struct pim_rpf *rpf);

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -346,6 +346,87 @@ void pim_static_route_configs_fini(struct pim_instance *pim)
  * Called whenever a new VIF becomes available. Walk the deferred queue and
  * install any route whose input and output interfaces are now both ready.
  */
+static struct static_route *pim_static_match(struct pim_instance *pim, ifindex_t iif_vif,
+					     pim_addr group, pim_addr source)
+{
+	struct listnode *node;
+	struct static_route *s_route;
+
+	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, s_route)) {
+		if (s_route->iif != iif_vif)
+			continue;
+		if (pim_addr_cmp(s_route->group, group))
+			continue;
+		if (!pim_addr_is_any(s_route->source) && pim_addr_cmp(s_route->source, source))
+			continue;
+		return s_route;
+	}
+
+	return NULL;
+}
+
+static bool pim_static_config_matches(struct static_route_config *cfg, const char *iifname,
+				      pim_addr group, pim_addr source)
+{
+	if (strcmp(cfg->iifname, iifname))
+		return false;
+	if (pim_addr_cmp(cfg->group, group))
+		return false;
+	if (!pim_addr_is_any(cfg->source) && pim_addr_cmp(cfg->source, source))
+		return false;
+	return true;
+}
+
+/*
+ * Kernel upcall (NOCACHE / WRONGVIF) for traffic matching "ip mroute OIF GROUP
+ * [SOURCE]" configured on the ingress interface.  Re-install the static MFC.
+ *
+ * Returns 0 on successful reinstall, 1 when no static route matches (caller
+ * should continue normal PIM processing), -1 when a static route matched but
+ * reinstall failed (caller should stop without running WRONGVIF assert logic).
+ */
+int pim_static_nocache_resolve(struct pim_instance *pim, struct interface *ifp, pim_sgaddr *sg)
+{
+	struct pim_interface *pim_ifp;
+	struct static_route *s_route;
+	struct static_route_config *cfg;
+	bool deferred_match = false;
+
+	if (!ifp || !ifp->info)
+		return 1;
+
+	pim_ifp = ifp->info;
+	if (pim_ifp->mroute_vif_index <= 0)
+		return 1;
+
+	s_route = pim_static_match(pim, pim_ifp->mroute_vif_index, sg->grp, sg->src);
+	if (!s_route) {
+		frr_each (pim_static_route_cfgs, &pim->static_route_configs, cfg) {
+			if (!pim_static_config_matches(cfg, ifp->name, sg->grp, sg->src))
+				continue;
+			deferred_match = true;
+			break;
+		}
+		if (deferred_match)
+			pim_static_reconcile(pim);
+		s_route = pim_static_match(pim, pim_ifp->mroute_vif_index, sg->grp, sg->src);
+	}
+	if (!s_route)
+		return 1;
+
+	if (pim_static_mroute_add(&s_route->c_oil, __func__)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: failed to reinstall static mroute %pSG on %s", __func__,
+				   sg, ifp->name);
+		return -1;
+	}
+
+	if (PIM_DEBUG_MROUTE)
+		zlog_debug("%s: reinstalled static mroute %pSG on %s", __func__, sg, ifp->name);
+
+	return 0;
+}
+
 void pim_static_reconcile(struct pim_instance *pim)
 {
 	struct static_route_config *cfg;

--- a/pimd/pim_static.h
+++ b/pimd/pim_static.h
@@ -55,4 +55,6 @@ void pim_static_reconcile(struct pim_instance *pim);
 int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty,
 			    struct interface *ifp);
 
+int pim_static_nocache_resolve(struct pim_instance *pim, struct interface *ifp, pim_sgaddr *sg);
+
 #endif /* PIM_STATIC_H_ */

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -37,7 +37,7 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	up = pim_upstream_find(pim, &sg);
 	if (up) {
 		memcpy(&nexthop, &up->rpf.source_nexthop, sizeof(struct pim_nexthop));
-		if (!pim_nht_lookup_ecmp(pim, &nexthop, vif_source, &grp, false))
+		if (!pim_nht_lookup_ecmp(pim, &nexthop, vif_source, &grp, false, NULL))
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug("%s: Nexthop Lookup failed vif_src:%pPA, sg.src:%pPA, sg.grp:%pPA",
 					   __func__, &vif_source, &sg.src, &sg.grp);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -880,7 +880,7 @@ static void pim_upstream_transition_dm_to_sm(struct pim_instance *pim, struct pi
 				 */
 				old_rpf.source_nexthop.interface = up->rpf.source_nexthop.interface;
 				old_rpf.rpf_addr = up->rpf.rpf_addr;
-				rpf_result = pim_rpf_update(pim, up, &old_rpf, __func__);
+				rpf_result = pim_rpf_update(pim, up, &old_rpf, NULL, __func__);
 				if (rpf_result == PIM_RPF_CHANGED ||
 				    (rpf_result == PIM_RPF_FAILURE &&
 				     old_rpf.source_nexthop.interface))
@@ -1268,12 +1268,12 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 			 * Set the right RPF so that future changes will
 			 * be right
 			 */
-			(void)pim_rpf_update(pim, up, NULL, __func__);
+			(void)pim_rpf_update(pim, up, NULL, NULL, __func__);
 			pim_upstream_keep_alive_timer_start(
 				up, pim->keep_alive_time);
 		}
 	} else if (!pim_addr_is_any(up->upstream_addr)) {
-		rpf_result = pim_rpf_update(pim, up, NULL, __func__);
+		rpf_result = pim_rpf_update(pim, up, NULL, NULL, __func__);
 		pim_upstream_update_use_rpt(up, false /*update_mroute*/);
 		if (rpf_result == PIM_RPF_FAILURE) {
 			up->channel_oil->oil_inherited_rescan = 1;
@@ -2270,7 +2270,7 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 					__func__, up->sg_str);
 			old.source_nexthop.interface =
 				up->rpf.source_nexthop.interface;
-			rpf_result = pim_rpf_update(pim, up, &old, __func__);
+			rpf_result = pim_rpf_update(pim, up, &old, NULL, __func__);
 			if (rpf_result == PIM_RPF_CHANGED ||
 					(rpf_result == PIM_RPF_FAILURE &&
 					 old.source_nexthop.interface))

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2362,7 +2362,7 @@ bool pim_upstream_equal(const void *arg1, const void *arg2)
  * set KeepaliveTimer(S,G) to Keepalive_Period
  * }
  */
-static bool pim_upstream_kat_start_ok(struct pim_upstream *up)
+bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 {
 	struct channel_oil *c_oil = up->channel_oil;
 	struct interface *ifp = up->rpf.source_nexthop.interface;

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -373,6 +373,8 @@ int pim_upstream_inherited_olist(struct pim_instance *pim,
 				 struct pim_upstream *up);
 int pim_upstream_empty_inherited_olist(struct pim_upstream *up);
 
+bool pim_upstream_kat_start_ok(struct pim_upstream *up);
+
 void pim_upstream_find_new_rpf(struct pim_instance *pim);
 
 void pim_upstream_init(struct pim_instance *pim);

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -315,7 +315,7 @@ static void pim_vxlan_orig_mr_up_del(struct pim_vxlan_sg *vxlan_sg)
 		if (up) {
 			enum pim_rpf_result r;
 
-			r = pim_rpf_update(vxlan_sg->pim, up, NULL, __func__);
+			r = pim_rpf_update(vxlan_sg->pim, up, NULL, NULL, __func__);
 			if (r == PIM_RPF_FAILURE) {
 				if (PIM_DEBUG_VXLAN)
 					zlog_debug(

--- a/tests/topotests/pim_nocache_forward/fhr/frr.conf
+++ b/tests/topotests/pim_nocache_forward/fhr/frr.conf
@@ -1,0 +1,36 @@
+hostname fhr
+!
+service integrated-vtysh-config
+!
+interface fhr-eth0
+ ip address 10.10.3.1/24
+ ip pim
+!
+interface fhr-eth1
+ ip address 10.10.4.1/24
+ ip igmp
+ ip pim
+!
+interface fhr-eth2
+ ip address 10.10.5.1/24
+ ip igmp
+ ip pim
+!
+interface fhr-eth3
+ ip address 10.10.6.1/24
+ ip igmp
+ ip pim
+!
+ip forwarding
+!
+router pim
+ rp 10.255.0.1
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+!
+ip route 10.255.0.1/32 10.10.3.2
+ip route 10.10.1.0/24 10.10.3.2
+ip route 10.10.2.0/24 10.10.3.2
+ip route 10.50.0.0/16 10.10.6.2
+!

--- a/tests/topotests/pim_nocache_forward/l1/frr.conf
+++ b/tests/topotests/pim_nocache_forward/l1/frr.conf
@@ -1,0 +1,26 @@
+hostname l1
+!
+service integrated-vtysh-config
+!
+interface l1-eth0
+ ip address 10.10.1.1/24
+ ip igmp
+ ip pim
+!
+interface l1-eth1
+ ip address 10.10.2.1/24
+ ip pim
+!
+ip forwarding
+!
+router pim
+ rp 10.255.0.1
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+!
+ip route 10.255.0.1/32 10.10.2.2
+ip route 10.10.3.0/24 10.10.2.2
+ip route 10.10.4.0/24 10.10.2.2
+ip route 10.10.5.0/24 10.10.2.2
+!

--- a/tests/topotests/pim_nocache_forward/r_passive/frr.conf
+++ b/tests/topotests/pim_nocache_forward/r_passive/frr.conf
@@ -1,0 +1,28 @@
+hostname r_passive
+!
+service integrated-vtysh-config
+!
+interface r_passive-eth0
+ ip address 10.10.6.2/24
+ ip pim
+ ip pim passive
+!
+interface r_passive-eth1
+ ip address 10.50.1.1/24
+ ip igmp
+ ip pim
+!
+ip forwarding
+!
+router pim
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+!
+ip route 10.255.0.1/32 10.10.6.1
+ip route 10.10.1.0/24 10.10.6.1
+ip route 10.10.2.0/24 10.10.6.1
+ip route 10.10.3.0/24 10.10.6.1
+ip route 10.10.4.0/24 10.10.6.1
+ip route 10.10.5.0/24 10.10.6.1
+!

--- a/tests/topotests/pim_nocache_forward/rp/frr.conf
+++ b/tests/topotests/pim_nocache_forward/rp/frr.conf
@@ -1,0 +1,31 @@
+hostname rp
+!
+service integrated-vtysh-config
+!
+interface rp-eth0
+ ip address 10.10.2.2/24
+ ip pim
+!
+interface rp-eth1
+ ip address 10.10.3.2/24
+ ip pim
+!
+interface lo
+ ip address 10.255.0.1/32
+ ip pim
+!
+ip forwarding
+!
+router pim
+ rp 10.255.0.1
+ join-prune-interval 5
+ keep-alive-timer 15
+ register-suppress-time 12
+ register-accept-list ACCEPT
+!
+ip prefix-list ACCEPT seq 5 permit any
+!
+ip route 10.10.1.0/24 10.10.2.1
+ip route 10.10.4.0/24 10.10.3.1
+ip route 10.10.5.0/24 10.10.3.1
+!

--- a/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
+++ b/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_pim_nocache_forward.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+
+"""
+Topotests for pimd NOCACHE handling:
+
+1. Non-connected source on LHR: (S,G) must forward when iif == RPF_interface(S)
+   and local receivers exist (RFC 4601 section 4.2).  Source 10.10.4.2 is not on
+   l1-eth1 (10.10.2.0/24).
+
+2. Interface static mroute (ip mroute OIF GROUP [SOURCE] on IIF): traffic must
+   flow through the static MFC entry installed by pim_static_nocache_resolve()'s
+   configuration path.
+
+3. Edge router with PIM passive neighbor: foreign-domain source (10.50.1.2) is
+   not on the LAN subnet of fhr-eth3 (10.10.6.0/24) but RPF points there via
+   static route through r_passive.  Static ip mroute is required because IGMP
+   from a non-connected source on the receive interface is dropped (efe6f18);
+   data on that path uses NOCACHE forwarding (test 1) and static mroutes
+   (tests 2-3).
+
+4. ECMP RPF on LHR: when MRIB lists multiple valid nexthops to the source,
+   NOCACHE must prefer the kernel ingress interface so (S,G) forwarding
+   survives after MFC flush.
+"""
+
+import json
+import os
+import sys
+import time
+from functools import partial
+
+import pytest
+
+pytestmark = [pytest.mark.pimd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.common_config import step, write_test_footer, write_test_header
+from lib.pim import (
+    McastTesterHelper,
+    clear_mroute,
+    verify_igmp_groups,
+    verify_mroutes,
+    verify_pim_neighbors,
+)
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+TOPOLOGY = """
+                              h_recv
+                                |
+                               l1
+                                |
+                               rp
+                                |
+                           fhr-eth0
+                                |
+                               fhr
+              +-----------------+-----------------+
+              |                 |                 |
+           h_src             h_local    r_passive [passive->fhr]
+         fhr-eth1           fhr-eth2           fhr-eth3
+                                                  |
+                                             h_foreign
+
+    RP 10.255.0.1 (rp lo)
+"""
+
+SOURCE = "10.10.4.2"
+FOREIGN_SOURCE = "10.50.1.2"
+RP_ADDR = "10.255.0.1"
+
+GROUP_LHR_NOCACHE = "225.1.3.1"
+GROUP_STATIC = "239.77.1.1"
+GROUP_PASSIVE_EDGE = "225.1.3.2"
+GROUP_ECMP_INGRESS = "225.1.3.3"
+
+L1_RECV_NH = "10.10.1.2"
+SOURCE_PREFIX = "10.10.4.0/24"
+
+L1_TO_RP = "l1-eth1"
+L1_TO_RECV = "l1-eth0"
+RP_TO_FHR = "rp-eth1"
+FHR_TO_RP = "fhr-eth0"
+FHR_TO_SRC = "fhr-eth1"
+FHR_TO_LOCAL = "fhr-eth2"
+FHR_TO_PASSIVE = "fhr-eth3"
+R_PASSIVE_TO_FHR = "r_passive-eth0"
+R_PASSIVE_TO_FOREIGN = "r_passive-eth1"
+
+PIM_TOPO = {
+    "routers": {
+        "l1": {
+            "links": {
+                "rp": {"interface": L1_TO_RP, "ipv4": "10.10.2.1/24", "pim": "enable"},
+            }
+        },
+        "rp": {
+            "links": {
+                "l1": {"interface": "rp-eth0", "ipv4": "10.10.2.2/24", "pim": "enable"},
+                "fhr": {
+                    "interface": RP_TO_FHR,
+                    "ipv4": "10.10.3.2/24",
+                    "pim": "enable",
+                },
+            }
+        },
+        "fhr": {
+            "links": {
+                "rp": {"interface": FHR_TO_RP, "ipv4": "10.10.3.1/24", "pim": "enable"},
+            }
+        },
+        "r_passive": {"links": {}},
+    }
+}
+
+app_helper = McastTesterHelper()
+
+
+def build_topo(tgen):
+    tgen.add_router("l1")
+    tgen.add_router("rp")
+    tgen.add_router("fhr")
+    tgen.add_router("r_passive")
+
+    tgen.add_host("h_recv", "10.10.1.2/24", "via 10.10.1.1")
+    tgen.add_host("h_src", "10.10.4.2/24", "via 10.10.4.1")
+    tgen.add_host("h_local", "10.10.5.2/24", "via 10.10.5.1")
+    tgen.add_host("h_foreign", "10.50.1.2/24", "via 10.50.1.1")
+
+    tgen.add_link(tgen.gears["h_recv"], tgen.gears["l1"], "h_recv-eth0", "l1-eth0")
+    tgen.add_link(tgen.gears["l1"], tgen.gears["rp"], "l1-eth1", "rp-eth0")
+    tgen.add_link(tgen.gears["rp"], tgen.gears["fhr"], "rp-eth1", "fhr-eth0")
+    tgen.add_link(tgen.gears["h_src"], tgen.gears["fhr"], "h_src-eth0", "fhr-eth1")
+    tgen.add_link(tgen.gears["h_local"], tgen.gears["fhr"], "h_local-eth0", "fhr-eth2")
+    tgen.add_link(
+        tgen.gears["r_passive"], tgen.gears["fhr"], R_PASSIVE_TO_FHR, FHR_TO_PASSIVE
+    )
+    tgen.add_link(
+        tgen.gears["h_foreign"],
+        tgen.gears["r_passive"],
+        "h_foreign-eth0",
+        R_PASSIVE_TO_FOREIGN,
+    )
+
+
+def setup_module(mod):
+    logger.info("Testsuite start time: %s", time.asctime(time.localtime(time.time())))
+    logger.info("Topology:\n%s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    app_helper.init(tgen)
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    result = verify_pim_neighbors(tgen, PIM_TOPO)
+    assert result is True, "PIM neighbors failed to establish: {}".format(result)
+
+
+def teardown_module():
+    tgen = get_topogen()
+    app_helper.cleanup()
+    tgen.stop_topology()
+
+
+def prepare_test(tgen):
+    app_helper.stop_all_hosts()
+    clear_mroute(tgen)
+    tgen.errors = ""
+    tgen.errorsd = {}
+
+
+def start_remote_join_and_traffic(tgen, group):
+    assert app_helper.run_join("h_recv", group, join_intf="h_recv-eth0") is True
+    assert verify_igmp_groups(tgen, "l1", L1_TO_RECV, group) is True
+    assert verify_mroutes(tgen, "l1", "*", group, L1_TO_RP, L1_TO_RECV) is True
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth0") is True
+
+
+def verify_upstream_json(tgen, dut, source, group, expected_fields):
+    router = tgen.routers()[dut]
+
+    def _check():
+        output = router.vtysh_cmd("show ip pim upstream json", isjson=True)
+        upstream = output.get(group, {}).get(source)
+        if not upstream:
+            return False
+        for key, val in expected_fields.items():
+            if upstream.get(key) != val:
+                return False
+        return True
+
+    _, result = topotest.run_and_expect(_check, True, count=60, wait=1)
+    return result
+
+
+def verify_receiver_traffic(host, group, recv_intf, source, min_pkts=1):
+    report = app_helper.collect_receiver_sources(
+        host, group, recv_intf, duration=3, source=source
+    )
+    count = report.get("sources", {}).get(source, 0)
+    return count >= min_pkts, report
+
+
+def verify_mroute_json(router, expected, count=30, wait=1):
+    test_func = partial(
+        topotest.router_json_cmp, router, "show ip mroute json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    return result
+
+
+def verify_static_route_ecmp(router, prefix, num_nhs=2, count=30, wait=1):
+    def _check():
+        output = router.vtysh_cmd("show ip route {} json".format(prefix), isjson=True)
+        for route in output.get(prefix, []):
+            if route.get("protocol") == "static":
+                nhs = route.get("nexthops", [])
+                if len(nhs) == num_nhs:
+                    return True
+        return False
+
+    _, result = topotest.run_and_expect(_check, True, count=count, wait=wait)
+    return result
+
+
+def test_nocache_non_connected_lhr_forwarding(request):
+    """
+    LHR receives (S,G) on the RP-facing interface where the source address is
+    not locally connected.  Forwarding and upstream state must reflect the SPT
+    path (iif == RPF_interface(S), not FHR).
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    group = GROUP_LHR_NOCACHE
+
+    step("Establish remote IGMP join and source traffic")
+    start_remote_join_and_traffic(tgen, group)
+
+    step("Verify (S,G) on LHR with non-connected source on {}".format(L1_TO_RP))
+    result = verify_mroutes(tgen, "l1", SOURCE, group, L1_TO_RP, L1_TO_RECV)
+    assert result is True, "{}: (S,G) mroute failed: {}".format(tc_name, result)
+
+    step("Verify LHR upstream uses RP-facing IIF and is not marked FHR")
+    result = verify_upstream_json(
+        tgen,
+        "l1",
+        SOURCE,
+        group,
+        {
+            "inboundInterface": L1_TO_RP,
+            "firstHopRouter": False,
+            "joinState": "Joined",
+        },
+    )
+    assert result is True, "{}: upstream check failed: {}".format(tc_name, result)
+
+    step("Verify receiver gets traffic from non-connected source through LHR")
+    ok, report = verify_receiver_traffic("h_recv", group, "h_recv-eth0", SOURCE)
+    assert ok is True, "{}: no end-to-end traffic: {}".format(
+        tc_name, json.dumps(report)
+    )
+
+    write_test_footer(tc_name)
+
+
+def test_nocache_ecmp_prefer_kernel_ingress(request):
+    """
+    LHR with ECMP static routes to the source prefix must pick the kernel
+    ingress interface on NOCACHE so existing (S,G) state forwards after MFC
+    flush even when another equal-cost nexthop exists on the receiver LAN.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    l1 = tgen.gears["l1"]
+    group = GROUP_ECMP_INGRESS
+
+    step("Establish remote IGMP join and source traffic")
+    start_remote_join_and_traffic(tgen, group)
+
+    step("Verify baseline (S,G) on LHR before ECMP is introduced")
+    result = verify_mroutes(tgen, "l1", SOURCE, group, L1_TO_RP, L1_TO_RECV)
+    assert result is True, "{}: baseline (S,G) failed: {}".format(tc_name, result)
+
+    step("Install equal-cost ECMP static route via receiver LAN on l1")
+    l1.vtysh_cmd(
+        f"""
+        conf t
+           router pim
+              ecmp
+           ip route {SOURCE_PREFIX} {L1_RECV_NH}
+    """
+    )
+    result = verify_static_route_ecmp(l1, SOURCE_PREFIX, num_nhs=2)
+    assert result is True, "{}: ECMP static route not installed: {}".format(
+        tc_name, result
+    )
+
+    step("Flush MFC on LHR to force NOCACHE with ECMP RPF ambiguity")
+    clear_mroute(tgen, "l1")
+
+    step("Verify (S,G) reinstalled with RP-facing IIF after NOCACHE")
+    result = verify_mroutes(tgen, "l1", SOURCE, group, L1_TO_RP, L1_TO_RECV)
+    assert result is True, "{}: (S,G) mroute failed after MFC flush: {}".format(
+        tc_name, result
+    )
+
+    step("Verify upstream RPF still uses kernel ingress interface")
+    result = verify_upstream_json(
+        tgen,
+        "l1",
+        SOURCE,
+        group,
+        {
+            "inboundInterface": L1_TO_RP,
+            "firstHopRouter": False,
+            "joinState": "Joined",
+        },
+    )
+    assert result is True, "{}: upstream check failed: {}".format(tc_name, result)
+
+    step("Verify receiver still gets traffic after MFC flush with ECMP RPF")
+    ok, report = verify_receiver_traffic("h_recv", group, "h_recv-eth0", SOURCE)
+    assert ok is True, "{}: no end-to-end traffic: {}".format(
+        tc_name, json.dumps(report)
+    )
+
+    step("Remove ECMP static route and PIM ECMP configuration")
+    l1.vtysh_cmd(
+        f"""
+        conf t
+           no ip route {SOURCE_PREFIX} {L1_RECV_NH}
+           router pim
+              no ecmp
+    """
+    )
+
+    write_test_footer(tc_name)
+
+
+def test_nocache_non_connected_passive_edge_forwarding(request):
+    """
+    Edge router (fhr) receives multicast from a foreign domain via a PIM passive
+    neighbor.  Source 10.50.1.2 is not on fhr-eth3 (10.10.6.0/24) but URIB RPF
+    points there via r_passive.  Register/FHR cannot apply (non-connected on IIF),
+    so a static MFC on the ingress interface bootstraps forwarding.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    fhr = tgen.gears["fhr"]
+    group = GROUP_PASSIVE_EDGE
+
+    step("Verify PIM passive is enabled toward fhr on r_passive")
+    output = tgen.gears["r_passive"].vtysh_cmd("show running-config")
+    assert "ip pim passive" in output, "{}: passive PIM not configured".format(tc_name)
+
+    step("Configure static mroutes on passive router and edge fhr")
+    r_passive = tgen.gears["r_passive"]
+    r_passive.vtysh_cmd(
+        f"""
+        conf t
+           interface {R_PASSIVE_TO_FOREIGN}
+              ip mroute {R_PASSIVE_TO_FHR} {group} {FOREIGN_SOURCE}
+    """
+    )
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           interface {FHR_TO_PASSIVE}
+              ip mroute {FHR_TO_LOCAL} {group} {FOREIGN_SOURCE}
+    """
+    )
+
+    expected = {group: {FOREIGN_SOURCE: {"oil": {FHR_TO_LOCAL: "*"}}}}
+    result = verify_mroute_json(fhr, expected)
+    assert result is None, "{}: static edge mroute not installed: {}".format(
+        tc_name, result
+    )
+
+    step("Join local receiver and start foreign-domain source traffic")
+    assert app_helper.run_join("h_local", group, join_intf="h_local-eth0") is True
+    assert (
+        app_helper.run_traffic("h_foreign", group, bind_intf="h_foreign-eth0") is True
+    )
+
+    step(
+        "Verify static (S,G) on edge fhr with foreign source on {}".format(
+            FHR_TO_PASSIVE
+        )
+    )
+    result = verify_mroute_json(fhr, expected)
+    assert result is None, "{}: (S,G) mroute failed: {}".format(tc_name, result)
+
+    step("Verify local receiver gets traffic from foreign source")
+    ok, report = verify_receiver_traffic(
+        "h_local", group, "h_local-eth0", FOREIGN_SOURCE
+    )
+    assert ok is True, "{}: no traffic from foreign source: {}".format(
+        tc_name, json.dumps(report)
+    )
+
+    step("Remove static mroute configuration")
+    r_passive.vtysh_cmd(
+        f"""
+        conf t
+           interface {R_PASSIVE_TO_FOREIGN}
+              no ip mroute {R_PASSIVE_TO_FHR} {group} {FOREIGN_SOURCE}
+    """
+    )
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           interface {FHR_TO_PASSIVE}
+              no ip mroute {FHR_TO_LOCAL} {group} {FOREIGN_SOURCE}
+    """
+    )
+
+    write_test_footer(tc_name)
+
+
+def test_static_mroute_forward_with_traffic(request):
+    """
+    Interface static mroute on FHR (ip mroute fhr-eth2 GROUP SOURCE on fhr-eth1)
+    must forward source traffic to the local receiver without PIM joins on the
+    shared tree.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    fhr = tgen.gears["fhr"]
+    group = GROUP_STATIC
+
+    step("Configure static mroute on FHR ingress interface")
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           interface {FHR_TO_SRC}
+              ip mroute {FHR_TO_LOCAL} {group} {SOURCE}
+    """
+    )
+
+    expected = {group: {SOURCE: {"oil": {FHR_TO_LOCAL: "*"}}}}
+    result = verify_mroute_json(fhr, expected)
+    assert result is None, "{}: static mroute not installed: {}".format(tc_name, result)
+
+    step("Join local receiver and start source traffic")
+    assert app_helper.run_join("h_local", group, join_intf="h_local-eth0") is True
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth0") is True
+
+    step("Verify local receiver gets traffic via static mroute")
+    ok, report = verify_receiver_traffic("h_local", group, "h_local-eth0", SOURCE)
+    assert ok is True, "{}: no static forward traffic: {}".format(
+        tc_name, json.dumps(report)
+    )
+
+    step("Remove static mroute configuration")
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           interface {FHR_TO_SRC}
+              no ip mroute {FHR_TO_LOCAL} {group} {SOURCE}
+    """
+    )
+
+    write_test_footer(tc_name)
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION

Align with RFC 4601 4.2 data forwarding when multicast arrives on
`RPF_interface(S)` with existing `(S,G)` state, even if source `S` is not on a
connected prefix of the ingress interface. Previously pimd dropped these
NOCACHE upcalls breaking LHR/transit and edge paths where
sources are routed or NAT’d off-subnet.

Also install static `ip mroute` MFC entries on NOCACHE/WRONGVIF kernel upcalls
so configured ingress policy is honored before sparse/dense handling.