### PR TITLE
lib: Print multicast-source-interface rmap match

### DIFF
--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -340,6 +340,8 @@ DECLARE_QOBJ_TYPE(route_map);
 	(strmatch(C, "frr-pim-route-map:ipv6-multicast-group-prefix-list"))
 #define IS_MATCH_MULTICAST_INTERFACE(C) \
 	(strmatch(C, "frr-pim-route-map:multicast-interface"))
+#define IS_MATCH_MULTICAST_SOURCE_INTERFACE(C) \
+	(strmatch(C, "frr-pim-route-map:multicast-source-interface"))
 
 /* Route-map set actions */
 #define IS_SET_IPv4_NH(A)                                                      \

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -912,6 +912,11 @@ void route_map_condition_show(struct vty *vty, const struct lyd_node *dnode,
 			yang_dnode_get_string(
 				dnode,
 				"./rmap-match-condition/frr-pim-route-map:multicast-interface"));
+	} else if (IS_MATCH_MULTICAST_SOURCE_INTERFACE(condition)) {
+		vty_out(vty, " match multicast-source-interface %s\n",
+			yang_dnode_get_string(
+				dnode,
+				"./rmap-match-condition/frr-pim-route-map:multicast-source-interface"));
 	}
 }
 


### PR DESCRIPTION
Fix missing `cli_show` portion for `rmap-match-condition/frr-pim-route-map:multicast-source-interface`