### PR TITLE
bfdd: fix silent session loss when dataplane registration overflows the output buffer

### DIFF
--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -417,6 +417,25 @@ static int bfd_dplane_enqueue(struct bfd_dplane_ctx *bdc, const void *buf,
 	if (bdc->client && bdc->sock == -1)
 		return -1;
 
+	/*
+	 * Not enough space: the buffer may simply not have been drained
+	 * yet, e.g. the initial session registration burst enqueues all
+	 * sessions before the write event ever runs. Try flushing
+	 * synchronously before giving up: the socket is normally
+	 * writable. Skip clients still connecting (flush would spin on
+	 * EAGAIN until the connection finishes).
+	 */
+	if (buflen > STREAM_WRITEABLE(bdc->outbuf) &&
+	    !(bdc->client && bdc->connecting)) {
+		/*
+		 * On socket failure or close the context is freed by
+		 * the flush. The buffer is non empty here, so a zero
+		 * return means exactly that: don't touch `bdc` again.
+		 */
+		if (bfd_dplane_flush(bdc) == 0)
+			return -1;
+	}
+
 	/* Not enough space. */
 	if (buflen > STREAM_WRITEABLE(bdc->outbuf)) {
 		bdc->out_fullev++;

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -659,7 +659,19 @@ static void _bfd_session_register_dplane(struct hash_bucket *hb, void *arg)
 	bfd_session_disable(bs);
 
 	/* Move session to data plane. */
-	_bfd_dplane_add_session(bdc, bs);
+	if (_bfd_dplane_add_session(bdc, bs) != 0) {
+		/*
+		 * The data plane didn't take the session (e.g. output
+		 * buffer full): return it to the software
+		 * implementation instead of leaving it implemented by
+		 * neither. Same recovery as data plane detach
+		 * (`_bfd_session_unregister_dplane`).
+		 */
+		zlog_warn(
+			"%s: failed to register session with data plane, keeping it in software",
+			__func__);
+		bfd_session_enable(bs);
+	}
 }
 
 static struct bfd_dplane_ctx *bfd_dplane_ctx_new(int sock)


### PR DESCRIPTION
Fixes #22638.

When bfdd (re)connects to a distributed-BFD dataplane, the session registration walk enqueues one message per configured session into the dataplane client's 8KB output buffer in a single event-loop pass, before the write event ever runs. Sessions past the buffer limit were silently and permanently lost: never delivered to the dataplane, software implementation already disabled, `bs->bdc` reset to NULL, and every subsequent operation on them a silent no-op. Full mechanism and an independent reproducer (byte-counting TCP sink, no dataplane implementation required) are in the issue.

Two commits, independently useful:

1. **bfdd: flush data plane output buffer before failing enqueue** — when the buffer lacks space, attempt `bfd_dplane_flush()` and re-check before failing. The socket is normally writable during the registration burst (the issue shows zero TCP backpressure), so the common case now succeeds. Clients still connecting are skipped (flush would spin on EAGAIN); a zero return from the flush with a non-empty buffer means the ctx was freed on socket error, so it is not touched again.

2. **bfdd: keep session in software when data plane registration fails** — on registration failure, log a warning and return the session to the software implementation, mirroring the existing recovery on dataplane detach (`_bfd_session_unregister_dplane`), instead of leaving it implemented by neither.

Validation (master, x86_64):

- 128 configured sessions, dataplane reconnect (the issue's reproducer): unpatched delivers exactly 58 registrations (8120 bytes) and strands 70 with `Output full events: 140` (each stranded session fails in both the unregister-walk's `bfd_session_enable` dataplane attempt and the register walk); patched delivers 128/128, `Output full events: 0`, `Output bytes peak: 8120` showing the buffer filled to the old failure line and was flushed through.
- End-to-end against a real external dataplane implementation with 64 timer-configured sessions (203-byte messages): the dataplane restart/reconnect burst previously delivered 40/64; patched, all 64 register and come up.