### PR TITLE
bgpd: Fix link-bandwidth extended community handling above ~34 Gbps

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1069,15 +1069,15 @@ static int ecommunity_rt_soo_str(char *buf, size_t bufsz, const uint8_t *pnt,
 					      ECOMMUNITY_SIZE);
 }
 
-/* Helper function to convert IEEE-754 Floating Point to uint32 */
-static uint32_t ieee_float_uint32_to_uint32(uint32_t u)
+/* Helper function to convert IEEE-754 Floating Point to uint64 */
+static uint64_t ieee_float_uint32_to_uint64(uint32_t u)
 {
 	union {
 		float r;
 		uint32_t d;
 	} f = {.d = u};
 
-	return (uint32_t)f.r;
+	return (uint64_t)f.r;
 }
 
 static int ecommunity_lb_str(char *buf, size_t bufsz, const uint8_t *pnt,
@@ -1085,15 +1085,15 @@ static int ecommunity_lb_str(char *buf, size_t bufsz, const uint8_t *pnt,
 {
 	int len = 0;
 	as_t as;
-	uint32_t bw_tmp, bw;
+	uint32_t bw_tmp;
+	uint64_t bw;
 	char bps_buf[20] = {0};
 
 	as = (*pnt++ << 8);
 	as |= (*pnt++);
 	(void)ptr_get_be32(pnt, &bw_tmp);
 
-	bw = disable_ieee_floating ? bw_tmp
-				   : ieee_float_uint32_to_uint32(bw_tmp);
+	bw = disable_ieee_floating ? bw_tmp : ieee_float_uint32_to_uint64(bw_tmp);
 
 	if (bw >= ONE_GBPS_BYTES)
 		snprintf(bps_buf, sizeof(bps_buf), "%.3f Gbps",
@@ -1105,9 +1105,9 @@ static int ecommunity_lb_str(char *buf, size_t bufsz, const uint8_t *pnt,
 		snprintf(bps_buf, sizeof(bps_buf), "%.3f Kbps",
 			 (float)(bw / ONE_KBPS_BYTES));
 	else
-		snprintf(bps_buf, sizeof(bps_buf), "%u bps", bw * 8);
+		snprintfrr(bps_buf, sizeof(bps_buf), "%" PRIu64 " bps", bw * 8);
 
-	len = snprintf(buf, bufsz, "LB:%u:%u (%s)", as, bw, bps_buf);
+	len = snprintfrr(buf, bufsz, "LB:%u:%" PRIu64 " (%s)", as, bw, bps_buf);
 	return len;
 }
 
@@ -2142,8 +2142,7 @@ const uint8_t *ecommunity_linkbw_present(struct ecommunity *ecom, uint64_t *bw)
 			if (bw)
 				*bw = (uint64_t)(ecom->disable_ieee_floating
 							 ? bwval
-							 : ieee_float_uint32_to_uint32(
-								   bwval));
+							 : ieee_float_uint32_to_uint64(bwval));
 			return data;
 		} else if (CHECK_FLAG(type, ~ECOMMUNITY_FLAG_NON_TRANSITIVE) ==
 				   ECOMMUNITY_ENCODE_AS4 &&
@@ -2198,7 +2197,7 @@ struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom,
 	 * extcommunity for this - refer to AS-Path replace function
 	 * for reference.
 	 */
-	if (cum_bw > 0xFFFFFFFF)
+	if (!extended && disable_ieee_floating && cum_bw > 0xFFFFFFFF)
 		cum_bw = 0xFFFFFFFF;
 
 	if (extended) {

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -250,8 +250,8 @@ static inline void encode_route_target_as4(as_t as, uint16_t val,
 	eval->val[7] = val & 0xff;
 }
 
-/* Helper function to convert uint32 to IEEE-754 Floating Point */
-static uint32_t uint32_to_ieee_float_uint32(uint32_t u)
+/* Helper function to convert uint64 to IEEE-754 Floating Point */
+static uint32_t uint64_to_ieee_float_uint32(uint64_t u)
 {
 	union {
 		float r;
@@ -269,9 +269,7 @@ static inline void encode_lb_extcomm(as_t as, uint64_t bw, bool non_trans,
 				     struct ecommunity_val *eval,
 				     bool disable_ieee_floating)
 {
-	uint64_t bandwidth = disable_ieee_floating
-				     ? bw
-				     : uint32_to_ieee_float_uint32(bw);
+	uint64_t bandwidth = disable_ieee_floating ? bw : uint64_to_ieee_float_uint32(bw);
 
 	memset(eval, 0, sizeof(*eval));
 	eval->val[0] = ECOMMUNITY_ENCODE_AS;

--- a/tests/topotests/bgp_link_bandwidth_cumulative/r1/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative/r1/frr.conf
@@ -1,0 +1,30 @@
+!
+int r1-eth0
+ ip address 192.168.12.1/24
+!
+int r1-eth1
+ ip address 192.168.13.1/24
+!
+int r1-eth2
+ ip address 192.168.14.1/24
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ bgp bestpath as-path multipath-relax
+ neighbor 192.168.12.2 remote-as internal
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ neighbor 192.168.13.3 remote-as internal
+ neighbor 192.168.13.3 timers 1 3
+ neighbor 192.168.13.3 timers connect 1
+ neighbor 192.168.14.4 remote-as external
+ neighbor 192.168.14.4 timers 1 3
+ neighbor 192.168.14.4 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.2 activate
+  neighbor 192.168.13.3 activate
+  neighbor 192.168.14.4 activate
+  maximum-paths ibgp 2
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative/r2/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative/r2/frr.conf
@@ -1,0 +1,19 @@
+!
+int r2-eth0
+ ip address 192.168.12.2/24
+!
+route-map lb-out permit 10
+ set extcommunity bandwidth 30000
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.12.1 remote-as internal
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.1 activate
+  network 10.10.10.10/32
+  neighbor 192.168.12.1 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative/r3/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative/r3/frr.conf
@@ -1,0 +1,19 @@
+!
+int r3-eth0
+ ip address 192.168.13.3/24
+!
+route-map lb-out permit 10
+ set extcommunity bandwidth 100000
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.13.1 remote-as internal
+ neighbor 192.168.13.1 timers 1 3
+ neighbor 192.168.13.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.13.1 activate
+  network 10.10.10.10/32
+  neighbor 192.168.13.1 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative/r4/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative/r4/frr.conf
@@ -1,0 +1,13 @@
+!
+int r4-eth0
+ ip address 192.168.14.4/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 192.168.14.1 remote-as external
+ neighbor 192.168.14.1 timers 1 3
+ neighbor 192.168.14.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.14.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative/test_bgp_link_bandwidth_cumulative.py
+++ b/tests/topotests/bgp_link_bandwidth_cumulative/test_bgp_link_bandwidth_cumulative.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Srinivasan Koona Lokabiraman <srinivasan@nexthop.ai>
+#
+
+"""
+Test cumulative link-bandwidth re-advertisement to eBGP.
+
+Topology
+--------
+
+          r2  (iBGP, set extcommunity bandwidth 30000)
+         /
+   DUT r1 ────── r4  (eBGP, expects cumulative LB bytes below)
+         \\
+          r3  (iBGP, set extcommunity bandwidth 100000)
+
+Prefix: 10.10.10.10/32 (originated on both r2 and r3)
+Bandwidth Mbps values above match BW_MBPS_FROM_R2 / BW_MBPS_FROM_R3 in this file.
+
+Link-bandwidth extended communities use classic 8-byte IEEE float32 encoding.
+Assertions match only the integer in LB:AS:<bytes> (not the human Gbps suffix),
+using the same float32 semantics as bgpd encode/decode helpers.
+
+Checks:
+  - r1 RIB: per-peer LB bytes from r2 and r3
+  - r1 advertised to r4: cumulative LB bytes on the eBGP UPDATE
+  - r4 RIB: same cumulative LB bytes as received from r1
+"""
+
+import os
+import re
+import sys
+import json
+import struct
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+PREFIX = "10.10.10.10/32"
+R4_NEIGHBOR = "192.168.14.4"
+
+# Mbps values must match r2/r3 frr.conf: set extcommunity bandwidth <Mbps>
+BW_MBPS_FROM_R2 = 30000
+BW_MBPS_FROM_R3 = 100000
+
+_LB_BYTES_RE = re.compile(r"LB:\d+:(\d+)")
+
+
+def mbps_to_bytes_per_sec(mbps):
+    """Bytes/sec passed to encode_lb_extcomm (integer Mbps, same as FRR CLI)."""
+    return (mbps * 1_000_000) // 8
+
+
+def frr_lb_ieee_uint32(bytes_per_sec):
+    """
+    IEEE float32 wire encoding for link-bandwidth EC.
+
+    Matches bgpd uint64_to_ieee_float_uint32(): store (float)bytes_per_sec as
+    uint32 bit pattern (union float / uint32_t d).
+    """
+    return struct.unpack("I", struct.pack("f", float(bytes_per_sec)))[0]
+
+
+def frr_lb_display_bytes(bytes_per_sec):
+    """
+    Integer shown in 'LB:AS:<bytes>' after one encode/decode cycle.
+
+    Matches bgpd ieee_float_uint32_to_uint64() / ecommunity_lb_str(): the
+    uint32 wire bits reinterpreted as float, cast to uint64 for display.
+    """
+    wire = frr_lb_ieee_uint32(bytes_per_sec)
+    return int(struct.unpack("f", struct.pack("I", wire))[0])
+
+
+def frr_lb_cumulative_display_bytes(bytes_per_sec_list):
+    """
+    LB:AS:<bytes> after cumulative replace (sum decoded values, re-encode).
+
+    Matches ecommunity_replace_linkbw(): cum_bw is sum of per-path decoded
+    bandwidth, then encode_lb_extcomm() applies another float32 round-trip.
+    """
+    total = sum(frr_lb_display_bytes(bps) for bps in bytes_per_sec_list)
+    return frr_lb_display_bytes(total)
+
+
+def lb_bytes_from_string(lb_string):
+    """Parse the bytes field from LB:AS:<bytes> (...)."""
+    match = _LB_BYTES_RE.search(lb_string or "")
+    return int(match.group(1)) if match else None
+
+
+BPS_FROM_R2 = mbps_to_bytes_per_sec(BW_MBPS_FROM_R2)
+BPS_FROM_R3 = mbps_to_bytes_per_sec(BW_MBPS_FROM_R3)
+LB_BYTES_FROM_R2 = frr_lb_display_bytes(BPS_FROM_R2)
+LB_BYTES_FROM_R3 = frr_lb_display_bytes(BPS_FROM_R3)
+LB_BYTES_CUMULATIVE_EBGP = frr_lb_cumulative_display_bytes(
+    [BPS_FROM_R2, BPS_FROM_R3]
+)
+
+
+def setup_module(mod):
+    topodef = {
+        "s1": ("r1", "r2"),
+        "s2": ("r1", "r3"),
+        "s3": ("r1", "r4"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _paths_for_prefix(output, prefix, key="routes"):
+    """Normalize show bgp json detail vs detail json path layouts."""
+    entry = output.get(key, {}).get(prefix)
+    if isinstance(entry, list):
+        return entry
+    if isinstance(entry, dict):
+        return entry.get("paths", [])
+    return []
+
+
+def _path_lb_bytes_from_peer(output, peer_hostname, expected_bytes):
+    """Return True if path from peer_hostname has LB:AS:expected_bytes."""
+    for path in _paths_for_prefix(output, PREFIX):
+        peer = path.get("peer", {})
+        if peer.get("hostname") != peer_hostname:
+            continue
+        ec = path.get("extendedCommunity")
+        if ec and lb_bytes_from_string(ec.get("string")) == expected_bytes:
+            return True
+    return False
+
+
+def _any_path_lb_bytes_match(output, routes_key, expected_bytes):
+    """Return True if any path under routes_key carries LB:AS:expected_bytes."""
+    for path in _paths_for_prefix(output, PREFIX, key=routes_key):
+        ec = path.get("extendedCommunity")
+        if ec and lb_bytes_from_string(ec.get("string")) == expected_bytes:
+            return True
+    return False
+
+
+def test_bgp_link_bandwidth_cumulative():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    dut = tgen.gears["r1"]
+    ebgp = tgen.gears["r4"]
+
+    def _check_dut_ibgp_paths():
+        output = json.loads(dut.vtysh_cmd("show bgp ipv4 unicast json detail"))
+        if not _path_lb_bytes_from_peer(output, "r2", LB_BYTES_FROM_R2):
+            return "r2 path missing LB bytes %u" % LB_BYTES_FROM_R2
+        if not _path_lb_bytes_from_peer(output, "r3", LB_BYTES_FROM_R3):
+            return "r3 path missing LB bytes %u" % LB_BYTES_FROM_R3
+        return None
+
+    test_func = functools.partial(_check_dut_ibgp_paths)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "DUT should receive expected link-bandwidth from r2 and r3"
+
+    def _check_dut_advertised_cumulative():
+        output = json.loads(
+            dut.vtysh_cmd(
+                "show bgp ipv4 unicast neighbor %s advertised-routes detail json"
+                % R4_NEIGHBOR
+            )
+        )
+        if not _any_path_lb_bytes_match(
+            output, "advertisedRoutes", LB_BYTES_CUMULATIVE_EBGP
+        ):
+            paths = _paths_for_prefix(output, PREFIX, key="advertisedRoutes")
+            got = [
+                lb_bytes_from_string(p.get("extendedCommunity", {}).get("string"))
+                for p in paths
+            ]
+            return "r1 advertised cumulative LB bytes %u, paths=%d got %s" % (
+                LB_BYTES_CUMULATIVE_EBGP,
+                len(paths),
+                got,
+            )
+        return None
+
+    test_func = functools.partial(_check_dut_advertised_cumulative)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), "DUT should advertise cumulative LB bytes %u to r4" % LB_BYTES_CUMULATIVE_EBGP
+
+    def _check_ebgp_received_cumulative():
+        output = json.loads(ebgp.vtysh_cmd("show bgp ipv4 unicast json detail"))
+        paths = _paths_for_prefix(output, PREFIX)
+        if len(paths) != 1:
+            return "expected one eBGP path, got %d" % len(paths)
+        if not _any_path_lb_bytes_match(output, "routes", LB_BYTES_CUMULATIVE_EBGP):
+            ec = paths[0].get("extendedCommunity")
+            return "r4 received cumulative LB bytes %u, got %s" % (
+                LB_BYTES_CUMULATIVE_EBGP,
+                ec.get("string") if ec else None,
+            )
+        return None
+
+    test_func = functools.partial(_check_ebgp_received_cumulative)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), "eBGP peer should receive cumulative LB bytes %u" % LB_BYTES_CUMULATIVE_EBGP
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r1/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r1/frr.conf
@@ -1,0 +1,31 @@
+!
+int r1-eth0
+ ip address 192.168.12.1/24
+!
+int r1-eth1
+ ip address 192.168.13.1/24
+!
+int r1-eth2
+ ip address 192.168.14.1/24
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ bgp bestpath as-path multipath-relax
+ neighbor 192.168.12.2 remote-as internal
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ neighbor 192.168.13.3 remote-as internal
+ neighbor 192.168.13.3 timers 1 3
+ neighbor 192.168.13.3 timers connect 1
+ neighbor 192.168.14.4 remote-as external
+ neighbor 192.168.14.4 timers 1 3
+ neighbor 192.168.14.4 timers connect 1
+ neighbor 192.168.14.4 disable-link-bw-encoding-ieee
+ address-family ipv4 unicast
+  neighbor 192.168.12.2 activate
+  neighbor 192.168.13.3 activate
+  neighbor 192.168.14.4 activate
+  maximum-paths ibgp 2
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r2/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r2/frr.conf
@@ -1,0 +1,19 @@
+!
+int r2-eth0
+ ip address 192.168.12.2/24
+!
+route-map lb-out permit 10
+ set extcommunity bandwidth 30000
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.12.1 remote-as internal
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.1 activate
+  network 10.10.10.10/32
+  neighbor 192.168.12.1 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r3/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r3/frr.conf
@@ -1,0 +1,19 @@
+!
+int r3-eth0
+ ip address 192.168.13.3/24
+!
+route-map lb-out permit 10
+ set extcommunity bandwidth 100000
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.13.1 remote-as internal
+ neighbor 192.168.13.1 timers 1 3
+ neighbor 192.168.13.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.13.1 activate
+  network 10.10.10.10/32
+  neighbor 192.168.13.1 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r4/frr.conf
+++ b/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/r4/frr.conf
@@ -1,0 +1,13 @@
+!
+int r4-eth0
+ ip address 192.168.14.4/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 192.168.14.1 remote-as external
+ neighbor 192.168.14.1 timers 1 3
+ neighbor 192.168.14.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.14.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/test_bgp_link_bandwidth_cumulative_disable_ieee.py
+++ b/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/test_bgp_link_bandwidth_cumulative_disable_ieee.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Srinivasan Koona Lokabiraman <srinivasan@nexthop.ai>
+#
+
+"""
+Test cumulative link-bandwidth with disable-link-bw-encoding-ieee on eBGP.
+
+Same topology as bgp_link_bandwidth_cumulative, but r1 exports raw 32-bit LB
+encoding to r4. Cumulative bandwidth exceeds UINT32_MAX and must be capped at
+0xFFFFFFFF instead of silently truncating the lower 32 bits.
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+PREFIX = "10.10.10.10/32"
+R4_NEIGHBOR = "192.168.14.4"
+
+BW_MBPS_FROM_R2 = 30000
+BW_MBPS_FROM_R3 = 100000
+
+_LB_BYTES_RE = re.compile(r"LB:\d+:(\d+)")
+
+
+def mbps_to_bytes_per_sec(mbps):
+    return (mbps * 1_000_000) // 8
+
+
+def lb_bytes_from_string(lb_string):
+    match = _LB_BYTES_RE.search(lb_string or "")
+    return int(match.group(1)) if match else None
+
+
+BPS_FROM_R2 = mbps_to_bytes_per_sec(BW_MBPS_FROM_R2)
+BPS_FROM_R3 = mbps_to_bytes_per_sec(BW_MBPS_FROM_R3)
+LB_BYTES_CUMULATIVE_RAW_SUM = BPS_FROM_R2 + BPS_FROM_R3
+LB_BYTES_CUMULATIVE_RAW_CLAMP = 0xFFFFFFFF
+LB_BYTES_CUMULATIVE_RAW_TRUNCATED = LB_BYTES_CUMULATIVE_RAW_SUM & 0xFFFFFFFF
+
+
+def setup_module(mod):
+    topodef = {
+        "s1": ("r1", "r2"),
+        "s2": ("r1", "r3"),
+        "s3": ("r1", "r4"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _paths_for_prefix(output, prefix, key="routes"):
+    entry = output.get(key, {}).get(prefix)
+    if isinstance(entry, list):
+        return entry
+    if isinstance(entry, dict):
+        return entry.get("paths", [])
+    return []
+
+
+def _any_path_lb_bytes_match(output, routes_key, expected_bytes):
+    for path in _paths_for_prefix(output, PREFIX, key=routes_key):
+        ec = path.get("extendedCommunity")
+        if ec and lb_bytes_from_string(ec.get("string")) == expected_bytes:
+            return True
+    return False
+
+
+def test_bgp_link_bandwidth_cumulative_disable_ieee():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    dut = tgen.gears["r1"]
+
+    def _check_dut_advertised_raw_cumulative():
+        output = json.loads(
+            dut.vtysh_cmd(
+                "show bgp ipv4 unicast neighbor %s advertised-routes detail json"
+                % R4_NEIGHBOR
+            )
+        )
+        if not _any_path_lb_bytes_match(
+            output, "advertisedRoutes", LB_BYTES_CUMULATIVE_RAW_CLAMP
+        ):
+            paths = _paths_for_prefix(output, PREFIX, key="advertisedRoutes")
+            got = [
+                lb_bytes_from_string(p.get("extendedCommunity", {}).get("string"))
+                for p in paths
+            ]
+            return (
+                "r1 advertised raw cumulative LB bytes %u (not truncated %u), "
+                "paths=%d got %s"
+                % (
+                    LB_BYTES_CUMULATIVE_RAW_CLAMP,
+                    LB_BYTES_CUMULATIVE_RAW_TRUNCATED,
+                    len(paths),
+                    got,
+                )
+            )
+        return None
+
+    test_func = functools.partial(_check_dut_advertised_raw_cumulative)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "DUT should cap cumulative LB at %u for disable-link-bw-encoding-ieee"
+        % LB_BYTES_CUMULATIVE_RAW_CLAMP
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary

Link-bandwidth extended communities carry bandwidth in bytes/sec. When IEEE float encoding is enabled, the on-wire value is float32, but BGP tracks bandwidth as `uint64_t` (e.g. cumulative multipath weight). Several helpers still narrowed values to `uint32` during encode/decode/display, and cumulative replace unconditionally clamped at `UINT32_MAX` (~34 Gbps).

This series fixes uint64 precision end-to-end for the IEEE float path, removes the unconditional cumulative clamp so values above ~34 Gbps work correctly, and restores a **conditional** clamp only when `disable-link-bw-encoding-ieee` is used (raw 32-bit wire encoding).

## Problem

### IEEE float path (> ~34 Gbps)

- `encode_lb_extcomm()` passed `uint64` bandwidth into `uint32_to_ieee_float_uint32()`, truncating before the float was formed.
- `ieee_float_uint32_to_uint32()` decoded the wire float, then cast back to `uint32_t`, dropping high values on read.
- `ecommunity_lb_str()` stored and printed decoded bandwidth as `uint32`.
- `ecommunity_replace_linkbw()` clamped cumulative bandwidth to `0xFFFFFFFF` before re-encoding, so iBGP multipath sums above ~34 Gbps were wrong even when individual paths were below the limit.

### Raw encoding path (`disable-link-bw-encoding-ieee`)

Removing the unconditional clamp is correct for IEEE float, but when `disable-link-bw-encoding-ieee` is configured on the export peer, classic link-bandwidth uses raw `uint32` bytes on the wire. Cumulative bandwidth above `UINT32_MAX` would then be silently truncated to the lower 32 bits instead of being capped explicitly (see Greptile review on #22681).

Additionally, `ecommunity_replace_linkbw()` encoded with the peer's raw mode but did not set `disable_ieee_floating` on the dup'd ecommunity, so `show bgp ... advertised-routes` could IEEE-decode raw wire bits and display bogus values (e.g. capped `0xFFFFFFFF` shown as a huge integer).

## Fix

| Area | Change |
|------|--------|
| Encode/decode/display | Use `uint64` end-to-end: `uint64_to_ieee_float_uint32()` on encode, `ieee_float_uint32_to_uint64()` on decode, `uint64` in `ecommunity_lb_str()` and `ecommunity_linkbw_present()`. On-wire EC remains 32-bit float for IEEE mode. |
| Cumulative replace (IEEE) | Remove unconditional `cum_bw > 0xFFFFFFFF` clamp so multipath sums above ~34 Gbps re-encode correctly via float32. |
| Cumulative replace (raw) | Restore clamp only when `!extended && disable_ieee_floating && cum_bw > 0xFFFFFFFF` — cap at `UINT32_MAX` instead of silent truncation. |
| Cumulative replace (display) | Set `new->disable_ieee_floating = disable_ieee_floating` after `ecommunity_dup()` so JSON/CLI matches export encoding. |

## Tests

### `bgp_link_bandwidth_cumulative/` (IEEE float)

- r2 (30 Gbps) and r3 (100 Gbps) iBGP paths → r1 DUT → r4 eBGP
- Verifies cumulative LB bytes **`16249999360`** on r1 advertised-routes and r4 RIB

### `bgp_link_bandwidth_cumulative_disable_ieee/` (raw encoding)

- Same topology; r1 has `neighbor <r4> disable-link-bw-encoding-ieee`
- Cumulative sum exceeds `UINT32_MAX`; verifies r1 advertises capped **`4294967295`** (`0xFFFFFFFF`), not silently truncated lower 32 bits (e.g. `3365098112`)
- Asserts r1 `advertised-routes detail` only (receiver without disable-IEEE decodes `0xFFFFFFFF` as IEEE NaN)

Wire format unchanged for default IEEE mode (RFC 10005 float32).