### PR TITLE
bgpd: use bm buffer for rcvd_attr_str debug logging

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2398,8 +2398,8 @@ static int bgp_update_receive(struct peer_connection *connection, bgp_size_t siz
 	attr.label_index = BGP_INVALID_LABEL_INDEX;
 	attr.label = MPLS_INVALID_LABEL;
 	memset(&nlris, 0, sizeof(nlris));
-	memset(peer->rcvd_attr_str, 0, BUFSIZ);
-	peer->rcvd_attr_printed = false;
+	bm->rcvd_attr_str[0] = '\0';
+	bm->rcvd_attr_printed = false;
 
 	s = connection->curr;
 	end = stream_pnt(s) + size;
@@ -2494,8 +2494,7 @@ static int bgp_update_receive(struct peer_connection *connection, bgp_size_t siz
 	if (attr_parse_ret == BGP_ATTR_PARSE_WITHDRAW ||
 	    attr_parse_ret == BGP_ATTR_PARSE_WITHDRAW_IGNORE || BGP_DEBUG(update, UPDATE_IN) ||
 	    BGP_DEBUG(update, UPDATE_PREFIX)) {
-		ret = bgp_dump_attr(&attr, peer->rcvd_attr_str,
-				    sizeof(peer->rcvd_attr_str));
+		ret = bgp_dump_attr(&attr, bm->rcvd_attr_str, sizeof(bm->rcvd_attr_str));
 
 		if (attr_parse_ret == BGP_ATTR_PARSE_WITHDRAW ||
 		    attr_parse_ret == BGP_ATTR_PARSE_WITHDRAW_IGNORE) {
@@ -2508,9 +2507,8 @@ static int bgp_update_receive(struct peer_connection *connection, bgp_size_t siz
 
 		if (ret && bgp_debug_update(peer, NULL, NULL, 1) &&
 		    BGP_DEBUG(update, UPDATE_DETAIL)) {
-			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
-				   peer->rcvd_attr_str);
-			peer->rcvd_attr_printed = true;
+			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer, bm->rcvd_attr_str);
+			bm->rcvd_attr_printed = true;
 		}
 	}
 
@@ -2616,6 +2614,9 @@ static int bgp_update_receive(struct peer_connection *connection, bgp_size_t siz
 
 	/* Notify BGP Conditional advertisement scanner process */
 	peer->advmap_table_change = true;
+
+	/* Clear attribute string to prevent stale state from other call paths */
+	bm->rcvd_attr_str[0] = '\0';
 
 	return Receive_UPDATE_message;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6236,12 +6236,10 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			{
 				peer->pcount_dup[afi][safi]++;
 				if (unlikely(bgp_debug_update(peer, p, NULL, 1))) {
-					if (!peer->rcvd_attr_printed) {
-						zlog_debug(
-							"%pBP rcvd UPDATE w/ attr: %s",
-							peer,
-							peer->rcvd_attr_str);
-						peer->rcvd_attr_printed = true;
+					if (!bm->rcvd_attr_printed && bm->rcvd_attr_str[0]) {
+						zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
+							   bm->rcvd_attr_str);
+						bm->rcvd_attr_printed = true;
 					}
 
 					bgp_debug_rdpfxpath2str(
@@ -6563,10 +6561,9 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 	/* Received Logging. */
 	if (unlikely(bgp_debug_update(peer, p, NULL, 1))) {
-		if (!peer->rcvd_attr_printed) {
-			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
-				   peer->rcvd_attr_str);
-			peer->rcvd_attr_printed = true;
+		if (!bm->rcvd_attr_printed && bm->rcvd_attr_str[0]) {
+			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer, bm->rcvd_attr_str);
+			bm->rcvd_attr_printed = true;
 		}
 
 		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,
@@ -6684,10 +6681,9 @@ filtered:
 	hook_call(bgp_process, bgp, afi, safi, dest, peer, true);
 
 	if (bgp_debug_update(peer, p, NULL, 1)) {
-		if (!peer->rcvd_attr_printed) {
-			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
-				   peer->rcvd_attr_str);
-			peer->rcvd_attr_printed = true;
+		if (!bm->rcvd_attr_printed && bm->rcvd_attr_str[0]) {
+			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer, bm->rcvd_attr_str);
+			bm->rcvd_attr_printed = true;
 		}
 
 		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -233,6 +233,10 @@ struct bgp_master {
 
 	bool v6_with_v4_nexthops;
 
+	/* Debug buffer for received UPDATE attributes (single-threaded) */
+	char rcvd_attr_str[BUFSIZ];
+	bool rcvd_attr_printed;
+
 	/* To preserve ordering of installations into zebra across all Vrfs */
 	struct zebra_announce_head zebra_announce_head;
 	struct zebra_announce_head zebra_announce_early_head;
@@ -2098,19 +2102,6 @@ struct peer {
 
 	/* ORF Prefix-list */
 	struct prefix_list *orf_plist[AFI_MAX][SAFI_MAX];
-
-	/* Text description of last attribute rcvd */
-	char rcvd_attr_str[BUFSIZ];
-
-	/*
-	 * Track if we printed the attribute in debugs
-	 *
-	 * These two rcvd_attr_str and rcvd_attr_printed are going to
-	 * be fun in the long term when we want to break up parsing
-	 * of data from the nlri in multiple pthreads or really
-	 * if we ever change order of things this will just break
-	 */
-	bool rcvd_attr_printed;
 
 	/* Accepted prefix count */
 	uint32_t pcount[AFI_MAX][SAFI_MAX];


### PR DESCRIPTION
The embedded rcvd_attr_str[BUFSIZ] array in struct peer consumes 8192 bytes per peer, but is only used for debug logging of received BGP UPDATE attributes.

Change to a bm buffer since BGP packet processing is single-threaded in the event loop. This eliminates 8KB of memory usage per peer.