### PR TITLE
bgpd: fix const-qualifier build error with strrchr

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -326,7 +326,7 @@ static struct rpki_vrf *find_rpki_vrf_from_ident(const char *ident)
 	size_t host_len;
 	char *endptr;
 	char *host;
-	char *ptr;
+	const char *ptr;
 	char *buf;
 
 	/* extract the <SOCKET> */


### PR DESCRIPTION
On newer glibc/GCC (seen on Ubuntu 26.04, GCC 15.2), strrchr() preserves the const qualifier of its argument, so strrchr() on a `const char *` returns `const char *`. Changing ptr to const fixes the "-Werror" on this system during the build