### PR TITLE
tests: fix OSPF TI-LFA test flakiness by verifying SR convergence

### DIFF
--- a/tests/topotests/ospf_tilfa_topo1/rt1/step1/show_mpls_table.ref
+++ b/tests/topotests/ospf_tilfa_topo1/rt1/step1/show_mpls_table.ref
@@ -1,0 +1,54 @@
+{
+  "16020":{
+    "inLabel":16020,
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "installed":true,
+        "nexthop":"10.0.1.2",
+        "interface":"eth-rt2"
+      }
+    ]
+  },
+  "16030":{
+    "inLabel":16030,
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":3,
+        "installed":true,
+        "nexthop":"10.0.2.2",
+        "interface":"eth-rt3"
+      }
+    ]
+  },
+  "16040":{
+    "inLabel":16040,
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":16040,
+        "installed":true,
+        "nexthop":"10.0.1.2",
+        "interface":"eth-rt2"
+      }
+    ]
+  },
+  "16050":{
+    "inLabel":16050,
+    "installed":true,
+    "nexthops":[
+      {
+        "type":"SR (OSPF)",
+        "outLabel":16050,
+        "installed":true,
+        "nexthop":"10.0.2.2",
+        "interface":"eth-rt3"
+      }
+    ]
+  }
+}

--- a/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
+++ b/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
@@ -130,6 +130,27 @@ def test_ospf_initial_convergence_step1():
     )
 
 
+def test_ospf_sr_convergence_step1b():
+    """
+    Verify SR prefix SIDs are learned before TI-LFA tests.
+
+    This is critical for TI-LFA because backup paths require SR labels.
+    Without this check, TI-LFA tests may fail intermittently when SR
+    labels haven't fully propagated yet.
+    """
+    logger.info("Test (step 1b): check SR label convergence")
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router_compare_json_output(
+        "rt1",
+        "show mpls table json",
+        "step1/show_mpls_table.ref",
+    )
+
+
 def test_ospf_link_protection_step2():
     logger.info("Test (step 2): check OSPF link protection")
     tgen = get_topogen()


### PR DESCRIPTION
The OSPF TI-LFA test can fail intermittently with errors like:
  backupNexthops[0]: expected has key 'labels' which is not present

This happens because TI-LFA backup paths require SR prefix SIDs from neighbor routers. If the test enables TI-LFA before SR labels have fully propagated via OSPF opaque LSAs, the backup nexthops may be computed without valid label stacks.

Add a new test step (step 1b) that verifies the MPLS table contains the expected SR prefix SIDs (16020, 16030, 16040, 16050) before proceeding to TI-LFA tests. This mirrors the approach used by the ISIS TI-LFA test which also verifies MPLS table convergence in step 1.