### PR TITLE
bgpd, zebra: restore EVPN VTEP fallback for VXLAN without local IP

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3540,9 +3540,16 @@ static int bgp_zebra_process_local_vni(ZAPI_CALLBACK_ARGS)
 			vrf_id_to_name(vrf_id), vni,
 			vrf_id_to_name(tenant_vrf_id), svi_ifindex);
 
-	if (ipaddr_is_zero(&vtep_ip)) {
+	/* Preserve legacy behavior for VXLAN devices with no explicit local
+	 * address: treat IPv4/IPv6 zero as unspecified and use the router-id as
+	 * the EVPN VTEP/originator IP.
+	 */
+	if (cmd == ZEBRA_VNI_ADD && ipaddr_is_zero(&vtep_ip)) {
 		SET_IPADDR_V4(&vtep_ip);
 		vtep_ip.ipaddr_v4 = bgp->router_id;
+		if (BGP_DEBUG(zebra, ZEBRA))
+			zlog_debug("Rx VNI add with unspecified VTEP IP, using router-id %pIA",
+				   &vtep_ip);
 	}
 
 	if (cmd == ZEBRA_VNI_ADD) {

--- a/tests/topotests/bgp_evpn_vxlan_local_vtep_none/r1/frr.conf
+++ b/tests/topotests/bgp_evpn_vxlan_local_vtep_none/r1/frr.conf
@@ -1,0 +1,17 @@
+!
+interface lo
+ ip address 10.0.0.1/32
+!
+interface r1-eth0
+ ip address 192.0.2.1/24
+!
+router bgp 65000
+ bgp router-id 10.0.0.1
+ no bgp default ipv4-unicast
+ neighbor 192.0.2.2 remote-as 65000
+ !
+ address-family l2vpn evpn
+  neighbor 192.0.2.2 activate
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_vxlan_local_vtep_none/r2/frr.conf
+++ b/tests/topotests/bgp_evpn_vxlan_local_vtep_none/r2/frr.conf
@@ -1,0 +1,16 @@
+!
+interface lo
+ ip address 10.0.0.2/32
+!
+interface r2-eth0
+ ip address 192.0.2.2/24
+!
+router bgp 65000
+ bgp router-id 10.0.0.2
+ no bgp default ipv4-unicast
+ neighbor 192.0.2.1 remote-as 65000
+ !
+ address-family l2vpn evpn
+  neighbor 192.0.2.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_vxlan_local_vtep_none/test_bgp_evpn_vxlan_local_vtep_none.py
+++ b/tests/topotests/bgp_evpn_vxlan_local_vtep_none/test_bgp_evpn_vxlan_local_vtep_none.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+Verify that an L2VNI with no VXLAN local address reaches bgpd and uses the
+router-id as its originator IP.
+"""
+
+import os
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
+
+VNI = 101
+ROUTER_ID = "10.0.0.1"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router = tgen.gears["r1"]
+    router.cmd_raises(f"ip link add name br{VNI} type bridge")
+    router.cmd_raises("ip link set dev r1-eth0 up")
+    router.cmd_raises(
+        f"ip link add vxlan{VNI} type vxlan id {VNI} dstport 4789 "
+        "group 239.1.1.1 dev r1-eth0 nolearning"
+    )
+    router.cmd_raises(f"ip link set dev vxlan{VNI} master br{VNI}")
+    router.cmd_raises(f"ip link set dev br{VNI} up")
+    router.cmd_raises(f"ip link set dev vxlan{VNI} up")
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_vni_without_local_vtep_uses_router_id():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    def _check_bgp_vni():
+        output = router.vtysh_cmd(
+            f"show bgp l2vpn evpn vni {VNI} json", isjson=True
+        )
+        expected = {"originatorIp": ROUTER_ID}
+        return topotest.json_cmp(output, expected)
+
+    _, result = topotest.run_and_expect(_check_bgp_vni, None, count=30, wait=1)
+    assert result is None, (
+        f"VNI {VNI} originator IP did not fall back to router-id {ROUTER_ID}"
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1099,6 +1099,7 @@ int zebra_evpn_send_add_to_client(struct zebra_evpn *zevpn)
 	struct zserv *client;
 	struct stream *s;
 	ifindex_t svi_index;
+	struct ipaddr local_vtep_ip;
 	int rc;
 
 	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
@@ -1112,7 +1113,12 @@ int zebra_evpn_send_add_to_client(struct zebra_evpn *zevpn)
 
 	zclient_create_header(s, ZEBRA_VNI_ADD, zebra_vrf_get_evpn_id());
 	stream_putl(s, zevpn->vni);
-	stream_put_ipaddr(s, &zevpn->local_vtep_ip);
+	local_vtep_ip = zevpn->local_vtep_ip;
+	if (IS_IPADDR_NONE(&local_vtep_ip)) {
+		SET_IPADDR_V4(&local_vtep_ip);
+		local_vtep_ip.ipaddr_v4.s_addr = INADDR_ANY;
+	}
+	stream_put_ipaddr(s, &local_vtep_ip);
 	stream_put(s, &zevpn->vrf_id, sizeof(vrf_id_t)); /* tenant vrf */
 	stream_put_in_addr(s, &zevpn->mcast_grp);
 	stream_put(s, &svi_index, sizeof(ifindex_t));
@@ -1122,7 +1128,7 @@ int zebra_evpn_send_add_to_client(struct zebra_evpn *zevpn)
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug("Send EVPN_ADD %u %pIA tenant vrf %s(%u) SVI index %u to %s", zevpn->vni,
-			   &zevpn->local_vtep_ip, vrf_id_to_name(zevpn->vrf_id), zevpn->vrf_id,
+			   &local_vtep_ip, vrf_id_to_name(zevpn->vrf_id), zevpn->vrf_id,
 			   (zevpn->svi_if ? zevpn->svi_if->ifindex : 0),
 			   zebra_route_string(client->proto));
 


### PR DESCRIPTION
Fix EVPN VXLAN handling when a VXLAN interface has no explicit local VTEP IP configured.

After the switch to `struct ipaddr`, zebra could store the missing local address as `IPADDR_NONE`, which the ZAPI stream helpers reject. This prevented `ZEBRA_VNI_ADD` from reaching bgpd and broke the existing router-id fallback.

This change encodes an unspecified local VTEP as IPv4 0.0.0.0 on the zebra side, allowing bgpd to detect it and use the BGP router-id as the EVPN VTEP/originator IP.

Also adds a topotest covering an L2VNI with no VXLAN local address.
