### PR TITLE
*: fix overflow in comparator functions used by sorted containers

### DIFF
--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -95,7 +95,11 @@ struct nbr_pid_head nbrs_by_pid = RB_INITIALIZER(&nbrs_by_pid);
 static __inline int
 nbr_id_compare(const struct nbr *a, const struct nbr *b)
 {
-	return (ntohl(a->id.s_addr) - ntohl(b->id.s_addr));
+	if (ntohl(a->id.s_addr) > ntohl(b->id.s_addr))
+		return 1;
+	if (ntohl(a->id.s_addr) < ntohl(b->id.s_addr))
+		return -1;
+	return 0;
 }
 
 static __inline int
@@ -765,7 +769,11 @@ nbr_send_labelmappings(struct nbr *nbr)
 static __inline int
 nbr_params_compare(const struct nbr_params *a, const struct nbr_params *b)
 {
-	return (ntohl(a->lsr_id.s_addr) - ntohl(b->lsr_id.s_addr));
+	if (ntohl(a->lsr_id.s_addr) > ntohl(b->lsr_id.s_addr))
+		return 1;
+	if (ntohl(a->lsr_id.s_addr) < ntohl(b->lsr_id.s_addr))
+		return -1;
+	return 0;
 }
 
 struct nbr_params *

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -70,9 +70,9 @@ static int ospf6_vertex_cmp(const struct ospf6_vertex *va,
 {
 	/* ascending order */
 	if (va->cost != vb->cost)
-		return (va->cost - vb->cost);
+		return (va->cost > vb->cost) ? 1 : -1;
 	if (va->hops != vb->hops)
-		return (va->hops - vb->hops);
+		return (va->hops > vb->hops) ? 1 : -1;
 	return 0;
 }
 DECLARE_SKIPLIST_NONUNIQ(vertex_pqueue, struct ospf6_vertex, pqi,

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -64,7 +64,7 @@ static void ospf_spf_set_reason(ospf_spf_reason_t reason)
 static int vertex_cmp(const struct vertex *v1, const struct vertex *v2)
 {
 	if (v1->distance != v2->distance)
-		return v1->distance - v2->distance;
+		return (v1->distance > v2->distance) ? 1 : -1;
 
 	if (v1->type != v2->type) {
 		switch (v1->type) {

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -97,15 +97,27 @@ static void ospf_free_refresh_queue(struct ospf *ospf)
 
 int p_spaces_compare_func(const struct p_space *a, const struct p_space *b)
 {
-	if (a->protected_resource->type == OSPF_TI_LFA_LINK_PROTECTION
-	    && b->protected_resource->type == OSPF_TI_LFA_LINK_PROTECTION)
-		return (a->protected_resource->link->link_id.s_addr
-			- b->protected_resource->link->link_id.s_addr);
+	if (a->protected_resource->type == OSPF_TI_LFA_LINK_PROTECTION &&
+	    b->protected_resource->type == OSPF_TI_LFA_LINK_PROTECTION) {
+		if (a->protected_resource->link->link_id.s_addr >
+		    b->protected_resource->link->link_id.s_addr)
+			return 1;
+		if (a->protected_resource->link->link_id.s_addr <
+		    b->protected_resource->link->link_id.s_addr)
+			return -1;
+		return 0;
+	}
 
-	if (a->protected_resource->type == OSPF_TI_LFA_NODE_PROTECTION
-	    && b->protected_resource->type == OSPF_TI_LFA_NODE_PROTECTION)
-		return (a->protected_resource->router_id.s_addr
-			- b->protected_resource->router_id.s_addr);
+	if (a->protected_resource->type == OSPF_TI_LFA_NODE_PROTECTION &&
+	    b->protected_resource->type == OSPF_TI_LFA_NODE_PROTECTION) {
+		if (a->protected_resource->router_id.s_addr >
+		    b->protected_resource->router_id.s_addr)
+			return 1;
+		if (a->protected_resource->router_id.s_addr <
+		    b->protected_resource->router_id.s_addr)
+			return -1;
+		return 0;
+	}
 
 	/* This should not happen */
 	return 0;
@@ -113,7 +125,11 @@ int p_spaces_compare_func(const struct p_space *a, const struct p_space *b)
 
 int q_spaces_compare_func(const struct q_space *a, const struct q_space *b)
 {
-	return (a->root->id.s_addr - b->root->id.s_addr);
+	if (a->root->id.s_addr > b->root->id.s_addr)
+		return 1;
+	if (a->root->id.s_addr < b->root->id.s_addr)
+		return -1;
+	return 0;
 }
 
 DECLARE_RBTREE_UNIQ(p_spaces, struct p_space, p_spaces_item,


### PR DESCRIPTION
Several comparator functions registered with DECLARE_SKIPLIST_NONUNIQ, DECLARE_RBTREE_UNIQ, and RB_GENERATE use unsigned integer subtraction to produce a comparison result. When the difference between two uint32_t values exceeds INT_MAX, the subtraction wraps around in unsigned arithmetic and the resulting value, when interpreted as a signed int, can have the wrong sign. This causes incorrect ordering in skip-lists and red-black trees.

The fix replaces `return a - b` with explicit greater-than/less-than comparisons that always produce the correct sign.