### PR TITLE
ripd: allow neighbor updates with network IFNAME

### DIFF
--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -39,6 +39,7 @@ static void rip_enable_apply(struct interface *);
 static void rip_passive_interface_apply(struct interface *);
 static int rip_if_down(struct interface *ifp);
 static int rip_enable_if_lookup(struct rip *rip, const char *ifname);
+static int rip_enable_network_prefix_lookup(struct connected *connected);
 static void rip_enable_apply_all(struct rip *rip);
 
 const struct message ri_version_msg[] = {{RI_RIP_VERSION_1, "1"},
@@ -492,10 +493,8 @@ static void rip_apply_address_add(struct connected *ifc)
 	nh.ifindex = ifc->ifp->ifindex;
 	nh.type = NEXTHOP_TYPE_IFINDEX;
 
-	/* Check if this interface is RIP enabled or not
-	   or  Check if this address's prefix is RIP enabled */
-	if ((rip_enable_if_lookup(rip, ifc->ifp->name) >= 0)
-	    || (rip_enable_network_lookup2(ifc) >= 0))
+	/* Check if this connected address is RIP enabled. */
+	if (rip_enable_network_connected_lookup(ifc) >= 0)
 		rip_redistribute_add(rip, ZEBRA_ROUTE_CONNECT,
 				     RIP_ROUTE_INTERFACE, &address, &nh, 0, 0,
 				     0);
@@ -615,8 +614,8 @@ static int rip_enable_network_lookup_if(struct interface *ifp)
 	return -1;
 }
 
-/* Check whether connected is within the ripng_enable_network table. */
-int rip_enable_network_lookup2(struct connected *connected)
+/* Check whether connected is within the RIP prefix-form network table. */
+static int rip_enable_network_prefix_lookup(struct connected *connected)
 {
 	struct rip_interface *ri = connected->ifp->info;
 	struct rip *rip = ri->rip;
@@ -645,6 +644,19 @@ int rip_enable_network_lookup2(struct connected *connected)
 
 	return -1;
 }
+
+/* Check whether connected is enabled by either form of `network`. */
+int rip_enable_network_connected_lookup(struct connected *connected)
+{
+	struct rip_interface *ri = connected->ifp->info;
+	struct rip *rip = ri->rip;
+
+	if (rip_enable_if_lookup(rip, connected->ifp->name) >= 0)
+		return 1;
+
+	return rip_enable_network_prefix_lookup(connected);
+}
+
 /* Add RIP enable network. */
 int rip_enable_network_add(struct rip *rip, struct prefix *p)
 {
@@ -791,11 +803,10 @@ static void rip_connect_set(struct interface *ifp, int set)
 		nh.ifindex = connected->ifp->ifindex;
 		nh.type = NEXTHOP_TYPE_IFINDEX;
 		if (set) {
-			/* Check once more whether this prefix is within a
-			 * "network IF_OR_PREF" one */
-			if ((rip_enable_if_lookup(rip, connected->ifp->name)
-			     >= 0)
-			    || (rip_enable_network_lookup2(connected) >= 0))
+			/* Check once more whether this connected address is
+			 * enabled by a network statement.
+			 */
+			if (rip_enable_network_connected_lookup(connected) >= 0)
 				rip_redistribute_add(rip, ZEBRA_ROUTE_CONNECT,
 						     RIP_ROUTE_INTERFACE,
 						     &address, &nh, 0, 0, 0);

--- a/ripd/rip_interface.h
+++ b/ripd/rip_interface.h
@@ -25,6 +25,6 @@ extern int rip_interface_address_delete(int cmd, struct zclient *zclient, zebra_
 					vrf_id_t vrf_id);
 extern int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS);
 extern void rip_interface_sync(struct interface *ifp);
-extern int rip_enable_network_lookup2(struct connected *connected);
+extern int rip_enable_network_connected_lookup(struct connected *connected);
 
 #endif /* _QUAGGA_RIP_INTERFACE_H */

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2506,14 +2506,13 @@ static void rip_update_process(struct rip *rip, int route_type)
 			continue;
 		}
 
-		/* If unicast is used, but `network X.Y.Z.W` is not defined
-		 * for this interface, we SHOULD NOT send an update to this
-		 * neighbor.
+		/* If unicast is used, but no `network` statement enables
+		 * this interface, we SHOULD NOT send an update to this neighbor.
 		 * If RIP is configured on such an interface, the redistribution
 		 * of route(s) from another routing protocol into RIP, received
 		 * through that interface, does not work.
 		 */
-		if (rip_enable_network_lookup2(connected) < 0) {
+		if (rip_enable_network_connected_lookup(connected) < 0) {
 			if (RIP_DEBUG_SEND)
 				zlog_debug("Neighbor %pI4 is not in any `network` statement!",
 					   &p->u.prefix4);

--- a/tests/topotests/rip_no_neighbor/r2/frr.conf
+++ b/tests/topotests/rip_no_neighbor/r2/frr.conf
@@ -8,7 +8,7 @@ int r2-eth0
 exit
 !
 router rip
- network 10.1.12.0/24
+ network r2-eth0
  passive-interface r2-eth0
  redistribute static
  neighbor 10.1.12.1

--- a/tests/topotests/rip_no_neighbor/test_rip_no_neighbor.py
+++ b/tests/topotests/rip_no_neighbor/test_rip_no_neighbor.py
@@ -9,7 +9,11 @@
 #
 
 r"""
-test_rip_no_neighbor.py: Test to verify that disabling a rip neighbor via the "no neighbor" command works correctly.
+test_rip_no_neighbor.py: Test to verify that disabling a RIP neighbor via the
+"no neighbor" command works correctly.
+
+The sender uses `network IFNAME` on a passive interface so the neighbor unicast
+path is also covered for interface-name based RIP enablement.
 """
 
 import os
@@ -83,7 +87,10 @@ def test_rip_no_neighbor(tgen):
 
         return topotest.json_cmp(output, expected, exact=exact)
 
-    step("verify r1 has 192.168.105.0/24 in routing table as a rip route")
+    step(
+        "verify r1 has 192.168.105.0/24 from r2's "
+        "ifname-enabled RIP interface"
+    )
 
     expected = {
         "192.168.105.0/24": [


### PR DESCRIPTION
RIP accepts both prefix and interface-name forms of the network command.

The neighbor unicast update path only checked the prefix-form table.

That skipped updates when the outgoing interface was enabled only with network IFNAME.

Reuse a single connected-interface enable helper that accepts either network form.