### PR TITLE
pimd: retry MSDP listener bind after VRF master interface up

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -38,6 +38,9 @@
 #include "pim_jp_agg.h"
 #include "pim_igmp_join.h"
 #include "pim_vxlan.h"
+#if PIM_IPV == 4
+#include "pim_msdp.h"
+#endif
 #include "pim_static.h"
 #include "pim_tib.h"
 #include "pim_util.h"
@@ -1923,6 +1926,12 @@ static int pim_ifp_create(struct interface *ifp)
 			ifp->mtu, if_is_operative(ifp));
 	}
 
+	if (ifp->vrf->vrf_id != VRF_DEFAULT && strcmp(ifp->name, ifp->vrf->name) == 0) {
+#if PIM_IPV == 4
+		pim_msdp_vrf_iface_up(pim);
+#endif
+	}
+
 	if (if_is_operative(ifp)) {
 		struct pim_interface *pim_ifp;
 
@@ -2043,6 +2052,12 @@ static int pim_ifp_up(struct interface *ifp)
 
 	if (pim == NULL || pim->shutdown)
 		return 0;
+
+	if (ifp->vrf->vrf_id != VRF_DEFAULT && strcmp(ifp->name, ifp->vrf->name) == 0) {
+#if PIM_IPV == 4
+		pim_msdp_vrf_iface_up(pim);
+#endif
+	}
 
 	pim_ifp = ifp->info;
 

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1573,7 +1573,19 @@ void pim_msdp_exit(struct pim_instance *pim)
 
 	pim_msdp_sa_adv_timer_setup(pim, false);
 
-	/* Stop listener and delete all peer sessions */
+	/*
+	 * Tear down the listener first; otherwise every VRF delete leaks the
+	 * listener fd and leaves a libevent watcher pointing at the
+	 * about-to-be-freed pim_instance.
+	 */
+	if (pim->msdp.flags & PIM_MSDPF_LISTENER) {
+		event_cancel(&pim->msdp.listener.event);
+		close(pim->msdp.listener.fd);
+		pim->msdp.listener.fd = -1;
+		pim->msdp.flags &= ~PIM_MSDPF_LISTENER;
+	}
+
+	/* Delete all peer sessions */
 	while ((mg = SLIST_FIRST(&pim->msdp.mglist)) != NULL)
 		pim_msdp_mg_free(pim, &mg);
 

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -934,20 +934,23 @@ void pim_msdp_vrf_iface_up(struct pim_instance *pim)
 	if (pim->msdp.shutdown)
 		return;
 
-	if (pim->msdp.flags & PIM_MSDPF_LISTENER)
-		return;
-
+	/*
+	 * Walk all listener-side peers and retry any socket bind that failed
+	 * during config-parse (when pim->vrf->vrf_id was still VRF_UNKNOWN).
+	 *   - MSDP_AUTH_NONE peers share the global pim_msdp_sock_listen()
+	 *     socket, guarded by PIM_MSDPF_LISTENER (one bind per VRF).
+	 *   - Auth peers each own a per-peer pim_msdp_sock_auth_listen()
+	 *     socket tracked by mp->auth_listen_sock.
+	 */
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.peer_list, node, mp)) {
-		if (PIM_MSDP_PEER_IS_LISTENER(mp)) {
-			(void)pim_msdp_sock_listen(pim);
-			/*
-			 * On success PIM_MSDPF_LISTENER is set, so any
-			 * subsequent peer in this loop would be a no-op
-			 * anyway. On failure we still stop after one
-			 * attempt; the iface event will fire again on
-			 * any future VRF master state transition.
-			 */
-			break;
+		if (!PIM_MSDP_PEER_IS_LISTENER(mp))
+			continue;
+
+		if (mp->auth_type == MSDP_AUTH_NONE) {
+			if (!(pim->msdp.flags & PIM_MSDPF_LISTENER))
+				(void)pim_msdp_sock_listen(pim);
+		} else if (mp->auth_listen_sock == -1) {
+			(void)pim_msdp_sock_auth_listen(mp);
 		}
 	}
 }

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -922,6 +922,36 @@ static void pim_msdp_peer_connect(struct pim_msdp_peer *mp)
 	pim_msdp_peer_cr_timer_setup(mp, true /* start */);
 }
 
+void pim_msdp_vrf_iface_up(struct pim_instance *pim)
+{
+	struct pim_msdp_peer *mp;
+	struct listnode *node;
+
+	if (!pim || !pim->msdp.peer_list)
+		return;
+
+	/* Don't re-establish the listener while MSDP is shut down. */
+	if (pim->msdp.shutdown)
+		return;
+
+	if (pim->msdp.flags & PIM_MSDPF_LISTENER)
+		return;
+
+	for (ALL_LIST_ELEMENTS_RO(pim->msdp.peer_list, node, mp)) {
+		if (PIM_MSDP_PEER_IS_LISTENER(mp)) {
+			(void)pim_msdp_sock_listen(pim);
+			/*
+			 * On success PIM_MSDPF_LISTENER is set, so any
+			 * subsequent peer in this loop would be a no-op
+			 * anyway. On failure we still stop after one
+			 * attempt; the iface event will fire again on
+			 * any future VRF master state transition.
+			 */
+			break;
+		}
+	}
+}
+
 /* 11.2.A3: passive peer - just listen for connections */
 static void pim_msdp_peer_listen(struct pim_msdp_peer *mp)
 {

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -256,6 +256,7 @@ void pim_msdp_exit(struct pim_instance *pim);
 char *pim_msdp_state_dump(enum pim_msdp_peer_state state, char *buf,
 			  int buf_size);
 struct pim_msdp_peer *pim_msdp_peer_find(const struct pim_instance *pim, struct in_addr peer_addr);
+void pim_msdp_vrf_iface_up(struct pim_instance *pim);
 void pim_msdp_peer_established(struct pim_msdp_peer *mp);
 void pim_msdp_peer_pkt_rxed(struct pim_msdp_peer *mp);
 void pim_msdp_peer_stop_tcp_conn(struct pim_msdp_peer *mp, bool chg_state);


### PR DESCRIPTION
Issue:
When pimd parses an "ip msdp peer X source Y" inside a VRF block at config time, libvrf has not yet activated the VRF and pim->vrf is a name-only stub with vrf_id == VRF_UNKNOWN.  For passive (listener-side) peers, pim_msdp_peer_listen() immediately calls pim_msdp_sock_listen(), whose if_lookup_by_name(vrf->name, VRF_UNKNOWN) deterministically returns NULL.  The function logs "Unable to lookup vrf interface" and returns -1.  No code path ever retries it

The race is timing-dependent.  Some startup orderings happen to populate pim->vrf->vrf_id before MSDP peer config is processed and the listener binds normally.

Fix:
1)Adding a small pim_msdp_vrf_iface_up() helper that retries pim_msdp_sock_listen() when pim_iface.c sees the VRF-master interface appear (pim_ifp_create / pim_ifp_up).
2)tear down MSDP listener in pim_msdp_exit()