### PR TITLE
ospf6d: use strict inequality for LSA MaxAgeDiff comparison

### DIFF
--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -453,9 +453,9 @@ int ospf6_lsa_compare(struct ospf6_lsa *a, struct ospf6_lsa *b)
 		return 1;
 
 	/* Age check */
-	if (agea > ageb && agea - ageb >= OSPF_LSA_MAXAGE_DIFF)
+	if (agea > ageb && agea - ageb > OSPF_LSA_MAXAGE_DIFF)
 		return 1;
-	else if (agea < ageb && ageb - agea >= OSPF_LSA_MAXAGE_DIFF)
+	else if (agea < ageb && ageb - agea > OSPF_LSA_MAXAGE_DIFF)
 		return -1;
 
 	/* neither recent */

--- a/tests/ospf6d/test_lsdb.c
+++ b/tests/ospf6d/test_lsdb.c
@@ -11,6 +11,7 @@
 #include "prefix.h"
 #include "vector.h"
 #include "vty.h"
+#include "monotime.h"
 
 #include "ospf6d/ospf6_proto.h" /* for struct ospf6_prefix */
 #include "ospf6d/ospf6_lsa.h"
@@ -203,6 +204,33 @@ DEFPY(lsa_refcounts, lsa_refcounts_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(lsa_compare_age, lsa_compare_age_cmd,
+      "lsa compare-age (0-999999)$a (0-999999)$b ages (0-65535)$agea (0-65535)$ageb",
+      "LSA\n"
+      "compare two (otherwise identical) LSAs at the given LS ages\n"
+      "first LSA index in array\n"
+      "second LSA index in array\n"
+      "set the LS ages used for the comparison\n"
+      "LS age of the first LSA\n"
+      "LS age of the second LSA\n")
+{
+	struct timeval now;
+
+	/* Use a single time reference so the resulting age difference is
+	 * exact regardless of how long the comparison itself takes.
+	 */
+	monotime(&now);
+	lsas[a]->header->age = 0;
+	lsas[a]->birth.tv_sec = now.tv_sec - agea;
+	lsas[a]->birth.tv_usec = now.tv_usec;
+	lsas[b]->header->age = 0;
+	lsas[b]->birth.tv_sec = now.tv_sec - ageb;
+	lsas[b]->birth.tv_usec = now.tv_usec;
+
+	vty_out(vty, "compare = %d\n", ospf6_lsa_compare(lsas[a], lsas[b]));
+	return CMD_SUCCESS;
+}
+
 DEFPY(lsdb_create, lsdb_create_cmd,
       "lsdb create",
       "LSDB\n"
@@ -234,6 +262,7 @@ void test_init(int argc, char **argv)
 	install_element(ENABLE_NODE, &lsa_set_cmd);
 	install_element(ENABLE_NODE, &lsa_refcounts_cmd);
 	install_element(ENABLE_NODE, &lsa_drop_cmd);
+	install_element(ENABLE_NODE, &lsa_compare_age_cmd);
 
 	install_element(ENABLE_NODE, &lsdb_create_cmd);
 	install_element(ENABLE_NODE, &lsdb_delete_cmd);

--- a/tests/ospf6d/test_lsdb.in
+++ b/tests/ospf6d/test_lsdb.in
@@ -70,3 +70,13 @@ lsa drop 3
 lsa drop 4
 lsa drop 5
 
+lsa set 10 type 1 adv 1.2.3.4 id 0.0.0.9
+lsa set 11 type 1 adv 1.2.3.4 id 0.0.0.9
+lsa compare-age 10 11 ages 900 0
+lsa compare-age 10 11 ages 901 0
+lsa compare-age 10 11 ages 899 0
+lsa compare-age 10 11 ages 0 900
+lsa compare-age 10 11 ages 0 901
+lsa drop 10
+lsa drop 11
+

--- a/tests/ospf6d/test_lsdb.refout
+++ b/tests/ospf6d/test_lsdb.refout
@@ -188,5 +188,20 @@ test# lsa drop 3
 test# lsa drop 4
 test# lsa drop 5
 test# 
+test# lsa set 10 type 1 adv 1.2.3.4 id 0.0.0.9
+test# lsa set 11 type 1 adv 1.2.3.4 id 0.0.0.9
+test# lsa compare-age 10 11 ages 900 0
+compare = 0
+test# lsa compare-age 10 11 ages 901 0
+compare = 1
+test# lsa compare-age 10 11 ages 899 0
+compare = 0
+test# lsa compare-age 10 11 ages 0 900
+compare = 0
+test# lsa compare-age 10 11 ages 0 901
+compare = -1
+test# lsa drop 10
+test# lsa drop 11
+test# 
 test# 
 end.


### PR DESCRIPTION
### Problem

`ospf6_lsa_compare()` decides which of two instances of the same LSA is
more recent. Per RFC 2328 §12.1.1 (and RFC 5340 for OSPFv3), an LSA is
considered more recent than another only when their LS ages differ by
**more than** MaxAgeDiff (`OSPF_LSA_MAXAGE_DIFF`, 900 seconds). The age
check used `>=`:

```c
if (agea > ageb && agea - ageb >= OSPF_LSA_MAXAGE_DIFF)
        return 1;
else if (agea < ageb && ageb - agea >= OSPF_LSA_MAXAGE_DIFF)
        return -1;
```

so an age difference of *exactly* MaxAgeDiff was wrongly treated as "more
recent" instead of "neither more recent". OSPFv2's
`ospf_lsa_more_recent()` already uses the strict `>`.

Fixes #22062.

### Fix

Use `>` instead of `>=` so an exact-MaxAgeDiff age difference is treated
as "neither more recent", matching the RFC and the OSPFv2 implementation.

### Testing

Added a unit test to `tests/ospf6d/test_lsdb` that compares two
otherwise-identical LSAs across the MaxAgeDiff boundary (899, 900 and 901
seconds, in both directions) and checks the `ospf6_lsa_compare()` verdict.
The two ages are derived from a single monotonic-time reference so the age
difference is exact and the test is deterministic.

- With the fix the test passes (ran 15× consecutively — stable); a 900 s
  difference yields "neither more recent" (`compare = 0`).
- Reverting only the fix (back to `>=`) makes the test fail on exactly the
  two boundary cases (900 s → spuriously more recent), so it pins the
  defect rather than just exercising the function.
- `checkpatch` is clean on the C change.
