### PR TITLE
bgpd: match regex extcommunity delete per value as part of bgp extcommunity-list

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -691,6 +691,26 @@ static bool ecommunity_regexp_match(struct ecommunity *ecom, struct frregex *reg
 	return false;
 }
 
+/* Like ecommunity_regexp_match(), but recomputes the display string on every
+ * call instead of using the cached ecom->str.  Required when matching a reused
+ * ecommunity whose ->val is repointed per iteration (e.g. the delete path),
+ * where a stale cached ->str would match the wrong community.
+ */
+static bool ecommunity_regexp_match_uncached(struct ecommunity *ecom, struct frregex *reg)
+{
+	char *str;
+	bool match;
+
+	if (ecom == NULL || ecom->size == 0)
+		return regexec(&reg->real, "", 0, NULL, 0) == 0;
+
+	str = ecommunity_ecom2str(ecom, ECOMMUNITY_FORMAT_DISPLAY, 0);
+	match = regexec(&reg->real, str, 0, NULL, 0) == 0;
+	XFREE(MTYPE_ECOMMUNITY_STR, str);
+
+	return match;
+}
+
 /* When given community attribute matches to the community-list return
    1 else return 0.  */
 bool community_list_match(struct community *com, struct community_list *list)
@@ -1138,7 +1158,7 @@ struct ecommunity *ecommunity_list_match_delete(struct ecommunity *ecom,
 	uint8_t *ptr;
 	uint32_t delete_index = 0;
 	uint32_t i;
-	struct ecommunity local_ecom = {.size = 1};
+	struct ecommunity local_ecom = { .size = 1, .unit_size = ECOMMUNITY_SIZE };
 	struct ecommunity_val local_eval = {0};
 
 	local_ecom.unit_size = ecom->unit_size;
@@ -1149,7 +1169,7 @@ struct ecommunity *ecommunity_list_match_delete(struct ecommunity *ecom,
 			if (((entry->style == EXTCOMMUNITY_LIST_STANDARD) &&
 			     ecommunity_include(entry->u.ecom, &local_ecom)) ||
 			    ((entry->style == EXTCOMMUNITY_LIST_EXPANDED) &&
-			     ecommunity_regexp_match(&local_ecom, entry->reg))) {
+			     ecommunity_regexp_match_uncached(&local_ecom, entry->reg))) {
 				if (entry->direct == COMMUNITY_PERMIT) {
 					com_index_to_delete[delete_index] = i;
 					delete_index++;

--- a/tests/topotests/bgp_extcomm_list_delete/r1/bgpd.conf
+++ b/tests/topotests/bgp_extcomm_list_delete/r1/bgpd.conf
@@ -6,6 +6,8 @@ router bgp 65000
     network 10.10.10.1/32 route-map r2-out-rt
     network 10.10.10.2/32 route-map r2-out-soo
     network 10.10.10.3/32 route-map r2-out-nt
+    network 10.10.10.4/32 route-map r2-out-soo-lb
+    network 10.10.10.5/32 route-map r2-out-soo-lb
     redistribute connected
   exit-address-family
 !
@@ -17,4 +19,8 @@ route-map r2-out-soo permit 20
 !
 route-map r2-out-nt permit 30
  set extcommunity nt 192.168.255.2:0 2.2.2.2:0 3.3.3.3:0 4.4.4.4:0
+!
+route-map r2-out-soo-lb permit 40
+ set extcommunity soo 51.1.1.1:11
+ set extcommunity bandwidth 200
 !

--- a/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
+++ b/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
@@ -76,7 +76,7 @@ def test_bgp_convergence():
                 "bgpState": "Established",
                 "addressFamilyInfo": {
                     "ipv4Unicast": {
-                        "acceptedPrefixCounter": 4,
+                        "acceptedPrefixCounter": 6,
                     }
                 },
             }
@@ -125,6 +125,22 @@ def _set_extcomm_list_regex(gear, ecom_t, ecom):
     )
 
 
+def _set_expanded_extcomm_list_entries(gear, name, regexes):
+    "Set expanded extended community-list entries for deletion."
+    cmd = ["con t\n"]
+    for seq, regex in enumerate(regexes, 1):
+        cmd.append(
+            f"bgp extcommunity-list expanded {name} seq {seq * 5} permit {regex}\n"
+        )
+    cmd.extend(
+        [
+            "route-map r1-in permit 10\n",
+            f"set extended-comm-list delete {name}\n",
+        ]
+    )
+    gear.vtysh_cmd("".join(cmd))
+
+
 def _bgp_extcomm_list_del_check(gear, prefix, ecom):
     """
     Check the non-presense of the extended community for the given prefix.
@@ -138,6 +154,32 @@ def _bgp_extcomm_list_del_check(gear, prefix, ecom):
     if not ecoms:
         return False
     return re.search(ecom, ecoms) is None
+
+
+def _bgp_extcomm_deleted_and_preserved_check(gear, prefix, deleted, preserved):
+    """
+    Check one extended community was deleted while another one remains.
+    """
+    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
+    ecoms = output.get("paths", [])[0].get("extendedCommunity", {})
+    ecoms = ecoms.get("string")
+
+    if not ecoms:
+        return False
+    return re.search(deleted, ecoms) is None and re.search(preserved, ecoms) is not None
+
+
+def _bgp_extcomm_list_all_del_check(gear, prefix, ecoms):
+    """
+    Check the absence of all listed extended communities for the given prefix.
+    """
+    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
+    route_ecoms = output.get("paths", [])[0].get("extendedCommunity", {})
+    route_ecoms = route_ecoms.get("string")
+
+    if not route_ecoms:
+        return True
+    return all(re.search(ecom, route_ecoms) is None for ecom in ecoms)
 
 
 def test_rt_extcomm_list_delete():
@@ -201,6 +243,47 @@ def test_rt_extcomm_list_expanded_delete():
     )
     _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
     assert result, "RT extended community 1.1.1.1:1 was not stripped."
+
+
+def test_expanded_soo_extcomm_list_delete_preserves_lb():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    # Delete the matching SoO with an expanded regex. Other extended
+    # communities on the same route, such as link-bandwidth, must remain.
+    _set_expanded_extcomm_list_entries(
+        r2, "r1-expanded-soo", [r"SoO:51\.1\.1\.1:[0-9]+"]
+    )
+
+    test_func = functools.partial(
+        _bgp_extcomm_deleted_and_preserved_check,
+        r2,
+        "10.10.10.4/32",
+        r"SoO:51\.1\.1\.1:11",
+        r"LB:",
+    )
+    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
+    assert result, "Expanded SoO delete stripped LB or left the matching SoO."
+
+
+def test_expanded_soo_and_lb_extcomm_list_delete():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    _set_expanded_extcomm_list_entries(
+        r2,
+        "r1-expanded-soo-lb",
+        [r"LB:.*", r"SoO:([0-9]{1,3}[.]){3}[0-9]{1,3}:[0-9]+"],
+    )
+
+    test_func = functools.partial(
+        _bgp_extcomm_list_all_del_check,
+        r2,
+        "10.10.10.5/32",
+        [r"LB:", r"SoO:51\.1\.1\.1:11"],
+    )
+    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
+    assert result, "Expanded wildcard delete left LB or the matching SoO."
 
 
 if __name__ == "__main__":

--- a/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
+++ b/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
@@ -26,6 +26,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib import topotest
+from lib.topolog import logger
 
 
 pytestmark = [pytest.mark.bgpd]
@@ -141,45 +142,102 @@ def _set_expanded_extcomm_list_entries(gear, name, regexes):
     gear.vtysh_cmd("".join(cmd))
 
 
+def _get_route_extcomm_string(gear, prefix):
+    """Return extendedCommunity.string for the best path of prefix."""
+    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
+    paths = output.get("paths", [])
+    if not paths:
+        return None
+    return paths[0].get("extendedCommunity", {}).get("string")
+
+
 def _bgp_extcomm_list_del_check(gear, prefix, ecom):
     """
     Check the non-presense of the extended community for the given prefix.
     """
-    # get the extended community list attribute for the given prefix
-    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
-    ecoms = output.get("paths", [])[0].get("extendedCommunity", {})
-    ecoms = ecoms.get("string")
+    ecoms = _get_route_extcomm_string(gear, prefix)
 
     # ecoms might be None at the first time
     if not ecoms:
+        logger.debug("%s: no extendedCommunity yet", prefix)
         return False
-    return re.search(ecom, ecoms) is None
+    if re.search(ecom, ecoms) is not None:
+        logger.debug(
+            "%s: extended community %r still present in %r", prefix, ecom, ecoms
+        )
+        return False
+
+    logger.debug(
+        "%s: extended community %r stripped, remaining %r", prefix, ecom, ecoms
+    )
+    return True
 
 
 def _bgp_extcomm_deleted_and_preserved_check(gear, prefix, deleted, preserved):
     """
     Check one extended community was deleted while another one remains.
     """
-    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
-    ecoms = output.get("paths", [])[0].get("extendedCommunity", {})
-    ecoms = ecoms.get("string")
+    ecoms = _get_route_extcomm_string(gear, prefix)
 
     if not ecoms:
+        logger.debug("%s: no extendedCommunity yet", prefix)
         return False
-    return re.search(deleted, ecoms) is None and re.search(preserved, ecoms) is not None
+    if re.search(deleted, ecoms) is not None:
+        logger.debug(
+            "%s: extended community %r still present in %r", prefix, deleted, ecoms
+        )
+        return False
+    if re.search(preserved, ecoms) is None:
+        logger.debug(
+            "%s: extended community %r was stripped but %r was not preserved (%r)",
+            prefix,
+            deleted,
+            preserved,
+            ecoms,
+        )
+        return False
+
+    logger.debug(
+        "%s: extended community %r stripped, %r preserved in %r",
+        prefix,
+        deleted,
+        preserved,
+        ecoms,
+    )
+    return True
 
 
 def _bgp_extcomm_list_all_del_check(gear, prefix, ecoms):
     """
     Check the absence of all listed extended communities for the given prefix.
     """
-    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
-    route_ecoms = output.get("paths", [])[0].get("extendedCommunity", {})
-    route_ecoms = route_ecoms.get("string")
+    route_ecoms = _get_route_extcomm_string(gear, prefix)
 
     if not route_ecoms:
+        logger.debug("%s: all extended communities stripped", prefix)
         return True
-    return all(re.search(ecom, route_ecoms) is None for ecom in ecoms)
+
+    still_present = [ecom for ecom in ecoms if re.search(ecom, route_ecoms)]
+    if still_present:
+        logger.debug(
+            "%s: extended communit%s %r still present in %r",
+            prefix,
+            "y" if len(still_present) == 1 else "ies",
+            still_present,
+            route_ecoms,
+        )
+        return False
+
+    logger.debug("%s: extended communities %r stripped", prefix, ecoms)
+    return True
+
+
+def _assert_extcomm_stripped(test_func, err_msg):
+    """Poll test_func and log an error if the extended community was not stripped."""
+    ok, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
+    if not ok:
+        logger.error(err_msg)
+    assert result, err_msg
 
 
 def test_rt_extcomm_list_delete():
@@ -190,11 +248,12 @@ def test_rt_extcomm_list_delete():
     _set_extcomm_list(r2, "rt", "1.1.1.1:1")
 
     # check for the deletion of the extended community
-    test_func = functools.partial(
-        _bgp_extcomm_list_del_check, r2, "10.10.10.1/32", r"1.1.1.1:1"
+    _assert_extcomm_stripped(
+        functools.partial(
+            _bgp_extcomm_list_del_check, r2, "10.10.10.1/32", r"1.1.1.1:1"
+        ),
+        "RT extended community 1.1.1.1:1 was not stripped.",
     )
-    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
-    assert result, "RT extended community 1.1.1.1:1 was not stripped."
 
 
 def test_soo_extcomm_list_delete():
@@ -205,11 +264,12 @@ def test_soo_extcomm_list_delete():
     _set_extcomm_list(r2, "soo", "2.2.2.2:2")
 
     # check for the deletion of the extended community
-    test_func = functools.partial(
-        _bgp_extcomm_list_del_check, r2, "10.10.10.2/32", r"2.2.2.2:2"
+    _assert_extcomm_stripped(
+        functools.partial(
+            _bgp_extcomm_list_del_check, r2, "10.10.10.2/32", r"2.2.2.2:2"
+        ),
+        "SoO extended community 2.2.2.2:2 was not stripped.",
     )
-    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
-    assert result, "SoO extended community 2.2.2.2:2 was not stripped."
 
 
 def test_nt_extcomm_list_delete():
@@ -220,11 +280,10 @@ def test_nt_extcomm_list_delete():
     _set_extcomm_list(r2, "nt", "3.3.3.3:0")
 
     # check for the deletion of the extended community
-    test_func = functools.partial(
-        _bgp_extcomm_list_del_check, r2, "10.10.10.3/32", r"3.3.3.3"
+    _assert_extcomm_stripped(
+        functools.partial(_bgp_extcomm_list_del_check, r2, "10.10.10.3/32", r"3.3.3.3"),
+        "NT extended community 3.3.3.3:0 was not stripped.",
     )
-    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
-    assert result, "NT extended community 3.3.3.3:0 was not stripped."
 
 
 def test_rt_extcomm_list_expanded_delete():
@@ -238,11 +297,12 @@ def test_rt_extcomm_list_expanded_delete():
     _set_extcomm_list_regex(r2, "rt", "1.1.1.[1-2]:1")
 
     # check for the deletion of the extended community
-    test_func = functools.partial(
-        _bgp_extcomm_list_del_check, r2, "10.10.10.1/32", r"1.1.1.1:1"
+    _assert_extcomm_stripped(
+        functools.partial(
+            _bgp_extcomm_list_del_check, r2, "10.10.10.1/32", r"1.1.1.1:1"
+        ),
+        "RT extended community 1.1.1.1:1 was not stripped.",
     )
-    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
-    assert result, "RT extended community 1.1.1.1:1 was not stripped."
 
 
 def test_expanded_soo_extcomm_list_delete_preserves_lb():
@@ -255,15 +315,16 @@ def test_expanded_soo_extcomm_list_delete_preserves_lb():
         r2, "r1-expanded-soo", [r"SoO:51\.1\.1\.1:[0-9]+"]
     )
 
-    test_func = functools.partial(
-        _bgp_extcomm_deleted_and_preserved_check,
-        r2,
-        "10.10.10.4/32",
-        r"SoO:51\.1\.1\.1:11",
-        r"LB:",
+    _assert_extcomm_stripped(
+        functools.partial(
+            _bgp_extcomm_deleted_and_preserved_check,
+            r2,
+            "10.10.10.4/32",
+            r"SoO:51\.1\.1\.1:11",
+            r"LB:",
+        ),
+        "Expanded SoO delete stripped LB or left the matching SoO.",
     )
-    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
-    assert result, "Expanded SoO delete stripped LB or left the matching SoO."
 
 
 def test_expanded_soo_and_lb_extcomm_list_delete():
@@ -276,14 +337,15 @@ def test_expanded_soo_and_lb_extcomm_list_delete():
         [r"LB:.*", r"SoO:([0-9]{1,3}[.]){3}[0-9]{1,3}:[0-9]+"],
     )
 
-    test_func = functools.partial(
-        _bgp_extcomm_list_all_del_check,
-        r2,
-        "10.10.10.5/32",
-        [r"LB:", r"SoO:51\.1\.1\.1:11"],
+    _assert_extcomm_stripped(
+        functools.partial(
+            _bgp_extcomm_list_all_del_check,
+            r2,
+            "10.10.10.5/32",
+            [r"LB:", r"SoO:51\.1\.1\.1:11"],
+        ),
+        "Expanded wildcard delete left LB or the matching SoO.",
     )
-    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
-    assert result, "Expanded wildcard delete left LB or the matching SoO."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 bgpd: match regex extcommunity delete per value

 Apply expanded extcommunity-list delete matches to each individual extended community value so regex-based deletes remove only matching entries and preserve unrelated attributes such as link-bandwidth.
It is possible to remove one or more ext-communities based on individual regex match.

```
    bgp extcommunity-list expanded strip-extcomm seq 5 permit
    SoO:([0-9]{1,3}[.]){3}[0-9]{1,3}:[0-9]+
    bgp extcommunity-list expanded strip-extcomm seq 6 permit LB:.*
```


    route-map SOOEXTSTRIP permit 10
     set extended-comm-list strip-extcomm delete


```
    Paths: (1 available, best #1, table default)
      Advertised to peers:
      spine1(2001:db8:14::1)
      64650 64661 64601
        2001:db8:1::10 (DCI1) from DCI1(2001:db8:1::10) (8.0.0.1)
        (fe80::202:ff:fe00:9) (used)
          Origin IGP, valid, external, bestpath-from-AS 64650, best (First path received)
          Extended Community: LB:64650:1500000 (12.000 Mbps) SoO:51.1.1.1:12
          Last update: Thu Jul 16 13:25:58 2026
```


    Both extended communities (LB:64650:1500000 (12.000 Mbps) SoO:51.1.1.1:12)
    are stripped after applying SOOEXTSTRIP to peer out


```
    DCI1(config-router-af)# neighbor 2001:db8:1::11 route-map SOOEXTSTRIP out
```

    
```
        Paths: (1 available, best #1, table default)
      Advertised to peers:
      spine1(2001:db8:14::1)
      64650 64661 64601
        2001:db8:1::10 (DCI1) from DCI1(2001:db8:1::10) (8.0.0.1)
        (fe80::202:ff:fe00:9) (used)
          Origin IGP, valid, external, bestpath-from-AS 64650, best (First path received)
          Last update: Thu Jul 16 13:43:55 2026
```