### PR TITLE
babeld: reschedule the main loop when an interface is enabled

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -639,6 +639,14 @@ static int interface_recalculate(struct interface *ifp)
 	if (rc > 0)
 		send_update(ifp, 0, NULL, 0);
 
+	/* The interface's hello/update timers were just (re)armed.  If the main
+	 * loop is asleep on an earlier-scheduled, far-future wakeup (e.g. the
+	 * daemon was running with no enabled interface), it would not honour
+	 * these timers until then, stalling Hellos on this interface for many
+	 * seconds.  Reschedule the loop to run now.
+	 */
+	babel_schedule_now();
+
 	return 1;
 }
 

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -492,6 +492,21 @@ static void babel_set_timer(struct timeval *timeout)
 			     &babel_routing_process->t_update);
 }
 
+/* Wake the main loop immediately.  The main loop only re-arms its own timer at
+ * the end of each pass, using the timeouts that existed at that time.  When a
+ * per-interface timer (e.g. a freshly enabled interface's hello/update timeout)
+ * is set outside the loop, it would otherwise not take effect until the
+ * previously scheduled, possibly far-future, wakeup.  Call this to reschedule
+ * the loop to run now so those timers are honoured promptly.
+ */
+void babel_schedule_now(void)
+{
+	struct timeval now = { 0, 0 };
+
+	if (babel_routing_process)
+		babel_set_timer(&now);
+}
+
 void schedule_neighbours_check(int msecs, int override)
 {
 	struct timeval timeout;

--- a/babeld/babeld.h
+++ b/babeld/babeld.h
@@ -101,6 +101,7 @@ extern int redistribute_filter(const unsigned char *prefix, unsigned short plen,
 			       unsigned int ifindex, int proto);
 extern int resize_receive_buffer(int size);
 extern void schedule_neighbours_check(int msecs, int override);
+extern void babel_schedule_now(void);
 extern struct babel *babel_lookup(void);
 extern void babel_clean_routing_process(void);
 


### PR DESCRIPTION
`babel_main_loop()` (babeld's periodic Hello/Update sender) is the only place that re-arms its `t_update` timer, and it only schedules a wakeup for interfaces that are already up. So if an interface is enabled at runtime (`network <ifname>` → `babel_enable_if_add()` → `interface_recalculate()`), the loop keeps sleeping on its previous far-future wakeup (~16s, the neighbour-check / route-expiry timeout). The new interface's Hellos aren't sent until then; the fresh neighbour's cost latches at infinity and every route from it installs as `metric 65535` / reject.

Fix: add `babel_schedule_now()` and call it from `interface_recalculate()` so the loop runs immediately when an interface is enabled.

Closes #22484
