### PR TITLE
zebra: fix ES-present transition uninstall in remote_macip_add

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2058,15 +2058,23 @@ int zebra_evpn_mac_remote_macip_add(struct zebra_evpn *zevpn, struct zebra_vrf *
 				return -1;
 
 			old_es_present = !!mac->es;
-			zebra_evpn_es_mac_ref(mac, esi);
-			new_es_present = !!mac->es;
+			/* Derive new_es_present from the incoming ESI, not
+			 * mac->es after es_mac_ref(). The transition uninstall
+			 * below must delete using the old binding (single VTEP
+			 * vs NHG) while mac->es still reflects it.
+			 */
+			new_es_present = !!memcmp(esi, zero_esi, sizeof(esi_t));
 			/* XXX - dataplane is currently not able to handle a MAC
 			 * replace if the destination changes from L2-NHG to
 			 * single VTEP and vice-versa. So delete the old entry
-			 * and re-install
+			 * and re-install. Only when the MAC is already remote:
+			 * on local-to-remote, fwd_info still holds local if
+			 * fields and rem_mac_uninstall would use a bogus VTEP.
 			 */
-			if (old_es_present != new_es_present)
+			if (old_es_present != new_es_present &&
+			    CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE))
 				zebra_evpn_rem_mac_uninstall(zevpn, mac, false);
+			zebra_evpn_es_mac_ref(mac, esi);
 		}
 
 		/* Check MAC's current state is local (this is the case


### PR DESCRIPTION
## Summary

Fix the remote MAC FDB lifecycle during EVPN multihoming ES/NHG
transitions so kernel/dataplane entries are not left bound to a single
VTEP while the zebra control plane already reflects a remote+ES state
(or vice-versa).

## Root cause

In `zebra_evpn_mac_remote_macip_add()`, `zebra_evpn_es_mac_ref()` ran
*before* the ES-present transition uninstall. As a result:

- The uninstall could use the wrong delete key, because `mac->es` had
  already been updated to the new ES state while the kernel binding
  still matched the old one.
- On a local-to-remote move, `fwd_info` still holds local interface
  fields; treating that union as `r_vtep_ip` could enqueue a remote FDB
  delete with a bogus VTEP.

The dataplane cannot handle a MAC replace when the destination changes
between an L2-NHG and a single VTEP, so the old entry must be removed
while it still reflects the old binding.

## Fix

- Derive `new_es_present` from the incoming `esi` (compared against
  `zero_esi`) instead of from `mac->es` after the ref.
- Perform the transition uninstall while `mac->es` still reflects the
  old binding, and only when the existing MAC is `ZEBRA_MAC_REMOTE`.
- Attach the new ES via `zebra_evpn_es_mac_ref()` after the uninstall.

## Test plan

`bgp_evpn_mh` and `bgp_evpn_mh_l2l3vni` topotests:

```
Suite               | Total | Pass | Fail | Error | Skip | Time(s)
--------------------+-------+------+------+-------+------+--------
bgp_evpn_mh         |     6 |    6 |    0 |     0 |    0 |   54.43
bgp_evpn_mh_l2l3vni |    11 |    9 |    1 |     0 |    1 |  180.33
```

- `bgp_evpn_mh`: all 6 pass.
- `bgp_evpn_mh_l2l3vni`: the single failure
  (`test_evpn_sync_neigh_probe_fail_cleanup`) is a sync-neigh kernel
  install timeout unrelated to this change; `test_evpn_daemon_restart`
  is skipped by suite policy following that failure.