### PR TITLE
lib: fix use-after-free of src_table in srcdest_srcnode_destroy

### DIFF
--- a/lib/srcdest_table.c
+++ b/lib/srcdest_table.c
@@ -88,6 +88,7 @@ static void srcdest_srcnode_destroy(route_table_delegate_t *delegate,
 				    struct route_node *rn)
 {
 	struct srcdest_rnode *srn;
+	struct route_table *src_table;
 
 	XFREE(MTYPE_ROUTE_SRC_NODE, rn);
 
@@ -97,8 +98,17 @@ static void srcdest_srcnode_destroy(route_table_delegate_t *delegate,
 		 * permitted IF table->count is 0!  see lib/table.c
 		 * route_node_delete()
 		 * for details */
-		route_table_finish(srn->src_table);
+
+		/* Null the pointer before calling route_table_finish to ensure
+		 * srn->src_table is never a dangling pointer. route_table_finish
+		 * may call back into srcdest_srcnode_destroy for remaining nodes;
+		 * any such re-entrant read of srn->src_table must see NULL, not
+		 * a pointer to memory that is in the process of being freed.
+		 * This mirrors the same pattern used in srcdest_rnode_destroy().
+		 */
+		src_table = srn->src_table;
 		srn->src_table = NULL;
+		route_table_finish(src_table);
 
 		/* drop the ref we're holding in srcdest_node_get().  there
 		 * might be


### PR DESCRIPTION
## Summary

Fix a use-after-free of `src_table` in
`lib/srcdest_table.c:srcdest_srcnode_destroy()`.

## Root cause

`srcdest_srcnode_destroy()` freed `srn->src_table` via `route_table_finish()`
before nulling the pointer. After `route_table_finish()` returned,
`srn->src_table` still held the address of the freed `route_table` struct.

A subsequent dplane FIB notification for the same destination prefix calls
`srcdest_rnode_get() → srcdest_srcnode_get()`, which guards new-table creation
with `if (!srn->src_table)`. Because the pointer was non-NULL (dangling), the
guard evaluated false and the freed struct was passed to `route_node_get()`,
causing a SIGSEGV.

`route_table_finish()` can also re-enter `srcdest_srcnode_destroy()` for the
remaining nodes during the finish sweep
(`route_table_free → route_node_free → destroy_node`); any such re-entrant read
of `srn->src_table` observed the same dangling pointer.

## Fix

Null `srn->src_table` before calling `route_table_finish()`, mirroring the
identical null-before-finish pattern already present and commented in
`srcdest_rnode_destroy()`:

```c
struct route_table *src_table = srn->src_table;

srn->src_table = NULL;
route_table_finish(src_table);
```

With the pointer nulled first, any re-entrant call to
`srcdest_srcnode_destroy()` during the finish sweep sees `NULL` and exits
cleanly, and any subsequent call to `srcdest_srcnode_get()` allocates a fresh,
valid `route_table` instead of dereferencing freed memory.

## Test plan

- [x] Rebuild and load on an affected setup
- [x] Exercise EVPN/VXLAN multi-homing route teardown that previously crashed
- [x] Confirm no zebra core is generated and route state stays consistent