### PR TITLE
lib: fix wrong nexthop comparision for SRv6

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -71,7 +71,7 @@ static int _nexthop_srv6_cmp(const struct nexthop *nh1,
 	if (nh1->nh_srv6->seg6local_action > nh2->nh_srv6->seg6local_action)
 		return 1;
 
-	if (nh2->nh_srv6->seg6local_action < nh1->nh_srv6->seg6local_action)
+	if (nh1->nh_srv6->seg6local_action < nh2->nh_srv6->seg6local_action)
 		return -1;
 
 	ret = memcmp(&nh1->nh_srv6->seg6local_ctx,


### PR DESCRIPTION
By accident, i found the wrong nexthop comparision: When "nh1->seg6local_action < nh2->seg6local_action", execution wrongly falls through to memcmp(&seg6local_ctx, ...) instead of returning -1.