### PR TITLE
tests: Ensure test uses run_and_expect for convergence.

### DIFF
--- a/tests/topotests/bgp_local_as_dynamic_peer_ttl/test_bgp_local_as_dynamic_peer_ttl.py
+++ b/tests/topotests/bgp_local_as_dynamic_peer_ttl/test_bgp_local_as_dynamic_peer_ttl.py
@@ -204,13 +204,20 @@ def test_bgp_listen_range_local_as_replace_as_session_established():
     )
 
     step("Cross-check from r3 side")
-    out = json.loads(
-        tgen.gears["r3"].vtysh_cmd("show bgp neighbors {} json".format(R1_LO))
-    )
-    state = out.get(R1_LO, {}).get("bgpState")
-    assert state == "Established", (
+
+    def _r3_session_up():
+        out = json.loads(
+            tgen.gears["r3"].vtysh_cmd("show bgp neighbors {} json".format(R1_LO))
+        )
+        state = out.get(R1_LO, {}).get("bgpState")
+        return None if state == "Established" else out
+
+    _, res = topotest.run_and_expect(_r3_session_up, None, count=120, wait=0.5)
+    assert res is None, (
         "r3 view of session to {} is {} (expected Established). "
-        "Full output: {}".format(R1_LO, state, json.dumps(out, indent=2)[:1000])
+        "Full output: {}".format(
+            R1_LO, res.get(R1_LO, {}).get("bgpState"), json.dumps(res, indent=2)[:1000]
+        )
     )
 
 


### PR DESCRIPTION
test_bgp_local-as_dynamic_peer_ttl.py has a dynamic neighbor setup on r1 --- r3.  r1 the test is checking that the neighbor is established. while in a failing case it is in `OpenConfirm` on r3 after r1 is established.  This tells me that r3 has not had a chance, under heavy load, to handle the final packet to transition to established on r3.  Modify the code to use a run_and_expect to make sure this happens.