### PR TITLE
pimd: prefer kernel ingress on WRONGVIF when MFC iif is stale

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -840,6 +840,124 @@ static int pim_upstream_wrongvif_wrvifwhole_compat(struct interface *ifp, pim_sg
 	return 0;
 }
 
+/*
+ * On WRONGVIF, realign upstream RPF and MFC iif with the kernel ingress
+ * interface when it is a valid nexthop (e.g. passive GRE tunnel vs parent
+ * with duplicate addressing).  Mirrors pim_mroute_nocache_forward_existing().
+ *
+ * Returns 0 when (S,G) state was updated and MFC iif was reconciled, -1
+ * when nothing was done (no upstream, ingress not valid RPF, etc.).
+ */
+static int pim_mroute_wrongvif_prefer_ingress(struct interface *ifp, pim_sgaddr *sg)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_instance *pim = pim_ifp->pim;
+	struct pim_upstream *up;
+	struct pim_nexthop rpf_nh;
+	struct prefix grp;
+	struct pim_rpf old;
+	vifi_t ingress_vif;
+	bool force_connected_ingress = false;
+
+	up = pim_upstream_find(pim, sg);
+	if (!up)
+		return -1;
+
+	memset(&rpf_nh, 0, sizeof(rpf_nh));
+	pim_addr_to_prefix(&grp, sg->grp);
+
+	/*
+	 * Live RPF lookup with ingress preference (neighbor_needed=false so
+	 * passive receive interfaces are accepted when routing selects them).
+	 */
+	if (!pim_nht_lookup_ecmp(pim, &rpf_nh, sg->src, &grp, false, ifp)) {
+		if (PIM_DEBUG_MROUTE_DETAIL)
+			zlog_debug("%s: %pSG WRONGVIF on %s, no RPF route to source", __func__, sg,
+				   ifp->name);
+		return -1;
+	}
+
+	if (!rpf_nh.interface || rpf_nh.interface->ifindex != ifp->ifindex) {
+		/*
+		 * Overlapping connected prefixes (e.g. parent secondary vs
+		 * PIM-passive tunnel covering the same source): zebra may
+		 * still select the parent as RPF while data arrives on the
+		 * tunnel.  If the kernel ingress is itself connected to S,
+		 * force RPF/MFC iif onto that ingress so WRONGVIF can clear.
+		 */
+		if (pim_if_connected_to_source(ifp, sg->src)) {
+			force_connected_ingress = true;
+			if (PIM_DEBUG_MROUTE_DETAIL)
+				zlog_debug("%s: %pSG WRONGVIF on %s, forcing connected ingress (RPF is %s)",
+					   __func__, sg, ifp->name,
+					   rpf_nh.interface ? rpf_nh.interface->name : "(none)");
+		} else {
+			if (PIM_DEBUG_MROUTE_DETAIL)
+				zlog_debug("%s: %pSG WRONGVIF on %s, ingress is not RPF interface (RPF is %s)",
+					   __func__, sg, ifp->name,
+					   rpf_nh.interface ? rpf_nh.interface->name : "(none)");
+			return -1;
+		}
+	}
+
+	ingress_vif = pim_ifp->mroute_vif_index;
+	if (up->channel_oil->installed && up->rpf.source_nexthop.interface == ifp &&
+	    *oil_incoming_vif(up->channel_oil) == ingress_vif)
+		return -1;
+
+	if (force_connected_ingress) {
+		memset(&old, 0, sizeof(old));
+		old = up->rpf;
+		pim_upstream_fill_static_iif(up, ifp);
+		if (old.source_nexthop.interface != ifp)
+			pim_zebra_upstream_rpf_changed(pim, up, &old);
+	} else if (up->rpf.source_nexthop.interface != rpf_nh.interface ||
+		   pim_addr_cmp(up->rpf.source_nexthop.mrib_nexthop_addr,
+				rpf_nh.mrib_nexthop_addr)) {
+		enum pim_rpf_result rpf_result;
+
+		memset(&old, 0, sizeof(old));
+		rpf_result = pim_rpf_update(pim, up, &old, ifp, __func__);
+		if (rpf_result == PIM_RPF_CHANGED ||
+		    (rpf_result == PIM_RPF_FAILURE && old.source_nexthop.interface))
+			pim_zebra_upstream_rpf_changed(pim, up, &old);
+	}
+
+	pim_upstream_inherited_olist_decide(pim, up);
+	if (pim_upstream_empty_inherited_olist(up)) {
+		if (PIM_DEBUG_MROUTE_DETAIL)
+			zlog_debug("%s: %pSG WRONGVIF on %s, no local receivers", __func__, sg,
+				   ifp->name);
+		/*
+		 * Handled: do not fall through to WRVIFWHOLE compat, which can
+		 * install/update MFC without this empty-OIL guard.
+		 */
+		return 0;
+	}
+
+	if (up->sptbit != PIM_UPSTREAM_SPTBIT_TRUE)
+		pim_upstream_set_sptbit(up, ifp);
+
+	PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
+	up->channel_oil->cc.pktcnt++;
+
+	pim_upstream_update_join_desired(pim, up);
+
+	if (pim_upstream_kat_start_ok(up))
+		pim_upstream_keep_alive_timer_start(up, pim->keep_alive_time);
+
+	if (!up->channel_oil->installed)
+		pim_upstream_mroute_add(up->channel_oil, __func__);
+	else
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+
+	if (PIM_DEBUG_MROUTE)
+		zlog_debug("%s: %pSG WRONGVIF on %s, realigned MFC iif to ingress%s", __func__, sg,
+			   ifp->name, force_connected_ingress ? " (connected)" : "");
+
+	return 0;
+}
+
 int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 {
 	struct pim_ifchannel *ch, *throwaway;
@@ -904,17 +1022,25 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 				   __func__, &star_g, ifp->name);
 	}
 
-	if (!mroute_wrvifwhole_supported) {
+	if (!sg_channel && !pim_iface_grp_dm(pim_ifp, sg.grp) && ifp != pim_ifp->pim->regiface) {
 		/*
-		 * Old kernels without WRVIFWHOLE: WRONGVIF may be the only
-		 * upcall.  Mirror pim_mroute_msg_wrvifwhole() when there is no
-		 * (S,G) ifchannel on ingress -- FHR on the source-connected
-		 * interface (join-before-data, bidirectional) and LHR / SPT
-		 * switch on upstream interfaces (e.g. (S,G) MFC reinstall after
-		 * pimd restart).
+		 * Prefer kernel ingress only when there is no ifchannel on
+		 * ingress (neither (S,G) nor (*,G)).  A (*,G)-only channel
+		 * must fall through to the Assert state machine below.
 		 */
-		if (!sg_channel && !pim_iface_grp_dm(pim_ifp, sg.grp) &&
-		    ifp != pim_ifp->pim->regiface) {
+		if (!any_channel && pim_mroute_wrongvif_prefer_ingress(ifp, &sg) == 0)
+			return 0;
+
+		if (!mroute_wrvifwhole_supported) {
+			/*
+			 * Old kernels without WRVIFWHOLE: WRONGVIF may be the
+			 * only upcall.  Mirror pim_mroute_msg_wrvifwhole()
+			 * when there is no (S,G) ifchannel on ingress -- FHR on
+			 * the source-connected interface (join-before-data,
+			 * bidirectional) and LHR / SPT switch on upstream
+			 * interfaces (e.g. (S,G) MFC reinstall after pimd
+			 * restart).
+			 */
 			/*
 			 * FHR activation requires DR: only the DR originates
 			 * register state on a shared LAN.

--- a/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
+++ b/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
@@ -9,7 +9,7 @@
 #
 
 """
-Topotests for pimd NOCACHE handling:
+Topotests for pimd NOCACHE / WRONGVIF ingress handling:
 
 1. Non-connected source on LHR: (S,G) must forward when iif == RPF_interface(S)
    and local receivers exist (RFC 4601 section 4.2).  Source 10.10.4.2 is not on
@@ -29,6 +29,14 @@ Topotests for pimd NOCACHE handling:
 4. ECMP RPF on LHR: when MRIB lists multiple valid nexthops to the source,
    NOCACHE must prefer the kernel ingress interface so (S,G) forwarding
    survives after MFC flush.
+
+5. WRONGVIF ingress prefer on FHR: parent has a broad secondary prefix that
+   also covers the tunnel source subnet (e.g. /16 on the parent while GRE
+   tunnels carry the same /16).  Join/FHR installs MFC iif on the parent; a
+   more-specific static via the tunnel does not change that connected RPF.
+   Data then arrives on the passive tunnel -> WRONGVIF.  pimd must realign
+   MFC iif to the kernel ingress.  NOCACHE does not apply because the MFC
+   already exists.
 """
 
 import json
@@ -66,24 +74,41 @@ TOPOLOGY = """
                            fhr-eth0
                                 |
                                fhr
-              +-----------------+-----------------+
-              |                 |                 |
-           h_src             h_local    r_passive [passive->fhr]
-         fhr-eth1           fhr-eth2           fhr-eth3
-                                                  |
+              +--------+--------+-----------------+
+              |        |        |                 |
+           h_src    h_src    h_local    r_passive [passive->fhr]
+         fhr-eth1  fhr-eth4  fhr-eth2           fhr-eth3
+         (parent)  (tunnel)                       |
                                              h_foreign
 
     RP 10.255.0.1 (rp lo)
+
+    WRONGVIF overlapping-prefix shape (test_wrongvif_prefer_kernel_ingress):
+      fhr-eth1 primary 10.10.4.1/24 + secondary 10.20.0.1/16
+      fhr-eth4          10.20.2.253/16  (PIM passive tunnel stand-in)
+      static            10.20.1.0/24 via tunnel
+      source            10.20.1.4 on h_src-eth1 (data on tunnel)
+      Connected /16 on parent makes RPF stick to fhr-eth1 while packets
+      arrive on fhr-eth4.
 """
 
 SOURCE = "10.10.4.2"
 FOREIGN_SOURCE = "10.50.1.2"
 RP_ADDR = "10.255.0.1"
 
+# WRONGVIF source covered by parent secondary /16; data arrives on tunnel.
+WRONGVIF_SOURCE = "10.20.1.4"
+WRONGVIF_SRC_PREFIX = "10.20.1.0/24"
+WRONGVIF_OVERLAP = "10.20.0.0/16"
+WRONGVIF_PARENT_SEC = "10.20.0.1/16"
+WRONGVIF_TUNNEL_ADDR = "10.20.2.253/16"
+WRONGVIF_TUNNEL_GW = "10.20.2.253"
+
 GROUP_LHR_NOCACHE = "225.1.3.1"
 GROUP_STATIC = "239.77.1.1"
 GROUP_PASSIVE_EDGE = "225.1.3.2"
 GROUP_ECMP_INGRESS = "225.1.3.3"
+GROUP_WRONGVIF_INGRESS = "225.1.3.4"
 
 L1_RECV_NH = "10.10.1.2"
 SOURCE_PREFIX = "10.10.4.0/24"
@@ -95,6 +120,7 @@ FHR_TO_RP = "fhr-eth0"
 FHR_TO_SRC = "fhr-eth1"
 FHR_TO_LOCAL = "fhr-eth2"
 FHR_TO_PASSIVE = "fhr-eth3"
+FHR_TO_TUNNEL = "fhr-eth4"
 R_PASSIVE_TO_FHR = "r_passive-eth0"
 R_PASSIVE_TO_FOREIGN = "r_passive-eth1"
 
@@ -152,6 +178,8 @@ def build_topo(tgen):
         "h_foreign-eth0",
         R_PASSIVE_TO_FOREIGN,
     )
+    # Second path from source host to FHR (tunnel stand-in for WRONGVIF test).
+    tgen.add_link(tgen.gears["h_src"], tgen.gears["fhr"], "h_src-eth1", FHR_TO_TUNNEL)
 
 
 def setup_module(mod):
@@ -506,6 +534,160 @@ def test_static_mroute_forward_with_traffic(request):
               no ip mroute {FHR_TO_LOCAL} {group} {SOURCE}
     """
     )
+
+    write_test_footer(tc_name)
+
+
+def test_wrongvif_prefer_kernel_ingress(request):
+    """
+    Overlapping connected prefix on parent vs PIM-passive tunnel:
+
+      - Parent (fhr-eth1) has primary LAN plus secondary overlapping /16
+      - Tunnel stand-in (fhr-eth4) is PIM passive on the same /16
+      - More-specific static points the source prefix at the tunnel
+      - Connected /16 on parent still makes join/FHR RPF stick to parent
+
+    Traffic arrives on the tunnel while MFC iif is parent -> WRONGVIF.
+    pimd must realign MFC iif / upstream RPF to the kernel ingress.
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    prepare_test(tgen)
+    fhr = tgen.gears["fhr"]
+    h_src = tgen.gears["h_src"]
+    group = GROUP_WRONGVIF_INGRESS
+    source = WRONGVIF_SOURCE
+
+    step("Configure parent secondary /16 overlapping tunnel source space")
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           interface {FHR_TO_SRC}
+              ip address {WRONGVIF_PARENT_SEC}
+    """
+    )
+
+    step("Readdress source host on parent path to overlapping-prefix source")
+    # SO_BINDTODEVICE uses the interface primary address; temporarily replace
+    # 10.10.4.2 so packets are sourced as WRONGVIF_SOURCE toward the parent.
+    h_src.run("ip addr del 10.10.4.2/24 dev h_src-eth0 || true")
+    h_src.run(f"ip addr add {source}/16 dev h_src-eth0")
+    h_src.run(f"ip route replace default via {WRONGVIF_PARENT_SEC.split('/')[0]} || true")
+
+    step("Join local receiver and start traffic on parent path {}".format(FHR_TO_SRC))
+    assert app_helper.run_join("h_local", group, join_intf="h_local-eth0") is True
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth0") is True
+
+    step("Verify baseline (S,G) MFC iif is parent via overlapping secondary")
+    result = verify_mroutes(tgen, "fhr", source, group, FHR_TO_SRC, FHR_TO_LOCAL)
+    assert result is True, "{}: baseline parent iif failed: {}".format(tc_name, result)
+
+    result = verify_upstream_json(
+        tgen,
+        "fhr",
+        source,
+        group,
+        {
+            "inboundInterface": FHR_TO_SRC,
+            "firstHopRouter": True,
+        },
+    )
+    assert result is True, "{}: baseline upstream on parent failed: {}".format(
+        tc_name, result
+    )
+
+    step("Bring up PIM-passive tunnel stand-in and more-specific static via tunnel")
+    # Install after baseline so join/FHR RPF is already stuck on the parent.
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           interface {FHR_TO_TUNNEL}
+              ip address {WRONGVIF_TUNNEL_ADDR}
+              ip pim
+              ip pim passive
+           ip route {WRONGVIF_SRC_PREFIX} {source} {FHR_TO_TUNNEL}
+    """
+    )
+
+    step("Confirm overlapping connected /16 is present on parent and tunnel")
+
+    def _check_overlap_routes():
+        output = fhr.vtysh_cmd(
+            "show ip route {} json".format(WRONGVIF_OVERLAP), isjson=True
+        )
+        routes = output.get(WRONGVIF_OVERLAP, [])
+        ifaces = set()
+        for route in routes:
+            for nh in route.get("nexthops", []):
+                if nh.get("directlyConnected") or route.get("protocol") == "connected":
+                    ifaces.add(nh.get("interfaceName"))
+        return FHR_TO_SRC in ifaces and FHR_TO_TUNNEL in ifaces
+
+    _, ok = topotest.run_and_expect(_check_overlap_routes, True, count=30, wait=1)
+    assert ok is True, "{}: overlapping /16 not on parent+tunnel".format(tc_name)
+
+    step("Confirm MFC iif remains stuck on parent after tunnel/static install")
+    result = verify_mroutes(tgen, "fhr", source, group, FHR_TO_SRC, FHR_TO_LOCAL)
+    assert result is True, "{}: parent iif not sticky after tunnel: {}".format(
+        tc_name, result
+    )
+
+    step("Move source traffic to tunnel stand-in {}".format(FHR_TO_TUNNEL))
+    h_src.run(f"ip addr add {source}/16 dev h_src-eth1 || true")
+    h_src.run("ip link set h_src-eth1 up")
+    h_src.run(f"ip route replace {WRONGVIF_TUNNEL_GW}/32 dev h_src-eth1 || true")
+    app_helper.stop_traffic_senders()
+    assert app_helper.run_traffic("h_src", group, bind_intf="h_src-eth1") is True
+
+    step("Verify WRONGVIF realigned MFC iif to tunnel stand-in")
+    result = verify_mroutes(tgen, "fhr", source, group, FHR_TO_TUNNEL, FHR_TO_LOCAL)
+    assert result is True, "{}: tunnel iif not installed after WRONGVIF: {}".format(
+        tc_name, result
+    )
+
+    result = verify_upstream_json(
+        tgen,
+        "fhr",
+        source,
+        group,
+        {
+            "inboundInterface": FHR_TO_TUNNEL,
+            "firstHopRouter": True,
+        },
+    )
+    assert result is True, "{}: upstream not realigned to tunnel: {}".format(
+        tc_name, result
+    )
+
+    step("Verify local receiver still gets traffic after WRONGVIF realignment")
+    ok, report = verify_receiver_traffic("h_local", group, "h_local-eth0", source)
+    assert ok is True, "{}: no traffic after WRONGVIF realignment: {}".format(
+        tc_name, json.dumps(report)
+    )
+
+    step("Remove overlapping secondary / tunnel configuration")
+    fhr.vtysh_cmd(
+        f"""
+        conf t
+           no ip route {WRONGVIF_SRC_PREFIX} {source} {FHR_TO_TUNNEL}
+           interface {FHR_TO_TUNNEL}
+              no ip pim
+              no ip address {WRONGVIF_TUNNEL_ADDR}
+           interface {FHR_TO_SRC}
+              no ip address {WRONGVIF_PARENT_SEC}
+    """
+    )
+    h_src.run(f"ip route del {WRONGVIF_TUNNEL_GW}/32 || true")
+    h_src.run(f"ip addr del {source}/16 dev h_src-eth1 || true")
+    h_src.run(f"ip addr del {source}/16 dev h_src-eth0 || true")
+    h_src.run("ip addr add 10.10.4.2/24 dev h_src-eth0 || true")
+    h_src.run("ip route replace default via 10.10.4.1 || true")
 
     write_test_footer(tc_name)
 


### PR DESCRIPTION
When interfaces with duplicate addresses cause join-time RPF to pick the wrong interface, the kernel keeps delivering WRONGVIF after the MFC is installed. Extend the existing NOCACHE ingress-prefer logic to the WRONGVIF handler so upstream RPF and MFC iif realign with the interface the packet actually arrived on.