### PR TITLE
bgpd: send proper ORF on inbound policy change

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6973,8 +6973,14 @@ void peer_on_policy_change(struct peer *peer, afi_t afi, safi_t safi,
 			return;
 
 		if (CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_RCV))
-			bgp_route_refresh_send(peer->connection, afi, safi, 0, 0, 0,
-					       BGP_ROUTE_REFRESH_NORMAL);
+			/*
+			 * Use the ORF-aware soft-clear so that if this peer
+			 * previously sent an ORF (PEER_STATUS_ORF_PREFIX_SEND)
+			 * and the inbound prefix-list has just been removed, a
+			 * REMOVE_ALL ORF is sent to the remote peer instead of
+			 * a plain route-refresh.
+			 */
+			peer_clear_soft(peer, afi, safi, BGP_CLEAR_SOFT_IN_ORF_PREFIX);
 	}
 }
 
@@ -9410,11 +9416,7 @@ int peer_clear_soft(struct peer *peer, afi_t afi, safi_t safi,
 		    CHECK_FLAG(peer->af_cap[afi][safi],
 			       PEER_CAP_ORF_PREFIX_RM_RCV)) {
 			struct bgp_filter *filter = &peer->filter[afi][safi];
-			uint8_t prefix_type;
-
-			if (CHECK_FLAG(peer->af_cap[afi][safi],
-				       PEER_CAP_ORF_PREFIX_RM_RCV))
-				prefix_type = ORF_TYPE_PREFIX;
+			uint8_t prefix_type = ORF_TYPE_PREFIX;
 
 			if (filter->plist[FILTER_IN].plist) {
 				if (CHECK_FLAG(peer->af_sflags[afi][safi],

--- a/tests/topotests/bgp_orf/test_bgp_orf.py
+++ b/tests/topotests/bgp_orf/test_bgp_orf.py
@@ -189,6 +189,130 @@ def test_bgp_orf():
     assert result is None, "Can't display reverted ORF prefix-list on R1"
 
 
+def test_bgp_orf_remove_neighbor_plist():
+    """
+    Remove r2's 'neighbor ... prefix-list ... in' configuration.
+    This should trigger a REMOVE_ALL ORF to r1, clearing the filter
+    so r1 advertises all routes to r2.
+
+    This tests the fix where peer_on_policy_change() now uses
+    peer_clear_soft(BGP_CLEAR_SOFT_IN_ORF_PREFIX) to properly send
+    ORF messages when the inbound prefix-list is removed.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Remove the inbound prefix-list config from r2.
+    r2.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 65002
+          address-family ipv4 unicast
+           no neighbor 192.168.1.1 prefix-list r1 in
+          exit-address-family
+        """
+    )
+
+    # r1 should now advertise both prefixes to r2 (ORF filter cleared).
+    def _r1_advertised_all():
+        output = json.loads(
+            r1.vtysh_cmd(
+                "show bgp ipv4 unicast neighbor 192.168.1.2 advertised-routes json"
+            )
+        )
+        expected = {"advertisedRoutes": {"10.10.10.1/32": {}, "10.10.10.2/32": {}}}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_r1_advertised_all)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), "r1 did not clear ORF filter after neighbor prefix-list removal"
+
+    # r2 should receive both prefixes.
+    def _r2_receives_all():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast json"))
+        expected = {
+            "routes": {
+                "10.10.10.1/32": [{"valid": True}],
+                "10.10.10.2/32": [{"valid": True}],
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_r2_receives_all)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "r2 did not receive all prefixes after ORF removal"
+
+
+def test_bgp_orf_reattach_neighbor_plist():
+    """
+    Re-attach r2's 'neighbor ... prefix-list ... in' configuration after
+    it was removed in test_bgp_orf_remove_neighbor_plist.
+
+    This should trigger an ORF ADD to r1, re-installing the filter so
+    r1 filters outbound routes to r2 again.
+
+    This tests the fix where peer_on_policy_change() now uses
+    peer_clear_soft(BGP_CLEAR_SOFT_IN_ORF_PREFIX) to properly send
+    ORF messages when the inbound prefix-list is re-added.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Re-attach the inbound prefix-list config on r2.
+    r2.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 65002
+          address-family ipv4 unicast
+           neighbor 192.168.1.1 prefix-list r1 in
+          exit-address-family
+        """
+    )
+
+    # r1 should now advertise only 10.10.10.1/32 to r2 (ORF filter re-installed).
+    def _r1_advertised_filtered():
+        output = json.loads(
+            r1.vtysh_cmd(
+                "show bgp ipv4 unicast neighbor 192.168.1.2 advertised-routes json"
+            )
+        )
+        expected = {"advertisedRoutes": {"10.10.10.1/32": {}, "10.10.10.2/32": None}}
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_r1_advertised_filtered)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), "r1 did not re-install ORF filter after neighbor prefix-list re-attach"
+
+    # r2 should receive only 10.10.10.1/32.
+    def _r2_receives_filtered():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast json"))
+        expected = {
+            "routes": {
+                "10.10.10.1/32": [{"valid": True}],
+                "10.10.10.2/32": None,
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_r2_receives_filtered)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "r2 did not receive filtered routes after ORF re-attach"
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
When a neighbor's inbound ORF prefix-list is removed or re-attached
on an established session ("no neighbor X prefix-list Y in" or
"neighbor X prefix-list Y in"), peer_on_policy_change() sends only
a plain route-refresh instead of the appropriate ORF message.  This
leaves the remote peer's outbound ORF filter stale: removal should
send REMOVE_ALL ORF so the remote clears its filter, and re-attach
should send ORF ADD so the remote installs the new filter.

Fix by using peer_clear_soft() with BGP_CLEAR_SOFT_IN_ORF_PREFIX,
which checks PEER_STATUS_ORF_PREFIX_SEND and sends the correct ORF
message when ORF is negotiated, or falls back to a normal route
refresh otherwise.  The session-establishment path already sends ORF
correctly; this fix addresses the dynamic configuration change path.