### PR TITLE
bgpd: fix BGP-LS NLRI size calculation in bgp_packet_mpattr_prefix_si…

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -5273,8 +5273,7 @@ size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi,
 		size = ((struct prefix_fs *)p)->prefix.prefixlen;
 		break;
 	case SAFI_BGP_LS:
-		/* TODO: add explaination */
-		size = 0;
+		size = BGP_LS_NLRI_MAX_SIZE;
 		break;
 	}
 

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -695,6 +695,18 @@ static inline void bgp_attr_set_nhc(struct attr *attr, struct bgp_nhc *bnc)
 	(CHECK_FLAG((peer)->flags, PEER_FLAG_AIGP) || ((peer)->sub_sort == BGP_PEER_EBGP_OAD) ||   \
 	 ((peer)->sort != BGP_PEER_EBGP))
 
+/*
+ * Maximum wire size for BGP-LS Link NLRI (RFC 9552 Section 3.3.2.2).
+ * Breakdown:
+ *   - Protocol ID: 1 byte
+ *   - Identifier: 8 bytes
+ *   - Local Node Descriptor: 52 bytes (max)
+ *   - Remote Node Descriptor: 52 bytes (max)
+ *   - Link Descriptor: 94 bytes (max, includes all possible sub-TLVs)
+ * Total: 207 bytes, rounded up to 256 for alignment and safety margin.
+ */
+#define BGP_LS_NLRI_MAX_SIZE 256
+
 static inline uint64_t bgp_attr_get_aigp_metric(const struct attr *attr)
 {
 	return attr->extra ? attr->extra->aigp_metric : 0;


### PR DESCRIPTION
  The SAFI_BGP_LS case returned size=0, which means no space was reserved for the NLRI when assembling UPDATE messages. This could cause UPDATE packets to exceed the maximum size when carrying BGP-LS Link NLRIs.
The maximum Link NLRI wire size is:
      Protocol-ID(1) + Identifier(8) + Local Node Descriptor(52) +
      Remote Node Descriptor(52) + Link Descriptor(94) = 207 bytes
Use a conservative value of 256 bytes (next power of 2) to ensure sufficient space is reserved for any BGP-LS NLRI type.