### PR TITLE
bgpd: Fix link-bandwidth replace for non-transitive extended communities

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -65,6 +65,42 @@ static void ecommunity_hash_free(struct ecommunity *ecom)
 	ecommunity_free(&ecom);
 }
 
+static bool ecommunity_type_match(uint8_t existing_type, uint8_t new_type)
+{
+	uint8_t existing_base = existing_type & ~ECOMMUNITY_FLAG_NON_TRANSITIVE;
+	uint8_t new_base = new_type & ~ECOMMUNITY_FLAG_NON_TRANSITIVE;
+
+	return existing_base == new_base;
+}
+
+/*
+ * Decide whether an existing extended community entry matches a candidate
+ * for unique/overwrite insertion in ecommunity_add_val_internal().
+ *
+ * RFC 4360 treats transitive (e.g. 0x00) and non-transitive (e.g. 0x40)
+ * as distinct type bytes; two communities are equal only when all eight
+ * octets match.  That strict model is preserved for every subtype except
+ * Link Bandwidth.
+ *
+ * Link Bandwidth is different: route-map "set extcommunity bandwidth" adds
+ * a new EC via ecommunity_add_val(..., unique, overwrite).  When the path
+ * already carries a non-transitive Link Bandwidth EC, the type bytes differ
+ * and the old logic appended a second entry instead of replacing the first
+ * (RFC 10005 Section 7.1).  Match Link Bandwidth subtypes on the base type,
+ * ignoring the non-transitive bit, so overwrite replaces the existing EC.
+ *
+ * Other subtypes (route-target, origin-validation, etc.) keep exact type-byte
+ * matching because callers rely on RFC 4360 byte identity.
+ */
+static bool ecommunity_unique_type_match(uint8_t existing_type,
+					 uint8_t new_type, uint8_t subtype)
+{
+	if (subtype == ECOMMUNITY_LINK_BANDWIDTH ||
+	    subtype == ECOMMUNITY_EXTENDED_LINK_BANDWIDTH)
+		return ecommunity_type_match(existing_type, new_type);
+
+	return existing_type == new_type;
+}
 
 /* Add a new Extended Communities value to Extended Communities
    Attribute structure.  When the value is already exists in the
@@ -104,7 +140,8 @@ static bool ecommunity_add_val_internal(struct ecommunity *ecom,
 	     p += ecom_size, c++) {
 		if (unique) {
 			if (ecom_size == ECOMMUNITY_SIZE) {
-				if (p[0] == eval4->val[0] &&
+				if (ecommunity_unique_type_match(
+					    p[0], eval4->val[0], eval4->val[1]) &&
 				    p[1] == eval4->val[1]) {
 					if (overwrite) {
 						memcpy(p, eval4->val,
@@ -114,7 +151,8 @@ static bool ecommunity_add_val_internal(struct ecommunity *ecom,
 					return false;
 				}
 			} else {
-				if (p[0] == eval6->val[0] &&
+				if (ecommunity_unique_type_match(
+					    p[0], eval6->val[0], eval6->val[1]) &&
 				    p[1] == eval6->val[1]) {
 					if (overwrite) {
 						memcpy(p, eval6->val,

--- a/tests/topotests/bgp_link_bandwidth_non_transitive/r1/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_non_transitive/r1/frr.conf
@@ -1,0 +1,27 @@
+!
+interface r1-eth0
+ ip address 192.168.12.1/24
+!
+interface r1-eth1
+ ip address 192.168.13.1/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 192.168.12.2 remote-as 65002
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ neighbor 192.168.13.3 remote-as internal
+ neighbor 192.168.13.3 timers 1 3
+ neighbor 192.168.13.3 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.13.3 next-hop-self
+  neighbor 192.168.13.3 route-map TO-R3 out
+ exit-address-family
+!
+ip prefix-list PL-TEST seq 5 permit 10.10.10.100/32
+!
+route-map TO-R3 permit 10
+ match ip address prefix-list PL-TEST
+ set extcommunity bandwidth 50
+exit
+!

--- a/tests/topotests/bgp_link_bandwidth_non_transitive/r2/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_non_transitive/r2/frr.conf
@@ -1,0 +1,25 @@
+!
+interface lo
+ ip address 10.10.10.100/32
+!
+interface r2-eth0
+ ip address 192.168.12.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.12.1 remote-as 65001
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ address-family ipv4 unicast
+  network 10.10.10.100/32
+  neighbor 192.168.12.1 route-map TO-R1 out
+ exit-address-family
+!
+ip prefix-list PL-TEST seq 5 permit 10.10.10.100/32
+!
+route-map TO-R1 permit 10
+ match ip address prefix-list PL-TEST
+ set extcommunity bandwidth 20 non-transitive
+exit
+!

--- a/tests/topotests/bgp_link_bandwidth_non_transitive/r3/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_non_transitive/r3/frr.conf
@@ -1,0 +1,11 @@
+!
+interface r3-eth0
+ ip address 192.168.13.3/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 192.168.13.1 remote-as internal
+ neighbor 192.168.13.1 timers 1 3
+ neighbor 192.168.13.1 timers connect 1
+ !
+!

--- a/tests/topotests/bgp_link_bandwidth_non_transitive/test_bgp_link_bandwidth_non_transitive.py
+++ b/tests/topotests/bgp_link_bandwidth_non_transitive/test_bgp_link_bandwidth_non_transitive.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+Verify non-transitive link-bandwidth extended communities are replaced
+correctly when a route-map sets bandwidth on export.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+pytestmark = [pytest.mark.bgpd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+PREFIX = "10.10.10.100/32"
+R1_R3 = "192.168.13.3"
+R1_AS = "65001"
+EXPORT_LB_MBPS = "50.000 Mbps"
+
+
+def setup_module(mod):
+    topodef = {
+        "s1": ("r2", "r1"),
+        "s2": ("r1", "r3"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for router in router_list.values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _lb_count(path):
+    ec = path.get("extendedCommunity")
+    if not ec:
+        return 0
+    if isinstance(ec, dict):
+        return ec.get("string", "").count("LB:")
+    return str(ec).count("LB:")
+
+
+def _check_link_bandwidth_export_path(path, where):
+    """Validate a single route-map LB EC on a BGP path JSON object."""
+    lb_count = _lb_count(path)
+    if lb_count != 1:
+        ec = path.get("extendedCommunity", {})
+        return "{}: expected 1 link-bandwidth EC, found {} in {!r}".format(
+            where, lb_count, ec
+        )
+
+    ec_str = path.get("extendedCommunity", {}).get("string", "")
+    if R1_AS not in ec_str:
+        return "{}: expected r1 AS in link-bandwidth EC, got {!r}".format(
+            where, ec_str
+        )
+    if EXPORT_LB_MBPS not in ec_str:
+        return "{}: expected 50 Mbps link-bandwidth from route-map, got {!r}".format(
+            where, ec_str
+        )
+    return None
+
+
+def test_replace_non_transitive_link_bandwidth_on_export():
+    """
+    r2 advertises non-transitive link-bandwidth to r1; r1 applies a fixed
+    bandwidth route-map toward r3. The export must contain a single LB EC
+    from the route-map, not duplicate transitive/non-transitive entries.
+
+    r3 is iBGP so non-transitive communities are not stripped on export;
+    without the fix, both the received non-transitive LB and the route-map
+    transitive LB would appear on r1 (advertised-routes) and on r3 (RIB).
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r3 = tgen.gears["r3"]
+
+    def _check_export():
+        adv_output = json.loads(
+            r1.vtysh_cmd(
+                "show bgp ipv4 unicast neighbors {} advertised-routes detail json".format(
+                    R1_R3
+                )
+            )
+        )
+        adv_routes = adv_output.get("advertisedRoutes", {})
+        if PREFIX not in adv_routes:
+            return "r1: prefix {} missing from advertised routes".format(PREFIX)
+
+        adv_paths = adv_routes[PREFIX].get("paths", [])
+        if not adv_paths:
+            return "r1: no paths advertised for {}".format(PREFIX)
+
+        err = _check_link_bandwidth_export_path(
+            adv_paths[0], "r1 advertised-routes"
+        )
+        if err:
+            return err
+
+        rib_output = json.loads(r3.vtysh_cmd("show bgp ipv4 unicast json detail"))
+        rib_routes = rib_output.get("routes", {})
+        if PREFIX not in rib_routes:
+            return "r3: prefix {} missing from BGP RIB".format(PREFIX)
+
+        rib_paths = rib_routes[PREFIX].get("paths", [])
+        if not rib_paths:
+            return "r3: no paths in BGP RIB for {}".format(PREFIX)
+
+        return _check_link_bandwidth_export_path(rib_paths[0], "r3 BGP RIB")
+
+    test_func = functools.partial(_check_export)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary

Fix route-map `set extcommunity bandwidth` appending a second Link Bandwidth
extended community when the path already carries one with the opposite
transitivity bit (transitive `0x00` vs non-transitive `0x40`).

Add `ecommunity_unique_type_match()` so unique/overwrite insertion in
`ecommunity_add_val_internal()` ignores the non-transitive bit for Link
Bandwidth subtypes only; other extended community types keep RFC 4360 exact
type-byte matching.

Add topotest `bgp_link_bandwidth_non_transitive/` (r2 → r1 → r3) that
verifies a single route-map LB value on both the exporting router and the
iBGP peer RIB.

## Problem

RFC 4360 treats transitive and non-transitive extended community type bytes as
distinct. When a route already has a non-transitive Link Bandwidth EC and a
route-map adds a transitive one (or the reverse), the old code treated them as
different subtypes for unique/overwrite purposes and **appended** a second LB EC
instead of replacing the first.

That produces the inconsistent dual–Link Bandwidth case described in RFC 10005
Section 7.1 (two LB communities with different bandwidth values on the same
UPDATE).

Example (covered by the topotest):

1. r2 advertises `10.10.10.100/32` with `set extcommunity bandwidth 20 non-transitive`
2. r1 applies `set extcommunity bandwidth 50` toward an iBGP peer on export
3. Without the fix: both `LB:65002:… (20 Mbps)` and `LB:65001:… (50 Mbps)` appear
4. With the fix: a single `LB:65001:… (50 Mbps)` replaces the existing entry

The fix is symmetric: transitive present + route-map sets non-transitive also
replaces rather than duplicates.

## Fix

| Location | Change |
|----------|--------|
| `ecommunity_type_match()` | Static helper: compare type bytes with T bit masked |
| `ecommunity_unique_type_match()` | Use T-bit-insensitive match only for LB / extended-LB subtypes |
| `ecommunity_add_val_internal()` | Call `ecommunity_unique_type_match()` in unique/overwrite path |

`ecommunity_linkbw_present()` is unchanged. `ecommunity_replace_linkbw()`
(cumulative bandwidth on next-hop-self re-advertise) is unchanged and still
returns early when the existing LB is non-transitive.

## Test plan

- [x] Topotest: `./tests/topotests/docker/frr-topotests.sh -vv -s bgp_link_bandwidth_non_transitive/`
- [ ] Manual: route-map `set extcommunity bandwidth` on export with opposite transitivity vs received LB → single LB EC on UPDATE
- [ ] Manual: confirm without fix, topotest fails with duplicate LB communities
