### PR TITLE
pimd: MLAG: gate FHR flag on DR check in wrvifwhole/wholepkt upcalls

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -601,8 +601,21 @@ int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf,
 				src_pim_ifp = src_conn->ifp->info;
 
 			if (src_conn != NULL && src_pim_ifp && src_pim_ifp->pim_enable) {
-				up = pim_upstream_add(pim_ifp->pim, &sg, src_conn->ifp,
-						      PIM_UPSTREAM_FLAG_MASK_FHR, __func__, NULL);
+				/*
+				 * Same rationale as pim_mroute_msg_wrvifwhole():
+				 * only the DR on the source-connected interface is
+				 * the FHR. On a non-DR, install as SRC_NOCACHE to
+				 * avoid setting the FHR flag, which would later
+				 * cause pim_upstream_switch() to silently attach
+				 * pimreg to the OIF and CPU-punt every packet.
+				 */
+				int up_flags = PIM_UPSTREAM_FLAG_MASK_FHR;
+
+				if (!PIM_I_am_DR(src_pim_ifp))
+					up_flags = PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE;
+
+				up = pim_upstream_add(pim_ifp->pim, &sg, src_conn->ifp, up_flags,
+						      __func__, NULL);
 				PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
 				pim_upstream_keep_alive_timer_start(up,
 								    pim_ifp->pim->keep_alive_time);
@@ -1135,9 +1148,21 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
 
 	pim_ifp = ifp->info;
 	if (pim_if_connected_to_source(ifp, sg.src)) {
-		up = pim_upstream_add(pim_ifp->pim, &sg, ifp,
-				      PIM_UPSTREAM_FLAG_MASK_FHR, __func__,
-				      NULL);
+		/*
+		 * Per RFC 7761 only the DR on the incoming interface is the
+		 * FHR for a directly-connected source. On a non-DR (e.g.
+		 * MLAG active-active peer, or any shared-LAN neighbor), an
+		 * FHR-flagged upstream would later trip pim_upstream_switch()
+		 * into silently adding pimreg to the channel_oil OIF, causing
+		 * every data packet on the (S,G) to be CPU-punted forever.
+		 * Install as SRC_NOCACHE (self-aging blackhole) instead.
+		 */
+		int up_flags = PIM_UPSTREAM_FLAG_MASK_FHR;
+
+		if (!PIM_I_am_DR(pim_ifp))
+			up_flags = PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE;
+
+		up = pim_upstream_add(pim_ifp->pim, &sg, ifp, up_flags, __func__, NULL);
 		if (!up) {
 			if (PIM_DEBUG_MROUTE)
 				zlog_debug(

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1099,10 +1099,14 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 		 * In FHR pimreg interface is needed all the time
 		 * inorder to send register packets.
 		 * Only for ASM (Any Source Multicast) groups, NOT for SSM or Dense mode.
+		 *
+		 * pimreg addition to channel_oil is not valid in non-DR
+		 * cases; handle the same by pim_upstream_could_register()
+		 * check.
 		 */
 		if (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) && up->reg_state == PIM_REG_NOINFO &&
 		    pim->regiface->configured && !pim_is_grp_ssm(pim, up->sg.grp) &&
-		    !PIM_UPSTREAM_DM_TEST_INTERFACE(up->flags)) {
+		    !PIM_UPSTREAM_DM_TEST_INTERFACE(up->flags) && pim_upstream_could_register(up)) {
 			pim_channel_add_oif(up->channel_oil, pim->regiface, PIM_OIF_FLAG_PROTO_PIM,
 					    __func__);
 		}


### PR DESCRIPTION
Issue: On an MLAG active-active pair where both PIM peers sit on the
same source SVI, every data packet on the SVI is CPU-punted on the
non-DR peer, forever.
    
Root cause and fix: In pim_mroute_msg_wrvifwhole() we set
PIM_UPSTREAM_FLAG_MASK_FHR without a DR check, so the non-DR peer ends
up with an FHR-flagged upstream. Later, on a state re-evaluation,
pim_upstream_switch() silently adds pimreg to the channel_oil OIF via
pim_channel_add_oif(). From then on, the kernel copies every packet of
that (S,G) to pimreg, which upcalls pimd (WHOLEPKT) forever -- CPU-punt
loop.
    
Per RFC 7761, only the DR is the FHR for a directly-connected source;
the non-DR must not send Register and must not have pimreg in the
channel OIF.
    
Has two commits:
1)Handled the exact issue by DR check and setting appropraite flag.
2)Defensive check in pim_upstream_switch , so in future if some flow missed DR check,
it will not add pimreg silently. 