### PR TITLE
bgpd: Add 'show bgp neighbors <peer> orf-prefix-list' command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -18956,6 +18956,52 @@ DEFPY(show_ip_bgp_neighbors, show_ip_bgp_neighbors_cmd,
 	return bgp_show_neighbor_vty(vty, vrf, sh_type, sh_arg, peer_show_flags, use_json);
 }
 
+/* "show [ip] bgp neighbors <peer> orf-prefix-list" command */
+DEFPY (show_bgp_neighbor_orf_prefix_list,
+       show_bgp_neighbor_orf_prefix_list_cmd,
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] neighbors <A.B.C.D|X:X::X:X|WORD>$neighbor orf-prefix-list [json$uj]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       BGP_INSTANCE_HELP_STR
+       BGP_AFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
+       "Detailed information on TCP and BGP neighbor connections\n"
+       "Neighbor to display information about\n"
+       "Neighbor to display information about\n"
+       "Neighbor on BGP configured interface\n"
+       "Display the ORF prefix-list received from this neighbor\n"
+       JSON_STR)
+{
+	int idx = 0;
+	struct bgp *bgp = NULL;
+	struct peer *peer;
+	afi_t afi = AFI_IP;
+	safi_t safi = SAFI_UNICAST;
+	char orf_name[BUFSIZ];
+	bool use_json = !!uj;
+
+	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi, &bgp, use_json);
+	if (!idx)
+		return CMD_WARNING;
+
+	peer = peer_lookup_in_view(vty, bgp, neighbor, use_json);
+	if (!peer)
+		return CMD_WARNING;
+
+	snprintf(orf_name, sizeof(orf_name), "%s.%d.%d", peer->host, afi, safi);
+	if (!prefix_bgp_show_prefix_list(NULL, afi, orf_name, use_json)) {
+		if (use_json)
+			vty_out(vty, "{}\n");
+		else
+			vty_out(vty, "%% No ORF prefix-list received from %s\n", neighbor);
+		return CMD_SUCCESS;
+	}
+
+	prefix_bgp_show_prefix_list(vty, afi, orf_name, use_json);
+	return CMD_SUCCESS;
+}
+
 /* Show BGP's AS paths internal data.  There are both `show [ip] bgp
    paths' and `show ip mbgp paths'.  Those functions results are the
    same.*/
@@ -24997,6 +25043,7 @@ void bgp_vty_init(void)
 
 	/* "show [ip] bgp neighbors" commands. */
 	install_element(VIEW_NODE, &show_ip_bgp_neighbors_cmd);
+	install_element(VIEW_NODE, &show_bgp_neighbor_orf_prefix_list_cmd);
 
 	/* "show [ip] bgp peer-group" commands. */
 	install_element(VIEW_NODE, &show_ip_bgp_peer_groups_cmd);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5304,6 +5304,19 @@ incoming/outgoing directions.
 
    Display Address Prefix ORFs received from this peer.
 
+.. clicmd:: show [ip] bgp [<view|vrf> VIEWVRFNAME] [afi] [safi] neighbors PEER orf-prefix-list [json]
+
+   Display the ORF prefix-list entries received from this peer. This command
+   shows the individual prefix entries that make up the Outbound Route
+   Filtering (ORF) prefix-list sent by the peer, which is used to filter
+   outbound route advertisements to that peer.
+
+   Example output::
+
+      r1# show bgp ipv4 unicast neighbors 192.168.12.2 orf-prefix-list
+      ip prefix-list 192.168.12.2.1.1: 1 entries
+         seq 5 permit 10.0.0.1/32
+
 .. clicmd:: show bgp [afi] [safi] [all] dampening dampened-paths [wide|json]
 
    Display paths suppressed due to dampening of the selected afi and safi

--- a/tests/topotests/bgp_orf/test_bgp_orf.py
+++ b/tests/topotests/bgp_orf/test_bgp_orf.py
@@ -12,6 +12,9 @@ prefix-list.
 Initially advertise 10.10.10.1/32 from R1 to R2. Add new prefix
 10.10.10.2/32 to r1 prefix list on R2. Test if we updated ORF
 prefix-list correctly.
+
+Also verify that 'show bgp neighbors <peer> orf-prefix-list' correctly
+displays the ORF prefix-list entries received from the peer.
 """
 
 import os
@@ -75,6 +78,23 @@ def test_bgp_orf():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Can't apply ORF from R1 to R2"
 
+    # Verify 'show bgp neighbors <peer> orf-prefix-list' displays the
+    # ORF prefix-list entries received from R2.
+    def _bgp_orf_prefix_list_r1():
+        output = r1.vtysh_cmd(
+            "show bgp ipv4 unicast neighbors 192.168.1.2 orf-prefix-list"
+        )
+        # Should contain the prefix-list entry for 10.10.10.1/32
+        if "10.10.10.1/32" not in output:
+            return "ORF prefix-list entry 10.10.10.1/32 not found"
+        if "permit" not in output:
+            return "ORF prefix-list 'permit' action not found"
+        return None
+
+    test_func = functools.partial(_bgp_orf_prefix_list_r1)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Can't display ORF prefix-list on R1"
+
     def _bgp_converge_r2():
         output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast summary json"))
         expected = {
@@ -113,6 +133,21 @@ def test_bgp_orf():
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Can't apply new ORF from R1 to R2"
 
+    # Verify 'show bgp neighbors <peer> orf-prefix-list' now shows both entries.
+    def _bgp_orf_prefix_list_extended_r1():
+        output = r1.vtysh_cmd(
+            "show bgp ipv4 unicast neighbors 192.168.1.2 orf-prefix-list"
+        )
+        if "10.10.10.1/32" not in output:
+            return "ORF prefix-list entry 10.10.10.1/32 not found"
+        if "10.10.10.2/32" not in output:
+            return "ORF prefix-list entry 10.10.10.2/32 not found"
+        return None
+
+    test_func = functools.partial(_bgp_orf_prefix_list_extended_r1)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Can't display extended ORF prefix-list on R1"
+
     def _bgp_orf_changed_r2():
         output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast json"))
         expected = {
@@ -137,6 +172,21 @@ def test_bgp_orf():
     test_func = functools.partial(_bgp_converge_r1)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Can't apply initial ORF from R1 to R2"
+
+    # Verify 'show bgp neighbors <peer> orf-prefix-list' reverts to single entry.
+    def _bgp_orf_prefix_list_reverted_r1():
+        output = r1.vtysh_cmd(
+            "show bgp ipv4 unicast neighbors 192.168.1.2 orf-prefix-list"
+        )
+        if "10.10.10.1/32" not in output:
+            return "ORF prefix-list entry 10.10.10.1/32 not found"
+        if "10.10.10.2/32" in output:
+            return "ORF prefix-list entry 10.10.10.2/32 should have been removed"
+        return None
+
+    test_func = functools.partial(_bgp_orf_prefix_list_reverted_r1)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Can't display reverted ORF prefix-list on R1"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a new show command to display the ORF prefix-list entries received
from a neighbor:

  show [ip] bgp [<view|vrf> VIEWVRFNAME] [<AFI> [<SAFI>]]
       neighbors <A.B.C.D|X:X::X:X|WORD> orf-prefix-list [json]

Previously, 'show bgp neighbors <peer>' reported only a count of
received ORF entries ("received (N entries)") with no way to inspect
the individual prefixes.  The new command calls
prefix_bgp_show_prefix_list() with a live vty to display all entries,
and supports JSON output.