### PR TITLE
ospf6d: check length before accessing grace LSA TLVs

### DIFF
--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -145,7 +145,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 
 	length = ntohs(lsah->length) - OSPF6_LSA_HEADER_SIZE;
 
-	for (tlvh = lsdesc_start(lsah); sum < length && tlvh;
+	/* Iterate as long as we have at least a TLV header available */
+	for (tlvh = lsdesc_start(lsah); sum + TLV_HDR_SIZE <= length && tlvh;
 	     tlvh = TLV_HDR_NEXT(tlvh)) {
 		/* Check TLV len against overall LSA */
 		if (sum + TLV_SIZE(tlvh) > length) {


### PR DESCRIPTION
Ensure that there is at least a TLV header's worth of data before accessing the header octets when iterating through a grace LSA's TLVs.
