### PR TITLE
build: remove libfrr.la from grpc and sysrepo module dependencies

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -415,7 +415,7 @@ endif
 
 lib_sysrepo_la_CFLAGS = $(AM_CFLAGS) $(SYSREPO_CFLAGS)
 lib_sysrepo_la_LDFLAGS = $(MODULE_LDFLAGS)
-lib_sysrepo_la_LIBADD = lib/libfrr.la $(SYSREPO_LIBS)
+lib_sysrepo_la_LIBADD = $(SYSREPO_LIBS)
 lib_sysrepo_la_SOURCES = lib/northbound_sysrepo.c
 
 #
@@ -427,7 +427,7 @@ endif
 
 lib_grpc_la_CXXFLAGS = $(WERROR) $(GRPC_CFLAGS)
 lib_grpc_la_LDFLAGS = $(MODULE_LDFLAGS)
-lib_grpc_la_LIBADD = lib/libfrr.la grpc/libfrrgrpc_pb.la $(GRPC_LIBS)
+lib_grpc_la_LIBADD = grpc/libfrrgrpc_pb.la $(GRPC_LIBS)
 lib_grpc_la_SOURCES = lib/northbound_grpc.cpp
 
 #


### PR DESCRIPTION
The grpc and sysrepo modules were incorrectly linking against libfrr.la. As noted in the comment at lines 352-360 of lib/subdir.am, modules should NOT link libfrr because with --enable-static-bin, daemons link libfrr statically (via libfrr.a), and the dynamic linker will make libfrr symbols available to modules from the executable.

Linking libfrr.la into modules caused libfrr.so to be loaded when the module was loaded, which triggered duplicate constructor runs and memgroup list corruption (fixed separately in memory.h).

Follow the same pattern as other module helper libraries (libfrrsnmp, libfrrcares) which do not link against libfrr.