### PR TITLE
zebra: fix outdated SRv6 headend behavior comment

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1859,11 +1859,10 @@ static ssize_t fill_seg6ipt_encap(char *buffer, size_t buflen,
 
 	/*
 	 * Note: even if Zebra is capable of programming all the SRv6
-	 * Headend Behaviors defined in RFC 8986, FRR daemons support
+	 * Headend Behaviors defined in RFC 8986, FRR daemons may support
 	 * only a subset of them.
-	 * Currently, STATIC currently supports H.Encaps and H.Encaps.Red.
-	 * BGP supports only H.Encaps.
-	 * Daemons need to be extended to support other behaviors.
+	 * Daemons need to be extended individually to support additional
+	 * behaviors.
 	 */
 	switch (segs->encap_behavior) {
 	case SRV6_HEADEND_BEHAVIOR_H_INSERT:


### PR DESCRIPTION
The comment stated that BGP only supports H.Encaps, but BGP also supports H.Encaps.Red. Update the comment to reflect this and fix the duplicated "currently" word.

Of course, the feature is documented under https://docs.frrouting.org/en/latest/bgp.html#bgp-based-l3-service-over-srv6; but due to this outdated comment, for weeks I was convinced that the feature did not exist for BGP.