### PR TITLE
test: Fix occassional failure of test_ospf_rfc4222_dscp.py

### DIFF
--- a/tests/topotests/ospf_rfc4222_dscp/test_ospf_rfc4222_dscp.py
+++ b/tests/topotests/ospf_rfc4222_dscp/test_ospf_rfc4222_dscp.py
@@ -232,7 +232,7 @@ interface r1-eth0
     for i in range(1, 10):
         r1.cmd(f"ip addr add 198.51.100.{i}/32 dev lo")
     # Capture packets on R1's interface
-    topotest.sleep(3, "Gathering Packets")
+    topotest.sleep(10, "Gathering Packets")
     _stop_ospf_capture(r1, "r1-eth0", pcap)
 
     tuples = _tshark_dscp_and_type(r1, pcap)


### PR DESCRIPTION
pattern is:

a) start packet capture
b) sleep 3 seconds
c) stop packet capture

Look for packets sent.  Change the time to 10 seconds in b).  Yes I know this is a run_and_expect pattern.  I just don't know what state I should be looking for to know why we should stop looking. So I am making it 10 seconds.