### PR TITLE
ospfd, ospf6d: fix GR remaining time calculation

### DIFF
--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -244,12 +244,18 @@ void ospf6_gr_restart_enter(struct ospf6 *ospf6,
 			    time_t timestamp)
 {
 	unsigned long remaining_time;
+	time_t now;
 
 	ospf6->gr_info.restart_in_progress = true;
 	ospf6->gr_info.reason = reason;
 
 	/* Schedule grace period timeout. */
-	remaining_time = timestamp - time(NULL);
+	now = time(NULL);
+	if (timestamp <= now)
+		remaining_time = 0;
+	else
+		remaining_time = timestamp - now;
+
 	if (IS_DEBUG_OSPF6_GR)
 		zlog_debug(
 			"GR: remaining time until grace period expires: %lu(s)",

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -286,12 +286,18 @@ void ospf_gr_restart_enter(struct ospf *ospf,
 			   enum ospf_gr_restart_reason reason, time_t timestamp)
 {
 	unsigned long remaining_time;
+	time_t now;
 
 	ospf->gr_info.restart_in_progress = true;
 	ospf->gr_info.reason = reason;
 
 	/* Schedule grace period timeout. */
-	remaining_time = timestamp - time(NULL);
+	now = time(NULL);
+	if (timestamp <= now)
+		remaining_time = 0;
+	else
+		remaining_time = timestamp - now;
+
 	if (IS_DEBUG_OSPF_GR)
 		zlog_debug(
 			"GR: remaining time until grace period expires: %lu(s)",


### PR DESCRIPTION
In `ospf_gr_restart_enter()` and `ospf6_gr_restart_enter()`, the "remaining_time" is declared as unsigned long and computed as (timestamp - time(NULL)). There is TOCTOU issue in the two functions.

If the grace period has already expired (timestamp <= current time), the subtraction wraps around to an extremely large positive value, scheduling the grace period expiry timer into the future.