### PR TITLE
pimd: fix MLD subscriber lookup crash on ILP32 with 64-bit time_t

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -120,21 +120,26 @@ static struct gm_packet_sg *gm_packet_sg_find(struct gm_sg *sg,
 					      enum gm_sub_sense sense,
 					      struct gm_subscriber *sub)
 {
-	struct {
+	/* gm_packet_sg_cmp() resolves each item back to its containing
+	 * gm_packet_state with container_of math against items[], so the
+	 * reference item MUST sit exactly offsetof(items[0]) after the
+	 * header.  A plain `struct { hdr; item; }` does NOT guarantee that:
+	 * on ILP32 targets with 64-bit time_t (e.g. armv7/musl), sizeof(hdr)
+	 * pads to 48 while items[] begins at 44, so the compare read
+	 * `subscriber` from 4 bytes past the real header -- NULL deref or
+	 * garbage compares.  Size the storage through items[1] itself so the
+	 * layout is right by construction.
+	 */
+	union {
 		struct gm_packet_state hdr;
-		struct gm_packet_sg item;
-	} ref = {
-		/* clang-format off */
-		.hdr = {
-			.subscriber = sub,
-		},
-		.item = {
-			.offset = 0,
-		},
-		/* clang-format on */
-	};
+		uint8_t storage[offsetof(struct gm_packet_state, items[1])];
+	} ref;
 
-	return gm_packet_sg_subs_find(&sg->subs[sense], &ref.item);
+	memset(&ref, 0, sizeof(ref));
+	ref.hdr.subscriber = sub;
+	ref.hdr.items[0].offset = 0;
+
+	return gm_packet_sg_subs_find(&sg->subs[sense], &ref.hdr.items[0]);
 }
 
 /*


### PR DESCRIPTION
`gm_packet_sg_find()` builds its on-stack reference item as a plain
`struct { struct gm_packet_state hdr; struct gm_packet_sg item; }` and hands
`&ref.item` to the rb-tree, whose compare resolves every item back to its
`gm_packet_state` via `container_of` against `items[]`. That only works if the
item sits exactly `offsetof(struct gm_packet_state, items[0])` after the
header — and it does not on ILP32 targets whose `struct timeval` forces 8-byte
alignment (e.g. armv7/musl with 64-bit time_t): there `sizeof(hdr)` pads to 48
while `items[]` begins at 44, so `gm_packet_sg_cmp()` reads `subscriber` from
4 bytes past the real header and dereferences NULL.

In practice pim6d segfaults within seconds of becoming MLD querier on a real
LAN — the kernel's own retransmitted ff02::16 report is the second report for
a group, which makes the subs-tree search non-trivial. With the deref guarded,
the same broken reference instead misses the existing entry and pass2 dies on
`assert(!item_dup)`. Both signatures were observed live on an OpenWrt/armv7
router (100% reproducible, crash < 5 s after enabling `ipv6 mld` on the LAN
interface); the bug is invisible on all 64-bit platforms, which is why
topotests never caught it. The struct offsets (items[] at 44, sizeof padded to
48) were confirmed empirically on the affected target.

Fix: size the reference storage through `items[1]` itself (a union with
`uint8_t storage[offsetof(struct gm_packet_state, items[1])]`), so the layout
is correct by construction on every ABI.
