### PR TITLE
tests: fix flaky pim6 topotest by reducing join-prune-interval

### DIFF
--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -254,6 +254,15 @@ def test_pim6_multiple_groups_same_RP_address_p2(request):
 
     result = create_debug_log_config(tgen, input_dict)
 
+    step("Configure shorter join-prune-interval for faster prune propagation")
+    input_dict = {
+        "r1": {"pim6": {"join-prune-interval": "10"}},
+        "r2": {"pim6": {"join-prune-interval": "10"}},
+        "r3": {"pim6": {"join-prune-interval": "10"}},
+    }
+    result = create_pim_config(tgen, TOPO, input_dict)
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
     step("Enable MLD on r1 interface")
     step("Enable the PIM6 on all the interfaces of r1, r2, r3 and r4 routers")
     step("r2: Configure r2 as RP")


### PR DESCRIPTION
The test test_pim6_multiple_groups_same_RP_address_p2 was flaky because it expected joinState=NotJoined on the RP after SPT switchover, but the default PIM join-prune-interval (60s) matched the test retry timeout (60s), causing a race condition.

After SPT switchover, the LHR sends an (S,G) prune to the RP, but this prune is batched in the next join/prune message which could take up to 60 seconds. The test could timeout before the prune was processed.

Fix by configuring a shorter join-prune-interval (10s) so prunes are sent well within the retry timeout.