### PR TITLE
pimd: fix MSDP mesh-group/peer create crash on config reload

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1409,6 +1409,7 @@ int pim_msdp_shutdown_modify(struct nb_cb_modify_args *args)
  */
 int pim_msdp_mesh_group_create(struct nb_cb_create_args *args)
 {
+	const struct lyd_node *vrf_dnode;
 	struct pim_msdp_mg *mg;
 	struct vrf *vrf;
 
@@ -1418,7 +1419,15 @@ int pim_msdp_mesh_group_create(struct nb_cb_create_args *args)
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		/*
+		 * This callback stores its own mesh-group pointer on
+		 * args->dnode. On a reload re-apply a recursive lookup would
+		 * return that stored pointer instead of climbing to the VRF,
+		 * so fetch the VRF from the control-plane-protocol ancestor
+		 * with a non-recursive lookup.
+		 */
+		vrf_dnode = yang_dnode_get_parent(args->dnode, "control-plane-protocol");
+		vrf = nb_running_get_entry_non_rec(vrf_dnode, NULL, true);
 		mg = pim_msdp_mg_new(vrf->info, yang_dnode_get_string(
 							args->dnode, "./name"));
 		nb_running_set_entry(args->dnode, mg);
@@ -1584,6 +1593,7 @@ int pim_msdp_peer_authentication_key_destroy(struct nb_cb_destroy_args *args)
  */
 int pim_msdp_mesh_group_members_create(struct nb_cb_create_args *args)
 {
+	const struct lyd_node *mg_dnode;
 	const struct lyd_node *vrf_dnode;
 	struct pim_msdp_mg_mbr *mbr;
 	struct pim_msdp_mg *mg;
@@ -1596,7 +1606,15 @@ int pim_msdp_mesh_group_members_create(struct nb_cb_create_args *args)
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		mg = nb_running_get_entry(args->dnode, NULL, true);
+		/*
+		 * This callback stores its own member pointer on args->dnode.
+		 * On a reload re-apply a recursive lookup would return that
+		 * stored pointer instead of the mesh-group, so fetch the
+		 * mesh-group from the msdp-mesh-groups ancestor with a
+		 * non-recursive lookup.
+		 */
+		mg_dnode = yang_dnode_get_parent(args->dnode, "msdp-mesh-groups");
+		mg = nb_running_get_entry_non_rec(mg_dnode, NULL, true);
 		vrf_dnode =
 			yang_dnode_get_parent(args->dnode, "address-family");
 		vrf = nb_running_get_entry(vrf_dnode, "../../", true);
@@ -1640,6 +1658,7 @@ int pim_msdp_mesh_group_members_destroy(struct nb_cb_destroy_args *args)
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_create(
 	struct nb_cb_create_args *args)
 {
+	const struct lyd_node *vrf_dnode;
 	struct pim_msdp_peer *mp;
 	struct pim_instance *pim;
 	struct vrf *vrf;
@@ -1652,7 +1671,15 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ms
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		/*
+		 * This callback stores its own peer pointer on args->dnode.
+		 * On a reload re-apply a recursive lookup would return that
+		 * stored pointer instead of climbing to the VRF, so fetch the
+		 * VRF from the control-plane-protocol ancestor with a
+		 * non-recursive lookup.
+		 */
+		vrf_dnode = yang_dnode_get_parent(args->dnode, "control-plane-protocol");
+		vrf = nb_running_get_entry_non_rec(vrf_dnode, NULL, true);
 		pim = vrf->info;
 		yang_dnode_get_ip(&peer_ip, args->dnode, "peer-ip");
 		yang_dnode_get_ip(&source_ip, args->dnode, "source-ip");


### PR DESCRIPTION
The MSDP mesh-group, mesh-group member and MSDP peer "create" northbound callbacks store their own runtime object on args->dnode via nb_running_set_entry(). They then look up the parent VRF (or mesh-group) with a recursive nb_running_get_entry(args->dnode, NULL, true).

On a configuration reload the create callback can be re-invoked on a node that already holds its own entry. The recursive lookup then returns the callback's own object (mesh-group / member / peer) instead of climbing up to the VRF or mesh-group, so the following vrf->info / mesh-group dereference operates on a type-confused pointer and crashes pimd with SIGSEGV.

Resolve the VRF / mesh-group from the correct ancestor node (control-plane-protocol / msdp-mesh-groups) using a non-recursive lookup so the callbacks always resolve the intended object.