### PR TITLE
zebra: keep route_node lock in NB RIB route lookup_next

### DIFF
--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -411,14 +411,16 @@ lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args)
 		rn = route_top(zrt->table);
 	else
 		rn = srcdest_route_next(rn);
-	/* Optimization: skip empty route nodes. */
-	while (rn && rn->info == NULL)
+	/*
+	 * Skip empty route nodes and link-local IPv6 routes. Link-locals are
+	 * excluded because the multiple connected link-local routes a router
+	 * holds (one per interface) collapse to identical YANG keys
+	 * (route[prefix='fe80::/64']/route-entry[protocol='connected']), which
+	 * breaks key-based resume of the async walk.
+	 */
+	while (rn && (rn->info == NULL ||
+		      (rn->p.family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL(&rn->p.u.prefix6))))
 		rn = route_next(rn);
-
-	/* Skip link-local routes. */
-	if (rn && rn->p.family == AF_INET6
-	    && IN6_IS_ADDR_LINKLOCAL(&rn->p.u.prefix6))
-		return NULL;
 
 	return rn;
 }

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -466,8 +466,14 @@ lib_vrf_zebra_ribs_rib_route_lookup_next(struct nb_cb_lookup_entry_args *args)
 	if (!rn)
 		return NULL;
 
-	route_unlock_node(rn);
-
+	/*
+	 * Unlike lib_vrf_zebra_ribs_rib_route_lookup_entry() (a self-contained
+	 * point lookup), this function seeds the get_next iteration: the
+	 * returned node is carried as args->list_entry into
+	 * lib_vrf_zebra_ribs_rib_route_get_next() -> srcdest_route_next() ->
+	 * route_next(), which unlocks its input node. The node returned by
+	 * route_table_get_next() must therefore keep the lock it carries.
+	 */
 	return rn;
 }
 


### PR DESCRIPTION
### Summary

zebra aborts with `assertion (node->lock > 0) failed` while serving the northbound oper-state walk of the `/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route` list over a large RIB.

Root cause is a lock-contract mismatch in `zebra/zebra_nb_state.c`:

- `lib_vrf_zebra_ribs_rib_route_lookup_next()` calls `route_table_get_next()`, which returns a `route_node` with the lock it acquired **held**, and then immediately drops it with `route_unlock_node()` before returning the node.
- That node is carried back into the walk as `args->list_entry` and passed to `lib_vrf_zebra_ribs_rib_route_get_next()` -> `srcdest_route_next()` -> `route_next()`, which unlocks its input node as part of advancing.

Because `lookup_next()` had already released the lock, `route_next()` under-runs the lock count to zero and trips the `route_unlock_node()` assert, aborting zebra. The companion `lookup_entry()` is a self-contained point lookup and correctly unlocks the node it returns; `lookup_next()`, by contrast, seeds an iteration whose first step (`route_next`) expects the carried node to still be locked.

The fix removes the erroneous `route_unlock_node()` so the iterator lock contract holds.

**How it triggers:** the oper-state notification walk yields when the RIB is large enough to exceed the per-iteration work budget, then resumes via `lookup_next()`. A walk small enough to complete without yielding never re-enters `lookup_next()` and does not hit the assert, which is why this surfaces only on sizeable RIBs.

**Reproduction (generic FRR):**

1. Single zebra instance with a large RIB (several thousand routes across v4 and v6, e.g. injected via a BGP peer or `sharpd`).
2. Drive the `frr-zebra` oper-state route list while the RIB is fully populated so the walk yields and resumes -- e.g. a northbound/mgmtd get on `/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route`, or any event that re-runs the VRF oper-state notification walk (such as a zebra restart with the routes already present).
3. zebra aborts: `zebra: assertion (node->lock > 0) failed`, backtrace `route_next -> _zlog_assert_failed -> abort` under `lib_vrf_zebra_ribs_rib_route_get_next` on a thread scheduled from `nb_op_yield()`.

**Validation:** verified downstream in SONiC (FRR 10.5.4, where this code path is byte-identical to `master`) with a controlled before/after test -- same ~12.9k-route RIB (IPv4+IPv6) and same trigger, changing only the FRR build:

- **Before (unfixed):** zebra aborts in the `nb_op_walk -> route_next` assert and leaves a core dump; vtysh becomes unresponsive.
- **After (this fix):** zebra survives the identical condition across 5/5 trials -- no core, no assert, vtysh responsive.

**No new topotest:** triggering this needs the oper-state route walk to yield on a large RIB and resume through `lookup_next()`, which is hard to force reliably in topotests. I've instead confirmed the fix by validating that zebra no longer crashes in SONiC under the same trigger (before/after above).

### Second commit (`8b5dc38`) — skip link-local routes without leaking the node lock

Per @mjstapp's review note, the same northbound callback `lib_vrf_zebra_ribs_rib_route_get_next()` also filtered IPv6 link-local routes with a bare `return NULL`. That had two problems: it leaked the lock `route_top()`/`route_next()` had taken on the node (the node was never handed back to `route_next()` to be unlocked), and it truncated the entire walk at the first link-local instead of skipping past it.

The fix folds the link-local test into the existing empty-node skip loop, so `route_next()` balances the lock and the walk continues past link-locals. The filter itself is retained: a router holds one connected link-local route per interface, all kept as separate route-entries under the single `fe80::/64` node, and they collapse to identical YANG keys (`route[prefix='fe80::/64']/route-entry[protocol='connected']`), which would break key-based resume of the asynchronous walk.

**Validation (same SONiC setup):** in the default VRF a connected `fec0::/64` route sorts *after* the interface link-locals in tree-walk order, so the bare `return NULL` truncated the walk and dropped it.

- **Before (unfixed):** the NB oper-data walk of the v6 RIB returns `{ ::/0, fc00:1::/64, fc00:1::32/128 }` — `fec0::/64` is missing.
- **After (this commit):** the walk returns `{ ::/0, fc00:1::/64, fc00:1::32/128, fec0::/64 }` — `fec0::/64` is present, while `fe80::/64` stays filtered. No new core or `route_unlock_node` assert under the same kill/sweep trigger.

### Related Issue

Fixes #22489

Reported downstream as https://github.com/sonic-net/sonic-buildimage/issues/27788

### Components

zebra

