### PR TITLE
zebra: Issue fix northbound RIB iteration skipping link-locals

### DIFF
--- a/tests/topotests/zebra_operational_data/r1/frr.conf
+++ b/tests/topotests/zebra_operational_data/r1/frr.conf
@@ -39,3 +39,6 @@ ip route 12.12.12.12/32 2.2.2.2
 ip route 13.0.0.0/8 Null0 vrf red
 ip route 13.13.13.13/32 3.3.3.2 vrf red
 ip route 14.14.14.14/32 4.4.4.2 vrf red
+
+ipv6 route 2001:db8:1::/64 Null0
+ipv6 route 2001:db8:2::/64 Null0

--- a/tests/topotests/zebra_operational_data/test_zebra_operational.py
+++ b/tests/topotests/zebra_operational_data/test_zebra_operational.py
@@ -9,12 +9,13 @@
 Test zebra operational values
 """
 
+import sys
 import pytest
 import json
 from lib.topogen import Topogen
 from lib.topolog import logger
 from lib import topotest
-
+from lib.common_config import step
 
 pytestmark = [pytest.mark.mgmtd]
 
@@ -36,7 +37,7 @@ def tgen(request):
         router.net.attach_iface_to_l3vrf("lo-red", "red")
         router.net.attach_iface_to_l3vrf(rname + "-eth2", "red")
         router.net.attach_iface_to_l3vrf(rname + "-eth3", "red")
-        router.load_frr_config("frr.conf")
+        router.load_frr_config()
 
     tgen.start_router()
     yield tgen
@@ -107,6 +108,92 @@ def test_zebra_operationalr(tgen):
             check_ipv6_forwarding_restored, True, count=30, wait=1
         )
         assert result is True, "IPv6 forwarding should be restored to True"
+
+
+def test_zebra_nb_rib_link_local_not_skipped(tgen):
+    """
+    Test that the northbound RIB iteration does not skip link-local IPv6
+    routes.
+
+    Regression test for issue #22535: link-local routes (e.g. fe80::/64)
+    were excluded from the northbound RIB iteration, making the NB API
+    inconsistent with the CLI ("show ipv6 route") which displays them.
+    """
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("Query the northbound RIB for IPv6 routes in the default VRF")
+    xpath = (
+        "/frr-vrf:lib/vrf[frr-vrf:name='default']"
+        "/frr-zebra:zebra/ribs/rib[afi-safi-name='frr-zebra:ipv6-unicast']"
+        "/route"
+    )
+
+    nb_data = [None]
+
+    def get_nb_routes():
+        raw = r1.vtysh_cmd("show mgmt get-data {}".format(xpath))
+        if not raw or raw.strip() == "":
+            return False
+        try:
+            nb_data[0] = json.loads(raw)
+        except ValueError:
+            return False
+        return True
+
+    _, result = topotest.run_and_expect(get_nb_routes, True, count=10, wait=1)
+    assert result is True, "No output from northbound RIB query"
+
+    data = nb_data[0]
+    logger.info("Northbound RIB output: %s", json.dumps(data, indent=2))
+
+    #
+    # Extract the set of route prefixes returned by the northbound API.
+    # The YANG list key is the prefix string, e.g. "2001:db8:1::/64".
+    #
+    def extract_prefixes(d):
+        prefixes = set()
+        try:
+            rib = d["frr-vrf:lib"]["vrf"][0]["zebra"]["ribs"]["rib"][0]
+            routes = rib.get("route", [])
+            for r in routes:
+                if "prefix" in r:
+                    prefixes.add(r["prefix"])
+        except (KeyError, IndexError, TypeError):
+            pass
+        return prefixes
+
+    prefixes = extract_prefixes(data)
+    logger.info("Prefixes returned by northbound RIB: %s", prefixes)
+
+    #
+    # The frr.conf has:
+    #   - link-local routes (fe80::/64) created by the kernel when
+    #     interfaces are brought up
+    #   - global routes 2001:db8:1::/64 and 2001:db8:2::/64 (static, Null0)
+    #     plus connected routes from interface addresses (2001:1111::/64, etc.)
+    #
+    # Before the fix, link-locals were skipped entirely, making the NB API
+    # inconsistent with the CLI.  After the fix, link-locals are included.
+    #
+    step("Verify that link-local routes are present in the northbound RIB")
+    link_local_found = any(p.startswith("fe80") for p in prefixes)
+    assert link_local_found, (
+        "No link-local route found in northbound RIB; "
+        "expected at least one fe80::/64 entry"
+    )
+
+    step("Verify that global IPv6 routes are also present")
+    assert (
+        "2001:db8:1::/64" in prefixes
+    ), "Global route 2001:db8:1::/64 missing from northbound RIB"
+    assert (
+        "2001:db8:2::/64" in prefixes
+    ), "Global route 2001:db8:2::/64 missing from northbound RIB"
+
+    logger.info("All expected routes are present in the northbound RIB")
 
 
 if __name__ == "__main__":

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -411,14 +411,9 @@ lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args)
 		rn = route_top(zrt->table);
 	else
 		rn = srcdest_route_next(rn);
-	/* Optimization: skip empty route nodes. */
+	/* Skip empty route nodes. */
 	while (rn && rn->info == NULL)
 		rn = route_next(rn);
-
-	/* Skip link-local routes. */
-	if (rn && rn->p.family == AF_INET6
-	    && IN6_IS_ADDR_LINKLOCAL(&rn->p.u.prefix6))
-		return NULL;
 
 	return rn;
 }
@@ -466,8 +461,14 @@ lib_vrf_zebra_ribs_rib_route_lookup_next(struct nb_cb_lookup_entry_args *args)
 	if (!rn)
 		return NULL;
 
-	route_unlock_node(rn);
-
+	/*
+	 * Unlike lib_vrf_zebra_ribs_rib_route_lookup_entry() (a self-contained
+	 * point lookup), this function seeds the get_next iteration: the
+	 * returned node is carried as args->list_entry into
+	 * lib_vrf_zebra_ribs_rib_route_get_next() -> srcdest_route_next() ->
+	 * route_next(), which unlocks its input node. The node returned by
+	 * route_table_get_next() must therefore keep the lock it carries.
+	 */
 	return rn;
 }
 


### PR DESCRIPTION
In lib_vrf_zebra_ribs_rib_route_get_next(), when the iteration hit a link-local IPv6 route (e.g. fe80::/64), the code returned NULL to skip it.  However, NULL signals "end of list" to the northbound framework, which terminated the entire iteration and hid all subsequent routes from northbound clients.  This made the NB API inconsistent with the CLI ("show ipv6 route"), which does display link-locals.

Replace the "if link-local then return NULL" with a while loop that skips link-local routes (and empty nodes) by continuing iteration with route_next(), so routes after the link-local are properly returned.

Fixes #22535