### PR TITLE
bgpd: don't fabricate BMP pre-policy withdrawals without adj-in

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1747,7 +1747,8 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 		written = true;
 	}
 
-	if (CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_PREPOLICY)) {
+	if (CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_PREPOLICY) &&
+	    CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG)) {
 		struct bgp_adj_in *adjin;
 
 		for (adjin = bn ? bn->adj_in : NULL; adjin;

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -965,6 +965,50 @@ static int bmp_outgoing_packet(struct peer *peer, uint8_t type, bgp_size_t size,
 	return 0;
 }
 
+/*
+ * BMP pre-policy monitoring reads exclusively from Adj-RIB-In, which bgpd
+ * only maintains under PEER_FLAG_SOFT_RECONFIG.  Without it, the affected
+ * peer's routes are simply absent from the pre-policy feed.  Warn about
+ * this dependency instead of leaving operators to notice a silently empty
+ * feed.
+ */
+static void bmp_prepolicy_softreconfig_warn(struct vty *vty, struct peer *peer, afi_t afi,
+					    safi_t safi)
+{
+	if (vty)
+		vty_out(vty,
+			"%% peer %s has no Adj-RIB-In for %s %s (soft-reconfiguration inbound is not configured); pre-policy monitoring will not report its routes until soft-reconfiguration inbound is enabled\n",
+			peer->host, afi2str_lower(afi), safi2str(safi));
+	else
+		zlog_warn("bmp: peer %s has no Adj-RIB-In for %s %s (soft-reconfiguration inbound is not configured); pre-policy monitoring will not report its routes until soft-reconfiguration inbound is enabled",
+			  peer->host, afi2str_lower(afi), safi2str(safi));
+}
+
+static void bmp_peer_up_warn_prepolicy(struct peer *peer)
+{
+	struct bmp_bgp *bmpbgp = bmp_bgp_find(peer->bgp);
+	struct bmp_targets *bt;
+	afi_t afi;
+	safi_t safi;
+
+	if (!bmpbgp)
+		return;
+
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (!peer->afc_nego[afi][safi])
+			continue;
+		if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
+			continue;
+
+		frr_each (bmp_targets, &bmpbgp->targets, bt) {
+			if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_PREPOLICY)) {
+				bmp_prepolicy_softreconfig_warn(NULL, peer, afi, safi);
+				break;
+			}
+		}
+	}
+}
+
 static int bmp_peer_status_changed(struct peer *peer)
 {
 	struct bmp_bgp_peer *bbpeer, *bbdopp;
@@ -986,6 +1030,8 @@ static int bmp_peer_status_changed(struct peer *peer)
 	if ((peer->connection->ostatus != OpenConfirm) ||
 	    !(peer_established(peer->connection)))
 		return 0;
+
+	bmp_peer_up_warn_prepolicy(peer);
 
 	if (peer->doppelganger &&
 	    (peer->doppelganger->connection->status != Deleted)) {
@@ -3096,6 +3142,21 @@ DEFPY(bmp_stats_send_experimental,
 #define BMP_POLICY_IS_LOCRIB(str) ((str)[0] == 'l') /* __l__oc-rib */
 #define BMP_POLICY_IS_PRE(str) ((str)[1] == 'r')    /* p__r__e-policy */
 
+static void bmp_monitor_cfg_warn_prepolicy(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
+{
+	struct peer *peer;
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+		if (!peer->afc[afi][safi])
+			continue;
+		if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
+			continue;
+
+		bmp_prepolicy_softreconfig_warn(vty, peer, afi, safi);
+	}
+}
+
 DEFPY(bmp_monitor_cfg, bmp_monitor_cmd,
       "[no] bmp monitor <ipv4|ipv6|l2vpn> <unicast|multicast|evpn|vpn> <pre-policy|post-policy|loc-rib>$policy",
       NO_STR BMP_STR
@@ -3128,6 +3189,9 @@ DEFPY(bmp_monitor_cfg, bmp_monitor_cmd,
 		UNSET_FLAG(bt->afimon[afi][safi], flag);
 	else
 		SET_FLAG(bt->afimon[afi][safi], flag);
+
+	if (!no && flag == BMP_MON_PREPOLICY)
+		bmp_monitor_cfg_warn_prepolicy(vty, bt->bgp, afi, safi);
 
 	if (prev == bt->afimon[afi][safi])
 		return CMD_SUCCESS;

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -163,6 +163,14 @@ associated with a particular ``bmp targets``:
    All BGP neighbors are included in Route Monitoring.  Options to select
    a subset of BGP sessions may be added in the future.
 
+   .. note::
+
+      Pre-policy Route Monitoring is sourced from a peer's Adj-RIB-In, which
+      *bgpd* only maintains when :clicmd:`neighbor PEER soft-reconfiguration
+      inbound` is configured for that peer.  Without it, the peer's routes
+      are simply absent from the pre-policy feed; *bgpd* logs a warning
+      naming the affected peer when this is the case.
+
 .. clicmd:: bmp mirror
 
    Perform Route Mirroring for all BGP neighbors.  Since this provides a

--- a/tests/topotests/bgp_bmp/r1nosr/frr.conf
+++ b/tests/topotests/bgp_bmp/r1nosr/frr.conf
@@ -1,0 +1,25 @@
+interface r1nosr-eth0
+ ip address 192.0.2.1/24
+!
+interface r1nosr-eth1
+ ip address 192.168.0.1/24
+!
+router bgp 65501
+ bmp targets bmp1nosr
+  bmp connect 192.0.2.10 port 1789 min-retry 100 max-retry 10000
+   bmp monitor ipv4 unicast pre-policy
+   bmp monitor ipv4 unicast post-policy
+ exit
+!
+router bgp 65501
+ timers bgp 1 10
+ bgp router-id 192.168.0.1
+ bgp log-neighbor-changes
+ no bgp ebgp-requires-policy
+ neighbor 192.168.0.2 remote-as 65502
+ neighbor 192.168.0.2 timers delayopen 5
+!
+ address-family ipv4 unicast
+  neighbor 192.168.0.2 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_bmp/r2nosr/frr.conf
+++ b/tests/topotests/bgp_bmp/r2nosr/frr.conf
@@ -1,0 +1,16 @@
+interface r2nosr-eth0
+ ip address 192.168.0.2/24
+!
+router bgp 65502
+ timers bgp 1 10
+ bgp router-id 192.168.0.2
+ bgp log-neighbor-changes
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.0.1 remote-as 65501
+ neighbor 192.168.0.1 timers delayopen 5
+!
+ address-family ipv4 unicast
+  neighbor 192.168.0.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
@@ -109,6 +109,11 @@ def _route_messages(policy, bmp_log_type, prefix):
     ]
 
 
+def _r1nosr_bgpd_log_path():
+    tgen = get_topogen()
+    return os.path.join(tgen.logdir, "r1nosr", "bgpd.log")
+
+
 def test_bgp_convergence():
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -116,6 +121,33 @@ def test_bgp_convergence():
 
     result = verify_bgp_convergence_from_running_config(tgen, dut="r1nosr")
     assert result is True, "BGP is not converging"
+
+
+def test_prepolicy_no_softreconfig_warning():
+    """
+    r1nosr has ``bmp monitor ipv4 unicast pre-policy`` configured, but its
+    neighbor 192.168.0.2 (r2nosr) has no ``soft-reconfiguration inbound``
+    and therefore no Adj-RIB-In.  bgpd must warn about this at peer-up
+    instead of silently omitting the peer's routes from the pre-policy
+    feed.
+    """
+    tgen = get_topogen()
+
+    def _warning_logged():
+        out = tgen.gears["r1nosr"].run("cat {}".format(_r1nosr_bgpd_log_path()))
+        needle = (
+            "peer 192.168.0.2 has no Adj-RIB-In for ipv4 unicast "
+            "(soft-reconfiguration inbound is not configured)"
+        )
+        if needle in out:
+            return True
+        return "warning not logged yet"
+
+    success, res = topotest.run_and_expect(_warning_logged, True, count=30, wait=1)
+    assert success, (
+        "expected r1nosr's bgpd.log to warn that 192.168.0.2 has no "
+        "Adj-RIB-In for pre-policy monitoring: {}".format(res)
+    )
 
 
 def test_bmp_server_logging():

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright 2026 RouteViews
+# Authored by Anton Berezin <tobez@tobez.org>
+#
+
+"""
+test_bgp_bmp_prepolicy_no_softreconfig.py: BMP pre-policy monitoring of a
+neighbor that does NOT have ``soft-reconfiguration inbound``.
+
+    +----------+            +----------+               +----------+
+    |          |            |          |               |          |
+    | bmp1nosr |------------|  r1nosr  |---------------|  r2nosr  |
+    |          |            |          |               |          |
+    +----------+            +----------+               +----------+
+
+Without ``soft-reconfiguration inbound`` bgpd keeps no Adj-RIB-In for the
+peer.  BMP pre-policy monitoring reads exclusively from Adj-RIB-In, so an
+announcement from r2nosr must NOT be turned into a fabricated pre-policy
+*withdrawal* towards the BMP collector (FRRouting/frr issue #10240).
+Post-policy monitoring, which reads the main RIB, must stay correct.
+"""
+
+import os
+import sys
+import pytest
+from functools import partial
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join("../"))
+sys.path.append(os.path.join("../lib/"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.bgp import verify_bgp_convergence_from_running_config
+from lib.bgp import bgp_configure_prefixes
+from .bgpbmp import BMPSequenceContext, bmp_update_seq, get_bmp_messages
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd]
+
+# Prefix whose BMP treatment we assert on, plus a sentinel prefix announced
+# afterwards.  Once the sentinel's post-policy update is logged, any message
+# bgpd fabricated while processing WATCHED_PREFIX is already in the log, so
+# the "no fabricated pre-policy withdrawal" assertion has no timing race.
+WATCHED_PREFIX = "203.0.113.1/32"
+SENTINEL_PREFIX = "203.0.113.254/32"
+
+bmp_seq_context = BMPSequenceContext()
+
+
+def build_topo(tgen):
+    tgen.add_router("r1nosr")
+    tgen.add_router("r2nosr")
+    tgen.add_bmp_server("bmp1nosr", ip="192.0.2.10", defaultRoute="via 192.0.2.1")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1nosr"])
+    switch.add_link(tgen.gears["bmp1nosr"])
+
+    tgen.add_link(tgen.gears["r1nosr"], tgen.gears["r2nosr"], "r1nosr-eth1", "r2nosr-eth0")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config(
+            daemons=["zebra", ("bgpd", "-M bmp")],
+        )
+
+    tgen.start_router()
+
+    logger.info("starting BMP servers")
+    for bmp_name, server in tgen.get_bmp_servers().items():
+        server.start(log_file=os.path.join(tgen.logdir, bmp_name, "bmp.log"))
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _bmp_log_file():
+    tgen = get_topogen()
+    return os.path.join(tgen.logdir, "bmp1nosr", "bmp.log")
+
+
+def _route_messages(policy, bmp_log_type, prefix):
+    """
+    Return the new BMP route-monitoring messages (seq beyond the recorded
+    baseline) matching the given policy, message type and prefix.
+    """
+    tgen = get_topogen()
+    baseline = bmp_seq_context.get_seq()
+    messages = get_bmp_messages(tgen.gears["bmp1nosr"], _bmp_log_file())
+    return [
+        m
+        for m in messages
+        if m.get("seq", 0) > baseline
+        and m.get("policy") == policy
+        and m.get("bmp_log_type") == bmp_log_type
+        and m.get("ip_prefix") == prefix
+    ]
+
+
+def test_bgp_convergence():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    result = verify_bgp_convergence_from_running_config(tgen, dut="r1nosr")
+    assert result is True, "BGP is not converging"
+
+
+def test_bmp_server_logging():
+    """
+    Wait for the BMP collector to start logging (session established).
+    """
+
+    def check_for_log_file():
+        tgen = get_topogen()
+        output = tgen.gears["bmp1nosr"].run(
+            "ls {}".format(os.path.join(tgen.logdir, "bmp1nosr"))
+        )
+        return "bmp.log" in output
+
+    success, _ = topotest.run_and_expect(check_for_log_file, True, count=30, wait=1)
+    assert success, "The BMP server is not logging"
+
+
+def test_no_fabricated_prepolicy_withdrawal():
+    """
+    Announce a prefix from r2nosr (which r1nosr does not keep an Adj-RIB-In
+    for) and assert that:
+
+    * a post-policy update is emitted for it (control: the RIB path is fine);
+    * no pre-policy *withdrawal* is fabricated for it (the bug).
+    """
+    tgen = get_topogen()
+
+    # Record the BMP sequence baseline so we only look at messages produced
+    # from here on (peer-up, table sync, etc. are excluded).
+    bmp_update_seq(tgen.gears["bmp1nosr"], _bmp_log_file(), bmp_seq_context)
+
+    # Announce the watched prefix, then a sentinel prefix.  Both are injected
+    # from r2nosr and travel over a session with no soft-reconfiguration.
+    bgp_configure_prefixes(
+        tgen.gears["r2nosr"], 65502, "unicast", [WATCHED_PREFIX], update=True
+    )
+    bgp_configure_prefixes(
+        tgen.gears["r2nosr"], 65502, "unicast", [SENTINEL_PREFIX], update=True
+    )
+
+    # Wait until both prefixes have reached r1nosr's BGP table.
+    def _prefixes_in_rib():
+        out = tgen.gears["r1nosr"].vtysh_cmd("show bgp ipv4 unicast json", isjson=True)
+        routes = out.get("routes", {}) or {}
+        for p in (WATCHED_PREFIX, SENTINEL_PREFIX):
+            if p not in routes:
+                return "prefix {} not in RIB yet".format(p)
+        return True
+
+    success, res = topotest.run_and_expect(_prefixes_in_rib, True, count=30, wait=1)
+    assert success, "prefixes did not reach r1nosr's BGP table: {}".format(res)
+
+    # Gate on the sentinel's post-policy update.  Once it is logged, every
+    # message bgpd emitted while processing WATCHED_PREFIX is already present.
+    def _sentinel_seen():
+        if _route_messages("post-policy", "update", SENTINEL_PREFIX):
+            return True
+        return "sentinel post-policy update not logged yet"
+
+    success, res = topotest.run_and_expect(_sentinel_seen, True, count=30, wait=1)
+    assert success, "sentinel post-policy update never reached the BMP log: {}".format(
+        res
+    )
+
+    # Control: the watched prefix must have a post-policy update.
+    post_updates = _route_messages("post-policy", "update", WATCHED_PREFIX)
+    assert post_updates, (
+        "expected a post-policy update for {} but none was logged".format(
+            WATCHED_PREFIX
+        )
+    )
+
+    # The bug: with no Adj-RIB-In, bgpd fabricated a pre-policy withdrawal for
+    # a prefix that was only ever announced.  There must be none.
+    fabricated = _route_messages("pre-policy", "withdraw", WATCHED_PREFIX)
+    assert not fabricated, (
+        "bgpd fabricated {} pre-policy withdrawal(s) for {} that was only "
+        "announced (no soft-reconfiguration inbound -> no Adj-RIB-In): {}".format(
+            len(fabricated), WATCHED_PREFIX, fabricated
+        )
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
BMP pre-policy Route Monitoring reads from a peer's Adj-RIB-In, which bgpd only maintains for peers with `soft-reconfiguration inbound` (`PEER_FLAG_SOFT_RECONFIG`). Without that flag `bn->adj_in` is empty, so the pre-policy branch of `bmp_wrqueue()` looks up nothing and calls `bmp_monitor()` with a NULL attribute — which encodes as a withdrawal. Every incoming announcement from such a peer is then forwarded as a pre-policy withdrawal, and the initial table sync is just an immediate End-of-RIB.

This is #10240. RouteViews hit it in production: a 2025-12-08 pre-policy test on a collector produced 1,966,176 BMP withdrawals and 0 announcements.

This is the minimal fix — stop emitting wrong data. It guards the pre-policy branch on `PEER_FLAG_SOFT_RECONFIG` so the unsupported configuration is silent rather than poisoning the feed, warns when pre-policy monitoring is configured for a peer without an Adj-RIB-In, and documents the dependency. A follow-up PR (submitted separately) makes pre-policy monitoring work without `soft-reconfiguration inbound`.

Tested with a new `bgp_bmp` topotest; existing `bgp_bmp` topotests unchanged.
