### PR TITLE
zebra: preserve FIFO order for skip-kernel ctxs in dplane providers

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1550,6 +1550,19 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		if (ctx == NULL)
 			break;
 
+		/*
+		 * Skip-kernel ctxs are routed through work_list to preserve
+		 * FIFO ordering for downstream providers. Ride them along in
+		 * the batch's ordered ctx_list without encoding a netlink
+		 * message: curlen/msgcnt stay untouched so batching efficiency
+		 * is preserved, and the ctx is moved to handled_list in its
+		 * correct FIFO position when the batch is drained.
+		 */
+		if (dplane_ctx_is_skip_kernel(ctx)) {
+			dplane_ctx_enqueue_tail(&(batch.ctx_list), ctx);
+			continue;
+		}
+
 		if (batch.zns != NULL
 		    && batch.zns->ns_id != dplane_ctx_get_ns(ctx)->ns_id)
 			nl_batch_send(&batch);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1599,6 +1599,17 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		ctx = dplane_ctx_dequeue(ctx_list);
 		if (ctx == NULL)
 			break;
+
+		/*
+		 * Skip-kernel ctxs are routed through work_list to preserve
+		 * FIFO ordering for downstream providers. Pass them directly
+		 * to handled_list without kernel programming.
+		 */
+		if (dplane_ctx_is_skip_kernel(ctx)) {
+			dplane_ctx_enqueue_tail(&handled_list, ctx);
+			continue;
+		}
+
 		switch (dplane_ctx_get_op(ctx)) {
 
 		case DPLANE_OP_ROUTE_INSTALL:

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -7736,11 +7736,13 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 
 		/*
 		 * A previous provider plugin may have asked to skip the
-		 * kernel update.
+		 * kernel update. Route through work_list so the FIFO order
+		 * (and therefore NHG dependency order) is preserved when
+		 * the ctx is forwarded to downstream providers like FPM.
 		 */
 		if (dplane_ctx_is_skip_kernel(ctx)) {
 			dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
-			dplane_provider_enqueue_out_ctx(prov, ctx);
+			dplane_ctx_list_add_tail(&work_list, ctx);
 			continue;
 		}
 


### PR DESCRIPTION
#### Problem Description
Currently, the kernel dplane provider enqueues skip_kernel ctxs to the OUT queue immediately while kernel-bound ctxs are deferred until after kernel_update_multi() returns. Because ctxs on the OUT queue are forwarded to the next dplane provider (e.g. FPM) as soon as they arrive, skip_kernel ctxs overtake their kernel-bound peers from the same batch and reach downstream providers out of order.

This breaks any downstream consumer that relies on the FIFO ordering implicitly established by zebra when it enqueues ctxs into the kernel provider's IN queue. For example, when an NHG that is skip_kernel depends on other NHGs that must still be programmed to the kernel, the downstream provider can observe the parent before the children. In RIB/FIB, for instance, recursive NHGs are propagated to FPM while their resolved descendants are still programmed to the kernel, so fpmsyncd rejects the parent with "NextHop id <child> in group not found".
We see the following logs from FPM side (for the dependency 119 → 120 → {121, 122}):
```
# NHG 119 depends on NHG 120 but received earlier, and FPM failed to install because of the lack of 120

2026 Jun 29 13:39:10.660855 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 119  JSON string:  {"id":119,..."depends":[120],"dependents":[114] ...}
2026 Jun 29 13:39:10.661588 PE3 NOTICE bgp#fpmsyncd: :- addNHGFull: Receiving NHG 119, type 4, af 0
2026 Jun 29 13:39:10.661680 PE3 ERR bgp#fpmsyncd: :- setEntry: NextHop id 120 in group not found.
2026 Jun 29 13:39:10.661708 PE3 ERR bgp#fpmsyncd: :- addNewNHGFull: Failed to add NHG 119
2026 Jun 29 13:39:10.661729 PE3 ERR bgp#fpmsyncd: :- addNHGFull: Failed to add NHG 119
2026 Jun 29 13:39:10.661745 PE3 ERR bgp#fpmsyncd: :- onNextHopGroupFullMsg: Failed to add NHG 119 to rib_fib_nhg_mgr
2026 Jun 29 13:39:10.667201 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 121 JSON string:  {"id":121,..."depends":[ ],"dependents":[120]...}
2026 Jun 29 13:39:10.667962 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 122 JSON string:  {"id":122,..."depends":[ ],"dependents":[120]...}
2026 Jun 29 13:39:10.668646 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 120 JSON string:  {"id":120,..."depends":[121,122],"dependents":[119],...}
2026 Jun 29 13:39:10.669453 PE3 NOTICE bgp#fpmsyncd: :- addNHGFull: Receiving NHG 120, type 0, af 0
...
```

#### Approach
Route skip_kernel ctxs through the same work_list used for kernel-bound ctxs so the post-batch pop preserves arrival order. Update both kernel_update_multi implementations (netlink and socket) to pass skip_kernel ctxs through to handled_list without kernel programming; the netlink path additionally flushes the pending batch before pushing the skip_kernel ctx to handled_list, otherwise batched ctxs would land in handled_list after the skip_kernel ctx and reintroduce the reorder.

#### Test and Verification
Since this fix does not introduce any new functionality and the reorder is not reliably reproducible through topotest, so no new topotest case is added. The existing coverage in `tests/topotests/fpm_testing_topo1/` continues to exercise skip_kernel ctxs flowing through the kernel provider to the FPM listener (system routes, connected/local/kernel), which guards against regressions that break this path outright.

Verified manually on an internal FRR/SONiC setup with recursive NHG scenarios. In one representative batch, three-level dependencies (116 → 117 → {118, 119}) all reach fpmsyncd in leaf-before-parent order (118, 119, 117, 116):
```
2026 Jul  2 18:09:30.563699 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 118 JSON string: {"id":118,..."depends":[],"dependents":[117]...}
2026 Jul  2 18:09:30.564009 PE3 NOTICE bgp#fpmsyncd: :- addNHGFull: Receiving NHG 118, type 5, af 10
2026 Jul  2 18:09:30.564969 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 119 JSON string: {"id":119,..."depends":[],"dependents":[117]...}
2026 Jul  2 18:09:30.565197 PE3 NOTICE bgp#fpmsyncd: :- addNHGFull: Receiving NHG 119, type 5, af 10
2026 Jul  2 18:09:30.565956 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 117 JSON string: {"id":117,..."depends":[118,119],"dependents":[116]...}
2026 Jul  2 18:09:30.566949 PE3 NOTICE bgp#fpmsyncd: :- addNHGFull: Receiving NHG 117, type 0, af 0
2026 Jul  2 18:09:30.568013 PE3 NOTICE bgp#fpmsyncd: :- onNextHopGroupFullMsg: Received NHGFULL 116 JSON string: {"id":116,..."depends":[117],"dependents":[115]...}
2026 Jul  2 18:09:30.568624 PE3 NOTICE bgp#fpmsyncd: :- addNHGFull: Receiving NHG 116, type 4, af 0
```
With the fix, the order issue no longer occurs.