### PR TITLE
staticd: guard static_add_route() against duplicate prefix insertion

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -876,6 +876,14 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_cr
 		yang_afi_safi_identity2value(afi_safi, &afi, &safi);
 
 		rn = static_add_route(afi, safi, &prefix, (struct prefix_ipv6 *)src_p, svrf);
+		if (!rn) {
+			flog_warn(EC_LIB_NB_CB_CONFIG_APPLY,
+				  "route %pFX already exists, skipping duplicate create",
+				  &prefix);
+			return NB_OK;
+		}
+
+
 		if (!svrf->vrf || svrf->vrf->vrf_id == VRF_UNKNOWN)
 			snprintf(
 				args->errmsg, args->errmsg_len,

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -84,6 +84,12 @@ struct route_node *static_add_route(afi_t afi, safi_t safi, struct prefix *p,
 	/* Lookup static route prefix. */
 	rn = srcdest_rnode_get(stable, p, src_p);
 
+	/* Return NULL to signal the caller that no new route was created. */
+	if (rn->info) {
+		route_unlock_node(rn);
+		return NULL;
+	}
+
 	si = XCALLOC(MTYPE_STATIC_ROUTE, sizeof(struct static_route_info));
 
 	si->svrf = svrf;


### PR DESCRIPTION
The `static_add_route()` unconditionally allocates a new data and assigns it to rn->info without checking whether the rn already holds data.

Currently the NB list semantics prevent duplicate route-list CREATE callbacks for the same prefix under normal operation, so this leak is solved by chance. Howerver, we can make it follow the consistent rule to be more robust.