### PR TITLE
ospfd/eigrpd: correct IN_MULTICAST() byte order

### DIFF
--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -388,7 +388,7 @@ void eigrp_write(struct event *event)
 	sa_dst.sin_port = htons(0);
 
 	/* Set DONTROUTE flag if dst is unicast. */
-	if (!IN_MULTICAST(htonl(ep->dst.s_addr)))
+	if (!IN_MULTICAST(ntohl(ep->dst.s_addr)))
 		flags = MSG_DONTROUTE;
 
 	iph.ip_hl = sizeof(struct ip) >> EIGRP_WRITE_IPHL_SHIFT;

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -609,7 +609,7 @@ static void ospf_write(struct event *event)
 
 		/* Set DONTROUTE flag if dst is unicast. */
 		if (oi->type != OSPF_IFTYPE_VIRTUALLINK)
-			if (!IN_MULTICAST(htonl(op->dst.s_addr)))
+			if (!IN_MULTICAST(ntohl(op->dst.s_addr)))
 				flags = MSG_DONTROUTE;
 
 		iph.ip_hl = sizeof(struct ip) >> OSPF_WRITE_IPHL_SHIFT;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1005,7 +1005,7 @@ static int ospf_external_lsa_originate_check(struct ospf *ospf,
 					     struct external_info *ei)
 {
 	/* If prefix is multicast, then do not originate LSA. */
-	if (IN_MULTICAST(htonl(ei->p.prefix.s_addr))) {
+	if (IN_MULTICAST(ntohl(ei->p.prefix.s_addr))) {
 		zlog_info(
 			"LSA[Type5:%pI4]: Not originate AS-external-LSA, Prefix belongs multicast",
 			&ei->p.prefix);


### PR DESCRIPTION
The `IN_MULTICAST()` expects its argument in host byte order, but several places were incorrectly using htonl(), the other places are correct.

htonl() and ntohl() produce the same result on little/big-order platforms, so this bug is masked. Howerver, the semantic intent is wrong.