### PR TITLE
tools: frr-reload.py: log and flush before config operations

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -2658,6 +2658,12 @@ if __name__ == "__main__":
             # apply to other scenarios as well where configuring FOO adds BAR
             # to the config.
             if lines_to_del and x == 0:
+                log.info("lines_to_del content\n%s", pformat(lines_to_del))
+
+                # Flush log before executing deletes so content is preserved if crash occurs
+                for handler in log.handlers:
+                    handler.flush()
+
                 for ctx_keys, line in lines_to_del:
                     if line == "!":
                         continue
@@ -2709,7 +2715,6 @@ if __name__ == "__main__":
                             new_last_arg = last_arg[0:-1]
                             cmd[-1] = " ".join(new_last_arg)
                         else:
-                            log.info(f'Executed "{" ".join(cmd)}"')
                             break
 
             if lines_to_add:
@@ -2737,6 +2742,10 @@ if __name__ == "__main__":
 
                     filename = args.rundir + "/reload-%s.txt" % random_string
                     log.info(f"{filename} content\n{pformat(lines_to_configure)}")
+
+                    # Flush log before vtysh.exec_file() so content is preserved if crash occurs
+                    for handler in log.handlers:
+                        handler.flush()
 
                     with open(filename, "w") as fh:
                         for line in lines_to_configure:


### PR DESCRIPTION
Currently, when a crash occurs during frr-reload.py config loading,
the log may not contain the commands that were being executed:

- ADD operations are logged upfront but the buffer may not be
  flushed to disk before a crash.

- DELETE operations are logged only after successful execution,
  so a crash during DELETE leaves no trace of what was attempted.

Fix by:
- Logging DELETE commands upfront, consistent with ADD.
- Flushing log handlers before both ADD and DELETE operations.

This ensures log content is preserved on disk if a crash occurs
during config loading. The per-command success log for DELETE is
removed to avoid double logging, consistent with ADD. No critical
info is lost since error logs for failed commands are retained.