### PR TITLE
vtysh: add -s/--stdin to execute commands from stdin until EOF

### DIFF
--- a/doc/manpages/vtysh.rst
+++ b/doc/manpages/vtysh.rst
@@ -11,6 +11,8 @@ vtysh [ -b ]
 
 vtysh [ -E ] [ -d *daemon* ] [ -c *command* ]
 
+vtysh [ -E ] [ -d *daemon* ] [ -B ]
+
 DESCRIPTION
 ===========
 vtysh is an integrated shell for the FRRouting suite of protocol daemons.
@@ -28,6 +30,12 @@ OPTIONS available for the vtysh command:
    Specify command to be executed under batch mode. It behaves like -c option in any other shell - command is executed and vtysh exits.
 
    It's useful for gathering info from FRRouting daemons or reconfiguring daemons from inside shell scripts, etc. Note that multiple commands may be executed by using more than one -c option and/or embedding linefeed characters inside the command string.
+
+.. option:: -B, --batch
+
+   Read commands from stdin, one command per line, and execute each one as it is read, in the same way as commands given with -c. vtysh keeps waiting for further input until stdin is closed, then exits.
+
+   This makes it possible to keep a single long-lived vtysh attached to the daemons and feed it commands through a pipe as they become available, avoiding the startup cost of invoking vtysh once per command. The -E flag echoes each command prior to its results, and unless -n is given, vtysh exits with a non-zero status as soon as a command fails. vtysh flushes its output after every command, so all of a command's output is written to the pipe before the next command is read. A driving program that needs to delimit the output of consecutive commands can combine this with -E, using the echoed prompt and command line as a separator. As in the other non-interactive modes, -n redirects standard output to /dev/null, so no command output is produced in that combination.
 
 .. option:: -d, --daemon daemon_name
 

--- a/tests/topotests/vtysh/test_vtysh.py
+++ b/tests/topotests/vtysh/test_vtysh.py
@@ -82,6 +82,148 @@ def test_ping_command():
     assert result, "'ping' output mismatch: \n{}".format(diff)
 
 
+def test_batch_basic():
+    "Test that vtysh -B executes commands piped through stdin"
+
+    tgen = get_topogen()
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("pipe a batch of show commands into vtysh -B")
+    output = r1.cmd_raises("printf 'show version\\nshow running-config\\n' | vtysh -B")
+    assert "FRRouting" in output, "'show version' output missing: \n{}".format(output)
+    assert "hostname r1" in output, "'show running-config' output missing: \n{}".format(
+        output
+    )
+
+
+def test_batch_config():
+    "Test that configuration commands piped into vtysh -B are applied"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("configure a static route through vtysh -B")
+    r1.cmd_raises(
+        "printf 'configure\\nip route 10.99.99.0/24 blackhole\\nexit\\n'" " | vtysh -B"
+    )
+
+    step("verify the static route was installed")
+
+    def _route_installed(router):
+        output = router.vtysh_cmd("show ip route 10.99.99.0/24")
+        if "blackhole" in output:
+            return None
+        return output
+
+    test_func = partial(_route_installed, r1)
+    result, diff = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result, "static route not installed: \n{}".format(diff)
+
+
+def test_batch_persistent_pipe():
+    "Test that vtysh -B waits for further commands until stdin is closed"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    fifo = "/tmp/vtysh_batch_r1.fifo"
+    outf = "/tmp/vtysh_batch_r1.out"
+    flag = "/tmp/vtysh_batch_r1.flag"
+
+    step("start vtysh -B reading from a fifo")
+    r1.cmd_raises("rm -f {0} {1} {2} && mkfifo {0}".format(fifo, outf, flag))
+    r1.cmd_raises(
+        "( vtysh -B -E < {0} > {1} 2>&1; echo EXITCODE:$? >> {1} )"
+        " > /dev/null 2>&1 < /dev/null &".format(fifo, outf)
+    )
+
+    # The writer sends one command, holds the fifo open until the flag file
+    # shows up, then sends a second command and closes the fifo.
+    r1.cmd_raises(
+        "( exec 3>{0}; echo 'show version' >&3;"
+        " n=0; while [ ! -f {1} ] && [ $n -lt 300 ]; do sleep 0.2; n=$((n+1)); done;"
+        " echo 'show running-config' >&3; exec 3>&- )"
+        " > /dev/null 2>&1 < /dev/null &".format(fifo, flag)
+    )
+
+    step("verify the first command was executed and its output flushed")
+
+    def _first_command_done(router):
+        output = router.run("cat {}".format(outf))
+        if "FRRouting" in output:
+            return None
+        return output
+
+    test_func = partial(_first_command_done, r1)
+    result, diff = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result, "first command output missing: \n{}".format(diff)
+
+    step("verify vtysh is still waiting for input, not exited")
+    output = r1.run("cat {}".format(outf))
+    assert (
+        "EXITCODE:" not in output
+    ), "vtysh exited instead of waiting for more input: \n{}".format(output)
+    assert "# show version" in output, "-E did not echo the command: \n{}".format(
+        output
+    )
+
+    step("release the second command and close the fifo")
+    r1.cmd_raises("touch {}".format(flag))
+
+    def _second_command_done(router):
+        output = router.run("cat {}".format(outf))
+        if "hostname r1" in output and "EXITCODE:0" in output:
+            return None
+        return output
+
+    test_func = partial(_second_command_done, r1)
+    result, diff = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result, "second command output or clean exit missing: \n{}".format(diff)
+
+    r1.run("rm -f {0} {1} {2}".format(fifo, outf, flag))
+
+
+def test_batch_exit_codes():
+    "Test vtysh -B exit codes and option conflicts"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("a failing command must stop execution and exit non-zero")
+    rc, output, _ = r1.net.cmd_status(
+        "printf 'show garbage nonsense\\nshow version\\n' | vtysh -B", warn=False
+    )
+    assert rc != 0, "vtysh -B did not exit non-zero on unknown command"
+    assert (
+        "FRRouting" not in output
+    ), "vtysh -B kept executing after a failed command: \n{}".format(output)
+
+    step("with -n a failing command must not affect the exit code")
+    rc, _, _ = r1.net.cmd_status(
+        "printf 'show garbage nonsense\\nshow version\\n' | vtysh -B -n", warn=False
+    )
+    assert rc == 0, "vtysh -B -n exited non-zero: {}".format(rc)
+
+    step("-B must be rejected in combination with -c")
+    rc, _, error = r1.net.cmd_status("vtysh -B -c 'show version'", warn=False)
+    assert rc != 0, "vtysh accepted -B combined with -c"
+    assert "combination" in error, "missing option conflict error: \n{}".format(error)
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -71,6 +71,12 @@ struct event_loop *master;
 /* Command logging */
 FILE *logfile;
 
+/* -E option: echo command before printing its output */
+static int echo_command;
+
+/* -n option: ignore errors for purposes of exit code */
+static int no_error;
+
 static struct event *ev_exec_timeout;
 uint32_t vtysh_exec_timeout;
 
@@ -234,6 +240,7 @@ static FRR_NORETURN void usage(int status)
 		       "-c, --command            Execute argument as command\n"
 		       "-d, --daemon             Connect only to the specified daemon\n"
 		       "-f, --inputfile          Execute commands from specific file and exit\n"
+		       "-B, --batch              Execute commands from stdin, one per line, until EOF\n"
 		       "-E, --echo               Echo prompt and command in -c mode\n"
 		       "-C, --dryrun             Check configuration for validity and exit\n"
 		       "-m, --markfile           Mark input file with context end\n"
@@ -270,6 +277,7 @@ struct option longopts[] = {
 	{"vty_socket", required_argument, NULL, OPTION_VTYSOCK},
 	{"config_dir", required_argument, NULL, OPTION_CONFDIR},
 	{"inputfile", required_argument, NULL, 'f'},
+	{"batch", no_argument, NULL, 'B'},
 	{"histfile", required_argument, NULL, 'H'},
 	{"echo", no_argument, NULL, 'E'},
 	{"dryrun", no_argument, NULL, 'C'},
@@ -338,6 +346,45 @@ static void log_it(const char *line)
 	strftime(tod, sizeof(tod), "%Y%m%d-%H:%M.%S", &tmp);
 
 	fprintf(logfile, "%s:%s %s\n", tod, user, line);
+}
+
+/*
+ * Execute a single non-interactive command line (-c argument or line
+ * read in batch mode), honoring the -E and -n options, and exit on a
+ * failed command unless -n was given.
+ */
+static int vtysh_execute_command_line(char *line, bool use_history,
+				      bool question_mark)
+{
+	int ret;
+
+	if (use_history) {
+		add_history(line);
+		append_history(1, history_file);
+	}
+
+	if (echo_command)
+		printf("%s%s\n", vtysh_prompt(), line);
+
+	if (logfile)
+		log_it(line);
+
+	/*
+	 * Parsing logic for regular commands will be different than for
+	 * those commands requiring further processing, such as cli
+	 * instructions terminating with question-mark character.
+	 */
+	if (question_mark && !vtysh_execute_command_questionmark(line))
+		ret = CMD_SUCCESS;
+	else
+		ret = vtysh_execute_no_pager(line);
+
+	if (!no_error
+	    && !(ret == CMD_SUCCESS || ret == CMD_SUCCESS_DAEMON
+		 || ret == CMD_WARNING))
+		exit(1);
+
+	return ret;
 }
 
 static int flock_fd;
@@ -410,10 +457,9 @@ int main(int argc, char **argv, char **env)
 		struct cmd_rec *next;
 	} *cmd = NULL;
 	struct cmd_rec *tail = NULL;
-	int echo_command = 0;
-	int no_error = 0;
 	int markfile = 0;
 	int writeconfig = 0;
+	int batch_mode = 0;
 	int ret = 0;
 	char *homedir = NULL;
 	int ditch_suid = 0;
@@ -447,7 +493,7 @@ int main(int argc, char **argv, char **env)
 
 	/* Option handling. */
 	while (1) {
-		opt = getopt_long(argc, argv, "be:c:d:nf:H:mEhCwN:ut", longopts,
+		opt = getopt_long(argc, argv, "be:c:d:nf:BH:mEhCwN:ut", longopts,
 				  0);
 
 		if (opt == EOF)
@@ -496,6 +542,9 @@ int main(int argc, char **argv, char **env)
 			break;
 		case 'f':
 			inputfile = optarg;
+			break;
+		case 'B':
+			batch_mode = 1;
 			break;
 		case 'm':
 			markfile = 1;
@@ -549,6 +598,13 @@ int main(int argc, char **argv, char **env)
 	if (markfile + writeconfig + dryrun + boot_flag > 1) {
 		fprintf(stderr,
 			"Invalid combination of arguments.  Please specify at most one of:\n\t-b, -C, -m, -w\n");
+		return 1;
+	}
+	if (batch_mode &&
+	    (cmd || inputfile || markfile || writeconfig || dryrun ||
+	     boot_flag)) {
+		fprintf(stderr,
+			"Invalid combination of arguments.  The -B option cannot be combined with:\n\t-b, -c, -C, -f, -m, -w\n");
 		return 1;
 	}
 	if (inputfile && (writeconfig || boot_flag)) {
@@ -625,16 +681,8 @@ int main(int argc, char **argv, char **env)
 				if (next)
 					*next++ = '\0';
 
-				if (echo_command)
-					printf("%s%s\n", vtysh_prompt(),
-					       cmdnow);
-
-				ret = vtysh_execute_no_pager(cmdnow);
-				if (!no_error
-				    && !(ret == CMD_SUCCESS
-					 || ret == CMD_SUCCESS_DAEMON
-					 || ret == CMD_WARNING))
-					exit(1);
+				ret = vtysh_execute_command_line(cmdnow, false,
+								 false);
 			} while ((cmdnow = next) != NULL);
 
 			cr = cmd;
@@ -741,6 +789,36 @@ int main(int argc, char **argv, char **env)
 		}
 	}
 
+	/* If batch mode: execute commands from stdin, one per line, blocking
+	 * for further input until it is closed.  Command semantics are the
+	 * same as for -c, but the daemon connections are set up only once.
+	 */
+	if (batch_mode) {
+		char line[VTY_BUFSIZ];
+
+		/* Enter into enable node. */
+		if (!user_mode)
+			vtysh_execute("enable");
+
+		vtysh_add_timestamp = ts_flag;
+
+		while (fgets(line, sizeof(line), stdin) != NULL) {
+			char *eol = strchr(line, '\n');
+
+			if (eol)
+				*eol = '\0';
+
+			vtysh_execute_command_line(line, false, true);
+
+			/* Make each command's output visible to a consumer of
+			 * our stdout as soon as it completed.
+			 */
+			fflush(stdout);
+		}
+
+		exit(0);
+	}
+
 	/* If eval mode. */
 	if (cmd && cmd->line) {
 		/* Enter into enable node. */
@@ -755,50 +833,13 @@ int main(int argc, char **argv, char **env)
 			while ((eol = strchr(cmd->line, '\n')) != NULL) {
 				*eol = '\0';
 
-				add_history(cmd->line);
-				append_history(1, history_file);
-
-				if (echo_command)
-					printf("%s%s\n", vtysh_prompt(),
-					       cmd->line);
-
-				if (logfile)
-					log_it(cmd->line);
-
-				ret = vtysh_execute_no_pager(cmd->line);
-				if (!no_error
-				    && !(ret == CMD_SUCCESS
-					 || ret == CMD_SUCCESS_DAEMON
-					 || ret == CMD_WARNING))
-					exit(1);
+				ret = vtysh_execute_command_line(cmd->line,
+								 true, false);
 
 				cmd->line = eol + 1;
 			}
 
-			add_history(cmd->line);
-			append_history(1, history_file);
-
-			if (echo_command)
-				printf("%s%s\n", vtysh_prompt(), cmd->line);
-
-			if (logfile)
-				log_it(cmd->line);
-
-			/*
-			 * Parsing logic for regular commands will be different
-			 * than for those commands requiring further
-			 * processing, such as cli instructions terminating
-			 * with question-mark character.
-			 */
-			if (!vtysh_execute_command_questionmark(cmd->line))
-				ret = CMD_SUCCESS;
-			else
-				ret = vtysh_execute_no_pager(cmd->line);
-
-			if (!no_error
-			    && !(ret == CMD_SUCCESS || ret == CMD_SUCCESS_DAEMON
-				 || ret == CMD_WARNING))
-				exit(1);
+			ret = vtysh_execute_command_line(cmd->line, true, true);
 
 			{
 				struct cmd_rec *cr;


### PR DESCRIPTION
### Summary

Add a new `-s`/`--stdin` batch mode to vtysh, plus topotests exercising it and two small topotest-harness robustness fixes found while writing the tests.

**vtysh: add -s/--stdin to execute commands from stdin until EOF**

Scripts that need to issue many vtysh commands currently pay the vtysh startup cost (config read, daemon socket connections, etc.) once per invocation, or have to know all the commands up front to chain them with multiple `-c` arguments.

The new mode reads commands from stdin, one command per line, and executes each one as it is read, with the same semantics as `-c` (enable node, no pager, `-E` echo, `-n` error handling, question-mark support). vtysh blocks waiting for more input until stdin is closed, so a long-lived vtysh can be driven through a pipe by another process, with commands executed as they become available. stdout is flushed after every command so the driving process can consume each command's complete output before sending the next one.

```sh
mkfifo /tmp/cmds
vtysh -s < /tmp/cmds &
exec 3>/tmp/cmds        # keep the pipe open
echo 'show version' >&3
echo 'show ip route' >&3
exec 3>&-               # closing the pipe makes vtysh exit
```

`-s` is rejected in combination with `-b`, `-c`, `-C`, `-f`, `-m` and `-w`.

**tests: add topotests for vtysh -s/--stdin mode**

Extend `tests/topotests/vtysh` with four tests: batch execution of piped show commands, configuration applied through stdin, the long-lived-pipe behavior (first command executed and flushed while vtysh keeps waiting, clean exit 0 on pipe close, `-E` echo), and exit-code semantics (non-zero on failing command, `-n` override, `-s`/`-c` option conflict).

**tests: don't crash on kernels without loadable module support**

`module_present_linux()` unconditionally opens `/proc/modules`, which does not exist on kernels built with `CONFIG_MODULES=n`, aborting the whole topotest run during environment diagnosis. Fall through to modprobe instead.

**tests: don't abort when rlimits cannot be raised**

`rlimit_atleast()` is written to tolerate failure by default, but only catches `subprocess.CalledProcessError` while `resource.setrlimit()` raises `ValueError`/`OSError`, so containers that disallow raising hard limits kill the run during setup.

The two harness fixes are independent and can be split into their own PR if preferred.

### Related Issue

Related (not fixed by this PR): FRRouting/frr#14194 — `vtysh -f /dev/stdin` regression; `-f` retains whole-file config-apply semantics, which this new mode does not replace.

### Components

vtysh, tests, doc