### PR TITLE
isisd: fix find SR-Capabilities sub-TLV

### DIFF
--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -80,16 +80,28 @@ DECLARE_RBTREE_UNIQ(srdb_prefix_cfg, struct sr_prefix_cfg, entry, sr_prefix_sid_
  */
 struct isis_sr_block *isis_sr_find_srgb(struct lspdb_head *lspdb, const uint8_t *sysid)
 {
-	struct isis_lsp *lsp;
+	struct listnode *node;
+	struct isis_lsp *lsp0, *lsp;
 
-	lsp = isis_root_system_lsp(lspdb, sysid);
-	if (!lsp)
+	lsp0 = isis_root_system_lsp(lspdb, sysid);
+	if (!lsp0)
 		return NULL;
 
-	if (!lsp->tlvs->router_cap || lsp->tlvs->router_cap->srgb.range_size == 0)
+	if (lsp0->tlvs && lsp0->tlvs->router_cap && lsp0->tlvs->router_cap->srgb.range_size)
+		return &lsp0->tlvs->router_cap->srgb;
+
+	if (!lsp0->lspu.frags)
 		return NULL;
 
-	return &lsp->tlvs->router_cap->srgb;
+	for (ALL_LIST_ELEMENTS_RO(lsp0->lspu.frags, node, lsp)) {
+		if (!lsp->tlvs || !lsp->tlvs->router_cap ||
+		    lsp->tlvs->router_cap->srgb.range_size == 0)
+			continue;
+
+		return &lsp->tlvs->router_cap->srgb;
+	}
+
+	return NULL;
 }
 
 /**


### PR DESCRIPTION
This "isis_sr_find_srgb()" supposes that router capability TLV and its sub-TLVs is present in the LSP-ID frag 0.

Below an example of wireshark capture which is not the case: ..
>Internet Protocol Version 4, Src: xxx.xx.xx.xxx, Dst: xxx.xx.xxx.xx
>Generic Routing Encapsulation (OSI)
>    Flags and Version: 0x0000
>    Protocol Type: OSI (0x00fe)
>ISO 10589 ISIS InTRA Domain Routeing Information Exchange Protocol
>ISO 10589 ISIS Link State Protocol Data Unit
>    PDU length: 1480
>    Remaining lifetime: 49970
>    LSP-ID: 1720.3100.0165.00-01 <--- fragid 1
>    ...
>    Router Capability (t=242, l=35)
>    Extended IS reachability (t=22, l=137)
>    Extended IS reachability (t=22, l=137)
>    Extended IS reachability (t=22, l=137)

And RFC 8667:

The SR-Capabilities sub-TLV MAY be advertised in an LSP of any number, but a router MUST NOT advertise more than one SR-Capabilities sub-TLV. A router receiving multiple SR-Capabilities sub-TLVs from the same originator SHOULD select the first advertisement in the lowest-numbered LSP.