### PR TITLE
zebra: fix cross-VRF recursive route resolution

### DIFF
--- a/tests/topotests/zebra_recursive_cross_vrf_nexthop/r1/frr.conf
+++ b/tests/topotests/zebra_recursive_cross_vrf_nexthop/r1/frr.conf
@@ -1,0 +1,65 @@
+!
+! Single-router topology for recursive cross-VRF static route resolution.
+! r1-eth0 is in vrf-blue; r1-eth1 is in default. Two switches (s1, s2) are
+! used so each router interface attaches to its own munet switch.
+!
+! Address plan: Part 1 uses host IDs 1/2/3 in default; Part 2 uses 4/5/6 in
+! vrf-blue (orthogonal blocks). Role mapping: outer=2/5, intermediate=1/4,
+! direct=3/6 (IPv6: db8:1:: and db8:4:: respectively).
+!
+! Part 1 - default VRF routes, egress in vrf-blue (r1-eth0):
+!   2.2.2.2/32 -> 1.1.1.1
+!   1.1.1.1/32 -> 10.1.2.2 nexthop-vrf vrf-blue
+!   3.3.3.3/32 -> 10.1.2.2 nexthop-vrf vrf-blue (direct)
+!
+! Part 2 - vrf-blue routes, egress in default VRF (r1-eth1, vrf block below):
+!   5.5.5.5/32 -> 4.4.4.4
+!   4.4.4.4/32 -> 10.2.2.2 nexthop-vrf default
+!   6.6.6.6/32 -> 10.2.2.2 nexthop-vrf default (direct)
+!
+! IPv6 part 1 (default -> vrf-blue):
+!   2001:db8:1::2/128 -> 2001:db8:1::1
+!   2001:db8:1::1/128 -> 2001:db8:2::2 nexthop-vrf vrf-blue
+!   2001:db8:1::3/128 -> 2001:db8:2::2 nexthop-vrf vrf-blue (direct)
+!
+! IPv6 part 2 (vrf-blue -> default):
+!   2001:db8:4::5/128 -> 2001:db8:4::4
+!   2001:db8:4::4/128 -> 2001:db8:3::2 nexthop-vrf default
+!   2001:db8:4::6/128 -> 2001:db8:3::2 nexthop-vrf default (direct)
+!
+
+ipv6 forwarding
+
+vrf vrf-blue
+exit-vrf
+
+interface r1-eth0 vrf vrf-blue
+ ip address 10.1.2.1/24
+ ipv6 address 2001:db8:2::1/64
+exit
+
+interface r1-eth1
+ ip address 10.2.2.1/24
+ ipv6 address 2001:db8:3::1/64
+exit
+
+! Part 1: default VRF -> vrf-blue egress.
+ip route 2.2.2.2/32 1.1.1.1
+ip route 1.1.1.1/32 10.1.2.2 nexthop-vrf vrf-blue
+ip route 3.3.3.3/32 10.1.2.2 nexthop-vrf vrf-blue
+
+ipv6 route 2001:db8:1::2/128 2001:db8:1::1
+ipv6 route 2001:db8:1::1/128 2001:db8:2::2 nexthop-vrf vrf-blue
+ipv6 route 2001:db8:1::3/128 2001:db8:2::2 nexthop-vrf vrf-blue
+
+! Part 2: vrf-blue routes -> default VRF egress.
+vrf vrf-blue
+ ip route 5.5.5.5/32 4.4.4.4
+ ip route 4.4.4.4/32 10.2.2.2 nexthop-vrf default
+ ip route 6.6.6.6/32 10.2.2.2 nexthop-vrf default
+ ipv6 route 2001:db8:4::5/128 2001:db8:4::4
+ ipv6 route 2001:db8:4::4/128 2001:db8:3::2 nexthop-vrf default
+ ipv6 route 2001:db8:4::6/128 2001:db8:3::2 nexthop-vrf default
+exit-vrf
+
+!

--- a/tests/topotests/zebra_recursive_cross_vrf_nexthop/r1/frr.conf
+++ b/tests/topotests/zebra_recursive_cross_vrf_nexthop/r1/frr.conf
@@ -1,0 +1,66 @@
+!
+! Single-router topology for recursive cross-VRF static route resolution.
+! r1-eth0 is in vrf-blue; r1-eth1 is in default. Two switches (s1, s2) are
+! used so each router interface attaches to its own munet switch.
+!
+! Address plan: Part 1 uses host IDs 1/2/3 in default (192.0.2.0/24);
+! Part 2 uses 4/5/6 in vrf-blue (198.51.100.0/24, orthogonal blocks).
+! Role mapping: outer=2/5, intermediate=1/4, direct=3/6
+! (IPv6: db8:1:: and db8:4:: respectively).
+!
+! Part 1 - default VRF routes, egress in vrf-blue (r1-eth0):
+!   192.0.2.2/32 -> 192.0.2.1
+!   192.0.2.1/32 -> 10.1.2.2 nexthop-vrf vrf-blue
+!   192.0.2.3/32 -> 10.1.2.2 nexthop-vrf vrf-blue (direct)
+!
+! Part 2 - vrf-blue routes, egress in default VRF (r1-eth1, vrf block below):
+!   198.51.100.5/32 -> 198.51.100.4
+!   198.51.100.4/32 -> 10.2.2.2 nexthop-vrf default
+!   198.51.100.6/32 -> 10.2.2.2 nexthop-vrf default (direct)
+!
+! IPv6 part 1 (default -> vrf-blue):
+!   2001:db8:1::2/128 -> 2001:db8:1::1
+!   2001:db8:1::1/128 -> 2001:db8:2::2 nexthop-vrf vrf-blue
+!   2001:db8:1::3/128 -> 2001:db8:2::2 nexthop-vrf vrf-blue (direct)
+!
+! IPv6 part 2 (vrf-blue -> default):
+!   2001:db8:4::5/128 -> 2001:db8:4::4
+!   2001:db8:4::4/128 -> 2001:db8:3::2 nexthop-vrf default
+!   2001:db8:4::6/128 -> 2001:db8:3::2 nexthop-vrf default (direct)
+!
+
+ipv6 forwarding
+
+vrf vrf-blue
+exit-vrf
+
+interface r1-eth0 vrf vrf-blue
+ ip address 10.1.2.1/24
+ ipv6 address 2001:db8:2::1/64
+exit
+
+interface r1-eth1
+ ip address 10.2.2.1/24
+ ipv6 address 2001:db8:3::1/64
+exit
+
+! Part 1: default VRF -> vrf-blue egress.
+ip route 192.0.2.2/32 192.0.2.1
+ip route 192.0.2.1/32 10.1.2.2 nexthop-vrf vrf-blue
+ip route 192.0.2.3/32 10.1.2.2 nexthop-vrf vrf-blue
+
+ipv6 route 2001:db8:1::2/128 2001:db8:1::1
+ipv6 route 2001:db8:1::1/128 2001:db8:2::2 nexthop-vrf vrf-blue
+ipv6 route 2001:db8:1::3/128 2001:db8:2::2 nexthop-vrf vrf-blue
+
+! Part 2: vrf-blue routes -> default VRF egress.
+vrf vrf-blue
+ ip route 198.51.100.5/32 198.51.100.4
+ ip route 198.51.100.4/32 10.2.2.2 nexthop-vrf default
+ ip route 198.51.100.6/32 10.2.2.2 nexthop-vrf default
+ ipv6 route 2001:db8:4::5/128 2001:db8:4::4
+ ipv6 route 2001:db8:4::4/128 2001:db8:3::2 nexthop-vrf default
+ ipv6 route 2001:db8:4::6/128 2001:db8:3::2 nexthop-vrf default
+exit-vrf
+
+!

--- a/tests/topotests/zebra_recursive_cross_vrf_nexthop/test_zebra_recursive_cross_vrf_nexthop.py
+++ b/tests/topotests/zebra_recursive_cross_vrf_nexthop/test_zebra_recursive_cross_vrf_nexthop.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026 Nexthop AI
+#               Srinivasan Koona Lokabiraman
+#
+"""
+Test recursive static route resolution across VRFs.
+
+When a route resolves recursively through an intermediate route whose
+nexthop is in a different VRF, the final resolved nexthop must carry
+the egress interface VRF, not the outer route VRF.
+
+Two directions are tested with separate functions:
+
+- default_to_blue: outer route in default VRF, egress on r1-eth0 (vrf-blue)
+- blue_to_default: outer route in vrf-blue, egress on r1-eth1 (default VRF)
+
+Address plan (see r1/frr.conf): default uses 1/2/3 (outer/intermediate/
+direct); vrf-blue uses 4/5/6. IPv6 mirrors this on db8:1:: and db8:4::.
+"""
+
+import os
+import sys
+import json
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+VRF_BLUE = "vrf-blue"
+VRF_DEFAULT = "default"
+
+DEFAULT_TO_BLUE = {
+    4: {
+        "prefix_recursive": "2.2.2.2/32",
+        "prefix_direct": "3.3.3.3/32",
+        "recursive_nh": "1.1.1.1",
+        "resolved_nh": "10.1.2.2",
+        "ifname": "r1-eth0",
+        "egress_vrf": VRF_BLUE,
+        "route_json": "show ip route {} json",
+        "route_text": "show ip route {}",
+    },
+    6: {
+        "prefix_recursive": "2001:db8:1::2/128",
+        "prefix_direct": "2001:db8:1::3/128",
+        "recursive_nh": "2001:db8:1::1",
+        "resolved_nh": "2001:db8:2::2",
+        "ifname": "r1-eth0",
+        "egress_vrf": VRF_BLUE,
+        "route_json": "show ipv6 route {} json",
+        "route_text": "show ipv6 route {}",
+    },
+}
+
+BLUE_TO_DEFAULT = {
+    4: {
+        "prefix_recursive": "5.5.5.5/32",
+        "prefix_direct": "6.6.6.6/32",
+        "recursive_nh": "4.4.4.4",
+        "resolved_nh": "10.2.2.2",
+        "ifname": "r1-eth1",
+        "egress_vrf": VRF_DEFAULT,
+        "route_vrf": VRF_BLUE,
+        "route_json": "show ip route vrf {} {} json",
+        "route_text": "show ip route vrf {} {}",
+    },
+    6: {
+        "prefix_recursive": "2001:db8:4::5/128",
+        "prefix_direct": "2001:db8:4::6/128",
+        "recursive_nh": "2001:db8:4::4",
+        "resolved_nh": "2001:db8:3::2",
+        "ifname": "r1-eth1",
+        "egress_vrf": VRF_DEFAULT,
+        "route_vrf": VRF_BLUE,
+        "route_json": "show ipv6 route vrf {} {} json",
+        "route_text": "show ipv6 route vrf {} {}",
+    },
+}
+
+
+def build_topo(tgen):
+    """Single router with two interfaces, each on its own munet switch."""
+    tgen.add_router("r1")
+    switch1 = tgen.add_switch("s1")
+    switch1.add_link(tgen.gears["r1"])
+    switch2 = tgen.add_switch("s2")
+    switch2.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1 = tgen.gears["r1"]
+    r1.net.add_l3vrf(VRF_BLUE, 100)
+    r1.net.attach_iface_to_l3vrf("r1-eth0", VRF_BLUE)
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _route_cmd(params, prefix, kind):
+    if "route_vrf" in params:
+        return params[kind].format(params["route_vrf"], prefix)
+    return params[kind].format(prefix)
+
+
+def _collect_nexthops(route_json, prefix):
+    if prefix not in route_json:
+        return None, "{} not in RIB".format(prefix)
+
+    nexthops = []
+    for entry in route_json[prefix]:
+        nexthops.extend(entry.get("nexthops", []))
+
+    if not nexthops:
+        return None, "no nexthops for {}".format(prefix)
+
+    return nexthops, None
+
+
+def _find_nexthop(nexthops, ip):
+    return [nh for nh in nexthops if nh.get("ip") == ip]
+
+
+def _expect_check(check_fn):
+    """Poll check_fn until it returns None or time out."""
+    _, result = topotest.run_and_expect(check_fn, None, count=30, wait=1)
+    assert result is None, result
+
+
+def _check_recursive_resolved_nexthop_vrf(r1, params):
+    """Verify a two-hop static route via show route JSON.
+
+    The outer prefix (params["prefix_recursive"]) must resolve through an
+    intermediate nexthop (params["recursive_nh"], marked recursive) to a
+    leaf nexthop (params["resolved_nh"]) on params["ifname"] in
+    params["egress_vrf"]. The outer route VRF and egress VRF always differ
+    in this topology.
+
+    Returns an error string, or None on success.
+    """
+    prefix = params["prefix_recursive"]
+    cmd = _route_cmd(params, prefix, "route_json")
+    output = r1.vtysh_cmd(cmd)
+    logger.info("%s: %s", cmd, output)
+    route = json.loads(output)
+
+    nexthops, err = _collect_nexthops(route, prefix)
+    if err:
+        return err
+
+    recursive = _find_nexthop(nexthops, params["recursive_nh"])
+    if not recursive:
+        return "missing recursive nexthop {}".format(params["recursive_nh"])
+    if not recursive[0].get("recursive", False):
+        return "nexthop {} is not marked recursive".format(params["recursive_nh"])
+
+    resolved = _find_nexthop(nexthops, params["resolved_nh"])
+    if not resolved:
+        return "missing resolved nexthop {}".format(params["resolved_nh"])
+
+    nh = resolved[0]
+    if not nh.get("active", False):
+        return "resolved nexthop {} is not active".format(params["resolved_nh"])
+    if nh.get("interfaceName") != params["ifname"]:
+        return "expected interface {}, got {}".format(
+            params["ifname"], nh.get("interfaceName")
+        )
+    if nh.get("vrf") != params["egress_vrf"]:
+        return "expected vrf {} on resolved nexthop, got {!r}".format(
+            params["egress_vrf"], nh.get("vrf")
+        )
+    return None
+
+
+def _check_recursive_show_route_text(r1, params):
+    """Verify show route text for the recursive outer prefix.
+
+    Confirms the resolved gateway and a (vrf NAME) tag for the egress
+    interface VRF appear in CLI output. Returns an error string, or None.
+    """
+    prefix = params["prefix_recursive"]
+    cmd = _route_cmd(params, prefix, "route_text")
+    output = r1.vtysh_cmd(cmd)
+    logger.info("%s:\n%s", cmd, output)
+    if prefix not in output:
+        return "prefix not shown"
+    if params["resolved_nh"] not in output:
+        return "resolved nexthop {} not shown".format(params["resolved_nh"])
+    if "(vrf {})".format(params["egress_vrf"]) not in output:
+        return "missing (vrf {}) indicator".format(params["egress_vrf"])
+    return None
+
+
+def _check_direct_cross_vrf_nexthop_vrf(r1, params):
+    """Verify a direct nexthop-vrf static route via show route JSON.
+
+    The direct prefix (params["prefix_direct"]) must be active with
+    params["resolved_nh"] on params["ifname"] in params["egress_vrf"].
+    Control case: direct cross-VRF statics worked before the recursive fix
+    and should still expose the egress VRF on the nexthop. Returns an error
+    string, or None on success.
+    """
+    prefix = params["prefix_direct"]
+    cmd = _route_cmd(params, prefix, "route_json")
+    output = r1.vtysh_cmd(cmd)
+    logger.info("%s: %s", cmd, output)
+    route = json.loads(output)
+
+    nexthops, err = _collect_nexthops(route, prefix)
+    if err:
+        return err
+
+    matches = _find_nexthop(nexthops, params["resolved_nh"])
+    if not matches:
+        return "missing nexthop {}".format(params["resolved_nh"])
+
+    nh = matches[0]
+    if not nh.get("active", False):
+        return "nexthop {} is not active".format(params["resolved_nh"])
+    if nh.get("interfaceName") != params["ifname"]:
+        return "expected interface {}, got {}".format(
+            params["ifname"], nh.get("interfaceName")
+        )
+    if nh.get("vrf") != params["egress_vrf"]:
+        return "expected vrf {} on direct nexthop, got {!r}".format(
+            params["egress_vrf"], nh.get("vrf")
+        )
+    return None
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_resolved_nexthop_vrf_default_to_blue(ip_version):
+    """Recursive default -> vrf-blue route exposes egress VRF on resolved NH."""
+    params = DEFAULT_TO_BLUE[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check recursive default -> vrf-blue resolved nexthop (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_resolved_nexthop_vrf(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_resolved_nexthop_vrf_blue_to_default(ip_version):
+    """Recursive vrf-blue -> default route exposes egress VRF on resolved NH."""
+    params = BLUE_TO_DEFAULT[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check recursive vrf-blue -> default resolved nexthop (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_resolved_nexthop_vrf(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_show_route_text_default_to_blue(ip_version):
+    """CLI shows (vrf vrf-blue) for recursive default -> vrf-blue route."""
+    params = DEFAULT_TO_BLUE[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check show route text for default -> vrf-blue (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_show_route_text(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_show_route_text_blue_to_default(ip_version):
+    """CLI shows (vrf default) for recursive vrf-blue -> default route."""
+    params = BLUE_TO_DEFAULT[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check show route text for vrf-blue -> default (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_show_route_text(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_direct_cross_vrf_nexthop_vrf_default_to_blue(ip_version):
+    """Direct default -> vrf-blue route exposes vrf-blue on the nexthop."""
+    params = DEFAULT_TO_BLUE[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check direct default -> vrf-blue cross-VRF route (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_direct_cross_vrf_nexthop_vrf(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_direct_cross_vrf_nexthop_vrf_blue_to_default(ip_version):
+    """Direct vrf-blue -> default route exposes default on the nexthop."""
+    params = BLUE_TO_DEFAULT[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check direct vrf-blue -> default cross-VRF route (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_direct_cross_vrf_nexthop_vrf(r1, params))
+
+
+def test_memory_leak():
+    """Run the memory leak test and report results."""
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([os.path.basename(__file__)] + sys.argv[1:]))

--- a/tests/topotests/zebra_recursive_cross_vrf_nexthop/test_zebra_recursive_cross_vrf_nexthop.py
+++ b/tests/topotests/zebra_recursive_cross_vrf_nexthop/test_zebra_recursive_cross_vrf_nexthop.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026 Nexthop AI
+#               Srinivasan Koona Lokabiraman
+#
+"""
+Test recursive static route resolution across VRFs.
+
+When a route resolves recursively through an intermediate route whose
+nexthop is in a different VRF, the final resolved nexthop must carry
+the egress interface VRF, not the outer route VRF.
+
+Two directions are tested with separate functions:
+
+- default_to_blue: outer route in default VRF, egress on r1-eth0 (vrf-blue)
+- blue_to_default: outer route in vrf-blue, egress on r1-eth1 (default VRF)
+
+Address plan (see r1/frr.conf): default uses 192.0.2.1/2/3 (outer/
+intermediate/direct); vrf-blue uses 198.51.100.4/5/6. IPv6 mirrors this
+on db8:1:: and db8:4::.
+"""
+
+import os
+import sys
+import json
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+VRF_BLUE = "vrf-blue"
+VRF_DEFAULT = "default"
+
+DEFAULT_TO_BLUE = {
+    4: {
+        "prefix_recursive": "192.0.2.2/32",
+        "prefix_direct": "192.0.2.3/32",
+        "recursive_nh": "192.0.2.1",
+        "resolved_nh": "10.1.2.2",
+        "ifname": "r1-eth0",
+        "egress_vrf": VRF_BLUE,
+        "route_json": "show ip route {} json",
+        "route_text": "show ip route {}",
+    },
+    6: {
+        "prefix_recursive": "2001:db8:1::2/128",
+        "prefix_direct": "2001:db8:1::3/128",
+        "recursive_nh": "2001:db8:1::1",
+        "resolved_nh": "2001:db8:2::2",
+        "ifname": "r1-eth0",
+        "egress_vrf": VRF_BLUE,
+        "route_json": "show ipv6 route {} json",
+        "route_text": "show ipv6 route {}",
+    },
+}
+
+BLUE_TO_DEFAULT = {
+    4: {
+        "prefix_recursive": "198.51.100.5/32",
+        "prefix_direct": "198.51.100.6/32",
+        "recursive_nh": "198.51.100.4",
+        "resolved_nh": "10.2.2.2",
+        "ifname": "r1-eth1",
+        "egress_vrf": VRF_DEFAULT,
+        "route_vrf": VRF_BLUE,
+        "route_json": "show ip route vrf {} {} json",
+        "route_text": "show ip route vrf {} {}",
+    },
+    6: {
+        "prefix_recursive": "2001:db8:4::5/128",
+        "prefix_direct": "2001:db8:4::6/128",
+        "recursive_nh": "2001:db8:4::4",
+        "resolved_nh": "2001:db8:3::2",
+        "ifname": "r1-eth1",
+        "egress_vrf": VRF_DEFAULT,
+        "route_vrf": VRF_BLUE,
+        "route_json": "show ipv6 route vrf {} {} json",
+        "route_text": "show ipv6 route vrf {} {}",
+    },
+}
+
+
+def build_topo(tgen):
+    """Single router with two interfaces, each on its own munet switch."""
+    tgen.add_router("r1")
+    switch1 = tgen.add_switch("s1")
+    switch1.add_link(tgen.gears["r1"])
+    switch2 = tgen.add_switch("s2")
+    switch2.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1 = tgen.gears["r1"]
+    r1.net.add_l3vrf(VRF_BLUE, 100)
+    r1.net.attach_iface_to_l3vrf("r1-eth0", VRF_BLUE)
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _route_cmd(params, prefix, kind):
+    if "route_vrf" in params:
+        return params[kind].format(params["route_vrf"], prefix)
+    return params[kind].format(prefix)
+
+
+def _collect_nexthops(route_json, prefix):
+    if prefix not in route_json:
+        return None, "{} not in RIB".format(prefix)
+
+    nexthops = []
+    for entry in route_json[prefix]:
+        nexthops.extend(entry.get("nexthops", []))
+
+    if not nexthops:
+        return None, "no nexthops for {}".format(prefix)
+
+    return nexthops, None
+
+
+def _find_nexthop(nexthops, ip):
+    return [nh for nh in nexthops if nh.get("ip") == ip]
+
+
+def _expect_check(check_fn):
+    """Poll check_fn until it returns None or time out."""
+    _, result = topotest.run_and_expect(check_fn, None, count=30, wait=1)
+    assert result is None, result
+
+
+def _check_recursive_resolved_nexthop_vrf(r1, params):
+    """Verify a two-hop static route via show route JSON.
+
+    The outer prefix (params["prefix_recursive"]) must resolve through an
+    intermediate nexthop (params["recursive_nh"], marked recursive) to a
+    leaf nexthop (params["resolved_nh"]) on params["ifname"] in
+    params["egress_vrf"]. The outer route VRF and egress VRF always differ
+    in this topology.
+
+    Returns an error string, or None on success.
+    """
+    prefix = params["prefix_recursive"]
+    cmd = _route_cmd(params, prefix, "route_json")
+    output = r1.vtysh_cmd(cmd)
+    logger.info("%s: %s", cmd, output)
+    route = json.loads(output)
+
+    nexthops, err = _collect_nexthops(route, prefix)
+    if err:
+        return err
+
+    recursive = _find_nexthop(nexthops, params["recursive_nh"])
+    if not recursive:
+        return "missing recursive nexthop {}".format(params["recursive_nh"])
+    if not recursive[0].get("recursive", False):
+        return "nexthop {} is not marked recursive".format(params["recursive_nh"])
+
+    resolved = _find_nexthop(nexthops, params["resolved_nh"])
+    if not resolved:
+        return "missing resolved nexthop {}".format(params["resolved_nh"])
+
+    nh = resolved[0]
+    if not nh.get("active", False):
+        return "resolved nexthop {} is not active".format(params["resolved_nh"])
+    if nh.get("interfaceName") != params["ifname"]:
+        return "expected interface {}, got {}".format(
+            params["ifname"], nh.get("interfaceName")
+        )
+    if nh.get("vrf") != params["egress_vrf"]:
+        return "expected vrf {} on resolved nexthop, got {!r}".format(
+            params["egress_vrf"], nh.get("vrf")
+        )
+    return None
+
+
+def _check_recursive_show_route_text(r1, params):
+    """Verify show route text for the recursive outer prefix.
+
+    Confirms the resolved gateway and a (vrf NAME) tag for the egress
+    interface VRF appear in CLI output. Returns an error string, or None.
+    """
+    prefix = params["prefix_recursive"]
+    cmd = _route_cmd(params, prefix, "route_text")
+    output = r1.vtysh_cmd(cmd)
+    logger.info("%s:\n%s", cmd, output)
+    if prefix not in output:
+        return "prefix not shown"
+    if params["resolved_nh"] not in output:
+        return "resolved nexthop {} not shown".format(params["resolved_nh"])
+    if "(vrf {})".format(params["egress_vrf"]) not in output:
+        return "missing (vrf {}) indicator".format(params["egress_vrf"])
+    return None
+
+
+def _check_direct_cross_vrf_nexthop_vrf(r1, params):
+    """Verify a direct nexthop-vrf static route via show route JSON.
+
+    The direct prefix (params["prefix_direct"]) must be active with
+    params["resolved_nh"] on params["ifname"] in params["egress_vrf"].
+    Control case: direct cross-VRF statics worked before the recursive fix
+    and should still expose the egress VRF on the nexthop. Returns an error
+    string, or None on success.
+    """
+    prefix = params["prefix_direct"]
+    cmd = _route_cmd(params, prefix, "route_json")
+    output = r1.vtysh_cmd(cmd)
+    logger.info("%s: %s", cmd, output)
+    route = json.loads(output)
+
+    nexthops, err = _collect_nexthops(route, prefix)
+    if err:
+        return err
+
+    matches = _find_nexthop(nexthops, params["resolved_nh"])
+    if not matches:
+        return "missing nexthop {}".format(params["resolved_nh"])
+
+    nh = matches[0]
+    if not nh.get("active", False):
+        return "nexthop {} is not active".format(params["resolved_nh"])
+    if nh.get("interfaceName") != params["ifname"]:
+        return "expected interface {}, got {}".format(
+            params["ifname"], nh.get("interfaceName")
+        )
+    if nh.get("vrf") != params["egress_vrf"]:
+        return "expected vrf {} on direct nexthop, got {!r}".format(
+            params["egress_vrf"], nh.get("vrf")
+        )
+    return None
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_resolved_nexthop_vrf_default_to_blue(ip_version):
+    """Recursive default -> vrf-blue route exposes egress VRF on resolved NH."""
+    params = DEFAULT_TO_BLUE[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check recursive default -> vrf-blue resolved nexthop (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_resolved_nexthop_vrf(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_resolved_nexthop_vrf_blue_to_default(ip_version):
+    """Recursive vrf-blue -> default route exposes egress VRF on resolved NH."""
+    params = BLUE_TO_DEFAULT[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check recursive vrf-blue -> default resolved nexthop (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_resolved_nexthop_vrf(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_show_route_text_default_to_blue(ip_version):
+    """CLI shows (vrf vrf-blue) for recursive default -> vrf-blue route."""
+    params = DEFAULT_TO_BLUE[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check show route text for default -> vrf-blue (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_show_route_text(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_recursive_cross_vrf_show_route_text_blue_to_default(ip_version):
+    """CLI shows (vrf default) for recursive vrf-blue -> default route."""
+    params = BLUE_TO_DEFAULT[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check show route text for vrf-blue -> default (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_recursive_show_route_text(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_direct_cross_vrf_nexthop_vrf_default_to_blue(ip_version):
+    """Direct default -> vrf-blue route exposes vrf-blue on the nexthop."""
+    params = DEFAULT_TO_BLUE[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check direct default -> vrf-blue cross-VRF route (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_direct_cross_vrf_nexthop_vrf(r1, params))
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_direct_cross_vrf_nexthop_vrf_blue_to_default(ip_version):
+    """Direct vrf-blue -> default route exposes default on the nexthop."""
+    params = BLUE_TO_DEFAULT[ip_version]
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    step("Check direct vrf-blue -> default cross-VRF route (IPv{})".format(ip_version))
+    _expect_check(lambda: _check_direct_cross_vrf_nexthop_vrf(r1, params))
+
+
+def test_memory_leak():
+    """Run the memory leak test and report results."""
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([os.path.basename(__file__)] + sys.argv[1:]))

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1941,7 +1941,8 @@ static struct nexthop *nexthop_set_resolved(afi_t afi, const struct nexthop *new
 	resolved_hop = nexthop_new();
 	SET_FLAG(resolved_hop->flags, NEXTHOP_FLAG_ACTIVE);
 
-	resolved_hop->vrf_id = nexthop->vrf_id;
+	/* Use newhop's VRF - it reflects where the egress interface lives. */
+	resolved_hop->vrf_id = newhop->vrf_id;
 
 	/* Using weighted ECMP, we should respect the weight and use
 	 * the same value for non-recursive next-hop.


### PR DESCRIPTION
## Summary

When a route resolves recursively through an intermediate route whose nexthop uses `nexthop-vrf`, zebra copied the recursive nexthop's VRF onto the resolved leaf nexthop. The leaf should inherit the egress nexthop's VRF (where the resolved gateway and interface live).

The resolved leaf then carries incorrect VRF metadata. That can affect code paths that rely on `nexthop->vrf_id` (for example interface or neighbor lookup in the egress VRF). The issue is visible as missing or wrong `(vrf NAME)` on the resolved nexthop in `show ip route`, `show ip route vrf WORD`, `show ipv6 route`, and `show ipv6 route vrf WORD`, and as an incorrect `vrf` field on the resolved nexthop in the corresponding `json` output. Single-hop (direct) cross-VRF routes were unaffected.

## Components

zebra, topotests

## Fix

In `nexthop_set_resolved()`, set `resolved_hop->vrf_id` from `newhop->vrf_id` (the leaf/egress nexthop) instead of `nexthop->vrf_id` (the recursive nexthop).

## Topotest

Add `tests/topotests/zebra_recursive_cross_vrf_nexthop/` (uses static routes to exercise the scenario):

- Single router, two VRFs (`default`, `vrf-blue`), egress on `r1-eth0` (vrf-blue) and `r1-eth1` (default)
- **default → vrf-blue** and **vrf-blue → default**, IPv4 and IPv6
- **Recursive** (two-hop static chain): verify resolved nexthop `vrf` and `interfaceName` in JSON, and `(vrf NAME)` in `show ip route` / `show ipv6 route` (and vrf variants)
- **Direct** (single-hop cross-VRF static): control case to ensure existing behavior still works