### PR TITLE
ospfd: support for weighted ECMP on multipath routes

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -873,6 +873,14 @@ Interfaces
 
       Example:
 
+.. clicmd:: ip ospf weight (1-16777214)
+
+   Configure relative weight for next-hops via this interface associated with
+   multipath routes. The weight is relative and will be used to calculate
+   the actual next-hop weight when compared to all other next-hops for the
+   same route. Kernel next-hop weights will be between 1 and 255. This value
+   is local only and not distributed as part of the OSPF protocol.
+
 .. code-block:: frr
 
    !

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -513,6 +513,8 @@ static int ospf_ase_route_match_same(struct route_table *rt,
 			return 0;
 		if (op->ifindex != newop->ifindex)
 			return 0;
+		if (op->nh_weight != newop->nh_weight)
+			return 0;
 	}
 
 	if (or->u.ext.tag != newor->u.ext.tag)

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -571,6 +571,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, auth_crypt);
 	UNSET_IF_PARAM(oip, auth_type);
 	UNSET_IF_PARAM(oip, if_area);
+	UNSET_IF_PARAM(oip, weight);
 	UNSET_IF_PARAM(oip, opaque_capable);
 	UNSET_IF_PARAM(oip, keychain_name);
 	UNSET_IF_PARAM(oip, nbr_filter_name);
@@ -635,6 +636,7 @@ void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 	    !OSPF_IF_PARAM_CONFIGURED(oip, keychain_name) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, nbr_filter_name) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, dead_timer_any) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, weight) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_ospf_all) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_low_control) && listcount(oip->auth_crypt) == 0) {
 		ospf_del_if_params(ifp, oip);
@@ -747,6 +749,9 @@ int ospf_if_new_hook(struct interface *ifp)
 
 	SET_IF_PARAM(IF_DEF_PARAMS(ifp), opaque_capable);
 	IF_DEF_PARAMS(ifp)->opaque_capable = OSPF_OPAQUE_CAPABLE_DEFAULT;
+
+	SET_IF_PARAM(IF_DEF_PARAMS(ifp), weight);
+	IF_DEF_PARAMS(ifp)->weight = 0;
 
 	IF_DEF_PARAMS(ifp)->prefix_suppression = OSPF_PREFIX_SUPPRESSION_DEFAULT;
 

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -45,6 +45,7 @@ struct ospf_if_params {
 	DECLARE_IF_PARAM(uint32_t, transmit_delay); /* Interface Transmission Delay */
 	DECLARE_IF_PARAM(uint32_t,
 			 output_cost_cmd); /* Command Interface Output Cost */
+	DECLARE_IF_PARAM(uint64_t, weight); /* Command Interface Nexthop Weight */
 	DECLARE_IF_PARAM(uint32_t,
 			 retransmit_interval); /* Retransmission Interval */
 	DECLARE_IF_PARAM(uint32_t,

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -232,6 +232,8 @@ int ospf_route_match_same(struct route_table *rt, struct prefix_ipv4 *prefix,
 					return 0;
 				if (op->ifindex != newop->ifindex)
 					return 0;
+				if (op->nh_weight != newop->nh_weight)
+					return 0;
 
 				/* check TI-LFA backup paths */
 				if (!ospf_route_backup_path_same(&op->srni,
@@ -697,9 +699,12 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 
 			path = ospf_path_new();
 			path->nexthop.s_addr = INADDR_ANY;
+			path->nh_weight = 0;
 
 			if (oi) {
 				path->ifindex = oi->ifp->ifindex;
+				if (OSPF_IF_PARAM(oi, weight))
+					path->nh_weight = OSPF_IF_PARAM(oi, weight);
 				if (CHECK_FLAG(oi->connected->flags,
 					       ZEBRA_IFA_UNNUMBERED))
 					path->unnumbered = 1;
@@ -846,8 +851,8 @@ static int ospf_path_exist(struct list *plist, struct in_addr nexthop,
 	struct ospf_path *path;
 
 	for (ALL_LIST_ELEMENTS(plist, node, nnode, path))
-		if (IPV4_ADDR_SAME(&path->nexthop, &nexthop)
-		    && path->ifindex == oi->ifp->ifindex)
+		if (IPV4_ADDR_SAME(&path->nexthop, &nexthop) && path->ifindex == oi->ifp->ifindex &&
+		    path->nh_weight == OSPF_IF_PARAM(oi, weight))
 			return 1;
 
 	return 0;
@@ -880,9 +885,12 @@ void ospf_route_copy_nexthops_from_vertex(struct ospf_area *area,
 			path = ospf_path_new();
 			path->nexthop = nexthop->router;
 			path->adv_router = v->lsa->adv_router;
+			path->nh_weight = 0;
 
 			if (oi) {
 				path->ifindex = oi->ifp->ifindex;
+				if (OSPF_IF_PARAM(oi, weight))
+					path->nh_weight = OSPF_IF_PARAM(oi, weight);
 				if (CHECK_FLAG(oi->connected->flags,
 					       ZEBRA_IFA_UNNUMBERED))
 					path->unnumbered = 1;
@@ -904,6 +912,8 @@ struct ospf_path *ospf_path_lookup(struct list *plist, struct ospf_path *path)
 		if (!IPV4_ADDR_SAME(&op->adv_router, &path->adv_router))
 			continue;
 		if (op->ifindex != path->ifindex)
+			continue;
+		if (op->nh_weight != path->nh_weight)
 			continue;
 		return op;
 	}

--- a/ospfd/ospf_route.h
+++ b/ospfd/ospf_route.h
@@ -38,6 +38,7 @@ struct ospf_path {
 	struct in_addr nexthop;
 	struct in_addr adv_router;
 	ifindex_t ifindex;
+	uint64_t nh_weight;
 	unsigned char unnumbered;
 	struct sr_nexthop_info srni;
 };

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4113,6 +4113,16 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 		else
 			vty_out(vty, "  LSA retransmissions: %u\n",
 				oi->ls_rxmt_lsa);
+
+		/* Interface multipath weight */
+		if (OSPF_IF_PARAM(oi, weight)) {
+			if (use_json)
+				json_object_int_add(json_interface_sub, "weight",
+						    OSPF_IF_PARAM(oi, weight));
+			else
+				vty_out(vty, "  Weight: %llu\n",
+					(unsigned long long)OSPF_IF_PARAM(oi, weight));
+		}
 	}
 }
 
@@ -8142,6 +8152,43 @@ DEFUN_HIDDEN (no_ospf_cost,
               "Address of interface\n")
 {
 	return no_ip_ospf_cost(self, vty, argc, argv);
+}
+
+DEFPY (ip_ospf_weight,
+       ip_ospf_weight_cmd,
+       "[no] ip ospf weight ![(1-16777214)]$weight", NO_STR
+       "IP Information\n"
+       "OSPF interface commands\n"
+       "Interface weight for multipath\n"
+       "Weight\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	int change = 0;
+	struct ospf_if_params *params;
+	struct route_node *rn;
+
+	params = IF_DEF_PARAMS(ifp);
+
+	if (!!no)
+		weight = 0;
+
+	if ((unsigned long long)params->weight != (unsigned long long)weight)
+		change = 1;
+	SET_IF_PARAM(params, weight);
+	params->weight = weight;
+
+	if (change) {
+		for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
+			struct ospf_interface *oi = rn->info;
+
+			if (oi == NULL)
+				continue;
+			ospf_restart_spf(oi->ospf);
+			break;
+		}
+	}
+
+	return CMD_SUCCESS;
 }
 
 static void ospf_nbr_timer_update(struct ospf_interface *oi)
@@ -12396,6 +12443,11 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				vty_out(vty, "\n");
 			}
 
+			/* Interface Output Weight print. */
+			if (params && params->weight)
+				vty_out(vty, " ip ospf weight %llu\n",
+					(unsigned long long)params->weight);
+
 			/* Hello Interval print. */
 			if (OSPF_IF_PARAM_CONFIGURED(params, v_hello)
 			    && params->v_hello != OSPF_HELLO_INTERVAL_DEFAULT) {
@@ -13366,6 +13418,9 @@ static void ospf_vty_if_init(void)
 	/* "ip ospf cost" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_cost_cmd);
 	install_element(INTERFACE_NODE, &no_ip_ospf_cost_cmd);
+
+	/* "ip ospf weight" commands. */
+	install_element(INTERFACE_NODE, &ip_ospf_weight_cmd);
 
 	/* "ip ospf mtu-ignore" commands. */
 	install_element(INTERFACE_NODE, &ip_ospf_mtu_ignore_addr_cmd);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -211,6 +211,12 @@ static void ospf_zebra_add_nexthop(struct ospf *ospf, struct ospf_path *path,
 	}
 	api_nh->vrf_id = ospf->vrf_id;
 
+	if (path->nh_weight) {
+		SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_WEIGHT);
+		api_nh->weight = path->nh_weight;
+	} else
+		UNSET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_WEIGHT);
+
 	/* Set TI-LFA backup nexthop info if present */
 	if (path->srni.backup_label_stack) {
 		SET_FLAG(api->message, ZAPI_MESSAGE_BACKUP_NEXTHOPS);

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -2078,6 +2078,7 @@ def create_interfaces_cfg(tgen, topo, build=False):
                     "network",
                     "priority",
                     "cost",
+                    "weight",
                     "mtu_ignore",
                 ]
                 if "ospf" in data:

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -404,6 +404,7 @@ def config_ospf_interface(
             data_ospf_auth = ospf_data.setdefault("authentication", None)
             data_ospf_dr_priority = ospf_data.setdefault("priority", None)
             data_ospf_cost = ospf_data.setdefault("cost", None)
+            data_ospf_weight = ospf_data.setdefault("weight", None)
             data_ospf_mtu = ospf_data.setdefault("mtu_ignore", None)
 
             try:
@@ -466,6 +467,14 @@ def config_ospf_interface(
             # interface ospf cost
             if data_ospf_cost:
                 cmd = "ip ospf cost {}".format(ospf_data["cost"])
+                if "del_action" in ospf_data:
+                    cmd = "no {}".format(cmd)
+                config_data.append(cmd)
+
+            # interface ospf weight
+            if data_ospf_weight:
+                cmd = "ip ospf weight {}".format(ospf_data["weight"])
+                print(cmd)
                 if "del_action" in ospf_data:
                     cmd = "no {}".format(cmd)
                 config_data.append(cmd)

--- a/tests/topotests/ospf_weighted_ecmp/r1/frr.conf
+++ b/tests/topotests/ospf_weighted_ecmp/r1/frr.conf
@@ -1,0 +1,44 @@
+!
+hostname r1
+ip forwarding
+!
+interface r1-eth0
+ ip address 10.1.1.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+ ip ospf weight 10
+!
+interface r1-eth1
+ ip address 10.1.2.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+ ip ospf weight 100
+!
+!
+interface r1-eth2
+ ip address 10.1.3.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+ ip ospf weight 200
+!
+interface r1-eth3
+ ip address 10.1.4.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+ ip ospf weight 400
+!
+interface r1-eth4
+ ip address 10.1.7.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+router ospf
+  ospf router-id 1.1.1.1
+  distance 20
+  network 10.1.1.0/24 area 0
+  network 10.1.2.0/24 area 0
+  network 10.1.3.0/24 area 0
+  network 10.1.4.0/24 area 0
+  network 10.1.7.0/24 area 0
+!

--- a/tests/topotests/ospf_weighted_ecmp/r2/frr.conf
+++ b/tests/topotests/ospf_weighted_ecmp/r2/frr.conf
@@ -1,0 +1,43 @@
+!
+hostname r2
+ip forwarding
+!
+interface r2-eth0
+ ip address 10.1.1.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+interface r2-eth1
+ ip address 10.1.2.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r2-eth2
+ ip address 10.1.3.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r2-eth3
+ ip address 10.1.4.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r2-eth4
+ ip address 10.1.5.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+!
+router ospf
+  ospf router-id 2.2.2.2
+  distance 20
+  network 10.1.1.0/24 area 0
+  network 10.1.2.0/24 area 0
+  network 10.1.3.0/24 area 0
+  network 10.1.4.0/24 area 0
+  network 10.1.5.0/24 area 0
+!

--- a/tests/topotests/ospf_weighted_ecmp/test_ospf_weighted_ecmp.py
+++ b/tests/topotests/ospf_weighted_ecmp/test_ospf_weighted_ecmp.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_ospf_weighted_ecmp.py
+#
+# Brian Miller
+#
+
+import os
+import sys
+import json
+from operator import itemgetter
+from functools import partial
+import pytest
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+from lib.common_config import (
+    step,
+)
+
+
+"""
+test_ospf_weighted_ecmp.py: Test OSPF weighted ECMP on multipath routes
+"""
+
+TOPOLOGY = """
+
+
+            +-----+             +-----+ 
+       eth4 |     |   eth0      |     | eth4
+      ------+     +-------------+     +------
+10.1.7.0/24 |     | 10.1.1.0/24 |     | 10.1.5.0/24
+            |     |             |     |
+            |     |   eth1      |     |
+            |     +-------------+     |
+            | R1  | 10.1.2.0/24 |  R2 |
+            |     |             |     |
+            |     |   eth2      |     |
+            |     +-------------+     |
+            |     | 10.1.3.0/24 |     |
+            |     |             |     |
+            |     |   eth3      |     |
+            |     +-------------+     |
+            |     | 10.1.4.0/24 |     |
+         .1 +-----+.1         .2+-----+.2
+
+"""
+
+#This assumes zebra was started without the '--nexthop-weight-16-bit' flag
+RIB_MAX_WEIGHT = 255
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# Required to instantiate the topology builder class.
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 3 routers
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    # Interconect router 1, 2 (0)
+    switch = tgen.add_switch("s1-1-2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Interconect router 1, 2 (1)
+    switch = tgen.add_switch("s2-1-2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Interconect router 1, 2 (2)
+    switch = tgen.add_switch("s3-1-2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Interconect router 1, 2 (3)
+    switch = tgen.add_switch("s4-1-2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Add standalone network to router 1
+    switch = tgen.add_switch("s7-1")
+    switch.add_link(tgen.gears["r1"])
+
+    # Add standalone network to router 2
+    switch = tgen.add_switch("s5-1")
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    logger.info("OSPF Prefix Suppression:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # Starting Routers
+    router_list = tgen.routers()
+
+    for router in router_list.values():
+        router.load_frr_config()
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def get_nexthops_with_weights(nexthops):
+    m = max(nexthops, key=itemgetter(2))[2]
+    _nh = []
+    for i,(iface,ip,weight) in enumerate(nexthops):
+        weight = int(RIB_MAX_WEIGHT * weight / m)
+        weight = 1 if weight == 0 else weight
+        _nh.append({"interfaceName":iface,"ip":ip,"weight":weight})
+    return _nh
+
+
+def test_ospf_weighted_ecmp_startup():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of router(s) failure")
+
+    # Verify OSPF route is installed with appropriate next-hops and weights
+    step("Check next-hop weights on R1 for route 10.1.5.0/24")
+    r1 = tgen.gears["r1"]
+    nh_list = [("r1-eth0","10.1.1.2",10),
+               ("r1-eth1","10.1.2.2",100),
+               ("r1-eth2","10.1.3.2",200),
+               ("r1-eth3","10.1.4.2",400)]
+    nexthops = get_nexthops_with_weights(nh_list)
+    input_dict = {
+        "10.1.5.0/24": [
+            {
+                "prefix": "10.1.5.0/24",
+                "prefixLen": 24,
+                "protocol": "ospf",
+                "nexthops": nexthops
+            }
+        ]
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route 10.1.5.0/24 json", input_dict
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "10.1.5.0/24 either not installed on router r1 or next-hop weights are invalid"
+    assert result is None, assertmsg
+
+
+def test_ospf_weight_config_removal():
+    tgen = get_topogen()
+    #Test removal of weight from an interface
+    step("Configure R1 interface r1-eth3 without ospf weight")
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd("""
+        conf term
+            interface r1-eth3
+                no ip ospf weight
+    """)
+
+    step("Verify the R1 configuration of 'no ip ospf weight'")
+    def check_no_ospf_weight_config():
+        rc, _, _ = tgen.net["r1"].cmd_status(
+            "show running ospfd | sed -n '/interface r1-eth3/,/exit/p' | grep -q 'ip ospf weight'", warn=False
+        )
+        return rc
+
+    _, rc = topotest.run_and_expect(
+        check_no_ospf_weight_config, 1, count=30, wait=1
+    )
+    assertmsg = (
+        "'ip ospf weight' not applied, but present in R1 configuration"
+    )
+    assert rc, assertmsg
+
+    step("Check next-hop weights on R1 for route 10.1.5.0/24 after removing ospf weight config from r1-eth3")
+    nh_list = [("r1-eth0","10.1.1.2",10),
+               ("r1-eth1","10.1.2.2",100),
+               ("r1-eth2","10.1.3.2",200),
+               ("r1-eth3","10.1.4.2",1)]
+    nexthops = get_nexthops_with_weights(nh_list)
+    input_dict = {
+        "10.1.5.0/24": [
+            {
+                "prefix": "10.1.5.0/24",
+                "prefixLen": 24,
+                "protocol": "ospf",
+                "nexthops": nexthops
+            }
+        ]
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route 10.1.5.0/24 json", input_dict
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "RIB for 10.1.5.0/24 not correct after removing weight from r1-eth3"
+    assert result is None, assertmsg
+
+def test_ospf_weight_config():
+    tgen = get_topogen()
+    #Test insertion of weight on an interface
+    step("Configure R1 interface r1-eth3 with ospf weight 65536")
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd("""
+        conf term
+            interface r1-eth3
+                ip ospf weight 65536
+    """)
+
+    step("Verify the R1 configuration of 'ip ospf weight 65536'")
+
+    def check_ospf_weight_config():
+        return (
+            tgen.net["r1"]
+            .cmd('vtysh -c "show running ospfd" | sed -n \'/interface r1-eth3/,/exit/p\' | grep "^ ip ospf weight"')
+            .rstrip()
+        )
+
+    _, ospf_weight_cfg = topotest.run_and_expect(
+        check_ospf_weight_config,
+        " ip ospf weight 65536",
+        count=30,
+        wait=1,
+    )
+    assertmsg = "'ip ospf weight 65536' applied, but not present in configuration"
+    assert ospf_weight_cfg == " ip ospf weight 65536", assertmsg
+
+    step("Check next-hop weights on R1 for route 10.1.5.0/24 after setting ospf weight config to r1-eth3")
+    nh_list = [("r1-eth0","10.1.1.2",10),
+               ("r1-eth1","10.1.2.2",100),
+               ("r1-eth2","10.1.3.2",200),
+               ("r1-eth3","10.1.4.2",65536)]
+    nexthops = get_nexthops_with_weights(nh_list)
+    input_dict = {
+        "10.1.5.0/24": [
+            {
+                "prefix": "10.1.5.0/24",
+                "prefixLen": 24,
+                "protocol": "ospf",
+                "nexthops": nexthops
+            }
+        ]
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route 10.1.5.0/24 json", input_dict
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "RIB for 10.1.5.0/24 not correct after setting weight on r1-eth3"
+    assert result is None, assertmsg
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
ospfd: support for weighted ECMP on multipath routes
    
Implement weighted ECMP on multipath OSPF routes:
- Added '[no] ip ospf weight <weight>' to interface configuration
- Added weight output of 'show ip ospf interface [json]'
- Topotest for weight calculation, config removal and addition