### PR TITLE
lib: make memgroup/memtype constructors idempotent

### DIFF
--- a/lib/memory.h
+++ b/lib/memory.h
@@ -76,6 +76,8 @@ struct memgroup {
 	static void _mginit_##mname(void)                                      \
 	{                                                                      \
 		extern struct memgroup **mg_insert;                            \
+		if (_mg_##mname.ref)                                           \
+			return;                                                \
 		_mg_##mname.ref = mg_insert;                                   \
 		*mg_insert = &_mg_##mname;                                     \
 		mg_insert = &_mg_##mname.next;                                 \
@@ -109,6 +111,8 @@ struct memgroup {
 	static void _mtinit_##mname(void) __attribute__((_CONSTRUCTOR(1001))); \
 	static void _mtinit_##mname(void)                                      \
 	{                                                                      \
+		if (MTYPE_##mname->ref)                                        \
+			return;                                                \
 		if (_mg_##group.insert == NULL)                                \
 			_mg_##group.insert = &_mg_##group.types;               \
 		MTYPE_##mname->ref = _mg_##group.insert;                       \


### PR DESCRIPTION
Make the memgroup and memtype constructor functions idempotent by checking the ref pointer before initialization. If ref is already set, the constructor returns early without modifying the linked list.

This is a defense-in-depth fix for the case where libfrr.so gets loaded at runtime (e.g., by a module incorrectly linking against libfrr.la). With --enable-static-bin, when RTLD_GLOBAL causes the constructors to run with the main executable's symbol copies, the same memgroup/memtype would be inserted twice into the linked list, creating a cycle that causes qmem_walk() to loop forever.

The primary fix is to remove libfrr.la from module dependencies (done in a separate commit), but this idempotent guard prevents list corruption if the constructors are ever called twice.