### PR TITLE
Feature: add dataplane-provider refresh support

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1119,8 +1119,8 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		break;
-
 	}
 
 	/* Skip empty enqueues. */

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1121,8 +1121,8 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		break;
-
 	}
 
 	/* Skip empty enqueues. */

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1530,6 +1530,9 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 		return netlink_put_sr_tunsrc_set_msg(bth, ctx);
+
+	case DPLANE_OP_PROVIDER_REFRESH:
+		return FRR_NETLINK_SUCCESS;
 	}
 
 	return FRR_NETLINK_ERROR;

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1560,6 +1560,9 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 		return netlink_put_sr_tunsrc_set_msg(bth, ctx);
+
+	case DPLANE_OP_PROVIDER_REFRESH:
+		return FRR_NETLINK_SUCCESS;
 	}
 
 	return FRR_NETLINK_ERROR;

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1711,6 +1711,7 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		case DPLANE_OP_NEIGH_READ:
 		case DPLANE_OP_TC_QDISC_READ:
 		case DPLANE_OP_TC_QDISC_NOTIFY:
+		case DPLANE_OP_PROVIDER_REFRESH:
 			flog_err(EC_ZEBRA_DPLANE_OP_UNHANDLED, "Unhandled dplane data for %s",
 				 dplane_op2str(dplane_ctx_get_op(ctx)));
 			res = ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1717,6 +1717,7 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		case DPLANE_OP_NEIGH_READ:
 		case DPLANE_OP_TC_QDISC_READ:
 		case DPLANE_OP_TC_QDISC_NOTIFY:
+		case DPLANE_OP_PROVIDER_REFRESH:
 			flog_err(EC_ZEBRA_DPLANE_OP_UNHANDLED, "Unhandled dplane data for %s",
 				 dplane_op2str(dplane_ctx_get_op(ctx)));
 			res = ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -429,6 +429,7 @@ extern void rib_update(enum rib_update_event event);
 extern void rib_update_table(struct route_table *table,
 			     enum rib_update_event event, int rtype);
 extern void rib_sweep_route(struct event *t);
+void rib_provider_refresh(uint32_t refresh_flags);
 extern void rib_sweep_table(struct route_table *table);
 extern void rib_close_table(struct route_table *table);
 extern void zebra_rib_init(void);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -483,6 +483,9 @@ struct zebra_dplane_ctx {
 
 	bool zd_startup;
 
+	/* refresh bitmap: each bit represents a piece of state to refresh */
+	uint32_t refresh_flags;
+
 	/* Support info for different kinds of updates */
 	union {
 		struct dplane_route_info rinfo;
@@ -8572,13 +8575,14 @@ void zebra_dplane_startup_stage(ns_id_t ns_id,
 	dplane_provider_enqueue_to_zebra(ctx);
 }
 
-void zebra_dplane_provider_refresh(uint32_t zd_provider)
+void zebra_dplane_provider_refresh(uint32_t zd_provider, uint32_t refresh_flags)
 {
 	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
 
 	ctx->zd_op = DPLANE_OP_PROVIDER_REFRESH;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_QUEUED;
 	ctx->zd_provider = zd_provider;
+	ctx->refresh_flags = refresh_flags;
 
 	dplane_provider_enqueue_to_zebra(ctx);
 }

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -739,9 +739,10 @@ static enum zebra_dplane_result lsp_update_internal(struct zebra_lsp *lsp,
 						    enum dplane_op_e op);
 static enum zebra_dplane_result pw_update_internal(struct zebra_pw *pw,
 						   enum dplane_op_e op);
-static enum zebra_dplane_result intf_addr_update_internal(
-	const struct interface *ifp, const struct connected *ifc,
-	enum dplane_op_e op);
+static enum zebra_dplane_result intf_addr_update_internal(const struct interface *ifp,
+							  const struct connected *ifc,
+							  enum dplane_op_e op, bool skip_kernel);
+
 static enum zebra_dplane_result mac_update_common(enum dplane_op_e op, const struct interface *ifp,
 						  const struct interface *br_ifp, vlanid_t vid,
 						  const struct ethaddr *mac, vni_t vni,
@@ -5568,8 +5569,19 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 	}
 #endif
 
-	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_INSTALL);
+	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_INSTALL, false);
 }
+
+/*
+ * Enqueue interface address refresh for the dataplane. This is identical to
+ * dplane_intf_addr_set(), except that the ctx is flagged with skip kernel.
+ */
+enum zebra_dplane_result dplane_intf_addr_refresh(const struct interface *ifp,
+						  const struct connected *ifc)
+{
+	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_INSTALL, true);
+}
+
 
 /*
  * Enqueue interface address remove/uninstall for the dataplane.
@@ -5577,12 +5589,12 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 						const struct connected *ifc)
 {
-	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_UNINSTALL);
+	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_UNINSTALL, false);
 }
 
-static enum zebra_dplane_result intf_addr_update_internal(
-	const struct interface *ifp, const struct connected *ifc,
-	enum dplane_op_e op)
+static enum zebra_dplane_result intf_addr_update_internal(const struct interface *ifp,
+							  const struct connected *ifc,
+							  enum dplane_op_e op, bool skip_kernel)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	int ret = EINVAL;
@@ -5599,6 +5611,9 @@ static enum zebra_dplane_result intf_addr_update_internal(
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
 	ctx->zd_vrf_id = ifp->vrf->vrf_id;
+
+	if (skip_kernel)
+		dplane_ctx_set_skip_kernel(ctx);
 
 	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
@@ -5665,8 +5680,8 @@ static enum zebra_dplane_result intf_addr_update_internal(
  *
  * Return:	Result of the change
  */
-static enum zebra_dplane_result
-dplane_intf_update_internal(const struct interface *ifp, enum dplane_op_e op)
+static enum zebra_dplane_result dplane_intf_update_internal(const struct interface *ifp,
+							    enum dplane_op_e op, bool skip_kernel)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	int ret;
@@ -5676,8 +5691,12 @@ dplane_intf_update_internal(const struct interface *ifp, enum dplane_op_e op)
 	ctx = dplane_ctx_alloc();
 
 	ret = dplane_ctx_intf_init(ctx, op, ifp);
-	if (ret == AOK)
+	if (ret == AOK) {
+		if (skip_kernel)
+			dplane_ctx_set_skip_kernel(ctx);
+
 		ret = dplane_update_enqueue(ctx);
+	}
 
 	/* Update counter */
 	atomic_fetch_add_explicit(&zdplane_info.dg_intfs_in, 1,
@@ -5703,7 +5722,7 @@ enum zebra_dplane_result dplane_intf_add(const struct interface *ifp)
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (ifp)
-		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_INSTALL);
+		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_INSTALL, false);
 	return ret;
 }
 
@@ -5715,7 +5734,20 @@ enum zebra_dplane_result dplane_intf_update(const struct interface *ifp)
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (ifp)
-		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_UPDATE);
+		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_UPDATE, false);
+	return ret;
+}
+
+/*
+ * Enqueue a interface refresh for the dataplane. This is identical to dplane_intf_update()
+ * except that the ctx is flagged with skip kernel.
+ */
+enum zebra_dplane_result dplane_intf_refresh(const struct interface *ifp)
+{
+	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	if (ifp)
+		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_UPDATE, true);
 	return ret;
 }
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -975,6 +975,7 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		break;
 	case DPLANE_OP_VLAN_INSTALL:
 		if (ctx->u.vlan_info.vlan_array)
@@ -1298,6 +1299,8 @@ const char *dplane_op2str(enum dplane_op_e op)
 		return "TC_QDISC_READ";
 	case DPLANE_OP_TC_QDISC_NOTIFY:
 		return "TC_QDISC_NOTIFY";
+	case DPLANE_OP_PROVIDER_REFRESH:
+		return "PROVIDER_REFRESH";
 	}
 
 	return "UNKNOWN";
@@ -7464,6 +7467,8 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 				   : "del",
 			   dplane_ctx_tc_qdisc_notify_get_major_handle(ctx),
 			   dplane_ctx_get_startup(ctx));
+	case DPLANE_OP_PROVIDER_REFRESH:
+		zlog_debug("Got provider refresh request");
 		break;
 	}
 }
@@ -7646,6 +7651,7 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 
 	case DPLANE_OP_NONE:
 	case DPLANE_OP_STARTUP_STAGE:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
 			atomic_fetch_add_explicit(&zdplane_info.dg_other_errors,
 						  1, memory_order_relaxed);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -8561,6 +8561,11 @@ dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx)
 	return ctx->u.spot;
 }
 
+uint32_t dplane_ctx_get_refresh_flags(struct zebra_dplane_ctx *ctx)
+{
+	return ctx->refresh_flags;
+}
+
 void zebra_dplane_startup_stage(ns_id_t ns_id,
 				enum zebra_dplane_startup_notifications spot)
 {

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -7467,6 +7467,8 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 				   : "del",
 			   dplane_ctx_tc_qdisc_notify_get_major_handle(ctx),
 			   dplane_ctx_get_startup(ctx));
+		break;
+
 	case DPLANE_OP_PROVIDER_REFRESH:
 		zlog_debug("Got provider refresh request");
 		break;
@@ -8569,6 +8571,18 @@ void zebra_dplane_startup_stage(ns_id_t ns_id,
 
 	dplane_provider_enqueue_to_zebra(ctx);
 }
+
+void zebra_dplane_provider_refresh(uint32_t zd_provider)
+{
+	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
+
+	ctx->zd_op = DPLANE_OP_PROVIDER_REFRESH;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_QUEUED;
+	ctx->zd_provider = zd_provider;
+
+	dplane_provider_enqueue_to_zebra(ctx);
+}
+
 /*
  * Initialize the dataplane module at startup; called by zebra rib_init()
  */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -7631,6 +7631,8 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 				   : "del",
 			   dplane_ctx_tc_qdisc_notify_get_major_handle(ctx),
 			   dplane_ctx_get_startup(ctx));
+		break;
+
 	case DPLANE_OP_PROVIDER_REFRESH:
 		zlog_debug("Got provider refresh request");
 		break;
@@ -8740,6 +8742,18 @@ void zebra_dplane_startup_stage(ns_id_t ns_id,
 
 	dplane_provider_enqueue_to_zebra(ctx);
 }
+
+void zebra_dplane_provider_refresh(uint32_t zd_provider)
+{
+	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
+
+	ctx->zd_op = DPLANE_OP_PROVIDER_REFRESH;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_QUEUED;
+	ctx->zd_provider = zd_provider;
+
+	dplane_provider_enqueue_to_zebra(ctx);
+}
+
 /*
  * Initialize the dataplane module at startup; called by zebra rib_init()
  */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -8732,6 +8732,11 @@ dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx)
 	return ctx->u.spot;
 }
 
+uint32_t dplane_ctx_get_refresh_flags(struct zebra_dplane_ctx *ctx)
+{
+	return ctx->refresh_flags;
+}
+
 void zebra_dplane_startup_stage(ns_id_t ns_id,
 				enum zebra_dplane_startup_notifications spot)
 {

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -996,6 +996,7 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		break;
 	case DPLANE_OP_VLAN_INSTALL:
 		if (ctx->u.vlan_info.vlan_array)
@@ -1324,6 +1325,8 @@ const char *dplane_op2str(enum dplane_op_e op)
 		return "TC_QDISC_READ";
 	case DPLANE_OP_TC_QDISC_NOTIFY:
 		return "TC_QDISC_NOTIFY";
+	case DPLANE_OP_PROVIDER_REFRESH:
+		return "PROVIDER_REFRESH";
 	}
 
 	return "UNKNOWN";
@@ -7628,6 +7631,8 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 				   : "del",
 			   dplane_ctx_tc_qdisc_notify_get_major_handle(ctx),
 			   dplane_ctx_get_startup(ctx));
+	case DPLANE_OP_PROVIDER_REFRESH:
+		zlog_debug("Got provider refresh request");
 		break;
 	}
 }
@@ -7817,6 +7822,7 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 
 	case DPLANE_OP_NONE:
 	case DPLANE_OP_STARTUP_STAGE:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
 			atomic_fetch_add_explicit(&zdplane_info.dg_other_errors,
 						  1, memory_order_relaxed);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -498,6 +498,9 @@ struct zebra_dplane_ctx {
 
 	bool zd_startup;
 
+	/* refresh bitmap: each bit represents a piece of state to refresh */
+	uint32_t refresh_flags;
+
 	/* Support info for different kinds of updates */
 	union {
 		struct dplane_route_info rinfo;
@@ -8743,13 +8746,14 @@ void zebra_dplane_startup_stage(ns_id_t ns_id,
 	dplane_provider_enqueue_to_zebra(ctx);
 }
 
-void zebra_dplane_provider_refresh(uint32_t zd_provider)
+void zebra_dplane_provider_refresh(uint32_t zd_provider, uint32_t refresh_flags)
 {
 	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
 
 	ctx->zd_op = DPLANE_OP_PROVIDER_REFRESH;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_QUEUED;
 	ctx->zd_provider = zd_provider;
+	ctx->refresh_flags = refresh_flags;
 
 	dplane_provider_enqueue_to_zebra(ctx);
 }

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -758,9 +758,10 @@ static enum zebra_dplane_result lsp_update_internal(struct zebra_lsp *lsp,
 						    enum dplane_op_e op);
 static enum zebra_dplane_result pw_update_internal(struct zebra_pw *pw,
 						   enum dplane_op_e op);
-static enum zebra_dplane_result intf_addr_update_internal(
-	const struct interface *ifp, const struct connected *ifc,
-	enum dplane_op_e op);
+static enum zebra_dplane_result intf_addr_update_internal(const struct interface *ifp,
+							  const struct connected *ifc,
+							  enum dplane_op_e op, bool skip_kernel);
+
 static enum zebra_dplane_result mac_update_common(enum dplane_op_e op, const struct interface *ifp,
 						  const struct interface *br_ifp, vlanid_t vid,
 						  const struct ethaddr *mac, vni_t vni,
@@ -5720,8 +5721,19 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 	}
 #endif
 
-	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_INSTALL);
+	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_INSTALL, false);
 }
+
+/*
+ * Enqueue interface address refresh for the dataplane. This is identical to
+ * dplane_intf_addr_set(), except that the ctx is flagged with skip kernel.
+ */
+enum zebra_dplane_result dplane_intf_addr_refresh(const struct interface *ifp,
+						  const struct connected *ifc)
+{
+	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_INSTALL, true);
+}
+
 
 /*
  * Enqueue interface address remove/uninstall for the dataplane.
@@ -5729,12 +5741,12 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 						const struct connected *ifc)
 {
-	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_UNINSTALL);
+	return intf_addr_update_internal(ifp, ifc, DPLANE_OP_ADDR_UNINSTALL, false);
 }
 
-static enum zebra_dplane_result intf_addr_update_internal(
-	const struct interface *ifp, const struct connected *ifc,
-	enum dplane_op_e op)
+static enum zebra_dplane_result intf_addr_update_internal(const struct interface *ifp,
+							  const struct connected *ifc,
+							  enum dplane_op_e op, bool skip_kernel)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	int ret = EINVAL;
@@ -5751,6 +5763,9 @@ static enum zebra_dplane_result intf_addr_update_internal(
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
 	ctx->zd_vrf_id = ifp->vrf->vrf_id;
+
+	if (skip_kernel)
+		dplane_ctx_set_skip_kernel(ctx);
 
 	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
@@ -5817,8 +5832,8 @@ static enum zebra_dplane_result intf_addr_update_internal(
  *
  * Return:	Result of the change
  */
-static enum zebra_dplane_result
-dplane_intf_update_internal(const struct interface *ifp, enum dplane_op_e op)
+static enum zebra_dplane_result dplane_intf_update_internal(const struct interface *ifp,
+							    enum dplane_op_e op, bool skip_kernel)
 {
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 	int ret;
@@ -5828,8 +5843,12 @@ dplane_intf_update_internal(const struct interface *ifp, enum dplane_op_e op)
 	ctx = dplane_ctx_alloc();
 
 	ret = dplane_ctx_intf_init(ctx, op, ifp);
-	if (ret == AOK)
+	if (ret == AOK) {
+		if (skip_kernel)
+			dplane_ctx_set_skip_kernel(ctx);
+
 		ret = dplane_update_enqueue(ctx);
+	}
 
 	/* Update counter */
 	atomic_fetch_add_explicit(&zdplane_info.dg_intfs_in, 1,
@@ -5855,7 +5874,7 @@ enum zebra_dplane_result dplane_intf_add(const struct interface *ifp)
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (ifp)
-		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_INSTALL);
+		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_INSTALL, false);
 	return ret;
 }
 
@@ -5867,7 +5886,20 @@ enum zebra_dplane_result dplane_intf_update(const struct interface *ifp)
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (ifp)
-		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_UPDATE);
+		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_UPDATE, false);
+	return ret;
+}
+
+/*
+ * Enqueue a interface refresh for the dataplane. This is identical to dplane_intf_update()
+ * except that the ctx is flagged with skip kernel.
+ */
+enum zebra_dplane_result dplane_intf_refresh(const struct interface *ifp)
+{
+	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	if (ifp)
+		ret = dplane_intf_update_internal(ifp, DPLANE_OP_INTF_UPDATE, true);
 	return ret;
 }
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1033,13 +1033,15 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 					      const struct connected *ifc);
 enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 						const struct connected *ifc);
-
+enum zebra_dplane_result dplane_intf_addr_refresh(const struct interface *ifp,
+						  const struct connected *ifc);
 /*
  * Enqueue interface link changes for the dataplane.
  */
 enum zebra_dplane_result dplane_intf_add(const struct interface *ifp);
 enum zebra_dplane_result dplane_intf_update(const struct interface *ifp);
 enum zebra_dplane_result dplane_intf_speed_get(const struct interface *ifp);
+enum zebra_dplane_result dplane_intf_refresh(const struct interface *ifp);
 
 /*
  * Enqueue tc link changes for the dataplane.

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -239,6 +239,7 @@ enum dplane_op_e {
 #define ZEBRA_DPLANE_BR_STATE_FORWARDING 0x08
 #define ZEBRA_DPLANE_BR_STATE_BLOCKING	 0x10
 
+
 /*
  * The vxlan/evpn neighbor management code needs some values to use
  * when programming neighbor changes. Offer some platform-neutral values
@@ -279,9 +280,10 @@ enum dplane_op_e {
 #define DPLANE_REFRESH_L3VNI_RMAC (1 << 1)
 #define DPLANE_REFRESH_INTERFACES (1 << 2)
 #define DPLANE_REFRESH_IFADDRS	  (1 << 3)
+#define DPLANE_REFRESH_LSPS	  (1 << 4)
 #define DPLANE_REFRESH_ALL                                                                        \
 	(DPLANE_REFRESH_RIB | DPLANE_REFRESH_L3VNI_RMAC | DPLANE_REFRESH_INTERFACES |             \
-	 DPLANE_REFRESH_IFADDRS)
+	 DPLANE_REFRESH_IFADDRS | DPLANE_REFRESH_LSPS)
 
 
 /* Definitions for the dplane 'netconf' apis, corresponding to the netlink
@@ -478,6 +480,8 @@ void dplane_ctx_set_ifp_speed_set(struct zebra_dplane_ctx *ctx, bool set);
 bool dplane_ctx_get_ifp_speed_set(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_ifp_speed(struct zebra_dplane_ctx *ctx, uint32_t speed);
 uint32_t dplane_ctx_get_ifp_speed(const struct zebra_dplane_ctx *ctx);
+
+uint32_t dplane_ctx_get_refresh_flags(struct zebra_dplane_ctx *ctx);
 
 /*
  * These defines mirror the values for bridge values in linux

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -274,6 +274,16 @@ enum dplane_op_e {
 
 #define DPLANE_BR_PORT_NON_DF (1 << 0)
 
+/* Refresh bitmap bits: indicate what to refresh  */
+#define DPLANE_REFRESH_RIB	  (1 << 0)
+#define DPLANE_REFRESH_L3VNI_RMAC (1 << 1)
+#define DPLANE_REFRESH_INTERFACES (1 << 2)
+#define DPLANE_REFRESH_IFADDRS	  (1 << 3)
+#define DPLANE_REFRESH_ALL                                                                        \
+	(DPLANE_REFRESH_RIB | DPLANE_REFRESH_L3VNI_RMAC | DPLANE_REFRESH_INTERFACES |             \
+	 DPLANE_REFRESH_IFADDRS)
+
+
 /* Definitions for the dplane 'netconf' apis, corresponding to the netlink
  * NETCONF api.
  * Sadly, netlink sends incremental updates, so its messages may contain
@@ -1411,7 +1421,7 @@ void zebra_dplane_shutdown(void);
 void zebra_dplane_startup_stage(ns_id_t ns_id,
 				enum zebra_dplane_startup_notifications spot);
 
-void zebra_dplane_provider_refresh(uint32_t zd_provider);
+void zebra_dplane_provider_refresh(uint32_t zd_provider, uint32_t refresh_flags);
 
 enum zebra_dplane_startup_notifications
 dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -219,6 +219,7 @@ enum dplane_op_e {
 	/* Source address for SRv6 encapsulation */
 	DPLANE_OP_SRV6_ENCAP_SRCADDR_SET,
 
+
 	/* EVPN FDB/neighbor reads */
 	DPLANE_OP_FDB_READ,
 	DPLANE_OP_NEIGH_READ,
@@ -226,6 +227,9 @@ enum dplane_op_e {
 	/* Traffic control qdisc read */
 	DPLANE_OP_TC_QDISC_READ,
 	DPLANE_OP_TC_QDISC_NOTIFY,
+
+	/* Refresh provider */
+	DPLANE_OP_PROVIDER_REFRESH
 };
 
 /* Operational status of Bridge Ports */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1411,6 +1411,8 @@ void zebra_dplane_shutdown(void);
 void zebra_dplane_startup_stage(ns_id_t ns_id,
 				enum zebra_dplane_startup_notifications spot);
 
+void zebra_dplane_provider_refresh(uint32_t zd_provider);
+
 enum zebra_dplane_startup_notifications
 dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx);
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -243,6 +243,7 @@ enum dplane_op_e {
 #define ZEBRA_DPLANE_BR_STATE_FORWARDING 0x08
 #define ZEBRA_DPLANE_BR_STATE_BLOCKING	 0x10
 
+
 /*
  * The vxlan/evpn neighbor management code needs some values to use
  * when programming neighbor changes. Offer some platform-neutral values
@@ -283,9 +284,10 @@ enum dplane_op_e {
 #define DPLANE_REFRESH_L3VNI_RMAC (1 << 1)
 #define DPLANE_REFRESH_INTERFACES (1 << 2)
 #define DPLANE_REFRESH_IFADDRS	  (1 << 3)
+#define DPLANE_REFRESH_LSPS	  (1 << 4)
 #define DPLANE_REFRESH_ALL                                                                        \
 	(DPLANE_REFRESH_RIB | DPLANE_REFRESH_L3VNI_RMAC | DPLANE_REFRESH_INTERFACES |             \
-	 DPLANE_REFRESH_IFADDRS)
+	 DPLANE_REFRESH_IFADDRS | DPLANE_REFRESH_LSPS)
 
 
 /* Definitions for the dplane 'netconf' apis, corresponding to the netlink
@@ -482,6 +484,8 @@ void dplane_ctx_set_ifp_speed_set(struct zebra_dplane_ctx *ctx, bool set);
 bool dplane_ctx_get_ifp_speed_set(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_ifp_speed(struct zebra_dplane_ctx *ctx, uint32_t speed);
 uint32_t dplane_ctx_get_ifp_speed(const struct zebra_dplane_ctx *ctx);
+
+uint32_t dplane_ctx_get_refresh_flags(struct zebra_dplane_ctx *ctx);
 
 /*
  * These defines mirror the values for bridge values in linux

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1045,13 +1045,15 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 					      const struct connected *ifc);
 enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 						const struct connected *ifc);
-
+enum zebra_dplane_result dplane_intf_addr_refresh(const struct interface *ifp,
+						  const struct connected *ifc);
 /*
  * Enqueue interface link changes for the dataplane.
  */
 enum zebra_dplane_result dplane_intf_add(const struct interface *ifp);
 enum zebra_dplane_result dplane_intf_update(const struct interface *ifp);
 enum zebra_dplane_result dplane_intf_speed_get(const struct interface *ifp);
+enum zebra_dplane_result dplane_intf_refresh(const struct interface *ifp);
 
 /*
  * Enqueue tc link changes for the dataplane.

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -219,6 +219,7 @@ enum dplane_op_e {
 	/* Source address for SRv6 encapsulation */
 	DPLANE_OP_SRV6_ENCAP_SRCADDR_SET,
 
+
 	/* EVPN FDB/neighbor reads */
 	DPLANE_OP_FDB_READ,
 	DPLANE_OP_NEIGH_READ,
@@ -230,6 +231,9 @@ enum dplane_op_e {
 	/* EVPN-MH FDB (L2) nexthop update */
 	DPLANE_OP_NH_FDB_INSTALL,
 	DPLANE_OP_NH_FDB_DELETE,
+
+	/* Refresh provider */
+	DPLANE_OP_PROVIDER_REFRESH
 };
 
 /* Operational status of Bridge Ports */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -278,6 +278,16 @@ enum dplane_op_e {
 
 #define DPLANE_BR_PORT_NON_DF (1 << 0)
 
+/* Refresh bitmap bits: indicate what to refresh  */
+#define DPLANE_REFRESH_RIB	  (1 << 0)
+#define DPLANE_REFRESH_L3VNI_RMAC (1 << 1)
+#define DPLANE_REFRESH_INTERFACES (1 << 2)
+#define DPLANE_REFRESH_IFADDRS	  (1 << 3)
+#define DPLANE_REFRESH_ALL                                                                        \
+	(DPLANE_REFRESH_RIB | DPLANE_REFRESH_L3VNI_RMAC | DPLANE_REFRESH_INTERFACES |             \
+	 DPLANE_REFRESH_IFADDRS)
+
+
 /* Definitions for the dplane 'netconf' apis, corresponding to the netlink
  * NETCONF api.
  * Sadly, netlink sends incremental updates, so its messages may contain
@@ -1434,7 +1444,7 @@ void zebra_dplane_shutdown(void);
 void zebra_dplane_startup_stage(ns_id_t ns_id,
 				enum zebra_dplane_startup_notifications spot);
 
-void zebra_dplane_provider_refresh(uint32_t zd_provider);
+void zebra_dplane_provider_refresh(uint32_t zd_provider, uint32_t refresh_flags);
 
 enum zebra_dplane_startup_notifications
 dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1434,6 +1434,8 @@ void zebra_dplane_shutdown(void);
 void zebra_dplane_startup_stage(ns_id_t ns_id,
 				enum zebra_dplane_startup_notifications spot);
 
+void zebra_dplane_provider_refresh(uint32_t zd_provider);
+
 enum zebra_dplane_startup_notifications
 dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5342,7 +5342,11 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_FDB_READ:
 			case DPLANE_OP_NEIGH_READ:
 			case DPLANE_OP_TC_QDISC_READ:
+				break;
+
 			case DPLANE_OP_PROVIDER_REFRESH:
+				zlog_debug("Got request to refresh from provider %u",
+					   dplane_ctx_get_provider(ctx));
 				break;
 
 			} /* Dispatch by op code */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5087,7 +5087,7 @@ static void rib_refresh_interface_address(struct interface *ifp)
 		if (ifc->address != NULL) {
 			zlog_debug("Refreshing address %pFX on interface %s", ifc->address,
 				   ifp->name);
-			dplane_intf_addr_set(ifp, ifc);
+			dplane_intf_addr_refresh(ifp, ifc);
 		}
 	}
 }
@@ -5116,7 +5116,7 @@ static void rib_refresh_interfaces(void)
 				   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id, ifp->ifindex,
 				   ifp->metric, ifp->mtu, ifp->mtu6, if_flag_dump(ifp->flags));
 
-			dplane_intf_update(ifp);
+			dplane_intf_refresh(ifp);
 		}
 }
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4997,6 +4997,197 @@ void rib_sweep_route(struct event *t)
 	zebra_evpn_stale_entries_cleanup(zrouter.startup_time);
 }
 
+/* Refresh: all RIB routes */
+static void rib_refresh_routes_all(void)
+{
+	zlog_debug("Refreshing rib routes...");
+	struct route_node *rn;
+	struct route_table *rt;
+	rib_dest_t *dest;
+	rib_tables_iter_t rt_iter;
+
+	rt_iter.state = RIB_TABLES_ITER_S_INIT;
+	while ((rt = rib_tables_iter_next(&rt_iter))) {
+		for (rn = route_top(rt); rn; rn = srcdest_route_next(rn)) {
+			dest = rib_dest_from_rnode(rn);
+			if (dest == NULL || !dest->selected_fib)
+				continue;
+			dplane_route_add(rn, dest->selected_fib);
+		}
+	}
+}
+
+/* Refresh: l3vni rmacs */
+static void rib_refresh_l3vni_rmac_table(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_l3vni *zl3vni = arg;
+	struct zebra_vxlan_vni *vni;
+	struct interface *br_ifp;
+	struct zebra_if *br_zif;
+	struct zebra_if *zif;
+	vlanid_t vid;
+	bool sticky;
+	struct interface *vxlan_if;
+	struct zebra_mac *zrmac = bucket->data;
+
+	// mirror install path: only remote MACs
+	if (!CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE) ||
+	    !CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC)) {
+		return;
+	}
+
+	vxlan_if = zl3vni->vxlan_if;
+	if (!vxlan_if)
+		return;
+
+	zif = vxlan_if->info;
+	if (!zif)
+		return;
+
+	br_ifp = zif->brslave_info.br_if;
+	if (!br_ifp)
+		return;
+
+	br_zif = (struct zebra_if *)(br_ifp->info);
+	if (!br_zif)
+		return;
+
+	vni = zebra_vxlan_if_vni_find(zif, zl3vni->vni);
+	if (!vni)
+		return;
+
+
+	vid = IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif) ? vni->access_vlan : 0;
+	sticky = !!CHECK_FLAG(zrmac->flags, (ZEBRA_MAC_STICKY | ZEBRA_MAC_REMOTE_DEF_GW));
+
+	dplane_rem_mac_add(zif->ifp, br_zif->ifp, vid, &zrmac->macaddr, vni->vni,
+			   &zrmac->fwd_info.r_vtep_ip, sticky, 0, 0);
+}
+static void rib_refresh_l3vni(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_l3vni *zl3vni = bucket->data;
+
+	zlog_debug("Refreshing rmac table for vni %u...(%lu macs)", zl3vni->vni,
+		   zl3vni->rmac_table->count);
+	hash_iterate(zl3vni->rmac_table, rib_refresh_l3vni_rmac_table, zl3vni);
+}
+static void rib_refresh_rmacs(void)
+{
+	zlog_debug("Refreshing l3vni table (%lu vnis)...", zrouter.l3vni_table->count);
+	hash_iterate(zrouter.l3vni_table, rib_refresh_l3vni, NULL);
+}
+
+/* Refresh: interface addresses */
+static void rib_refresh_interface_address(struct interface *ifp)
+{
+	/* addresses  */
+	struct connected *ifc;
+
+	frr_each (if_connected, ifp->connected, ifc) {
+		if (ifc->address != NULL) {
+			zlog_debug("Refreshing address %pFX on interface %s", ifc->address,
+				   ifp->name);
+			dplane_intf_addr_set(ifp, ifc);
+		}
+	}
+}
+static void rib_refresh_interface_addresses(void)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	zlog_debug("Refreshing interface addresses...");
+	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			rib_refresh_interface_address(ifp);
+		}
+}
+
+/* Refresh: interfaces */
+static void rib_refresh_interfaces(void)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	zlog_debug("Refreshing interfaces...");
+	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			zlog_debug("Interface %s vrf %s(%u) index %d metric %d mtu %d mtu6 %d %s",
+				   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id, ifp->ifindex,
+				   ifp->metric, ifp->mtu, ifp->mtu6, if_flag_dump(ifp->flags));
+
+			dplane_intf_update(ifp);
+		}
+}
+
+/* log refreshed lsps */
+static void log_lsp_refresh(struct zebra_lsp *lsp)
+{
+	if (!lsp->best_nhlfe) {
+		zlog_debug("Omitting refresh of LSP for label %u: no best nhlfe",
+			   lsp->ile.in_label);
+	} else {
+		char nh_buff[BUFSIZ] = "";
+		char labels_buff[BUFSIZ] = "";
+		struct nexthop *nexthop = lsp->best_nhlfe ? lsp->best_nhlfe->nexthop : NULL;
+		struct mpls_label_stack *nh_label = nexthop ? nexthop->nh_label : NULL;
+
+		if (nexthop)
+			nexthop2str(nexthop, nh_buff, sizeof(nh_buff));
+
+		if (nh_label) {
+			for (int n = 0; n < nh_label->num_labels; n++) {
+				char label[BUFSIZ] = "";
+
+				label2str(nh_label->label[n], 0, label, sizeof(label));
+				if (n)
+					strlcat(labels_buff, "/", sizeof(labels_buff));
+				strlcat(labels_buff, label, sizeof(labels_buff));
+			}
+		}
+		zlog_debug("Refreshing LSP for label: %u (num-ecmp: %u) best is next-hop: %s labels: %s",
+			   lsp->ile.in_label, lsp->num_ecmp, nh_buff, labels_buff);
+	}
+}
+
+/* Refresh: lsps */
+static void rib_refresh_lsp(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_lsp *lsp = bucket->data;
+
+	if (!lsp->best_nhlfe) {
+		zlog_debug("Omitting refresh of LSP for label: %u num-ecmp: %u: no best nhlfe",
+			   lsp->ile.in_label, lsp->num_ecmp);
+	} else {
+		log_lsp_refresh(lsp);
+		dplane_lsp_add(lsp);
+	}
+}
+static void rib_refresh_lsps(void)
+{
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (zvrf && zvrf->lsp_table) {
+		zlog_debug("Refreshing LSPs...");
+		hash_iterate(zvrf->lsp_table, rib_refresh_lsp, NULL);
+	}
+}
+
+/* Refresh dplane provider(s) */
+void rib_provider_refresh(uint32_t refresh_flags)
+{
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_INTERFACES))
+		rib_refresh_interfaces();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_IFADDRS))
+		rib_refresh_interface_addresses();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_L3VNI_RMAC))
+		rib_refresh_rmacs();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_RIB))
+		rib_refresh_routes_all();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_LSPS))
+		rib_refresh_lsps();
+}
+
 /* Remove specific by protocol routes from 'table'. */
 unsigned long rib_score_proto_table(uint8_t proto, unsigned short instance,
 				    struct route_table *table)
@@ -5347,6 +5538,7 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_PROVIDER_REFRESH:
 				zlog_debug("Got request to refresh from provider %u",
 					   dplane_ctx_get_provider(ctx));
+				rib_provider_refresh(dplane_ctx_get_refresh_flags(ctx));
 				break;
 
 			} /* Dispatch by op code */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5342,7 +5342,9 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_FDB_READ:
 			case DPLANE_OP_NEIGH_READ:
 			case DPLANE_OP_TC_QDISC_READ:
+			case DPLANE_OP_PROVIDER_REFRESH:
 				break;
+
 			} /* Dispatch by op code */
 
 			dplane_ctx_fini(&ctx);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5382,7 +5382,9 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_FDB_READ:
 			case DPLANE_OP_NEIGH_READ:
 			case DPLANE_OP_TC_QDISC_READ:
+			case DPLANE_OP_PROVIDER_REFRESH:
 				break;
+
 			} /* Dispatch by op code */
 
 			dplane_ctx_fini(&ctx);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5006,6 +5006,197 @@ void rib_sweep_route(struct event *t)
 	zebra_evpn_stale_entries_cleanup(zrouter.startup_time);
 }
 
+/* Refresh: all RIB routes */
+static void rib_refresh_routes_all(void)
+{
+	zlog_debug("Refreshing rib routes...");
+	struct route_node *rn;
+	struct route_table *rt;
+	rib_dest_t *dest;
+	rib_tables_iter_t rt_iter;
+
+	rt_iter.state = RIB_TABLES_ITER_S_INIT;
+	while ((rt = rib_tables_iter_next(&rt_iter))) {
+		for (rn = route_top(rt); rn; rn = srcdest_route_next(rn)) {
+			dest = rib_dest_from_rnode(rn);
+			if (dest == NULL || !dest->selected_fib)
+				continue;
+			dplane_route_add(rn, dest->selected_fib);
+		}
+	}
+}
+
+/* Refresh: l3vni rmacs */
+static void rib_refresh_l3vni_rmac_table(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_l3vni *zl3vni = arg;
+	struct zebra_vxlan_vni *vni;
+	struct interface *br_ifp;
+	struct zebra_if *br_zif;
+	struct zebra_if *zif;
+	vlanid_t vid;
+	bool sticky;
+	struct interface *vxlan_if;
+	struct zebra_mac *zrmac = bucket->data;
+
+	// mirror install path: only remote MACs
+	if (!CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE) ||
+	    !CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC)) {
+		return;
+	}
+
+	vxlan_if = zl3vni->vxlan_if;
+	if (!vxlan_if)
+		return;
+
+	zif = vxlan_if->info;
+	if (!zif)
+		return;
+
+	br_ifp = zif->brslave_info.br_if;
+	if (!br_ifp)
+		return;
+
+	br_zif = (struct zebra_if *)(br_ifp->info);
+	if (!br_zif)
+		return;
+
+	vni = zebra_vxlan_if_vni_find(zif, zl3vni->vni);
+	if (!vni)
+		return;
+
+
+	vid = IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif) ? vni->access_vlan : 0;
+	sticky = !!CHECK_FLAG(zrmac->flags, (ZEBRA_MAC_STICKY | ZEBRA_MAC_REMOTE_DEF_GW));
+
+	dplane_rem_mac_add(zif->ifp, br_zif->ifp, vid, &zrmac->macaddr, vni->vni,
+			   &zrmac->fwd_info.r_vtep_ip, sticky, 0, 0);
+}
+static void rib_refresh_l3vni(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_l3vni *zl3vni = bucket->data;
+
+	zlog_debug("Refreshing rmac table for vni %u...(%lu macs)", zl3vni->vni,
+		   zl3vni->rmac_table->count);
+	hash_iterate(zl3vni->rmac_table, rib_refresh_l3vni_rmac_table, zl3vni);
+}
+static void rib_refresh_rmacs(void)
+{
+	zlog_debug("Refreshing l3vni table (%lu vnis)...", zrouter.l3vni_table->count);
+	hash_iterate(zrouter.l3vni_table, rib_refresh_l3vni, NULL);
+}
+
+/* Refresh: interface addresses */
+static void rib_refresh_interface_address(struct interface *ifp)
+{
+	/* addresses  */
+	struct connected *ifc;
+
+	frr_each (if_connected, ifp->connected, ifc) {
+		if (ifc->address != NULL) {
+			zlog_debug("Refreshing address %pFX on interface %s", ifc->address,
+				   ifp->name);
+			dplane_intf_addr_set(ifp, ifc);
+		}
+	}
+}
+static void rib_refresh_interface_addresses(void)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	zlog_debug("Refreshing interface addresses...");
+	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			rib_refresh_interface_address(ifp);
+		}
+}
+
+/* Refresh: interfaces */
+static void rib_refresh_interfaces(void)
+{
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	zlog_debug("Refreshing interfaces...");
+	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			zlog_debug("Interface %s vrf %s(%u) index %d metric %d mtu %d mtu6 %d %s",
+				   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id, ifp->ifindex,
+				   ifp->metric, ifp->mtu, ifp->mtu6, if_flag_dump(ifp->flags));
+
+			dplane_intf_update(ifp);
+		}
+}
+
+/* log refreshed lsps */
+static void log_lsp_refresh(struct zebra_lsp *lsp)
+{
+	if (!lsp->best_nhlfe) {
+		zlog_debug("Omitting refresh of LSP for label %u: no best nhlfe",
+			   lsp->ile.in_label);
+	} else {
+		char nh_buff[BUFSIZ] = "";
+		char labels_buff[BUFSIZ] = "";
+		struct nexthop *nexthop = lsp->best_nhlfe ? lsp->best_nhlfe->nexthop : NULL;
+		struct mpls_label_stack *nh_label = nexthop ? nexthop->nh_label : NULL;
+
+		if (nexthop)
+			nexthop2str(nexthop, nh_buff, sizeof(nh_buff));
+
+		if (nh_label) {
+			for (int n = 0; n < nh_label->num_labels; n++) {
+				char label[BUFSIZ] = "";
+
+				label2str(nh_label->label[n], 0, label, sizeof(label));
+				if (n)
+					strlcat(labels_buff, "/", sizeof(labels_buff));
+				strlcat(labels_buff, label, sizeof(labels_buff));
+			}
+		}
+		zlog_debug("Refreshing LSP for label: %u (num-ecmp: %u) best is next-hop: %s labels: %s",
+			   lsp->ile.in_label, lsp->num_ecmp, nh_buff, labels_buff);
+	}
+}
+
+/* Refresh: lsps */
+static void rib_refresh_lsp(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_lsp *lsp = bucket->data;
+
+	if (!lsp->best_nhlfe) {
+		zlog_debug("Omitting refresh of LSP for label: %u num-ecmp: %u: no best nhlfe",
+			   lsp->ile.in_label, lsp->num_ecmp);
+	} else {
+		log_lsp_refresh(lsp);
+		dplane_lsp_add(lsp);
+	}
+}
+static void rib_refresh_lsps(void)
+{
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (zvrf && zvrf->lsp_table) {
+		zlog_debug("Refreshing LSPs...");
+		hash_iterate(zvrf->lsp_table, rib_refresh_lsp, NULL);
+	}
+}
+
+/* Refresh dplane provider(s) */
+void rib_provider_refresh(uint32_t refresh_flags)
+{
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_INTERFACES))
+		rib_refresh_interfaces();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_IFADDRS))
+		rib_refresh_interface_addresses();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_L3VNI_RMAC))
+		rib_refresh_rmacs();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_RIB))
+		rib_refresh_routes_all();
+	if (CHECK_FLAG(refresh_flags, DPLANE_REFRESH_LSPS))
+		rib_refresh_lsps();
+}
+
 /* Remove specific by protocol routes from 'table'. */
 unsigned long rib_score_proto_table(uint8_t proto, unsigned short instance,
 				    struct route_table *table)
@@ -5387,6 +5578,7 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_PROVIDER_REFRESH:
 				zlog_debug("Got request to refresh from provider %u",
 					   dplane_ctx_get_provider(ctx));
+				rib_provider_refresh(dplane_ctx_get_refresh_flags(ctx));
 				break;
 
 			} /* Dispatch by op code */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5096,7 +5096,7 @@ static void rib_refresh_interface_address(struct interface *ifp)
 		if (ifc->address != NULL) {
 			zlog_debug("Refreshing address %pFX on interface %s", ifc->address,
 				   ifp->name);
-			dplane_intf_addr_set(ifp, ifc);
+			dplane_intf_addr_refresh(ifp, ifc);
 		}
 	}
 }
@@ -5125,7 +5125,7 @@ static void rib_refresh_interfaces(void)
 				   ifp->name, ifp->vrf->name, ifp->vrf->vrf_id, ifp->ifindex,
 				   ifp->metric, ifp->mtu, ifp->mtu6, if_flag_dump(ifp->flags));
 
-			dplane_intf_update(ifp);
+			dplane_intf_refresh(ifp);
 		}
 }
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5382,7 +5382,11 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_FDB_READ:
 			case DPLANE_OP_NEIGH_READ:
 			case DPLANE_OP_TC_QDISC_READ:
+				break;
+
 			case DPLANE_OP_PROVIDER_REFRESH:
+				zlog_debug("Got request to refresh from provider %u",
+					   dplane_ctx_get_provider(ctx));
 				break;
 
 			} /* Dispatch by op code */

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -433,6 +433,7 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		break;
 	} /* Dispatch by op code */
 }

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -435,6 +435,7 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_PROVIDER_REFRESH:
 		break;
 	} /* Dispatch by op code */
 }


### PR DESCRIPTION
Zebra's dataplane (dplane) susbystem allows installing routing state in remote dataplane(s) (e.g. forwarding engines), other than the kernel. The lifecycle of those providers, however, can differ from that of zebra/FRR: providers may crash, be restarted or reinitialized, in which case they may lose all the "routing state" learnt from zebra, without the current dplane subsystem having the infrastructure to resend it.

This PR extends zebra's dplane with a new operation -DPLANE_OP_PROVIDER_REFRESH- that dataplane providers can request to zebra's dplane to make it re-send routing state. Since zebra dplane manages the install of distinct types of routing objects not all of which a provider may be interested in, a bitmap allows indicating which pieces of the routing state are to be re-sent. The implementation in this PR includes refresh for: routes, LSPs, l3vni remote macs and interface addresses.
