### PR TITLE
bfdd: drain data plane output buffer on shutdown

### DIFF
--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -710,6 +710,49 @@ static void _bfd_session_unregister_dplane(struct hash_bucket *hb, void *arg)
 	bfd_session_enable(bs);
 }
 
+/*
+ * Best-effort synchronous drain of the output buffer during shutdown.
+ *
+ * At shutdown every session enqueues a `DP_DELETE_SESSION` message, but
+ * the event loop never runs again to service the write event, so anything
+ * still buffered when the context is freed would be silently lost. Write
+ * it out here with a bounded retry so the data plane learns about all
+ * teardowns.
+ *
+ * This must not call `bfd_dplane_flush()`: its error path frees the
+ * context, and we are called from inside `bfd_dplane_ctx_free()`.
+ */
+static void bfd_dplane_ctx_shutdown_drain(struct bfd_dplane_ctx *bdc)
+{
+	size_t remaining;
+	ssize_t rv;
+
+	/* Nothing to write or nowhere to write it. */
+	if (bdc->sock == -1 || bdc->connecting)
+		return;
+
+	/*
+	 * Best-effort flush of the queued session deletions. The event
+	 * loop is already gone at shutdown and the socket is owned by the
+	 * frrevent machinery, so we do not re-arm a write event or block
+	 * waiting on it: a single pass writing whatever the socket will
+	 * take, and if it would block or errors we give up. Any unsent
+	 * deletions are simply timed out by the data plane instead.
+	 */
+	while ((remaining = STREAM_READABLE(bdc->outbuf)) > 0) {
+		rv = write(bdc->sock, stream_pnt(bdc->outbuf), remaining);
+		if (rv <= 0)
+			break;
+		bdc->out_bytes += (uint64_t)rv;
+		stream_forward_getp(bdc->outbuf, (size_t)rv);
+	}
+
+	remaining = STREAM_READABLE(bdc->outbuf);
+	if (remaining)
+		zlog_warn("%s: %zu bytes of data plane messages lost on shutdown", __func__,
+			  remaining);
+}
+
 static void bfd_dplane_ctx_free(struct bfd_dplane_ctx *bdc)
 {
 	if (bglobal.debug_dplane)
@@ -741,6 +784,10 @@ free_resources:
 	/* Detach all associated sessions. */
 	if (bglobal.bg_shutdown == false)
 		bfd_key_iterate(_bfd_session_unregister_dplane, bdc);
+
+	/* Deliver pending messages (e.g. session deletions) on shutdown. */
+	if (bglobal.bg_shutdown)
+		bfd_dplane_ctx_shutdown_drain(bdc);
 
 	/* Free resources. */
 	socket_close(&bdc->sock);


### PR DESCRIPTION
Fixes #22691.

At shutdown, session teardown enqueues one `DP_DELETE_SESSION` per data plane session (`bfd_session_free()` -> `bfd_dplane_delete_session()`), but the event loop never runs again to service the write event: `bfd_dplane_ctx_free()` on the shutdown path closes the socket and frees the output buffer with the messages still in it. Before #22645 the data plane received none of the shutdown deletions; since #22645 the mid-burst synchronous flush delivers exactly one buffer's worth and the tail is freed unsent. Full mechanism and reproducer in the issue.

One commit: **bfdd: drain data plane output buffer on shutdown** — a bounded synchronous drain (retry on EAGAIN via poll, capped at ~1s) in `bfd_dplane_ctx_free()` before `socket_close()` when `bg_shutdown` is set, plus a warning if bytes are still lost after the cap. This is the shutdown-side counterpart of the enqueue-side flush from #22645. `bfd_dplane_flush()` is deliberately not reused: its error path frees the context this code is called from.

Validation (master, x86_64), byte-counting TCP sink from the issue plus a real external dataplane implementation:

- Sink, 64 configured sessions, clean stop: unpatched delivers 58 of 64 DELETEs (8120 bytes, exactly one full buffer); patched delivers 64/64, total byte count exact at 140 bytes/message, no loss warning logged.
- Sink, 128 sessions, clean stop: patched delivers 128/128 DELETEs (17920 bytes — two full buffer-loads plus a tail), confirming the drain loops through multiple write-out cycles.
- End-to-end against an external dataplane holding 64 established sessions (32 IPv4 + 32 IPv6): unpatched, a clean bfdd restart delivered 58 DELETEs and stranded 6 sessions as orphans (adopted on reconnect); patched, all 64 DELETEs are delivered, the dataplane holds zero orphans across the restart, and all 64 sessions re-register cleanly (`Output full events: 0`, output bytes peak 8120). A second restart in the same run behaves identically, confirming the registration-side behavior from #22645 is undisturbed.
