### PR TITLE
bgpd: Fix flags used by use-underlays-nexthop-weight command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2892,7 +2892,7 @@ DEFPY (bgp_use_underlying_nexthop_weight,
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	if (no)
-		UNSET_FLAG(bgp->flags, BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE);
+		UNSET_FLAG(bgp->flags, BGP_FLAG_USE_RECURSIVE_WEIGHT);
 	else
 		SET_FLAG(bgp->flags, BGP_FLAG_USE_RECURSIVE_WEIGHT);
 
@@ -22708,7 +22708,7 @@ int bgp_config_write(struct vty *vty)
 		if (bgp->allow_martian)
 			vty_out(vty, " bgp allow-martian-nexthop\n");
 
-		if (CHECK_FLAG(bgp->flags, BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_USE_RECURSIVE_WEIGHT))
 			vty_out(vty, " use-underlays-nexthop-weight\n");
 
 		if (bgp->fast_convergence)


### PR DESCRIPTION
### Summary
After upgrading a router from FRR 10.5.1 to 10.6.1 I noticed that the following line appeared in the config:

```
 use-underlays-nexthop-weight
```

There is very little documentation about what this setting does, and after a bit of digging it seems this is unintended and is a bug.

`use-underlays-nexthop-weight` (83706fe188fb, first shipped in 10.6.0) uses `BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE` — an enum value of 3 — as a `bgp->flags` bitmask in the command's `no` handler and in the config writer. Bits 0 and 1 of `bgp->flags` are `BGP_FLAG_ALWAYS_COMPARE_MED` and `BGP_FLAG_DETERMINISTIC_MED`, so:

- `show running-config` emits ` use-underlays-nexthop-weight` whenever always-compare-med or deterministic-med is set, even if the command was never entered. Since `frr defaults datacenter` enables deterministic-med, the line appears on datacenter-profile routers upgraded to 10.6, while `bgp deterministic-med` itself stays hidden as a profile default.
- `no use-underlays-nexthop-weight` clears the two MED flags, silently changing bestpath selection, and does not clear `BGP_FLAG_USE_RECURSIVE_WEIGHT`.

Use `BGP_FLAG_USE_RECURSIVE_WEIGHT` in both places, matching what the positive form of the command sets.

Affects 10.6.0/10.6.1 — candidate for backport to stable/10.6.

Tested on Ubuntu 24.04 (libyang 3.13.6, gcc 13.2): before this patch, a bgpd configured with only `frr defaults datacenter` and `router bgp 65001` emits the line in `show running-config`, and `no use-underlays-nexthop-weight` makes `no bgp deterministic-med` appear and clears a configured `bgp always-compare-med`; after this patch, the line appears only when configured, the no-form removes it and leaves deterministic-med and always-compare-med intact, and `tests/bgpd` passes (371 tests).

LLM assistance was used to root-cause the bug, prepare and test the fix, and draft the commit message and this description.

### Related Issue
None found.

### Components
bgpd
