### PR TITLE
ospf6d: avoid route use after unlock in best route iterator

### DIFF
--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1015,10 +1015,11 @@ struct ospf6_route *ospf6_route_best_next(struct ospf6_route *route)
 	struct route_node *rnode;
 	struct ospf6_route *next;
 
+	rnode = route->rnode;
+	assert(rnode);
+	route_lock_node(rnode);
 	ospf6_route_unlock(route);
 
-	rnode = route->rnode;
-	route_lock_node(rnode);
 	rnode = route_next(rnode);
 	while (rnode && rnode->info == NULL)
 		rnode = route_next(rnode);


### PR DESCRIPTION
ospf6_route_best_next() unlocked the current route before reading route->rnode. The iterator is called with a existing route from ospf6_route_head()/ospf6_route_best_next(), so route->rnode is expected to be set. Assert that route->rnode is set and take a node reference before dropping the route reference.

This most likely never caused any issues in practice, because the route always comes from ospf6_route_head(), which always locks the route, so the unlock here should never actually hit a refcount of 0.

Related to: #22491