### PR TITLE
zebra: route IPv4 link-local neighbor updates through the dplane

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -37,6 +37,7 @@
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_trace.h"
 #include "zebra/zebra_l2.h"
+#include "zebra/zebra_dplane.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZINFO, "Zebra Interface Information");
 
@@ -862,22 +863,22 @@ void if_nbr_mac_to_ipv4ll_neigh_update(struct interface *ifp,
 				       struct in6_addr *address,
 				       int add)
 {
+	struct ipaddr ip = {.ipa_type = IPADDR_V4};
 	struct zebra_vrf *zvrf = ifp->vrf->info;
 	struct zebra_if *zif = ifp->info;
 	char buf[16] = "169.254.0.1";
 	struct in_addr ipv4_ll;
-	ns_id_t ns_id;
+	struct ethaddr ethaddr;
 
 	inet_pton(AF_INET, buf, &ipv4_ll);
-
-	ns_id = zvrf->zns->ns_id;
+	ip.ipaddr_v4 = ipv4_ll;
+	memcpy(&ethaddr, mac, ETH_ALEN);
 
 	/*
 	 * Remove and re-add any existing neighbor entry for this address,
 	 * since Netlink doesn't currently offer update message types.
 	 */
-	kernel_neigh_update(0, ifp->ifindex, (void *)&ipv4_ll.s_addr, mac, 6,
-			    ns_id, AF_INET, true);
+	dplane_rem_neigh_delete(ifp, &ip);
 
 	/* Add new neighbor entry.
 	 *
@@ -889,8 +890,7 @@ void if_nbr_mac_to_ipv4ll_neigh_update(struct interface *ifp,
 	 * they'll be useless to us.
 	 */
 	if (add)
-		kernel_neigh_update(add, ifp->ifindex, (void *)&ipv4_ll.s_addr,
-				    mac, 6, ns_id, AF_INET, true);
+		dplane_local_neigh_add(ifp, &ip, &ethaddr, false, true, false);
 
 	memcpy(&zif->neigh_mac[0], &mac[0], 6);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -37,6 +37,7 @@
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_trace.h"
 #include "zebra/zebra_l2.h"
+#include "zebra/zebra_dplane.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZINFO, "Zebra Interface Information");
 
@@ -875,22 +876,22 @@ void if_nbr_mac_to_ipv4ll_neigh_update(struct interface *ifp,
 				       struct in6_addr *address,
 				       int add)
 {
+	struct ipaddr ip = {.ipa_type = IPADDR_V4};
 	struct zebra_vrf *zvrf = ifp->vrf->info;
 	struct zebra_if *zif = ifp->info;
 	char buf[16] = "169.254.0.1";
 	struct in_addr ipv4_ll;
-	ns_id_t ns_id;
+	struct ethaddr ethaddr;
 
 	inet_pton(AF_INET, buf, &ipv4_ll);
-
-	ns_id = zvrf->zns->ns_id;
+	ip.ipaddr_v4 = ipv4_ll;
+	memcpy(&ethaddr, mac, ETH_ALEN);
 
 	/*
 	 * Remove and re-add any existing neighbor entry for this address,
 	 * since Netlink doesn't currently offer update message types.
 	 */
-	kernel_neigh_update(0, ifp->ifindex, (void *)&ipv4_ll.s_addr, mac, 6,
-			    ns_id, AF_INET, true);
+	dplane_rem_neigh_delete(ifp, &ip);
 
 	/* Add new neighbor entry.
 	 *
@@ -902,8 +903,7 @@ void if_nbr_mac_to_ipv4ll_neigh_update(struct interface *ifp,
 	 * they'll be useless to us.
 	 */
 	if (add)
-		kernel_neigh_update(add, ifp->ifindex, (void *)&ipv4_ll.s_addr,
-				    mac, 6, ns_id, AF_INET, true);
+		dplane_local_neigh_add(ifp, &ip, &ethaddr, false, true, false);
 
 	memcpy(&zif->neigh_mac[0], &mac[0], 6);
 


### PR DESCRIPTION
if_nbr_mac_to_ipv4ll_neigh_update() calls kernel_neigh_update() directly, bypassing the dataplane abstraction layer. This causes a crash when zebra is using a non-netlink dplane plugin because the netlink socket is not initialized.

This function creates synthetic ARP entries that map an auto-generated IPv4 link-local address (169.254.0.1) to a MAC derived from the peer's IPv6 link-local address. It is used by BGP unnumbered (RFC 5549).

Use dplane_rem_neigh_delete() and dplane_local_neigh_add() so that the operation is handled by whatever dplane provider is active.