### PR TITLE
zebra: guard against NULL nlsock in netlink_talk_info

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1062,6 +1062,12 @@ static int netlink_talk_info(netlink_parse_filter_t filter, struct nlmsghdr *n,
 	struct nlsock *nl;
 
 	nl = kernel_netlink_nlsock_lookup(dp_info->sock);
+	if (nl == NULL) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: no netlink socket for sock %d; dataplane disabled, skipping",
+				   __func__, dp_info->sock);
+		return -1;
+	}
 	n->nlmsg_seq = dp_info->seq;
 	n->nlmsg_pid = nl->snl.nl_pid;
 


### PR DESCRIPTION
### Summary

`kernel_netlink_nlsock_lookup()` returns `NULL` when no netlink socket is
registered for a namespace. This is the case once a dataplane plugin takes over
the FIB and disables the kernel netlink sockets via `zebra_ns_disabled()` (which
unregisters them from the nlsock hash).

In that state, `netlink_talk_info()` dereferenced the lookup result
unconditionally (`nl->snl.nl_pid`) and crashed zebra with a NULL pointer
dereference. The RFC 5549 IPv4 link-local neighbor bookkeeping is one such
caller — `if_nbr_mac_to_ipv4ll_neigh_update() -> kernel_neigh_update() ->
netlink_neigh_update() -> netlink_talk()` — which still uses the legacy
synchronous kernel API rather than the dataplane provider. It fires when an
IPv6 Router Advertisement is received on an unnumbered interface.

This PR guards the lookup and fails the operation gracefully instead of
crashing. Programming through the kernel is a no-op anyway once the namespace
has been handed to an alternate dataplane.

No test is added: the crash is only reachable with an out-of-tree dataplane
plugin that disables the kernel namespace, so there is no in-tree topotest that
can exercise it meaningfully.

### Related Issue

Discovered while adding IPv6 Router Advertisement punting to the
[grout](https://github.com/DPDK/grout) dataplane (grout's `dplane_grout` zebra
plugin calls `zebra_ns_disabled()`):

- grout issue: https://github.com/DPDK/grout/issues/657
- companion grout PR (RA punt datapath fix): https://github.com/DPDK/grout/pull/658

With this guard in place, v4-over-v6 (RFC 5549) unnumbered BGP over grout works
end to end — the IPv4 prefix installs into grout's FIB with a resolved IPv6
link-local nexthop, and zebra no longer crashes.

### Components

zebra
