### PR TITLE
pimd: sanitize IGMPv3 and mtrace packet-derived lengths

### DIFF
--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -216,6 +216,8 @@ static void mtrace_debug(struct pim_interface *pim_ifp,
 					"Mtrace response block of wrong length");
 
 		responses = responses / sizeof(struct igmp_mtrace_rsp);
+		if (responses > MTRACE_MAX_HOPS)
+			responses = MTRACE_MAX_HOPS;
 
 		for (i = 0; i < responses; i++)
 			mtrace_rsp_debug(mtracep->qry_id, i, &mtracep->rsp[i]);
@@ -549,7 +551,7 @@ int igmp_mtrace_recv_qry_req(struct gm_sock *igmp, struct ip *ip_hdr, struct in_
 			     char *igmp_msg, int igmp_msg_len)
 {
 	static uint32_t qry_id, qry_src;
-	char mtrace_buf[MTRACE_HDR_SIZE + MTRACE_MAX_HOPS * MTRACE_RSP_SIZE];
+	char mtrace_buf[MTRACE_MAX_MSG_LEN];
 	struct interface *ifp;
 	struct interface *out_ifp = NULL;
 	struct pim_interface *pim_ifp;
@@ -580,10 +582,15 @@ int igmp_mtrace_recv_qry_req(struct gm_sock *igmp, struct ip *ip_hdr, struct in_
 					 pim->vrf->vrf_id))
 			return mtrace_forward_packet(pim, ip_hdr);
 
-	if (igmp_msg_len < (int)sizeof(struct igmp_mtrace)) {
+	/*
+	 * Sanitize packet-derived length before using it as an offset /
+	 * memcpy length. Cap matches mtrace_buf.
+	 */
+	if (igmp_msg_len < (int)MTRACE_HDR_SIZE || igmp_msg_len > (int)MTRACE_MAX_MSG_LEN) {
 		if (PIM_DEBUG_MTRACE)
-			zlog_debug("Recv mtrace packet from %pI4s on %s: too short, len=%d, min=%zu",
-				   &from, ifp->name, igmp_msg_len, sizeof(struct igmp_mtrace));
+			zlog_debug("Recv mtrace packet from %pI4s on %s: invalid length %d (min=%zu max=%zu)",
+				   &from, ifp->name, igmp_msg_len, MTRACE_HDR_SIZE,
+				   MTRACE_MAX_MSG_LEN);
 		return -1;
 	}
 
@@ -790,10 +797,11 @@ int igmp_mtrace_recv_response(struct gm_sock *igmp, struct ip *ip_hdr, struct in
 	pim_ifp = ifp->info;
 	pim = pim_ifp->pim;
 
-	if (igmp_msg_len < (int)sizeof(struct igmp_mtrace)) {
+	if (igmp_msg_len < (int)MTRACE_HDR_SIZE || igmp_msg_len > (int)MTRACE_MAX_MSG_LEN) {
 		if (PIM_DEBUG_MTRACE)
-			zlog_debug("Recv mtrace packet from %pI4s on %s: too short, len=%d, min=%zu",
-				   &from, ifp->name, igmp_msg_len, sizeof(struct igmp_mtrace));
+			zlog_debug("Recv mtrace response from %pI4s on %s: invalid length %d (min=%zu max=%zu)",
+				   &from, ifp->name, igmp_msg_len, MTRACE_HDR_SIZE,
+				   MTRACE_MAX_MSG_LEN);
 		return -1;
 	}
 

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -334,12 +334,28 @@ static int mtrace_un_forward_packet(struct pim_instance *pim, struct ip *ip_hdr,
 	int fd;
 	int sent;
 	uint16_t checksum;
+	uint16_t pkt_len;
+	uint16_t ip_hlen;
+
+	pkt_len = ntohs(ip_hdr->ip_len);
+	ip_hlen = ip_hdr->ip_hl << 2;
+	/*
+	 * Sanitize packet-derived IP length before sendto(). Payload must fit
+	 * the mtrace maximum; header length must be consistent.
+	 */
+	if (ip_hlen < sizeof(struct ip) || pkt_len < ip_hlen ||
+	    (size_t)(pkt_len - ip_hlen) > MTRACE_MAX_MSG_LEN) {
+		if (PIM_DEBUG_MTRACE)
+			zlog_debug("Dropping mtrace packet with invalid length %u (ihl=%u max_payload=%zu)",
+				   pkt_len, ip_hlen, MTRACE_MAX_MSG_LEN);
+		return -1;
+	}
 
 	checksum = ip_hdr->ip_sum;
 
 	ip_hdr->ip_sum = 0;
 
-	if (checksum != in_cksum(ip_hdr, ip_hdr->ip_hl * 4))
+	if (checksum != in_cksum(ip_hdr, ip_hlen))
 		return -1;
 
 	if (ip_hdr->ip_ttl-- <= 1)
@@ -360,7 +376,7 @@ static int mtrace_un_forward_packet(struct pim_instance *pim, struct ip *ip_hdr,
 		if_out = interface;
 	}
 
-	ip_hdr->ip_sum = in_cksum(ip_hdr, ip_hdr->ip_hl * 4);
+	ip_hdr->ip_sum = in_cksum(ip_hdr, ip_hlen);
 
 	fd = pim_socket_raw(IPPROTO_RAW);
 
@@ -381,8 +397,7 @@ static int mtrace_un_forward_packet(struct pim_instance *pim, struct ip *ip_hdr,
 	to.sin_addr = ip_hdr->ip_dst;
 	tolen = sizeof(to);
 
-	sent = sendto(fd, ip_hdr, ntohs(ip_hdr->ip_len), 0,
-		      (struct sockaddr *)&to, tolen);
+	sent = sendto(fd, ip_hdr, pkt_len, 0, (struct sockaddr *)&to, tolen);
 
 	close(fd);
 
@@ -397,8 +412,8 @@ static int mtrace_un_forward_packet(struct pim_instance *pim, struct ip *ip_hdr,
 	if (PIM_DEBUG_MTRACE) {
 		struct in_addr dstaddr = ip_hdr->ip_dst;
 
-		zlog_debug("Fwd mtrace packet len=%u to %pI4 ttl=%u", ntohs(ip_hdr->ip_len),
-			   &dstaddr, ip_hdr->ip_ttl);
+		zlog_debug("Fwd mtrace packet len=%u to %pI4 ttl=%u", pkt_len, &dstaddr,
+			   ip_hdr->ip_ttl);
 	}
 
 	return 0;

--- a/pimd/pim_igmp_mtrace.h
+++ b/pimd/pim_igmp_mtrace.h
@@ -80,6 +80,7 @@ struct igmp_mtrace {
 
 #define MTRACE_HDR_SIZE (sizeof(struct igmp_mtrace))
 #define MTRACE_RSP_SIZE (sizeof(struct igmp_mtrace_rsp))
+#define MTRACE_MAX_MSG_LEN (MTRACE_HDR_SIZE + MTRACE_MAX_HOPS * MTRACE_RSP_SIZE)
 
 int igmp_mtrace_recv_qry_req(struct gm_sock *igmp, struct ip *ip_hdr, struct in_addr from,
 			     char *igmp_msg, int igmp_msg_len);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1688,18 +1688,23 @@ void igmp_v3_recv_query(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 			group = find_group_by_addr(igmp, group_addr);
 			if (group) {
 				uint16_t recv_num_sources_n;
-				size_t expected_msg_len;
+				size_t max_sources;
 				int recv_num_sources;
 
 				memcpy(&recv_num_sources_n, igmp_msg + IGMP_V3_NUMSOURCES_OFFSET,
 				       sizeof(recv_num_sources_n));
 				recv_num_sources = ntohs(recv_num_sources_n);
-				expected_msg_len =
-					IGMP_V3_SOURCES_OFFSET +
-					((size_t)recv_num_sources * sizeof(struct in_addr));
-				if ((size_t)igmp_msg_len < expected_msg_len) {
-					zlog_warn("IGMP query v3 from %pI4s on %s truncated source list: len=%d expected=%zu",
-						  &from, ifp->name, igmp_msg_len, expected_msg_len);
+				/*
+				 * Sanitize packet Number of Sources against the
+				 * bytes remaining in the message before using it
+				 * as a loop bound.
+				 */
+				max_sources = ((size_t)igmp_msg_len - IGMP_V3_SOURCES_OFFSET) /
+					      sizeof(struct in_addr);
+				if ((size_t)recv_num_sources > max_sources) {
+					zlog_warn("IGMP query v3 from %pI4s on %s truncated source list: sources=%d max=%zu len=%d",
+						  &from, ifp->name, recv_num_sources, max_sources,
+						  igmp_msg_len);
 					return;
 				}
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1806,6 +1806,7 @@ static bool igmp_pkt_grp_addr_ok(struct interface *ifp, struct in_addr from, str
 int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from, char *igmp_msg, int igmp_msg_len)
 {
 	int num_groups;
+	size_t max_groups;
 	uint8_t *group_record;
 	uint8_t *report_pastend = (uint8_t *)igmp_msg + igmp_msg_len;
 	struct interface *ifp = igmp->interface;
@@ -1845,6 +1846,19 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 		return -1;
 	}
 
+	/*
+	 * Sanitize Number of Group Records against remaining bytes before using
+	 * it as a loop bound (minimum-sized records; larger records are still
+	 * rejected by the per-record checks below).
+	 */
+	max_groups = ((size_t)igmp_msg_len - IGMP_V3_REPORT_GROUPPRECORD_OFFSET) /
+		     IGMP_V3_GROUP_RECORD_MIN_SIZE;
+	if ((size_t)num_groups > max_groups) {
+		zlog_warn("Recv IGMP report v3 from %pI4s on %s: too many group records: groups=%d max=%zu len=%d",
+			  &from, ifp->name, num_groups, max_groups, igmp_msg_len);
+		return -1;
+	}
+
 	if (PIM_DEBUG_GM_PACKETS) {
 		zlog_debug("Recv IGMP report v3 from %pI4s on %s: size=%d groups=%d", &from,
 			   ifp->name, igmp_msg_len, num_groups);
@@ -1860,6 +1874,8 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 		int rec_type;
 		int rec_auxdatalen;
 		int rec_num_sources;
+		size_t max_sources;
+		size_t record_len;
 		int j;
 
 		if ((group_record + IGMP_V3_GROUP_RECORD_MIN_SIZE)
@@ -1889,15 +1905,26 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 		/* Scan sources */
 
 		sources = group_record + IGMP_V3_GROUP_RECORD_SOURCE_OFFSET;
+		/*
+		 * Sanitize Number of Sources against remaining bytes before
+		 * using it as a loop bound.
+		 */
+		max_sources = (size_t)(report_pastend - sources) / sizeof(struct in_addr);
+		if ((size_t)rec_num_sources > max_sources) {
+			zlog_warn("Recv IGMP report v3 from %pI4s on %s: truncated group source list: sources=%d max=%zu",
+				  &from, ifp->name, rec_num_sources, max_sources);
+			return -1;
+		}
+
+		record_len = IGMP_V3_GROUP_RECORD_MIN_SIZE + ((size_t)rec_num_sources << 2) +
+			     ((size_t)rec_auxdatalen << 2);
+		if (group_record + record_len > report_pastend) {
+			zlog_warn("Recv IGMP report v3 from %pI4s on %s: group record beyond report end",
+				  &from, ifp->name);
+			return -1;
+		}
 
 		for (j = 0, src = sources; j < rec_num_sources; ++j, src += 4) {
-
-			if ((src + 4) > report_pastend) {
-				zlog_warn("Recv IGMP report v3 from %pI4s on %s: group source beyond report end",
-					  &from, ifp->name);
-				return -1;
-			}
-
 			if (PIM_DEBUG_GM_PACKETS) {
 				char src_str[200];
 
@@ -1949,8 +1976,7 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from, char *igmp_ms
 					  &from, ifp->name, rec_type);
 			}
 
-		group_record +=
-			8 + (rec_num_sources << 2) + (rec_auxdatalen << 2);
+		group_record += record_len;
 
 	} /* for (group records) */
 


### PR DESCRIPTION
Coverity: 1672940, 1482151, 1482180, 1482188