### PR TITLE
isisd: fix off-by-one bound check in SNMP circuit lookup

### DIFF
--- a/isisd/isis_snmp.c
+++ b/isisd/isis_snmp.c
@@ -965,7 +965,7 @@ static int isis_snmp_circuit_lookup_exact(oid *oid_idx, size_t oid_idx_len,
 	struct isis_circuit *circuit;
 
 	if (oid_idx == NULL || oid_idx_len < 1
-	    || oid_idx[0] > SNMP_CIRCUITS_MAX)
+	    || oid_idx[0] >= SNMP_CIRCUITS_MAX)
 		return 0;
 
 	circuit = snmp_circuits[oid_idx[0]];


### PR DESCRIPTION
Reject SNMP circuit index greater than or equal to SNMP_CIRCUITS_MAX before indexing snmp_circuits. Previously an index of 512 was allowed, which causes and out-of-bounds access on the array.

Reported in: #22493