### PR TITLE
bgpd: fix bmp connect deletion with source-interface

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2995,8 +2995,7 @@ DEFPY(bmp_connect,
 		}
 		/* connection deletion need same hostname port and interface */
 		if (ba->ifsrc || srcif)
-			if ((!ba->ifsrc) || (!srcif) ||
-			    !strcmp(ba->ifsrc, srcif)) {
+			if ((!ba->ifsrc) || (!srcif) || !strmatch(ba->ifsrc, srcif)) {
 				vty_out(vty,
 					"%% No such active connection found\n");
 				return CMD_WARNING;


### PR DESCRIPTION
bmp_connect() rejects deletion when source-interface is provided. The check compares the configured source-interface with the one in the command. It uses !strcmp(), which is true when the strings are equal. But this result feeds an if-block that rejects the deletion. So the command is rejected exactly when the source-interface is correct, and accepted when it is wrong. Fix by using !strmatch() which is false when strings are equal, so the rejection block is skipped for matching parameters.

Before
```
vyos(config-bgp-bmp)# 
vyos(config-bgp-bmp)# bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
vyos(config-bgp-bmp)# do show running-config 
Building configuration...

Current configuration:
!
frr version 10.5.2
frr defaults traditional
hostname vyos
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 XX.XX.XX.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
  bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
 exit
exit
!
end
vyos(config-bgp-bmp)# no bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
% No such active connection found
vyos(config-bgp-bmp)# no bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth0
vyos(config-bgp-bmp)# do show running-config 
Building configuration...

Current configuration:
!
frr version 10.5.2
frr defaults traditional
hostname vyos
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 XX.XX.XX.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
 exit
exit
!
end
vyos(config-bgp-bmp)# 
```