### PR TITLE
tools: Have checkpatch tell developer to use snprintfrr

### DIFF
--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -7568,6 +7568,12 @@ sub process {
 			ERROR("BZERO",
 			      "bzero() is deprecated; use memset()"  . $herecurr);
 		}
+
+# check for use of snprintf()
+		if ($line =~ /\bsnprintf\s*\(.*\)/) {
+			ERROR("SNPRINTF",
+			      "snprintf() does not support FRR format extensions; please use snprintfrr()\n" . $herecurr);
+		}
 	}
 
 	# If we have no input at all, then there is nothing to report on

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -7540,37 +7540,37 @@ sub process {
 		}
 
 # check for use of strcpy()
-		if ($line =~ /\bstrcpy\s*\(.*\)/) {
+		if ($line =~ /\bstrcpy\s*\(/) {
 			ERROR("STRCPY",
 			      "strcpy() is error-prone; please use strlcpy()"  . $herecurr);
 		}
 
 # check for use of strncpy()
-		if ($line =~ /\bstrncpy\s*\(.*\)/) {
+		if ($line =~ /\bstrncpy\s*\(/) {
 			WARN("STRNCPY",
 			     "strncpy() is error-prone; please use strlcpy() if possible, or memcpy()"  . $herecurr);
 		}
 
 # check for use of strcat()
-		if ($line =~ /\bstrcat\s*\(.*\)/) {
+		if ($line =~ /\bstrcat\s*\(/) {
 			ERROR("STRCAT",
 			      "strcat() is error-prone; please use strlcat() if possible"  . $herecurr);
 		}
 
 # check for use of strncat()
-		if ($line =~ /\bstrncat\s*\(.*\)/) {
+		if ($line =~ /\bstrncat\s*\(/) {
 			WARN("STRNCAT",
 			     "strncat() is error-prone; please use strlcat() if possible"  . $herecurr);
 		}
 
 # check for use of bzero()
-		if ($line =~ /\bbzero\s*\(.*\)/) {
+		if ($line =~ /\bbzero\s*\(/) {
 			ERROR("BZERO",
 			      "bzero() is deprecated; use memset()"  . $herecurr);
 		}
 
 # check for use of snprintf()
-		if ($line =~ /\bsnprintf\s*\(.*\)/) {
+		if ($line =~ /\bsnprintf\s*\(/) {
 			ERROR("SNPRINTF",
 			      "snprintf() does not support FRR format extensions; please use snprintfrr()\n" . $herecurr);
 		}


### PR DESCRIPTION
Currently snprintf does not fully understand the list of extensions that we have to printf.  Instead of causing problems or having further bifurcation where somepeople use snprintf and some people use snprintfrr let's just make all new code use snprintfrr instead.