### PR TITLE
bgpd: fix stuck PROCESS_SCHEDULED after best-path defer

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4294,6 +4294,8 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 			zlog_debug(
 				"%s: bgp delete in progress, ignoring event, p=%pBD(%s)",
 				__func__, dest, bgp->name_pretty);
+		if (dest)
+			UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 		return;
 	}
 	/* Is it end of initial update? (after startup) */
@@ -4342,6 +4344,7 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 		if (BGP_DEBUG(update, UPDATE_OUT))
 			zlog_debug("SELECT_DEFER flag set for route %p(%s)",
 				   dest, bgp->name_pretty);
+		UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 		return;
 	}
 
@@ -5338,6 +5341,9 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 				 struct bgp_path_info *pi, afi_t afi,
 				 safi_t safi, bool early_process)
 {
+	struct bgp_table *table;
+	int ret;
+
 	/*
 	 * Indicate that *this* pi is in an unsorted
 	 * situation, even if the node is already
@@ -5384,17 +5390,31 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 	}
 
 	/* all unlocked in process_subq_xxx functions */
-	bgp_table_lock(bgp_dest_table(dest));
+	table = bgp_dest_table(dest);
+	bgp_table_lock(table);
 
 	SET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 	bgp_dest_lock_node(dest);
 
 	if (early_process) {
 		SET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
-		early_route_process(bgp, dest);
+		ret = early_route_process(bgp, dest);
 	} else {
 		UNSET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
-		other_route_process(bgp, dest);
+		ret = other_route_process(bgp, dest);
+	}
+
+	/*
+	 * On success the dest stays enqueued with the node/table locks held
+	 * and BGP_NODE_PROCESS_SCHEDULED set; they are released and the flag
+	 * cleared asynchronously at dequeue time by process_subq_*_route() ->
+	 * bgp_process_main_one(). On enqueue failure the dequeue never runs,
+	 * so unwind the flag and both locks here.
+	 */
+	if (ret < 0) {
+		UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
+		bgp_dest_unlock_node(dest);
+		bgp_table_unlock(table);
 	}
 
 	return;


### PR DESCRIPTION
## Summary

A prefix can get permanently stuck with `BGP_NODE_PROCESS_SCHEDULED` set
but never actually enqueued for processing, so best-path selection and the
resulting UPDATE never complete.

There are two ways this happens today:

- `bgp_process_main_one()` returns early for a hidden-instance delete or when
  `BGP_NODE_SELECT_DEFER` is set, without clearing `BGP_NODE_PROCESS_SCHEDULED`.
- `bgp_process_internal()` sets `BGP_NODE_PROCESS_SCHEDULED` and takes the
  table/node locks before calling `early_route_process()` /
  `other_route_process()`, but does not roll any of that back if the
  meta-queue enqueue fails.

In both cases the dest is left valid and unsorted (`*u`) with
`processScheduled` set, while `bgp_process()` refuses to re-queue it because
the flag is already set — a permanent stall.

## Changes

- Clear `BGP_NODE_PROCESS_SCHEDULED` on the hidden-instance-delete early
  return (guarded by `if (dest)`, since EOIU markers call this with
  `dest == NULL`) and on the `BGP_NODE_SELECT_DEFER` early return in
  `bgp_process_main_one()`.
- In `bgp_process_internal()`, capture the return value of
  `early_route_process()` / `other_route_process()` and, on failure
  (`ret < 0`), roll back: unset `BGP_NODE_PROCESS_SCHEDULED` and release the
  dest and table locks.

## Test plan

- [ ] Build passes (verified locally: `make bgpd/bgpd`, clang-format clean).
- [ ] BGP topotests (best-path / GR / EVPN suites) show no regressions.