### PR TITLE
pimd: avoid stale RPF ifp during vrf/interface events

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -34,6 +34,7 @@
 #include "pim_time.h"
 #include "pim_ssmpingd.h"
 #include "pim_rp.h"
+#include "pim_rpf.h"
 #include "pim_nht.h"
 #include "pim_jp_agg.h"
 #include "pim_igmp_join.h"
@@ -204,6 +205,9 @@ void pim_if_delete(struct interface *ifp)
 	assert(pim_ifp);
 
 	pim_ifp->pim->mcast_if_count--;
+
+	pim_upstream_rpf_interface_del(ifp);
+
 	if (pim_ifp->gm_join_list) {
 		pim_if_gm_join_del_all(ifp);
 		/*
@@ -788,6 +792,8 @@ static void pim_if_addr_del_pim(struct connected *ifc)
 		return;
 	}
 
+	pim_upstream_rpf_interface_del(ifc->ifp);
+
 	/*
 	  pim_sock_delete() closes the socket, stops read and timer threads,
 	  and kills all neighbors.
@@ -1129,6 +1135,8 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 int pim_if_del_vif(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp = ifp->info;
+
+	pim_upstream_rpf_interface_del(ifp);
 
 	if (pim_ifp->mroute_vif_index < 1) {
 		zlog_warn("%s: vif_index=%d < 1 on interface %s ifindex=%d",
@@ -2140,6 +2148,9 @@ static int pim_ifp_destroy(struct interface *ifp)
 			ifp->mtu, if_is_operative(ifp));
 	}
 
+	if (ifp->info)
+		pim_upstream_rpf_interface_del(ifp);
+
 	if (!if_is_operative(ifp))
 		pim_if_addr_del_all(ifp);
 
@@ -2199,6 +2210,8 @@ void pim_pim_interface_delete(struct interface *ifp)
 		return;
 
 	pim_ifp->pim_enable = false;
+
+	pim_upstream_rpf_interface_del(ifp);
 
 #if PIM_IPV == 4
 	pim_autorp_rm_ifp(ifp);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -1826,9 +1826,9 @@ static int pim_upstream_get_mroute_iif(struct channel_oil *c_oil,
 		} else {
 			ifp = up->rpf.source_nexthop.interface;
 		}
-		if (ifp) {
-			pim_ifp = (struct pim_interface *)ifp->info;
-			if (pim_ifp)
+		if (ifp && !PIM_IF_IS_DELETED(ifp) && ifp->info) {
+			pim_ifp = ifp->info;
+			if (pim_ifp->pim == c_oil->pim)
 				iif = pim_ifp->mroute_vif_index;
 		}
 	}

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -7,6 +7,7 @@
 #include <zebra.h>
 
 #include "if.h"
+#include "vrf.h"
 
 #include "log.h"
 #include "prefix.h"
@@ -214,6 +215,37 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 		up->rpf.rpf_addr = PIMADDR_ANY;
 		if (up->channel_oil)
 			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+	}
+}
+
+/* Clear upstream RPF during interface teardown/vrf migration */
+void pim_upstream_rpf_interface_del(struct interface *ifp)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+	struct pim_upstream *up;
+
+	if (!ifp)
+		return;
+
+	/* Scan every VRF, not just ifp's current one: during a VRF move the
+	 * ifp is migrating between instances, so an upstream in another VRF
+	 * may still reference it. Going through just ifp->vrf will not
+	 * cover vrf migration case.
+	 */
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		pim = vrf->info;
+		/* Avoid re-entering a partially torn down PIM instance. */
+		if (!pim || pim->stopping)
+			continue;
+
+		frr_each_safe (rb_pim_upstream, &pim->upstream_head, up) {
+			/* Interface teardown must not leave upstreams with
+			 * stale ifp.
+			 */
+			if (up->rpf.source_nexthop.interface == ifp)
+				pim_upstream_rpf_clear(pim, up);
+		}
 	}
 }
 

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -58,6 +58,7 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim, struct pim_upstream
 				   const char *caller);
 void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up);
+void pim_upstream_rpf_interface_del(struct interface *ifp);
 int pim_rpf_addr_is_inaddr_any(struct pim_rpf *rpf);
 
 int pim_rpf_is_same(struct pim_rpf *rpf1, struct pim_rpf *rpf2);


### PR DESCRIPTION
Issue: Crash in following sequence of calls.
Received signal 11 at 1783550915 (si_addr 0xcf, PC 0x55a503563b7c); aborting...

  /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(zlog_backtrace_sigsafe+0x6f) [0x7f93388c66bf]
  /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(zlog_signal+0xf5) [0x7f93388c68c5]
  /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(+0x101ad1) [0x7f9338901ad1]
  /lib/x86_64-linux-gnu/libc.so.6(+0x3c050) [0x7f933865a050]
  /usr/lib/frr/pimd(pim_upstream_mroute_iif_update+0x5c) [0x55a503563b7c]
  /usr/lib/frr/pimd(pim_scan_oil+0x4f) [0x55a50357af4f]
  /usr/lib/frr/pimd(+0x8af85) [0x55a50357af85]
  /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(event_call+0x81) [0x7f9338914791]
  /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(frr_run+0xc0) [0x7f93388bde40]
  /usr/lib/frr/pimd(main+0xeb) [0x55a50354812b]
  /lib/x86_64-linux-gnu/libc.so.6(+0x2724a) [0x7f933864524a]
  /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7f9338645305]
  /usr/lib/frr/pimd(_start+0x21) [0x55a503548191]

Root cause:
During VRF/interface churn, upstream RPF state can retain an interface
pointer after the interface is deleted, loses its VIF, or moves to another
PIM instance. A delayed RPF cache refresh can then rescan OIL state and
derive the mroute IIF from stale interface data, leading to a pimd crash.

Fix:
1)Clear upstream RPF references for the affected interface during PIM
interface/VIF teardown and VRF migration/delete paths.

2)Scan all PIM instances when clearing stale RPF interface references,
because ifp->vrf may already point to the new VRF while stale upstreams
still exist in the old PIM instance.

3)It defensively refuses to derive an mroute IIF from deleted or
wrong-PIM-instance interfaces.

4)Skip PIM instances that are already stopping during the all-VRF RPF
cleanup, avoiding side effects against partially torn-down VRF/PIM state.
