### PR TITLE
bgpd: drive Adj-RIB-In from BMP pre-policy monitoring

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1010,47 +1010,74 @@ static int bmp_adj_in_needed(struct peer *peer, afi_t afi, safi_t safi)
 	return bmp_prepolicy_covers(peer->bgp, afi, safi, NULL);
 }
 
-/*
- * BMP pre-policy monitoring reads exclusively from Adj-RIB-In, which bgpd
- * only maintains under PEER_FLAG_SOFT_RECONFIG.  Without it, the affected
- * peer's routes are simply absent from the pre-policy feed.  Warn about
- * this dependency instead of leaving operators to notice a silently empty
- * feed.
+/* enable path: peers newly covered by pre-policy monitoring have their
+ * Adj-RIB-In repopulated through a route refresh (or a session reset for
+ * peers without the refresh capability), like enabling soft-reconfiguration
+ * inbound does.
  */
-static void bmp_prepolicy_softreconfig_warn(struct vty *vty, struct peer *peer, afi_t afi,
-					    safi_t safi)
+static void bmp_adj_in_refresh_bgp(struct bgp *bgp, afi_t afi, safi_t safi)
 {
-	if (vty)
-		vty_out(vty,
-			"%% peer %s has no Adj-RIB-In for %s %s (soft-reconfiguration inbound is not configured); pre-policy monitoring will not report its routes until soft-reconfiguration inbound is enabled\n",
-			peer->host, afi2str_lower(afi), safi2str(safi));
-	else
-		zlog_warn("bmp: peer %s has no Adj-RIB-In for %s %s (soft-reconfiguration inbound is not configured); pre-policy monitoring will not report its routes until soft-reconfiguration inbound is enabled",
-			  peer->host, afi2str_lower(afi), safi2str(safi));
+	struct listnode *node;
+	struct peer *peer;
+
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+		if (peer->afc_nego[afi][safi] &&
+		    !CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
+			peer_change_action(peer, afi, safi, peer_change_reset_in);
+
+		/* labeled-unicast routes live in the unicast table */
+		if (safi == SAFI_UNICAST && peer->afc_nego[afi][SAFI_LABELED_UNICAST] &&
+		    !CHECK_FLAG(peer->af_flags[afi][SAFI_LABELED_UNICAST], PEER_FLAG_SOFT_RECONFIG))
+			peer_change_action(peer, afi, SAFI_LABELED_UNICAST, peer_change_reset_in);
+	}
 }
 
-static void bmp_peer_up_warn_prepolicy(struct peer *peer)
+/* disable path: free the Adj-RIB-In of peers no consumer needs it for */
+static void bmp_adj_in_release_bgp(struct bgp *bgp, afi_t afi, safi_t safi)
 {
-	struct bmp_bgp *bmpbgp = bmp_bgp_find(peer->bgp);
-	struct bmp_targets *bt;
-	afi_t afi;
-	safi_t safi;
+	struct listnode *node;
+	struct peer *peer;
 
-	if (!bmpbgp)
-		return;
-
-	FOREACH_AFI_SAFI (afi, safi) {
-		if (!peer->afc_nego[afi][safi])
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+		if (bgp_adj_in_needed(peer, afi, safi))
 			continue;
-		if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
+		/* labeled-unicast adj-in entries share the unicast table */
+		if (safi == SAFI_UNICAST && bgp_adj_in_needed(peer, afi, SAFI_LABELED_UNICAST))
 			continue;
+		bgp_clear_adj_in(peer, afi, safi);
+	}
+}
 
-		frr_each (bmp_targets, &bmpbgp->targets, bt) {
-			if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_PREPOLICY)) {
-				bmp_prepolicy_softreconfig_warn(NULL, peer, afi, safi);
-				break;
-			}
-		}
+static void bmp_adj_in_ensure(struct bmp_targets *bt, afi_t afi, safi_t safi)
+{
+	struct bmp_imported_bgp *bib;
+	struct bgp *bgp;
+
+	if (bt->bgp && !bmp_prepolicy_covers(bt->bgp, afi, safi, bt))
+		bmp_adj_in_refresh_bgp(bt->bgp, afi, safi);
+
+	frr_each (bmp_imported_bgps, &bt->imported_bgps, bib) {
+		bgp = bgp_lookup_by_name(bib->name);
+		if (!bgp)
+			continue;
+		if (!bmp_prepolicy_covers(bgp, afi, safi, bt))
+			bmp_adj_in_refresh_bgp(bgp, afi, safi);
+	}
+}
+
+static void bmp_adj_in_release(struct bmp_targets *bt, afi_t afi, safi_t safi)
+{
+	struct bmp_imported_bgp *bib;
+	struct bgp *bgp;
+
+	if (bt->bgp)
+		bmp_adj_in_release_bgp(bt->bgp, afi, safi);
+
+	frr_each (bmp_imported_bgps, &bt->imported_bgps, bib) {
+		bgp = bgp_lookup_by_name(bib->name);
+		if (!bgp)
+			continue;
+		bmp_adj_in_release_bgp(bgp, afi, safi);
 	}
 }
 
@@ -1075,8 +1102,6 @@ static int bmp_peer_status_changed(struct peer *peer)
 	if ((peer->connection->ostatus != OpenConfirm) ||
 	    !(peer_established(peer->connection)))
 		return 0;
-
-	bmp_peer_up_warn_prepolicy(peer);
 
 	if (peer->doppelganger &&
 	    (peer->doppelganger->connection->status != Deleted)) {
@@ -2479,6 +2504,8 @@ static void bmp_targets_put(struct bmp_targets *bt)
 	struct bmp *bmp;
 	struct bmp_active *ba;
 	struct bmp_imported_bgp *bib;
+	afi_t afi;
+	safi_t safi;
 
 	event_cancel(&bt->t_stats);
 
@@ -2492,6 +2519,14 @@ static void bmp_targets_put(struct bmp_targets *bt)
 
 	bmp_targets_del(&bt->bmpbgp->targets, bt);
 	QOBJ_UNREG(bt);
+
+	/* this target no longer drives Adj-RIB-In maintenance; free what no
+	 * other consumer needs
+	 */
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_PREPOLICY))
+			bmp_adj_in_release(bt, afi, safi);
+	}
 
 	frr_each_safe (bmp_imported_bgps, &bt->imported_bgps, bib)
 		bmp_imported_bgp_free(bib);
@@ -3000,6 +3035,10 @@ DEFPY(bmp_import_vrf,
 			return CMD_WARNING;
 		bmp_send_peerdown_vrf_per_instance(bt, bgp);
 		bmp_imported_bgp_put(bt, bib);
+		FOREACH_AFI_SAFI (afi, safi) {
+			if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_PREPOLICY))
+				bmp_adj_in_release_bgp(bgp, afi, safi);
+		}
 		return CMD_SUCCESS;
 	}
 	bib = bmp_imported_bgp_find(bt, (char *)vrfname);
@@ -3010,6 +3049,13 @@ DEFPY(bmp_import_vrf,
 	bgp = bgp_lookup_by_name(bib->name);
 	if (!bgp)
 		return CMD_SUCCESS;
+
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (!CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_PREPOLICY))
+			continue;
+		if (!bmp_prepolicy_covers(bgp, afi, safi, bt))
+			bmp_adj_in_refresh_bgp(bgp, afi, safi);
+	}
 
 	frr_each (bmp_session, &bt->sessions, bmp) {
 		if (bmp->state != BMP_PeerUp && bmp->state != BMP_Run)
@@ -3191,21 +3237,6 @@ DEFPY(bmp_stats_send_experimental,
 #define BMP_POLICY_IS_LOCRIB(str) ((str)[0] == 'l') /* __l__oc-rib */
 #define BMP_POLICY_IS_PRE(str) ((str)[1] == 'r')    /* p__r__e-policy */
 
-static void bmp_monitor_cfg_warn_prepolicy(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
-{
-	struct peer *peer;
-	struct listnode *node;
-
-	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
-		if (!peer->afc[afi][safi])
-			continue;
-		if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
-			continue;
-
-		bmp_prepolicy_softreconfig_warn(vty, peer, afi, safi);
-	}
-}
-
 DEFPY(bmp_monitor_cfg, bmp_monitor_cmd,
       "[no] bmp monitor <ipv4|ipv6|l2vpn> <unicast|multicast|evpn|vpn> <pre-policy|post-policy|loc-rib>$policy",
       NO_STR BMP_STR
@@ -3239,11 +3270,15 @@ DEFPY(bmp_monitor_cfg, bmp_monitor_cmd,
 	else
 		SET_FLAG(bt->afimon[afi][safi], flag);
 
-	if (!no && flag == BMP_MON_PREPOLICY)
-		bmp_monitor_cfg_warn_prepolicy(vty, bt->bgp, afi, safi);
-
 	if (prev == bt->afimon[afi][safi])
 		return CMD_SUCCESS;
+
+	if (flag == BMP_MON_PREPOLICY) {
+		if (no)
+			bmp_adj_in_release(bt, afi, safi);
+		else
+			bmp_adj_in_ensure(bt, afi, safi);
+	}
 
 	frr_each (bmp_session, &bt->sessions, bmp) {
 		bmp_update_syncro(bmp, afi, safi, NULL);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -965,6 +965,51 @@ static int bmp_outgoing_packet(struct peer *peer, uint8_t type, bgp_size_t size,
 	return 0;
 }
 
+/* true if any bmp_targets performs pre-policy monitoring of the given bgp
+ * instance for afi/safi, either directly or through bmp import-vrf-view.
+ * "skip" excludes one bmp_targets from consideration (used while its own
+ * configuration is being changed); pass NULL to consider all.
+ */
+static bool bmp_prepolicy_covers(struct bgp *bgp, afi_t afi, safi_t safi, struct bmp_targets *skip)
+{
+	struct bgp *bgp_vrf;
+	struct listnode *node;
+	struct bmp_bgp *bmpbgp;
+	struct bmp_targets *bt;
+
+	/* cheap early-out for the common case of no BMP configuration */
+	if (!bmp_bgph_count(&bmp_bgph))
+		return false;
+
+	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp_vrf)) {
+		bmpbgp = bmp_bgp_find(bgp_vrf);
+		if (!bmpbgp)
+			continue;
+		frr_each (bmp_targets, &bmpbgp->targets, bt) {
+			if (bt == skip)
+				continue;
+			if (!CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_PREPOLICY))
+				continue;
+			if (bgp_vrf != bgp && !bmp_imported_bgp_find(bt, bgp->name))
+				continue;
+			return true;
+		}
+	}
+	return false;
+}
+
+/* bgp_adj_in_needed hook: pre-policy monitoring reads from Adj-RIB-In, so
+ * bgpd must maintain it for every peer the monitoring covers.
+ */
+static int bmp_adj_in_needed(struct peer *peer, afi_t afi, safi_t safi)
+{
+	/* labeled-unicast routes live in the unicast table */
+	if (safi == SAFI_LABELED_UNICAST)
+		safi = SAFI_UNICAST;
+
+	return bmp_prepolicy_covers(peer->bgp, afi, safi, NULL);
+}
+
 /*
  * BMP pre-policy monitoring reads exclusively from Adj-RIB-In, which bgpd
  * only maintains under PEER_FLAG_SOFT_RECONFIG.  Without it, the affected
@@ -1794,7 +1839,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 	}
 
 	if (CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_PREPOLICY) &&
-	    CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG)) {
+	    bgp_adj_in_needed(peer, afi, safi)) {
 		struct bgp_adj_in *adjin;
 
 		for (adjin = bn ? bn->adj_in : NULL; adjin;
@@ -3784,6 +3829,7 @@ static int bgp_bmp_module_init(void)
 	hook_register(peer_status_changed, bmp_peer_status_changed);
 	hook_register(peer_backward_transition, bmp_peer_backward);
 	hook_register(bgp_process, bmp_process);
+	hook_register(bgp_adj_in_needed, bmp_adj_in_needed);
 	hook_register(bgp_nht_path_update, bmp_nht_path_valid);
 	hook_register(bgp_inst_config_write, bmp_config_write);
 	hook_register(bgp_inst_delete, bmp_bgp_del);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2973,6 +2973,10 @@ DEFPY(bmp_import_vrf,
 		bmp_send_peerup_vrf_per_instance(bmp, &bib->vrf_state, bgp);
 		FOREACH_AFI_SAFI (afi, safi)
 			bmp_update_syncro(bmp, afi, safi, bgp);
+		/* wake the session's write loop, otherwise the requested
+		 * table sync only starts when unrelated traffic does it
+		 */
+		pullwr_bump(bmp->pullwr);
 	}
 	return CMD_SUCCESS;
 }
@@ -3196,8 +3200,13 @@ DEFPY(bmp_monitor_cfg, bmp_monitor_cmd,
 	if (prev == bt->afimon[afi][safi])
 		return CMD_SUCCESS;
 
-	frr_each (bmp_session, &bt->sessions, bmp)
+	frr_each (bmp_session, &bt->sessions, bmp) {
 		bmp_update_syncro(bmp, afi, safi, NULL);
+		/* wake the session's write loop, otherwise the requested
+		 * table sync only starts when unrelated traffic does it
+		 */
+		pullwr_bump(bmp->pullwr);
+	}
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -237,6 +237,20 @@ DEFINE_HOOK(bgp_process,
 	     struct peer *peer, bool withdraw),
 	    (bgp, afi, safi, bn, peer, withdraw));
 
+DEFINE_HOOK(bgp_adj_in_needed, (struct peer *peer, afi_t afi, safi_t safi), (peer, afi, safi));
+
+/* The peer's Adj-RIB-In is maintained when soft-reconfiguration inbound is
+ * configured, or when another component consuming it (BMP pre-policy
+ * monitoring) claims it through the bgp_adj_in_needed hook.
+ */
+bool bgp_adj_in_needed(struct peer *peer, afi_t afi, safi_t safi)
+{
+	if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
+		return true;
+
+	return hook_call(bgp_adj_in_needed, peer, afi, safi) > 0;
+}
+
 /** Test if path is suppressed. */
 bool bgp_path_suppressed(struct bgp_path_info *pi)
 {
@@ -5819,14 +5833,15 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			bgp_labels.label[i] = label[i];
 	}
 
-	/* When peer's soft reconfiguration enabled.  Record input packet in
-	   Adj-RIBs-In.  */
-	if (!soft_reconfig && CHECK_FLAG(peer->af_flags[afi][orig_safi], PEER_FLAG_SOFT_RECONFIG) &&
-	    peer != bgp->peer_self) {
+	/*
+	 * When the peer's Adj-RIB-In is maintained (soft reconfiguration or
+	 * BMP pre-policy monitoring), record the input route in it.
+	 */
+	if (!soft_reconfig && bgp_adj_in_needed(peer, afi, orig_safi) && peer != bgp->peer_self) {
 		/*
-		 * If the trigger is not from soft_reconfig and if
-		 * PEER_FLAG_SOFT_RECONFIG is enabled for the peer, then attr
-		 * will not be interned. In which case, it is ok to update the
+		 * If the trigger is not from soft_reconfig and if the
+		 * Adj-RIB-In is maintained for the peer, then attr will not
+		 * be interned. In which case, it is ok to update the
 		 * attr->evpn_overlay, so that, this can be stored in adj_in.
 		 */
 		if (evpn && afi == AFI_L2VPN) {
@@ -6088,8 +6103,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	 * attr->evpn_overlay with evpn directly. Instead memcpy
 	 * evpn to new_atr.evpn_overlay before it is interned.
 	 */
-	if (evpn && afi == AFI_L2VPN &&
-	    (soft_reconfig || !CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))) {
+	if (evpn && afi == AFI_L2VPN && (soft_reconfig || !bgp_adj_in_needed(peer, afi, safi))) {
 		bgp_attr_set_evpn_overlay(&new_attr, evpn);
 		evpn = NULL;
 		p_evpn = NULL;
@@ -6845,8 +6859,7 @@ void bgp_withdraw(struct peer *peer, const struct prefix *p,
 	/* Lookup node. */
 	dest = bgp_afi_node_get(bgp->rib[afi][safi], afi, safi, p, prd);
 
-	/* If peer is soft reconfiguration enabled.  Record input packet for
-	 * further calculation.
+	/* If the peer's Adj-RIB-In is maintained, drop the route from it.
 	 *
 	 * Cisco IOS 12.4(24)T4 on session establishment sends withdraws for all
 	 * routes that are filtered.  This tanks out Quagga RS pretty badly due
@@ -6856,8 +6869,7 @@ void bgp_withdraw(struct peer *peer, const struct prefix *p,
 	 * and
 	 * if there was no entry, we don't need to do anything more.
 	 */
-	if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG)
-	    && peer != bgp->peer_self)
+	if (bgp_adj_in_needed(peer, afi, safi) && peer != bgp->peer_self)
 		if (!bgp_adj_in_unset(&dest, peer, addpath_id)) {
 			assert(dest);
 			peer->stat_pfx_dup_withdraw++;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -795,6 +795,11 @@ DECLARE_HOOK(bgp_process,
 	      struct peer *peer, bool withdraw),
 	     (bgp, afi, safi, bn, peer, withdraw));
 
+/* whether a component other than soft-reconfiguration inbound needs the
+ * peer's Adj-RIB-In to be maintained (e.g. BMP pre-policy monitoring)
+ */
+DECLARE_HOOK(bgp_adj_in_needed, (struct peer *peer, afi_t afi, safi_t safi), (peer, afi, safi));
+
 /* called when a route is updated in the rib */
 DECLARE_HOOK(bgp_route_update,
 	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
@@ -848,6 +853,7 @@ extern bool bgp_clear_node_queue_drain(struct peer *peer);
 /* Clear routes for a batch of peers */
 void bgp_clear_route_batch(struct bgp_clearing_info *cinfo);
 
+extern bool bgp_adj_in_needed(struct peer *peer, afi_t afi, safi_t safi);
 extern void bgp_clear_adj_in(struct peer *peer, afi_t afi, safi_t safi);
 extern void bgp_clear_stale_route(struct peer *peer, afi_t afi, safi_t safi);
 extern void bgp_set_stale_route(struct peer *peer, afi_t afi, safi_t safi);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6065,9 +6065,13 @@ static int peer_af_flag_modify(struct peer *peer, afi_t afi, safi_t safi,
 	/* Execute action when peer is established.  */
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP) &&
 	    peer_established(peer->connection)) {
-		if (!set && flag == PEER_FLAG_SOFT_RECONFIG)
-			bgp_clear_adj_in(peer, afi, safi);
-		else {
+		if (!set && flag == PEER_FLAG_SOFT_RECONFIG) {
+			/* keep the Adj-RIB-In while another consumer (BMP
+			 * pre-policy monitoring) still needs it
+			 */
+			if (!bgp_adj_in_needed(peer, afi, safi))
+				bgp_clear_adj_in(peer, afi, safi);
+		} else {
 			if (flag == PEER_FLAG_REFLECTOR_CLIENT)
 				peer_set_last_reset(peer, PEER_DOWN_RR_CLIENT_CHANGE);
 			else if (flag == PEER_FLAG_RSERVER_CLIENT)
@@ -6128,9 +6132,14 @@ static int peer_af_flag_modify(struct peer *peer, afi_t afi, safi_t safi,
 
 			/* Execute flag action on peer-group member. */
 			if (peer_established(member->connection)) {
-				if (!set && flag == PEER_FLAG_SOFT_RECONFIG)
-					bgp_clear_adj_in(member, afi, safi);
-				else {
+				if (!set && flag == PEER_FLAG_SOFT_RECONFIG) {
+					/* keep the Adj-RIB-In while another
+					 * consumer (BMP pre-policy monitoring)
+					 * still needs it
+					 */
+					if (!bgp_adj_in_needed(member, afi, safi))
+						bgp_clear_adj_in(member, afi, safi);
+				} else {
 					if (flag == PEER_FLAG_REFLECTOR_CLIENT)
 						peer_set_last_reset(member,
 								    PEER_DOWN_RR_CLIENT_CHANGE);

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -166,10 +166,15 @@ associated with a particular ``bmp targets``:
    .. note::
 
       Pre-policy Route Monitoring is sourced from a peer's Adj-RIB-In, which
-      *bgpd* only maintains when :clicmd:`neighbor PEER soft-reconfiguration
-      inbound` is configured for that peer.  Without it, the peer's routes
-      are simply absent from the pre-policy feed; *bgpd* logs a warning
-      naming the affected peer when this is the case.
+      *bgpd* maintains automatically for every peer the monitoring covers;
+      configuring :clicmd:`neighbor PEER soft-reconfiguration inbound` is not
+      required.  When pre-policy monitoring is enabled at runtime, *bgpd*
+      repopulates the Adj-RIB-In of covered peers through a route refresh
+      (peers without the route refresh capability are reset).  Disabling it
+      frees the Adj-RIB-In memory again, unless soft-reconfiguration or
+      another monitoring target still needs it.  ``show bgp neighbors PEER
+      received-routes`` remains available only with soft-reconfiguration
+      inbound configured.
 
 .. clicmd:: bmp mirror
 

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
@@ -123,33 +123,6 @@ def test_bgp_convergence():
     assert result is True, "BGP is not converging"
 
 
-def test_prepolicy_no_softreconfig_warning():
-    """
-    r1nosr has ``bmp monitor ipv4 unicast pre-policy`` configured, but its
-    neighbor 192.168.0.2 (r2nosr) has no ``soft-reconfiguration inbound``
-    and therefore no Adj-RIB-In.  bgpd must warn about this at peer-up
-    instead of silently omitting the peer's routes from the pre-policy
-    feed.
-    """
-    tgen = get_topogen()
-
-    def _warning_logged():
-        out = tgen.gears["r1nosr"].run("cat {}".format(_r1nosr_bgpd_log_path()))
-        needle = (
-            "peer 192.168.0.2 has no Adj-RIB-In for ipv4 unicast "
-            "(soft-reconfiguration inbound is not configured)"
-        )
-        if needle in out:
-            return True
-        return "warning not logged yet"
-
-    success, res = topotest.run_and_expect(_warning_logged, True, count=30, wait=1)
-    assert success, (
-        "expected r1nosr's bgpd.log to warn that 192.168.0.2 has no "
-        "Adj-RIB-In for pre-policy monitoring: {}".format(res)
-    )
-
-
 def test_bmp_server_logging():
     """
     Wait for the BMP collector to start logging (session established).

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_prepolicy_no_softreconfig.py
@@ -15,14 +15,27 @@ neighbor that does NOT have ``soft-reconfiguration inbound``.
     |          |            |          |               |          |
     +----------+            +----------+               +----------+
 
-Without ``soft-reconfiguration inbound`` bgpd keeps no Adj-RIB-In for the
-peer.  BMP pre-policy monitoring reads exclusively from Adj-RIB-In, so an
-announcement from r2nosr must NOT be turned into a fabricated pre-policy
-*withdrawal* towards the BMP collector (FRRouting/frr issue #10240).
-Post-policy monitoring, which reads the main RIB, must stay correct.
+BMP pre-policy monitoring reads from Adj-RIB-In, which bgpd maintains
+whenever pre-policy monitoring covers the peer -- no user-visible
+``soft-reconfiguration inbound`` is required (FRRouting/frr issue #10240).
+
+Checks, in order:
+
+* announcements from r2nosr produce pre-policy updates (and no fabricated
+  pre-policy withdrawals);
+* no "no Adj-RIB-In" warning is logged;
+* a fresh table sync carries the initial pre-policy dump before the
+  pre-policy End-of-RIB;
+* genuine withdrawals produce pre-policy withdrawals -- and only those;
+* a peer bounce re-announces the full pre-policy feed;
+* disabling pre-policy monitoring at runtime frees the Adj-RIB-In memory;
+* re-enabling it repopulates Adj-RIB-In via route refresh;
+* ``show bgp ... received-routes`` still requires the user-visible
+  soft-reconfiguration flag.
 """
 
 import os
+import re
 import sys
 import pytest
 from functools import partial
@@ -45,10 +58,12 @@ pytestmark = [pytest.mark.bgpd]
 
 # Prefix whose BMP treatment we assert on, plus a sentinel prefix announced
 # afterwards.  Once the sentinel's post-policy update is logged, any message
-# bgpd fabricated while processing WATCHED_PREFIX is already in the log, so
-# the "no fabricated pre-policy withdrawal" assertion has no timing race.
+# bgpd emitted while processing WATCHED_PREFIX is already in the log, so the
+# assertions on WATCHED_PREFIX have no timing race.
 WATCHED_PREFIX = "203.0.113.1/32"
 SENTINEL_PREFIX = "203.0.113.254/32"
+
+ADJ_RIB_IN_WARNING = "has no Adj-RIB-In for"
 
 bmp_seq_context = BMPSequenceContext()
 
@@ -109,9 +124,52 @@ def _route_messages(policy, bmp_log_type, prefix):
     ]
 
 
-def _r1nosr_bgpd_log_path():
+def _prepolicy_eor_seq():
+    """
+    Return the seq of the first pre-policy End-of-RIB logged beyond the
+    recorded baseline, or None.  An EoR is a route-monitoring message (an
+    empty BGP UPDATE) carrying neither an NLRI nor withdrawn routes, so the
+    collector logs it as an "update" without an "ip_prefix" field.
+    """
     tgen = get_topogen()
-    return os.path.join(tgen.logdir, "r1nosr", "bgpd.log")
+    baseline = bmp_seq_context.get_seq()
+    messages = get_bmp_messages(tgen.gears["bmp1nosr"], _bmp_log_file())
+    for m in messages:
+        if (
+            m.get("seq", 0) > baseline
+            and m.get("policy") == "pre-policy"
+            and m.get("bmp_log_type") == "update"
+            and "ip_prefix" not in m
+        ):
+            return m["seq"]
+    return None
+
+
+def _r1nosr_bgpd_log():
+    tgen = get_topogen()
+    path = os.path.join(tgen.logdir, "r1nosr", "bgpd.log")
+    return tgen.gears["r1nosr"].run("cat {}".format(path))
+
+
+def _adj_in_count():
+    """
+    r1nosr's Adj-RIB-In entry count, from bgpd's MTYPE_BGP_ADJ_IN allocation
+    counter in ``show memory``.  Returns None if the counter has never been
+    non-zero (bgpd omits such lines).
+    """
+    tgen = get_topogen()
+    out = tgen.gears["r1nosr"].vtysh_cmd("show memory")
+    m = re.search(r"BGP adj in\s*:\s*(\d+)", out)
+    if m is None:
+        return None
+    return int(m.group(1))
+
+
+def _r1nosr_bmp_targets_config(*lines):
+    tgen = get_topogen()
+    cmd = "configure terminal\nrouter bgp 65501\nbmp targets bmp1nosr\n"
+    cmd += "\n".join(lines) + "\n"
+    return tgen.gears["r1nosr"].vtysh_cmd(cmd)
 
 
 def test_bgp_convergence():
@@ -139,13 +197,16 @@ def test_bmp_server_logging():
     assert success, "The BMP server is not logging"
 
 
-def test_no_fabricated_prepolicy_withdrawal():
+def test_prepolicy_feed_announce():
     """
-    Announce a prefix from r2nosr (which r1nosr does not keep an Adj-RIB-In
-    for) and assert that:
+    Announce a prefix from r2nosr (whose session has no soft-reconfiguration
+    inbound) and assert that:
 
+    * a pre-policy update is emitted for it (BMP pre-policy monitoring keeps
+      Adj-RIB-In by itself);
     * a post-policy update is emitted for it (control: the RIB path is fine);
-    * no pre-policy *withdrawal* is fabricated for it (the bug).
+    * no pre-policy *withdrawal* is fabricated for it (the original
+      FRRouting/frr issue #10240 bug).
     """
     tgen = get_topogen()
 
@@ -194,14 +255,215 @@ def test_no_fabricated_prepolicy_withdrawal():
         )
     )
 
-    # The bug: with no Adj-RIB-In, bgpd fabricated a pre-policy withdrawal for
-    # a prefix that was only ever announced.  There must be none.
+    # The fix: pre-policy monitoring maintains Adj-RIB-In itself, so the
+    # announcement must show up in the pre-policy feed even without
+    # soft-reconfiguration inbound.
+    def _prepolicy_update_seen():
+        if _route_messages("pre-policy", "update", WATCHED_PREFIX):
+            return True
+        return "pre-policy update not logged yet"
+
+    success, res = topotest.run_and_expect(_prepolicy_update_seen, True, count=30, wait=1)
+    assert success, (
+        "expected a pre-policy update for {} (no soft-reconfiguration "
+        "inbound, adj-in driven by BMP pre-policy monitoring): {}".format(
+            WATCHED_PREFIX, res
+        )
+    )
+
+    # The original bug: with no Adj-RIB-In, bgpd fabricated a pre-policy
+    # withdrawal for a prefix that was only ever announced.  Must stay fixed.
     fabricated = _route_messages("pre-policy", "withdraw", WATCHED_PREFIX)
     assert not fabricated, (
         "bgpd fabricated {} pre-policy withdrawal(s) for {} that was only "
-        "announced (no soft-reconfiguration inbound -> no Adj-RIB-In): {}".format(
-            len(fabricated), WATCHED_PREFIX, fabricated
+        "announced: {}".format(len(fabricated), WATCHED_PREFIX, fabricated)
+    )
+
+
+def test_no_adj_rib_in_warning():
+    """
+    Pre-policy monitoring drives Adj-RIB-In maintenance itself, so bgpd must
+    NOT warn about a missing Adj-RIB-In -- neither at peer-up nor at
+    configuration time.
+    """
+    out = _r1nosr_bgpd_log()
+
+    # Positive control: make sure we are looking at a live bgpd log before
+    # asserting on the absence of the warning.
+    assert "ADJCHANGE" in out, (
+        "r1nosr's bgpd.log looks empty or unreadable; cannot assert on it"
+    )
+
+    assert ADJ_RIB_IN_WARNING not in out, (
+        "bgpd warned about a missing Adj-RIB-In although BMP pre-policy "
+        "monitoring maintains it"
+    )
+
+
+def test_prepolicy_initial_dump():
+    """
+    Force a fresh table sync on the live BMP session (any monitor flag
+    change re-triggers it; the test collector only accepts a single TCP
+    session, so the BMP session itself cannot be bounced) and verify that
+    the pre-policy routes are dumped from Adj-RIB-In before the pre-policy
+    End-of-RIB.
+    """
+    tgen = get_topogen()
+
+    bmp_update_seq(tgen.gears["bmp1nosr"], _bmp_log_file(), bmp_seq_context)
+
+    _r1nosr_bmp_targets_config("no bmp monitor ipv4 unicast post-policy")
+
+    def _eor_seen():
+        if _prepolicy_eor_seq() is not None:
+            return True
+        return "pre-policy EoR not logged yet"
+
+    success, res = topotest.run_and_expect(_eor_seen, True, count=60, wait=1)
+    assert success, "no pre-policy EoR after the forced table sync: {}".format(res)
+
+    eor_seq = _prepolicy_eor_seq()
+    for prefix in (WATCHED_PREFIX, SENTINEL_PREFIX):
+        updates = _route_messages("pre-policy", "update", prefix)
+        assert updates, (
+            "expected {} in the initial pre-policy dump of the new BMP "
+            "session but it was never logged".format(prefix)
         )
+        assert min(m["seq"] for m in updates) < eor_seq, (
+            "{} was logged only after the pre-policy EoR (seq {}); it must "
+            "be part of the initial table dump".format(prefix, eor_seq)
+        )
+
+    # Restore the configuration for the remaining tests.
+    _r1nosr_bmp_targets_config("bmp monitor ipv4 unicast post-policy")
+
+
+def test_prepolicy_genuine_withdraw():
+    """
+    Withdraw the watched prefix on r2nosr: the pre-policy feed must carry a
+    withdrawal for it -- and no withdrawal for the still-announced sentinel.
+    """
+    tgen = get_topogen()
+
+    bmp_update_seq(tgen.gears["bmp1nosr"], _bmp_log_file(), bmp_seq_context)
+
+    bgp_configure_prefixes(
+        tgen.gears["r2nosr"], 65502, "unicast", [WATCHED_PREFIX], update=False
+    )
+
+    def _withdraw_seen():
+        if _route_messages("pre-policy", "withdraw", WATCHED_PREFIX):
+            return True
+        return "pre-policy withdraw not logged yet"
+
+    success, res = topotest.run_and_expect(_withdraw_seen, True, count=30, wait=1)
+    assert success, (
+        "expected a pre-policy withdrawal for the genuinely withdrawn "
+        "{}: {}".format(WATCHED_PREFIX, res)
+    )
+
+    fabricated = _route_messages("pre-policy", "withdraw", SENTINEL_PREFIX)
+    assert not fabricated, (
+        "pre-policy withdrawal(s) logged for {} which was never "
+        "withdrawn: {}".format(SENTINEL_PREFIX, fabricated)
+    )
+
+
+def test_prepolicy_peer_bounce():
+    """
+    Hard-clear the BGP session on r1nosr.  After re-establishment the peer
+    re-announces its routes, and the pre-policy feed must carry them again.
+    """
+    tgen = get_topogen()
+
+    bmp_update_seq(tgen.gears["bmp1nosr"], _bmp_log_file(), bmp_seq_context)
+
+    tgen.gears["r1nosr"].vtysh_cmd("clear ip bgp 192.168.0.2")
+
+    def _reannounced():
+        if _route_messages("pre-policy", "update", SENTINEL_PREFIX):
+            return True
+        return "pre-policy update not re-logged yet"
+
+    success, res = topotest.run_and_expect(_reannounced, True, count=60, wait=1)
+    assert success, (
+        "expected a pre-policy update for {} after the peer bounce: "
+        "{}".format(SENTINEL_PREFIX, res)
+    )
+
+
+def test_prepolicy_disable_frees_adj_in():
+    """
+    Disabling pre-policy monitoring at runtime must free the Adj-RIB-In
+    entries bgpd only kept on its behalf (observable through the
+    MTYPE_BGP_ADJ_IN allocation count in ``show memory``).
+    """
+    count = _adj_in_count()
+    assert count is not None and count > 0, (
+        "expected a non-zero Adj-RIB-In entry count while BMP pre-policy "
+        "monitoring is enabled, got {}".format(count)
+    )
+
+    _r1nosr_bmp_targets_config("no bmp monitor ipv4 unicast pre-policy")
+
+    def _adj_in_freed():
+        count = _adj_in_count()
+        if count == 0:
+            return True
+        return "Adj-RIB-In count still {}".format(count)
+
+    success, res = topotest.run_and_expect(_adj_in_freed, True, count=30, wait=1)
+    assert success, (
+        "Adj-RIB-In was not freed after disabling pre-policy "
+        "monitoring: {}".format(res)
+    )
+
+
+def test_prepolicy_reenable_repopulates_adj_in():
+    """
+    Re-enabling pre-policy monitoring must repopulate Adj-RIB-In via route
+    refresh (the peer stays established) and resume the pre-policy feed,
+    without any warning on the configuration terminal.
+    """
+    tgen = get_topogen()
+
+    bmp_update_seq(tgen.gears["bmp1nosr"], _bmp_log_file(), bmp_seq_context)
+
+    out = _r1nosr_bmp_targets_config("bmp monitor ipv4 unicast pre-policy")
+    assert ADJ_RIB_IN_WARNING not in out, (
+        "enabling pre-policy monitoring warned about a missing Adj-RIB-In "
+        "although bgpd now maintains it: {}".format(out)
+    )
+
+    def _repopulated():
+        count = _adj_in_count()
+        if not count:
+            return "Adj-RIB-In count is {}".format(count)
+        if not _route_messages("pre-policy", "update", SENTINEL_PREFIX):
+            return "pre-policy update not logged yet"
+        return True
+
+    success, res = topotest.run_and_expect(_repopulated, True, count=60, wait=1)
+    assert success, (
+        "Adj-RIB-In was not repopulated or the pre-policy feed did not "
+        "resume after re-enabling pre-policy monitoring: {}".format(res)
+    )
+
+
+def test_received_routes_still_refused():
+    """
+    ``show bgp ... received-routes`` remains gated on the user-visible
+    soft-reconfiguration flag, even while BMP pre-policy monitoring keeps
+    an Adj-RIB-In for the peer.
+    """
+    tgen = get_topogen()
+
+    out = tgen.gears["r1nosr"].vtysh_cmd(
+        "show bgp ipv4 unicast neighbors 192.168.0.2 received-routes"
+    )
+    assert "Inbound soft reconfiguration not enabled" in out, (
+        "received-routes must still require soft-reconfiguration inbound, "
+        "got: {}".format(out)
     )
 
 


### PR DESCRIPTION
Fixes #10240.

BMP pre-policy Route Monitoring reads from a peer's Adj-RIB-In, but bgpd only maintained one for peers with `soft-reconfiguration inbound`. Without that flag pre-policy monitoring saw an empty Adj-RIB-In: no initial dump and no announcements. Requiring operators to enable `soft-reconfiguration inbound` as a side condition of BMP is undocumented and costly (a full second copy of every received path), so pre-policy monitoring should maintain the Adj-RIB-In it needs itself.

This replaces the bare `PEER_FLAG_SOFT_RECONFIG` test gating Adj-RIB-In maintenance with `bgp_adj_in_needed()`, which is also true when a registered consumer claims the peer through a new hook. The BMP module claims every peer covered by pre-policy monitoring. bgpd core keeps no knowledge of BMP; with the module unloaded the predicate degenerates to the old flag test. Runtime toggles repopulate the Adj-RIB-In via route refresh when monitoring is enabled and free it when no consumer remains. A first, standalone commit wakes the BMP write loop when monitor configuration changes (a pre-existing latent bug, cherry-pickable on its own).

Depends on #22588, which stops the fabricated withdrawals; this PR removes its now-unreachable warnings.

Validated on a RouteViews production collector running this change backported to 10.5.1 — the same code path as master: with `soft-reconfiguration inbound` removed, the pre-policy BMP feed carried announcements rather than the original all-withdrawals stream, and 100% of per-peer headers were pre-policy (`L=0`). Also covered by a `bgp_bmp` topotest asserting the full pre-policy feed — initial dump, genuine withdrawals, peer bounce, and that disabling frees the Adj-RIB-In while re-enabling repopulates it; existing `bgp_bmp` topotests unchanged.
