### PR TITLE
isisd: cast SPF distances before tier subtraction

### DIFF
--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -378,7 +378,7 @@ static uint8_t fabricd_calculate_fabric_tier(struct isis_area *area)
 			furthest_from_remote->N.id, furthest_from_remote->d_N);
 	}
 
-	int64_t tier = furthest_from_remote->d_N - furthest_t0->d_N;
+	int64_t tier = (int64_t)furthest_from_remote->d_N - (int64_t)furthest_t0->d_N;
 	isis_spftree_del(remote_tree);
 
 	if (tier < 0 || tier >= ISIS_TIER_UNDEFINED) {


### PR DESCRIPTION
d_N is uint32_t, so subtracting two d_N values performs unsigned 32-bit arithmetic before assigning the result to int64_t. If the remote distance is smaller than the local T0 distance, the result overflows and the negative tier check below won't work.

Cast both d_N to (int64_t) to force int64_t arithmetic.

Reported in: #22497