### PR TITLE
BGP LS srv6 bug fixes

### DIFF
--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -1930,12 +1930,44 @@ int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct 
 	return bgp_ls_originate_prefix_internal(bgp, afi, p, route_type, NULL);
 }
 
+static bool bgp_ls_bgp_prefix_nlri_is_active(struct bgp *bgp, const struct prefix *p,
+					     enum bgp_ls_bgp_route_type route_type)
+{
+	struct bgp_ls_nlri *nlri;
+	struct bgp_dest *dest;
+	struct bgp_path_info *bpi;
+	struct prefix lookup;
+	bool active = false;
+
+	nlri = bgp_ls_lookup_bgp_prefix_nlri(bgp, p, route_type);
+	if (!nlri)
+		return false;
+
+	memset(&lookup, 0, sizeof(lookup));
+	lookup.family = AF_UNSPEC;
+	lookup.prefixlen = 32;
+	lookup.u.val32[0] = nlri->id;
+
+	dest = bgp_node_lookup(bgp->rib[AFI_BGP_LS][SAFI_BGP_LS], &lookup);
+	if (!dest)
+		return false;
+
+	for (bpi = bgp_dest_get_bgp_path_info(dest); bpi; bpi = bpi->next) {
+		if (bpi->peer == bgp->peer_self && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
+			active = true;
+			break;
+		}
+	}
+
+	bgp_dest_unlock_node(dest);
+	return active;
+}
+
 int bgp_ls_originate_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locator *locator)
 {
 	struct bgp_ls_attr *ls_attr;
-	struct bgp_ls_nlri *existing_nlri;
 	bool had_srv6_cap;
-	bool is_new_locator_nlri;
+	bool was_active;
 	int ret;
 
 	if (!bgp || !bgp->ls_info || !locator)
@@ -1960,9 +1992,8 @@ int bgp_ls_originate_srv6_locator_prefix(struct bgp *bgp, const struct srv6_loca
 	}
 
 	had_srv6_cap = bgp_ls_has_srv6_capability(bgp);
-	existing_nlri = bgp_ls_lookup_bgp_prefix_nlri(bgp, (const struct prefix *)&locator->prefix,
+	was_active = bgp_ls_bgp_prefix_nlri_is_active(bgp, (const struct prefix *)&locator->prefix,
 						      BGP_LS_BGP_RT_LOCAL);
-	is_new_locator_nlri = (existing_nlri == NULL);
 
 	if (BGP_DEBUG(linkstate, LINKSTATE))
 		zlog_debug("BGP-LS [locator]: advertising locator %s prefix=%pFX algo=%u",
@@ -1992,7 +2023,7 @@ int bgp_ls_originate_srv6_locator_prefix(struct bgp *bgp, const struct srv6_loca
 		return -1;
 	}
 
-	if (is_new_locator_nlri)
+	if (!was_active)
 		bgp->ls_info->srv6_locator_nlri_count++;
 
 	if (!had_srv6_cap)
@@ -2013,6 +2044,7 @@ int bgp_ls_withdraw_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locat
 	struct bgp_ls_nlri *nlri;
 	int ret;
 	bool had_srv6_cap;
+	bool was_active;
 
 	if (!bgp || !bgp->ls_info || !locator)
 		return -1;
@@ -2029,6 +2061,8 @@ int bgp_ls_withdraw_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locat
 		return 0;
 
 	had_srv6_cap = bgp_ls_has_srv6_capability(bgp);
+	was_active = bgp_ls_bgp_prefix_nlri_is_active(bgp, (const struct prefix *)&locator->prefix,
+						      BGP_LS_BGP_RT_LOCAL);
 
 	if (BGP_DEBUG(linkstate, LINKSTATE))
 		zlog_debug("BGP-LS [locator]: withdrawn locator prefix NLRI for %s", locator->name);
@@ -2037,7 +2071,7 @@ int bgp_ls_withdraw_srv6_locator_prefix(struct bgp *bgp, const struct srv6_locat
 	if (ret != 0)
 		return ret;
 
-	if (bgp->ls_info->srv6_locator_nlri_count > 0)
+	if (was_active && bgp->ls_info->srv6_locator_nlri_count > 0)
 		bgp->ls_info->srv6_locator_nlri_count--;
 
 	if (bgp->ls_info->srv6_locator_nlri_count == 0 && had_srv6_cap)

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -879,8 +879,10 @@ static void zebra_srv6_sid_entry_delete_all(struct zebra_srv6_sid *sid)
 {
 	struct zebra_srv6_sid_entry *entry;
 
-	frr_each_safe (zebra_srv6_sid_entry_list, &sid->entries, entry)
+	frr_each_safe (zebra_srv6_sid_entry_list, &sid->entries, entry) {
 		zebra_srv6_sid_entry_list_del(&sid->entries, entry);
+		zebra_srv6_sid_entry_free(entry);
+	}
 }
 
 struct zebra_srv6_sid_entry *zebra_srv6_sid_entry_add(struct zebra_srv6_sid *sid,


### PR DESCRIPTION
two separate fixes:

a) memory leak in zebra on shutdown
b) failure to take into account that the locator prefix has been removed.