### PR TITLE
pimd: do not proxy IGMP leave while other downstream receivers remain

### DIFF
--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -16,6 +16,9 @@
 #include "pim_nht.h"
 #include "pim_dm.h"
 #include "pim_routemap.h"
+#if PIM_IPV == 6
+#include "pim6_mld.h"
+#endif
 
 static struct channel_oil *
 tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
@@ -79,6 +82,187 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	return pim_channel_oil_add(pim, &sg, __func__);
 }
 
+/*
+ * True when some interface other than leave_oif still has downstream interest
+ * in sg that would be accepted by proxy_ifp's proxy route-map.  Used so a leave
+ * on one downstream interface does not proxy-prune upstream while other
+ * unfiltered downstream interfaces still have receivers for the same group.
+ *
+ * Remaining (*,G) interest covers a specific (S,G) leave: IGMPv2 / EXCLUDE
+ * and group-only static/manual joins keep upstream flow for every source in G.
+ *
+ * Downstream interest that fails the proxy route-map (e.g. match
+ * multicast-source-interface) must not keep the upstream proxy join: that
+ * interface could not have created the join and must not block its prune.
+ */
+static bool tib_sg_interest_covers(pim_addr interest_src, pim_addr leave_src)
+{
+	if (!pim_addr_cmp(interest_src, leave_src))
+		return true;
+
+	/* Wildcard (*,G) covers any specific source leave. */
+	return pim_addr_is_any(interest_src);
+}
+
+static bool tib_sg_ifp_has_downstream_interest(struct interface *ifp, pim_sgaddr sg)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct listnode *node;
+
+	if (!pim_ifp)
+		return false;
+
+	/* Proxy interfaces are upstream outputs, not downstream sources. */
+	if (pim_ifp->gm_proxy)
+		return false;
+
+#if PIM_IPV == 4
+	if (pim_ifp->gm_group_list) {
+		struct gm_group *group;
+
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, node, group)) {
+			struct listnode *srcnode;
+			struct gm_source *src;
+
+			if (pim_addr_cmp(group->group_addr, sg.grp))
+				continue;
+
+			/*
+			 * IGMPv2 / IGMPv3 EXCLUDE {empty} is (*,G) interest.
+			 * Steady-state usually has a forwarding * source from
+			 * igmp_anysource_forward_start(), but that can fail or
+			 * briefly be absent — still treat the group as joined.
+			 */
+			if (group->group_filtermode_isexcl &&
+			    listcount(group->group_source_list) < 1)
+				return true;
+
+			for (ALL_LIST_ELEMENTS_RO(group->group_source_list, srcnode, src)) {
+				if (!tib_sg_interest_covers(src->source_addr, sg.src))
+					continue;
+				if (IGMP_SOURCE_TEST_FORWARDING(src->source_flags))
+					return true;
+			}
+		}
+	}
+#else
+	if (pim_ifp->mld) {
+		struct gm_sg *mlsg, ref = {};
+
+		ref.sgaddr = sg;
+		mlsg = gm_sgs_find(pim_ifp->mld->sgs, &ref);
+		if (mlsg && mlsg->tib_joined)
+			return true;
+
+		/* (*,G) covers a specific (S,G) leave. */
+		if (!pim_addr_is_any(sg.src)) {
+			ref.sgaddr.src = PIMADDR_ANY;
+			mlsg = gm_sgs_find(pim_ifp->mld->sgs, &ref);
+			if (mlsg && mlsg->tib_joined)
+				return true;
+		}
+	}
+#endif
+
+	if (pim_ifp->static_group_list) {
+		struct static_group *stgrp;
+
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->static_group_list, node, stgrp)) {
+			if (!pim_addr_cmp(stgrp->group_addr, sg.grp) &&
+			    tib_sg_interest_covers(stgrp->source_addr, sg.src))
+				return true;
+		}
+	}
+
+	if (pim_ifp->gm_join_list) {
+		struct gm_join *ij;
+
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_join_list, node, ij)) {
+			if (ij->join_type == GM_JOIN_PROXY)
+				continue;
+			if (!pim_addr_cmp(ij->group_addr, sg.grp) &&
+			    tib_sg_interest_covers(ij->source_addr, sg.src))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+static bool tib_sg_downstream_receivers_remain(struct pim_instance *pim, pim_sgaddr sg,
+					       struct interface *leave_oif,
+					       struct interface *proxy_ifp)
+{
+	struct pim_interface *pim_proxy = proxy_ifp->info;
+	struct prefix_sg pfx;
+	struct interface *ifp;
+
+	if (!pim_proxy)
+		return false;
+
+	pim_sg_to_prefix(&sg, &pfx);
+
+	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		if (ifp == leave_oif || ifp == proxy_ifp)
+			continue;
+		if (!tib_sg_ifp_has_downstream_interest(ifp, sg))
+			continue;
+		/* Same filter path used when creating the proxy join. */
+		if (!pim_filter_match(&pim_proxy->gm_proxy_filter, &pfx, proxy_ifp, ifp))
+			continue;
+		return true;
+	}
+
+	return false;
+}
+
+/*
+ * After the last (*,G) proxy interest is pruned, drop any specific (S,G)
+ * proxy joins for the same group that were only kept alive earlier because
+ * tib_sg_interest_covers() treated remaining (*,G) as covering that (S,G).
+ *
+ * That mix is an ASM static-group edge case: join-group will not install
+ * proxied (S,G) in ASM, but static-group can, alongside (*,G) interest.
+ * Without this cleanup those (S,G) entries stay in gm_join_list until the
+ * proxy interface is cycled.
+ */
+static void tib_sg_proxy_prune_uncovered_sources(struct pim_instance *pim, pim_addr group,
+						 struct interface *leave_oif,
+						 struct interface *proxy_ifp)
+{
+	struct pim_interface *pim_ifp = proxy_ifp->info;
+	struct listnode *node, *nextnode;
+	struct gm_join *ij;
+
+	if (!pim_ifp || !pim_ifp->gm_join_list)
+		return;
+
+	for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node, nextnode, ij)) {
+		pim_sgaddr check;
+
+		if (ij->join_type != GM_JOIN_PROXY && ij->join_type != GM_JOIN_BOTH)
+			continue;
+		if (pim_addr_cmp(ij->group_addr, group))
+			continue;
+		/* Exact (*,G) was already handled by the caller. */
+		if (pim_addr_is_any(ij->source_addr))
+			continue;
+
+		memset(&check, 0, sizeof(check));
+		check.src = ij->source_addr;
+		check.grp = group;
+
+		if (tib_sg_downstream_receivers_remain(pim, check, leave_oif, proxy_ifp))
+			continue;
+
+		if (PIM_DEBUG_GM_TRACE)
+			zlog_debug("%s: prune uncovered proxy %pSG on %s after (*,G) leave on %s",
+				   __func__, &check, proxy_ifp->name, leave_oif->name);
+
+		pim_if_gm_join_del(proxy_ifp, group, ij->source_addr, GM_JOIN_PROXY);
+	}
+}
+
 void tib_sg_proxy_join_prune_check(struct pim_instance *pim, pim_sgaddr sg,
 				   struct interface *oif, bool join)
 {
@@ -97,23 +281,38 @@ void tib_sg_proxy_join_prune_check(struct pim_instance *pim, pim_sgaddr sg,
 			struct prefix_sg pfx;
 
 			pim_sg_to_prefix(&sg, &pfx);
-			/* Apply the proxy route-map only to joins.  Prunes must always run
-			 * so tightening the filter without cycling the proxy cannot strand
-			 * proxy (*,G)/(S,G) state after the last host leaves.
+			/*
+			 * Apply the proxy route-map only to joins.  Prunes must
+			 * always run so tightening the filter without cycling
+			 * the proxy cannot strand proxy (*,G)/(S,G) state after
+			 * the last host leaves.
+			 *
+			 * On leave, only skip the prune when another downstream
+			 * interface still has interest that this proxy iface's
+			 * route-map would accept.
 			 */
-			if (join && !pim_filter_match(&pim_ifp->gm_proxy_filter, &pfx, ifp, oif)) {
+			if (join) {
+				if (!pim_filter_match(&pim_ifp->gm_proxy_filter, &pfx, ifp, oif)) {
+					if (PIM_DEBUG_GM_TRACE)
+						zlog_debug("%s: proxy join for SG%pPSG from %s to %s filtered due to route-map",
+							   __func__, &pfx, oif->name, ifp->name);
+					continue;
+				}
+				pim_if_gm_join_add(ifp, sg.grp, sg.src, GM_JOIN_PROXY);
+			} else if (tib_sg_downstream_receivers_remain(pim, sg, oif, ifp)) {
 				if (PIM_DEBUG_GM_TRACE)
-					zlog_debug("%s: proxy join for SG%pPSG from %s to %s filtered due to route-map",
-						   __func__, &pfx, oif->name, ifp->name);
-				continue;
+					zlog_debug("%s: skip proxy prune for %pSG after leave on %s; other unfiltered receivers remain for %s",
+						   __func__, &sg, oif->name, ifp->name);
+			} else {
+				pim_if_gm_join_del(ifp, sg.grp, sg.src, GM_JOIN_PROXY);
+				/*
+				 * (*,G) coverage can have deferred (S,G) proxy
+				 * prunes; re-evaluate those when (*,G) itself
+				 * finally leaves.
+				 */
+				if (pim_addr_is_any(sg.src))
+					tib_sg_proxy_prune_uncovered_sources(pim, sg.grp, oif, ifp);
 			}
-
-			if (join)
-				pim_if_gm_join_add(ifp, sg.grp, sg.src,
-						   GM_JOIN_PROXY);
-			else
-				pim_if_gm_join_del(ifp, sg.grp, sg.src,
-						   GM_JOIN_PROXY);
 		}
 	} /* scan interfaces */
 }

--- a/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
+++ b/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
@@ -19,6 +19,12 @@ Following tests are covered to test pim igmp proxy:
         proxy join removal
 6. TC:6 Verify that 'ip igmp proxy route-map' filters proxied groups
 7. TC:7 Verify 'match multicast-source-interface' filters by source iface
+8. TC:8 Verify leave on one downstream interface does not prune proxy
+        while another downstream interface still has receivers for the
+        same group
+9. TC:9 Verify filtered downstream interest does not block proxy prune
+10. TC:10 Verify (S,G) static-group covered by (*,G) is pruned when that
+        (*,G) later leaves
 """
 
 import os
@@ -410,9 +416,9 @@ int r2-eth0
     _, result = topotest.run_and_expect(
         step5_join_seen_proxy_omits_denied, True, count=30, wait=1
     )
-    assert result is True, (
-        "Timed out waiting for r2 IGMP join while r1 proxy omits denied groups"
-    )
+    assert (
+        result is True
+    ), "Timed out waiting for r2 IGMP join while r1 proxy omits denied groups"
 
     # Step 6: remove the route-map and cycle proxy — all groups should return
     r2.vtysh_cmd(
@@ -573,6 +579,209 @@ conf
 no route-map PROXY_SRC_IFC
 """
     )
+
+
+def test_pim_igmp_proxy_multi_downstream_leave():
+    """
+    TC:8 - Leave on one downstream must not proxy-prune while another still wants G.
+
+    Topology reminder:
+      r1-eth0 <-> r2   (downstream)
+      r1-eth1 <-> rp   (upstream / igmp proxy)
+      r1-eth2 <-> r3   (downstream)
+
+    Join the same group on both downstream interfaces, leave on eth0 only, and
+    confirm the upstream proxy join remains until the last downstream receiver
+    leaves.
+    """
+    logger.info("Verify multi-downstream leave does not prune remaining proxy join")
+    tgen = get_topogen()
+
+    r1 = tgen.gears["r1"]
+    group = "239.0.0.1"
+
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth0
+  ip igmp join {group}
+ interface r1-eth2
+  ip igmp join {group}
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [group], [])
+    assert result is True, "Error: {}".format(result)
+
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth0
+  no ip igmp join {group}
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [group], [])
+    assert result is True, "Error: proxy pruned while r1-eth2 still joined: {}".format(
+        result
+    )
+
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth2
+  no ip igmp join {group}
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [], [group])
+    assert (
+        result is True
+    ), "Error: proxy join remained after last downstream leave: {}".format(result)
+
+
+def test_pim_igmp_proxy_filtered_downstream_leave():
+    """
+    TC:9 - Filtered downstream interest must not keep the upstream proxy join.
+
+    Join the same group on eth0 (permitted) and eth2 (denied by source-interface
+    route-map).  Leaving eth0 must proxy-prune even though eth2 still has a join.
+    """
+    logger.info("Verify filtered downstream does not block proxy prune on leave")
+    tgen = get_topogen()
+
+    r1 = tgen.gears["r1"]
+    group = "239.0.0.2"
+
+    r1.vtysh_cmd(
+        f"""
+conf
+route-map PROXY_LEAVE_FILTER permit 10
+ match multicast-source-interface r1-eth0
+!
+interface r1-eth0
+ ip igmp join {group}
+interface r1-eth2
+ ip igmp join {group}
+interface r1-eth1
+ ip igmp proxy route-map PROXY_LEAVE_FILTER
+ no ip igmp proxy
+ ip igmp proxy
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [group], [])
+    assert result is True, "Error: {}".format(result)
+
+    # Leave the only unfiltered downstream; eth2 still joined but denied by rmap.
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth0
+  no ip igmp join {group}
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [], [group])
+    assert result is True, (
+        "Error: proxy join remained after last unfiltered downstream leave "
+        "(filtered eth2 still joined): {}".format(result)
+    )
+
+    # cleanup
+    r1.vtysh_cmd(
+        f"""
+conf
+interface r1-eth2
+ no ip igmp join {group}
+interface r1-eth1
+ no ip igmp proxy route-map
+no route-map PROXY_LEAVE_FILTER
+"""
+    )
+
+
+def test_pim_igmp_proxy_starg_covers_sg_leave():
+    """
+    TC:10 - (S,G) kept by covering (*,G) must prune when that (*,G) later leaves.
+
+    This is an ASM static-group edge case: join-group cannot install proxied
+    (S,G) in ASM (igmp_source_forward_start refuses ASM+source), and SSM
+    cannot hold covering (*,G).  static-group is the way to create (S,G) on
+    an ASM group that also has (*,G) interest.
+
+    Sequence:
+      1. eth0 static-group (S,G) -> proxy adds (S,G)
+      2. eth2 static-group (*,G) -> proxy adds (*,G)
+      3. eth0 removes (S,G) -> skip (S,G) prune because eth2 (*,G) covers it
+      4. eth2 removes (*,G) -> prune (*,G) and also the uncovered (S,G)
+    """
+    logger.info("Verify (S,G) proxy covered by (*,G) is not stranded on (*,G) leave")
+    tgen = get_topogen()
+
+    r1 = tgen.gears["r1"]
+    group = "239.0.0.3"
+    source = "10.1.1.10"
+
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth0
+  ip igmp static-group {group} {source}
+ interface r1-eth2
+  ip igmp static-group {group}
+"""
+    )
+
+    expected_both = {
+        "r1-eth1": {
+            "groups": [
+                {
+                    "source": source,
+                    "group": group,
+                },
+                {
+                    "source": "*",
+                    "group": group,
+                },
+            ],
+        },
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip igmp proxy json", expected_both
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "expected both (S,G) and (*,G) proxy joins: {}".format(
+        r1.vtysh_cmd("show ip igmp proxy json")
+    )
+
+    # Remove (S,G); (*,G) on eth2 must keep coverage (and may keep (S,G) proxy).
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth0
+  no ip igmp static-group {group} {source}
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [group], [])
+    assert result is True, "Error: proxy pruned while eth2 still has (*,G): {}".format(
+        result
+    )
+
+    # Remove covering (*,G); uncovered (S,G) proxy must go with it.
+    r1.vtysh_cmd(
+        f"""
+conf
+ interface r1-eth2
+  no ip igmp static-group {group}
+"""
+    )
+
+    result = verify_local_igmp_proxy_groups(tgen, "r1", [], [group])
+    assert (
+        result is True
+    ), "Error: (S,G) proxy join stranded after covering (*,G) leave: {}".format(result)
 
 
 def test_memory_leak():


### PR DESCRIPTION

- If we have multiple downstream receivers all join a multicast group, and
- the igmp joins form those receivers are proxied to an upstream interface

We must not proxy igmp leave from any downstream receivers unless that receiver happens to be THE last one. Otherwise we end up pruning the multicast flow prematurely.
   