### PR TITLE
bfdd: declare bg_session_count as unsigned

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -539,7 +539,7 @@ struct bfd_vrf_global {
 	struct event *bg_ev[7];
 
 	/** Number of active BFD sessions using this VRF's sockets. */
-	int bg_session_count;
+	unsigned int bg_session_count;
 
 	/** Number of SBFD reflectors using this VRF's sockets. */
 	int bg_reflector_count;


### PR DESCRIPTION
bg_session_count is a non-negative reference count of the active BFD sessions sharing a VRF's listening sockets. Declare it unsigned to make that intent explicit. No functional change: the value is already guarded by > 0 checks, so it can never go negative.