### PR TITLE
ci: set GH_REPO for label workflows using gh

### DIFF
--- a/.github/workflows/base-branch-label.yml
+++ b/.github/workflows/base-branch-label.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Add base branch label
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_LABEL: ${{ github.event.pull_request.base.ref }}
         run: gh pr edit "$PR_NUMBER" --add-label "$BASE_LABEL"

--- a/.github/workflows/behind-base.yml
+++ b/.github/workflows/behind-base.yml
@@ -31,5 +31,6 @@ jobs:
         if: ${{ steps.vars.outputs.behind_by > 50 }}
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr edit "$PR_NUMBER" --add-label rebase

--- a/.github/workflows/mergifyio_backport.yml
+++ b/.github/workflows/mergifyio_backport.yml
@@ -14,6 +14,7 @@ jobs:
         if: ${{ github.event.issue.pull_request && github.event.comment.body }}
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |


### PR DESCRIPTION
gh pr edit has no repository context when these jobs skip checkout, so set GH_REPO explicitly.