### PR TITLE
tests: fix flaky test_BGP_GR_15_p2 by verifying routes on R1 first

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
@@ -1187,13 +1187,15 @@ def test_BGP_GR_15_p2(request):
         result = verify_rib(tgen, addr_type, dut, input_dict_1)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
-        # Verifying BGP RIB routes (r2's 102.x via r1); use longer retry
-        # as r1->r6 propagation after GR can be delayed under load.
-        dut = "r6"
+        # First verify R1 has received R2's routes after GR restart.
+        # This ensures proper sequencing before checking R6.
         input_dict_2 = {key: topo["routers"][key] for key in ["r2"]}
-        result = verify_bgp_rib(
-            tgen, addr_type, dut, input_dict_2, retry_timeout=60
-        )
+        result = verify_bgp_rib(tgen, addr_type, "r1", input_dict_2)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+        # Verifying BGP RIB routes (r2's 102.x via r1) on r6
+        dut = "r6"
+        result = verify_bgp_rib(tgen, addr_type, dut, input_dict_2)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
         # Verifying RIB routes before shutting down BGPd daemon


### PR DESCRIPTION
The test was flaky because it checked for R2's routes on R6 without first verifying that R1 had received those routes after graceful restart. Under ASAN builds, the route propagation from R2 to R1 could be slow enough that the check on R6 would fail.

Fix by adding a verification step to ensure R1 has R2's routes before checking R6. This properly sequences the route propagation chain (R2 -> R1 -> R6) and avoids the need for arbitrary timeout increases.