### PR TITLE
bgpd: fix missing updating route for evpn mh

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2550,6 +2550,28 @@ int bgp_evpn_local_es_add(struct bgp *bgp, esi_t *esi, struct ipaddr originator_
 		zlog_debug("add local es %s orig-ip %pIA df_pref %u %s", es->esi_str,
 			   &originator_ip, df_pref, bypass ? "bypass" : "");
 
+	/* Handle tunnel IP (originator_ip) change for an existing local ES */
+	if (!new_es && !ipaddr_is_same(&es->originator_ip, &originator_ip)) {
+		if (BGP_DEBUG(evpn_mh, EVPN_MH_ES))
+			zlog_debug("local es %s tunnel-ip changed from %pIA to %pIA", es->esi_str,
+				   &es->originator_ip, &originator_ip);
+
+		if (bgp_evpn_local_es_is_active(es)) {
+			struct prefix_evpn p;
+			int ret;
+
+			build_evpn_type4_prefix(&p, &es->esi, es->originator_ip);
+			ret = bgp_evpn_type4_route_delete(bgp, es, &p);
+			if (ret) {
+				flog_err(EC_BGP_EVPN_ROUTE_DELETE,
+					 "%u failed to delete type-4 route for ESI %s",
+					 bgp->vrf_id, es->esi_str);
+			}
+		}
+
+		regen_esr = true;
+	}
+
 	es->originator_ip = originator_ip;
 	if (df_pref != es->df_pref) {
 		es->df_pref = df_pref;

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -823,6 +823,9 @@ def test_evpn_vtep_change():
     Test that changing the originator VTEP IP on a remote TOR removes the
     stale VTEP from ES tables on the receiver.
 
+    Also verifies that local Type-4 (ESR) routes are properly updated when
+    VXLAN tunnel IP changes, preventing stale Type-4 routes.
+
     torm21 has two loopback addresses: 192.168.100.17 (primary) and
     192.168.100.117 (secondary). The VTEP is switched from primary to
     secondary and back to verify stale VTEP cleanup.
@@ -853,17 +856,37 @@ def test_evpn_vtep_change():
     assertmsg = f"torm11: primary VTEP {primary_vtep} not found in ES {esi} initially"
     assert result is None, assertmsg
 
+    # Helper to check that NO Type-4 (ES) route with the given IP exists.
+    # Returns None if no Type-4 prefix contains stale_ip, error string otherwise.
+    def check_type4_ip_not_present(node, stale_ip):
+        output = node.vtysh_cmd("show bgp l2vpn evpn route type es json")
+        data = json.loads(output)
+        for rd_key, rd_data in data.items():
+            if not isinstance(rd_data, dict):
+                continue
+            for key in rd_data.keys():
+                if key.startswith("[4]:") and stale_ip in key:
+                    return f"Type-4 route with stale IP {stale_ip} still present: {key}"
+        return None
+
     # 3. Switch VTEP from primary to secondary (vxlan local IP change
     #    triggers zebra to update ES originator IP and BGP re-advertises)
     remote_tor.run(f"ip link set dev vx-1000 type vxlan local {secondary_vtep}")
 
-    # 4. Verify new VTEP appears and old VTEP is removed
+    # 4.1 Verify new VTEP appears and old VTEP is removed
     test_fn = partial(check_remote_es_vtep_present, dut, esi, secondary_vtep)
     _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
     assertmsg = (
         f"torm11: secondary VTEP {secondary_vtep} not found in ES {esi} after switch"
     )
     assert result is None, assertmsg
+
+    # 4.2 Verify Type-4 route with old(primary IP) is gone on dut
+    test_fn = partial(check_type4_ip_not_present, dut, primary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assert (
+        result is None
+    ), f"torm11: {result} (stale Type-4 with primary IP after tunnel IP change)"
 
     test_fn = partial(check_remote_es_vtep_absent, dut, esi, primary_vtep)
     _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
@@ -878,6 +901,13 @@ def test_evpn_vtep_change():
     _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
     assertmsg = f"torm11: primary VTEP {primary_vtep} not restored in ES {esi}"
     assert result is None, assertmsg
+
+    # Verify Type-4 route with old(secondary IP) is gone on dut after restore
+    test_fn = partial(check_type4_ip_not_present, dut, secondary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assert (
+        result is None
+    ), f"torm11: {result} (stale Type-4 with secondary IP after restore)"
 
     test_fn = partial(check_remote_es_vtep_absent, dut, esi, secondary_vtep)
     _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)


### PR DESCRIPTION
When the VXLAN tunnel IP (originator_ip) changes for an ES, `bgp_evpn_local_es_add()` didn't withdraw the old Type-4 route with old originator_ip and didn't send the new Type-4 route with new originator_ip.

The other kinds of EVPN routes have been already handled by existing refresh and withdraw mechanism that use the latest es->originator_ip when tunnel IP changes.