### PR TITLE
pimd: Fix dense LAN prune/override and FHR Assert skip

### DIFF
--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -371,6 +371,97 @@ bool pim_gm_has_igmp_join(struct interface *ifp, pim_addr group_addr)
 	return false;
 }
 
+/*
+ * Dense flood installs (S,G) OIFs with oil_if_set() (no PROTO_GM).  IGMP/MLD
+ * leave only removes PROTO_GM from the (*,G)/(S,G) channel_oil that GM tracks,
+ * so those DM-native OIFs would otherwise stick forever and block upstream
+ * prune.  Clear the leave interface from matching dense (S,G) oils and prune
+ * toward RPF when nothing downstream remains.
+ *
+ * While tib_sg_gm_prune runs, the leaving group is still on gm_group_list, so
+ * pim_upstream_up_connected() would still see local membership on oif.  Skip
+ * IGMP/MLD on the leave interface when deciding whether to prune.
+ */
+void pim_dm_gm_oif_del(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
+{
+	struct channel_oil *c_oil;
+	struct pim_interface *pim_oif = oif->info;
+
+	if (!pim_oif || !pim_iface_grp_dm(pim_oif, sg.grp))
+		return;
+
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
+		struct pim_upstream *up = c_oil->up;
+		struct interface *ifp;
+		struct interface *rpf_ifp;
+		struct pim_interface *pim_rpf;
+		struct pim_ifchannel *ch, *throwaway;
+		bool connected = false;
+
+		if (pim_addr_cmp(sg.grp, *oil_mcastgrp(c_oil)))
+			continue;
+		/* Dense forwarding state is on (S,G); skip (*,G) oils. */
+		if (pim_addr_is_any(*oil_origin(c_oil)))
+			continue;
+		if (!pim_addr_is_any(sg.src) && pim_addr_cmp(sg.src, *oil_origin(c_oil)))
+			continue;
+		if (!up || !up->channel_oil)
+			continue;
+		if (!oil_if_has(c_oil, pim_oif->mroute_vif_index))
+			continue;
+
+		oil_if_set(c_oil, pim_oif->mroute_vif_index, 0);
+		pim_upstream_mroute_update(c_oil, __func__);
+
+		FOR_ALL_INTERFACES (up->pim->vrf, ifp) {
+			struct pim_interface *pim_ifp = ifp->info;
+
+			if (!pim_ifp || !pim_ifp->pim_enable)
+				continue;
+
+			if (HAVE_DENSE_MODE(pim_ifp->pim_mode) &&
+			    up->rpf.source_nexthop.interface &&
+			    ifp->ifindex != up->rpf.source_nexthop.interface->ifindex &&
+			    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+				connected = true;
+				break;
+			}
+			/* Leave interface still has the group on gm_group_list. */
+			if (ifp != oif && pim_gm_has_igmp_join(ifp, up->sg.grp)) {
+				connected = true;
+				break;
+			}
+		}
+
+		if (connected)
+			continue;
+
+		rpf_ifp = up->rpf.source_nexthop.interface;
+		if (!rpf_ifp || !rpf_ifp->info)
+			continue;
+
+		pim_rpf = rpf_ifp->info;
+		if (!HAVE_DENSE_MODE(pim_rpf->pim_mode))
+			continue;
+
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG leave on %s, pruning upstream on %s", __func__,
+				   &up->sg, oif->name, rpf_ifp->name);
+
+		event_cancel(&up->t_graft_timer);
+		event_cancel(&up->t_join_timer);
+		PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
+		if (up->join_state == PIM_UPSTREAM_JOINED)
+			pim_upstream_switch(up->pim, up, PIM_UPSTREAM_NOTJOINED);
+		/* Cancel any pending Join-override on the RPF LAN. */
+		pim_ifchannel_find(rpf_ifp, &up->sg, &ch, &throwaway);
+		if (ch)
+			event_cancel(&ch->t_ifjoin_prune_pending_timer);
+		pim_dm_prune_send(up->rpf, up, 0);
+		prune_timer_start(up);
+	}
+}
+
 void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 {
 	struct pim_upstream *up;
@@ -415,18 +506,159 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 }
 
 
+/*
+ * Apply a received dense prune on a forwarding OIF: clear the OIL, optionally
+ * prune further upstream, and arm the prune-holdtime re-flood timer.
+ */
+static void pim_dm_apply_oif_prune(struct interface *ifp, struct pim_upstream *up,
+				   uint16_t holdtime, uint8_t source_flags)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_ifchannel *ch, *throwaway;
+	struct interface *ifp2;
+	struct pim_interface *pim_ifp2;
+	struct vrf *vrf;
+	bool sg_connected = false;
+
+	if (!oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index))
+		return;
+
+	oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+	pim_upstream_mroute_update(up->channel_oil, __func__);
+
+	vrf = up->pim->vrf;
+	FOR_ALL_INTERFACES (vrf, ifp2) {
+		pim_ifp2 = ifp2->info;
+
+		if (!pim_ifp2)
+			continue;
+		if (HAVE_DENSE_MODE(pim_ifp2->pim_mode) && ifp2->ifindex != ifp->ifindex &&
+		    oil_if_has(up->channel_oil, pim_ifp2->mroute_vif_index)) {
+			sg_connected = true;
+			break;
+		}
+		if (pim_gm_has_igmp_join(ifp2, up->sg.grp)) {
+			sg_connected = true;
+			break;
+		}
+	}
+
+	if (!sg_connected) {
+		event_cancel(&up->t_graft_timer);
+		event_cancel(&up->t_join_timer);
+		PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
+		if (up->join_state == PIM_UPSTREAM_JOINED)
+			pim_upstream_switch(up->pim, up, PIM_UPSTREAM_NOTJOINED);
+		pim_dm_prune_send(up->rpf, up, 0);
+		prune_timer_start(up);
+	}
+
+	pim_ifchannel_find(ifp, &up->sg, &ch, &throwaway);
+	if (!ch)
+		ch = pim_ifchannel_add(ifp, &up->sg, source_flags, PIM_UPSTREAM_DM_FLAG_MASK_PRUNE);
+	PIM_UPSTREAM_DM_SET_PRUNE(ch->flags);
+	ch->prune_holdtime = holdtime;
+	event_cancel(&ch->t_ifjoin_expiry_timer);
+	event_add_timer(router->master, pim_dm_prune_iff_on_timer, ch, holdtime,
+			&ch->t_ifjoin_expiry_timer);
+}
+
+void pim_dm_prune_pending_on_timer(struct event *t)
+{
+	struct pim_ifchannel *ch = EVENT_ARG(t);
+	struct interface *ifp = ch->interface;
+	struct pim_upstream *up = ch->upstream;
+	uint16_t holdtime = ch->prune_holdtime;
+
+	if (PIM_DEBUG_PIM_J_P)
+		zlog_debug("%s: (S,G)=%s LAN prune-pending expired on %s, applying prune",
+			   __func__, ch->sg_str, ifp->name);
+
+	if (!up)
+		return;
+
+	pim_dm_apply_oif_prune(ifp, up, holdtime, 0);
+}
+
+void pim_dm_join_override_on_timer(struct event *t)
+{
+	struct pim_ifchannel *ch = EVENT_ARG(t);
+	struct pim_upstream *up = ch->upstream;
+	struct interface *ifp = ch->interface;
+
+	if (!up)
+		return;
+
+	if (PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) || !pim_upstream_up_connected(up))
+		return;
+
+	if (PIM_DEBUG_PIM_J_P)
+		zlog_debug("%s: (S,G)=%s sending LAN Join override on %s", __func__, ch->sg_str,
+			   ifp->name);
+
+	pim_dm_prune_send(up->rpf, up, true);
+}
+
+/*
+ * Dense Join on a multi-access LAN: cancel a pending OIF prune (override),
+ * cancel a pending Join override (suppression), or re-add an already-pruned
+ * OIF like a Graft directed at this forwarder.
+ */
+void pim_dm_recv_join(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
+		      pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_upstream *up;
+	struct pim_ifchannel *ch, *throwaway;
+	bool directed_to_us;
+
+	if (!pim_ifp || !pim_ifp->pim_enable)
+		return;
+
+	if (!HAVE_DENSE_MODE(pim_ifp->pim_mode) || !pim_iface_grp_dm(pim_ifp, sg->grp))
+		return;
+
+	up = pim_upstream_find(pim_ifp->pim, sg);
+	if (!up)
+		return;
+
+	directed_to_us = !pim_addr_cmp(upstream, pim_ifp->primary_address);
+
+	pim_ifchannel_find(ifp, sg, &ch, &throwaway);
+
+	if (!directed_to_us) {
+		/* Join suppression: another router already overrode the prune. */
+		if (ch && event_is_scheduled(ch->t_ifjoin_prune_pending_timer) &&
+		    up->rpf.source_nexthop.interface == ifp) {
+			if (PIM_DEBUG_PIM_J_P)
+				zlog_debug("%s: (S,G)=%pSG suppressing Join override on %s",
+					   __func__, sg, ifp->name);
+			event_cancel(&ch->t_ifjoin_prune_pending_timer);
+		}
+		return;
+	}
+
+	/* Directed to us (LAN forwarder). */
+	if (ch && event_is_scheduled(ch->t_ifjoin_prune_pending_timer)) {
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG Join override cancels prune-pending on %s",
+				   __func__, sg, ifp->name);
+		event_cancel(&ch->t_ifjoin_prune_pending_timer);
+	}
+
+	/*
+	 * After the OIF is pruned, restoration is via Graft (pim_dm_recv_graft),
+	 * not Join. Join only cancels prune-pending during the override window.
+	 */
+}
+
 void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
 		       pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags)
 {
 	struct pim_upstream *up;
 	struct pim_interface *pim_ifp;
-	pim_addr group_addr = sg->grp;
 	struct pim_ifchannel *ch, *throwaway;
-
-	struct interface *ifp2 = NULL;
-	struct pim_interface *pim_ifp2;
-	bool sg_connected;
-	struct vrf *vrf;
+	int jp_override_interval_msec;
 
 	pim_ifp = ifp->info;
 	if (!pim_ifp || !pim_ifp->pim_enable)
@@ -435,52 +667,73 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 	if (!HAVE_DENSE_MODE(pim_ifp->pim_mode))
 		return;
 
-	up = pim_upstream_find(pim_ifp->pim, sg);
+	if (!pim_iface_grp_dm(pim_ifp, sg->grp))
+		return;
 
+	up = pim_upstream_find(pim_ifp->pim, sg);
 	if (!up)
 		return;
 
-	sg_connected = false;
-	vrf = up->pim->vrf;
+	/*
+	 * Prune not directed to us: if this is our RPF interface and we still
+	 * have downstream interest, schedule a Join override (RFC 3973).
+	 */
+	if (pim_addr_cmp(upstream, pim_ifp->primary_address)) {
+		/*
+		 * Overheard prune on our RPF LAN: Join-override only while we
+		 * still want the stream.  Already-pruned upstreams must not
+		 * keep canceling the forwarder's prune-pending.
+		 */
+		if (up->rpf.source_nexthop.interface == ifp &&
+		    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) && pim_upstream_up_connected(up)) {
+			pim_ifchannel_find(ifp, sg, &ch, &throwaway);
+			if (!ch)
+				ch = pim_ifchannel_add(ifp, sg, source_flags, 0);
+			if (!event_is_scheduled(ch->t_ifjoin_prune_pending_timer)) {
+				int t_override_msec = pim_if_t_override_msec(ifp);
 
-	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
-	    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
-		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
-		pim_upstream_mroute_update(up->channel_oil, __func__);
-
-		/* dm: we need to forward the prune upstream if needed */
-		FOR_ALL_INTERFACES (vrf, ifp2) {
-			pim_ifp2 = ifp2->info;
-
-			if (!pim_ifp2)
-				continue;
-			if (HAVE_DENSE_MODE(pim_ifp2->pim_mode) && ifp2->ifindex != ifp->ifindex &&
-			    oil_if_has(up->channel_oil, pim_ifp2->mroute_vif_index)) {
-				sg_connected = true;
-				break;
-			}
-			if (pim_gm_has_igmp_join(ifp2, sg->grp)) {
-				sg_connected = true;
-				break;
+				if (PIM_DEBUG_PIM_J_P)
+					zlog_debug("%s: (S,G)=%pSG scheduling Join override in %d msec on %s",
+						   __func__, sg, t_override_msec, ifp->name);
+				event_add_timer_msec(router->master, pim_dm_join_override_on_timer,
+						     ch, t_override_msec,
+						     &ch->t_ifjoin_prune_pending_timer);
 			}
 		}
+		return;
+	}
 
-		if (!sg_connected) {
-			PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
-			pim_dm_prune_send(up->rpf, up, 0);
-			prune_timer_start(up);
-		}
+	/* Directed to us: we forward onto this interface. */
+	if (!up->channel_oil || !oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index))
+		return;
+
+	/*
+	 * Multi-access LAN with other neighbors: delay OIF removal so a sibling
+	 * with receivers can Join-override (RFC 3973). P2P or sole neighbor:
+	 * prune immediately.
+	 */
+	if (!if_is_pointopoint(ifp) && listcount(pim_ifp->pim_neighbor_list) > 1) {
+		jp_override_interval_msec = pim_if_jp_override_interval_msec(ifp);
 
 		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
 		if (!ch)
-			ch = pim_ifchannel_add(ifp, sg, source_flags,
-					       PIM_UPSTREAM_DM_FLAG_MASK_PRUNE);
-		PIM_UPSTREAM_DM_SET_PRUNE(ch->flags);
+			ch = pim_ifchannel_add(ifp, sg, source_flags, 0);
 		ch->prune_holdtime = holdtime;
-		event_cancel(&ch->t_ifjoin_expiry_timer);
-		event_add_timer(router->master, pim_dm_prune_iff_on_timer, ch, holdtime,
-				&ch->t_ifjoin_expiry_timer);
+		ch->upstream = up;
+
+		if (event_is_scheduled(ch->t_ifjoin_prune_pending_timer))
+			return;
+
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG LAN prune-pending %d msec on %s", __func__, sg,
+				   jp_override_interval_msec, ifp->name);
+
+		event_add_timer_msec(router->master, pim_dm_prune_pending_on_timer, ch,
+				     jp_override_interval_msec, &ch->t_ifjoin_prune_pending_timer);
+		return;
 	}
+
+	pim_dm_apply_oif_prune(ifp, up, holdtime, source_flags);
 }
 
 void pim_dm_prune_iff_on_timer(struct event *t)

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -183,6 +183,16 @@ void pim_dm_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *u
 			zlog_debug("%s: Dense Mode WRONGVIF on P2P %s, immediate prune (S,G)=%pSG",
 				   __func__, ifp->name, &sg);
 		pim_dm_prune_wrongif(ifp, sg, up);
+	} else if (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)) {
+		/*
+		 * The FHR injects on RPF_interface(S) only.  Reflected copies of
+		 * the same flow on other LAN interfaces are not competing forwarders;
+		 * Assert winner state there would keep stale OIFs and break prune.
+		 */
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: Dense Mode WRONGVIF on LAN %s at FHR, immediate prune (S,G)=%pSG",
+				   __func__, ifp->name, &sg);
+		pim_dm_prune_wrongif(ifp, sg, up);
 	} else {
 		if (PIM_DEBUG_PIM_J_P)
 			zlog_debug("%s: Dense Mode WRONGVIF on LAN %s, starting Assert (S,G)=%pSG",

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -26,6 +26,9 @@
 #include "pim_ifchannel.h"
 #include "pim_assert.h"
 #include "pim_macro.h"
+#include "pim_upstream.h"
+#include "pim_neighbor.h"
+#include "pim_jp_agg.h"
 #include "if.h"
 
 static void pim_dm_range_reevaluate(struct pim_instance *pim)
@@ -76,12 +79,8 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 					oil_if_set(c_oil, pim_ifp->mroute_vif_index, 1);
 					pim_upstream_mroute_update(c_oil, __func__);
 					if (pim_upstream_up_connected(c_oil->up) &&
-					    PIM_UPSTREAM_DM_TEST_PRUNE(c_oil->up->flags)) {
-						PIM_UPSTREAM_DM_UNSET_PRUNE(c_oil->up->flags);
-						event_cancel(&c_oil->up->t_prune_timer);
-						pim_dm_graft_send(c_oil->up->rpf, c_oil->up);
-						graft_timer_start(c_oil->up);
-					}
+					    PIM_UPSTREAM_DM_TEST_PRUNE(c_oil->up->flags))
+						pim_dm_upstream_graft(c_oil->up);
 				}
 			}
 		}
@@ -100,6 +99,56 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 		}
 	}
 	pim_ifp->pim_mode = mode;
+}
+
+/*
+ * Drop this (S,G) from the RPF neighbor's periodic JP-agg prune list.
+ * prune_timer_start() parks a Prune there; event_cancel(t_prune_timer) only
+ * stops the no-neighbor fallback timer.
+ */
+static void pim_dm_jp_agg_stop_prune(struct pim_upstream *up)
+{
+	struct pim_neighbor *nbr = NULL;
+
+	event_cancel(&up->t_prune_timer);
+
+	if (!up->rpf.source_nexthop.interface)
+		return;
+
+	nbr = pim_neighbor_find(up->rpf.source_nexthop.interface, up->rpf.rpf_addr, true);
+	if (!nbr && !pim_addr_is_any(up->rpf.source_nexthop.mrib_nexthop_addr))
+		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
+					up->rpf.source_nexthop.mrib_nexthop_addr, true);
+	if (nbr)
+		pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
+}
+
+/*
+ * Resume a dense (S,G) after local interest returns (Graft, IGMP, or an
+ * interface flipping to dense). Clear DM_PRUNE, stop periodic Prunes, graft
+ * toward RPF, and re-evaluate JoinDesired so joinState becomes Joined.
+ */
+void pim_dm_upstream_graft(struct pim_upstream *up)
+{
+	bool was_pruned;
+
+	if (!up)
+		return;
+
+	was_pruned = PIM_UPSTREAM_DM_TEST_PRUNE(up->flags);
+	PIM_UPSTREAM_DM_UNSET_PRUNE(up->flags);
+
+	/* Drop JP-agg Prune only while still NotJoined. If JoinDesired already
+	 * queued a Join, leave that entry in place.
+	 */
+	if (was_pruned && up->join_state == PIM_UPSTREAM_NOTJOINED)
+		pim_dm_jp_agg_stop_prune(up);
+
+	if (was_pruned || up->join_state == PIM_UPSTREAM_NOTJOINED) {
+		pim_dm_graft_send(up->rpf, up);
+		graft_timer_start(up);
+	}
+	pim_upstream_update_join_desired(up->pim, up);
 }
 
 void pim_dm_graft_send(struct pim_rpf rpf, struct pim_upstream *up)
@@ -170,6 +219,9 @@ static void pim_dm_assert_wrongif(struct interface *ifp, pim_sgaddr sg, struct p
 	}
 }
 
+static void pim_dm_apply_oif_prune(struct interface *ifp, struct pim_upstream *up,
+				   uint16_t holdtime, uint8_t source_flags);
+
 void pim_dm_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up)
 {
 	if (!up || !up->rpf.source_nexthop.interface)
@@ -211,13 +263,17 @@ void pim_dm_prune_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstr
 	if (!up)
 		return;
 
-	if (should_limit_prune(up))
-		return;
-
 	/* Just in case, cancel any possible graft timer */
 	event_cancel(&up->t_graft_timer);
 
-	PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
+	/*
+	 * Drop this OIF (or mark it pruned so dense flood will not add it).
+	 * Do not set upstream DM_PRUNE here: other OIFs may still be valid.
+	 */
+	pim_dm_apply_oif_prune(ifp, up, pim_if_jp_hold(pim_ifp), 0);
+
+	if (should_limit_prune(up))
+		return;
 
 	/* Prune to each neighbor on the received interface */
 	if (pim_ifp->pim_neighbor_list->count > 0) {
@@ -371,10 +427,109 @@ bool pim_gm_has_igmp_join(struct interface *ifp, pim_addr group_addr)
 	return false;
 }
 
-void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
+/*
+ * Dense flood installs (S,G) OIFs with oil_if_set() (no PROTO_GM).  IGMP/MLD
+ * leave only removes PROTO_GM from the (*,G)/(S,G) channel_oil that GM tracks,
+ * so those DM-native OIFs would otherwise stick forever and block upstream
+ * prune.  Clear the leave interface from matching dense (S,G) oils and prune
+ * toward RPF when nothing downstream remains.
+ *
+ * While tib_sg_gm_prune runs, the leaving group is still on gm_group_list, so
+ * pim_upstream_up_connected() would still see local membership on oif.  Skip
+ * IGMP/MLD on the leave interface when deciding whether to prune.
+ */
+void pim_dm_gm_oif_del(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
+{
+	struct channel_oil *c_oil;
+	struct pim_interface *pim_oif = oif->info;
+
+	if (!pim_oif || !pim_iface_grp_dm(pim_oif, sg.grp))
+		return;
+
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
+		struct pim_upstream *up = c_oil->up;
+		struct interface *ifp;
+		struct interface *rpf_ifp;
+		struct pim_interface *pim_rpf;
+		struct pim_ifchannel *ch, *throwaway;
+		bool connected = false;
+
+		if (pim_addr_cmp(sg.grp, *oil_mcastgrp(c_oil)))
+			continue;
+		/* Dense forwarding state is on (S,G); skip (*,G) oils. */
+		if (pim_addr_is_any(*oil_origin(c_oil)))
+			continue;
+		if (!pim_addr_is_any(sg.src) && pim_addr_cmp(sg.src, *oil_origin(c_oil)))
+			continue;
+		if (!up || !up->channel_oil)
+			continue;
+		if (!oil_if_has(c_oil, pim_oif->mroute_vif_index))
+			continue;
+
+		oil_if_set(c_oil, pim_oif->mroute_vif_index, 0);
+		pim_upstream_mroute_update(c_oil, __func__);
+
+		FOR_ALL_INTERFACES (up->pim->vrf, ifp) {
+			struct pim_interface *pim_ifp = ifp->info;
+
+			if (!pim_ifp || !pim_ifp->pim_enable)
+				continue;
+
+			if (HAVE_DENSE_MODE(pim_ifp->pim_mode) &&
+			    up->rpf.source_nexthop.interface &&
+			    ifp->ifindex != up->rpf.source_nexthop.interface->ifindex &&
+			    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+				connected = true;
+				break;
+			}
+			/*
+			 * IGMP on the leave interface is still listed; IGMP on
+			 * RPF_interface(S) does not require us to stay grafted —
+			 * those hosts are served by the upstream forwarder.
+			 */
+			if (ifp != oif &&
+			    (!up->rpf.source_nexthop.interface ||
+			     ifp != up->rpf.source_nexthop.interface) &&
+			    pim_gm_has_igmp_join(ifp, up->sg.grp)) {
+				connected = true;
+				break;
+			}
+		}
+
+		if (connected)
+			continue;
+
+		rpf_ifp = up->rpf.source_nexthop.interface;
+		if (!rpf_ifp || !rpf_ifp->info)
+			continue;
+
+		pim_rpf = rpf_ifp->info;
+		if (!HAVE_DENSE_MODE(pim_rpf->pim_mode))
+			continue;
+
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG leave on %s, pruning upstream on %s", __func__,
+				   &up->sg, oif->name, rpf_ifp->name);
+
+		event_cancel(&up->t_graft_timer);
+		event_cancel(&up->t_join_timer);
+		PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
+		if (up->join_state == PIM_UPSTREAM_JOINED)
+			pim_upstream_switch(up->pim, up, PIM_UPSTREAM_NOTJOINED);
+		/* Cancel any pending Join-override on the RPF LAN. */
+		pim_ifchannel_find(rpf_ifp, &up->sg, &ch, &throwaway);
+		if (ch)
+			event_cancel(&ch->t_ifjoin_prune_pending_timer);
+		pim_dm_prune_send(up->rpf, up, 0);
+		prune_timer_start(up);
+	}
+}
+
+void pim_dm_recv_graft(struct interface *ifp, pim_addr upstream, pim_sgaddr *sg)
 {
 	struct pim_upstream *up;
 	struct pim_interface *pim_ifp = ifp->info;
+	struct interface *rpf_ifp;
 	pim_addr group_addr = sg->grp;
 	struct pim_ifchannel *ch, *throwaway;
 
@@ -386,69 +541,64 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 	if (!HAVE_DENSE_MODE(pim_ifp->pim_mode))
 		return;
 
+	/*
+	 * Grafts are sent to ALL-PIM-ROUTERS. Only the named upstream
+	 * neighbor should add this interface as an OIF. A LAN sibling
+	 * whose IIF is this link must not join/graft from a neighbor's
+	 * Graft (that would Join-override later Prunes with no receivers).
+	 */
+	if (pim_addr_cmp(upstream, pim_ifp->primary_address))
+		return;
+
 	up = pim_upstream_find(pim_ifp->pim, sg);
 
 	if (!up)
 		return;
 
-	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
-	    !oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+	if (!pim_iface_grp_dm(pim_ifp, group_addr) || !up->channel_oil)
+		return;
+
+	rpf_ifp = up->rpf.source_nexthop.interface;
+	if (rpf_ifp && ifp->ifindex == rpf_ifp->ifindex)
+		return;
+
+	if (!oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
 		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
-
-		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
-
-		if (ch) {
-			PIM_UPSTREAM_DM_UNSET_PRUNE(ch->flags);
-			event_cancel(&ch->t_ifjoin_expiry_timer);
-			pim_ifchannel_delete(ch);
-		}
-
-		/* dm: forward graft message */
-		if (PIM_UPSTREAM_DM_TEST_PRUNE(up->flags)) {
-			PIM_UPSTREAM_DM_UNSET_PRUNE(up->flags);
-			event_cancel(&up->t_prune_timer);
-			pim_dm_graft_send(up->rpf, up);
-			graft_timer_start(up);
-		}
 	}
+
+	pim_ifchannel_find(ifp, sg, &ch, &throwaway);
+	if (ch) {
+		PIM_UPSTREAM_DM_UNSET_PRUNE(ch->flags);
+		event_cancel(&ch->t_ifjoin_expiry_timer);
+		pim_ifchannel_delete(ch);
+	}
+
+	pim_dm_upstream_graft(up);
 }
 
 
-void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
-		       pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags)
+/*
+ * Apply a received dense prune on a forwarding OIF: clear the OIL, optionally
+ * prune further upstream, and arm the prune-holdtime re-flood timer.
+ */
+static void pim_dm_apply_oif_prune(struct interface *ifp, struct pim_upstream *up,
+				   uint16_t holdtime, uint8_t source_flags)
 {
-	struct pim_upstream *up;
-	struct pim_interface *pim_ifp;
-	pim_addr group_addr = sg->grp;
+	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_ifchannel *ch, *throwaway;
-
-	struct interface *ifp2 = NULL;
+	struct interface *ifp2;
 	struct pim_interface *pim_ifp2;
-	bool sg_connected;
 	struct vrf *vrf;
+	bool sg_connected = false;
 
-	pim_ifp = ifp->info;
-	if (!pim_ifp || !pim_ifp->pim_enable)
-		return;
-
-	if (!HAVE_DENSE_MODE(pim_ifp->pim_mode))
-		return;
-
-	up = pim_upstream_find(pim_ifp->pim, sg);
-
-	if (!up)
-		return;
-
-	sg_connected = false;
-	vrf = up->pim->vrf;
-
-	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
-	    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+	if (up->channel_oil && oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
 		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
+	}
 
-		/* dm: we need to forward the prune upstream if needed */
+	if (up->channel_oil) {
+		vrf = up->pim->vrf;
 		FOR_ALL_INTERFACES (vrf, ifp2) {
 			pim_ifp2 = ifp2->info;
 
@@ -459,28 +609,208 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 				sg_connected = true;
 				break;
 			}
-			if (pim_gm_has_igmp_join(ifp2, sg->grp)) {
+			/* IGMP on RPF_interface(S) is not downstream interest for prune. */
+			if ((!up->rpf.source_nexthop.interface ||
+			     ifp2 != up->rpf.source_nexthop.interface) &&
+			    pim_gm_has_igmp_join(ifp2, up->sg.grp)) {
 				sg_connected = true;
 				break;
 			}
 		}
 
 		if (!sg_connected) {
+			event_cancel(&up->t_graft_timer);
+			event_cancel(&up->t_join_timer);
 			PIM_UPSTREAM_DM_SET_PRUNE(up->flags);
+			if (up->join_state == PIM_UPSTREAM_JOINED)
+				pim_upstream_switch(up->pim, up, PIM_UPSTREAM_NOTJOINED);
 			pim_dm_prune_send(up->rpf, up, 0);
 			prune_timer_start(up);
 		}
+	}
+
+	pim_ifchannel_find(ifp, &up->sg, &ch, &throwaway);
+	if (!ch)
+		ch = pim_ifchannel_add(ifp, &up->sg, source_flags, PIM_UPSTREAM_DM_FLAG_MASK_PRUNE);
+	PIM_UPSTREAM_DM_SET_PRUNE(ch->flags);
+	ch->upstream = up;
+	ch->prune_holdtime = holdtime;
+	event_cancel(&ch->t_ifjoin_expiry_timer);
+	event_add_timer(router->master, pim_dm_prune_iff_on_timer, ch, holdtime,
+			&ch->t_ifjoin_expiry_timer);
+}
+
+void pim_dm_prune_pending_on_timer(struct event *t)
+{
+	struct pim_ifchannel *ch = EVENT_ARG(t);
+	struct interface *ifp = ch->interface;
+	struct pim_upstream *up = ch->upstream;
+	uint16_t holdtime = ch->prune_holdtime;
+
+	if (PIM_DEBUG_PIM_J_P)
+		zlog_debug("%s: (S,G)=%s LAN prune-pending expired on %s, applying prune",
+			   __func__, ch->sg_str, ifp->name);
+
+	if (!up)
+		return;
+
+	pim_dm_apply_oif_prune(ifp, up, holdtime, 0);
+}
+
+void pim_dm_join_override_on_timer(struct event *t)
+{
+	struct pim_ifchannel *ch = EVENT_ARG(t);
+	struct pim_upstream *up = ch->upstream;
+	struct interface *ifp = ch->interface;
+
+	if (!up)
+		return;
+
+	if (PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) || !pim_upstream_up_connected(up))
+		return;
+
+	if (PIM_DEBUG_PIM_J_P)
+		zlog_debug("%s: (S,G)=%s sending LAN Join override on %s", __func__, ch->sg_str,
+			   ifp->name);
+
+	pim_dm_prune_send(up->rpf, up, true);
+}
+
+/*
+ * Dense Join on a multi-access LAN: cancel a pending OIF prune (override),
+ * cancel a pending Join override (suppression), or re-add an already-pruned
+ * OIF like a Graft directed at this forwarder.
+ */
+void pim_dm_recv_join(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
+		      pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_upstream *up;
+	struct pim_ifchannel *ch, *throwaway;
+	bool directed_to_us;
+
+	if (!pim_ifp || !pim_ifp->pim_enable)
+		return;
+
+	if (!HAVE_DENSE_MODE(pim_ifp->pim_mode) || !pim_iface_grp_dm(pim_ifp, sg->grp))
+		return;
+
+	up = pim_upstream_find(pim_ifp->pim, sg);
+	if (!up)
+		return;
+
+	directed_to_us = !pim_addr_cmp(upstream, pim_ifp->primary_address);
+
+	pim_ifchannel_find(ifp, sg, &ch, &throwaway);
+
+	if (!directed_to_us) {
+		/* Join suppression: another router already overrode the prune. */
+		if (ch && event_is_scheduled(ch->t_ifjoin_prune_pending_timer) &&
+		    up->rpf.source_nexthop.interface == ifp) {
+			if (PIM_DEBUG_PIM_J_P)
+				zlog_debug("%s: (S,G)=%pSG suppressing Join override on %s",
+					   __func__, sg, ifp->name);
+			event_cancel(&ch->t_ifjoin_prune_pending_timer);
+		}
+		return;
+	}
+
+	/* Directed to us (LAN forwarder). */
+	if (ch && event_is_scheduled(ch->t_ifjoin_prune_pending_timer)) {
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG Join override cancels prune-pending on %s",
+				   __func__, sg, ifp->name);
+		event_cancel(&ch->t_ifjoin_prune_pending_timer);
+	}
+
+	/*
+	 * After the OIF is pruned, restoration is via Graft (pim_dm_recv_graft),
+	 * not Join. Join only cancels prune-pending during the override window.
+	 */
+}
+
+void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
+		       pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags)
+{
+	struct pim_upstream *up;
+	struct pim_interface *pim_ifp;
+	struct pim_ifchannel *ch, *throwaway;
+	int jp_override_interval_msec;
+
+	pim_ifp = ifp->info;
+	if (!pim_ifp || !pim_ifp->pim_enable)
+		return;
+
+	if (!HAVE_DENSE_MODE(pim_ifp->pim_mode))
+		return;
+
+	if (!pim_iface_grp_dm(pim_ifp, sg->grp))
+		return;
+
+	up = pim_upstream_find(pim_ifp->pim, sg);
+	if (!up)
+		return;
+
+	/*
+	 * Prune not directed to us: if this is our RPF interface and we still
+	 * have downstream interest, schedule a Join override (RFC 3973).
+	 */
+	if (pim_addr_cmp(upstream, pim_ifp->primary_address)) {
+		/*
+		 * Overheard prune on our RPF LAN: Join-override only while we
+		 * still want the stream.  Already-pruned upstreams must not
+		 * keep canceling the forwarder's prune-pending.
+		 */
+		if (up->rpf.source_nexthop.interface == ifp &&
+		    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) && pim_upstream_up_connected(up)) {
+			pim_ifchannel_find(ifp, sg, &ch, &throwaway);
+			if (!ch)
+				ch = pim_ifchannel_add(ifp, sg, source_flags, 0);
+			ch->upstream = up;
+			if (!event_is_scheduled(ch->t_ifjoin_prune_pending_timer)) {
+				int t_override_msec = pim_if_t_override_msec(ifp);
+
+				if (PIM_DEBUG_PIM_J_P)
+					zlog_debug("%s: (S,G)=%pSG scheduling Join override in %d msec on %s",
+						   __func__, sg, t_override_msec, ifp->name);
+				event_add_timer_msec(router->master, pim_dm_join_override_on_timer,
+						     ch, t_override_msec,
+						     &ch->t_ifjoin_prune_pending_timer);
+			}
+		}
+		return;
+	}
+
+	/*
+	 * Directed to us.  Apply even if this OIF is not in the OIL yet, so a
+	 * later dense flood does not re-add it.
+	 *
+	 * Multi-access LAN with other neighbors: delay OIF removal so a sibling
+	 * with receivers can Join-override (RFC 3973). P2P or sole neighbor:
+	 * prune immediately.
+	 */
+	if (!if_is_pointopoint(ifp) && listcount(pim_ifp->pim_neighbor_list) > 1) {
+		jp_override_interval_msec = pim_if_jp_override_interval_msec(ifp);
 
 		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
 		if (!ch)
-			ch = pim_ifchannel_add(ifp, sg, source_flags,
-					       PIM_UPSTREAM_DM_FLAG_MASK_PRUNE);
-		PIM_UPSTREAM_DM_SET_PRUNE(ch->flags);
+			ch = pim_ifchannel_add(ifp, sg, source_flags, 0);
 		ch->prune_holdtime = holdtime;
-		event_cancel(&ch->t_ifjoin_expiry_timer);
-		event_add_timer(router->master, pim_dm_prune_iff_on_timer, ch, holdtime,
-				&ch->t_ifjoin_expiry_timer);
+		ch->upstream = up;
+
+		if (event_is_scheduled(ch->t_ifjoin_prune_pending_timer))
+			return;
+
+		if (PIM_DEBUG_PIM_J_P)
+			zlog_debug("%s: (S,G)=%pSG LAN prune-pending %d msec on %s", __func__, sg,
+				   jp_override_interval_msec, ifp->name);
+
+		event_add_timer_msec(router->master, pim_dm_prune_pending_on_timer, ch,
+				     jp_override_interval_msec, &ch->t_ifjoin_prune_pending_timer);
+		return;
 	}
+
+	pim_dm_apply_oif_prune(ifp, up, holdtime, source_flags);
 }
 
 void pim_dm_prune_iff_on_timer(struct event *t)

--- a/pimd/pim_dm.h
+++ b/pimd/pim_dm.h
@@ -29,10 +29,15 @@ void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_sta
 void pim_dm_prune_send(struct pim_rpf rpf, struct pim_upstream *up, bool is_join);
 bool pim_dm_check_gm_group_list(struct interface *ifp);
 bool pim_gm_has_igmp_join(struct interface *ifp, pim_addr group_addr);
+void pim_dm_gm_oif_del(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif);
 void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg);
+void pim_dm_recv_join(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
+		      pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags);
 void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
 		       pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags);
 void pim_dm_prune_iff_on_timer(struct event *t);
+void pim_dm_prune_pending_on_timer(struct event *t);
+void pim_dm_join_override_on_timer(struct event *t);
 void pim_dm_prefix_list_update(struct pim_instance *pim, struct prefix_list *plist);
 bool pim_is_grp_dm(struct pim_instance *pim, pim_addr group_addr);
 bool pim_is_dm_prefix_filter(struct pim_instance *pim, pim_addr group_addr);

--- a/pimd/pim_dm.h
+++ b/pimd/pim_dm.h
@@ -23,16 +23,22 @@ struct pim_dm {
 
 void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode);
 void pim_dm_graft_send(struct pim_rpf rpf, struct pim_upstream *up);
+void pim_dm_upstream_graft(struct pim_upstream *up);
 void pim_dm_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up);
 void pim_dm_prune_wrongif(struct interface *ifp, pim_sgaddr sg, struct pim_upstream *up);
 void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_state new_state);
 void pim_dm_prune_send(struct pim_rpf rpf, struct pim_upstream *up, bool is_join);
 bool pim_dm_check_gm_group_list(struct interface *ifp);
 bool pim_gm_has_igmp_join(struct interface *ifp, pim_addr group_addr);
-void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg);
+void pim_dm_gm_oif_del(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif);
+void pim_dm_recv_graft(struct interface *ifp, pim_addr upstream, pim_sgaddr *sg);
+void pim_dm_recv_join(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
+		      pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags);
 void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
 		       pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags);
 void pim_dm_prune_iff_on_timer(struct event *t);
+void pim_dm_prune_pending_on_timer(struct event *t);
+void pim_dm_join_override_on_timer(struct event *t);
 void pim_dm_prefix_list_update(struct pim_instance *pim, struct prefix_list *plist);
 bool pim_is_grp_dm(struct pim_instance *pim, pim_addr group_addr);
 bool pim_is_dm_prefix_filter(struct pim_instance *pim, pim_addr group_addr);

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -116,8 +116,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh, uint16_
 		sg->src = PIMADDR_ANY;
 	}
 	if (pim_iface_grp_dm(pim_ifp, sg->grp)) {
-		zlog_warn("%s: Specified Group(%pPA) in join is now in DM, not allowed to create PIM state",
-			  __func__, &sg->grp);
+		pim_dm_recv_join(ifp, neigh, holdtime, upstream, sg, source_flags);
 		return;
 	}
 

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -116,8 +116,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh, uint16_
 		sg->src = PIMADDR_ANY;
 	}
 	if (pim_iface_grp_dm(pim_ifp, sg->grp)) {
-		zlog_warn("%s: Specified Group(%pPA) in join is now in DM, not allowed to create PIM state",
-			  __func__, &sg->grp);
+		pim_dm_recv_join(ifp, neigh, holdtime, upstream, sg, source_flags);
 		return;
 	}
 
@@ -523,7 +522,7 @@ int pim_graft_recv(struct interface *ifp, struct pim_neighbor *neigh, pim_addr s
 				continue;
 
 			if (pim_msg_type == PIM_MSG_TYPE_GRAFT)
-				pim_dm_recv_graft(ifp, &sg);
+				pim_dm_recv_graft(ifp, msg_upstream_addr, &sg);
 			else if (pim_msg_type == PIM_MSG_TYPE_GRAFT_ACK) {
 				up = pim_upstream_find(pim_ifp->pim, &sg);
 				if (up)

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -232,7 +232,11 @@ int pim_macro_ch_could_assert_eval(const struct pim_ifchannel *ch)
 		/* RFC 3973 4.6.4: CouldAssert(S,G,I) = (RPF_interface(S) != I).
 		 * Require a resolved RPF interface so a transiently unresolved
 		 * RPF (NULL) does not make every interface assert-eligible.
+		 * FHR injects only on RPF_interface(S); reflected copies on other
+		 * LANs are not competing forwarders.
 		 */
+		if (PIM_UPSTREAM_FLAG_TEST_FHR(ch->upstream->flags))
+			return 0;
 		return ch->upstream->rpf.source_nexthop.interface != NULL &&
 		       ch->upstream->rpf.source_nexthop.interface != ifp;
 	}

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -348,6 +348,8 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 
 
 	if (dodense) {
+		struct interface *rpf_ifp;
+
 		/*
 		For proper dense handling....
 
@@ -400,21 +402,27 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 
 		up->channel_oil->cc.pktcnt++;
 
-		/* Detect if the rpf for the source is different from the interface the packet was received on.
-		 * In this case, we need to prune immediately
+		rpf_ifp = up->rpf.source_nexthop.interface;
+
+		/*
+		 * Packet arrived on an interface other than RPF_interface(S).
+		 * Still install an MFC with the correct parent vif: the kernel
+		 * keys the unresolved cache on (S,G) only, so returning here
+		 * would pin later packets (including those on RPF_interface(S))
+		 * to this wrong incoming vif and they would never be forwarded.
 		 */
-		if (!up->rpf.source_nexthop.interface ||
-		    up->rpf.source_nexthop.interface->ifindex != ifp->ifindex) {
+		if (!rpf_ifp || rpf_ifp->ifindex != ifp->ifindex) {
 			if (PIM_DEBUG_PIM_J_P)
 				zlog_debug("%s: Dense Mode WRONGVIF on %s for (S,G)=%pSG",
 					   __func__, ifp->name, &sg);
 			pim_dm_wrongif(ifp, sg, up);
-			return 0;
+			rpf_ifp = up->rpf.source_nexthop.interface;
+			if (!rpf_ifp)
+				return 0;
 		}
 
 		/* resolve mfcc_parent prior to mroute_add in channel_add_oif */
-		if (up->rpf.source_nexthop.interface &&
-		    *oil_incoming_vif(up->channel_oil) >= MAXVIFS) {
+		if (rpf_ifp && *oil_incoming_vif(up->channel_oil) >= MAXVIFS) {
 			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 		}
 
@@ -423,8 +431,9 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 
 			pim_ifp2 = ifp2->info;
 
-			/* Make sure the interface has PIM enabled and is not the current interface and is a dense type mode */
+			/* Skip ingress, RPF_interface(S), and non-dense interfaces. */
 			if (!pim_ifp2 || !pim_ifp2->pim_enable || ifp2->ifindex == ifp->ifindex ||
+			    (rpf_ifp && ifp2->ifindex == rpf_ifp->ifindex) ||
 			    !HAVE_DENSE_MODE(pim_ifp2->pim_mode))
 				continue;
 
@@ -443,7 +452,7 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 			}
 		}
 
-		if (update_oil || desync) {
+		if (update_oil || desync || (rpf_ifp && ifp->ifindex != rpf_ifp->ifindex)) {
 			PIM_UPSTREAM_DM_SET_INTERFACE(up->flags);
 			PIM_UPSTREAM_FLAG_UNSET_USE_RPT(up->flags);
 			PIM_UPSTREAM_FLAG_UNSET_DR_JOIN_DESIRED(up->flags);

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -469,25 +469,13 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 		return;
 	}
 
-	/* dm: check if we need to send a prune message */
-	if ((*oilp)->oil_size == 0) {
-		/* Not forwarding to any other interfaces, prune it */
-		/* Only if the upstream is dense and group is dense */
-		if (pim_iface_grp_dm(pim_oif, sg.grp) && HAVE_DENSE_MODE(pim_oif->pim_mode)) {
-			if ((*oilp)->up) {
-				struct interface *ifp = (*oilp)->up->rpf.source_nexthop.interface;
-				if (ifp && ifp->info) {
-					struct pim_interface *pim_ifp = ifp->info;
-					if (HAVE_DENSE_MODE(pim_ifp->pim_mode)) {
-						event_cancel(&(*oilp)->up->t_graft_timer);
-						PIM_UPSTREAM_DM_SET_PRUNE((*oilp)->up->flags);
-						pim_dm_prune_send((*oilp)->up->rpf, (*oilp)->up, 0);
-						prune_timer_start((*oilp)->up);
-					}
-				}
-			}
-		}
-	}
+	/*
+	 * Dense (S,G) OIFs are installed by flood via oil_if_set(), not
+	 * PROTO_GM.  Clear the leave interface from those oils and prune
+	 * upstream when no dense downstream remains.
+	 */
+	if (pim_iface_grp_dm(pim_oif, sg.grp) && HAVE_DENSE_MODE(pim_oif->pim_mode))
+		pim_dm_gm_oif_del(pim, sg, oif);
 
 	/*
 	  Feed IGMPv3-gathered local membership information into PIM

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -379,13 +379,8 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 						c_oil->up->rpf.source_nexthop.interface;
 					if (ifp && ifp->info) {
 						struct pim_interface *pim_ifp = ifp->info;
-						if (HAVE_DENSE_MODE(pim_ifp->pim_mode)) {
-							PIM_UPSTREAM_DM_UNSET_PRUNE(
-								c_oil->up->flags);
-							event_cancel(&c_oil->up->t_prune_timer);
-							pim_dm_graft_send(c_oil->up->rpf, c_oil->up);
-							graft_timer_start(c_oil->up);
-						}
+						if (HAVE_DENSE_MODE(pim_ifp->pim_mode))
+							pim_dm_upstream_graft(c_oil->up);
 					}
 				}
 			}
@@ -469,25 +464,13 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 		return;
 	}
 
-	/* dm: check if we need to send a prune message */
-	if ((*oilp)->oil_size == 0) {
-		/* Not forwarding to any other interfaces, prune it */
-		/* Only if the upstream is dense and group is dense */
-		if (pim_iface_grp_dm(pim_oif, sg.grp) && HAVE_DENSE_MODE(pim_oif->pim_mode)) {
-			if ((*oilp)->up) {
-				struct interface *ifp = (*oilp)->up->rpf.source_nexthop.interface;
-				if (ifp && ifp->info) {
-					struct pim_interface *pim_ifp = ifp->info;
-					if (HAVE_DENSE_MODE(pim_ifp->pim_mode)) {
-						event_cancel(&(*oilp)->up->t_graft_timer);
-						PIM_UPSTREAM_DM_SET_PRUNE((*oilp)->up->flags);
-						pim_dm_prune_send((*oilp)->up->rpf, (*oilp)->up, 0);
-						prune_timer_start((*oilp)->up);
-					}
-				}
-			}
-		}
-	}
+	/*
+	 * Dense (S,G) OIFs are installed by flood via oil_if_set(), not
+	 * PROTO_GM.  Clear the leave interface from those oils and prune
+	 * upstream when no dense downstream remains.
+	 */
+	if (pim_iface_grp_dm(pim_oif, sg.grp) && HAVE_DENSE_MODE(pim_oif->pim_mode))
+		pim_dm_gm_oif_del(pim, sg, oif);
 
 	/*
 	  Feed IGMPv3-gathered local membership information into PIM

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -490,6 +490,9 @@ void prune_timer_start(struct pim_upstream *up)
 
 	if (up->rpf.source_nexthop.interface) {
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface, up->rpf.rpf_addr, true);
+		if (!nbr && !pim_addr_is_any(up->rpf.source_nexthop.mrib_nexthop_addr))
+			nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
+						up->rpf.source_nexthop.mrib_nexthop_addr, true);
 
 		if (PIM_DEBUG_PIM_EVENTS) {
 			zlog_debug("%s: starting %d sec timer for upstream (S,G)=%s", __func__,
@@ -498,7 +501,7 @@ void prune_timer_start(struct pim_upstream *up)
 	}
 
 	if (nbr)
-		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, 1, nbr);
+		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, false, nbr);
 	else {
 		event_cancel(&up->t_prune_timer);
 		event_add_timer(router->master, on_prune_timer, up, router->t_periodic,
@@ -1540,6 +1543,10 @@ bool pim_upstream_evaluate_join_desired(struct pim_instance *pim,
 {
 	bool empty_imm_oil;
 	bool empty_inh_oil;
+
+	/* Dense-mode pruned streams must not emit sparse Join refreshes. */
+	if (PIM_UPSTREAM_DM_TEST_PRUNE(up->flags))
+		return false;
 
 	empty_imm_oil = pim_upstream_empty_immediate_olist(pim, up);
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -490,6 +490,9 @@ void prune_timer_start(struct pim_upstream *up)
 
 	if (up->rpf.source_nexthop.interface) {
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface, up->rpf.rpf_addr, true);
+		if (!nbr && !pim_addr_is_any(up->rpf.source_nexthop.mrib_nexthop_addr))
+			nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
+						up->rpf.source_nexthop.mrib_nexthop_addr, true);
 
 		if (PIM_DEBUG_PIM_EVENTS) {
 			zlog_debug("%s: starting %d sec timer for upstream (S,G)=%s", __func__,
@@ -498,7 +501,7 @@ void prune_timer_start(struct pim_upstream *up)
 	}
 
 	if (nbr)
-		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, 1, nbr);
+		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, false, nbr);
 	else {
 		event_cancel(&up->t_prune_timer);
 		event_add_timer(router->master, on_prune_timer, up, router->t_periodic,
@@ -977,10 +980,14 @@ void pim_upstream_update_use_rpt(struct pim_upstream *up,
 	if (pim_addr_is_any(up->sg.src))
 		return;
 
-	/* Ignore RP mapping when the upstream state
-	 * is NOT Joined on a FHR
+	/* Ignore RP mapping when the upstream is NOT Joined on an FHR, or
+	 * when it is a dense-mode stream (no RPT).  Switching those to
+	 * USE_RPT clears IIF (no (*,G) parent) and uninstalls the MFC, so
+	 * the next packet NOCACHEs and re-floods.
 	 */
-	if (up->join_state == PIM_UPSTREAM_NOTJOINED && PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
+	if (up->join_state == PIM_UPSTREAM_NOTJOINED &&
+	    (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) || PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) ||
+	     PIM_UPSTREAM_DM_TEST_INTERFACE(up->flags)))
 		return;
 
 	old_use_rpt = !!PIM_UPSTREAM_FLAG_TEST_USE_RPT(up->flags);
@@ -990,18 +997,18 @@ void pim_upstream_update_use_rpt(struct pim_upstream *up,
 	 * 2. We are FHR
 	 * 3. Source is directly connected
 	 * 4. We are RP (parent's IIF is lo or vrf-device)
+	 * 5. Dense-mode (S,G) (no RP tree)
 	 * In all other cases the source will stay along the RPT and
 	 * IIF=RPF_interface(RP).
 	 */
 	if (up->join_state == PIM_UPSTREAM_JOINED ||
-			PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) ||
-			pim_if_connected_to_source(
-				up->rpf.source_nexthop.interface,
-				up->sg.src) ||
-			/* XXX - need to switch this to a more efficient
-			 * lookup API
-			 */
-			I_am_RP(up->pim, up->sg.grp))
+	    PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) || PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) ||
+	    PIM_UPSTREAM_DM_TEST_INTERFACE(up->flags) ||
+	    pim_if_connected_to_source(up->rpf.source_nexthop.interface, up->sg.src) ||
+	    /* XXX - need to switch this to a more efficient
+	     * lookup API
+	     */
+	    I_am_RP(up->pim, up->sg.grp))
 		/* use SPT */
 		PIM_UPSTREAM_FLAG_UNSET_USE_RPT(up->flags);
 	else
@@ -1540,6 +1547,15 @@ bool pim_upstream_evaluate_join_desired(struct pim_instance *pim,
 {
 	bool empty_imm_oil;
 	bool empty_inh_oil;
+
+	/*
+	 * Dense-pruned streams with no OIL must not emit sparse Join
+	 * refreshes.  If an OIF is already present the prune flag is stale
+	 * (e.g. Graft added the OIF without clearing DM_PRUNE).
+	 */
+	if (PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) &&
+	    pim_upstream_empty_inherited_olist(up))
+		return false;
 
 	empty_imm_oil = pim_upstream_empty_immediate_olist(pim, up);
 
@@ -2406,12 +2422,14 @@ bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 }
 
 /* Check if any dense mode interface is in the OIL of this upstream
- * or if any interface has an IGMP join for this upstream group
+ * or if any non-RPF interface has an IGMP join for this upstream group.
+ * IGMP on RPF_interface(S) is served by the upstream forwarder on that LAN.
  */
 bool pim_upstream_up_connected(struct pim_upstream *up)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp;
+	struct interface *rpf_ifp = up->rpf.source_nexthop.interface;
 
 	FOR_ALL_INTERFACES (up->pim->vrf, ifp) {
 		pim_ifp = ifp->info;
@@ -2419,8 +2437,10 @@ bool pim_upstream_up_connected(struct pim_upstream *up)
 		if (!pim_ifp || !pim_ifp->pim_enable)
 			continue;
 
+		if (rpf_ifp && ifp->ifindex == rpf_ifp->ifindex)
+			continue;
+
 		if (HAVE_DENSE_MODE(pim_ifp->pim_mode) &&
-		    ifp->ifindex != up->rpf.source_nexthop.interface->ifindex &&
 		    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index))
 			return true;
 		if (pim_gm_has_igmp_join(ifp, up->sg.grp))

--- a/tests/topotests/pim_dense/r1/frr.conf
+++ b/tests/topotests/pim_dense/r1/frr.conf
@@ -31,6 +31,7 @@ ip route 10.0.4.0/24 10.0.0.2
 ip route 10.101.0.0/24 10.0.0.2
 ip route 10.102.0.0/24 10.0.0.2
 ip route 10.103.0.0/24 10.0.0.2
+ip route 10.104.0.0/24 10.0.0.2
 !
 !debug igmp
 !debug mroute

--- a/tests/topotests/pim_dense/r2/frr.conf
+++ b/tests/topotests/pim_dense/r2/frr.conf
@@ -29,6 +29,7 @@ ip route 10.100.0.0/24 10.0.0.1
 ip route 10.101.0.0/24 10.0.2.2
 ip route 10.102.0.0/24 10.0.1.2
 ip route 10.103.0.0/24 10.0.1.2
+ip route 10.104.0.0/24 10.0.2.3
 !
 !debug igmp
 !debug mroute

--- a/tests/topotests/pim_dense/r3/frr.conf
+++ b/tests/topotests/pim_dense/r3/frr.conf
@@ -36,6 +36,7 @@ ip route 10.100.0.0/24 10.0.1.1
 ip route 10.101.0.0/24 10.0.1.1
 ip route 10.102.0.0/24 10.0.3.2
 ip route 10.103.0.0/24 10.0.4.2
+ip route 10.104.0.0/24 10.0.1.1
 !
 !debug igmp
 !debug mroute

--- a/tests/topotests/pim_dense/r4/frr.conf
+++ b/tests/topotests/pim_dense/r4/frr.conf
@@ -28,6 +28,7 @@ ip route 10.0.4.0/24 10.0.2.1
 ip route 10.100.0.0/24 10.0.2.1
 ip route 10.102.0.0/24 10.0.2.1
 ip route 10.103.0.0/24 10.0.2.1
+ip route 10.104.0.0/24 10.0.2.3
 !
 !debug igmp
 !debug mroute

--- a/tests/topotests/pim_dense/r5/frr.conf
+++ b/tests/topotests/pim_dense/r5/frr.conf
@@ -28,6 +28,7 @@ ip route 10.0.4.0/24 10.0.3.1
 ip route 10.100.0.0/24 10.0.3.1
 ip route 10.101.0.0/24 10.0.3.1
 ip route 10.103.0.0/24 10.0.3.1
+ip route 10.104.0.0/24 10.0.3.1
 !
 !debug igmp
 !debug mroute

--- a/tests/topotests/pim_dense/r7/frr.conf
+++ b/tests/topotests/pim_dense/r7/frr.conf
@@ -1,14 +1,14 @@
 !
-hostname r6
+hostname r7
 password zebra
 !
-interface r6-eth0
- ip address 10.0.4.2/24
+interface r7-eth0
+ ip address 10.0.2.3/24
  ip igmp
  ip pim dm
 !
-interface r6-eth1
- ip address 10.103.0.1/24
+interface r7-eth1
+ ip address 10.104.0.1/24
  ip igmp
  ip pim dm
  ip pim passive
@@ -21,14 +21,14 @@ router pim
  rp 10.0.2.1 238.0.0.0/8
  dm prefix-list PIM_DM_LIST
 !
-ip route 10.0.0.0/24 10.0.4.1
-ip route 10.0.1.0/24 10.0.4.1
-ip route 10.0.2.0/24 10.0.4.1
-ip route 10.0.3.0/24 10.0.4.1
-ip route 10.100.0.0/24 10.0.4.1
-ip route 10.101.0.0/24 10.0.4.1
-ip route 10.102.0.0/24 10.0.4.1
-ip route 10.104.0.0/24 10.0.4.1
+ip route 10.0.0.0/24 10.0.2.1
+ip route 10.0.1.0/24 10.0.2.1
+ip route 10.0.3.0/24 10.0.2.1
+ip route 10.0.4.0/24 10.0.2.1
+ip route 10.100.0.0/24 10.0.2.1
+ip route 10.101.0.0/24 10.0.2.2
+ip route 10.102.0.0/24 10.0.2.1
+ip route 10.103.0.0/24 10.0.2.1
 !
 !debug igmp
 !debug mroute

--- a/tests/topotests/pim_dense/test_pim_dense.py
+++ b/tests/topotests/pim_dense/test_pim_dense.py
@@ -52,10 +52,21 @@ TOPOLOGY = """
  10.101.0.0/24   |                             |   10.0.0.0/24
                  |                             |
     r4-eth1 (p)  | .1                          | .2 r2-eth0 (d)
-              +--+--+      10.0.2.0/24      +--+--+
-              | R4  |-----------------------| R2  |
-              +--+--+ .2                 .1 +--+--+
-                  r4-eth0 (d)    r2-eth2 (sd)  | .1 r2-eth1 (sd)
+              +--+--+   10.0.2.0/24 (shared) +--+--+
+              | R4  |-------+--------+-------| R2  |
+              +--+--+ .2    |             .1 +--+--+
+              r4-eth0 (d)   |    r2-eth2 (sd)  | .1 r2-eth1 (sd)
+              r7-eth0 (d)   |                  |
+                        +--+--+                |
+                        | R7  |                |
+                        +--+--+                |
+               r7-eth1 (p) | .3                |
+        10.104.0.0/24      |                   |
+                           |                   |
+               h7-eth0     | .2                |
+                        +--+--+                |
+                        | H7  |                |
+                        +--+--+                |
                                                |
                                                |   10.0.1.0.24
                                                |
@@ -99,20 +110,26 @@ def build_topo(tgen):
     tgen.add_router("r4")
     tgen.add_router("r5")
     tgen.add_router("r6")
+    tgen.add_router("r7")
     tgen.add_host("h1", "10.100.0.2/24", "via 10.100.0.1")
     tgen.add_host("h4", "10.101.0.2/24", "via 10.101.0.1")
     tgen.add_host("h5", "10.102.0.2/24", "via 10.102.0.1")
     tgen.add_host("h6", "10.103.0.2/24", "via 10.103.0.1")
+    tgen.add_host("h7", "10.104.0.2/24", "via 10.104.0.1")
 
     # Create topology links
     tgen.add_link(tgen.gears["h1"], tgen.gears["r1"], "h1-eth0", "r1-eth1")
     tgen.add_link(tgen.gears["h4"], tgen.gears["r4"], "h4-eth0", "r4-eth1")
     tgen.add_link(tgen.gears["h5"], tgen.gears["r5"], "h5-eth0", "r5-eth1")
     tgen.add_link(tgen.gears["h6"], tgen.gears["r6"], "h6-eth0", "r6-eth1")
+    tgen.add_link(tgen.gears["h7"], tgen.gears["r7"], "h7-eth0", "r7-eth1")
     tgen.add_link(tgen.gears["r1"], tgen.gears["r2"], "r1-eth0", "r2-eth0")
     tgen.add_link(tgen.gears["r1"], tgen.gears["r3"], "r1-eth2", "r3-eth3")
     tgen.add_link(tgen.gears["r2"], tgen.gears["r3"], "r2-eth1", "r3-eth0")
-    tgen.add_link(tgen.gears["r2"], tgen.gears["r4"], "r2-eth2", "r4-eth0")
+    switch = tgen.add_switch("s02")
+    switch.add_link(tgen.gears["r2"], nodeif="r2-eth2")
+    switch.add_link(tgen.gears["r4"], nodeif="r4-eth0")
+    switch.add_link(tgen.gears["r7"], nodeif="r7-eth0")
     tgen.add_link(tgen.gears["r3"], tgen.gears["r5"], "r3-eth1", "r5-eth0")
     tgen.add_link(tgen.gears["r3"], tgen.gears["r6"], "r3-eth2", "r6-eth0")
 
@@ -191,6 +208,11 @@ def test_pim_dense_neighbors(request):
                     "neighbor": "10.0.2.2",
                     "drPriority": 1,
                 },
+                "10.0.2.3": {
+                    "interface": "r2-eth2",
+                    "neighbor": "10.0.2.3",
+                    "drPriority": 1,
+                },
             },
         },
         "r3": {
@@ -230,6 +252,25 @@ def test_pim_dense_neighbors(request):
                     "neighbor": "10.0.2.1",
                     "drPriority": 1,
                 },
+                "10.0.2.3": {
+                    "interface": "r4-eth0",
+                    "neighbor": "10.0.2.3",
+                    "drPriority": 1,
+                },
+            },
+        },
+        "r7": {
+            "r7-eth0": {
+                "10.0.2.1": {
+                    "interface": "r7-eth0",
+                    "neighbor": "10.0.2.1",
+                    "drPriority": 1,
+                },
+                "10.0.2.2": {
+                    "interface": "r7-eth0",
+                    "neighbor": "10.0.2.2",
+                    "drPriority": 1,
+                },
             },
         },
         "r5": {
@@ -267,7 +308,7 @@ def test_pim_dense_neighbors(request):
 
 def stop_all_hosts():
     """Stop multicast traffic and IGMP joins on all hosts."""
-    for host in ("h1", "h4", "h5", "h6"):
+    for host in ("h1", "h4", "h5", "h6", "h7"):
         app_helper.stop_host(host)
 
 
@@ -334,6 +375,42 @@ def check_mroute_iif(tgen, router, src, group, iif):
         return "Unexpected iif on {}: {} (expected {})".format(
             router, entry.get("iif"), iif
         )
+    return None
+
+
+def check_mroute_oif_present(tgen, router, src, group, oif):
+    """Return None if (S,G) OIL on router includes oif, else an error string."""
+    entry = mroute_entry(tgen, router, src, group)
+    if not entry or entry.get("installed", 0) == 0:
+        return "No installed mroute for ({},{}) on {}".format(src, group, router)
+    oil_names = mroute_oil_names(entry)
+    if oif not in oil_names:
+        return "Expected OIF {} on {}, got {}".format(oif, router, oil_names)
+    return None
+
+
+def check_mroute_oif_absent(tgen, router, src, group, oif):
+    """Return None if (S,G) OIL on router does not include oif."""
+    entry = mroute_entry(tgen, router, src, group)
+    if not entry or entry.get("installed", 0) == 0:
+        return None
+    oil_names = mroute_oil_names(entry)
+    if oif in oil_names:
+        return "Unexpected OIF {} still on {}, OIL {}".format(oif, router, oil_names)
+    return None
+
+
+def check_igmp_group_absent(tgen, router, interface, group):
+    """Return None when interface has no IGMP membership for group."""
+    output = tgen.gears[router].vtysh_cmd("show ip igmp groups json", isjson=True)
+    iface = output.get(interface)
+    if not iface:
+        return None
+    for entry in iface.get("groups", []):
+        if entry.get("group") == group:
+            return "IGMP group {} still present on {} {}".format(
+                group, router, interface
+            )
     return None
 
 
@@ -1512,6 +1589,153 @@ def test_pim_dense_to_sparse_on_rp_add(request):
                 no rp 10.0.2.1 239.0.0.0/8
             """
         )
+
+    stop_all_hosts()
+
+
+def test_pim_dense_lan_prune_with_active_branch(request):
+    """Verify LAN prune/override on the shared 10.0.2.0/24 segment (r2, r4, r7).
+
+    RFC 3973 items 4 and 5 with three PIM routers on one multi-access LAN:
+
+    - Item 5 (join override): when h4 leaves, r4 Prunes on the LAN but r7 still
+      has h7 joined. r7 must override so r2 keeps flooding on r2-eth2 and h7
+      keeps receiving.
+
+    - Item 4 (delayed prune): when h7 also leaves, no sibling on the LAN has
+      downstream receivers. r2 must wait for the LAN override window before
+      dropping r2-eth2 from its OIL.
+
+    - Graft: re-joining h4 after the LAN branch pruned must restore the r4 path.
+
+    Topology (r7 added on shared 10.0.2.0/24 with r2 and r4):
+      h1 -> r1 -> r2 === 10.0.2 LAN (r2-eth2, r4-eth0, r7-eth0) === r4 -> h4
+                                   |
+                                   +-> r7 -> h7
+
+    Uses a dedicated group so earlier tests cannot leave stale (S,G) state.
+    """
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    group = "239.8.8.8"
+
+    stop_all_hosts()
+
+    step("Join receivers on h4 and h7, then start dense traffic from h1")
+    for host, intf in (
+        ("h4", "h4-eth0"),
+        ("h7", "h7-eth0"),
+    ):
+        result = app_helper.run_join(host, group, join_intf=intf)
+        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    result = app_helper.run_traffic("h1", group, bind_intf="h1-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify r2 floods on the shared LAN and both receivers get traffic")
+    lan_setup = {
+        "r2": ("r2-eth0", "r2-eth2"),
+        "r4": ("r4-eth0", "r4-eth1"),
+        "r7": ("r7-eth0", "r7-eth1"),
+    }
+    for router, (iif, oil) in lan_setup.items():
+        _, result = topotest.run_and_expect(
+            functools.partial(check_mroute_oil, tgen, router, SRC, group, iif, oil),
+            None,
+            count=30,
+            wait=2,
+        )
+        assert result is None, "LAN setup failed on {}: {}".format(router, result)
+
+    step("Stop h4 so r4 Prunes on the shared LAN while r7 still has h7")
+    app_helper.stop_host("h4")
+
+    step("Wait until r4 has no IGMP membership for the group")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_igmp_group_absent, tgen, "r4", "r4-eth1", group),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "r4 still has IGMP membership after h4 leave: {}".format(
+        result
+    )
+
+    step("Verify the h7 branch stays up after r4 Prunes (item 5)")
+    _, result = topotest.run_and_expect(
+        functools.partial(
+            check_mroute_oil, tgen, "r7", SRC, group, "r7-eth0", "r7-eth1"
+        ),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "h7 branch lost after h4 left: {}".format(result)
+
+    step("Verify r2 keeps r2-eth2 in its OIL while r7 Join overrides r4 Prune (item 5)")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_oif_present, tgen, "r2", SRC, group, "r2-eth2"),
+        None,
+        count=15,
+        wait=1,
+    )
+    assert result is None, "LAN join override missing on r2-eth2: {}".format(result)
+
+    step("Stop h7 so no sibling on the LAN has downstream receivers")
+    app_helper.stop_host("h7")
+
+    step("Wait until r7 has no IGMP membership for the group")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_igmp_group_absent, tgen, "r7", "r7-eth1", group),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "r7 still has IGMP membership after h7 leave: {}".format(
+        result
+    )
+
+    step("Verify r2 keeps r2-eth2 in its OIL during the LAN override window (item 4)")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_oif_present, tgen, "r2", SRC, group, "r2-eth2"),
+        None,
+        count=2,
+        wait=1,
+    )
+    assert result is None, "LAN delayed prune missing on r2-eth2: {}".format(result)
+
+    step("Stop the source so continuous flood cannot re-add pruned LAN OIFs")
+    app_helper.stop_host("h1")
+
+    step("Verify r2 eventually stops flooding on the shared LAN")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_oif_absent, tgen, "r2", SRC, group, "r2-eth2"),
+        None,
+        count=30,
+        wait=1,
+    )
+    assert result is None, "r2 still flooding pruned LAN branch: {}".format(result)
+
+    step("Re-join h4, restart traffic, and verify the r4 branch grafts back")
+    result = app_helper.run_join("h4", group, join_intf="h4-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    result = app_helper.run_traffic("h1", group, bind_intf="h1-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    _, result = topotest.run_and_expect(
+        functools.partial(
+            check_mroute_oil, tgen, "r4", SRC, group, "r4-eth0", "r4-eth1"
+        ),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "Graft back to h4 failed: {}".format(result)
 
     stop_all_hosts()
 

--- a/tests/topotests/pim_dense/test_pim_dense.py
+++ b/tests/topotests/pim_dense/test_pim_dense.py
@@ -22,8 +22,6 @@ from lib.topolog import logger
 from lib.common_config import step, write_test_header
 
 from lib.pim import (
-    verify_mroutes,
-    verify_upstream_iif,
     verify_pim_neighbors,
     McastTesterHelper,
 )
@@ -52,10 +50,21 @@ TOPOLOGY = """
  10.101.0.0/24   |                             |   10.0.0.0/24
                  |                             |
     r4-eth1 (p)  | .1                          | .2 r2-eth0 (d)
-              +--+--+      10.0.2.0/24      +--+--+
-              | R4  |-----------------------| R2  |
-              +--+--+ .2                 .1 +--+--+
-                  r4-eth0 (d)    r2-eth2 (sd)  | .1 r2-eth1 (sd)
+              +--+--+   10.0.2.0/24 (shared) +--+--+
+              | R4  |-------+--------+-------| R2  |
+              +--+--+ .2    |             .1 +--+--+
+              r4-eth0 (d)   |    r2-eth2 (sd)  | .1 r2-eth1 (sd)
+              r7-eth0 (d)   |                  |
+                        +--+--+                |
+                        | R7  |                |
+                        +--+--+                |
+               r7-eth1 (p) | .3                |
+        10.104.0.0/24      |                   |
+                           |                   |
+               h7-eth0     | .2                |
+                        +--+--+                |
+                        | H7  |                |
+                        +--+--+                |
                                                |
                                                |   10.0.1.0.24
                                                |
@@ -99,20 +108,26 @@ def build_topo(tgen):
     tgen.add_router("r4")
     tgen.add_router("r5")
     tgen.add_router("r6")
+    tgen.add_router("r7")
     tgen.add_host("h1", "10.100.0.2/24", "via 10.100.0.1")
     tgen.add_host("h4", "10.101.0.2/24", "via 10.101.0.1")
     tgen.add_host("h5", "10.102.0.2/24", "via 10.102.0.1")
     tgen.add_host("h6", "10.103.0.2/24", "via 10.103.0.1")
+    tgen.add_host("h7", "10.104.0.2/24", "via 10.104.0.1")
 
     # Create topology links
     tgen.add_link(tgen.gears["h1"], tgen.gears["r1"], "h1-eth0", "r1-eth1")
     tgen.add_link(tgen.gears["h4"], tgen.gears["r4"], "h4-eth0", "r4-eth1")
     tgen.add_link(tgen.gears["h5"], tgen.gears["r5"], "h5-eth0", "r5-eth1")
     tgen.add_link(tgen.gears["h6"], tgen.gears["r6"], "h6-eth0", "r6-eth1")
+    tgen.add_link(tgen.gears["h7"], tgen.gears["r7"], "h7-eth0", "r7-eth1")
     tgen.add_link(tgen.gears["r1"], tgen.gears["r2"], "r1-eth0", "r2-eth0")
     tgen.add_link(tgen.gears["r1"], tgen.gears["r3"], "r1-eth2", "r3-eth3")
     tgen.add_link(tgen.gears["r2"], tgen.gears["r3"], "r2-eth1", "r3-eth0")
-    tgen.add_link(tgen.gears["r2"], tgen.gears["r4"], "r2-eth2", "r4-eth0")
+    switch = tgen.add_switch("s02")
+    switch.add_link(tgen.gears["r2"], nodeif="r2-eth2")
+    switch.add_link(tgen.gears["r4"], nodeif="r4-eth0")
+    switch.add_link(tgen.gears["r7"], nodeif="r7-eth0")
     tgen.add_link(tgen.gears["r3"], tgen.gears["r5"], "r3-eth1", "r5-eth0")
     tgen.add_link(tgen.gears["r3"], tgen.gears["r6"], "r3-eth2", "r6-eth0")
 
@@ -191,6 +206,11 @@ def test_pim_dense_neighbors(request):
                     "neighbor": "10.0.2.2",
                     "drPriority": 1,
                 },
+                "10.0.2.3": {
+                    "interface": "r2-eth2",
+                    "neighbor": "10.0.2.3",
+                    "drPriority": 1,
+                },
             },
         },
         "r3": {
@@ -230,6 +250,25 @@ def test_pim_dense_neighbors(request):
                     "neighbor": "10.0.2.1",
                     "drPriority": 1,
                 },
+                "10.0.2.3": {
+                    "interface": "r4-eth0",
+                    "neighbor": "10.0.2.3",
+                    "drPriority": 1,
+                },
+            },
+        },
+        "r7": {
+            "r7-eth0": {
+                "10.0.2.1": {
+                    "interface": "r7-eth0",
+                    "neighbor": "10.0.2.1",
+                    "drPriority": 1,
+                },
+                "10.0.2.2": {
+                    "interface": "r7-eth0",
+                    "neighbor": "10.0.2.2",
+                    "drPriority": 1,
+                },
             },
         },
         "r5": {
@@ -267,7 +306,7 @@ def test_pim_dense_neighbors(request):
 
 def stop_all_hosts():
     """Stop multicast traffic and IGMP joins on all hosts."""
-    for host in ("h1", "h4", "h5", "h6"):
+    for host in ("h1", "h4", "h5", "h6", "h7"):
         app_helper.stop_host(host)
 
 
@@ -317,6 +356,49 @@ def check_mroute_oil(tgen, router, src, group, iif, oil):
     return None
 
 
+def check_upstream_join(tgen, router, src, group, iif, join_state):
+    """Return None if upstream IIF and joinState match. No @retry."""
+    output = tgen.gears[router].vtysh_cmd("show ip pim upstream json", isjson=True)
+    entry = output.get(group, {}).get(src)
+    if not entry:
+        return "No upstream ({},{}) on {}".format(src, group, router)
+    if entry.get("joinState") != join_state:
+        return "joinState on {}: expected {}, got {}".format(
+            router, join_state, entry.get("joinState")
+        )
+    if isinstance(iif, str):
+        iif = [iif]
+    inbound = entry.get("inboundInterface")
+    if inbound not in iif:
+        return "IIF on {}: expected {}, got {}".format(router, iif, inbound)
+    return None
+
+
+def expect_dense_state(tgen, tc_name, state_dict, count=20, wait=1, check_join=True):
+    """Poll mroute OIL and upstream joinState. Fails in count*wait seconds."""
+    for dut, data in state_dict.items():
+
+        def _check(dut=dut, data=data):
+            err = check_mroute_oil(
+                tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
+            )
+            if err:
+                return err
+            if not check_join or "joinState" not in data:
+                return None
+            return check_upstream_join(
+                tgen,
+                dut,
+                data["src_address"],
+                DENSE_GROUP,
+                data["iif"],
+                data["joinState"],
+            )
+
+        _, result = topotest.run_and_expect(_check, None, count=count, wait=wait)
+        assert result is None, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+
 def check_mroute_iif(tgen, router, src, group, iif):
     """Return None once (S,G) is installed on router with the expected iif.
 
@@ -334,6 +416,42 @@ def check_mroute_iif(tgen, router, src, group, iif):
         return "Unexpected iif on {}: {} (expected {})".format(
             router, entry.get("iif"), iif
         )
+    return None
+
+
+def check_mroute_oif_present(tgen, router, src, group, oif):
+    """Return None if (S,G) OIL on router includes oif, else an error string."""
+    entry = mroute_entry(tgen, router, src, group)
+    if not entry or entry.get("installed", 0) == 0:
+        return "No installed mroute for ({},{}) on {}".format(src, group, router)
+    oil_names = mroute_oil_names(entry)
+    if oif not in oil_names:
+        return "Expected OIF {} on {}, got {}".format(oif, router, oil_names)
+    return None
+
+
+def check_mroute_oif_absent(tgen, router, src, group, oif):
+    """Return None if (S,G) OIL on router does not include oif."""
+    entry = mroute_entry(tgen, router, src, group)
+    if not entry or entry.get("installed", 0) == 0:
+        return None
+    oil_names = mroute_oil_names(entry)
+    if oif in oil_names:
+        return "Unexpected OIF {} still on {}, OIL {}".format(oif, router, oil_names)
+    return None
+
+
+def check_igmp_group_absent(tgen, router, interface, group):
+    """Return None when interface has no IGMP membership for group."""
+    output = tgen.gears[router].vtysh_cmd("show ip igmp groups json", isjson=True)
+    iface = output.get(interface)
+    if not iface:
+        return None
+    for entry in iface.get("groups", []):
+        if entry.get("group") == group:
+            return "IGMP group {} still present on {} {}".format(
+                group, router, interface
+            )
     return None
 
 
@@ -454,40 +572,18 @@ def test_pim_dense_flood_prune(request):
             "src_address": "10.100.0.2",
             "iif": "r2-eth0",
             "oil": "none",
-            "joinState": "Joined",
+            "joinState": "NotJoined",
         },
         "r3": {
             "src_address": "10.100.0.2",
             "iif": "r3-eth0",
             "oil": "none",
-            "joinState": "Joined",
+            "joinState": "NotJoined",
         },
     }
 
-    step("Verify 'show ip mroute' showing routes with no OIL on all the nodes")
-    for dut, data in prune_dict.items():
-
-        def _check_pruned(dut=dut, data=data):
-            return check_mroute_oil(
-                tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-            )
-
-        _, result = topotest.run_and_expect(_check_pruned, None, count=30, wait=2)
-        assert result is None, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    step(
-        "Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes"
-    )
-    for dut, data in prune_dict.items():
-        result = verify_upstream_iif(
-            tgen,
-            dut,
-            data["iif"],
-            data["src_address"],
-            DENSE_GROUP,
-            joinState=data["joinState"],
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    step("Verify pruned mroutes and joinState on r1/r2/r3")
+    expect_dense_state(tgen, tc_name, prune_dict, count=30, wait=2)
 
 
 def test_pim_dense_graft_r4(request):
@@ -513,7 +609,7 @@ def test_pim_dense_graft_r4(request):
             "src_address": "10.100.0.2",
             "iif": "r3-eth0",
             "oil": "none",
-            "joinState": "Joined",
+            "joinState": "NotJoined",
         },
         "r2": {
             "src_address": "10.100.0.2",
@@ -530,25 +626,7 @@ def test_pim_dense_graft_r4(request):
     }
 
     step("Verify 'show ip mroute' showing routes just to R4")
-    for dut, data in graft_dict.items():
-        result = verify_mroutes(
-            tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    step(
-        "Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes"
-    )
-    for dut, data in graft_dict.items():
-        result = verify_upstream_iif(
-            tgen,
-            dut,
-            data["iif"],
-            data["src_address"],
-            DENSE_GROUP,
-            joinState=data["joinState"],
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    expect_dense_state(tgen, tc_name, graft_dict)
 
 
 def test_pim_dense_graft_r5(request):
@@ -597,25 +675,7 @@ def test_pim_dense_graft_r5(request):
     }
 
     step("Verify 'show ip mroute' showing routes to R4 and R5")
-    for dut, data in graft_dict.items():
-        result = verify_mroutes(
-            tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    step(
-        "Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes"
-    )
-    for dut, data in graft_dict.items():
-        result = verify_upstream_iif(
-            tgen,
-            dut,
-            data["iif"],
-            data["src_address"],
-            DENSE_GROUP,
-            joinState=data["joinState"],
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    expect_dense_state(tgen, tc_name, graft_dict)
 
 
 def test_pim_dense_graft_r6(request):
@@ -670,25 +730,7 @@ def test_pim_dense_graft_r6(request):
     }
 
     step("Verify 'show ip mroute' showing routes to R4 and R5 and R6")
-    for dut, data in graft_dict.items():
-        result = verify_mroutes(
-            tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    step(
-        "Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes"
-    )
-    for dut, data in graft_dict.items():
-        result = verify_upstream_iif(
-            tgen,
-            dut,
-            data["iif"],
-            data["src_address"],
-            DENSE_GROUP,
-            joinState=data["joinState"],
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    expect_dense_state(tgen, tc_name, graft_dict)
 
 
 def test_pim_dense_prune_r4(request):
@@ -737,16 +779,7 @@ def test_pim_dense_prune_r4(request):
     }
 
     step("Verify 'show ip mroute' showing routes to R5 and R6")
-    for dut, data in prune_dict.items():
-        result = verify_mroutes(
-            tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    # step("Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes")
-    # for dut, data in prune_dict.items():
-    #     result = verify_upstream_iif(tgen, dut, data["iif"], data["src_address"], DENSE_GROUP, joinState=data["joinState"])
-    #     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    expect_dense_state(tgen, tc_name, prune_dict, check_join=False)
 
 
 def test_pim_dense_prune_r5(request):
@@ -789,16 +822,7 @@ def test_pim_dense_prune_r5(request):
     }
 
     step("Verify 'show ip mroute' showing routes to R6")
-    for dut, data in prune_dict.items():
-        result = verify_mroutes(
-            tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    # step("Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes")
-    # for dut, data in prune_dict.items():
-    #     result = verify_upstream_iif(tgen, dut, data["iif"], data["src_address"], DENSE_GROUP, joinState=data["joinState"])
-    #     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    expect_dense_state(tgen, tc_name, prune_dict, check_join=False)
 
 
 def test_pim_dense_prune_r6(request):
@@ -829,20 +853,7 @@ def test_pim_dense_prune_r6(request):
     }
 
     step("Verify 'show ip mroute' showing routes with no OIL")
-    for dut, data in prune_dict.items():
-        result = verify_mroutes(
-            tgen, dut, data["src_address"], DENSE_GROUP, data["iif"], data["oil"]
-        )
-        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
-
-    # TODO
-    # Moving to not joined state on R1 takes like 30 seconds, then after that, R2 takes
-    # another 2 minutes until it moves to not joined state...that is entirely too long.
-    # After the leave it should be pretty immediate to go to not joined
-    # step("Verify 'show ip pim upstream' showing correct IIF and join state on all the nodes")
-    # for dut, data in prune_dict.items():
-    #     result = verify_upstream_iif(tgen, dut, data["iif"], data["src_address"], DENSE_GROUP, joinState=data["joinState"])
-    #     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    expect_dense_state(tgen, tc_name, prune_dict, check_join=False)
 
 
 def verify_mroute_pimreg_absent(tgen, router, group, group_type):
@@ -1512,6 +1523,153 @@ def test_pim_dense_to_sparse_on_rp_add(request):
                 no rp 10.0.2.1 239.0.0.0/8
             """
         )
+
+    stop_all_hosts()
+
+
+def test_pim_dense_lan_prune_with_active_branch(request):
+    """Verify LAN prune/override on the shared 10.0.2.0/24 segment (r2, r4, r7).
+
+    RFC 3973 items 4 and 5 with three PIM routers on one multi-access LAN:
+
+    - Item 5 (join override): when h4 leaves, r4 Prunes on the LAN but r7 still
+      has h7 joined. r7 must override so r2 keeps flooding on r2-eth2 and h7
+      keeps receiving.
+
+    - Item 4 (delayed prune): when h7 also leaves, no sibling on the LAN has
+      downstream receivers. r2 must wait for the LAN override window before
+      dropping r2-eth2 from its OIL.
+
+    - Graft: re-joining h4 after the LAN branch pruned must restore the r4 path.
+
+    Topology (r7 added on shared 10.0.2.0/24 with r2 and r4):
+      h1 -> r1 -> r2 === 10.0.2 LAN (r2-eth2, r4-eth0, r7-eth0) === r4 -> h4
+                                   |
+                                   +-> r7 -> h7
+
+    Uses a dedicated group so earlier tests cannot leave stale (S,G) state.
+    """
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    group = "239.8.8.8"
+
+    stop_all_hosts()
+
+    step("Join receivers on h4 and h7, then start dense traffic from h1")
+    for host, intf in (
+        ("h4", "h4-eth0"),
+        ("h7", "h7-eth0"),
+    ):
+        result = app_helper.run_join(host, group, join_intf=intf)
+        assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    result = app_helper.run_traffic("h1", group, bind_intf="h1-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify r2 floods on the shared LAN and both receivers get traffic")
+    lan_setup = {
+        "r2": ("r2-eth0", "r2-eth2"),
+        "r4": ("r4-eth0", "r4-eth1"),
+        "r7": ("r7-eth0", "r7-eth1"),
+    }
+    for router, (iif, oil) in lan_setup.items():
+        _, result = topotest.run_and_expect(
+            functools.partial(check_mroute_oil, tgen, router, SRC, group, iif, oil),
+            None,
+            count=30,
+            wait=2,
+        )
+        assert result is None, "LAN setup failed on {}: {}".format(router, result)
+
+    step("Stop h4 so r4 Prunes on the shared LAN while r7 still has h7")
+    app_helper.stop_host("h4")
+
+    step("Wait until r4 has no IGMP membership for the group")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_igmp_group_absent, tgen, "r4", "r4-eth1", group),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "r4 still has IGMP membership after h4 leave: {}".format(
+        result
+    )
+
+    step("Verify the h7 branch stays up after r4 Prunes (item 5)")
+    _, result = topotest.run_and_expect(
+        functools.partial(
+            check_mroute_oil, tgen, "r7", SRC, group, "r7-eth0", "r7-eth1"
+        ),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "h7 branch lost after h4 left: {}".format(result)
+
+    step("Verify r2 keeps r2-eth2 in its OIL while r7 Join overrides r4 Prune (item 5)")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_oif_present, tgen, "r2", SRC, group, "r2-eth2"),
+        None,
+        count=15,
+        wait=1,
+    )
+    assert result is None, "LAN join override missing on r2-eth2: {}".format(result)
+
+    step("Stop h7 so no sibling on the LAN has downstream receivers")
+    app_helper.stop_host("h7")
+
+    step("Wait until r7 has no IGMP membership for the group")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_igmp_group_absent, tgen, "r7", "r7-eth1", group),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "r7 still has IGMP membership after h7 leave: {}".format(
+        result
+    )
+
+    step("Verify r2 keeps r2-eth2 in its OIL during the LAN override window (item 4)")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_oif_present, tgen, "r2", SRC, group, "r2-eth2"),
+        None,
+        count=2,
+        wait=1,
+    )
+    assert result is None, "LAN delayed prune missing on r2-eth2: {}".format(result)
+
+    step("Stop the source so continuous flood cannot re-add pruned LAN OIFs")
+    app_helper.stop_host("h1")
+
+    step("Verify r2 eventually stops flooding on the shared LAN")
+    _, result = topotest.run_and_expect(
+        functools.partial(check_mroute_oif_absent, tgen, "r2", SRC, group, "r2-eth2"),
+        None,
+        count=30,
+        wait=1,
+    )
+    assert result is None, "r2 still flooding pruned LAN branch: {}".format(result)
+
+    step("Re-join h4, restart traffic, and verify the r4 branch grafts back")
+    result = app_helper.run_join("h4", group, join_intf="h4-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+    result = app_helper.run_traffic("h1", group, bind_intf="h1-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    _, result = topotest.run_and_expect(
+        functools.partial(
+            check_mroute_oil, tgen, "r4", SRC, group, "r4-eth0", "r4-eth1"
+        ),
+        None,
+        count=30,
+        wait=2,
+    )
+    assert result is None, "Graft back to h4 failed: {}".format(result)
 
     stop_all_hosts()
 


### PR DESCRIPTION
* Skip Assert on FHR for LAN WRONGVIF so reflected traffic does not leave stale OIFs.
* On IGMP/MLD leave, clear flood-installed dense (S,G) OIFs and prune upstream.
* On multi-access LANs, delay OIF removal for the JP override window and Join-override when a sibling still has receivers (RFC 3973).
* Stop dense-pruned upstreams from sending sparse Join refreshes that cancel prune-pending.