### PR TITLE
tests: fix flaky pim6_mld_join_toggle test by waiting for RPF resolution

### DIFF
--- a/tests/topotests/pim6_mld_join_toggle/test_pim6_mld_join_toggle.py
+++ b/tests/topotests/pim6_mld_join_toggle/test_pim6_mld_join_toggle.py
@@ -130,6 +130,22 @@ interface r2-eth1
 """.format(GROUP6, SOURCE6)
     )
 
+    # First wait for RPF to be resolved (inboundInterface != "Unknown")
+    def _rpf_resolved():
+        ups = _json_cmd("r2", "show ipv6 pim upstream json")
+        if ups is None:
+            return "r2: unparseable v6 pim upstream JSON (pim6d dead?)"
+        sg = ups.get(GROUP6, {}).get(SOURCE6, {})
+        if not sg:
+            return "r2 (S,G) upstream not created yet: {}".format(ups)
+        iif = sg.get("inboundInterface", "Unknown")
+        if iif == "Unknown":
+            return "r2 (S,G) upstream RPF not resolved yet (iif=Unknown): {}".format(ups)
+        return None
+
+    _, result = topotest.run_and_expect(_rpf_resolved, None, count=60, wait=1)
+    assert result is None, result
+
     def _baseline():
         data = _json_cmd("r2", "show ipv6 pim local-membership json")
         if data is None:


### PR DESCRIPTION
The test_baseline_join test was flaky because it checked for the upstream to be in "Joined" state without first ensuring that the RPF (Reverse Path Forwarding) path was resolved.

When the join-group command is issued, the upstream is created and immediately tries to resolve RPF. If the NHT response from zebra hasn't arrived yet, or if there's a timing issue with neighbor secondary address availability, the RPF lookup fails. With inboundInterface = NULL, pim_upstream_switch() returns early without changing state to "Joined", even though drJoinDesired is true.

Fix this by adding an explicit wait for the inboundInterface to be resolved (not "Unknown") before checking for the "Joined" state.