### PR TITLE
Develop output modifiers

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1153,6 +1153,28 @@ DECLARE_KOOH(cmd_execute_done, (struct vty *vty, const char *cmd_exec),
 DEFINE_KOOH(cmd_execute_done, (struct vty *vty, const char *cmd_exec),
 	    (vty, cmd_exec));
 
+static enum output_filter resolve_filter(const char *token)
+{
+	enum output_filter match_filter = FILTER_NONE;
+	size_t token_len = strlen(token);
+	struct {
+		const char *str;
+		enum output_filter flag;
+	} filter[] = {
+		{"include", FILTER_INCLUDE}
+	};
+
+	for (unsigned i = 0; i < sizeof filter / sizeof filter[0]; i++) {
+		if (strnmatch(token, filter[i].str, token_len)) {
+			if (match_filter != FILTER_NONE)
+				return FILTER_AMBIGUOUS;
+			match_filter = filter[i].flag;
+		}
+	}
+
+	return match_filter;
+}
+
 /*
  * cmd_execute hook subscriber to handle `|` actions.
  */
@@ -1161,7 +1183,9 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 {
 	/* look for `|` */
 	char *pipe, *orig, *working, *token, *u, *regexp;
+	enum output_filter filter;
 	int ret = 0;
+	const char *action_err;
 
 	pipe = strstr(cmd_in, " | ");
 	if (!pipe)
@@ -1187,8 +1211,10 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 	assert(token);
 
 	/* match result to known actions */
-	if (!strmatch(token, "include")) {
-		vty_out(vty, "%% Unknown action '%s'\n", token);
+	filter = resolve_filter(token);
+	if (filter == FILTER_NONE || filter == FILTER_AMBIGUOUS) {
+		action_err = filter == FILTER_NONE ? "Unknown" : "Ambiguous";
+		vty_out(vty, "%% %s action '%s'\n", action_err, token);
 		ret = 1;
 		goto fail;
 	}

--- a/lib/command.c
+++ b/lib/command.c
@@ -1160,11 +1160,9 @@ static enum output_filter resolve_filter(const char *token)
 	struct {
 		const char *str;
 		enum output_filter flag;
-	} filter[] = {
-		{"include", FILTER_INCLUDE}
-	};
+	} filter[] = { { "include", FILTER_INCLUDE } };
 
-	for (unsigned i = 0; i < sizeof filter / sizeof filter[0]; i++) {
+	for (unsigned i = 0; i < sizeof(filter) / sizeof(filter[0]); i++) {
 		if (strnmatch(token, filter[i].str, token_len)) {
 			if (match_filter != FILTER_NONE)
 				return FILTER_AMBIGUOUS;
@@ -1175,6 +1173,63 @@ static enum output_filter resolve_filter(const char *token)
 	return match_filter;
 }
 
+static void extract_pipe_tail(const char *cmd_in, char **cmd_out)
+{
+	char *ptr;
+
+	*cmd_out = XSTRDUP(MTYPE_TMP, cmd_in);
+	ptr = *cmd_out;
+	strsep(&ptr, "|");
+}
+
+/*
+ * Parses and matches a command string against a node's command graph.
+ */
+static enum matcher_rv match_command_on_node(const char *cmd_str, enum node_type node,
+					     struct list **argv_out)
+{
+	struct graph *cmd_graph;
+	vector command;
+	enum matcher_rv rv;
+	const struct cmd_element *element = NULL;
+
+	*argv_out = NULL;
+
+	command = cmd_make_strvec(cmd_str);
+	if (!command || vector_active(command) == 0) {
+		cmd_free_strvec(command);
+		return MATCHER_NO_MATCH;
+	}
+
+	if (cmd_try_do_shortcut(node, vector_slot(command, 0))) {
+		vector_remove(command, 0);
+		node = ENABLE_NODE;
+	}
+
+	cmd_graph = cmd_node_graph(cmdvec, node);
+	rv = command_match(cmd_graph, command, argv_out, &element);
+
+	cmd_free_strvec(command);
+	return rv;
+}
+
+static enum matcher_rv match_show_command_on_node(const char *cmd_str, enum node_type node)
+{
+	struct cmd_token *token;
+	enum matcher_rv rv;
+	struct list *argv = NULL;
+
+	rv = match_command_on_node(cmd_str, node, &argv);
+	if (rv == MATCHER_OK) {
+		token = listnode_head(argv);
+		if (!token || !strmatch(token->text, "show"))
+			rv = MATCHER_NO_MATCH;
+		list_delete(&argv);
+	}
+
+	return rv;
+}
+
 /*
  * cmd_execute hook subscriber to handle `|` actions.
  */
@@ -1182,14 +1237,27 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 			      char **cmd_out)
 {
 	/* look for `|` */
-	char *pipe, *orig, *working, *token, *u, *regexp;
+	char *pipe, *orig, *working, *token, *regexp;
 	enum output_filter filter;
+	enum matcher_rv rv;
 	int ret = 0;
 	const char *action_err;
 
 	pipe = strstr(cmd_in, " | ");
 	if (!pipe)
 		return 0;
+
+	extract_pipe_tail(cmd_in, cmd_out);
+	rv = match_show_command_on_node(*cmd_out, vty->node);
+	if (MATCHER_ERROR(rv)) {
+		if (rv == MATCHER_NO_MATCH)
+			vty_out(vty, "%% Unknown command: %s\n", cmd_in);
+		else if (rv == MATCHER_INCOMPLETE)
+			vty_out(vty, "%% Incomplete command before pipe\n");
+		else if (rv == MATCHER_AMBIGUOUS)
+			vty_out(vty, "%% Ambiguous command: %s\n", *cmd_out);
+		return 1;
+	}
 
 	/*
 	 * duplicate string for processing purposes,
@@ -1243,10 +1311,6 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 		ret = 1;
 		goto fail;
 	}
-
-	*cmd_out = XSTRDUP(MTYPE_TMP, cmd_in);
-	u = *cmd_out;
-	strsep(&u, "|");
 
 fail:
 	XFREE(MTYPE_TMP, orig);

--- a/lib/command.c
+++ b/lib/command.c
@@ -1576,10 +1576,16 @@ static void print_cmd(struct vty *vty, const char *cmd)
 	j = 0;
 	for (i = 0; i < len; i++) {
 		/* skip varname */
-		if (cmd[i] == '$')
+		if (cmd[i] == '$') {
 			skip = true;
-		else if (strchr(" ()<>[]{}|", cmd[i]))
+		} else if (cmd[i] == '\\' && cmd[i + 1] == '|') {
+			buf[j++] = '|';
+			buf[j++] = ' ';
+			i++;
+			continue;
+		} else if (strchr(" ()<>[]{}|", cmd[i])) {
 			skip = false;
+		}
 
 		if (skip)
 			continue;

--- a/lib/command.c
+++ b/lib/command.c
@@ -1160,46 +1160,67 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 			      char **cmd_out)
 {
 	/* look for `|` */
-	char *orig, *working, *token, *u;
-	const char *pipe = strstr(cmd_in, "| ");
+	char *pipe, *orig, *working, *token, *u, *regexp;
 	int ret = 0;
 
+	pipe = strstr(cmd_in, " | ");
 	if (!pipe)
 		return 0;
 
-	/* duplicate string for processing purposes, not including pipe */
-	orig = working = XSTRDUP(MTYPE_TMP, pipe + 2);
+	/*
+	 * duplicate string for processing purposes,
+	 * not including pipe nor space.
+	 */
+	pipe += 3;
+	while (isblank((unsigned char)*pipe))
+		pipe++;
+
+	if (*pipe == '\0') {
+		vty_out(vty, "%% Command incomplete: %s\n", cmd_in);
+		return 1;
+	}
+
+	orig = working = XSTRDUP(MTYPE_TMP, pipe);
 
 	/* retrieve action */
 	token = strsep(&working, " ");
 	assert(token);
 
 	/* match result to known actions */
-	if (strmatch(token, "include")) {
-		/* the remaining text should be a regexp */
-		char *regexp = working;
-
-		if (!regexp) {
-			vty_out(vty, "%% Need a regexp to filter with\n");
-			ret = 1;
-			goto fail;
-		}
-
-		bool succ = vty_set_include(vty, regexp);
-
-		if (!succ) {
-			vty_out(vty, "%% Bad regexp '%s'\n", regexp);
-			ret = 1;
-			goto fail;
-		}
-		*cmd_out = XSTRDUP(MTYPE_TMP, cmd_in);
-		u = *cmd_out;
-		strsep(&u, "|");
-	} else {
+	if (!strmatch(token, "include")) {
 		vty_out(vty, "%% Unknown action '%s'\n", token);
 		ret = 1;
 		goto fail;
 	}
+
+	if (!working) {
+		vty_out(vty, "%% Command incomplete: %s\n", cmd_in);
+		ret = 1;
+		goto fail;
+	}
+
+	/* ignoring preliminary blank characters */
+	while (isblank((unsigned char)*working))
+		working++;
+
+	/* the remaining text should be a regexp */
+	regexp = working;
+	if (*regexp == '\0') {
+		vty_out(vty, "%% Need a regexp to filter with\n");
+		ret = 1;
+		goto fail;
+	}
+
+	bool succ = vty_set_include(vty, regexp);
+	if (!succ) {
+		vty_out(vty, "%% Bad regexp '%s'\n", regexp);
+		ret = 1;
+		goto fail;
+	}
+
+	*cmd_out = XSTRDUP(MTYPE_TMP, cmd_in);
+	u = *cmd_out;
+	strsep(&u, "|");
 
 fail:
 	XFREE(MTYPE_TMP, orig);

--- a/lib/command_lex.l
+++ b/lib/command_lex.l
@@ -69,6 +69,8 @@ ASNUM           ASNUM
 {VARIABLE}      {yylval->string = XSTRDUP(MTYPE_LEX, yytext); return VARIABLE;}
 {WORD}          {yylval->string = XSTRDUP(MTYPE_LEX, yytext); return WORD;}
 {RANGE}         {yylval->string = XSTRDUP(MTYPE_LEX, yytext); return RANGE;}
+\\\|            {yylval->string = XSTRDUP(MTYPE_LEX, "|"); return WORD;}
+\|              {yylval->string = NULL; return PIPE;}
 !\[             {yylval->string = NULL; return EXCL_BRACKET;}
 .               {return yytext[0];}
 %%

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -1024,6 +1024,8 @@ static enum match_type match_word(struct cmd_token *token, const char *word)
 static enum match_type match_variable(struct cmd_token *token, const char *word)
 {
 	assert(token->type == VARIABLE_TKN);
+	if (word[0] == '|')
+		return no_match;
 	return exact_match;
 }
 

--- a/lib/command_parse.y
+++ b/lib/command_parse.y
@@ -94,6 +94,7 @@
 
 /* special syntax, value is irrelevant */
 %token <string> EXCL_BRACKET
+%token <string> PIPE
 
 /* union types for parsed rules */
 %type <node> start
@@ -310,7 +311,7 @@ selector: '<' selector_seq_seq '>' varname_token
 };
 
 selector_seq_seq:
-  selector_seq_seq '|' selector_token_seq
+  selector_seq_seq PIPE selector_token_seq
 {
   $$ = $1;
   graph_add_edge ($$.start, $3.start);

--- a/lib/command_parse.y
+++ b/lib/command_parse.y
@@ -101,6 +101,7 @@
 %type <node> placeholder_token
 %type <node> placeholder_token_real
 %type <node> simple_token
+%type <node> variadic_token
 %type <subgraph> selector
 %type <subgraph> selector_token
 %type <subgraph> selector_token_seq
@@ -174,20 +175,6 @@ start:
   // tack on the command element
   terminate_graph (&@1, ctx, ctx->currnode);
 }
-| cmd_token_seq placeholder_token '.' '.' '.'
-{
-  if ((ctx->currnode = graph_add_edge (ctx->currnode, $2)) != $2)
-    graph_delete_node (ctx->graph, $2);
-
-  ((struct cmd_token *)ctx->currnode->data)->allowrepeat = 1;
-
-  // adding a node as a child of itself accepts any number
-  // of the same token, which is what we want for variadics
-  graph_add_edge (ctx->currnode, ctx->currnode);
-
-  // tack on the command element
-  terminate_graph (&@1, ctx, ctx->currnode);
-}
 ;
 
 varname_token: '$' WORD
@@ -207,6 +194,12 @@ cmd_token_seq:
 
 cmd_token:
   simple_token
+{
+  if ((ctx->currnode = graph_add_edge (ctx->currnode, $1)) != $1)
+    graph_delete_node (ctx->graph, $1);
+  cmd_token_varname_seqappend($1);
+}
+| variadic_token
 {
   if ((ctx->currnode = graph_add_edge (ctx->currnode, $1)) != $1)
     graph_delete_node (ctx->graph, $1);
@@ -300,6 +293,13 @@ placeholder_token:
   XFREE (MTYPE_LEX, $2);
 };
 
+variadic_token:
+  placeholder_token '.' '.' '.'
+{
+  ((struct cmd_token *)$1->data)->allowrepeat = 1;
+  graph_add_edge ($1, $1);
+  $$ = $1;
+};
 
 /* <selector|set> productions */
 selector: '<' selector_seq_seq '>' varname_token
@@ -348,6 +348,10 @@ selector: '{' selector_seq_seq '}' varname_token
 
 selector_token:
   simple_token
+{
+  $$.start = $$.end = $1;
+}
+| variadic_token
 {
   $$.start = $$.end = $1;
 }

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -52,6 +52,12 @@ enum vty_status {
 	VTY_PASSFD,
 };
 
+enum output_filter {
+	FILTER_AMBIGUOUS = -1,
+	FILTER_NONE,
+	FILTER_INCLUDE
+};
+
 PREDECL_DLIST(vtys);
 
 /* VTY struct. */

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -52,11 +52,7 @@ enum vty_status {
 	VTY_PASSFD,
 };
 
-enum output_filter {
-	FILTER_AMBIGUOUS = -1,
-	FILTER_NONE,
-	FILTER_INCLUDE
-};
+enum output_filter { FILTER_AMBIGUOUS = -1, FILTER_NONE, FILTER_INCLUDE };
 
 PREDECL_DLIST(vtys);
 

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -148,6 +148,7 @@ extern "C" {
 #include "lib/route_types.h"
 
 #define strmatch(a,b) (!strcmp((a), (b)))
+#define strnmatch(a,b,n) (!strncmp((a), (b), (n)))
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 #define htonll(x) (((uint64_t)htonl((x)&0xFFFFFFFF) << 32) | htonl((x) >> 32))

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -147,8 +147,8 @@ extern "C" {
 /* Zebra route's types are defined in route_types.h */
 #include "lib/route_types.h"
 
-#define strmatch(a,b) (!strcmp((a), (b)))
-#define strnmatch(a,b,n) (!strncmp((a), (b), (n)))
+#define strmatch(a, b)	   (!strcmp((a), (b)))
+#define strnmatch(a, b, n) (!strncmp((a), (b), (n)))
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 #define htonll(x) (((uint64_t)htonl((x)&0xFFFFFFFF) << 32) | htonl((x) >> 32))

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -168,6 +168,7 @@ handlers = {
 # jinja2)
 templ = Template(
     """$cond_begin/* $fnname => "$cmddef" */
+#define IS_SHOW_CMD_$fnname $is_show_cmd
 DEFUN_CMD_FUNC_DECL($fnname)
 #define funcdecl_$fnname static int ${fnname}_magic(\\
 	const struct cmd_element *self __attribute__ ((unused)),\\
@@ -361,6 +362,11 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
             # pprint(args)
 
             params = {"cmddef": cmddef, "fnname": entry["args"][0][0]}
+            if cmddef.startswith("show "):
+                params["is_show_cmd"] = "1"
+            else:
+                params["is_show_cmd"] = "0"
+
             argdefs = []
             argdecls = []
             arglist = []

--- a/python/xref2vtysh.py
+++ b/python/xref2vtysh.py
@@ -152,6 +152,8 @@ class CommandEntry:
         self._registered = False
 
         self.cmd = spec["string"]
+        if self.cmd.startswith("show "):
+            self.inject_output_modifiers()
         self._cmd_normalized = self.normalize_cmd(self.cmd)
 
         self.hidden = "hidden" in spec.get("attrs", [])
@@ -160,6 +162,15 @@ class CommandEntry:
         self.doclines = self._spec["doc"].splitlines(keepends=True)
         if not self.doclines[-1].endswith("\n"):
             self.warn_loc("docstring does not end with \\n")
+
+    def inject_output_modifiers(self):
+        self.cmd += " [\\| include REGEX...]"
+
+        if not self._spec["doc"].endswith("\n"):
+            self._spec["doc"] += "\n"
+        self._spec[
+            "doc"
+        ] += "Output modifiers\nInclude lines that match\nRegular Expression\n"
 
     @staticmethod
     def _warn_loc(name, spec, wtext, nodename=None):

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -41,6 +41,28 @@
 #include "ferr.h"
 #include "sockopt.h"
 
+#define output_modifiers_cmdstr " [\\| include REGEX...]"
+#define output_modifiers_helpstr                                                                  \
+	"Output modifiers\n"                                                                      \
+	"Include lines that match\n"                                                              \
+	"Regular Expression\n"
+
+#ifdef DEFPY
+#undef DEFPY
+#endif
+#define DEFPY(funcname, cmdname, cmdstr, helpstr)                                                 \
+	DEFPY_ATTR(funcname, cmdname,                                                             \
+		   __builtin_choose_expr(IS_SHOW_CMD_##funcname, cmdstr output_modifiers_cmdstr,  \
+					 cmdstr),                                                 \
+		   __builtin_choose_expr(IS_SHOW_CMD_##funcname,                                  \
+					 helpstr output_modifiers_helpstr, helpstr),              \
+		   0)
+
+#ifdef CLIPPY
+/* clippy/clidef can't process the DEFPY below without some value for this */
+#define DAEMONS_LIST "daemon"
+#endif
+
 DEFINE_MTYPE_STATIC(MVTYSH, VTYSH_CMD, "Vtysh cmd copy");
 
 /* Struct VTY. */
@@ -3159,7 +3181,7 @@ static int show_one_daemon(struct vty *vty, struct cmd_token **argv, int argc,
 	return ret;
 }
 
-DEFUN (vtysh_show_event_timer,
+DEFPY (vtysh_show_event_timer,
        vtysh_show_event_timer_cmd,
        "show event timers",
        SHOW_STR
@@ -3169,7 +3191,7 @@ DEFUN (vtysh_show_event_timer,
 	return show_per_daemon(vty, argv, argc, "Event timers for %s:\n");
 }
 
-DEFUN (vtysh_show_event_poll,
+DEFPY (vtysh_show_event_poll,
        vtysh_show_event_poll_cmd,
        "show event poll",
        SHOW_STR
@@ -3179,7 +3201,7 @@ DEFUN (vtysh_show_event_poll,
 	return show_per_daemon(vty, argv, argc, "Event statistics for %s:\n");
 }
 
-DEFUN (vtysh_show_event,
+DEFPY (vtysh_show_event,
        vtysh_show_event_cpu_cmd,
        "show event cpu [FILTER]",
        SHOW_STR
@@ -3190,7 +3212,7 @@ DEFUN (vtysh_show_event,
 	return show_per_daemon(vty, argv, argc, "Event statistics for %s:\n");
 }
 
-DEFUN (vtysh_show_work_queues,
+DEFPY (vtysh_show_work_queues,
        vtysh_show_work_queues_cmd,
        "show work-queues",
        SHOW_STR
@@ -3200,7 +3222,7 @@ DEFUN (vtysh_show_work_queues,
 			       "Work queue statistics for %s:\n");
 }
 
-DEFUN (vtysh_show_work_queues_daemon,
+DEFPY (vtysh_show_work_queues_daemon,
        vtysh_show_work_queues_daemon_cmd,
        "show work-queues " DAEMONS_LIST,
        SHOW_STR
@@ -3258,7 +3280,7 @@ DEFUNSH_HIDDEN (0x00,
 	return CMD_SUCCESS;
 }
 
-DEFUN (vtysh_show_debugging,
+DEFPY (vtysh_show_debugging,
        vtysh_show_debugging_cmd,
        "show debugging",
        SHOW_STR
@@ -3267,7 +3289,7 @@ DEFUN (vtysh_show_debugging,
 	return show_per_daemon(vty, argv, argc, "");
 }
 
-DEFUN (vtysh_show_debugging_hashtable,
+DEFPY (vtysh_show_debugging_hashtable,
        vtysh_show_debugging_hashtable_cmd,
        "show debugging hashtable [statistics]",
        SHOW_STR
@@ -3292,7 +3314,7 @@ DEFUN (vtysh_show_debugging_hashtable,
 			       "Hashtable statistics for %s:\n");
 }
 
-DEFUN (vtysh_show_error_code,
+DEFPY (vtysh_show_error_code,
        vtysh_show_error_code_cmd,
        "show error <(1-4294967296)|all> [json]",
        SHOW_STR
@@ -3323,7 +3345,7 @@ DEFUN (vtysh_show_error_code,
 }
 
 /* Northbound. */
-DEFUN (show_config_running,
+DEFPY (show_config_running,
        show_config_running_cmd,
        "show configuration running\
           [<json|xml> [translate WORD]]\
@@ -3341,7 +3363,7 @@ DEFUN (show_config_running,
 	return show_one_daemon(vty, argv, argc - 1, argv[argc - 1]->text);
 }
 
-DEFUN (show_yang_operational_data,
+DEFPY (show_yang_operational_data,
        show_yang_operational_data_cmd,
        "show yang operational-data XPATH\
          [{\
@@ -3364,7 +3386,7 @@ DEFUN (show_yang_operational_data,
 	return show_one_daemon(vty, argv, argc - 1, argv[argc - 1]->text);
 }
 
-DEFUN(show_yang_module, show_yang_module_cmd,
+DEFPY (show_yang_module, show_yang_module_cmd,
       "show yang module [module-translator WORD] " DAEMONS_LIST,
       SHOW_STR
       "YANG information\n"
@@ -3375,7 +3397,7 @@ DEFUN(show_yang_module, show_yang_module_cmd,
 	return show_one_daemon(vty, argv, argc - 1, argv[argc - 1]->text);
 }
 
-DEFUN(show_yang_module_detail, show_yang_module_detail_cmd,
+DEFPY (show_yang_module_detail, show_yang_module_detail_cmd,
       "show yang module\
           [module-translator WORD]\
           WORD <compiled|summary|tree|yang|yin> " DAEMONS_LIST,
@@ -3419,7 +3441,7 @@ DEFUNSH(VTYSH_ALL, debug_nb,
 	return CMD_SUCCESS;
 }
 
-DEFUN (vtysh_show_history,
+DEFPY (vtysh_show_history,
        vtysh_show_history_cmd,
        "show history",
        SHOW_STR
@@ -3476,7 +3498,7 @@ static void show_collate_json_send(const char *daemon, const char *command_line)
 }
 
 /* Memory */
-DEFUN (vtysh_show_memory,
+DEFPY (vtysh_show_memory,
        vtysh_show_memory_cmd,
        "show <memory|rcu> [" DAEMONS_LIST "] [json]",
        SHOW_STR
@@ -3519,7 +3541,7 @@ DEFUN (vtysh_show_memory,
  */
 #ifdef HAVE_TCMALLOC
 
-DEFUN (vtysh_show_tcmalloc_stats,
+DEFPY (vtysh_show_tcmalloc_stats,
        vtysh_show_tcmalloc_stats_cmd,
        "show tcmalloc stats [" DAEMONS_LIST "]",
        SHOW_STR
@@ -3560,7 +3582,7 @@ DEFUN (vtysh_tcmalloc_config,
 
 #endif /* HAVE_TCMALLOC */
 
-DEFUN (vtysh_show_modules,
+DEFPY (vtysh_show_modules,
        vtysh_show_modules_cmd,
        "show modules",
        SHOW_STR
@@ -3570,7 +3592,7 @@ DEFUN (vtysh_show_modules,
 }
 
 /* Logging commands. */
-DEFUN (vtysh_show_logging,
+DEFPY (vtysh_show_logging,
        vtysh_show_logging_cmd,
        "show logging",
        SHOW_STR
@@ -3732,7 +3754,7 @@ DEFUN (vtysh_write_terminal,
 	return CMD_SUCCESS;
 }
 
-DEFUN (vtysh_show_running_config,
+DEFPY (vtysh_show_running_config,
        vtysh_show_running_config_cmd,
        "show running-config ["DAEMONS_LIST"] [no-header]",
        SHOW_STR
@@ -4387,7 +4409,7 @@ ALIAS_DEPRECATED(vtysh_terminal_length,
        NO_STR
        "Set number of lines on a screen\n")
 
-DEFUN (vtysh_show_daemons,
+DEFPY (vtysh_show_daemons,
        vtysh_show_daemons_cmd,
        "show daemons",
        SHOW_STR
@@ -4606,11 +4628,6 @@ static void vtysh_log_read(struct event *event)
 	return;
 }
 
-#ifdef CLIPPY
-/* clippy/clidef can't process the DEFPY below without some value for this */
-#define DAEMONS_LIST "daemon"
-#endif
-
 DEFPY (vtysh_terminal_monitor,
        vtysh_terminal_monitor_cmd,
        "terminal monitor ["DAEMONS_LIST"]$daemon",
@@ -4794,7 +4811,7 @@ DEFPY (vtysh_ping,
 	return CMD_SUCCESS;
 }
 
-DEFUN(vtysh_motd, vtysh_motd_cmd, "show motd", SHOW_STR "Show motd\n")
+DEFPY(vtysh_motd, vtysh_motd_cmd, "show motd", SHOW_STR "Show motd\n")
 {
 	vty_hello(vty);
 	return CMD_SUCCESS;
@@ -5202,12 +5219,14 @@ static char *vtysh_completion_entry_function(const char *ignore,
 void vtysh_readline_init(void)
 {
 	/* readline related settings. */
+	static char custom_word_break_chars[] = " \t\n";
 	char *disable_bracketed_paste =
 		XSTRDUP(MTYPE_TMP, "set enable-bracketed-paste off");
 
 	rl_initialize();
 	rl_parse_and_bind(disable_bracketed_paste);
 	rl_bind_key('?', (rl_command_func_t *)vtysh_rl_describe);
+	rl_completer_word_break_characters = custom_word_break_chars;
 	rl_completion_entry_function = vtysh_completion_entry_function;
 	rl_attempted_completion_function = new_completion;
 


### PR DESCRIPTION
Some work has been done to develop output modifiers:

* Added changes to the lexer and parser to distinguish between the pipe (`|`) used for selection and the pipe used as the output modifier operator. In addition, there was previously no support for variadic syntax inside bracketed options. This has now been added so that `REGEX...` can be used, allowing the user to enter multiple words while remaining in the `REGEX` state.
* Disallowed `|` as the first character of variables to avoid the confusion that could arise when both `VARIABLE` tokens and the output-modifier pipe token are valid.
* Fixed several issues in the implementation of `handle_pipe_action()` to resolve the following problems:

  * Enforcing spacing between tokens
  * Supporting abbreviated filter names
  * Adding evaluation of `show` commands so that output modifiers can only be used with `show` commands
* Added support for appending output-modifier command strings and help strings to the end of `show` commands automatically in `vtysh`.
* Removed the pipe character from readline word-break characters.

NOTE: I am currently trying to add some tests and also complete docs as needed.