### PR TITLE
bgpd: fix ORF update-group isolation logic

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -300,7 +300,7 @@ static void *updgrp_hash_alloc(void *p)
  *       4. (AF-independent) Capability flags:
  *             AS4_RCV capability
  *       5. (AF-dependent) Capability flags:
- *             ORF_PREFIX_SM_RCV (peer can send prefix ORF)
+ *             ADDPATH, ENHE
  *       6. MRAI
  *       7. peer-group name
  *       8. Outbound route-map name (neighbor route-map <> out)
@@ -314,7 +314,9 @@ static void *updgrp_hash_alloc(void *p)
  *       16. Local-as should match, if configured.
  *       17. maximum-prefix-out
  *       18. Local-role should also match, if configured.
- *       19. Add-Path best selected paths count should match as well
+ *       19. ORF: peers with ORF_PREFIX_RM_ADV and ORF_PREFIX_SM_RCV are
+ *             each isolated into their own update-group (identified by
+ *             peer address).
  *      )
  */
 static unsigned int updgrp_hash_key_make(const void *p)
@@ -360,6 +362,11 @@ static unsigned int updgrp_hash_key_make(const void *p)
 	key = jhash_1word((peer->cap & PEER_UPDGRP_CAP_FLAGS), key);
 	key = jhash_1word((peer->af_cap[afi][safi] & PEER_UPDGRP_AF_CAP_FLAGS),
 			  key);
+	/* A peer sending ORF to us must get its own update-group. */
+	if (CHECK_FLAG(peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_ADV)
+	    && CHECK_FLAG(peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV))
+		key = jhash_1word(jhash(peer->host, strlen(peer->host), SEED2),
+				  key);
 	key = jhash_1word(peer->v_routeadv, key);
 	key = jhash_1word(peer->change_local_as, key);
 	key = jhash_1word(peer->max_packet_size, key);
@@ -431,11 +438,9 @@ static unsigned int updgrp_hash_key_make(const void *p)
 	/*
 	 * There are certain peers that must get their own update-group:
 	 * - lonesoul peers
-	 * - peers that negotiated ORF
 	 * - maximum-prefix-out is set
 	 */
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_LONESOUL)
-	    || CHECK_FLAG(peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)
 	    || CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_MAX_PREFIX_OUT))
 		key = jhash_1word(jhash(peer->host, strlen(peer->host), SEED2),
 				  key);
@@ -618,6 +623,14 @@ static bool updgrp_hash_cmp(const void *p1, const void *p2)
 	    != (pe2->af_cap[afi][safi] & PEER_UPDGRP_AF_CAP_FLAGS))
 		return false;
 
+	/* A peer sending ORF to us cannot share an update-group. */
+	if (((CHECK_FLAG(pe1->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_ADV)
+	      && CHECK_FLAG(pe1->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV))
+	     || (CHECK_FLAG(pe2->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_ADV)
+		 && CHECK_FLAG(pe2->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)))
+	    && !sockunion_same(&pe1->connection->su, &pe2->connection->su))
+		return false;
+
 	if (pe1->v_routeadv != pe2->v_routeadv)
 		return false;
 
@@ -684,9 +697,8 @@ static bool updgrp_hash_cmp(const void *p1, const void *p2)
 	if ((afi == AFI_IP6) && (pe1->shared_network != pe2->shared_network))
 		return false;
 
-	if ((CHECK_FLAG(pe1->flags, PEER_FLAG_LONESOUL) ||
-	     CHECK_FLAG(pe1->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)) &&
-	    !sockunion_same(&pe1->connection->su, &pe2->connection->su))
+	if (CHECK_FLAG(pe1->flags, PEER_FLAG_LONESOUL)
+	    && !sockunion_same(&pe1->connection->su, &pe2->connection->su))
 		return false;
 
 	if (afi == AFI_IP6 &&

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -62,8 +62,8 @@
 #define PEER_UPDGRP_CAP_FLAGS (PEER_CAP_AS4_RCV | PEER_CAP_LLGR_RCV)
 
 #define PEER_UPDGRP_AF_CAP_FLAGS                                               \
-	(PEER_CAP_ORF_PREFIX_SM_RCV | PEER_CAP_ADDPATH_AF_TX_ADV |             \
-	 PEER_CAP_ADDPATH_AF_RX_RCV | PEER_CAP_ENHE_AF_NEGO)
+	(PEER_CAP_ADDPATH_AF_TX_ADV | PEER_CAP_ADDPATH_AF_RX_RCV               \
+	 | PEER_CAP_ENHE_AF_NEGO)
 
 enum bpacket_attr_vec_type { BGP_ATTR_VEC_NH = 0, BGP_ATTR_VEC_MAX };
 

--- a/tests/topotests/bgp_orf_updgrp_isolation/r1/frr.conf
+++ b/tests/topotests/bgp_orf_updgrp_isolation/r1/frr.conf
@@ -1,0 +1,34 @@
+!
+hostname r1
+!
+interface lo
+ ip address 10.0.0.1/32
+!
+interface r1-eth0
+ ip address 192.168.12.1/24
+!
+interface r1-eth1
+ ip address 192.168.13.1/24
+!
+interface r1-eth2
+ ip address 192.168.14.1/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.12.2 remote-as 65002
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ neighbor 192.168.13.2 remote-as 65002
+ neighbor 192.168.13.2 timers 1 3
+ neighbor 192.168.13.2 timers connect 1
+ neighbor 192.168.14.2 remote-as 65002
+ neighbor 192.168.14.2 timers 1 3
+ neighbor 192.168.14.2 timers connect 1
+ !
+ address-family ipv4 unicast
+  network 10.0.0.1/32
+  ! NOTE: NO "capability orf prefix-list receive" for any neighbor.
+  ! Even though r2 advertises ORF send capability, ORF is NOT negotiated.
+ exit-address-family
+!

--- a/tests/topotests/bgp_orf_updgrp_isolation/r2/frr.conf
+++ b/tests/topotests/bgp_orf_updgrp_isolation/r2/frr.conf
@@ -1,0 +1,18 @@
+!
+hostname r2
+!
+interface r2-eth0
+ ip address 192.168.12.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 192.168.12.1 remote-as 65001
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ !
+ address-family ipv4 unicast
+  ! Advertise ORF send capability, but r1 does NOT have receive capability
+  ! So ORF is NOT negotiated. On r1: SM_RCV is set, RM_ADV is NOT.
+  neighbor 192.168.12.1 capability orf prefix-list send
+ exit-address-family
+!

--- a/tests/topotests/bgp_orf_updgrp_isolation/r3/frr.conf
+++ b/tests/topotests/bgp_orf_updgrp_isolation/r3/frr.conf
@@ -1,0 +1,16 @@
+!
+hostname r3
+!
+interface r3-eth0
+ ip address 192.168.13.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 192.168.13.1 remote-as 65001
+ neighbor 192.168.13.1 timers 1 3
+ neighbor 192.168.13.1 timers connect 1
+ !
+ address-family ipv4 unicast
+  ! No ORF capability - plain BGP peer
+ exit-address-family
+!

--- a/tests/topotests/bgp_orf_updgrp_isolation/r4/frr.conf
+++ b/tests/topotests/bgp_orf_updgrp_isolation/r4/frr.conf
@@ -1,0 +1,16 @@
+!
+hostname r4
+!
+interface r4-eth0
+ ip address 192.168.14.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 192.168.14.1 remote-as 65001
+ neighbor 192.168.14.1 timers 1 3
+ neighbor 192.168.14.1 timers connect 1
+ !
+ address-family ipv4 unicast
+  ! No ORF capability - plain BGP peer
+ exit-address-family
+!

--- a/tests/topotests/bgp_orf_updgrp_isolation/test_bgp_orf_updgrp_isolation.py
+++ b/tests/topotests/bgp_orf_updgrp_isolation/test_bgp_orf_updgrp_isolation.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_orf_updgrp_isolation_bug.py
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test BGP ORF update-group isolation bug.
+
+Verify that peers are NOT incorrectly isolated when ORF is not fully
+negotiated.  With the old (buggy) code, a peer with only SM_RCV
+(remote advertised ORF send capability) but no RM_ADV (we did not
+advertise ORF receive capability) would be incorrectly isolated into
+its own update-group.
+
+Topology:
+
+    r2 (AS 65002) -- r1 (AS 65001) -- r3 (AS 65002)
+                           |
+                          r4 (AS 65002)
+
+r1 advertises 10.0.0.1/32.
+
+All three peers (r2, r3, r4) are in the same AS 65002:
+  - r2: "capability orf prefix-list send" - r1 has NO receive capability
+        for r2, so ORF is NOT negotiated.  SM_RCV is set, RM_ADV is NOT.
+  - r3: No ORF capability at all - plain BGP peer.
+  - r4: No ORF capability at all - plain BGP peer.
+
+Expected behavior (with fix):
+  - r2, r3, r4 should all share the same update-group because ORF is NOT
+    negotiated for any of them.
+
+Buggy behavior (without fix):
+  - r2 would be incorrectly isolated into its own update-group because
+    the old code only checked SM_RCV.
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+
+    # r1 -- r2
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # r1 -- r3
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    # r1 -- r4
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def get_update_group(router, peer_ip, afi="ipv4 unicast"):
+    """
+    Return the update-group ID that contains peer_ip, or None if not found.
+    """
+    output = router.vtysh_cmd("show bgp {} update-group".format(afi))
+    current_group = None
+    for line in output.splitlines():
+        m = re.match(r"\s*Update-group (\d+):", line)
+        if m:
+            current_group = int(m.group(1))
+        if peer_ip in line:
+            return current_group
+    return None
+
+
+def test_bgp_orf_updgrp_isolation_bug():
+    """
+    Verify that r2, r3, r4 all share the same update-group.
+
+    r2 has "capability orf prefix-list send" but r1 did NOT configure
+    "capability orf prefix-list receive" for r2, so ORF is NOT negotiated.
+    SM_RCV is set on r1 (r2 advertised ORF send), but RM_ADV is NOT set
+    (r1 did not advertise ORF receive).
+
+    With the old buggy code, r2 would be isolated because the code only
+    checked SM_RCV.  With the fix, r2 is NOT isolated because both
+    RM_ADV and SM_RCV must be set for ORF isolation to apply.
+
+    Since all three peers are in the same AS with identical config
+    (same flags, same policies), they should share an update-group.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Wait for all sessions to reach Established.
+    def _bgp_sessions_established():
+        output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast summary json"))
+        expected = {
+            "peers": {
+                "192.168.12.2": {"state": "Established"},
+                "192.168.13.2": {"state": "Established"},
+                "192.168.14.2": {"state": "Established"},
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    _, result = topotest.run_and_expect(
+        _bgp_sessions_established, None, count=60, wait=0.5
+    )
+    assert result is None, "BGP sessions did not reach Established"
+
+    # Verify all three peers share the same update-group.
+    def _check_same_update_group():
+        grp_r2 = get_update_group(r1, "192.168.12.2")
+        grp_r3 = get_update_group(r1, "192.168.13.2")
+        grp_r4 = get_update_group(r1, "192.168.14.2")
+        if grp_r2 is None:
+            return "could not find update-group for r2"
+        if grp_r3 is None:
+            return "could not find update-group for r3"
+        if grp_r4 is None:
+            return "could not find update-group for r4"
+        if grp_r2 != grp_r3:
+            return (
+                "BUG: r2 (ORF not negotiated) is in different update-group "
+                "than r3.  r2 group={}, r3 group={}.  "
+                "This means r2 was incorrectly isolated due to SM_RCV alone.".format(
+                    grp_r2, grp_r3
+                )
+            )
+        if grp_r2 != grp_r4:
+            return (
+                "BUG: r2 is in different update-group than r4.  "
+                "r2 group={}, r4 group={}.".format(grp_r2, grp_r4)
+            )
+        return None
+
+    _, result = topotest.run_and_expect(
+        _check_same_update_group, None, count=60, wait=0.5
+    )
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
ORF prefix-list filtering is applied to outbound updates only when
both conditions are met: we advertised willingness to receive ORF
(PEER_CAP_ORF_PREFIX_RM_ADV), and the peer advertised intent to send
ORF (PEER_CAP_ORF_PREFIX_SM_RCV).  This matches the check in
subgroup_announce_check() at bgp_route.c:2656-2657.

However, the update-group hash and comparison functions checked only
SM_RCV, causing peers to be isolated into separate update-groups even
when RM_ADV was not set.  In that case, ORF is not actually negotiated
and no filtering occurs, so isolation is unnecessary and wastes memory
and CPU.

Fix by requiring both RM_ADV and SM_RCV before isolating a peer for
ORF, aligning the update-group logic with the actual filtering logic.
Also remove SM_RCV from PEER_UPDGRP_AF_CAP_FLAGS since the dedicated
check is now the single source of truth for ORF isolation.