### PR TITLE
yang: Duplicate choice name in frr-filter.yang

### DIFF
--- a/yang/frr-filter.yang
+++ b/yang/frr-filter.yang
@@ -277,7 +277,7 @@ module frr-filter {
           case ipv6-prefix {
             when "../type = 'ipv6'";
 
-            choice style {
+            choice ipv6-style {
               mandatory true;
               description "Access list entry style selection: zebra or cisco.";
 
@@ -296,7 +296,7 @@ module frr-filter {
               }
 
               case cisco {
-                choice standard-value {
+                choice ipv6-standard-value {
                   description "Source value to match";
 
                   leaf ipv6-host {
@@ -327,7 +327,7 @@ module frr-filter {
                   }
                 }
 
-                choice extended-value {
+                choice ipv6-extended-value {
                   description "Destination value to match";
 
                   leaf ipv6-destination-host {


### PR DESCRIPTION
Duplicate choice name in frr-filter.yang

frr-filter.yang:280: error: there is already a child node to "entry" at frr-filter.yang:181 with the name "style" defined at frr-filter.yang:201
frr-filter.yang:299: error: there is already a child node to "entry" at frr-filter.yang:181 with the name "standard-value" defined at frr-filter.yang:219
frr-filter.yang:330: error: there is already a child node to "entry" at frr-filter.yang:181 with the name "extended-value" defined at frr-filter.yang:249