### PR TITLE
bgpd: Preserve disable_ieee_floating on link-bandwidth extended communities

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -294,6 +294,7 @@ struct ecommunity *ecommunity_dup(struct ecommunity *ecom)
 	new = XCALLOC(MTYPE_ECOMMUNITY, sizeof(struct ecommunity));
 	new->size = ecom->size;
 	new->unit_size = ecom->unit_size;
+	new->disable_ieee_floating = ecom->disable_ieee_floating;
 	if (new->size) {
 		new->val = XMALLOC(MTYPE_ECOMMUNITY_VAL,
 				   ecom->size * ecom->unit_size);
@@ -2191,6 +2192,7 @@ struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom,
 		encode_lb_extcomm(as > BGP_AS_MAX ? BGP_AS_TRANS : as, cum_bw,
 				  false, &lb_eval, disable_ieee_floating);
 		new = ecommunity_dup(ecom);
+		new->disable_ieee_floating = disable_ieee_floating;
 		ecommunity_add_val(new, &lb_eval, true, true);
 	}
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3596,6 +3596,7 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 		} else {
 			ecom_lb.size = 1;
 			ecom_lb.unit_size = IPV6_ECOMMUNITY_SIZE;
+			ecom_lb.disable_ieee_floating = false;
 			ecom_lb.val = (uint8_t *)lb_eval.val;
 			new_ecom = ecommunity_dup(&ecom_lb);
 		}
@@ -3611,12 +3612,16 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 		old_ecom = bgp_attr_get_ecommunity(path->attr);
 		if (old_ecom) {
 			new_ecom = ecommunity_dup(old_ecom);
+			new_ecom->disable_ieee_floating =
+				CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE);
 			ecommunity_add_val(new_ecom, &lb_eval, true, true);
 			if (!old_ecom->refcnt)
 				ecommunity_free(&old_ecom);
 		} else {
 			ecom_lb.size = 1;
 			ecom_lb.unit_size = ECOMMUNITY_SIZE;
+			ecom_lb.disable_ieee_floating =
+				CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE);
 			ecom_lb.val = (uint8_t *)lb_eval.val;
 			new_ecom = ecommunity_dup(&ecom_lb);
 		}

--- a/tests/topotests/bgp_disable_link_bw_encoding_ieee/r1/frr.conf
+++ b/tests/topotests/bgp_disable_link_bw_encoding_ieee/r1/frr.conf
@@ -1,0 +1,30 @@
+!
+int r1-eth0
+ ip address 192.168.12.1/24
+!
+ip prefix-list ORIG_ONLY seq 5 permit 10.10.10.10/32
+ip prefix-list MERGE_EC seq 5 permit 10.10.10.11/32
+!
+route-map lb-out permit 10
+ match ip address prefix-list ORIG_ONLY
+ set extcommunity bandwidth 10000
+!
+route-map lb-out permit 20
+ match ip address prefix-list MERGE_EC
+ set extcommunity rt 65000:100
+ set extcommunity bandwidth 10000
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.12.2 remote-as internal
+ neighbor 192.168.12.2 disable-link-bw-encoding-ieee
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.2 activate
+  network 10.10.10.10/32
+  network 10.10.10.11/32
+  neighbor 192.168.12.2 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_disable_link_bw_encoding_ieee/r2/frr.conf
+++ b/tests/topotests/bgp_disable_link_bw_encoding_ieee/r2/frr.conf
@@ -1,0 +1,14 @@
+!
+int r2-eth0
+ ip address 192.168.12.2/24
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ neighbor 192.168.12.1 remote-as internal
+ neighbor 192.168.12.1 disable-link-bw-encoding-ieee
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_disable_link_bw_encoding_ieee/test_bgp_disable_link_bw_encoding_ieee.py
+++ b/tests/topotests/bgp_disable_link_bw_encoding_ieee/test_bgp_disable_link_bw_encoding_ieee.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Srinivasan Koona Lokabiraman <srinivasan@nexthop.ai>
+#
+
+"""
+Test raw link-bandwidth encoding with disable-link-bw-encoding-ieee.
+
+Topology
+--------
+
+  r1 ── iBGP ── r2
+
+Both routers use disable-link-bw-encoding-ieee on the session: r1 for outbound
+encode (route-map uses destination peer flags), r2 for inbound decode.
+
+Two prefixes exercise different route_set_ecommunity_lb() paths on r1:
+
+  - 10.10.10.10/32: set extcommunity bandwidth only (old_ecom == NULL)
+  - 10.10.10.11/32: set extcommunity rt then bandwidth (old_ecom merge path)
+
+Checks raw LB bytes 1250000000 (10 Gbps) on r1 advertised-routes and r2 RIB.
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+PREFIX_ORIG = "10.10.10.10/32"
+PREFIX_MERGE = "10.10.10.11/32"
+R2_NEIGHBOR = "192.168.12.2"
+
+# Mbps in r1 frr.conf route-map; FRR converts (Mbps * 1_000_000) / 8 bytes/sec.
+BW_MBPS = 10000
+LB_BYTES_RAW = (BW_MBPS * 1_000_000) // 8
+
+_LB_BYTES_RE = re.compile(r"LB:\d+:(\d+)")
+
+
+def lb_bytes_from_string(lb_string):
+    match = _LB_BYTES_RE.search(lb_string or "")
+    return int(match.group(1)) if match else None
+
+
+def _paths_for_prefix(output, prefix, key="routes"):
+    entry = output.get(key, {}).get(prefix)
+    if isinstance(entry, list):
+        return entry
+    if isinstance(entry, dict):
+        return entry.get("paths", [])
+    return []
+
+
+def _check_lb_bytes_in_output(output, prefix, label, routes_key="routes"):
+    paths = _paths_for_prefix(output, prefix, key=routes_key)
+    if not paths:
+        return "%s: prefix %s not found" % (label, prefix)
+
+    for path in paths:
+        ec = path.get("extendedCommunity")
+        got = lb_bytes_from_string(ec.get("string") if ec else None)
+        if got == LB_BYTES_RAW:
+            return None
+
+    got = [
+        lb_bytes_from_string(p.get("extendedCommunity", {}).get("string"))
+        for p in paths
+    ]
+    return "%s: expected raw LB bytes %d, paths=%d got %s" % (
+        label,
+        LB_BYTES_RAW,
+        len(paths),
+        got,
+    )
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_disable_link_bw_encoding_ieee_originator():
+    """LB only on originate path (old_ecom == NULL in route_set_ecommunity_lb)."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    originator = tgen.gears["r1"]
+    receiver = tgen.gears["r2"]
+
+    def _check_originator_advertised_lb():
+        output = json.loads(
+            originator.vtysh_cmd(
+                "show bgp ipv4 unicast neighbor %s advertised-routes detail json"
+                % R2_NEIGHBOR
+            )
+        )
+        return _check_lb_bytes_in_output(
+            output, PREFIX_ORIG, "r1 advertised", routes_key="advertisedRoutes"
+        )
+
+    test_func = functools.partial(_check_originator_advertised_lb)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "originator should retain disable_ieee_floating on outbound route-map attach"
+    )
+
+    def _check_receiver_lb():
+        output = json.loads(receiver.vtysh_cmd("show bgp ipv4 unicast json detail"))
+        return _check_lb_bytes_in_output(output, PREFIX_ORIG, "r2")
+
+    test_func = functools.partial(_check_receiver_lb)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "receiver should decode raw link-bandwidth on ingest"
+
+
+def test_bgp_disable_link_bw_encoding_ieee_merge_ec():
+    """RT then LB on same route-map entry (old_ecom merge path)."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    originator = tgen.gears["r1"]
+    receiver = tgen.gears["r2"]
+
+    def _check_originator_advertised_lb():
+        output = json.loads(
+            originator.vtysh_cmd(
+                "show bgp ipv4 unicast neighbor %s advertised-routes detail json"
+                % R2_NEIGHBOR
+            )
+        )
+        return _check_lb_bytes_in_output(
+            output, PREFIX_MERGE, "r1 advertised merge", routes_key="advertisedRoutes"
+        )
+
+    test_func = functools.partial(_check_originator_advertised_lb)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "merge path should set disable_ieee_floating from outbound peer after dup"
+    )
+
+    def _check_receiver_lb():
+        output = json.loads(receiver.vtysh_cmd("show bgp ipv4 unicast json detail"))
+        return _check_lb_bytes_in_output(output, PREFIX_MERGE, "r2 merge")
+
+    test_func = functools.partial(_check_receiver_lb)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "receiver should decode merge-path raw link-bandwidth"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary

When `disable-link-bw-encoding-ieee` is configured on a BGP peer, classic link-bandwidth extended communities use raw bytes/sec on the wire instead of IEEE float32. Several code paths encoded bandwidth correctly but did not preserve `disable_ieee_floating` on the ecommunity attribute, so decode and display treated raw wire values as float32.

## Problem

### Route-map attach (no prior extended community)

`route_set_ecommunity_lb()` builds a stack-local `ecommunity` and calls `ecommunity_dup()` before attaching link-bandwidth to the path attribute. Two gaps caused wrong decode/display:

- `ecommunity_dup()` did not copy `disable_ieee_floating` from the source.
- `route_set_ecommunity_lb()` did not set `disable_ieee_floating` from the destination peer's `PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE` before dup when no prior ecommunity existed (classic EC path).

With `disable-link-bw-encoding-ieee` on the session, a 10 Gbps route-map value should appear as raw bytes `1250000000` in `LB:AS:<bytes>`. Without the flag on the attribute, FRR decoded the same wire bits as IEEE float32 and showed a wrong integer (e.g. `4243008`).

### Route-map attach (merge into existing extended community)

When `old_ecom` is non-NULL (e.g. route-map already attached RT), `ecommunity_dup(old_ecom)` inherited `disable_ieee_floating` from the existing attribute rather than the outbound peer. `encode_lb_extcomm()` still wrote raw bytes for a peer with `disable-link-bw-encoding-ieee`, but `show bgp ... advertised-routes` could misinterpret those bytes as IEEE float32.

### Cumulative multipath replace
`ecommunity_replace_linkbw()` (cumulative mpath re-advertisement) already called `encode_lb_extcomm()` with the export peer's `disable-link-bw-encoding-ieee` setting, but `ecommunity_dup()` kept the incoming ecommunity's flag (typically IEEE from upstream paths). Advertised-route display could then IEEE-decode raw wire bits and show bogus values.

## Fix

| Location | Change |
|----------|--------|
| `ecommunity_dup()` | Copy `disable_ieee_floating` from source |
| `route_set_ecommunity_lb()` (no prior EC) | Set `disable_ieee_floating` from peer flag (classic EC) or `false` (IPv6 extended EC) on stack ecommunity before dup |
| `route_set_ecommunity_lb()` (merge path) | Set `new_ecom->disable_ieee_floating` from outbound peer flag after `ecommunity_dup(old_ecom)` |
| `ecommunity_replace_linkbw()` | Set `new->disable_ieee_floating = disable_ieee_floating` after `ecommunity_dup()` on classic EC cumulative replace |

Encode behavior was already correct in `encode_lb_extcomm()`; this ensures the attribute carries the mode through attach, merge, cumulative replace, and local decode/display.

## Test

Add `bgp_disable_link_bw_encoding_ieee/` (r1 ── iBGP ── r2, both with `disable-link-bw-encoding-ieee`):

| Prefix | Route-map | Path exercised |
|--------|-----------|----------------|
| `10.10.10.10/32` | `set extcommunity bandwidth 10000` only | `old_ecom == NULL` (originator) |
| `10.10.10.11/32` | `set extcommunity rt 65000:100` then `set extcommunity bandwidth 10000` | `old_ecom` merge path |
Both prefixes verify raw LB bytes **`1250000000`** (10 Gbps) on r1 `advertised-routes detail` and r2 BGP RIB.

Cumulative mpath + disable-IEEE above `UINT32_MAX` is covered by the separate truncation PR topotest (`bgp_link_bandwidth_cumulative_disable_ieee/`).

## Test plan

- [X] `bgp_disable_link_bw_encoding_ieee/test_bgp_disable_link_bw_encoding_ieee_originator`
- [X] `bgp_disable_link_bw_encoding_ieee/test_bgp_disable_link_bw_encoding_ieee_merge_ec`