### PR TITLE
isisd: fix show isis database detail truncate hostname

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -784,7 +784,7 @@ void lsp_print_detail(struct isis_lsp *lsp, struct vty *vty,
 			isis_format_tlvs(lsp->tlvs, json);
 		}
 	} else {
-		lsp_print_vty(lsp, vty, dynhost, isis);
+		lsp_print_vty(lsp, vty, false, isis);
 		if (lsp->tlvs)
 			vty_multiline(vty, "  ", "%s",
 				      isis_format_tlvs(lsp->tlvs, NULL));

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -6283,6 +6283,8 @@ struct isis_tlvs *isis_copy_tlvs(struct isis_tlvs *tlvs)
 static void format_tlvs(struct isis_tlvs *tlvs, struct sbuf *buf, struct json_object *json,
 			int indent)
 {
+	format_tlv_dynamic_hostname(tlvs->hostname, buf, json, indent);
+
 	format_tlv_protocols_supported(&tlvs->protocols_supported, buf, json, indent);
 
 	format_items(ISIS_CONTEXT_LSP, ISIS_TLV_AUTH, &tlvs->isis_auth, buf, json, indent);
@@ -6310,7 +6312,6 @@ static void format_tlvs(struct isis_tlvs *tlvs, struct sbuf *buf, struct json_ob
 
 	format_items(ISIS_CONTEXT_LSP, ISIS_TLV_LSP_ENTRY, &tlvs->lsp_entries, buf, json, indent);
 
-	format_tlv_dynamic_hostname(tlvs->hostname, buf, json, indent);
 	format_tlv_te_router_id(tlvs->te_router_id, buf, json, indent);
 	format_tlv_te_router_id_ipv6(tlvs->te_router_id_ipv6, buf, json, indent);
 	if (json)

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -6280,6 +6280,8 @@ struct isis_tlvs *isis_copy_tlvs(struct isis_tlvs *tlvs)
 static void format_tlvs(struct isis_tlvs *tlvs, struct sbuf *buf, struct json_object *json,
 			int indent)
 {
+	format_tlv_dynamic_hostname(tlvs->hostname, buf, json, indent);
+
 	format_tlv_protocols_supported(&tlvs->protocols_supported, buf, json, indent);
 
 	format_items(ISIS_CONTEXT_LSP, ISIS_TLV_AUTH, &tlvs->isis_auth, buf, json, indent);
@@ -6307,7 +6309,6 @@ static void format_tlvs(struct isis_tlvs *tlvs, struct sbuf *buf, struct json_ob
 
 	format_items(ISIS_CONTEXT_LSP, ISIS_TLV_LSP_ENTRY, &tlvs->lsp_entries, buf, json, indent);
 
-	format_tlv_dynamic_hostname(tlvs->hostname, buf, json, indent);
 	format_tlv_te_router_id(tlvs->te_router_id, buf, json, indent);
 	format_tlv_te_router_id_ipv6(tlvs->te_router_id_ipv6, buf, json, indent);
 	if (json)


### PR DESCRIPTION
The 'show isis database detail' command truncates the lsp hostname identifier is greater than 20 bytes.

> # show isis database detail
> Area router:
> IS-IS Level-2 Link State Database:
>
> LSP ID                  PduLen  SeqNumber   Chksum  Holdtime  ATT/P/OL
> router1verylon.00-00     185    0x00000012  0x4a2c    1194    0/0/0
>   Area Addresses: 49.0001
>   NLPID: IPv4, IPv6
>   Hostname: router1
>   TE Router ID: 192.0.2.1
>   Router Capability: 192.0.2.1, D:0, S:0
> [..]

Fix this by replacing hostname with lsp-id on first line, and appending the hostname on the line just after.

> # show isis database detail
> Area router:
> IS-IS Level-2 Link State Database:
>
> LSP ID                  PduLen  SeqNumber   Chksum  Holdtime  ATT/P/OL
> 49.0123.6452.1972.00     185  0x00000012  0x4a2c    1194    0/0/0
>   Hostname: router1verylong
>   Area Addresses: 49.0001
>   NLPID: IPv4, IPv6
>   TE Router ID: 192.0.2.1
>   Router Capability: 192.0.2.1, D:0, S:0
> [..]