### PR TITLE
Add DEFPY_ATTR to .clang-format WhitespaceSensitiveMacros list

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -210,6 +210,7 @@ TabWidth: 8
 UseTab: Always
 WhitespaceSensitiveMacros:
   - "DEFPY"
+  - "DEFPY_ATTR"
   - "DEFPY_HIDDEN"
   - "DEFPY_NOSH"
   - "DEFPY_YANG"


### PR DESCRIPTION
DEFPY_ATTR was missing from .clang-format's WhitespaceSensitiveMacros list, although other variants like DEFPY_HIDDEN, DEFPY_NOSH, etc.. are present

Seems like a simple oversight.
This should also prevent future issues with e.g. existing PIM commands from pim_cmd.c:

Reformatting the ip_pim_spt_switchover_infinity declaration without the addition gives:
```
DEFPY_ATTR(ip_pim_spt_switchover_infinity, ip_pim_spt_switchover_infinity_cmd,
	   "ip pim spt-switchover infinity-and-beyond",
	   IP_STR PIM_STR "SPT-Switchover\n"
			  "Never switch to SPT Tree\n",
	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
```

with the addition, formatting does not make any changes, as it should:
```
DEFPY_ATTR(ip_pim_spt_switchover_infinity,modify
			  ip_pim_spt_switchover_infinity_cmd,
			  "ip pim spt-switchover infinity-and-beyond",
			  IP_STR
			  PIM_STR
			  "SPT-Switchover\n"
			  "Never switch to SPT Tree\n",
	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
{
```