### PR TITLE
zebra: fix json output in "show ip route table all"

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -955,6 +955,9 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 		vty_json_close(vty, first_json);
 }
 
+/*
+ * Show all route tables in 'zvrf'
+ */
 static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t afi, safi_t safi,
 				 bool use_fib, bool use_json, route_tag_t tag,
 				 const struct prefix *longer_prefix_p, bool supernets_only,
@@ -964,6 +967,8 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t 
 {
 	struct zebra_router_table *zrt;
 	struct rib_table_info *info;
+	bool first_table = true;
+	char idbuf[20];
 
 	RB_FOREACH (zrt, zebra_router_table_head,
 		    &zrouter.tables) {
@@ -974,11 +979,19 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t 
 		if (zrt->afi != afi || zrt->safi != safi)
 			continue;
 
+		if (use_json) {
+			snprintf(idbuf, sizeof(idbuf), "%u", info->table_id);
+			vty_json_key(vty, idbuf, &first_table);
+		}
+
 		do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, use_fib, use_json, tag,
 				 longer_prefix_p, supernets_only, type, ospf_instance_id,
 				 zrt->tableid, show_ng, show_nhg_summary, ecmp_gt, ecmp_lt,
 				 ecmp_eq, ecmp_count, failed_only, ctx);
 	}
+
+	if (use_json)
+		vty_json_close(vty, first_table);
 }
 
 static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,


### PR DESCRIPTION
The json produced in the all-tables path wasn't valid: it was just a series of objects without a container or a separator. Output each table as a dict keyed by table-id, containing a dict of prefixes.

New output:
```
mjs-ubu-24-arm# sho ip route table all json 
{"254":{"0.0.0.0/0":[{"protocol":"kernel","distance":0,"metric":1002,"installed":true,"nexthopGroupId":22,"vrfId":0,"vrfName":"default","uptime":"00:00:19","prefix":"0.0.0.0/0","prefixLen":0,"table":254,"internalStatus":16,"internalFlags":0,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"receivedNexthopGroupId":22,"nexthops":[{"flags":3,"fib":true,"ip":"10.211.55.1","afi":"ipv4","interfaceIndex":2,"interfaceName":"enp0s5","active":true,"source":"10.211.55.5","weight":1}]},{"protocol":"kernel","selected":true,"destSelected":true,"distance":0,"metric":100,"installed":true,"nexthopGroupId":23,"vrfId":0,"vrfName":"default","uptime":"00:00:19","prefix":"0.0.0.0/0","prefixLen":0,"table":254,"internalStatus":16,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"installedNexthopGroupId":23,"receivedNexthopGroupId":23,"nexthops":[{"flags":3,"fib":true,"ip":"10.211.55.1","afi":"ipv4","interfaceIndex":2,"interfaceName":"enp0s5","active":true,"source":"10.211.55.4","weight":1}]}]
,"2.2.2.0/24":[{"protocol":"connected","selected":true,"destSelected":true,"distance":0,"metric":0,"installed":true,"nexthopGroupId":14,"vrfId":0,"vrfName":"default","uptime":"00:00:19","prefix":"2.2.2.0/24","prefixLen":24,"table":254,"internalStatus":16,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"installedNexthopGroupId":14,"receivedNexthopGroupId":14,"nexthops":[{"flags":3,"fib":true,"directlyConnected":true,"interfaceIndex":3,"interfaceName":"ANNIE","active":true,"weight":1}]}]
,"2.2.2.1/32":[{"protocol":"local","selected":true,"destSelected":true,"distance":0,"metric":0,"installed":true,"nexthopGroupId":14,"vrfId":0,"vrfName":"default","uptime":"00:00:19","prefix":"2.2.2.1/32","prefixLen":32,"table":254,"internalStatus":16,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"installedNexthopGroupId":14,"receivedNexthopGroupId":14,"nexthops":[{"flags":3,"fib":true,"directlyConnected":true,"interfaceIndex":3,"interfaceName":"ANNIE","active":true,"weight":1}]}]
}
,"555":{"5.5.5.0/24":[{"protocol":"kernel","selected":true,"destSelected":true,"distance":0,"metric":0,"installed":true,"nexthopGroupId":21,"vrfId":0,"vrfName":"default","uptime":"00:00:19","prefix":"5.5.5.0/24","prefixLen":24,"table":555,"internalStatus":16,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"installedNexthopGroupId":21,"receivedNexthopGroupId":21,"nexthops":[{"flags":3,"fib":true,"ip":"4.4.4.44","afi":"ipv4","interfaceIndex":5,"interfaceName":"GRETA","active":true,"weight":1}]}]
}
}

```

Existing output:
```
{"0.0.0.0/0":[{"protocol":"kernel","distance":0,"metric":1002,"nexthopGroupId":22,"vrfId":0,"vrfName":"default","uptime":"00:00:20","prefix":"0.0.0.0/0","prefixLen":0,"table":254,"internalStatus":0,"internalFlags":0,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":0,"receivedNexthopGroupId":22,"nexthops":[{"flags":1,"ip":"10.211.55.1","afi":"ipv4","interfaceIndex":2,"interfaceName":"enp0s5","active":true,"source":"10.211.55.5","weight":1}]},{"protocol":"kernel","selected":true,"destSelected":true,"distance":0,"metric":100,"failed":true,"nexthopGroupId":23,"vrfId":0,"vrfName":"default","uptime":"00:00:20","prefix":"0.0.0.0/0","prefixLen":0,"table":254,"internalStatus":32,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":0,"receivedNexthopGroupId":23,"nexthops":[{"flags":1,"ip":"10.211.55.1","afi":"ipv4","interfaceIndex":2,"interfaceName":"enp0s5","active":true,"source":"10.211.55.4","weight":1}]}]
,"2.2.2.0/24":[{"protocol":"connected","selected":true,"destSelected":true,"distance":0,"metric":0,"failed":true,"nexthopGroupId":14,"vrfId":0,"vrfName":"default","uptime":"00:00:20","prefix":"2.2.2.0/24","prefixLen":24,"table":254,"internalStatus":32,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"receivedNexthopGroupId":14,"nexthops":[{"flags":3,"fib":true,"directlyConnected":true,"interfaceIndex":3,"interfaceName":"ANNIE","active":true,"weight":1}]}]
,"2.2.2.1/32":[{"protocol":"local","selected":true,"destSelected":true,"distance":0,"metric":0,"failed":true,"nexthopGroupId":14,"vrfId":0,"vrfName":"default","uptime":"00:00:20","prefix":"2.2.2.1/32","prefixLen":32,"table":254,"internalStatus":32,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":1,"receivedNexthopGroupId":14,"nexthops":[{"flags":3,"fib":true,"directlyConnected":true,"interfaceIndex":3,"interfaceName":"ANNIE","active":true,"weight":1}]}]
}
{"5.5.5.0/24":[{"protocol":"kernel","selected":true,"destSelected":true,"distance":0,"metric":0,"failed":true,"nexthopGroupId":21,"vrfId":0,"vrfName":"default","uptime":"00:00:20","prefix":"5.5.5.0/24","prefixLen":24,"table":555,"internalStatus":32,"internalFlags":8,"internalNextHopNum":1,"internalNextHopActiveNum":1,"internalNextHopFibInstalledNum":0,"receivedNexthopGroupId":21,"nexthops":[{"flags":1,"ip":"4.4.4.44","afi":"ipv4","interfaceIndex":5,"interfaceName":"GRETA","active":true,"weight":1}]}]
}
mjs-ubu-24-arm# 

```