### PR TITLE
bfdd: reclaim data plane input buffer space in bfd_dplane_expect

### DIFF
--- a/bfdd/.gitignore
+++ b/bfdd/.gitignore
@@ -1,2 +1,2 @@
-# ignore binary files
 bfdd
+bfd_dplane_listener

--- a/bfdd/bfd_dplane_listener.c
+++ b/bfdd/bfd_dplane_listener.c
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * BFD data plane listener.
+ *
+ * A minimal stand-in for a real BFD data plane, used by the topology
+ * tests. It accepts the bfdd data plane connection, tracks the sessions
+ * bfdd registers, reports them up, answers session counter requests,
+ * and dumps what it has seen on SIGUSR1 so a test can inspect it.
+ *
+ * It runs no BFD state machine and sends no BFD packets: a session is
+ * declared up as soon as it is registered. That is enough for the
+ * daemon to treat it as established, which is what lets a test reach
+ * the code paths that only run when a data plane is attached.
+ *
+ * Copyright (C) 2026 Abdul Wasey <awasey8905@gmail.com>
+ */
+
+#include "config.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <libgen.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "lib/libfrr.h"
+
+#include "bfddp_packet.h"
+
+XREF_SETUP();
+
+#define BFD_DPLANE_DEFAULT_PORT 50700
+#define BFD_DPLANE_MAX_SESSIONS 256
+#define BFD_DPLANE_MSG_TYPES	8
+#define BFD_DPLANE_BUFSIZ	65536
+
+static const char *const msgtype_str[BFD_DPLANE_MSG_TYPES] = {
+	"ECHO_REQUEST",		"ECHO_REPLY",	    "DP_ADD_SESSION",
+	"DP_DELETE_SESSION",	"BFD_STATE_CHANGE", "DP_REQUEST_SESSION_COUNTERS",
+	"BFD_SESSION_COUNTERS", "UNKNOWN",
+};
+
+struct listener_glob {
+	FILE *output_file;
+	const char *dump_file;
+	int server_sock;
+	int client_sock;
+	bool connected;
+
+	unsigned long connections;
+	unsigned long msg_count[BFD_DPLANE_MSG_TYPES];
+	unsigned long counter_replies;
+	unsigned long state_changes;
+	unsigned long bytes_in;
+
+	/* Handed out as the remote discriminator, one per session. */
+	uint32_t next_rid;
+
+	uint32_t sessions[BFD_DPLANE_MAX_SESSIONS];
+	size_t session_count;
+};
+
+static struct listener_glob glob_space;
+static struct listener_glob *glob = &glob_space;
+
+static const char *get_timestamp(void)
+{
+	static char buf[64];
+	time_t now = time(NULL);
+	struct tm tm;
+
+	localtime_r(&now, &tm);
+	strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
+
+	return buf;
+}
+
+static bool session_add(uint32_t lid)
+{
+	size_t i;
+
+	for (i = 0; i < glob->session_count; i++)
+		if (glob->sessions[i] == lid)
+			return false;
+
+	if (glob->session_count >= BFD_DPLANE_MAX_SESSIONS)
+		return false;
+
+	glob->sessions[glob->session_count++] = lid;
+
+	return true;
+}
+
+static void session_del(uint32_t lid)
+{
+	size_t i;
+
+	for (i = 0; i < glob->session_count; i++) {
+		if (glob->sessions[i] != lid)
+			continue;
+
+		glob->sessions[i] = glob->sessions[glob->session_count - 1];
+		glob->session_count--;
+		return;
+	}
+}
+
+/* Signal handler for SIGUSR1: write everything seen so far. */
+static void sigusr1_handler(int signum)
+{
+	FILE *out = glob->output_file;
+	FILE *dump_fp = NULL;
+	size_t i;
+
+	(void)signum;
+
+	if (glob->dump_file) {
+		dump_fp = fopen(glob->dump_file, "w");
+		if (dump_fp) {
+			out = dump_fp;
+			setbuf(dump_fp, NULL);
+		}
+	}
+
+	fprintf(out, "\n=== BFD Data Plane Listener Dump ===\n");
+	fprintf(out, "Timestamp: %s\n", get_timestamp());
+	fprintf(out, "Connections accepted: %lu\n", glob->connections);
+	fprintf(out, "Connection state: %s\n", glob->connected ? "connected" : "disconnected");
+	fprintf(out, "Bytes received: %lu\n", glob->bytes_in);
+	fprintf(out, "Counter replies sent: %lu\n", glob->counter_replies);
+	fprintf(out, "State changes sent: %lu\n", glob->state_changes);
+
+	fprintf(out, "Messages received:\n");
+	for (i = 0; i < BFD_DPLANE_MSG_TYPES; i++)
+		fprintf(out, "  %s: %lu\n", msgtype_str[i], glob->msg_count[i]);
+
+	fprintf(out, "Sessions registered: %zu\n", glob->session_count);
+	for (i = 0; i < glob->session_count; i++)
+		fprintf(out, "  lid: %u\n", glob->sessions[i]);
+
+	fprintf(out, "====================================\n\n");
+	fflush(out);
+
+	if (dump_fp)
+		fclose(dump_fp);
+}
+
+FRR_NORETURN
+static void sigterm_handler(int signum)
+{
+	(void)signum;
+
+	if (glob->client_sock >= 0)
+		close(glob->client_sock);
+	if (glob->server_sock >= 0)
+		close(glob->server_sock);
+
+	exit(0);
+}
+
+static bool create_listen_sock(int port, int *sock_p)
+{
+	int sock;
+	int one = 1;
+	struct sockaddr_in addr = {};
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) {
+		fprintf(stderr, "Failed to create socket: %s\n", strerror(errno));
+		return false;
+	}
+
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one))) {
+		fprintf(stderr, "Failed to set SO_REUSEADDR: %s\n", strerror(errno));
+		close(sock);
+		return false;
+	}
+
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(port);
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr))) {
+		fprintf(stderr, "Failed to bind to port %d: %s\n", port, strerror(errno));
+		close(sock);
+		return false;
+	}
+
+	if (listen(sock, 5)) {
+		fprintf(stderr, "Failed to listen: %s\n", strerror(errno));
+		close(sock);
+		return false;
+	}
+
+	*sock_p = sock;
+
+	return true;
+}
+
+/*
+ * Answer a counter request. The values are all zero: the tests care that
+ * a well formed reply arrives and that the connection survives, not what
+ * the numbers are.
+ */
+static bool send_counters_reply(int sock, uint16_t id, uint32_t lid)
+{
+	struct bfddp_message msg = {};
+	uint16_t len = sizeof(struct bfddp_message_header) + sizeof(struct bfddp_session_counters);
+
+	msg.header.version = BFD_DP_VERSION;
+	msg.header.type = htons(BFD_SESSION_COUNTERS);
+	msg.header.id = id;
+	msg.header.length = htons(len);
+	msg.data.session_counters.lid = lid;
+
+	if (write(sock, &msg, len) != len) {
+		fprintf(glob->output_file, "Failed to send counters: %s\n", strerror(errno));
+		return false;
+	}
+
+	glob->counter_replies++;
+
+	return true;
+}
+
+static bool send_echo_reply(int sock, const struct bfddp_message *req)
+{
+	struct bfddp_message msg = {};
+	uint16_t len = sizeof(struct bfddp_message_header) + sizeof(struct bfddp_echo);
+
+	msg.header.version = BFD_DP_VERSION;
+	msg.header.type = htons(ECHO_REPLY);
+	msg.header.id = req->header.id;
+	msg.header.length = htons(len);
+	msg.data.echo = req->data.echo;
+
+	return write(sock, &msg, len) == len;
+}
+
+/*
+ * Report a session as up.
+ *
+ * A real data plane runs the BFD state machine and tells the daemon when
+ * a session changes state. This one has no peer to talk to, so it simply
+ * declares the session up as soon as it is registered and echoes the
+ * timers back. That is enough for the daemon to treat the session as
+ * established, which is what the tests need.
+ */
+static bool send_state_change(int sock, const struct bfddp_session *session)
+{
+	struct bfddp_message msg = {};
+	uint16_t len = sizeof(struct bfddp_message_header) + sizeof(struct bfddp_state_change);
+
+	msg.header.version = BFD_DP_VERSION;
+	msg.header.type = htons(BFD_STATE_CHANGE);
+	msg.header.id = 0; /* asynchronous, not a reply */
+	msg.header.length = htons(len);
+
+	msg.data.state.lid = session->lid;
+	msg.data.state.rid = htonl(glob->next_rid++);
+	msg.data.state.state = STATE_UP;
+	msg.data.state.diagnostics = 0;
+	msg.data.state.detection_multiplier = session->detect_mult;
+	msg.data.state.desired_tx = session->min_tx;
+	msg.data.state.required_rx = session->min_rx;
+	msg.data.state.required_echo_rx = 0;
+
+	if (write(sock, &msg, len) != len) {
+		fprintf(glob->output_file, "Failed to send state change: %s\n", strerror(errno));
+		return false;
+	}
+
+	glob->state_changes++;
+
+	return true;
+}
+
+static void handle_message(int sock, const struct bfddp_message *msg)
+{
+	uint16_t type = ntohs(msg->header.type);
+
+	if (type < BFD_DPLANE_MSG_TYPES - 1)
+		glob->msg_count[type]++;
+	else
+		glob->msg_count[BFD_DPLANE_MSG_TYPES - 1]++;
+
+	switch (type) {
+	case ECHO_REQUEST:
+		send_echo_reply(sock, msg);
+		break;
+	case DP_ADD_SESSION:
+		if (session_add(ntohl(msg->data.session.lid)))
+			send_state_change(sock, &msg->data.session);
+		break;
+	case DP_DELETE_SESSION:
+		session_del(ntohl(msg->data.session.lid));
+		break;
+	case DP_REQUEST_SESSION_COUNTERS:
+		send_counters_reply(sock, msg->header.id, msg->data.counters_req.lid);
+		break;
+	default:
+		break;
+	}
+}
+
+static void handle_connection(int sock)
+{
+	uint8_t buf[BFD_DPLANE_BUFSIZ];
+	size_t buflen = 0;
+
+	while (true) {
+		ssize_t rv;
+		size_t offset = 0;
+
+		rv = read(sock, buf + buflen, sizeof(buf) - buflen);
+		if (rv == 0) {
+			fprintf(glob->output_file, "Connection closed\n");
+			break;
+		}
+		if (rv < 0) {
+			if (errno == EINTR)
+				continue;
+			fprintf(glob->output_file, "Read failed: %s\n", strerror(errno));
+			break;
+		}
+
+		buflen += (size_t)rv;
+		glob->bytes_in += (size_t)rv;
+
+		while (buflen - offset >= sizeof(struct bfddp_message_header)) {
+			struct bfddp_message msg;
+			struct bfddp_message_header hdr;
+			uint16_t msglen;
+
+			/*
+			 * Copy rather than cast: the message starts at an
+			 * arbitrary offset in the byte buffer, and the
+			 * structures hold 32 and 64 bit fields that must
+			 * not be read unaligned.
+			 */
+			memcpy(&hdr, buf + offset, sizeof(hdr));
+			msglen = ntohs(hdr.length);
+
+			if (hdr.version != BFD_DP_VERSION || msglen < sizeof(hdr) ||
+			    msglen > sizeof(msg)) {
+				fprintf(glob->output_file, "Framing error: version %d length %d\n",
+					hdr.version, msglen);
+				return;
+			}
+
+			if (buflen - offset < msglen)
+				break;
+
+			memcpy(&msg, buf + offset, msglen);
+			handle_message(sock, &msg);
+			offset += msglen;
+		}
+
+		if (offset) {
+			memmove(buf, buf + offset, buflen - offset);
+			buflen -= offset;
+		}
+
+		/*
+		 * A message larger than the buffer cannot be assembled, and
+		 * the protocol has none that big.
+		 */
+		if (buflen == sizeof(buf)) {
+			fprintf(glob->output_file, "Buffer full with an incomplete message\n");
+			return;
+		}
+	}
+}
+
+int main(int argc, char **argv)
+{
+	struct sigaction sa;
+	bool fork_daemon = false;
+	const char *output_file = NULL;
+	int port = BFD_DPLANE_DEFAULT_PORT;
+	int r;
+
+	memset(glob, 0, sizeof(*glob));
+	glob->output_file = stdout;
+	glob->server_sock = -1;
+	glob->client_sock = -1;
+	glob->next_rid = 1;
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigusr1_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_RESTART;
+	if (sigaction(SIGUSR1, &sa, NULL) < 0) {
+		fprintf(stderr, "Failed to set up SIGUSR1 handler: %s\n", strerror(errno));
+		exit(1);
+	}
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigterm_handler;
+	sigemptyset(&sa.sa_mask);
+	if (sigaction(SIGTERM, &sa, NULL) < 0 || sigaction(SIGINT, &sa, NULL) < 0 ||
+	    sigaction(SIGHUP, &sa, NULL) < 0) {
+		fprintf(stderr, "Failed to set up signal handlers: %s\n", strerror(errno));
+		exit(1);
+	}
+
+	signal(SIGPIPE, SIG_IGN);
+
+	while ((r = getopt(argc, argv, "do:p:z:")) != -1) {
+		switch (r) {
+		case 'd':
+			fork_daemon = true;
+			break;
+		case 'o':
+			output_file = optarg;
+			break;
+		case 'p':
+			port = atoi(optarg);
+			break;
+		case 'z':
+			glob->dump_file = optarg;
+			break;
+		}
+	}
+
+	if (output_file) {
+		glob->output_file = fopen(output_file, "w");
+		if (!glob->output_file) {
+			fprintf(stderr, "Failed to open output file %s: %s\n", output_file,
+				strerror(errno));
+			exit(1);
+		}
+	}
+
+	setbuf(glob->output_file, NULL);
+
+	/*
+	 * Bind before forking. The daemon that connects to us is started
+	 * as soon as the parent exits, so the socket has to be accepting
+	 * by then or that first connection attempt is refused.
+	 */
+	if (!create_listen_sock(port, &glob->server_sock))
+		exit(1);
+
+	if (fork_daemon) {
+		if (fork())
+			exit(0);
+
+		if (glob->dump_file) {
+			char *copy = strdup(glob->dump_file);
+			char pid_path[PATH_MAX];
+			FILE *pid_file;
+
+			snprintf(pid_path, sizeof(pid_path), "%s/bfd_dplane_listener.pid",
+				 dirname(copy));
+
+			pid_file = fopen(pid_path, "w");
+			if (pid_file) {
+				fprintf(pid_file, "%d\n", getpid());
+				fclose(pid_file);
+			} else {
+				fprintf(stderr, "Failed to write PID file %s: %s\n", pid_path,
+					strerror(errno));
+			}
+			free(copy);
+		}
+	}
+
+	fprintf(glob->output_file, "Listening on 127.0.0.1:%d\n", port);
+
+	while (true) {
+		struct sockaddr_in from = {};
+		socklen_t fromlen = sizeof(from);
+		int sock;
+
+		sock = accept(glob->server_sock, (struct sockaddr *)&from, &fromlen);
+		if (sock < 0) {
+			if (errno == EINTR)
+				continue;
+			fprintf(stderr, "Failed to accept: %s\n", strerror(errno));
+			exit(1);
+		}
+
+		glob->connections++;
+		glob->connected = true;
+		glob->client_sock = sock;
+		fprintf(glob->output_file, "Connection %lu accepted\n", glob->connections);
+
+		handle_connection(sock);
+
+		glob->connected = false;
+		glob->client_sock = -1;
+		close(sock);
+	}
+
+	return 0;
+}

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -546,6 +546,16 @@ static int bfd_dplane_expect(struct bfd_dplane_ctx *bdc, uint16_t id,
 	ssize_t rv;
 
 	/*
+	 * Reclaim space consumed by previous calls. Synchronous callers
+	 * (e.g. the counters request) consume one message per call, so the
+	 * `reads`-based pulldown below never runs for them and consumed
+	 * bytes would otherwise accumulate until the buffer artificially
+	 * fills mid-message and a zero-length read is misdiagnosed as the
+	 * peer closing the connection.
+	 */
+	stream_pulldown(bdc->inbuf);
+
+	/*
 	 * Don't attempt to read if buffer is full, otherwise we'll get a
 	 * bogus 'connection closed' signal (rv == 0).
 	 */
@@ -553,6 +563,28 @@ static int bfd_dplane_expect(struct bfd_dplane_ctx *bdc, uint16_t id,
 		goto skip_read;
 
 read_again:
+	/*
+	 * Never issue a zero-length read: `read()` returns 0 and would be
+	 * misdiagnosed below as the peer closing the connection. If there
+	 * is no headroom, reclaim consumed space first; a buffer that is
+	 * still full after that holds a message larger than the buffer,
+	 * which is a protocol violation.
+	 */
+	if (STREAM_WRITEABLE(bdc->inbuf) == 0) {
+		stream_pulldown(bdc->inbuf);
+		if (STREAM_WRITEABLE(bdc->inbuf) == 0) {
+			/*
+			 * A single message larger than the whole buffer:
+			 * protocol violation, this peer cannot be parsed.
+			 * Tear the connection down like the other fatal
+			 * paths do.
+			 */
+			zlog_err("%s: input buffer full with incomplete message", __func__);
+			bfd_dplane_ctx_free(bdc);
+			return -1;
+		}
+	}
+
 	/* Attempt to read message from client. */
 	rv = stream_read_try(bdc->inbuf, bdc->sock,
 			     STREAM_WRITEABLE(bdc->inbuf));

--- a/bfdd/subdir.am
+++ b/bfdd/subdir.am
@@ -4,7 +4,7 @@
 
 if BFDD
 noinst_LIBRARIES += bfdd/libbfd.a
-sbin_PROGRAMS += bfdd/bfdd
+sbin_PROGRAMS += bfdd/bfdd bfdd/bfd_dplane_listener
 vtysh_daemons += bfdd
 man8 += $(MANBUILD)/frr-bfdd.8
 endif
@@ -47,3 +47,6 @@ nodist_bfdd_bfdd_SOURCES = \
 
 bfdd_bfdd_SOURCES = bfdd/bfdd.c
 bfdd_bfdd_LDADD = bfdd/libbfd.a lib/libfrr.la $(UST_LIBS)
+
+bfdd_bfd_dplane_listener_SOURCES = bfdd/bfd_dplane_listener.c
+bfdd_bfd_dplane_listener_LDADD = lib/libfrr.la

--- a/debian/frr-test-tools.install
+++ b/debian/frr-test-tools.install
@@ -1,1 +1,2 @@
 usr/lib/frr/fpm_listener
+usr/lib/frr/bfd_dplane_listener

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -728,6 +728,7 @@ fi
 %endif
 %exclude %{_sbindir}/ssd
 %exclude %{_sbindir}/fpm_listener
+%exclude %{_sbindir}/bfd_dplane_listener
 %if %{with_watchfrr}
     %{_sbindir}/watchfrr
 %endif

--- a/tests/topotests/bfd_dplane_counters_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_dplane_counters_topo1/r1/bfdd.conf
@@ -1,0 +1,20 @@
+!
+bfd
+ peer 10.0.1.100 interface r1-eth0
+ !
+ peer 10.0.1.101 interface r1-eth0
+ !
+ peer 10.0.1.102 interface r1-eth0
+ !
+ peer 10.0.1.103 interface r1-eth0
+ !
+ peer 10.0.1.104 interface r1-eth0
+ !
+ peer 10.0.1.105 interface r1-eth0
+ !
+ peer 10.0.1.106 interface r1-eth0
+ !
+ peer 10.0.1.107 interface r1-eth0
+ !
+exit
+!

--- a/tests/topotests/bfd_dplane_counters_topo1/r1/frr.conf
+++ b/tests/topotests/bfd_dplane_counters_topo1/r1/frr.conf
@@ -1,0 +1,23 @@
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+!
+bfd
+ peer 10.0.1.100 interface r1-eth0
+ !
+ peer 10.0.1.101 interface r1-eth0
+ !
+ peer 10.0.1.102 interface r1-eth0
+ !
+ peer 10.0.1.103 interface r1-eth0
+ !
+ peer 10.0.1.104 interface r1-eth0
+ !
+ peer 10.0.1.105 interface r1-eth0
+ !
+ peer 10.0.1.106 interface r1-eth0
+ !
+ peer 10.0.1.107 interface r1-eth0
+ !
+exit
+!

--- a/tests/topotests/bfd_dplane_counters_topo1/r1/zebra.conf
+++ b/tests/topotests/bfd_dplane_counters_topo1/r1/zebra.conf
@@ -1,0 +1,4 @@
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+!

--- a/tests/topotests/bfd_dplane_counters_topo1/test_bfd_dplane_counters_topo1.py
+++ b/tests/topotests/bfd_dplane_counters_topo1/test_bfd_dplane_counters_topo1.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_bfd_dplane_counters_topo1.py
+#
+# Copyright (c) 2026 by Abdul Wasey
+#
+
+"""
+Test that reading BFD session counters repeatedly does not tear down the
+data plane connection.
+
+`show bfd peers counters` asks the data plane for fresh counters for
+every session and reads each reply synchronously. Consumed replies used
+to leave their bytes behind in the input buffer, so after enough of them
+the buffer looked full, a zero length read was issued, and its zero
+return was misread as the data plane closing the connection.
+
+The listener stands in for a data plane. It runs no BFD state machine
+and sends no BFD packets, it simply reports each session up once the
+daemon registers it, which is enough for the daemon to treat the session
+as established.
+"""
+
+import json
+import os
+import sys
+import time
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bfdd]
+
+DPLANE_PORT = 50700
+SESSION_COUNT = 8
+
+# The input buffer holds a little over one hundred replies, so the
+# failure needs more than that many to show up. Eight sessions over
+# twenty sweeps is a comfortable margin either side of it.
+SWEEPS = 20
+
+
+def build_topo(tgen):
+    "Build function"
+    tgen.add_router("r1")
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router = tgen.gears["r1"]
+    dump_file = os.path.join(router.gearlogdir, "bfd_dplane.data")
+
+    # bfdd connects to the listener as a client, so the listener has to
+    # be accepting before bfdd starts.
+    router.load_config(
+        TopoRouter.RD_BFD_DPLANE_LISTENER,
+        None,
+        "-p {} -z {}".format(DPLANE_PORT, dump_file),
+    )
+    router.load_config(TopoRouter.RD_ZEBRA, os.path.join(CWD, "r1/zebra.conf"))
+    router.load_config(
+        TopoRouter.RD_BFD,
+        os.path.join(CWD, "r1/bfdd.conf"),
+        "--dplaneaddr ipv4c:127.0.0.1:{}".format(DPLANE_PORT),
+    )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _listener_dump(router):
+    "Ask the listener to write its state out, and return it."
+    pid_file = os.path.join(router.gearlogdir, "bfd_dplane_listener.pid")
+    dump_file = os.path.join(router.gearlogdir, "bfd_dplane.data")
+
+    try:
+        with open(pid_file) as f:
+            pid = f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+    router.run("kill -SIGUSR1 {}".format(pid))
+    time.sleep(0.2)
+
+    try:
+        with open(dump_file) as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def _dump_value(dump, prefix):
+    "Pull the integer off a `prefix: value` line, or -1 if absent."
+    for line in dump.splitlines():
+        if line.startswith(prefix):
+            try:
+                return int(line.split(":")[1])
+            except ValueError:
+                return -1
+    return -1
+
+
+def test_dplane_sessions_registered():
+    "The data plane should receive every configured session."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    def _registered():
+        return _dump_value(_listener_dump(router), "Sessions registered:")
+
+    _, result = topotest.run_and_expect(_registered, SESSION_COUNT, count=30, wait=1)
+    assert result == SESSION_COUNT, "data plane received {} of {} sessions".format(
+        result, SESSION_COUNT
+    )
+
+
+def test_sessions_reach_up():
+    "The data plane reports the sessions up, so the daemon should agree."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    def _up_count():
+        try:
+            peers = json.loads(router.vtysh_cmd("show bfd peers json"))
+        except ValueError:
+            return -1
+        return sum(1 for peer in peers if peer.get("status") == "up")
+
+    _, result = topotest.run_and_expect(_up_count, SESSION_COUNT, count=30, wait=1)
+    assert result == SESSION_COUNT, "{} of {} sessions came up".format(
+        result, SESSION_COUNT
+    )
+
+
+def test_counters_keep_dplane_connected():
+    "Reading counters repeatedly must not disconnect the data plane."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    for _ in range(SWEEPS):
+        router.vtysh_cmd("show bfd peers counters")
+
+    dump = _listener_dump(router)
+    logger.info("listener state after %d sweeps:\n%s", SWEEPS, dump)
+
+    expected = SESSION_COUNT * SWEEPS
+    replies = _dump_value(dump, "Counter replies sent:")
+    assert replies == expected, (
+        "{} of {} counter requests were answered, so the data plane "
+        "stopped being asked partway through:\n{}".format(replies, expected, dump)
+    )
+
+    assert (
+        "Connection state: connected" in dump
+    ), "the data plane connection was lost while reading counters:\n{}".format(dump)
+
+    # A reconnect means the connection dropped and bfdd came back, which
+    # the state line alone would not catch.
+    accepted = _dump_value(dump, "Connections accepted:")
+    assert (
+        accepted == 1
+    ), "bfdd reconnected {} times, so the connection was dropped:\n{}".format(
+        accepted - 1, dump
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/bfd_dplane_counters_topo1/test_bfd_dplane_counters_topo1.py
+++ b/tests/topotests/bfd_dplane_counters_topo1/test_bfd_dplane_counters_topo1.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_bfd_dplane_counters_topo1.py
+#
+# Copyright (c) 2026 by Abdul Wasey
+#
+
+"""
+Test that reading BFD session counters repeatedly does not tear down the
+data plane connection.
+
+`show bfd peers counters` asks the data plane for fresh counters for
+every session and reads each reply synchronously. Consumed replies used
+to leave their bytes behind in the input buffer, so after enough of them
+the buffer looked full, a zero length read was issued, and its zero
+return was misread as the data plane closing the connection.
+
+The listener stands in for a data plane. It runs no BFD state machine
+and sends no BFD packets, it simply reports each session up once the
+daemon registers it, which is enough for the daemon to treat the session
+as established.
+"""
+
+import os
+import sys
+import time
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bfdd]
+
+DPLANE_PORT = 50700
+SESSION_COUNT = 8
+
+# The input buffer holds a little over one hundred replies, so the
+# failure needs more than that many to show up. Eight sessions over
+# twenty sweeps is a comfortable margin either side of it.
+SWEEPS = 20
+
+
+def build_topo(tgen):
+    "Build function"
+    tgen.add_router("r1")
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router = tgen.gears["r1"]
+    dump_file = os.path.join(router.gearlogdir, "bfd_dplane.data")
+
+    # bfdd connects to the listener as a client, so the listener has to
+    # be accepting before bfdd starts. The daemons are listed explicitly
+    # rather than inferred, because two of the three need arguments.
+    router.load_frr_config(
+        daemons=[
+            (
+                TopoRouter.RD_BFD_DPLANE_LISTENER,
+                "-p {} -z {}".format(DPLANE_PORT, dump_file),
+            ),
+            (TopoRouter.RD_ZEBRA, None),
+            (
+                TopoRouter.RD_BFD,
+                "--dplaneaddr ipv4c:127.0.0.1:{}".format(DPLANE_PORT),
+            ),
+        ],
+    )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _listener_dump(router):
+    "Ask the listener to write its state out, and return it."
+    pid_file = os.path.join(router.gearlogdir, "bfd_dplane_listener.pid")
+    dump_file = os.path.join(router.gearlogdir, "bfd_dplane.data")
+
+    try:
+        with open(pid_file) as f:
+            pid = f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+    router.run("kill -SIGUSR1 {}".format(pid))
+    time.sleep(0.2)
+
+    try:
+        with open(dump_file) as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def _dump_value(dump, prefix):
+    "Pull the integer off a `prefix: value` line, or -1 if absent."
+    for line in dump.splitlines():
+        if line.startswith(prefix):
+            try:
+                return int(line.split(":")[1])
+            except ValueError:
+                return -1
+    return -1
+
+
+def test_dplane_sessions_registered():
+    "The data plane should receive every configured session."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    def _registered():
+        return _dump_value(_listener_dump(router), "Sessions registered:")
+
+    _, result = topotest.run_and_expect(_registered, SESSION_COUNT, count=30, wait=1)
+    assert result == SESSION_COUNT, "data plane received {} of {} sessions".format(
+        result, SESSION_COUNT
+    )
+
+
+def test_sessions_reach_up():
+    "The data plane reports the sessions up, so the daemon should agree."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    def _up_count():
+        peers = router.vtysh_cmd("show bfd peers json", isjson=True)
+        if not peers:
+            return -1
+        return sum(1 for peer in peers if peer.get("status") == "up")
+
+    _, result = topotest.run_and_expect(_up_count, SESSION_COUNT, count=30, wait=1)
+    assert result == SESSION_COUNT, "{} of {} sessions came up".format(
+        result, SESSION_COUNT
+    )
+
+
+def test_counters_keep_dplane_connected():
+    "Reading counters repeatedly must not disconnect the data plane."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    for _ in range(SWEEPS):
+        router.vtysh_cmd("show bfd peers counters")
+
+    dump = _listener_dump(router)
+    logger.info("listener state after %d sweeps:\n%s", SWEEPS, dump)
+
+    expected = SESSION_COUNT * SWEEPS
+    replies = _dump_value(dump, "Counter replies sent:")
+    assert replies == expected, (
+        "{} of {} counter requests were answered, so the data plane "
+        "stopped being asked partway through:\n{}".format(replies, expected, dump)
+    )
+
+    assert (
+        "Connection state: connected" in dump
+    ), "the data plane connection was lost while reading counters:\n{}".format(dump)
+
+    # A reconnect means the connection dropped and bfdd came back, which
+    # the state line alone would not catch.
+    accepted = _dump_value(dump, "Connections accepted:")
+    assert (
+        accepted == 1
+    ), "bfdd reconnected {} times, so the connection was dropped:\n{}".format(
+        accepted - 1, dump
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -812,6 +812,7 @@ class TopoRouter(TopoGear):
     RD_MGMTD = 20
     RD_TRAP = 21
     RD_FPM_LISTENER = 22
+    RD_BFD_DPLANE_LISTENER = 23
     RD = {
         RD_FRR: "frr",
         RD_ZEBRA: "zebra",
@@ -836,6 +837,7 @@ class TopoRouter(TopoGear):
         RD_MGMTD: "mgmtd",
         RD_TRAP: "snmptrapd",
         RD_FPM_LISTENER: "fpm_listener",
+        RD_BFD_DPLANE_LISTENER: "bfd_dplane_listener",
     }
 
     def __init__(self, tgen, cls, name, **params):
@@ -955,7 +957,7 @@ class TopoRouter(TopoGear):
         TopoRouter.RD_ISIS, TopoRouter.RD_BGP, TopoRouter.RD_LDP,
         TopoRouter.RD_PIM, TopoRouter.RD_PIM6, TopoRouter.RD_PBR,
         TopoRouter.RD_SNMP, TopoRouter.RD_MGMTD, TopoRouter.RD_TRAP,
-        TopoRouter.RD_FPM_LISTENER.
+        TopoRouter.RD_FPM_LISTENER, TopoRouter.RD_BFD_DPLANE_LISTENER.
 
         Possible `source` values are `None` for an empty config file, a path name which is
         used directly, or a file name with no path components which is first looked for
@@ -1001,6 +1003,7 @@ class TopoRouter(TopoGear):
                 and daemon != "snmpd"
                 and daemon != "snmptrapd"
                 and daemon != "fpm_listener"
+                and daemon != "bfd_dplane_listener"
             ):
                 self.vtysh_cmd(
                     "\n".join(
@@ -1082,6 +1085,7 @@ class TopoRouter(TopoGear):
                 and daemon != "snmpd"
                 and daemon != "snmptrapd"
                 and daemon != "fpm_listener"
+                and daemon != "bfd_dplane_listener"
             ):
                 self.vtysh_cmd(
                     "\n".join(

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1482,7 +1482,8 @@ class Router(Node):
     # Daemon stop order, mirroring the production init scripts
     # (tools/frrcommon.sh.in). all_stop() there signals daemons in the reverse
     # of the $DAEMONS start order, so this is that reversed list. Daemons not
-    # present here (e.g. fpm_listener, snmpd) sort before everything else.
+    # present here (e.g. fpm_listener, bfd_dplane_listener, snmpd) sort
+    # before everything else.
     # Keep this in sync with $DAEMONS in tools/frrcommon.sh.in.
     FRR_DAEMON_STOP_ORDER = {
         name: index
@@ -1587,6 +1588,7 @@ class Router(Node):
             "mgmtd": 0,
             "snmptrapd": 0,
             "fpm_listener": 0,
+            "bfd_dplane_listener": 0,
         }
         self.daemon_instances = {"ospfd": []}
         self.daemons_options = {"zebra": ""}
@@ -1687,28 +1689,30 @@ class Router(Node):
         return ret
 
     def stopRouter(self, assertOnError=True):
-        # fpm_listener writes its PID file to the gear log directory (next to
-        # its data dump), not to /var/run/frr/, so listDaemons() can't see it.
-        # Send it SIGTERM first and give it a brief moment to run its atexit
-        # handlers (in particular gcov flush under --enable-gcov) before the
-        # namespace teardown SIGKILLs it. This must happen before listDaemons()
-        # below sends SIGTERM to the FRR daemons because once zebra exits the
-        # FPM client side closes the socket and we want fpm_listener's last
-        # accept loop iteration to be reflected in coverage.
-        fpm_pidfile = "{}/{}/fpm_listener.pid".format(self.logdir, self.name)
-        try:
-            with open(fpm_pidfile) as f:
-                fpm_pid = int(f.read().strip())
+        # The listener helpers write their PID files to the gear log
+        # directory (next to their data dumps), not to /var/run/frr/, so
+        # listDaemons() can't see them. Send SIGTERM first and give them a
+        # brief moment to run their atexit handlers (in particular gcov flush
+        # under --enable-gcov) before the namespace teardown SIGKILLs them.
+        # This must happen before listDaemons() below sends SIGTERM to the FRR
+        # daemons because once the daemon exits its client side closes the
+        # socket, and we want the listener's last accept loop iteration to be
+        # reflected in coverage.
+        for listener in ("fpm_listener", "bfd_dplane_listener"):
+            pidfile = "{}/{}/{}.pid".format(self.logdir, self.name, listener)
             try:
-                os.kill(fpm_pid, signal.SIGTERM)
-                logger.debug(
-                    "%s: sent SIGTERM to fpm_listener pid %d", self.name, fpm_pid
-                )
-            except OSError:
+                with open(pidfile) as f:
+                    pid = int(f.read().strip())
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                    logger.debug(
+                        "%s: sent SIGTERM to %s pid %d", self.name, listener, pid
+                    )
+                except OSError:
+                    pass
+                time.sleep(0.1)
+            except (FileNotFoundError, ValueError):
                 pass
-            time.sleep(0.1)
-        except (FileNotFoundError, ValueError):
-            pass
 
         # Stop Running FRR Daemons
         running = self.listDaemons()
@@ -2158,6 +2162,10 @@ class Router(Node):
                 binary = "/usr/lib/frr/fpm_listener"
                 cmdenv = ""
                 cmdopt = "-d {}".format(daemon_opts)
+            elif daemon == "bfd_dplane_listener":
+                binary = os.path.join(self.daemondir, "bfd_dplane_listener")
+                cmdenv = ""
+                cmdopt = "-d {}".format(daemon_opts)
             elif daemon == "snmpd":
                 binary = "/usr/sbin/snmpd"
                 cmdenv = ""
@@ -2447,6 +2455,7 @@ class Router(Node):
                     daemon != "snmpd"
                     and daemon != "snmptrapd"
                     and daemon != "fpm_listener"
+                    and daemon != "bfd_dplane_listener"
                 ):
                     cmdopt += " -d "
                 cmdopt += rediropt
@@ -2582,6 +2591,13 @@ class Router(Node):
             start_daemon("fpm_listener")
             while "fpm_listener" in daemons_list:
                 daemons_list.remove("fpm_listener")
+
+        if "bfd_dplane_listener" in daemons_list:
+            # bfdd connects to the listener as a client, so it has to be
+            # accepting before bfdd starts or the first connect fails.
+            start_daemon("bfd_dplane_listener")
+            while "bfd_dplane_listener" in daemons_list:
+                daemons_list.remove("bfd_dplane_listener")
 
         # Now start all the other daemons
         for daemon in daemons_list:
@@ -2809,6 +2825,8 @@ class Router(Node):
             if daemon == "snmptrapd":
                 continue
             if daemon == "fpm_listener":
+                continue
+            if daemon == "bfd_dplane_listener":
                 continue
             if (self.daemons[daemon] == 1) and not (daemon in daemonsRunning):
                 sys.stderr.write("%s: Daemon %s not running\n" % (self.name, daemon))


### PR DESCRIPTION

Fixes #22693 

`bfd_dplane_expect()` never reclaims consumed input-buffer space on the synchronous path: the `reads >= 3` pulldown cannot trigger for callers that consume one message per call (the counters request), and the event path's pulldown only runs when a read event fires. Consumed bytes therefore accumulate across synchronous calls until the buffer artificially fills mid-message; the re-read path then bypasses the buffer-full guard and issues a zero-length read, whose 0 return is misdiagnosed as the peer closing the connection, tearing down a healthy data plane connection with a TCP RST. With 64 sessions, back-to-back `show bfd peers counters` invocations alternate pass/fail with the failing run dying at exactly the reply that crosses the buffer boundary (64 + 39 = 103 replies per connection, deterministic). Full mechanism and an engine-free reproducer (TCP counters responder, no data plane implementation required) are in the issue.

One commit: **bfdd: reclaim data plane input buffer space in bfd_dplane_expect** — pull the input buffer down at function entry so consumed space is reclaimed regardless of caller, and never issue a zero-length read: reclaim first, and treat a buffer still full of an incomplete message as the protocol error it is (a single message larger than the buffer).

Validation (master, x86_64):

- Responder harness, 64 configured sessions: unpatched delivers exactly 103 counters replies per connection (64 + 39) before bfdd RSTs, repeating every two invocations; patched delivers 384/384 across six consecutive invocations on one uninterrupted connection, zero resets.
- Against a real external data plane implementation with 64 established sessions: unpatched alternates strictly (39/64 across ten trials, each failure logging `bfd_dplane_expect: socket closed` under `debug bfd distributed` and re-triggering the full registration burst); patched completes ten consecutive sweeps with zero disconnects.
- Coexistence: validated together with #22692's shutdown drain on a combined build — clean restart still delivers all 64 DP_DELETE_SESSION messages and re-registers 64/64 with `Output full events: 0`.
