### PR TITLE
zebra: always drain the RTADV socket

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1433,9 +1433,6 @@ static void rtadv_start_interface_events(struct zebra_vrf *zvrf,
 				     &zif->icmpv6_join_timer);
 	}
 
-	if (adv_if_list_count(&zvrf->rtadv.adv_if) == 1)
-		rtadv_event(zvrf, RTADV_START, 0);
-
 	rtadv_send_packet(zvrf->rtadv.sock, zif->ifp, RA_ENABLE);
 	wheel_add_item(zrouter.ra_wheel, zif->ifp);
 }
@@ -2016,7 +2013,6 @@ static void rtadv_event(struct zebra_vrf *zvrf, enum rtadv_event event, int val)
 		break;
 	case RTADV_STOP:
 		event_cancel(&rtadv->ra_timer);
-		event_cancel(&rtadv->ra_read);
 		break;
 	case RTADV_TIMER:
 		event_add_timer(zrouter.master, rtadv_timer, zvrf, val,
@@ -2121,6 +2117,9 @@ void rtadv_vrf_init(struct zebra_vrf *zvrf)
 		return;
 
 	zvrf->rtadv.sock = rtadv_make_socket(zvrf->zns->ns_id);
+
+	if (zvrf->rtadv.sock >= 0)
+		rtadv_event(zvrf, RTADV_START, 0);
 }
 
 void rtadv_vrf_terminate(struct zebra_vrf *zvrf)
@@ -2129,6 +2128,7 @@ void rtadv_vrf_terminate(struct zebra_vrf *zvrf)
 		return;
 
 	rtadv_event(zvrf, RTADV_STOP, 0);
+	event_cancel(&zvrf->rtadv.ra_read);
 	if (zvrf->rtadv.sock >= 0) {
 		close(zvrf->rtadv.sock);
 		zvrf->rtadv.sock = -1;


### PR DESCRIPTION
### Problem

`rtadv_vrf_init()` creates the raw ICMPv6 socket unconditionally for the default VRF, but the socket's read event is only armed once an interface enables RA (`RTADV_START`, via `rtadv_start_interface_events()`). When no interface is configured for RA, the socket stays open but is never read, so received Router Advertisements accumulate up to `SO_RCVBUF`.

On systems where the NIC driver uses `page_pool`, those queued skbs pin `page_pool` pages. When an RX ring is later reconfigured — for example when a port is enslaved to a bridge, which puts it in promiscuous mode and resets the ring — the old `page_pool` cannot reach zero inflight and the kernel logs:

```
page_pool_release_retry() stalled pool shutdown N inflight M sec
```

### Fix

Keep the read event armed for the whole lifetime of the socket, independently of RA configuration:

- Arm the read event in `rtadv_vrf_init()`, right after the socket is created. `rtadv_read()` re-arms itself, so a single `RTADV_START` is enough.
- Stop `RTADV_STOP` from cancelling the read event, so unconfiguring RA on the last interface no longer stops draining the socket. `RTADV_STOP` now only cancels the RA transmit timer.
- Cancel the read event in `rtadv_vrf_terminate()`, before the socket is closed, since `RTADV_STOP` no longer does it.

Fixes #21702
