### PR TITLE
lib: Clear seg6local context when deleting seg6local state

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -711,6 +711,7 @@ void nexthop_del_srv6_seg6local(struct nexthop *nexthop)
 		return;
 
 	nexthop->nh_srv6->seg6local_action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
+	memset(&nexthop->nh_srv6->seg6local_ctx, 0, sizeof(nexthop->nh_srv6->seg6local_ctx));
 
 	if (nexthop->nh_srv6->seg6_segs &&
 	    (nexthop->nh_srv6->seg6_segs->num_segs == 0 ||


### PR DESCRIPTION
`nexthop_del_srv6_seg6local()` should clean up all seg6local state from a nexthop, including `seg6local_ctx`.

Without this, callers that use `nexthop_del_srv6_seg6local()` to clear seg6local state can still observe stale `seg6local_ctx` information from the previous seg6local state.