### PR TITLE
bgpd: preserve cli configured VPN export RT on router-id update

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -3100,17 +3100,20 @@ void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
 			if (!CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_CLI_SET))
 				bgp->vpn_policy[afi].tovpn_rd = bgp->vrf_prd_auto;
 
-			prefix_rd2str(&bgp->vpn_policy[afi].tovpn_rd, buf,
-				      sizeof(buf), bgp->asnotation);
-
-			/* free up pre-existing memory if any and allocate
-			 *  the ecommunity attribute with new RD/RT
+			/* Re-derive the export RT only when it was not configured
+			 * explicitly.  A CLI-configured RT may intentionally differ
+			 * from the RD and must survive router-id changes.
 			 */
-			if (bgp->vpn_policy[afi].rtlist[edir])
-				ecommunity_free(
-					&bgp->vpn_policy[afi].rtlist[edir]);
-			bgp->vpn_policy[afi].rtlist[edir] = ecommunity_str2com(
-				buf, ECOMMUNITY_ROUTE_TARGET, 0);
+			if (!CHECK_FLAG(bgp->vpn_policy[afi].flags,
+					BGP_VPN_POLICY_TOVPN_RT_CLI_SET)) {
+				prefix_rd2str(&bgp->vpn_policy[afi].tovpn_rd, buf, sizeof(buf),
+					      bgp->asnotation);
+
+				if (bgp->vpn_policy[afi].rtlist[edir])
+					ecommunity_free(&bgp->vpn_policy[afi].rtlist[edir]);
+				bgp->vpn_policy[afi].rtlist[edir] =
+					ecommunity_str2com(buf, ECOMMUNITY_ROUTE_TARGET, 0);
+			}
 
 			/* Update import_vrf rt_list */
 			ecom = bgp->vpn_policy[afi].rtlist[edir];
@@ -3246,16 +3249,25 @@ void vrf_import_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp, const char *i
 		SET_FLAG(from_bgp->vpn_policy[afi].flags,
 			 BGP_VPN_POLICY_TOVPN_RD_SET);
 
-		prefix_rd2str(&from_bgp->vpn_policy[afi].tovpn_rd, buf,
-			      sizeof(buf), from_bgp->asnotation);
-		from_bgp->vpn_policy[afi].rtlist[edir] =
-			ecommunity_str2com(buf, ECOMMUNITY_ROUTE_TARGET, 0);
+		if (!CHECK_FLAG(from_bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RT_CLI_SET)) {
+			prefix_rd2str(&from_bgp->vpn_policy[afi].tovpn_rd, buf, sizeof(buf),
+				      from_bgp->asnotation);
+			from_bgp->vpn_policy[afi].rtlist[edir] =
+				ecommunity_str2com(buf, ECOMMUNITY_ROUTE_TARGET, 0);
+		}
 		SET_FLAG(from_bgp->af_flags[afi][safi],
 			 BGP_CONFIG_VRF_TO_VRF_EXPORT);
 		from_bgp->vpn_policy[afi].tovpn_label =
 			BGP_PREVENT_VRF_2_VRF_LEAK;
 	}
 	ecom = from_bgp->vpn_policy[afi].rtlist[edir];
+	if (!ecom) {
+		if (debug)
+			zlog_debug("%s from %s to %s missing export RT", __func__, import_name,
+				   export_name);
+		return;
+	}
+
 	if (to_bgp->vpn_policy[afi].rtlist[idir])
 		to_bgp->vpn_policy[afi].rtlist[idir] =
 			ecommunity_merge(to_bgp->vpn_policy[afi]
@@ -3401,13 +3413,17 @@ void vrf_unimport_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp, const char 
 
 	if (!listcount(from_bgp->vpn_policy[afi].export_vrf)) {
 		vpn_leak_prechange(edir, afi, bgp_get_default(), from_bgp);
-		ecommunity_free(&from_bgp->vpn_policy[afi].rtlist[edir]);
-		UNSET_FLAG(from_bgp->af_flags[afi][safi],
-			   BGP_CONFIG_VRF_TO_VRF_EXPORT);
-		memset(&from_bgp->vpn_policy[afi].tovpn_rd, 0,
-		       sizeof(struct prefix_rd));
-		UNSET_FLAG(from_bgp->vpn_policy[afi].flags,
-			   BGP_VPN_POLICY_TOVPN_RD_SET);
+
+		if (!CHECK_FLAG(from_bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RT_CLI_SET))
+			ecommunity_free(&from_bgp->vpn_policy[afi].rtlist[edir]);
+
+		UNSET_FLAG(from_bgp->af_flags[afi][safi], BGP_CONFIG_VRF_TO_VRF_EXPORT);
+
+		if (!CHECK_FLAG(from_bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_CLI_SET)) {
+			memset(&from_bgp->vpn_policy[afi].tovpn_rd, 0, sizeof(struct prefix_rd));
+			UNSET_FLAG(from_bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_SET);
+		}
+
 		from_bgp->vpn_policy[afi].tovpn_label = MPLS_LABEL_NONE;
 
 	}

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11364,11 +11364,17 @@ DEFPY (af_rt_vpn_imexport,
 						&bgp->vpn_policy[afi].rtlist[dir]);
 			bgp->vpn_policy[afi].rtlist[dir] =
 				ecommunity_dup(ecom);
+			if (dir == BGP_VPN_POLICY_DIR_TOVPN)
+				SET_FLAG(bgp->vpn_policy[afi].flags,
+					 BGP_VPN_POLICY_TOVPN_RT_CLI_SET);
 		} else {
 			if (bgp->vpn_policy[afi].rtlist[dir])
 				ecommunity_free(
 						&bgp->vpn_policy[afi].rtlist[dir]);
 			bgp->vpn_policy[afi].rtlist[dir] = NULL;
+			if (dir == BGP_VPN_POLICY_DIR_TOVPN)
+				UNSET_FLAG(bgp->vpn_policy[afi].flags,
+					   BGP_VPN_POLICY_TOVPN_RT_CLI_SET);
 		}
 
 		vpn_leak_postchange(dir, afi, bgp_get_default(), bgp);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -328,9 +328,11 @@ struct vpn_policy {
 /* Manual label is registered with zebra label manager */
 #define BGP_VPN_POLICY_TOVPN_LABEL_MANUAL_REG (1 << 5)
 #define BGP_VPN_POLICY_TOVPN_SID_EXPLICIT     (1 << 6)
-/* Is this value set by the cli? */
+/* Is this RD value set by the cli? */
 #define BGP_VPN_POLICY_TOVPN_RD_CLI_SET       (1 << 7)
 #define BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE    (1 << 8)
+/* Is this RT value set by the cli? */
+#define BGP_VPN_POLICY_TOVPN_RT_CLI_SET (1 << 9)
 
 	/*
 	 * If we are importing another vrf into us keep a list of

--- a/tests/topotests/bgp_vrf_rt_rid_change/r1/frr.conf
+++ b/tests/topotests/bgp_vrf_rt_rid_change/r1/frr.conf
@@ -1,0 +1,23 @@
+!
+router bgp 65000
+exit
+!
+router bgp 65000 vrf RED
+ bgp router-id 192.168.2.1
+ no bgp network import-check
+ address-family ipv4 unicast
+  network 198.51.100.1/32
+  rd vpn export 65000:6
+  rt vpn both 65000:100
+  export vpn
+ exit-address-family
+exit
+!
+router bgp 65000 vrf BLUE
+ bgp router-id 192.0.2.2
+ address-family ipv4 unicast
+  rt vpn import 65000:100
+  import vpn
+ exit-address-family
+exit
+!

--- a/tests/topotests/bgp_vrf_rt_rid_change/test_bgp_vrf_rt_rid_change.py
+++ b/tests/topotests/bgp_vrf_rt_rid_change/test_bgp_vrf_rt_rid_change.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""Verify that a configured VPN export RT survives a BGP router-ID change."""
+
+import os
+import sys
+from functools import partial
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import step
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+PREFIX = "198.51.100.1/32"
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router = tgen.gears["r1"]
+    router.cmd_raises("ip link add RED type vrf table 10")
+    router.cmd_raises("ip link set RED up")
+    router.cmd_raises("ip link add BLUE type vrf table 20")
+    router.cmd_raises("ip link set BLUE up")
+    router.load_frr_config()
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    get_topogen().stop_topology()
+
+
+def _check_blue_route(router):
+    expected = {"routes": {PREFIX: [{"nhVrfName": "RED"}]}}
+    return topotest.router_json_cmp(
+        router, "show bgp vrf BLUE ipv4 unicast json", expected
+    )
+
+
+def test_export_rt_survives_router_id_change():
+    """Changing the router ID must not derive the export RT from the RD."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    step("Verify BLUE imports RED's route using RT 65000:100")
+    test_func = partial(_check_blue_route, router)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert success, f"Route was not imported before the router-ID change: {result}"
+
+    step("Change RED's explicitly configured BGP router ID")
+    router.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 65000 vrf RED
+          bgp router-id 192.168.2.10
+        """
+    )
+
+    step("Verify the configured export RT and imported route are preserved")
+    running_config = router.vtysh_cmd("show running-config")
+    assert "  rt vpn both 65000:100\n" in running_config, running_config
+
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert success, f"Route disappeared after the router-ID change: {result}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-s"] + sys.argv[1:]))


### PR DESCRIPTION
`rt vpn both` is stored internally as separate import and export RT lists. On router-id updates, bgpd re-derives the VPN RD/RT and overwrites the export RT with an RT derived from the current export RD.

This broke configurations such as:
```
 rd vpn export 65000:6
 rt vpn both 65000:100
```
After a router-id update, the import RT stayed `65000:100`, but the export RT was replaced with `65000:6`. The running config then appeared as split import/export RTs and VPN import matching no longer worked as configured.

Add a "CLI set" flag for the VPN export RT, set/clear it from the RT CLI, and skip automatic export RT derivation when the export RT was explicitly configured. Also do the same thing to the VRF-to-VRF auto RT setup and last-unimport cleanup, so explicit (cli-set) RT/RD values survive removing and re-adding `import vrf`.

Note that the router-id import-vrf RT refresh still removes only the first RT value before merging the current export RT list. This behavior already existed beforehand (the old code also removed `ecom->val` only) so I left it unchanged.

Fixes: #22579