### PR TITLE
ldpd: remove addresses from down interface

### DIFF
--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -344,7 +344,8 @@ kif_redistribute(const char *ifname)
 
 		frr_each (if_connected, ifp->connected, ifc) {
 			ifc2kaddr(ifp, ifc, &ka);
-			main_imsg_compose_ldpe(IMSG_NEWADDR, 0, &ka, sizeof(ka));
+			if (if_is_operative(ifp))
+				main_imsg_compose_ldpe(IMSG_NEWADDR, 0, &ka, sizeof(ka));
 		}
 	}
 }
@@ -455,7 +456,8 @@ ldp_interface_address_add(ZAPI_CALLBACK_ARGS)
 	    log_addr(ka.af, &ka.addr), ka.prefixlen, ifp->name);
 
 	/* notify ldpe about new address */
-	main_imsg_compose_ldpe(IMSG_NEWADDR, 0, &ka, sizeof(ka));
+	if (if_is_operative(ifp))
+	    main_imsg_compose_ldpe(IMSG_NEWADDR, 0, &ka, sizeof(ka));
 
 	return (0);
 }


### PR DESCRIPTION
when ldpd is activated on a router with a down interface, addresses of that interface are advertised.

seen in logs:

Jul 07 14:38:33 dut-vm ldpd[4285]: msg[out]: address: lsr-id 10.10.10.10, addres s 192.168.0.1
Jul 07 14:38:33 dut-vm ldpd[4285]: msg[out]: address: lsr-id 10.10.10.10, addres s 192.169.0.1

Interface vlan100 is down
  Link ups:       3    last: 2026/07/07 14:38:25.75
  Link downs:     2    last: 2026/07/07 14:38:25.75
  vrf: default
  index 9 metric 0 mtu 1500 speed 10000 txqlen 1000
  flags: <BROADCAST,MULTICAST>
  Type: Ethernet
  HWaddr: de:ed:02:0a:91:a3
  inet 192.168.0.1/24
  Interface Type Vlan
  Interface Slave Type None
  VLAN Id 100
  protodown: off
  Parent interface: ntfp2
Interface vlan200 is down
  Link ups:       3    last: 2026/07/07 14:38:25.75
  Link downs:     2    last: 2026/07/07 14:38:25.75
  vrf: default
  index 10 metric 0 mtu 1500 speed 10000 txqlen 1000
  flags: <BROADCAST,MULTICAST>
  Type: Ethernet
  HWaddr: de:ed:02:0a:91:a3
  inet 192.169.0.1/24
  Interface Type Vlan
  Interface Slave Type None
  VLAN Id 200
  protodown: off
  Parent interface: ntfp2

fix : avoid advertisement when interface is not operative