### PR TITLE
lib: Fix ZAPI SRv6 nexthop comparison

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -993,8 +993,13 @@ static int zapi_nexthop_srv6_cmp(const struct zapi_nexthop *next1,
 {
 	int ret = 0;
 
-	ret = memcmp(&next1->seg6_segs, &next2->seg6_segs,
-		     sizeof(struct in6_addr));
+	if (next1->seg_num > next2->seg_num)
+		return 1;
+
+	if (next1->seg_num < next2->seg_num)
+		return -1;
+
+	ret = memcmp(next1->seg6_segs, next2->seg6_segs, next1->seg_num * sizeof(struct in6_addr));
 	if (ret != 0)
 		return ret;
 


### PR DESCRIPTION
`zapi_nexthop_srv6_cmp()` only compared the first SRv6 segment and ignored `seg_num`. This could make different SRv6 segment lists compare equal during ZAPI nexthop sorting.

Compare `seg_num` first, then compare all SRv6 segments present in the nexthop.