### PR TITLE
bgpd: don't emit "no neighbor X capability link-local" for unnumbered…

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -21630,11 +21630,8 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 		if (!peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_LINK_LOCAL))
 			vty_out(vty, " no neighbor %s capability link-local\n", addr);
 	} else {
-		if (!peer->conf_if && peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_LINK_LOCAL))
+		if (peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_LINK_LOCAL))
 			vty_out(vty, " neighbor %s capability link-local\n", addr);
-		else if (peer->conf_if &&
-			 !peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_LINK_LOCAL))
-			vty_out(vty, " no neighbor %s capability link-local\n", addr);
 	}
 
 	/* dont-capability-negotiation */


### PR DESCRIPTION
… peers

bgp_config_write_peer_global() emits `no neighbor <ifname> capability link-local` for every unnumbered peer when both the instance flag BGP_FLAG_LINK_LOCAL_CAPABILITY and the peer flag
PEER_FLAG_CAPABILITY_LINK_LOCAL are off -- i.e. when the runtime state already matches the daemon default

frr-reload.py reads show-run: when it sees `no neighbor X capability link-local`
 in running but the target lacks that line, it strips
the leading "no " and issues the positive form to vtysh, silently setting PEER_FLAG_CAPABILITY_LINK_LOCAL on every unnumbered peer

  $ sudo systemctl restart frr && sleep 15
  $ sudo vtysh -c 'show running-config' | grep 'link-local'
   no neighbor swp1s3  capability link-local
   no neighbor swp31s0 capability link-local
   no neighbor swp31s1 capability link-local

  $ sudo /usr/lib/frr/frr-reload.py --test --stdout /etc/frr/frr.conf
  Lines To Delete
   neighbor swp1s3  capability link-local
   neighbor swp31s0 capability link-local
   neighbor swp31s1 capability link-local
  ...
  INFO: Executed "router bgp 10  neighbor swp1s3  capability link-local exit"
  INFO: Executed "router bgp 10  neighbor swp31s0 capability link-local exit"
  INFO: Executed "router bgp 10  neighbor swp31s1 capability link-local exit"

  $ sudo vtysh -c 'show bgp neighbor swp1s3 json' \
      | jq '.swp1s3.neighborCapabilities.linkLocalNextHop'
  { "advertised": true, "received": true }

After this patch:

  $ sudo systemctl restart frr && sleep 15
  $ sudo vtysh -c 'show running-config' | grep 'link-local'
  (empty)

  $ sudo /usr/lib/frr/frr-reload.py --test --stdout /etc/frr/frr.conf
  Lines To Delete
  Lines To Add
  (no LL-cap lines)

  $ sudo vtysh -c 'show bgp neighbor swp1s3 json' \
      | jq '.swp1s3.neighborCapabilities.linkLocalNextHop'
  { "advertised": false, "received": true }