### PR TITLE
lib: log_nb: fix crash when log file level modified without filename

### DIFF
--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -292,7 +292,7 @@ static int logging_file_level_modify(struct nb_cb_modify_args *args)
 	if (yang_dnode_exists(args->dnode, "../filename"))
 		fname = yang_dnode_get_string(args->dnode, "../filename");
 	if (!fname)
-		fname = zt_file.filename;
+		return NB_OK;
 	level = _get_level_value(args->dnode, NULL);
 	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS)
 		return NB_ERR_INCONSISTENCY;
@@ -342,7 +342,7 @@ static int logging_filtered_file_level_modify(struct nb_cb_modify_args *args)
 	if (yang_dnode_exists(args->dnode, "../filename"))
 		fname = yang_dnode_get_string(args->dnode, "../filename");
 	if (!fname)
-		fname = zt_file.filename;
+		return NB_OK;
 	level = _get_level_value(args->dnode, NULL);
 	if (set_log_file(&zt_filterfile.parent, NULL, fname, level) != CMD_SUCCESS)
 		return NB_ERR_INCONSISTENCY;

--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -293,6 +293,8 @@ static int logging_file_level_modify(struct nb_cb_modify_args *args)
 		fname = yang_dnode_get_string(args->dnode, "../filename");
 	if (!fname)
 		fname = zt_file.filename;
+	if (!fname)
+		return NB_OK;
 	level = _get_level_value(args->dnode, NULL);
 	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS)
 		return NB_ERR_INCONSISTENCY;
@@ -342,7 +344,9 @@ static int logging_filtered_file_level_modify(struct nb_cb_modify_args *args)
 	if (yang_dnode_exists(args->dnode, "../filename"))
 		fname = yang_dnode_get_string(args->dnode, "../filename");
 	if (!fname)
-		fname = zt_file.filename;
+		fname = zt_filterfile.parent.filename;
+	if (!fname)
+		return NB_OK;
 	level = _get_level_value(args->dnode, NULL);
 	if (set_log_file(&zt_filterfile.parent, NULL, fname, level) != CMD_SUCCESS)
 		return NB_ERR_INCONSISTENCY;


### PR DESCRIPTION
The logging_file_level_modify() and logging_filtered_file_level_modify()
callbacks crash with SIGSEGV when the log level is modified but no
filename is configured.

The code tries to fall back to zt_file.filename when ../filename doesn't
exist in the YANG tree, but if zt_file.filename is also NULL, the NULL
pointer is passed to set_log_file() which dereferences it at line 50:

    if (!IS_DIRECTORY_SEP(*fname))

This causes a crash during mgmtd configuration apply.

Fix by returning NB_OK early when no filename is available - there's
nothing to configure without a log file path.