### PR TITLE
tests: fix flaky pim6 topotest by reducing join-prune-interval

### DIFF
--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
@@ -524,6 +524,16 @@ def test_verify_mroute_when_receiver_is_outside_frr_p0(request):
     result = create_pim_config(tgen, topo, input_dict)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
+    step("Configure shorter join-prune-interval for faster SPT switchover")
+    input_dict = {
+        "r1": {"pim6": {"join-prune-interval": "10"}},
+        "r3": {"pim6": {"join-prune-interval": "10"}},
+        "r4": {"pim6": {"join-prune-interval": "10"}},
+        "r5": {"pim6": {"join-prune-interval": "10"}},
+    }
+    result = create_pim_config(tgen, topo, input_dict)
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
     step("send mld join (ffaa::1-5) to R1")
     result = app_helper.run_join("i1", _MLD_JOIN_RANGE, "r1")
     assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)


### PR DESCRIPTION
The test test_verify_mroute_when_receiver_is_outside_frr_p0 was flaky because when r5 joins as a late receiver and switches to SPT, PIM join/prune messages are batched and sent at the join-prune-interval (default 60s). This caused a race condition where verify_mroutes could succeed just as the (S,G) state converged, but verify_sg_traffic could fail if the state wasn't fully stable.

Fix by configuring a shorter join-prune-interval (10s) on all involved routers so PIM state converges well within the test retry timeouts.