### PR TITLE
pimd: avoid overflow in IGMP timer macro arithmetic

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -400,12 +400,10 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				PIM_IGMP_LMQT_MSEC(pim_ifp->gm_specific_query_max_response_time_dsec,
 						   if_gm_last_member_query_count(pim_ifp));
 
-			ohpi_msec =
-				PIM_IGMP_OHPI_DSEC(
-					igmp->querier_robustness_variable,
-					igmp->querier_query_interval,
-					pim_ifp->gm_query_max_response_time_dsec) *
-				100;
+			ohpi_msec = PIM_IGMP_OHPI_DSEC(igmp->querier_robustness_variable,
+						       igmp->querier_query_interval,
+						       pim_ifp->gm_query_max_response_time_dsec) *
+				    100L;
 
 			qri_msec = pim_ifp->gm_query_max_response_time_dsec * 100L;
 			lmqc = if_gm_last_member_query_count(pim_ifp);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1453,7 +1453,7 @@ void igmp_group_timer_lower_to_lmqt(struct gm_group *group)
 	char *ifname;
 	int lmqi_dsec; /* Last Member Query Interval */
 	int lmqc;      /* Last Member Query Count */
-	int lmqt_msec; /* Last Member Query Time */
+	long lmqt_msec; /* Last Member Query Time */
 
 	/*
 	  RFC 3376: 6.2.2. Definition of Group Timers
@@ -1478,7 +1478,7 @@ void igmp_group_timer_lower_to_lmqt(struct gm_group *group)
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
 	if (PIM_DEBUG_GM_TRACE) {
-		zlog_debug("%s: group %pI4s on %s: LMQC=%d LMQI=%d dsec LMQT=%d msec", __func__,
+		zlog_debug("%s: group %pI4s on %s: LMQC=%d LMQI=%d dsec LMQT=%ld msec", __func__,
 			   &group->group_addr, ifname, lmqc, lmqi_dsec, lmqt_msec);
 	}
 
@@ -1495,7 +1495,7 @@ void igmp_source_timer_lower_to_lmqt(struct gm_source *source)
 	char *ifname;
 	int lmqi_dsec; /* Last Member Query Interval */
 	int lmqc;      /* Last Member Query Count */
-	int lmqt_msec; /* Last Member Query Time */
+	long lmqt_msec; /* Last Member Query Time */
 
 	group = source->source_group;
 	ifp = group->interface;
@@ -1510,7 +1510,7 @@ void igmp_source_timer_lower_to_lmqt(struct gm_source *source)
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
 	if (PIM_DEBUG_GM_TRACE) {
-		zlog_debug("%s: group %pI4s source %pI4s on %s: LMQC=%d LMQI=%d dsec LMQT=%d msec",
+		zlog_debug("%s: group %pI4s source %pI4s on %s: LMQC=%d LMQI=%d dsec LMQT=%ld msec",
 			   __func__, &group->group_addr, &source->source_addr, ifname, lmqc,
 			   lmqi_dsec, lmqt_msec);
 	}

--- a/pimd/pim_igmpv3.h
+++ b/pimd/pim_igmpv3.h
@@ -26,19 +26,21 @@
 #define IGMP_GRP_REC_TYPE_BLOCK_OLD_SOURCES      (6)
 
 /* GMI: Group Membership Interval */
-#define PIM_IGMP_GMI_MSEC(qrv,qqi,qri_dsec) ((qrv) * (1000 * (qqi)) + 100 * (qri_dsec))
+#define PIM_IGMP_GMI_MSEC(qrv, qqi, qri_dsec)                                                     \
+	((int64_t)(qrv) * 1000 * (qqi) + (int64_t)100 * (qri_dsec))
 
 /* OQPI: Other Querier Present Interval */
-#define PIM_IGMP_OQPI_MSEC(qrv,qqi,qri_dsec) ((qrv) * (1000 * (qqi)) + 100 * ((qri_dsec) >> 1))
+#define PIM_IGMP_OQPI_MSEC(qrv, qqi, qri_dsec)                                                    \
+	((int64_t)(qrv) * 1000 * (qqi) + (int64_t)100 * ((qri_dsec) >> 1))
 
 /* SQI: Startup Query Interval */
 #define PIM_IGMP_SQI(qi) (((qi) < 4) ? 1 : ((qi) >> 2))
 
 /* LMQT: Last Member Query Time */
-#define PIM_IGMP_LMQT_MSEC(lmqi_dsec, lmqc) ((lmqc) * (100 * (lmqi_dsec)))
+#define PIM_IGMP_LMQT_MSEC(lmqi_dsec, lmqc) ((int64_t)(lmqc) * 100 * (lmqi_dsec))
 
 /* OHPI: Older Host Present Interval */
-#define PIM_IGMP_OHPI_DSEC(qrv,qqi,qri_dsec) ((qrv) * (10 * (qqi)) + (qri_dsec))
+#define PIM_IGMP_OHPI_DSEC(qrv, qqi, qri_dsec) ((int64_t)(qrv) * 10 * (qqi) + (qri_dsec))
 
 #if PIM_IPV == 4
 void igmp_group_reset_gmi(struct gm_group *group);


### PR DESCRIPTION
Static analysis reports possible overflow in the OHPI calculation in pim_cmd.c:

```
PIM_IGMP_OHPI_DSEC(...) * 100
```

This is valid, but the macro (and the other interval macros) suffers from the same overflow internally. The outer assignment is to long, but the macro and the trailing multiplication were evaluated using int arithmetic first. With allowed configuration ranges this can exceed 32-bit signed int.

Also widen the IGMP timer macros to perform arithmetic as int64_t, and make the reported OHPI conversion multiply by 100L. Also change the remaining LMQT local variables from int to long so the widened macro result is not immediately narrowed.

This fixes the reported overflow on normal LP64 builds.

Note: this does not completely solve range issues on platforms where long is only 32 bits, since the timer APIs and most local timer storage still use long.

Reported in: #22497