### PR TITLE
yang: metric-type identity declared but never used in an augment in f…

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -2332,13 +2332,12 @@ DEFUN_YANG (ospf6_routemap_set_metric_type, ospf6_routemap_set_metric_type_cmd,
 {
 	char *ext = argv[2]->text;
 
-	const char *xpath =
-		"./set-action[action='frr-ospf-route-map:metric-type']";
+	const char *xpath = "./set-action[action='frr-ospf6-route-map:metric-type']";
 	char xpath_value[XPATH_MAXLEN];
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 	snprintf(xpath_value, sizeof(xpath_value),
-		 "%s/rmap-set-action/frr-ospf-route-map:metric-type", xpath);
+		 "%s/rmap-set-action/frr-ospf6-route-map:metric-type", xpath);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, ext);
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -2352,8 +2351,7 @@ DEFUN_YANG (ospf6_routemap_no_set_metric_type, ospf6_routemap_no_set_metric_type
       "OSPF[6] external type 1 metric\n"
       "OSPF[6] external type 2 metric\n")
 {
-	const char *xpath =
-		"./set-action[action='frr-ospf-route-map:metric-type']";
+	const char *xpath = "./set-action[action='frr-ospf6-route-map:metric-type']";
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 	return nb_cli_apply_changes(vty, NULL);

--- a/ospf6d/ospf6_routemap_nb.c
+++ b/ospf6d/ospf6_routemap_nb.c
@@ -38,6 +38,13 @@ const struct frr_yang_module_info frr_ospf6_route_map_info = {
 			}
 		},
 		{
+			.xpath = "/frr-route-map:lib/route-map/entry/set-action/rmap-set-action/frr-ospf6-route-map:metric-type",
+			.cbs = {
+				.modify = lib_route_map_entry_set_action_rmap_set_action_metric_type_modify,
+				.destroy = lib_route_map_entry_set_action_rmap_set_action_metric_type_destroy,
+			}
+		},
+		{
 			.xpath = NULL,
 		},
 	}

--- a/yang/frr-ospf6-route-map.yang
+++ b/yang/frr-ospf6-route-map.yang
@@ -19,6 +19,14 @@ module frr-ospf6-route-map {
   description
     "This module defines ospf6 route map settings";
 
+  revision 2026-07-09 {
+    description
+      "Add metric-type set-action case";
+
+    reference
+      "FRRouting";
+  }
+
   revision 2020-01-02 {
     description
       "Initial revision";
@@ -49,6 +57,26 @@ module frr-ospf6-route-map {
         type inet:ipv6-address;
         description
           "IPv6 address used for forwarding actions";
+      }
+    }
+
+    case metric-type {
+      when "derived-from-or-self(../frr-route-map:action, 'metric-type')";
+      leaf metric-type {
+        type enumeration {
+          enum "type-1" {
+            value 0;
+            description
+              "OSPF6 external type 1 metric";
+          }
+          enum "type-2" {
+            value 1;
+            description
+              "OSPF6 external type 2 metric";
+          }
+        }
+        description
+          "Specifies the metric type for the route map entry";
       }
     }
   }


### PR DESCRIPTION
metric-type identity declared but never used in an augment
Added a case metric-type augment, similar to frr-ospf-route-map.yang

identity metric-type {
  base frr-route-map:rmap-set-type;
  description
    "Set the type of metric";
}

...
...