### PR TITLE
yang: Fix pyang errors in frr-bgp-rpki.yang

### DIFF
--- a/yang/frr-bgp-rpki.yang
+++ b/yang/frr-bgp-rpki.yang
@@ -48,6 +48,8 @@ module frr-bgp-rpki {
   revision 2019-12-03 {
     description
       "Initial revision.";
+    reference
+      "FRRouting.";
   }
 
   typedef transport-type {
@@ -63,9 +65,13 @@ module frr-bgp-rpki {
           "Connection to server is SSH based.";
       }
     }
+    description
+      "Type of transport for RPKI cache connection.";
   }
 
   grouping bgp-rpki-timers {
+    description
+      "RPKI timer configuration parameters.";
     container rpki-timers {
       description
         "RPKI timers config.";
@@ -103,11 +109,15 @@ module frr-bgp-rpki {
   }
 
   grouping bgp-rpki-cache-server {
+    description
+      "RPKI cache server configuration parameters.";
     container rpki-cache-server {
       description
         "Add a cache server to the socket.";
       list cache-list {
         key "preference";
+        description
+          "List of RPKI cache servers.";
         leaf preference {
           type uint8 {
             range "1..255";
@@ -124,10 +134,14 @@ module frr-bgp-rpki {
         }
 
         choice server {
+          description
+            "Choice of server address type.";
           case ip-address {
             leaf ip-address {
               type inet:ip-address;
               mandatory true;
+              description
+                "IP address of the RPKI cache server.";
             }
           }
 
@@ -135,17 +149,23 @@ module frr-bgp-rpki {
             leaf ip-host-address {
               type inet:host;
               mandatory true;
+              description
+                "Hostname of the RPKI cache server.";
             }
           }
         }
 
         container transport {
+          description
+            "Transport configuration for the cache server.";
           container tcp {
             when "../../cache-type = 'TCP'";
             description
               "TCP server details.";
             leaf tcp-port {
               type uint32;
+              description
+                "TCP port for the RPKI cache server.";
             }
           }
 
@@ -192,6 +212,8 @@ module frr-bgp-rpki {
   }
 
   augment "/frr-vrf:lib/frr-vrf:vrf" {
+    description
+      "Augment VRF with BGP RPKI configuration.";
     container bgp-rpki {
       description
         "RPKI configuration parameters.";


### PR DESCRIPTION
Fix pyang errors in frr-bgp-rpki.yang

frr-bgp-rpki.yang:48: error: RFC 8407: 4.8: statement "revision" must have a "reference" substatement
frr-bgp-rpki.yang:53: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-bgp-rpki.yang:68: error: RFC 8407: 4.14: statement "grouping" must have a "description" substatement
frr-bgp-rpki.yang:105: error: RFC 8407: 4.14: statement "grouping" must have a "description" substatement
frr-bgp-rpki.yang:109: error: RFC 8407: 4.14: statement "list" must have a "description" substatement
frr-bgp-rpki.yang:126: error: RFC 8407: 4.14: statement "choice" must have a "description" substatement
frr-bgp-rpki.yang:128: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-bgp-rpki.yang:135: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-bgp-rpki.yang:142: error: RFC 8407: 4.14: statement "container" must have a "description" substatement
frr-bgp-rpki.yang:147: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement
frr-bgp-rpki.yang:194: error: RFC 8407: 4.14: statement "augment" must have a "description" substatement