### PR TITLE
tests: Fix logging ending up in mgmtd.log

### DIFF
--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -185,9 +185,6 @@ def test_get_config(tgen):
     ]
   },
   "frr-logging:logging": {
-    "file": {
-      "filename": "mgmtd.log"
-    },
     "record-priority": true,
     "timestamp-precision": 6
   }

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -1005,9 +1005,7 @@ class TopoRouter(TopoGear):
                 self.vtysh_cmd(
                     "\n".join(
                         [
-                            "clear log cmdline-targets",
                             "conf t",
-                            "log file {}.log debug".format(daemon),
                             "log commands",
                             "log timestamp precision 6",
                         ]

--- a/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
+++ b/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
@@ -215,7 +215,7 @@ def test_rip_bfd_convergence(tgen):
                 }
             ],
         },
-        6,
+        15,
     )
 
     expect_routes(
@@ -225,7 +225,7 @@ def test_rip_bfd_convergence(tgen):
             "10.254.254.2/32": None,
             "10.254.254.100/32": [{"code": "S", "subCode": "r", "from": "self"}],
         },
-        6,
+        15,
     )
 
 
@@ -235,8 +235,8 @@ def test_rip_log_neighbor_changes(tgen):
     def poll_r1_mgmtd_log(expression):
         "Helper function to poll the log file"
 
-        r1_mgmtd_log = tgen.gears["r1"].net.getLog("log", "mgmtd")
-        if re.search(expression, r1_mgmtd_log) is None:
+        r1_ripd_log = tgen.gears["r1"].net.getLog("log", "ripd")
+        if re.search(expression, r1_ripd_log) is None:
             return False
         else:
             return True


### PR DESCRIPTION
Currently the two lines:
clear log cmdline-targets
log file <daemon>.log

Being passed to every daemon upon startup end up causing all daemons that use mgmtd for logging to have their log files in mgmtd.log in the topotests.  This is happening because the `clear log cmdline-targets` causes the daemons cli `--log-file <daemon>.log` to be removed from configuration and then since mgmtd is sent last in the loop in topogens.py all daemons use that now.  Since we have log files already configured by all the topotests already there is no need for these two lines.  Let's remove them.  Log files start appearing back in the their respective <daemon>.log file again.