### PR TITLE
pimd: improve IGMP interface and proxy show output

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -247,6 +247,91 @@ static void pim_show_assert_winner_metric(struct pim_instance *pim,
 	}
 }
 
+static unsigned int igmp_join_type_count(struct pim_interface *pim_ifp, enum gm_join_type join_type)
+{
+	struct listnode *node;
+	struct gm_join *ij;
+	unsigned int count = 0;
+
+	if (!pim_ifp->gm_join_list)
+		return 0;
+
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_join_list, node, ij)) {
+		if (ij->join_type == join_type || ij->join_type == GM_JOIN_BOTH)
+			count++;
+	}
+
+	return count;
+}
+
+/* IGMP interface operational state for show ip igmp interface [detail]. */
+static void igmp_show_ifp_state_json(json_object *json_row, struct pim_interface *pim_ifp)
+{
+	json_object_boolean_add(json_row, "igmpEnabled", pim_ifp->gm_enable);
+	json_object_boolean_add(json_row, "proxy", pim_ifp->gm_proxy);
+	json_object_boolean_add(json_row, "immediateLeave", pim_ifp->gmp_immediate_leave);
+	json_object_boolean_add(json_row, "requireRouterAlert", pim_ifp->gmp_require_ra);
+
+	if (pim_ifp->gm_proxy_filter.rmapname)
+		json_object_string_add(json_row, "proxyRouteMap",
+				       pim_ifp->gm_proxy_filter.rmapname);
+	if (pim_ifp->gmp_filter.rmapname)
+		json_object_string_add(json_row, "routeMap", pim_ifp->gmp_filter.rmapname);
+	if (pim_ifp->gmp_filter.alistname)
+		json_object_string_add(json_row, "accessList", pim_ifp->gmp_filter.alistname);
+
+	if (pim_ifp->gm_source_limit != UINT32_MAX)
+		json_object_int_add(json_row, "maxSources", pim_ifp->gm_source_limit);
+
+	if (pim_ifp->gm_group_limit != UINT32_MAX)
+		json_object_int_add(json_row, "maxGroups", pim_ifp->gm_group_limit);
+
+	json_object_int_add(json_row, "joinEntryCount",
+			    pim_ifp->gm_join_list ? listcount(pim_ifp->gm_join_list) : 0);
+	json_object_int_add(json_row, "joinGroupCount",
+			    igmp_join_type_count(pim_ifp, GM_JOIN_STATIC));
+	json_object_int_add(json_row, "proxyJoinCount",
+			    igmp_join_type_count(pim_ifp, GM_JOIN_PROXY));
+	json_object_int_add(json_row, "staticGroupCount",
+			    pim_ifp->static_group_list ? listcount(pim_ifp->static_group_list) : 0);
+	json_object_int_add(json_row, "groupCount",
+			    pim_ifp->gm_group_list ? listcount(pim_ifp->gm_group_list) : 0);
+}
+
+static void igmp_show_ifp_state(struct vty *vty, struct pim_interface *pim_ifp)
+{
+	vty_out(vty, "IGMP State\n");
+	vty_out(vty, "----------\n");
+	vty_out(vty, "Enabled              : %s\n", pim_ifp->gm_enable ? "yes" : "no");
+	vty_out(vty, "Proxy                : %s\n", pim_ifp->gm_proxy ? "yes" : "no");
+	vty_out(vty, "Proxy route-map      : %s\n",
+		pim_ifp->gm_proxy_filter.rmapname ? pim_ifp->gm_proxy_filter.rmapname : "none");
+	vty_out(vty, "Route-map            : %s\n",
+		pim_ifp->gmp_filter.rmapname ? pim_ifp->gmp_filter.rmapname : "none");
+	vty_out(vty, "Access-list          : %s\n",
+		pim_ifp->gmp_filter.alistname ? pim_ifp->gmp_filter.alistname : "none");
+	vty_out(vty, "Immediate leave      : %s\n", pim_ifp->gmp_immediate_leave ? "yes" : "no");
+	vty_out(vty, "Require router-alert : %s\n", pim_ifp->gmp_require_ra ? "yes" : "no");
+	if (pim_ifp->gm_source_limit != UINT32_MAX)
+		vty_out(vty, "Max sources          : %u\n", pim_ifp->gm_source_limit);
+	else
+		vty_out(vty, "Max sources          : unlimited\n");
+	if (pim_ifp->gm_group_limit != UINT32_MAX)
+		vty_out(vty, "Max groups           : %u\n", pim_ifp->gm_group_limit);
+	else
+		vty_out(vty, "Max groups           : unlimited\n");
+	vty_out(vty, "Join entries         : %u\n",
+		pim_ifp->gm_join_list ? listcount(pim_ifp->gm_join_list) : 0);
+	vty_out(vty, "Join-groups          : %u\n", igmp_join_type_count(pim_ifp, GM_JOIN_STATIC));
+	vty_out(vty, "Proxy joins          : %u\n", igmp_join_type_count(pim_ifp, GM_JOIN_PROXY));
+	vty_out(vty, "Static groups        : %u\n",
+		pim_ifp->static_group_list ? listcount(pim_ifp->static_group_list) : 0);
+	vty_out(vty, "Groups               : %u\n",
+		pim_ifp->gm_group_list ? listcount(pim_ifp->gm_group_list) : 0);
+	vty_out(vty, "\n");
+	vty_out(vty, "\n");
+}
+
 static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 				 bool uj)
 {
@@ -262,7 +347,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 		json = json_object_new_object();
 	else
 		vty_out(vty,
-			"Interface         State          Address  V  Querier          QuerierIp  Query Timer    Uptime\n");
+			"Interface         State          Address  V  Querier          QuerierIp  Query Timer    Uptime   Proxy\n");
 
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		struct pim_interface *pim_ifp;
@@ -292,6 +377,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 						       uptime);
 				json_object_int_add(json_row, "version",
 						    pim_ifp->igmp_version);
+				igmp_show_ifp_state_json(json_row, pim_ifp);
 
 				if (event_is_scheduled(igmp->t_igmp_query_timer)) {
 					json_object_boolean_true_add(json_row,
@@ -312,20 +398,15 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 						json_row, "mtraceOnly");
 				}
 			} else {
-				vty_out(vty,
-					"%-16s  %5s  %15s  %d  %7s  %17pI4  %11s  %8s\n",
+				vty_out(vty, "%-16s  %5s  %15s  %d  %7s  %17pI4  %11s  %8s  %5s\n",
 					ifp->name,
-					if_is_up(ifp)
-						? (igmp->mtrace_only ? "mtrc"
-								     : "up")
-						: "down",
-					inet_ntop(AF_INET, &igmp->ifaddr, buf,
-						  sizeof(buf)),
+					if_is_up(ifp) ? (igmp->mtrace_only ? "mtrc" : "up")
+						      : "down",
+					inet_ntop(AF_INET, &igmp->ifaddr, buf, sizeof(buf)),
 					pim_ifp->igmp_version,
-					igmp->t_igmp_query_timer ? "local"
-								 : "other",
-					&igmp->querier_addr, query_hhmmss,
-					uptime);
+					igmp->t_igmp_query_timer ? "local" : "other",
+					&igmp->querier_addr, query_hhmmss, uptime,
+					pim_ifp->gm_proxy ? "yes" : "no");
 			}
 		}
 	}
@@ -461,6 +542,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				json_object_int_add(json_row,
 						    "timerStartupQueryInterval",
 						    sqi);
+				igmp_show_ifp_state_json(json_row, pim_ifp);
 
 				json_object_object_add(json, ifp->name,
 						       json_row);
@@ -538,6 +620,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				vty_out(vty, "\n");
 				vty_out(vty, "\n");
 
+				igmp_show_ifp_state(vty, pim_ifp);
 				pim_print_ifp_flags(vty, ifp);
 			}
 		}

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -56,6 +56,7 @@
 #include "pim_nb.h"
 #include "pim_addr.h"
 #include "pim_cmd_common.h"
+#include "pim_tib.h"
 
 #include "pimd/pim_cmd_clippy.c"
 
@@ -632,6 +633,31 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 		vty_out(vty, "%% No such interface\n");
 }
 
+struct igmp_proxy_ds_ctx {
+	char text[256];
+	size_t len;
+	unsigned int count;
+	json_object *json_arr;
+};
+
+static void igmp_proxy_ds_cb(struct interface *ifp, void *arg)
+{
+	struct igmp_proxy_ds_ctx *ctx = arg;
+
+	if (ctx->json_arr)
+		json_object_array_add(ctx->json_arr, json_object_new_string(ifp->name));
+
+	if (ctx->count) {
+		if (ctx->len + 1 < sizeof(ctx->text)) {
+			ctx->text[ctx->len++] = ',';
+			ctx->text[ctx->len] = '\0';
+		}
+	}
+	(void)strlcat(ctx->text, ifp->name, sizeof(ctx->text));
+	ctx->len = strlen(ctx->text);
+	ctx->count++;
+}
+
 static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 				     bool uj, enum gm_join_type join_type)
 {
@@ -641,6 +667,7 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 	json_object *json_iface = NULL;
 	json_object *json_grp = NULL;
 	json_object *json_grp_arr = NULL;
+	bool show_downstream = (join_type == GM_JOIN_PROXY);
 
 	now = pim_time_monotonic_sec();
 
@@ -648,6 +675,9 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 		json = json_object_new_object();
 		json_object_string_add(json, "vrf",
 				       vrf_id_to_name(pim->vrf->vrf_id));
+	} else if (show_downstream) {
+		vty_out(vty,
+			"Interface        Address         Source          Group           Socket Uptime   Downstream\n");
 	} else {
 		vty_out(vty,
 			"Interface        Address         Source          Group           Socket Uptime  \n");
@@ -671,12 +701,23 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 
 		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_join_list, join_node, ij)) {
 			char uptime[10];
+			struct igmp_proxy_ds_ctx ds = {};
+			pim_sgaddr sg;
 
 			if (ij->join_type != join_type &&
 			    ij->join_type != GM_JOIN_BOTH)
 				continue;
 
 			pim_time_uptime(uptime, sizeof(uptime), now - ij->sock_creation);
+
+			if (show_downstream) {
+				sg.src = ij->source_addr;
+				sg.grp = ij->group_addr;
+				if (uj)
+					ds.json_arr = json_object_new_array();
+				tib_sg_downstream_ifaces_foreach(pim, sg, ifp, NULL,
+								 igmp_proxy_ds_cb, &ds);
+			}
 
 			if (uj) {
 				json_object_object_get_ex(json, ifp->name,
@@ -705,7 +746,14 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty,
 						    ij->sock_fd);
 				json_object_string_add(json_grp, "upTime",
 						       uptime);
+				if (show_downstream)
+					json_object_object_add(json_grp, "downstreamInterfaces",
+							       ds.json_arr);
 				json_object_array_add(json_grp_arr, json_grp);
+			} else if (show_downstream) {
+				vty_out(vty, "%-16s %-15pI4s %-15pI4s %-15pI4s %6d %8s %s\n",
+					ifp->name, &pri_addr, &ij->source_addr, &ij->group_addr,
+					ij->sock_fd, uptime, ds.count ? ds.text : "-");
 			} else {
 				vty_out(vty, "%-16s %-15pI4s %-15pI4s %-15pI4s %6d %8s\n",
 					ifp->name, &pri_addr, &ij->source_addr, &ij->group_addr,

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -263,6 +263,31 @@ static void tib_sg_proxy_prune_uncovered_sources(struct pim_instance *pim, pim_a
 	}
 }
 
+void tib_sg_downstream_ifaces_foreach(struct pim_instance *pim, pim_sgaddr sg,
+				      struct interface *proxy_ifp, struct interface *skip_ifp,
+				      void (*cb)(struct interface *ifp, void *arg), void *arg)
+{
+	struct pim_interface *pim_proxy;
+	struct prefix_sg pfx;
+	struct interface *ifp;
+
+	if (!proxy_ifp || !proxy_ifp->info)
+		return;
+
+	pim_proxy = proxy_ifp->info;
+	pim_sg_to_prefix(&sg, &pfx);
+
+	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		if (ifp == skip_ifp || ifp == proxy_ifp)
+			continue;
+		if (!tib_sg_ifp_has_downstream_interest(ifp, sg))
+			continue;
+		if (!pim_filter_match(&pim_proxy->gm_proxy_filter, &pfx, proxy_ifp, ifp))
+			continue;
+		cb(ifp, arg);
+	}
+}
+
 void tib_sg_proxy_join_prune_check(struct pim_instance *pim, pim_sgaddr sg,
 				   struct interface *oif, bool join)
 {

--- a/pimd/pim_tib.h
+++ b/pimd/pim_tib.h
@@ -19,5 +19,14 @@ extern void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 extern void tib_sg_proxy_join_prune_check(struct pim_instance *pim,
 					  pim_sgaddr sg, struct interface *oif,
 					  bool join);
+/*
+ * Invoke cb for each non-proxy interface with GM interest in sg that
+ * proxy_ifp's proxy route-map would accept. skip_ifp is excluded (may be NULL).
+ */
+extern void tib_sg_downstream_ifaces_foreach(struct pim_instance *pim, pim_sgaddr sg,
+					     struct interface *proxy_ifp,
+					     struct interface *skip_ifp,
+					     void (*cb)(struct interface *ifp, void *arg),
+					     void *arg);
 
 #endif /* _FRR_PIM_GLUE_H */

--- a/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
+++ b/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
@@ -22,9 +22,9 @@ Following tests are covered to test pim igmp proxy:
 8. TC:7 Verify 'match multicast-source-interface' filters by source iface
 9. TC:8 Verify leave on one downstream interface does not prune proxy
         while another downstream interface still has receivers for the
-        same group
-9. TC:9 Verify filtered downstream interest does not block proxy prune
-10. TC:10 Verify (S,G) static-group covered by (*,G) is pruned when that
+        same group (and show ip igmp proxy lists downstream ifaces)
+10. TC:9 Verify filtered downstream interest does not block proxy prune
+11. TC:10 Verify (S,G) static-group covered by (*,G) is pruned when that
         (*,G) later leaves
 """
 
@@ -124,21 +124,25 @@ def test_pim_igmp_proxy_config():
                     "source": "*",
                     "group": "225.4.4.4",
                     "primaryAddr": "10.0.30.1",
+                    "downstreamInterfaces": ["r1-eth2"],
                 },
                 {
                     "source": "*",
                     "group": "225.3.3.3",
                     "primaryAddr": "10.0.30.1",
+                    "downstreamInterfaces": ["r1-eth2"],
                 },
                 {
                     "source": "*",
                     "group": "225.2.2.2",
                     "primaryAddr": "10.0.30.1",
+                    "downstreamInterfaces": ["r1-eth0"],
                 },
                 {
                     "source": "*",
                     "group": "225.1.1.1",
                     "primaryAddr": "10.0.30.1",
+                    "downstreamInterfaces": ["r1-eth0"],
                 },
             ],
         },
@@ -695,6 +699,26 @@ conf
     result = verify_local_igmp_proxy_groups(tgen, "r1", [group], [])
     assert result is True, "Error: {}".format(result)
 
+    def proxy_downstream_for(group_addr):
+        out = r1.vtysh_cmd("show ip igmp proxy json", isjson=True)
+        for g in out.get("r1-eth1", {}).get("groups", []):
+            if g.get("group") == group_addr:
+                return g.get("downstreamInterfaces")
+        return None
+
+    def expect_downstream(want):
+        got = proxy_downstream_for(group)
+        if got is None:
+            return "group {} not in proxy json".format(group)
+        if sorted(got) != sorted(want):
+            return "downstreamInterfaces={!r}, want {!r}".format(got, want)
+        return None
+
+    _, result = topotest.run_and_expect(
+        lambda: expect_downstream(["r1-eth0", "r1-eth2"]), None, count=30, wait=1
+    )
+    assert result is None, result
+
     r1.vtysh_cmd(
         f"""
 conf
@@ -707,6 +731,11 @@ conf
     assert result is True, "Error: proxy pruned while r1-eth2 still joined: {}".format(
         result
     )
+
+    _, result = topotest.run_and_expect(
+        lambda: expect_downstream(["r1-eth2"]), None, count=30, wait=1
+    )
+    assert result is None, result
 
     r1.vtysh_cmd(
         f"""

--- a/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
+++ b/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
@@ -12,14 +12,15 @@
 Following tests are covered to test pim igmp proxy:
 
 1. TC:1 Verify correct joins were read from the config and proxied
-2. TC:2 Verify joins from another interface are proxied
-3. TC:3 Verify correct proxy disable on 'no ip igmp proxy'
-4. TC:4 Verify that proper proxy joins are set up on run-time enable
-5. TC:5 Verify igmp drops/timeouts from another interface cause
+2. TC:1b Verify show ip igmp interface reports operational state
+3. TC:2 Verify joins from another interface are proxied
+4. TC:3 Verify correct proxy disable on 'no ip igmp proxy'
+5. TC:4 Verify that proper proxy joins are set up on run-time enable
+6. TC:5 Verify igmp drops/timeouts from another interface cause
         proxy join removal
-6. TC:6 Verify that 'ip igmp proxy route-map' filters proxied groups
-7. TC:7 Verify 'match multicast-source-interface' filters by source iface
-8. TC:8 Verify leave on one downstream interface does not prune proxy
+7. TC:6 Verify that 'ip igmp proxy route-map' filters proxied groups
+8. TC:7 Verify 'match multicast-source-interface' filters by source iface
+9. TC:8 Verify leave on one downstream interface does not prune proxy
         while another downstream interface still has receivers for the
         same group
 9. TC:9 Verify filtered downstream interest does not block proxy prune
@@ -150,6 +151,62 @@ def test_pim_igmp_proxy_config():
     assertmsg = '"{}" JSON output mismatches'.format(r1.name)
     assert result is None, assertmsg
     # tgen.mininet_cli()
+
+
+def test_pim_igmp_interface_state():
+    """
+    TC:1b - Verify show ip igmp interface JSON includes operational state.
+
+    After TC:1, r1-eth1 is the proxy upstream with four proxied groups;
+    r1-eth0/r1-eth2 are receiver-facing with static join-groups only.
+    """
+    logger.info("Verify show ip igmp interface operational state")
+    tgen = get_topogen()
+
+    r1 = tgen.gears["r1"]
+
+    expected = {
+        "r1-eth0": {
+            "igmpEnabled": True,
+            "proxy": False,
+            "immediateLeave": False,
+            "requireRouterAlert": False,
+            "joinEntryCount": 2,
+            "joinGroupCount": 2,
+            "proxyJoinCount": 0,
+        },
+        "r1-eth1": {
+            "igmpEnabled": True,
+            "proxy": True,
+            "immediateLeave": False,
+            "requireRouterAlert": False,
+            "maxSources": None,
+            "maxGroups": None,
+            "joinEntryCount": 4,
+            "joinGroupCount": 0,
+            "proxyJoinCount": 4,
+        },
+        "r1-eth2": {
+            "igmpEnabled": True,
+            "proxy": False,
+            "joinEntryCount": 2,
+            "joinGroupCount": 2,
+            "proxyJoinCount": 0,
+        },
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip igmp interface json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = '"{}" IGMP interface state JSON mismatches'.format(r1.name)
+    assert result is None, assertmsg
+
+    # proxyRouteMap is omitted when unset
+    out = r1.vtysh_cmd("show ip igmp interface r1-eth1 json", isjson=True)
+    assert "proxyRouteMap" not in out.get("r1-eth1", {}), (
+        "proxyRouteMap present without proxy route-map configured: %s" % out
+    )
 
 
 def test_pim_igmp_proxy_learn():
@@ -389,6 +446,25 @@ int r1-eth1
     assertmsg = '"r1" proxy groups mismatch after route-map filter applied'
     assert result is None, assertmsg
 
+    # Interface state should reflect the active proxy route-map and filtered count
+    expected_iface = {
+        "r1-eth1": {
+            "proxy": True,
+            "proxyRouteMap": "PROXY_FILTER",
+            "proxyJoinCount": 2,
+        },
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        r1,
+        "show ip igmp interface r1-eth1 json",
+        expected_iface,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), '"r1" IGMP interface state mismatch with proxy route-map applied'
+
     # Step 5: add a new join that the route-map denies (225.9.9.9) — must NOT appear
     r2.vtysh_cmd(
         """
@@ -463,6 +539,12 @@ int r1-eth1
     running = r1.vtysh_cmd("show running-config")
     assert "ip igmp proxy route-map" not in running, (
         "running-config still has 'ip igmp proxy route-map' after removal:\n" + running
+    )
+
+    # And not in IGMP interface operational state
+    out = r1.vtysh_cmd("show ip igmp interface r1-eth1 json", isjson=True)
+    assert "proxyRouteMap" not in out.get("r1-eth1", {}), (
+        "proxyRouteMap still present after route-map removal: %s" % out
     )
 
     # cleanup route-map config


### PR DESCRIPTION
- Add IGMP operational state to `show ip igmp interface` (summary Proxy column + detail IGMP State: proxy, filters, leave/RA, limits, membership counts).
- Add Downstream interfaces to `show ip igmp proxy`, listing receiver-facing ifaces that still have unfiltered interest for each proxied group (same route-map rules as join/leave).
- Extend `pim_basic_igmp_proxy` topotests for both.

Sample output (`Downstream):
```
    r1# show ip igmp proxy
    Interface        Address         Source          Group           Socket Uptime   Downstream
    r1-eth1          10.0.30.1       *               225.2.2.2           19 00:06:37 r1-eth0
    r1-eth1          10.0.30.1       *               225.1.1.1           32 00:06:37 r1-eth0
    r1-eth1          10.0.30.1       *               225.4.4.4           33 00:06:37 r1-eth2
    r1-eth1          10.0.30.1       *               225.3.3.3           34 00:06:37 r1-eth0,r1-eth
   
```

New "Proxy" in the output:
```
    r1# show ip igmp interface
    Interface         State          Address  V  Querier          QuerierIp  Query Timer    Uptime   Proxy
    lo                 mtrc       10.254.0.1  3    other         10.254.0.1     --:--:--  00:00:13     no
    r1-eth0              up        10.0.20.1  3    local          10.0.20.1     00:00:19  00:00:13     no
    r1-eth1              up        10.0.30.1  3    local          10.0.30.1     00:00:19  00:00:13    yes
    r1-eth2              up        10.0.40.1  3    local          10.0.40.1     00:00:19  00:00:13     no
```
    
 New IGMP State block:
 ```
    r1# show ip igmp interface r1-eth1

    GMP State
    ----------
    Enabled              : yes
    Proxy                : yes
    Proxy route-map      : none
    Route-map            : none
    Access-list          : none
    Immediate leave      : no
    Require router-alert : no
    Max sources          : unlimited
    Max groups           : unlimited
    Join-groups          : 0
    Proxy joins          : 4
    Static groups        : 0
    Groups               : 4
    
```