### PR TITLE
lib: fix wrong nexthop comparision for SRv6

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -100,9 +100,11 @@ static int _nexthop_srv6_cmp(const struct nexthop *nh1,
 	if (ret != 0)
 		return ret;
 
-	if (nh1->nh_srv6->seg6_segs->num_segs !=
-	    nh2->nh_srv6->seg6_segs->num_segs)
+	if (nh1->nh_srv6->seg6_segs->num_segs < nh2->nh_srv6->seg6_segs->num_segs)
 		return -1;
+
+	if (nh1->nh_srv6->seg6_segs->num_segs > nh2->nh_srv6->seg6_segs->num_segs)
+		return 1;
 
 	for (i = 0; i < nh1->nh_srv6->seg6_segs->num_segs; i++) {
 		ret = memcmp(&nh1->nh_srv6->seg6_segs->seg[i],


### PR DESCRIPTION
This returns -1 regardless of which nexthop has more segments. Sorted insertion produces non-deterministic order when the two nexthops have different "num_segs".