### PR TITLE
tests: fix flaky OSPF authentication tests by configuring auth before clear

### DIFF
--- a/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
@@ -296,9 +296,9 @@ def test_ospf_authentication_simple_pass_tc28_p1(request):
     shutdown_bringup_interface(tgen, dut, intf, False)
     shutdown_bringup_interface(tgen, dut, intf, True)
 
-    # clear ip ospf after configuring the authentication.
-    clear_ospf(tgen, "r1")
-
+    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
+    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
+    # packets which R2 rejects.
     r1_ospf_auth = {
         "r1": {
             "links": {
@@ -308,6 +308,8 @@ def test_ospf_authentication_simple_pass_tc28_p1(request):
     }
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    clear_ospf(tgen, "r1")
 
     step(
         "Verify that the neighbour is FULL between R1 and R2 with new "
@@ -506,7 +508,10 @@ def test_ospf_authentication_md5_tc29_p1(request):
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
     shutdown_bringup_interface(tgen, dut, intf, True)
-    clear_ospf(tgen, "r1")
+
+    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
+    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
+    # packets which R2 rejects.
     r1_ospf_auth = {
         "r1": {
             "links": {
@@ -522,6 +527,8 @@ def test_ospf_authentication_md5_tc29_p1(request):
     }
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    clear_ospf(tgen, "r1")
 
     step(
         "Verify that the neighbour is FULL between R1 and R2 with new "
@@ -735,7 +742,10 @@ def test_ospf_authentication_md5_keychain_tc30_p1(request):
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
     shutdown_bringup_interface(tgen, dut, intf, True)
-    clear_ospf(tgen, "r1")
+
+    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
+    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
+    # packets which R2 rejects.
     router1.vtysh_cmd(
         """configure terminal
            key chain auth
@@ -757,6 +767,8 @@ def test_ospf_authentication_md5_keychain_tc30_p1(request):
     }
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    clear_ospf(tgen, "r1")
 
     step(
         "Verify that the neighbour is FULL between R1 and R2 with new "
@@ -970,7 +982,10 @@ def test_ospf_authentication_sha256_keychain_tc32_p1(request):
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
     shutdown_bringup_interface(tgen, dut, intf, True)
-    clear_ospf(tgen, "r1")
+
+    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
+    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
+    # packets which R2 rejects.
     router1.vtysh_cmd(
         """configure terminal
            key chain auth
@@ -992,6 +1007,8 @@ def test_ospf_authentication_sha256_keychain_tc32_p1(request):
     }
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    clear_ospf(tgen, "r1")
 
     step(
         "Verify that the neighbour is FULL between R1 and R2 with new "


### PR DESCRIPTION
The OSPF authentication tests (tc28, tc29, tc30, tc32) were flaky because of an authentication mismatch window during the "Change IP address" test step.

Root cause analysis:

1. Before Step 13, both R1 and R2 have key-chain (or simple/MD5) authentication configured and OSPF is converged.

2. Step 13 calls build_config_from_json() which runs "clear ip ospf process" on all routers, but does NOT touch authentication config.

3. The test then calls reset_config_on_routers(routerName="r1") which uses frr-reload.py to restore R1 to its initial backup config (frr_json_initial.conf). This backup was saved before any auth was configured, so reset_config_on_routers() REMOVES R1's authentication.

4. At this point:
   - R1: NO authentication (removed by reset_config_on_routers)
   - R2: Still has authentication configured

5. The test then calls clear_ospf(tgen, "r1") which runs "clear ip ospf interface" and restarts R1's OSPF process.

6. R1 starts sending unauthenticated Hello packets.

7. R2 receives these packets but rejects them because R2 expects authenticated packets. R2 logs auth failures and the adjacency takes much longer to form due to the authentication mismatch.

8. Only AFTER clear_ospf() does the test configure authentication on R1. By this time, the adjacency may have timed out and the OSPF state machines need to restart neighbor discovery.

The fix moves authentication configuration to BEFORE clear_ospf() so that R1 sends authenticated packets from the moment OSPF restarts. This eliminates the authentication mismatch window.