### PR TITLE
bfdd: use real address length when connecting to data plane

### DIFF
--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -987,7 +987,7 @@ static void bfd_dplane_client_init(const struct sockaddr *sa, socklen_t salen)
 	bdc = bfd_dplane_ctx_new(-1);
 	if (salen <= sizeof(bdc->addr)) {
 		memcpy(&bdc->addr, sa, salen);
-		bdc->addrlen = sizeof(bdc->addr);
+		bdc->addrlen = salen;
 	} else {
 		memcpy(&bdc->addr, sa, sizeof(bdc->addr));
 		bdc->addrlen = sizeof(bdc->addr);


### PR DESCRIPTION
bfd_dplane_client_init() stores sizeof(the address union) as the sockaddr length instead of the caller's salen. The union is padded to 112 bytes by sockaddr_in6 alignment, which exceeds sizeof(struct sockaddr_un) (110), so connect(2) for AF_UNIX rejects it with EINVAL and --dplaneaddr unixc: client mode never connects. Store the real address length instead.

Fixes: #22608