### PR TITLE
pimd: defer join-group socket joins until the interface exists

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -47,6 +47,7 @@
 
 static void pim_if_gm_join_del_all(struct interface *ifp);
 static void pim_if_static_group_del_all(struct interface *ifp);
+static void pim_if_gm_join_replay(struct interface *ifp);
 
 static int gm_join_sock(const char *ifname, ifindex_t ifindex,
 			pim_addr group_addr, pim_addr source_addr,
@@ -664,29 +665,8 @@ void pim_if_addr_add(struct connected *ifc)
 				pim_igmp_sock_add(pim_ifp->gm_socket_list, ifaddr, ifp, false);
 			}
 
-			/* Replay Static IGMP groups */
-			if (pim_ifp->gm_join_list) {
-				struct listnode *node;
-				struct listnode *nextnode;
-				struct gm_join *ij;
-				int join_fd;
-
-				for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node, nextnode, ij)) {
-					/* Close socket and reopen with Source and Group
-					 */
-					close(ij->sock_fd);
-					join_fd = gm_join_sock(ifp->name, ifp->ifindex,
-							       ij->group_addr, ij->source_addr,
-							       pim_ifp);
-					if (join_fd < 0) {
-						zlog_warn("%s: gm_join_sock() failure for IGMP group %pI4s source %pI4s on interface %s",
-							  __func__, &ij->group_addr,
-							  &ij->source_addr, ifp->name);
-						/* warning only */
-					} else
-						ij->sock_fd = join_fd;
-				}
-			}
+			/* Replay join-group socket joins */
+			pim_if_gm_join_replay(ifp);
 		} /* igmp */
 		else {
 			struct gm_sock *igmp;
@@ -700,6 +680,14 @@ void pim_if_addr_add(struct connected *ifc)
 					  true);
 		} /* igmp mtrace only */
 	}
+#else
+	/* Replay static MLD join-groups.  IPv4 replays inside the gm_enable
+	 * branch above; without this, a join deferred from startup config
+	 * (no ifindex from zebra yet) or issued against a stale ifindex
+	 * would never be (re)joined for IPv6.
+	 */
+	if (pim_ifp->gm_enable)
+		pim_if_gm_join_replay(ifp);
 #endif
 
 	if (pim_ifp->pim_enable) {
@@ -1419,13 +1407,24 @@ static struct gm_join *gm_join_new(struct interface *ifp, pim_addr group_addr,
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	join_fd = gm_join_sock(ifp->name, ifp->ifindex, group_addr, source_addr,
-			       pim_ifp);
-	if (join_fd < 0) {
-		zlog_warn("%s: gm_join_sock() failure for " GM
-			  " group %pPAs source %pPAs on interface %s",
-			  __func__, &group_addr, &source_addr, ifp->name);
-		return 0;
+	if (ifp->ifindex == IFINDEX_INTERNAL) {
+		/* The interface has no ifindex yet -- startup config is
+		 * read before zebra delivers interfaces.  Issuing the join
+		 * now would not just fail: with gsr_interface == 0 the
+		 * kernel resolves the interface through a route lookup and
+		 * silently subscribes on whatever device that returns.
+		 * Defer instead; pim_if_gm_join_replay() issues the join
+		 * once the interface has an address (and gm is enabled).
+		 */
+		join_fd = -1;
+	} else {
+		join_fd = gm_join_sock(ifp->name, ifp->ifindex, group_addr, source_addr, pim_ifp);
+		if (join_fd < 0) {
+			zlog_warn("%s: gm_join_sock() failure for " GM
+				  " group %pPAs source %pPAs on interface %s",
+				  __func__, &group_addr, &source_addr, ifp->name);
+			return 0;
+		}
 	}
 
 	ij = XCALLOC(MTYPE_PIM_IGMP_JOIN, sizeof(*ij));
@@ -1439,6 +1438,50 @@ static struct gm_join *gm_join_new(struct interface *ifp, pim_addr group_addr,
 	listnode_add(pim_ifp->gm_join_list, ij);
 
 	return ij;
+}
+
+/* (Re)issue the kernel socket joins for every configured join-group on
+ * the interface, against its current ifindex.  This is what makes
+ * deferred joins (sock_fd == -1, created while the interface had no
+ * ifindex) real, and what re-targets existing joins when the interface
+ * is recreated under a new ifindex.  Entries that fail here keep their
+ * previous socket (or stay deferred) and are retried on the next
+ * replay.
+ */
+static void pim_if_gm_join_replay(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct listnode *node;
+	struct listnode *nextnode;
+	struct gm_join *ij;
+	int join_fd;
+
+	if (!pim_ifp || !pim_ifp->gm_join_list)
+		return;
+
+	if (ifp->ifindex == IFINDEX_INTERNAL)
+		return;
+
+	for (ALL_LIST_ELEMENTS(pim_ifp->gm_join_list, node, nextnode, ij)) {
+		/* Open the replacement join before dropping any existing
+		 * membership, so a failed reopen keeps whatever the old
+		 * socket still holds (the kernel refcounts the interface's
+		 * group membership across sockets, so both briefly
+		 * coexisting is fine).
+		 */
+		join_fd = gm_join_sock(ifp->name, ifp->ifindex, ij->group_addr, ij->source_addr,
+				       pim_ifp);
+		if (join_fd < 0) {
+			zlog_warn("%s: gm_join_sock() failure for " GM
+				  " group %pPAs source %pPAs on interface %s",
+				  __func__, &ij->group_addr, &ij->source_addr, ifp->name);
+			/* warning only; keep the existing socket, if any */
+			continue;
+		}
+		if (ij->sock_fd >= 0)
+			close(ij->sock_fd);
+		ij->sock_fd = join_fd;
+	}
 }
 
 static struct static_group *static_group_new(struct interface *ifp,
@@ -1553,7 +1596,7 @@ int pim_if_gm_join_del(struct interface *ifp, pim_addr group_addr,
 		return 0;
 	}
 
-	if (close(ij->sock_fd)) {
+	if (ij->sock_fd >= 0 && close(ij->sock_fd)) {
 		zlog_warn(
 			"%s: failure closing sock_fd=%d for " GM
 			" group %pPAs source %pPAs on interface %s: errno=%d: %s",

--- a/tests/topotests/pim6_mld_join_startup/r1/frr.conf
+++ b/tests/topotests/pim6_mld_join_startup/r1/frr.conf
@@ -1,0 +1,7 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ipv6 address 2001:db8:1::1/64
+ ipv6 pim
+!

--- a/tests/topotests/pim6_mld_join_startup/r2/frr.conf
+++ b/tests/topotests/pim6_mld_join_startup/r2/frr.conf
@@ -1,0 +1,15 @@
+!
+hostname r2
+!
+interface r2-eth0
+ ipv6 address 2001:db8:1::2/64
+ ipv6 pim
+!
+interface r2-eth1
+ ipv6 address 2001:db8:2::1/64
+ ipv6 mld
+ ipv6 mld join-group ff3e::10 2001:db8:10::10
+ ipv6 pim
+!
+ipv6 route 2001:db8:10::/64 2001:db8:1::1
+!

--- a/tests/topotests/pim6_mld_join_startup/test_pim6_mld_join_startup.py
+++ b/tests/topotests/pim6_mld_join_startup/test_pim6_mld_join_startup.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 Blockcast
+#
+
+"""
+test_pim6_mld_join_startup.py: an `ipv6 mld join-group` present in the
+STARTUP configuration must produce a working join once the interface
+comes up.
+
+Regression test for the deferred-join gap: startup config is read
+before zebra delivers interfaces, so the join-group line is applied
+while the interface still has ifindex 0.  Passing gsr_interface == 0 to
+MCAST_JOIN_(SOURCE_)GROUP does not fail -- the kernel resolves
+interface 0 through a route lookup and silently subscribes on whatever
+device that returns -- so the join landed on the wrong interface (or
+was rejected outright when no route existed yet), no MLDv2 report was
+ever sent on the configured interface, and nothing re-issued the join
+when the interface appeared.  IPv4 partially masked this with the
+socket replay in pim_if_addr_add(); IPv6 had no replay at all.
+
+Topology:
+
+    r1 ---- s1 ---- r2 ---- s2 (receiver stub)
+
+r1 is only a PIM6 neighbor: r2 RPF-resolves the (never-sending) source
+2001:db8:10::10 through a static route toward r1.  The join-group is in
+r2's startup frr.conf on r2-eth1, where r2 is its own MLD querier and
+the kernel join-group socket supplies the MLDv2 report.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.pim6d, pytest.mark.staticd]
+
+SOURCE6 = "2001:db8:10::10"
+GROUP6 = "ff3e::10"
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    # s1: the RPF segment (r1 is r2's PIM6 neighbor toward the source)
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # s2: r2's receiver stub (the join-group interface)
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf", daemons=["zebra", "pim6d"])
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _json_cmd(rname, cmd):
+    """vtysh JSON helper: returns None (NOT {}) on unparseable output, so
+    a crashed/unresponsive daemon can never satisfy an absence-assertion
+    vacuously -- every predicate must treat None as failure."""
+    out = get_topogen().gears[rname].vtysh_cmd(cmd)
+    try:
+        return json.loads(out)
+    except ValueError:
+        return None
+
+
+def test_pim6_neighbor_up():
+    """r2 sees r1 as a PIM6 neighbor on the RPF segment."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _neighbor_up():
+        data = _json_cmd("r2", "show ipv6 pim neighbor json")
+        if data is None:
+            return "r2: unparseable v6 pim neighbor JSON (pim6d dead?)"
+        if not data.get("r2-eth0"):
+            return "r2 has no PIM6 neighbor on r2-eth0: {}".format(data)
+        return None
+
+    _, result = topotest.run_and_expect(_neighbor_up, None, count=60, wait=1)
+    assert result is None, result
+
+
+def test_startup_join_group_becomes_live():
+    """THE regression: the startup-config join-group must form an MLD sg
+    on r2-eth1 (proving the deferred socket join was replayed onto the
+    right interface and its report hit the wire) and INCLUDE local
+    membership.  That pair is the direct effect of the fix; the (S,G)
+    upstream's RPF/join convergence is a separate concern (staticd route
+    + nexthop resolution + PIM6 neighbor) covered by other suites, so it
+    is deliberately not asserted here -- it only adds cross-daemon timing
+    flakiness on slow runners without exercising this code path."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _startup_join_live():
+        joins = _json_cmd("r2", "show ipv6 mld joins json")
+        if joins is None:
+            return "r2: unparseable v6 mld joins JSON (pim6d dead?)"
+        # key the check to r2-eth1: the bug's failure mode is the kernel
+        # subscribing on the WRONG interface, which a whole-blob substring
+        # match would not catch
+        iface_joins = joins.get("default", {}).get("r2-eth1", {})
+        if GROUP6 not in json.dumps(iface_joins):
+            return "r2 startup join-group formed no MLD sg on r2-eth1: {}".format(joins)
+        data = _json_cmd("r2", "show ipv6 pim local-membership json")
+        if data is None:
+            return "r2: unparseable v6 local-membership JSON (pim6d dead?)"
+        row = data.get("r2-eth1", {}).get(GROUP6, {})
+        if row.get("localMembership") != "INCLUDE":
+            return "r2 v6 local membership not formed: {}".format(data)
+        return None
+
+    _, result = topotest.run_and_expect(_startup_join_live, None, count=90, wait=1)
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/pim_igmp_join_startup/r1/frr.conf
+++ b/tests/topotests/pim_igmp_join_startup/r1/frr.conf
@@ -1,0 +1,7 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+ ip pim
+!

--- a/tests/topotests/pim_igmp_join_startup/r2/frr.conf
+++ b/tests/topotests/pim_igmp_join_startup/r2/frr.conf
@@ -1,0 +1,15 @@
+!
+hostname r2
+!
+interface r2-eth0
+ ip address 10.0.1.2/24
+ ip pim
+!
+interface r2-eth1
+ ip address 10.0.2.1/24
+ ip igmp
+ ip igmp join-group 232.1.1.10 10.10.10.10
+ ip pim
+!
+ip route 10.10.10.0/24 10.0.1.1
+!

--- a/tests/topotests/pim_igmp_join_startup/test_pim_igmp_join_startup.py
+++ b/tests/topotests/pim_igmp_join_startup/test_pim_igmp_join_startup.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 Blockcast
+#
+
+"""
+test_pim_igmp_join_startup.py: an `ip igmp join-group` present in the
+STARTUP configuration must produce a working join once the interface
+comes up -- the IPv4 twin of pim6_mld_join_startup.
+
+Before the deferred-join fix, IPv4 behavior at config load (interface
+still at ifindex 0) was a race: the kernel either route-resolved the
+ifindex-0 join onto some wrong device (later healed by the address-add
+socket replay) or rejected it outright, in which case gm_join_new()
+dropped the entry and nothing ever joined.  The fix replaces both
+outcomes with a deterministic defer-then-replay, and this test pins
+that determinism: unlike the IPv6 twin it is a regression guard for
+the new deferral path rather than a fail-leg reproducer, because the
+pre-fix outcome depended on kernel route state at daemon start.
+
+Topology:
+
+    r1 ---- s1 ---- r2 ---- s2 (receiver stub)
+
+r1 is only a PIM neighbor: r2 RPF-resolves the (never-sending) source
+10.10.10.10 through a static route toward r1.  The join-group is in
+r2's startup frr.conf on r2-eth1, where r2 is its own IGMP querier
+and the kernel join-group socket supplies the IGMPv3 report.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
+
+SOURCE = "10.10.10.10"
+GROUP = "232.1.1.10"
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    # s1: the RPF segment (r1 is r2's PIM neighbor toward the source)
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # s2: r2's receiver stub (the join-group interface)
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf", daemons=["zebra", "pimd"])
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _json_cmd(rname, cmd):
+    """vtysh JSON helper: returns None (NOT {}) on unparseable output, so
+    a crashed/unresponsive daemon can never satisfy an absence-assertion
+    vacuously -- every predicate must treat None as failure."""
+    out = get_topogen().gears[rname].vtysh_cmd(cmd)
+    try:
+        return json.loads(out)
+    except ValueError:
+        return None
+
+
+def test_pim_neighbor_up():
+    """r2 sees r1 as a PIM neighbor on the RPF segment."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _neighbor_up():
+        data = _json_cmd("r2", "show ip pim neighbor json")
+        if data is None:
+            return "r2: unparseable pim neighbor JSON (pimd dead?)"
+        if not data.get("r2-eth0"):
+            return "r2 has no PIM neighbor on r2-eth0: {}".format(data)
+        return None
+
+    _, result = topotest.run_and_expect(_neighbor_up, None, count=60, wait=1)
+    assert result is None, result
+
+
+def test_startup_join_group_becomes_live():
+    """THE regression guard: the startup-config join-group must form an
+    IGMP group on r2-eth1 (proving the deferred socket join was replayed
+    onto the right interface and its report hit the wire) and INCLUDE
+    local membership.  That pair is the direct effect of the fix; the
+    (S,G) upstream's RPF/join convergence is a separate concern (staticd
+    route + nexthop resolution + PIM neighbor) covered by other suites,
+    so it is deliberately not asserted here -- it only adds cross-daemon
+    timing flakiness on slow runners without exercising this code path."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _startup_join_live():
+        groups = _json_cmd("r2", "show ip igmp groups json")
+        if groups is None:
+            return "r2: unparseable igmp groups JSON (pimd dead?)"
+        # key the check to r2-eth1: the bug's failure mode is the kernel
+        # subscribing on the WRONG interface, which a whole-blob substring
+        # match would not catch
+        iface_groups = groups.get("r2-eth1", {})
+        if GROUP not in json.dumps(iface_groups):
+            return "r2 startup join-group formed no IGMP group on r2-eth1: {}".format(
+                groups
+            )
+        data = _json_cmd("r2", "show ip pim local-membership json")
+        if data is None:
+            return "r2: unparseable local-membership JSON (pimd dead?)"
+        row = data.get("r2-eth1", {}).get(GROUP, {})
+        if row.get("localMembership") != "INCLUDE":
+            return "r2 local membership not formed: {}".format(data)
+        return None
+
+    _, result = topotest.run_and_expect(_startup_join_live, None, count=90, wait=1)
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
A join-group configured before zebra delivers the interface (startup config is
read while the interface still has ifindex 0) passes `gsr_interface = 0` to
`MCAST_JOIN_(SOURCE_)GROUP`. The kernel does not fail that call: it resolves
interface 0 through a route lookup and silently subscribes on whatever device
that returns — so the join lands on the wrong interface (or is rejected
outright when no route for the group exists yet, losing the config line since
`gm_join_new()` drops failed entries), no report is ever sent on the
configured interface, and nothing re-issues the join when the interface
appears. IPv4 partially masks this with the socket replay in
`pim_if_addr_add()`; IPv6 has no replay at all, so a startup-config
`ipv6 mld join-group` never produces an MLDv2 report — observed live:
pim6d logs `pim_if_add_vif: ifindex=0` at config-from-file, then the group
never shows in `show ipv6 mld joins` while all ambient link-local groups do.

Fix:
- defer the socket join when the interface has no ifindex yet, keeping the
  `gm_join` entry with `sock_fd == -1` instead of dropping it;
- factor the IPv4 replay loop into `pim_if_gm_join_replay()` and run it for
  both address families when an address is added (issuing deferred joins and
  re-targeting stale ones after an ifindex change);
- guard the close paths against deferred entries.

The new `pim6_mld_join_startup` topotest (plus its IPv4 twin `pim_igmp_join_startup`, which pins the deferral determinism for pimd where the pre-fix outcome was a race) boots the join-group from startup
config and asserts the MLD sg, INCLUDE local membership and Joined upstream
all form. Verified against current master: unpatched, the sg never appears
(fails after the full poll window); patched, 2/2 pass in ~20 s. The v4 side
of the refactor was regression-checked with `multicast_mld_join_topo1` and
`pim_basic_igmp_proxy` (both pass; proxy joins ride the same gm_join list).
