### PR TITLE
Allow safe RCU unregister for external threads

### DIFF
--- a/doc/developer/rcu.rst
+++ b/doc/developer/rcu.rst
@@ -238,16 +238,64 @@ Internals
    thread-local storage.
 
 .. c:function:: struct rcu_thread *rcu_thread_prepare(void)
+.. c:function:: struct rcu_thread *rcu_thread_new(void *arg)
 .. c:function:: void rcu_thread_unprepare(struct rcu_thread *rcu_thread)
 .. c:function:: void rcu_thread_start(struct rcu_thread *rcu_thread)
 
    Since the RCU code needs to have a list of all active threads, these
    functions are used by the ``frr_pthread`` code to set up threads.  Teardown
-   is automatic.  It should not be necessary to call these functions.
+   is automatic on thread exit (via a ``pthread_key`` destructor).
 
    Any thread that accesses RCU-protected data needs to be registered with
    these functions.  Threads that do not access RCU-protected data may call
    these functions but do not need to.
+
+   For threads created outside FRR (e.g. a Rust/Tokio worker pool), call
+   ``rcu_thread_start(rcu_thread_new(NULL))`` from the thread-start hook.
+   Prefer letting the thread exit so the destructor cleans up; if the
+   runtime provides a thread-stop hook and threads may outlive
+   ``rcu_shutdown()``, call ``rcu_thread_unprepare(NULL)`` from that hook
+   (NULL means "unregister the calling thread").  A second
+   ``rcu_thread_unprepare(NULL)`` after that is a no-op; do not pass the
+   same non-NULL ``rcu_thread`` pointer to unprepare twice.
+
+   ``rcu_thread_new(NULL)`` holds the current global RCU epoch rather than
+   inheriting a parent thread's epoch.  That is enough for zlog and similar
+   callbacks, but do not pass RCU-protected pointers into such a thread at
+   creation time — use ``rcu_thread_prepare()`` from the creating thread
+   when that is required.
+
+   Example with Tokio (FFI bindings omitted):
+
+   .. code-block:: rust
+
+      // Register so zlog / RCU are valid on this OS thread.
+      fn frr_register_thread(_name: &str) {
+          unsafe {
+              c_shim::rcu_thread_start(c_shim::rcu_thread_new(std::ptr::null_mut()));
+          }
+      }
+
+      // Unregister before the thread is gone / before rcu_shutdown().
+      fn frr_unregister_thread() {
+          unsafe {
+              c_shim::rcu_thread_unprepare(std::ptr::null_mut());
+          }
+      }
+
+      let runtime = tokio::runtime::Builder::new_multi_thread()
+          .on_thread_start(|| {
+              frr_register_thread("tokio-worker-thread");
+          })
+          .on_thread_stop(|| {
+              frr_unregister_thread();
+          })
+          .build()
+          .unwrap();
+
+   Workers must unregister (or fully exit) before ``rcu_shutdown()`` /
+   ``frr_fini()``, which asserts that only the main RCU thread remains.
+   See also ``tests/lib/test_rcu``.
 
    Note that passing a pointer to RCU-protected data to some library which
    accesses that pointer makes the library "access RCU-protected data".  In
@@ -278,6 +326,10 @@ Internals
    RCU operations are completed.  This is mostly to get a clean exit without
    memory leaks from queued RCU operations.  It should not be necessary to
    call this function as libfrr handles this.
+
+   Only the main thread may remain registered when this is called.  External
+   threads that called ``rcu_thread_start()`` must have exited or called
+   ``rcu_thread_unprepare()`` first.
 
 FRR specifics and implementation details
 ----------------------------------------

--- a/lib/frrcu.c
+++ b/lib/frrcu.c
@@ -157,9 +157,18 @@ struct rcu_thread *rcu_thread_new(void *arg)
 {
 	struct rcu_thread *rt, *cur = arg;
 
+	/* Ensure the sweeper exists so deferred frees from thread teardown
+	 * (and any RCU use on the new thread) actually complete.
+	 */
+	if (!rcu_active)
+		rcu_start();
+
 	/* new thread always starts with rcu_read_lock held at depth 1, and
 	 * holding the same epoch as the parent (this makes it possible to
-	 * use RCU for things passed into the thread through its arg)
+	 * use RCU for things passed into the thread through its arg).
+	 *
+	 * When arg is NULL (external / non-FRR thread self-registering),
+	 * hold the current global epoch instead.
 	 */
 	rt = XCALLOC(MTYPE_RCU_THREAD, sizeof(*rt));
 	rt->depth = 1;
@@ -167,6 +176,8 @@ struct rcu_thread *rcu_thread_new(void *arg)
 	seqlock_init(&rt->rcu);
 	if (cur)
 		seqlock_acquire(&rt->rcu, &cur->rcu);
+	else
+		seqlock_acquire(&rt->rcu, &rcu_seq);
 
 	rcu_threads_add_tail(&rcu_threads, rt);
 
@@ -182,9 +193,6 @@ struct rcu_thread *rcu_thread_prepare(void)
 
 	rcu_assert_read_locked();
 
-	if (!rcu_active)
-		rcu_start();
-
 	cur = rcu_self();
 	assert(cur->depth);
 
@@ -198,8 +206,20 @@ void rcu_thread_start(struct rcu_thread *rt)
 
 void rcu_thread_unprepare(struct rcu_thread *rt)
 {
-	if (rt == &rcu_thread_rcu)
+	/* NULL => unregister the calling thread (for external thread stop
+	 * callbacks).  Already-unregistered threads are a no-op.
+	 */
+	if (!rt)
+		rt = rcu_self();
+	if (!rt || rt == &rcu_thread_rcu)
 		return;
+
+	/* Drop TLS before freeing so the pthread_key destructor (and any
+	 * second explicit unprepare) cannot run cleanup twice.
+	 * pthread_setspecific(NULL) does not invoke the destructor.
+	 */
+	if (rcu_self() == rt)
+		pthread_setspecific(rcu_thread_key, NULL);
 
 	rt->depth = 1;
 	seqlock_acquire(&rt->rcu, &rcu_seq);
@@ -215,8 +235,8 @@ void rcu_thread_unprepare(struct rcu_thread *rt)
 
 static void rcu_thread_end(void *rtvoid)
 {
-	struct rcu_thread *rt = rtvoid;
-	rcu_thread_unprepare(rt);
+	/* key already cleared by pthread before destructor runs */
+	rcu_thread_unprepare(rtvoid);
 }
 
 /*

--- a/lib/frrcu.h
+++ b/lib/frrcu.h
@@ -42,7 +42,10 @@ struct rcu_thread;
 
 /* sets up rcu thread info
  *
- * return value must be passed into the thread's call to rcu_thread_start()
+ * arg is normally the creating thread's rcu_thread (from rcu_thread_prepare),
+ * or NULL when an external thread self-registers (e.g. non-FRR / Tokio
+ * workers).  return value must be passed into the thread's call to
+ * rcu_thread_start().
  */
 extern struct rcu_thread *rcu_thread_new(void *arg);
 
@@ -54,7 +57,17 @@ extern struct rcu_thread *rcu_thread_new(void *arg);
  */
 extern struct rcu_thread *rcu_thread_prepare(void);
 
-/* cleanup in case pthread_create() fails */
+/* Unregister an RCU thread.
+ *
+ * - After rcu_thread_prepare(), if pthread_create() fails, pass the pointer
+ *   returned by prepare (thread never started).
+ * - After rcu_thread_start(), pass that same pointer, or NULL to unregister
+ *   the calling thread (useful from external thread-stop hooks).
+ *
+ * Safe to call at most once per registration.  Clears thread-local state so
+ * the pthread_key destructor will not double-free.  Thread exit still cleans
+ * up automatically if this is never called.
+ */
 extern void rcu_thread_unprepare(struct rcu_thread *rcu_thread);
 
 /* called early in the new thread, with the return value from the above.
@@ -64,7 +77,9 @@ extern void rcu_thread_unprepare(struct rcu_thread *rcu_thread);
  */
 extern void rcu_thread_start(struct rcu_thread *rcu_thread);
 
-/* thread exit is handled through pthread_key_create's destructor function */
+/* thread exit is handled through pthread_key_create's destructor, or
+ * explicitly via rcu_thread_unprepare() / rcu_thread_unprepare(NULL)
+ */
 
 /* global RCU shutdown - must be called with only 1 active thread left.  waits
  * until remaining RCU actions are done & RCU thread has exited.

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -303,6 +303,14 @@ tests_lib_test_seqlock_LDADD = $(ALL_TESTS_LDADD)
 tests_lib_test_seqlock_SOURCES = tests/lib/test_seqlock.c
 
 
+check_PROGRAMS += tests/lib/test_rcu
+tests_lib_test_rcu_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_rcu_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_rcu_LDADD = $(ALL_TESTS_LDADD)
+tests_lib_test_rcu_SOURCES = tests/lib/test_rcu.c
+EXTRA_DIST += tests/lib/test_rcu.py
+
+
 check_PROGRAMS += tests/lib/test_sig
 tests_lib_test_sig_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_sig_CPPFLAGS = $(TESTS_CPPFLAGS)

--- a/tests/lib/test_rcu.c
+++ b/tests/lib/test_rcu.c
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: ISC
+/*
+ * RCU external-thread registration / teardown tests
+ *
+ * Copyright (C) 2026 ATCorp
+ * Jafar Al-Gharaibeh
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "frrcu.h"
+#include "seqlock.h"
+#include "printfrr.h"
+
+#define NWORKERS 8
+
+enum worker_mode {
+	/* Tokio-style: explicit unprepare(NULL), including a second call */
+	MODE_EXPLICIT_UNPREPARE,
+	/* rely on pthread_key destructor at thread exit */
+	MODE_DESTRUCTOR,
+};
+
+struct worker_arg {
+	enum worker_mode mode;
+	int id;
+};
+
+static void *worker(void *arg)
+{
+	struct worker_arg *wa = arg;
+	struct rcu_thread *rt;
+	struct rcu_local_state st;
+
+	rt = rcu_thread_new(NULL);
+	assert(rt);
+	rcu_thread_start(rt);
+
+	/* rcu_thread_new(NULL) must leave the thread holding an epoch */
+	st = rcu_local_state();
+	assert(st.seq_local & SEQLOCK_HELD);
+
+	rcu_assert_read_locked();
+	rcu_read_lock();
+	rcu_assert_read_locked();
+	rcu_read_unlock();
+	rcu_assert_read_locked();
+
+	if (wa->mode == MODE_EXPLICIT_UNPREPARE) {
+		rcu_thread_unprepare(NULL);
+		/* second call must be a no-op (no abort / double-free) */
+		rcu_thread_unprepare(NULL);
+	}
+
+	return NULL;
+}
+
+static void run_workers(enum worker_mode mode, const char *label)
+{
+	pthread_t thr[NWORKERS];
+	struct worker_arg args[NWORKERS];
+	int i, err;
+
+	printfrr("rcu: %s (%d workers)...\n", label, NWORKERS);
+
+	for (i = 0; i < NWORKERS; i++) {
+		args[i].mode = mode;
+		args[i].id = i;
+		err = pthread_create(&thr[i], NULL, worker, &args[i]);
+		assert(err == 0);
+	}
+
+	for (i = 0; i < NWORKERS; i++) {
+		err = pthread_join(thr[i], NULL);
+		assert(err == 0);
+	}
+}
+
+static void test_prepare_failed_create(void)
+{
+	struct rcu_thread *rt;
+
+	printfrr("rcu: prepare + unprepare without start...\n");
+
+	/* main thread is RCU-held from rcu_preinit() */
+	rcu_assert_read_locked();
+	rt = rcu_thread_prepare();
+	assert(rt);
+	/* simulate pthread_create() failure */
+	rcu_thread_unprepare(rt);
+}
+
+int main(int argc, char **argv)
+{
+	struct rcu_stats stats;
+
+	test_prepare_failed_create();
+	run_workers(MODE_EXPLICIT_UNPREPARE, "explicit unprepare(NULL)");
+	run_workers(MODE_DESTRUCTOR, "destructor cleanup");
+
+	/* all external threads gone; shutdown must see only main */
+	rcu_stats(&stats);
+	assert(stats.rcu_active);
+	assert(stats.holding >= 1);
+
+	printfrr("rcu: rcu_shutdown...\n");
+	rcu_shutdown();
+
+	printfrr("rcu: OK\n");
+	return 0;
+}

--- a/tests/lib/test_rcu.py
+++ b/tests/lib/test_rcu.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: ISC
+import frrtest
+
+
+class TestRcu(frrtest.TestMultiOut):
+    program = "./test_rcu"
+
+
+TestRcu.exit_cleanly()


### PR DESCRIPTION
External/non-FRR threads (e.g. Rust/Tokio workers) self-register with `rcu_thread_new(NULL)` + `rcu_thread_start()` so zlog works, but they were leaking RCU thread / sequence-barrier allocations at exit. Calling `rcu_thread_unprepare()` from a stop hook aborted because TLS still pointed at the same struct, so the pthread key destructor ran cleanup again.

This PR makes `rcu_thread_unprepare(NULL)` mean “unregister the calling thread”, clears TLS first to avoid the double-free, has `rcu_thread_new(NULL)` hold the current RCU epoch and start the sweeper, and adds a unit test plus docs (including a Tokio example).