### PR TITLE
zebra: deliver nexthop-tracking resolution changes to the dataplane

### DIFF
--- a/tests/topotests/zebra_nht_event/r1/frr.conf
+++ b/tests/topotests/zebra_nht_event/r1/frr.conf
@@ -1,0 +1,17 @@
+!
+hostname r1
+!
+password zebra
+!
+log file zebra.log
+debug zebra dplane detailed
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+ip route 200.0.0.0/24 192.168.100.1
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.2 remote-as 65002
+!

--- a/tests/topotests/zebra_nht_event/r2/frr.conf
+++ b/tests/topotests/zebra_nht_event/r2/frr.conf
@@ -1,0 +1,19 @@
+!
+hostname r2
+!
+password zebra
+!
+log file zebra.log
+!
+interface r2-eth0
+ ip address 10.0.0.2/24
+!
+ip route 192.168.100.0/24 Null0
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.1 remote-as 65001
+ address-family ipv4 unicast
+  network 192.168.100.0/24
+ exit-address-family
+!

--- a/tests/topotests/zebra_nht_event/test_nht_event.py
+++ b/tests/topotests/zebra_nht_event/test_nht_event.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+test_nht_event.py: Verify DPLANE_OP_NHT_EVENT_UPDATE emission from zebra.
+
+Coverage:
+1. prev != 0, curr == 0 (nexthop became unreachable via BGP withdraw)
+2. prev == 0, curr != 0 (nexthop came back up via BGP re-announce)
+3. Idle sanity: no NHT event lines when nothing changes
+
+"""
+
+import os
+import re
+import sys
+import time
+import pytest
+
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+
+pytestmark = [pytest.mark.bgpd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(CWD)
+
+# Log line grammar produced by dplane_nht_event_update() in zebra_dplane.c.
+NHT_LOG_RE = re.compile(
+    r"NHT_EVENT_UPDATE: "
+    r"rnh=(?P<rnh>\S+) "
+    r"prev_prefix=(?P<prev_prefix>\S+) "
+    r"prev_nhg=(?P<prev_nhg>\d+) "
+    r"curr_prefix=(?P<curr_prefix>\S+) "
+    r"curr_nhg=(?P<curr_nhg>\d+)"
+)
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(module):
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_BGP, None),
+            ],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(module):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _read_zebra_log(router):
+    """Return the current contents of r1's zebra.log."""
+    log_path = os.path.join(router.logdir, router.name, "zebra.log")
+    try:
+        with open(log_path, "r") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def _parse_nht_events(log_text):
+    """Return list of dicts parsed from all NHT_EVENT_UPDATE log lines."""
+    events = []
+    for line in log_text.splitlines():
+        m = NHT_LOG_RE.search(line)
+        if not m:
+            continue
+        events.append(
+            {
+                "rnh": m.group("rnh"),
+                "prev_prefix": m.group("prev_prefix"),
+                "prev_nhg": int(m.group("prev_nhg")),
+                "curr_prefix": m.group("curr_prefix"),
+                "curr_nhg": int(m.group("curr_nhg")),
+            }
+        )
+    return events
+
+
+def _wait_for_new_event(router, baseline_count, timeout=15.0):
+    """Poll r1's zebra.log until a new NHT event beyond baseline arrives."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        events = _parse_nht_events(_read_zebra_log(router))
+        if len(events) > baseline_count:
+            return events[-1]
+        time.sleep(0.2)
+    return None
+
+
+def test_nht_event_prev_only():
+    """Withdrawing the route for the nexthop should trigger an NHT event with curr_nhg=0."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    step("Wait for BGP to converge on r1")
+    time.sleep(5)
+
+    baseline = len(_parse_nht_events(_read_zebra_log(r1)))
+
+    step("Withdraw 192.168.100.0/24 on r2")
+    r2.vtysh_cmd(
+        "configure terminal\n"
+        "router bgp 65002\n"
+        " address-family ipv4 unicast\n"
+        "  no network 192.168.100.0/24\n"
+        " exit-address-family\n"
+        "end"
+    )
+
+    ev = _wait_for_new_event(r1, baseline, timeout=15.0)
+    assert ev is not None, "expected NHT_EVENT_UPDATE log line after withdraw"
+    assert ev["curr_nhg"] == 0, "curr_nhg should be 0 when nexthop unreachable, got {}".format(ev)
+
+
+def test_nht_event_curr_only():
+    """Re-announcing the route should trigger an NHT event with prev_nhg=0, curr_nhg!=0."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Ensure prefix is currently withdrawn -- force a clean state
+    r2.vtysh_cmd(
+        "configure terminal\n"
+        "router bgp 65002\n"
+        " address-family ipv4 unicast\n"
+        "  no network 192.168.100.0/24\n"
+        " exit-address-family\n"
+        "end"
+    )
+    time.sleep(2)
+
+    baseline = len(_parse_nht_events(_read_zebra_log(r1)))
+
+    step("Re-announce 192.168.100.0/24 on r2")
+    r2.vtysh_cmd(
+        "configure terminal\n"
+        "router bgp 65002\n"
+        " address-family ipv4 unicast\n"
+        "  network 192.168.100.0/24\n"
+        " exit-address-family\n"
+        "end"
+    )
+
+    ev = _wait_for_new_event(r1, baseline, timeout=15.0)
+    assert ev is not None, "expected NHT_EVENT_UPDATE log line after re-announce"
+    assert ev["prev_nhg"] == 0, "prev_nhg should be 0 when previously unreachable, got {}".format(ev)
+    assert ev["curr_nhg"] != 0, "curr_nhg should be non-zero after re-announce, got {}".format(ev)
+
+
+@pytest.mark.skip(
+    reason="Requires 3-router topology to change resolution NHG (prev!=0, curr!=0); "
+    "deferred to future phase."
+)
+def test_nht_event_prev_and_curr():
+    """IGP reconvergence switches the NHG -> prev != 0, curr != 0."""
+    pass
+
+
+def test_no_nht_event_when_idle():
+    """No new NHT event should occur while idle (sanity check)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    baseline = len(_parse_nht_events(_read_zebra_log(r1)))
+    time.sleep(3)
+    after = len(_parse_nht_events(_read_zebra_log(r1)))
+    assert after == baseline, (
+        "unexpected NHT events during idle period: baseline={}, after={}"
+        .format(baseline, after)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s", "-v"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1119,6 +1119,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_NHT_EVENT_UPDATE:
 		break;
 
 	}

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -874,14 +874,12 @@ static int netlink_parse_error(const struct nlsock *nl, struct nlmsghdr *h,
 	 * Deal with errors that occur because of races in link handling
 	 * or types are not supported in kernel.
 	 */
-	if (is_cmd &&
-	    ((msg_type == RTM_DELROUTE &&
-	      (-errnum == ENODEV || -errnum == ESRCH)) ||
-	     (msg_type == RTM_NEWROUTE &&
-	      (-errnum == ENETDOWN || -errnum == EEXIST)) ||
-	     ((msg_type == RTM_NEWTUNNEL || msg_type == RTM_DELTUNNEL ||
-	       msg_type == RTM_GETTUNNEL) &&
-	      (-errnum == EOPNOTSUPP)))) {
+	if (is_cmd && ((msg_type == RTM_DELROUTE && (-errnum == ENODEV || -errnum == ESRCH)) ||
+		       (msg_type == RTM_NEWROUTE && (-errnum == ENETDOWN || -errnum == EEXIST)) ||
+		       (msg_type == RTM_DELNEXTHOP && (-errnum == ENOENT || -errnum == ESRCH)) ||
+		       ((msg_type == RTM_NEWTUNNEL || msg_type == RTM_DELTUNNEL ||
+			 msg_type == RTM_GETTUNNEL) &&
+			(-errnum == EOPNOTSUPP)))) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("%s: error: %s type=%s(%u), seq=%u, pid=%u",
 				   nl->name, safe_strerror(-errnum),
@@ -1498,6 +1496,7 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_NHT_EVENT_UPDATE:
 		return FRR_NETLINK_ERROR;
 
 	case DPLANE_OP_GRE_SET:

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1711,6 +1711,7 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		case DPLANE_OP_NEIGH_READ:
 		case DPLANE_OP_TC_QDISC_READ:
 		case DPLANE_OP_TC_QDISC_NOTIFY:
+		case DPLANE_OP_NHT_EVENT_UPDATE:
 			flog_err(EC_ZEBRA_DPLANE_OP_UNHANDLED, "Unhandled dplane data for %s",
 				 dplane_op2str(dplane_ctx_get_op(ctx)));
 			res = ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -51,6 +51,14 @@ struct rnh {
 	uint32_t seqno;
 
 	struct route_entry *state;
+
+	/* The NHG ID of the resolved route entry. Used by NHT consumers
+	 * (e.g. fpmsyncd) to identify the nexthop-group when building FIB
+	 * entries from NHT notifications. We cache this ID in rnh instead
+	 * of the cached NHG entry due to some misuse concern on the cached
+	 * NHG entry after it gets a valid NHG ID.
+	 */
+	uint32_t resolved_nhg_id;
 	struct prefix resolved_route;
 
 	/* Single client that owns this rnh */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -443,6 +443,17 @@ struct dplane_vlan_info {
 };
 
 /*
+ * RNH (Nexthop Tracking) event info for the dataplane
+ */
+struct dplane_rnh_info {
+	struct prefix p; /* Tracked RNH prefix */
+	struct prefix previous_resolved_prefix;
+	uint32_t previous_resolved_nhg_id;
+	struct prefix current_resolved_prefix;
+	uint32_t current_resolved_nhg_id;
+};
+
+/*
  * The context block used to exchange info about route updates across
  * the boundary between the zebra main context (and pthread) and the
  * dataplane layer (and pthread).
@@ -511,6 +522,7 @@ struct zebra_dplane_ctx {
 		struct dplane_macfdb_read_info macfdb_read;
 		struct dplane_neigh_read_info neigh_read;
 		struct dplane_tc_qdisc_notify_info tc_qdisc_notify;
+		struct dplane_rnh_info rnh_info;
 	} u;
 
 	/* Namespace info, used especially for netlink kernel communication */
@@ -975,6 +987,7 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
+	case DPLANE_OP_NHT_EVENT_UPDATE:
 		break;
 	case DPLANE_OP_VLAN_INSTALL:
 		if (ctx->u.vlan_info.vlan_array)
@@ -1298,6 +1311,9 @@ const char *dplane_op2str(enum dplane_op_e op)
 		return "TC_QDISC_READ";
 	case DPLANE_OP_TC_QDISC_NOTIFY:
 		return "TC_QDISC_NOTIFY";
+
+	case DPLANE_OP_NHT_EVENT_UPDATE:
+		return "NHT_EVENT_UPDATE";
 	}
 
 	return "UNKNOWN";
@@ -2522,6 +2538,38 @@ uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.rinfo.nhe.nh_grp_count;
 }
 
+/* NHT event context accessors */
+
+const struct prefix *dplane_ctx_get_rnh_prefix(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &ctx->u.rnh_info.p;
+}
+
+const struct prefix *dplane_ctx_get_rnh_prev_resolved_prefix(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &ctx->u.rnh_info.previous_resolved_prefix;
+}
+
+uint32_t dplane_ctx_get_rnh_prev_resolved_nhg_id(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rnh_info.previous_resolved_nhg_id;
+}
+
+const struct prefix *dplane_ctx_get_rnh_curr_resolved_prefix(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &ctx->u.rnh_info.current_resolved_prefix;
+}
+
+uint32_t dplane_ctx_get_rnh_curr_resolved_nhg_id(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rnh_info.current_resolved_nhg_id;
+}
+
 /* Accessors for LSP information */
 
 mpls_label_t dplane_ctx_get_in_label(const struct zebra_dplane_ctx *ctx)
@@ -2530,6 +2578,75 @@ mpls_label_t dplane_ctx_get_in_label(const struct zebra_dplane_ctx *ctx)
 
 	return ctx->u.lsp.ile.in_label;
 }
+
+
+static int dplane_update_enqueue(struct zebra_dplane_ctx *ctx);
+/*
+ * Enqueue an NHT (Nexthop Tracking) event update to the dataplane.
+ */
+enum zebra_dplane_result dplane_nht_event_update(const struct prefix *rnh_prefix,
+						 const struct prefix *prev_resolved_prefix,
+						 uint32_t prev_nhg_id,
+						 const struct prefix *curr_resolved_prefix,
+						 uint32_t curr_nhg_id)
+{
+	struct zebra_dplane_ctx *ctx = NULL;
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	int ret;
+
+	if (rnh_prefix == NULL)
+		return result;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+		char rnh_buf[PREFIX_STRLEN];
+
+		prefix2str(rnh_prefix, rnh_buf, sizeof(rnh_buf));
+		zlog_debug("init dplane ctx %s: rnh=%s prev_nhg=%u curr_nhg=%u",
+			   dplane_op2str(DPLANE_OP_NHT_EVENT_UPDATE), rnh_buf, prev_nhg_id,
+			   curr_nhg_id);
+	}
+
+	ctx = dplane_ctx_alloc();
+	if (!ctx)
+		return result;
+
+	ctx->zd_op = DPLANE_OP_NHT_EVENT_UPDATE;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	/* NHT events are informational for the FPM; they never go to kernel. */
+	dplane_ctx_set_skip_kernel(ctx);
+
+	/* Populate RNH info */
+	prefix_copy(&ctx->u.rnh_info.p, rnh_prefix);
+
+	if (prev_resolved_prefix)
+		prefix_copy(&ctx->u.rnh_info.previous_resolved_prefix, prev_resolved_prefix);
+	else
+		memset(&ctx->u.rnh_info.previous_resolved_prefix, 0, sizeof(struct prefix));
+	ctx->u.rnh_info.previous_resolved_nhg_id = prev_nhg_id;
+
+	if (curr_resolved_prefix)
+		prefix_copy(&ctx->u.rnh_info.current_resolved_prefix, curr_resolved_prefix);
+	else
+		memset(&ctx->u.rnh_info.current_resolved_prefix, 0, sizeof(struct prefix));
+	ctx->u.rnh_info.current_resolved_nhg_id = curr_nhg_id;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
+		zlog_debug("NHT_EVENT_UPDATE: rnh=%pFX prev_prefix=%pFX prev_nhg=%u curr_prefix=%pFX curr_nhg=%u",
+			   &ctx->u.rnh_info.p, &ctx->u.rnh_info.previous_resolved_prefix,
+			   prev_nhg_id, &ctx->u.rnh_info.current_resolved_prefix, curr_nhg_id);
+
+	/* Enqueue context for processing */
+	ret = dplane_update_enqueue(ctx);
+
+	if (ret == AOK)
+		result = ZEBRA_DPLANE_REQUEST_QUEUED;
+	else
+		dplane_ctx_free(&ctx);
+
+	return result;
+}
+
 
 void dplane_ctx_set_in_label(struct zebra_dplane_ctx *ctx, mpls_label_t label)
 {
@@ -7473,6 +7590,10 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 			   dplane_ctx_tc_qdisc_notify_get_major_handle(ctx),
 			   dplane_ctx_get_startup(ctx));
 		break;
+
+	case DPLANE_OP_NHT_EVENT_UPDATE:
+		zlog_debug("Dplane NHT event update, rnh %pFX", dplane_ctx_get_rnh_prefix(ctx));
+		break;
 	}
 }
 
@@ -7654,6 +7775,7 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 
 	case DPLANE_OP_NONE:
 	case DPLANE_OP_STARTUP_STAGE:
+	case DPLANE_OP_NHT_EVENT_UPDATE:
 		if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
 			atomic_fetch_add_explicit(&zdplane_info.dg_other_errors,
 						  1, memory_order_relaxed);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -226,6 +226,9 @@ enum dplane_op_e {
 	/* Traffic control qdisc read */
 	DPLANE_OP_TC_QDISC_READ,
 	DPLANE_OP_TC_QDISC_NOTIFY,
+
+	/* NHT (Nexthop Tracking) event update */
+	DPLANE_OP_NHT_EVENT_UPDATE,
 };
 
 /* Operational status of Bridge Ports */
@@ -668,6 +671,13 @@ const struct nh_grp *
 dplane_ctx_get_nhe_nh_grp(const struct zebra_dplane_ctx *ctx);
 uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx);
 
+/* NHT event context accessors */
+const struct prefix *dplane_ctx_get_rnh_prefix(const struct zebra_dplane_ctx *ctx);
+const struct prefix *dplane_ctx_get_rnh_prev_resolved_prefix(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_rnh_prev_resolved_nhg_id(const struct zebra_dplane_ctx *ctx);
+const struct prefix *dplane_ctx_get_rnh_curr_resolved_prefix(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_rnh_curr_resolved_nhg_id(const struct zebra_dplane_ctx *ctx);
+
 /* Accessors for LSP information */
 
 /* Init the internal LSP data struct - necessary before adding to it.
@@ -987,6 +997,17 @@ struct nhg_hash_entry;
 enum zebra_dplane_result dplane_nexthop_add(struct nhg_hash_entry *nhe);
 enum zebra_dplane_result dplane_nexthop_update(struct nhg_hash_entry *nhe);
 enum zebra_dplane_result dplane_nexthop_delete(struct nhg_hash_entry *nhe);
+
+/*
+ * Enqueue an NHT event update - emitted when an RNH's resolved state changes
+ * so fpmsyncd can perform a fast RIB fixup. Takes independent fields so the
+ * dplane layer does not depend on struct rnh internals.
+ */
+enum zebra_dplane_result dplane_nht_event_update(const struct prefix *rnh_prefix,
+						 const struct prefix *prev_resolved_prefix,
+						 uint32_t prev_nhg_id,
+						 const struct prefix *curr_resolved_prefix,
+						 uint32_t curr_nhg_id);
 
 /*
  * Enqueue LSP change operations for the dataplane.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5336,6 +5336,9 @@ static void rib_process_dplane_results(struct event *event)
 				zebra_vlan_dplane_result(ctx);
 				break;
 
+			case DPLANE_OP_NHT_EVENT_UPDATE:
+				break;
+
 			case DPLANE_OP_NEIGH_IP_INSTALL:
 			case DPLANE_OP_NEIGH_IP_DELETE:
 			case DPLANE_OP_NEIGH_INSTALL:

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -31,6 +31,7 @@
 #include "zebra/redistribute.h"
 #include "zebra/debug.h"
 #include "zebra/zebra_rnh.h"
+#include "zebra/zebra_dplane.h"
 #include "zebra/zebra_routemap.h"
 #include "zebra/zebra_srte.h"
 #include "zebra/interface.h"
@@ -790,6 +791,12 @@ static void zebra_rnh_eval_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 					 struct route_entry *re)
 {
 	int state_changed = 0;
+	uint32_t prev_nhg_id = 0;
+	struct prefix prev_resolved;
+
+	/* Cache previous state BEFORE copy_state() updates rnh. */
+	prev_nhg_id = rnh->resolved_nhg_id;
+	prefix_copy(&prev_resolved, &rnh->resolved_route);
 
 	/* If we're resolving over a different route, resolution has changed or
 	 * the resolving route has some change (e.g., metric), there is a state
@@ -826,6 +833,27 @@ static void zebra_rnh_eval_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			rnh_empty.state = NULL;
 			zebra_rnh_notify_protocol_clients(zvrf, afi, nrn, &rnh_empty, prn, NULL);
 		}
+
+		/* Enqueue an NHT event update to the dplane for FPM consumers. */
+		if (state_changed) {
+			struct prefix curr_resolved;
+			uint32_t curr_nhg_id;
+			enum zebra_dplane_result dplane_res;
+
+			prefix_copy(&curr_resolved, &rnh->resolved_route);
+			curr_nhg_id = rnh->resolved_nhg_id;
+
+			if (IS_ZEBRA_DEBUG_NHT)
+				zlog_debug("NHT event: rnh=%pFX prev_nhg=%u curr_nhg=%u", &nrn->p,
+					   prev_nhg_id, curr_nhg_id);
+
+			dplane_res = dplane_nht_event_update(&nrn->p, &prev_resolved, prev_nhg_id,
+							     &curr_resolved, curr_nhg_id);
+			if (dplane_res != ZEBRA_DPLANE_REQUEST_QUEUED)
+				zlog_warn("NHT event enqueue failed for rnh=%pFX: result=%d",
+					  &nrn->p, dplane_res);
+		}
+
 		/* NOTE: Use the "copy" of resolving route stored in 'rnh' i.e.,
 		 * rnh->state.
 		 */
@@ -1026,6 +1054,7 @@ static void copy_state(struct rnh *rnh, const struct route_entry *re,
 		free_state(rnh->vrf_id, rnh->state, rn);
 		rnh->state = NULL;
 	}
+	rnh->resolved_nhg_id = 0;
 
 	if (!re)
 		return;
@@ -1038,6 +1067,7 @@ static void copy_state(struct rnh *rnh, const struct route_entry *re,
 	state->status = re->status;
 
 	state->nhe = zebra_nhe_copy(re->nhe, 0);
+	rnh->resolved_nhg_id = re->nhe->id;
 
 	rnh->state = state;
 }

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -433,6 +433,7 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_NEIGH_READ:
 	case DPLANE_OP_TC_QDISC_READ:
 	case DPLANE_OP_TC_QDISC_NOTIFY:
+	case DPLANE_OP_NHT_EVENT_UPDATE:
 		break;
 	} /* Dispatch by op code */
 }


### PR DESCRIPTION
Nexthop tracking notifies protocol clients when a tracked nexthop changes how it resolves. This PR extends that notification to the dataplane: on a resolution change, an event describing the transition is passed to the dataplane, so a consumer with its own forwarding view can react and converge without waiting for the control-plane path.

The event identifies the tracked nexthop and gives the resolving route before and after the change, each with its nexthop-group id. From this pair a consumer (e.g., FPM) can tell what changed and update only the forwarding state that depends on it, enabling prefix-independent convergence on events. The event skips the kernel.

A topotest (zebra_nht_event) validates event emission on nexthop withdraw and re-announce.