### PR TITLE
bgpd: Ignore duplicate Prefix-SID SRv6 L3 Service TLVs

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3840,6 +3840,7 @@ enum bgp_attr_parse_ret bgp_attr_prefix_sid(struct bgp_attr_parser_args *args)
 	size_t headersz = sizeof(type) + sizeof(length);
 	size_t tlv_total_len;
 	size_t psid_parsed_length = 0;
+	bool srv6_l3_service_tlv_seen = false;
 
 	if (peer->discard_attrs[args->type] || peer->withdraw_attrs[args->type])
 		goto prefix_sid_ignore;
@@ -3869,6 +3870,19 @@ enum bgp_attr_parse_ret bgp_attr_prefix_sid(struct bgp_attr_parser_args *args)
 		}
 
 		psid_parsed_length += tlv_total_len;
+
+		if (type == BGP_PREFIX_SID_SRV6_L3_SERVICE) {
+			if (srv6_l3_service_tlv_seen) {
+				/*
+				 * RFC 9252 Section 7: ignore all but the first
+				 * SRv6 L3 Service TLV instance.
+				 */
+				stream_forward_getp(connection->curr, length);
+				continue;
+			}
+
+			srv6_l3_service_tlv_seen = true;
+		}
 
 		ret = bgp_attr_psid_sub(type, length, args);
 

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3838,6 +3838,7 @@ enum bgp_attr_parse_ret bgp_attr_prefix_sid(struct bgp_attr_parser_args *args)
 	uint8_t type;
 	uint16_t length;
 	size_t headersz = sizeof(type) + sizeof(length);
+	size_t tlv_total_len;
 	size_t psid_parsed_length = 0;
 
 	if (peer->discard_attrs[args->type] || peer->withdraw_attrs[args->type])
@@ -3855,8 +3856,9 @@ enum bgp_attr_parse_ret bgp_attr_prefix_sid(struct bgp_attr_parser_args *args)
 
 		type = stream_getc(connection->curr);
 		length = stream_getw(connection->curr);
+		tlv_total_len = headersz + length;
 
-		if (((size_t)length + headersz + psid_parsed_length > (size_t)args->length) ||
+		if ((tlv_total_len + psid_parsed_length > (size_t)args->length) ||
 		    STREAM_READABLE(connection->curr) < length) {
 			flog_err(EC_BGP_ATTR_LEN,
 				 "Malformed Prefix SID attribute - insufficient data (need %hu for attribute body, have %zu remaining in UPDATE)",
@@ -3866,22 +3868,12 @@ enum bgp_attr_parse_ret bgp_attr_prefix_sid(struct bgp_attr_parser_args *args)
 						  args->total);
 		}
 
+		psid_parsed_length += tlv_total_len;
+
 		ret = bgp_attr_psid_sub(type, length, args);
 
 		if (ret != BGP_ATTR_PARSE_PROCEED)
 			return ret;
-
-		psid_parsed_length += length + headersz;
-
-		if (psid_parsed_length > args->length) {
-			flog_err(
-				EC_BGP_ATTR_LEN,
-				"Malformed Prefix SID attribute - TLV overflow by attribute (need %zu for TLV length, have %zu overflowed in UPDATE)",
-				length + headersz, psid_parsed_length - (length + headersz));
-			return bgp_attr_malformed(
-				args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-				args->total);
-		}
 	}
 
 	bgp_attr_set(attr, BGP_ATTR_PREFIX_SID);

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -954,6 +954,43 @@ static struct test_segment mp_prefix_sid[] = {
 		.len = 21,
 		.parses = SHOULD_PARSE,
 	},
+	{
+		.name = "PREFIX-SID-SRv6-L3-Service-duplicate",
+		.desc = "PREFIX-SID ignores duplicate SRv6 L3 Service TLVs",
+		.data = {
+			/* TLV[0] SRv6 L3 Service TLV */
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x19, /* Length */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-TLV type: SID Information */
+			0x00, 0x15, /* Sub-TLV length */
+			0x00,       /* Reserved */
+			0xfc, 0xbb, 0xbb, 0xbb, /* SID fcbb:bbbb:1:e000:: */
+			0x00, 0x01, 0xe0, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00,       /* SID flags */
+			0x00, 0x40, /* Endpoint behavior */
+			0x00,       /* Reserved */
+
+			/* TLV[1] duplicate SRv6 L3 Service TLV */
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x19, /* Length */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-TLV type: SID Information */
+			0x00, 0x15, /* Sub-TLV length */
+			0x00,       /* Reserved */
+			0xfc, 0xbb, 0xbb, 0xbb, /* SID fcbb:bbbb:1:e001:: */
+			0x00, 0x01, 0xe0, 0x01,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00,       /* SID flags */
+			0x00, 0x3e, /* Endpoint behavior */
+			0x00,       /* Reserved */
+		},
+		.len = 56,
+		.parses = SHOULD_PARSE,
+	},
 	{NULL, NULL, { 0 }, 0, 0},
 };
 
@@ -1048,6 +1085,7 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 			nlri_ret = bgp_nlri_parse(peer, &attr, &nlri, true);
 	}
 	handle_result(peer, t, parse_ret, nlri_ret);
+	bgp_attr_unintern_sub(&attr);
 }
 
 static struct bgp *bgp;

--- a/tests/bgpd/test_mp_attr.py
+++ b/tests/bgpd/test_mp_attr.py
@@ -48,6 +48,7 @@ TestMpAttr.okfail("IPv6-unreach-nlri: IPV6 MP Unreach, NLRI bitlen overflow")
 TestMpAttr.okfail("IPv4-unreach: IPv4 MP Unreach, 2 NLRIs + default")
 TestMpAttr.okfail("IPv4-unreach-nlrilen: IPv4 MP Unreach, nlri length overflow")
 TestMpAttr.okfail("IPv4-unreach-VPNv4: IPv4/MPLS-labeled VPN MP Unreach, RD, 3 NLRIs")
+TestMpAttr.okfail("PREFIX-SID: PREFIX-SID Test 1")
 TestMpAttr.okfail(
     "PREFIX-SID-SRv6-L3-Service-duplicate: PREFIX-SID ignores duplicate SRv6 L3 Service TLVs"
 )

--- a/tests/bgpd/test_mp_attr.py
+++ b/tests/bgpd/test_mp_attr.py
@@ -48,3 +48,6 @@ TestMpAttr.okfail("IPv6-unreach-nlri: IPV6 MP Unreach, NLRI bitlen overflow")
 TestMpAttr.okfail("IPv4-unreach: IPv4 MP Unreach, 2 NLRIs + default")
 TestMpAttr.okfail("IPv4-unreach-nlrilen: IPv4 MP Unreach, nlri length overflow")
 TestMpAttr.okfail("IPv4-unreach-VPNv4: IPv4/MPLS-labeled VPN MP Unreach, RD, 3 NLRIs")
+TestMpAttr.okfail(
+    "PREFIX-SID-SRv6-L3-Service-duplicate: PREFIX-SID ignores duplicate SRv6 L3 Service TLVs"
+)


### PR DESCRIPTION
Fix Prefix-SID SRv6 L3 Service TLV parsing to follow RFC 9252 Section 7 by ignoring duplicate SRv6 L3 Service TLV instances after the first one.

Currently, when a Prefix-SID attribute contains more than one SRv6 L3 Service TLV, FRR parses the first instance and then treats the next instance as a repeated SRv6 L3 Service field. This causes the attribute to be rejected as malformed.

That behavior is not compliant with RFC 9252 Section 7, which requires receivers to accept the attribute and ignore all SRv6 L3 Service TLV instances after the first one.

Fixes https://github.com/FRRouting/frr/issues/22528