### PR TITLE
ripd: Fix allow-ecmp for large values

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -485,6 +485,10 @@ _Static_assert(sizeof(_uint64_t) == 8 && sizeof(_int64_t) == 8,
 /* Wrapper for the 'noreturn' metadata */
 #define FRR_NORETURN __attribute__((noreturn))
 
+/* Stringify a macro's *expansion* rather than its name. */
+#define _STRINGIFY(x) #x
+#define STRINGIFY(x) _STRINGIFY(x)
+
 #ifdef __cplusplus
 }
 #endif

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -98,7 +98,7 @@ DEFUN_YANG (rip_allow_ecmp,
        "Number of paths\n")
 {
 	int idx_number = 0;
-	char mpaths[3] = {};
+	char mpaths[sizeof(STRINGIFY(MULTIPATH_NUM))] = {};
 	uint32_t paths = MULTIPATH_NUM;
 
 	if (argv_find(argv, argc, CMD_RANGE_STR(1, MULTIPATH_NUM), &idx_number))

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -125,9 +125,9 @@ DEFUN_YANG (no_rip_allow_ecmp,
 void cli_show_rip_allow_ecmp(struct vty *vty, const struct lyd_node *dnode,
 			     bool show_defaults)
 {
-	uint8_t paths;
+	uint16_t paths;
 
-	paths = yang_dnode_get_uint8(dnode, NULL);
+	paths = yang_dnode_get_uint16(dnode, NULL);
 
 	if (!paths)
 		vty_out(vty, " no allow-ecmp\n");

--- a/ripd/rip_nb_config.c
+++ b/ripd/rip_nb_config.c
@@ -100,7 +100,7 @@ int ripd_instance_allow_ecmp_modify(struct nb_cb_modify_args *args)
 
 	rip = nb_running_get_entry(args->dnode, NULL, true);
 	rip->ecmp =
-		MIN(yang_dnode_get_uint8(args->dnode, NULL), zebra_ecmp_count);
+		MIN(yang_dnode_get_uint16(args->dnode, NULL), zebra_ecmp_count);
 	if (!rip->ecmp) {
 		rip_ecmp_disable(rip);
 		return NB_OK;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2712,7 +2712,7 @@ struct rip *rip_create(const char *vrf_name, struct vrf *vrf, int socket)
 	rip->vrf_name = XSTRDUP(MTYPE_RIP_VRF_NAME, vrf_name);
 
 	/* Set initial value. */
-	rip->ecmp = yang_get_default_uint8("%s/allow-ecmp", RIP_INSTANCE);
+	rip->ecmp = yang_get_default_uint16("%s/allow-ecmp", RIP_INSTANCE);
 	rip->default_metric =
 		yang_get_default_uint8("%s/default-metric", RIP_INSTANCE);
 	rip->distance =

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -150,7 +150,7 @@ struct rip {
 	struct route_table *distance_table;
 
 	/* RIP ECMP flag */
-	uint8_t ecmp;
+	uint16_t ecmp;
 
 	/* Are we in passive-interface default mode? */
 	bool passive_default;

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -98,7 +98,7 @@ DEFUN_YANG (ripng_allow_ecmp,
             "Number of paths\n")
 {
 	int idx_number = 0;
-	char mpaths[3] = {};
+	char mpaths[sizeof(STRINGIFY(MULTIPATH_NUM))] = {};
 	uint32_t paths = MULTIPATH_NUM;
 
     if (argv_find(argv, argc, CMD_RANGE_STR(1, MULTIPATH_NUM), &idx_number))

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -124,9 +124,9 @@ DEFUN_YANG (no_ripng_allow_ecmp,
 void cli_show_ripng_allow_ecmp(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
-	uint8_t paths;
+	uint16_t paths;
 
-	paths = yang_dnode_get_uint8(dnode, NULL);
+	paths = yang_dnode_get_uint16(dnode, NULL);
 
 	if (!paths)
 		vty_out(vty, " no allow-ecmp\n");

--- a/ripngd/ripng_nb_config.c
+++ b/ripngd/ripng_nb_config.c
@@ -130,7 +130,7 @@ int ripngd_instance_allow_ecmp_modify(struct nb_cb_modify_args *args)
 
 	ripng = nb_running_get_entry(args->dnode, NULL, true);
 	ripng->ecmp =
-		MIN(yang_dnode_get_uint8(args->dnode, NULL), zebra_ecmp_count);
+		MIN(yang_dnode_get_uint16(args->dnode, NULL), zebra_ecmp_count);
 	if (!ripng->ecmp) {
 		ripng_ecmp_disable(ripng);
 		return NB_OK;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1889,7 +1889,7 @@ struct ripng *ripng_create(const char *vrf_name, struct vrf *vrf, int socket)
 		"%s/timers/flush-interval", RIPNG_INSTANCE);
 	ripng->default_metric =
 		yang_get_default_uint8("%s/default-metric", RIPNG_INSTANCE);
-	ripng->ecmp = yang_get_default_uint8("%s/allow-ecmp", RIPNG_INSTANCE);
+	ripng->ecmp = yang_get_default_uint16("%s/allow-ecmp", RIPNG_INSTANCE);
 
 	/* Make buffer.  */
 	ripng->ibuf = stream_new(RIPNG_MAX_PACKET_SIZE * 5);

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -136,7 +136,7 @@ struct ripng {
 	struct event *t_triggered_interval;
 
 	/* RIPng ECMP flag */
-	uint8_t ecmp;
+	uint16_t ecmp;
 
 	/* RIPng redistribute configuration. */
 	struct {

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -128,7 +128,7 @@ module frr-ripd {
           "VRF name.";
       }
       leaf allow-ecmp {
-        type uint8;
+        type uint16;
         default 0;
         description
           "Allow equal-cost multi-path.";

--- a/yang/frr-ripngd.yang
+++ b/yang/frr-ripngd.yang
@@ -91,7 +91,7 @@ module frr-ripngd {
           "VRF name.";
       }
       leaf allow-ecmp {
-        type uint8;
+        type uint16;
         default 0;
         description
           "Allow equal-cost multi-path.";


### PR DESCRIPTION
We allow up to 256 ECMP paths, but the buffer was only 3 bytes long for the string. So a 256 ECMP would have been truncated to 25. Correct is 4 byte long buffer: 3 chars plus null-termination