### PR TITLE
tests: fix flaky OSPF authentication tests by configuring auth before interface up

### DIFF
--- a/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
@@ -294,11 +294,10 @@ def test_ospf_authentication_simple_pass_tc28_p1(request):
     dut = "r1"
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
-    shutdown_bringup_interface(tgen, dut, intf, True)
 
-    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
-    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
-    # packets which R2 rejects.
+    # Configure authentication BEFORE bringing the interface up so R1 sends
+    # authenticated Hellos from the start. Otherwise R1 briefly sends
+    # unauthenticated packets which R2 rejects, causing flaky convergence.
     r1_ospf_auth = {
         "r1": {
             "links": {
@@ -309,6 +308,7 @@ def test_ospf_authentication_simple_pass_tc28_p1(request):
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
+    shutdown_bringup_interface(tgen, dut, intf, True)
     clear_ospf(tgen, "r1")
 
     step(
@@ -507,11 +507,10 @@ def test_ospf_authentication_md5_tc29_p1(request):
     dut = "r1"
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
-    shutdown_bringup_interface(tgen, dut, intf, True)
 
-    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
-    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
-    # packets which R2 rejects.
+    # Configure authentication BEFORE bringing the interface up so R1 sends
+    # authenticated Hellos from the start. Otherwise R1 briefly sends
+    # unauthenticated packets which R2 rejects, causing flaky convergence.
     r1_ospf_auth = {
         "r1": {
             "links": {
@@ -528,6 +527,7 @@ def test_ospf_authentication_md5_tc29_p1(request):
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
+    shutdown_bringup_interface(tgen, dut, intf, True)
     clear_ospf(tgen, "r1")
 
     step(
@@ -741,11 +741,10 @@ def test_ospf_authentication_md5_keychain_tc30_p1(request):
     dut = "r1"
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
-    shutdown_bringup_interface(tgen, dut, intf, True)
 
-    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
-    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
-    # packets which R2 rejects.
+    # Configure authentication BEFORE bringing the interface up so R1 sends
+    # authenticated Hellos from the start. Otherwise R1 briefly sends
+    # unauthenticated packets which R2 rejects, causing flaky convergence.
     router1.vtysh_cmd(
         """configure terminal
            key chain auth
@@ -768,6 +767,7 @@ def test_ospf_authentication_md5_keychain_tc30_p1(request):
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
+    shutdown_bringup_interface(tgen, dut, intf, True)
     clear_ospf(tgen, "r1")
 
     step(
@@ -981,11 +981,10 @@ def test_ospf_authentication_sha256_keychain_tc32_p1(request):
     dut = "r1"
     intf = topo["routers"]["r1"]["links"]["r2"]["interface"]
     shutdown_bringup_interface(tgen, dut, intf, False)
-    shutdown_bringup_interface(tgen, dut, intf, True)
 
-    # Configure authentication BEFORE clear_ospf so R1 sends authenticated
-    # Hellos from the start. Otherwise R1 briefly sends unauthenticated
-    # packets which R2 rejects.
+    # Configure authentication BEFORE bringing the interface up so R1 sends
+    # authenticated Hellos from the start. Otherwise R1 briefly sends
+    # unauthenticated packets which R2 rejects, causing flaky convergence.
     router1.vtysh_cmd(
         """configure terminal
            key chain auth
@@ -1008,6 +1007,7 @@ def test_ospf_authentication_sha256_keychain_tc32_p1(request):
     result = config_ospf_interface(tgen, topo, r1_ospf_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
+    shutdown_bringup_interface(tgen, dut, intf, True)
     clear_ospf(tgen, "r1")
 
     step(


### PR DESCRIPTION
The OSPF authentication tests (tc28, tc29, tc30, tc32) were flaky because authentication was configured AFTER bringing the interface up. This created a window where R1 sent unauthenticated Hello packets that R2 (with authentication configured) would reject.

The sequence was:
1. reset_config_on_routers() - removes R1's authentication config
2. shutdown_bringup_interface(False) - interface down
3. shutdown_bringup_interface(True) - interface up (R1 starts sending unauthenticated Hellos)
4. config_ospf_interface() - configure authentication (too late)
5. clear_ospf() - restart OSPF

Fix by moving authentication configuration between interface shutdown and bringup:
1. reset_config_on_routers() - removes R1's authentication config
2. shutdown_bringup_interface(False) - interface down
3. config_ospf_interface() - configure authentication while down
4. shutdown_bringup_interface(True) - interface up (R1 sends authenticated Hellos from the start)
5. clear_ospf() - restart OSPF

This ensures R1 sends authenticated packets from the first Hello after the interface comes up, eliminating the authentication mismatch window.