### PR TITLE
isisd: bug fix hostname truncation in brief 'show isis database'

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -670,10 +670,17 @@ void lspid_print(uint8_t *lsp_id, char *dest, size_t dest_len, char dynhost,
 	else
 		dyn = NULL;
 
+	/*
+	 * Truncate the hostname to 15 characters so that the full LSP ID
+	 * (hostname + ".XX-XX" suffix = 21 chars) fits the %-21s column
+	 * used by lsp_print_vty().  The 'id' buffer (SYSID_STRLEN = 24)
+	 * can hold up to 23 chars, so this limit is for column alignment,
+	 * not buffer safety.
+	 */
 	if (dyn)
-		snprintf(id, sizeof(id), "%.14s", dyn->hostname);
+		snprintf(id, sizeof(id), "%.15s", dyn->hostname);
 	else if (!memcmp(isis->sysid, lsp_id, ISIS_SYS_ID_LEN) && dynhost)
-		snprintf(id, sizeof(id), "%.14s", cmd_hostname_get());
+		snprintf(id, sizeof(id), "%.15s", cmd_hostname_get());
 	else
 		snprintfrr(id, sizeof(id), "%pSY", lsp_id);
 


### PR DESCRIPTION
lspid_print() truncates the dynamic hostname to 14 characters using "%.14s", even though the 'id' buffer is SYSID_STRLEN (24 bytes) and the output column is 21 chars wide.  Increase the limit to 17 chars (24 - 6 for ".NN-NN" suffix - 1 for NUL) so hostnames up to 17 characters display fully instead of being truncated at 14.