### PR TITLE
pimd: re-register RP nexthops once VRF id is resolved

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -213,6 +213,14 @@ static int pim_vrf_enable(struct vrf *vrf)
 		vrf_bind(pim->vrf->vrf_id, pim->global_scope.unicast_sock, NULL);
 	}
 
+	/*
+	 * Any RP / upstream nexthop registrations attempted during config
+	 * load were skipped (or silently dropped by zebra) because they
+	 * carried vrf_id == VRF_UNKNOWN. Re-register them now that the vrf
+	 * id is resolved so zebra can track these nexthops.
+	 */
+	pim_nht_reregister_all(pim);
+
 	return 0;
 }
 

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -214,6 +214,21 @@ static void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zcli
 	struct prefix p;
 	int ret;
 
+	/*
+	 * Defer when the VRF id has not yet been resolved.
+	 * zebra cannot map an RNH message with vrf_id == VRF_UNKNOWN to a
+	 * real VRF and silently drops it. Deferred registers are
+	 * re-driven from pim_vrf_enable() via pim_nht_reregister_all()
+	 * once the VRF id becomes valid.
+	 */
+	if (pim->vrf->vrf_id == VRF_UNKNOWN) {
+		if (PIM_DEBUG_PIM_NHT)
+			zlog_debug("%s: skip %sregister of %pPA in vrf %s: vrf_id not yet resolved",
+				   __func__, (command == ZEBRA_NEXTHOP_REGISTER) ? "" : "un",
+				   &addr, pim->vrf->name);
+		return;
+	}
+
 	pim_addr_to_prefix(&p, addr);
 
 	/* Register to track nexthops from the MRIB */
@@ -1077,6 +1092,24 @@ void pim_nht_upstream_if_update(struct pim_instance *pim, struct interface *ifp)
 	pwd.ifp = ifp;
 
 	hash_walk(pim->nht_hash, pim_upstream_nh_if_update_helper, &pwd);
+}
+
+static int pim_nht_reregister_helper(struct hash_bucket *bucket, void *arg)
+{
+	struct pim_nexthop_cache *pnc = bucket->data;
+	struct pim_instance *pim = arg;
+	struct zclient *zclient = pim_zebra_zclient_get();
+
+	pim_sendmsg_zebra_rnh(pim, zclient, pnc->addr, ZEBRA_NEXTHOP_REGISTER);
+	return HASHWALK_CONTINUE;
+}
+
+void pim_nht_reregister_all(struct pim_instance *pim)
+{
+	if (!pim || !pim->nht_hash || pim->vrf->vrf_id == VRF_UNKNOWN)
+		return;
+
+	hash_walk(pim->nht_hash, pim_nht_reregister_helper, pim);
 }
 
 static uint32_t pim_compute_ecmp_hash(struct prefix *src, struct prefix *grp)

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -123,6 +123,9 @@ void pim_nht_rp_del(struct rp_info *rp_info);
 /* Walk the NH cache and update every nexthop that uses the given interface */
 void pim_nht_upstream_if_update(struct pim_instance *pim, struct interface *ifp);
 
+/* Re-send ZEBRA_NEXTHOP_REGISTER once vrf_id is resolved. */
+void pim_nht_reregister_all(struct pim_instance *pim);
+
 /* Lookup nexthop information for src, returned in nexthop when function returns true.
  * Tries to find in cache first and does a synchronous lookup if not found in the cache.
  * If neighbor_needed is true, then nexthop is only considered valid if it's to a pim


### PR DESCRIPTION
Issue:
On a fresh pimd start with an "ip pim rp X.X.X.X" configured inside a non-default VRF, pim_rp_setup() with
pim->vrf->vrf_id is still VRF_UNKNOWN (0xFFFFFFFF).  It calls pim_find_or_track_nexthop() -> pim_nht_get() ->
pim_sendmsg_zebra_rnh(ZEBRA_NEXTHOP_REGISTER), which forwards zclient_send_rnh(zclient, REGISTER, &p, SAFI_UNICAST, false, false, 0xFFFFFFFF) to zebra.  zebra cannot map 0xFFFFFFFF to a real VRF and silently drops the RNH REGISTER (zread_rnh_register does not create an rnh node).From this point onwards, every subsequent pim_nht_get() for the same RP finds the cached (but never registered) PNC and returns it without re-sending REGISTER.  The RP is effectively invisible to zebra:
- zebra has no rnh_node for the RP address in that VRF
- pimd will never receive a ZEBRA_NEXTHOP_UPDATE for it
- pim_nexthop_update()/pim_rpf_update() will never re-run

The race is timing dependent.  If pim->vrf->vrf_id resolved before pim_rp_setup runs and the RP registers cleanly. When it loses the race, the failure is silent until an RPF-affecting event happens.

Fix:
1) In pim_sendmsg_zebra_rnh(), skip the register when pim->vrf->vrf_id == VRF_UNKNOWN.

2) Adding pim_nht_reregister_all(pim) api that walks pim->rpf_hash and re-sends ZEBRA_NEXTHOP_REGISTER for every PNC that does not yet have PIM_NEXTHOP_VALID set.  Already-valid PNCs are left alone.

3) Calling pim_nht_reregister_all(pim) from
pim_vrf_enable() to drive the deferred registers.