### PR TITLE
bfdd: negotiate echo interval for data plane sessions

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1754,6 +1754,8 @@ void bfd_set_echo(struct bfd_session *bs, bool echo)
 		/* Activate/update echo receive timeout timer. */
 		if (bs->bdc == NULL)
 			bs_echo_timer_handler(bs);
+		else
+			bfd_dplane_echo_negotiate(bs);
 	} else {
 		/* Check if echo mode is already disabled. */
 		if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -917,6 +917,7 @@ int bfd_dplane_add_session(struct bfd_session *bs);
  * \param bs the BFD session to update.
  */
 int bfd_dplane_update_session(const struct bfd_session *bs);
+void bfd_dplane_echo_negotiate(struct bfd_session *bs);
 
 /**
  * Deletes session from data plane.

--- a/bfdd/bfddp_packet.h
+++ b/bfdd/bfddp_packet.h
@@ -146,8 +146,12 @@ struct bfddp_session {
 	 */
 	uint32_t min_rx;
 	/**
-	 * Minimum desired echo transmission interval (in microseconds)
-	 * without jitter.
+	 * Echo transmission interval (in microseconds) without jitter.
+	 *
+	 * This is the negotiated value: the larger of the local desired
+	 * interval and the peer's advertised Required Min Echo RX (see
+	 * RFC 5880 Section 6.8.9). The BFD daemon performs the
+	 * negotiation, since only it processes control packets.
 	 */
 	uint32_t min_echo_tx;
 	/**

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -325,6 +325,34 @@ static void bfd_dplane_write(struct event *t)
 	bfd_dplane_flush(bdc);
 }
 
+/*
+ * RFC 5880 Section 6.8.9: echo packets must not be transmitted faster
+ * than the interval the peer advertises it is able to receive them at.
+ *
+ * The data plane performs echo transmission but does not process control
+ * packets, so it never sees the peer's Required Min Echo RX. The daemon
+ * performs the negotiation on its behalf and pushes the result down
+ * whenever it changes.
+ */
+void bfd_dplane_echo_negotiate(struct bfd_session *bs)
+{
+	uint32_t negotiated;
+
+	if (bs->bdc == NULL || !CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+		return;
+
+	negotiated = bs->remote_timers.required_min_echo >
+				     bs->timers.desired_min_echo_tx
+			     ? bs->remote_timers.required_min_echo
+			     : bs->timers.desired_min_echo_tx;
+
+	if (bs->echo_xmt_TO == negotiated)
+		return;
+
+	bs->echo_xmt_TO = negotiated;
+	bfd_dplane_update_session(bs);
+}
+
 static void
 bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 				const struct bfddp_state_change *state)
@@ -356,6 +384,8 @@ bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 	bs->remote_timers.desired_min_tx = ntohl(state->desired_tx);
 	bs->remote_timers.required_min_rx = ntohl(state->required_rx);
 	bs->remote_timers.required_min_echo = ntohl(state->required_echo_rx);
+
+	bfd_dplane_echo_negotiate(bs);
 
 	/* Notify and update counters. */
 	ptm_bfd_notify(bs, bs->ses_state);
@@ -792,7 +822,15 @@ static void _bfd_dplane_session_fill(const struct bfd_session *bs,
 	msg->data.session.lid = htonl(bs->discrs.my_discr);
 	msg->data.session.min_tx = htonl(bs->timers.desired_min_tx);
 	msg->data.session.min_rx = htonl(bs->timers.required_min_rx);
-	msg->data.session.min_echo_tx = htonl(bs->timers.desired_min_echo_tx);
+	/*
+	 * Echo transmission is performed by the data plane, but only bfdd
+	 * sees the peer's Required Min Echo RX in control packets, so send
+	 * the negotiated interval rather than the configured one. Before
+	 * negotiation `echo_xmt_TO` is zero and the configured value stands.
+	 */
+	msg->data.session.min_echo_tx =
+		htonl(bs->echo_xmt_TO ? bs->echo_xmt_TO
+				      : bs->timers.desired_min_echo_tx);
 	msg->data.session.min_echo_rx = htonl(bs->timers.required_min_echo_rx);
 }
 


### PR DESCRIPTION
Fixes #22804.

RFC 5880 Section 6.8.9 requires that echo packets are not transmitted faster than the peer's advertised Required Min Echo RX. bfdd performs this negotiation for normal sessions in `bs_echo_timer_handler()`, but that function is unreachable for offloaded sessions, so `bs->echo_xmt_TO` stays 0 and the data plane receives the locally configured interval instead of the negotiated one.

The peer's advertisement already reaches bfdd via `bfd_dplane_session_state_change()`, which stores it into `bs->remote_timers.required_min_echo`. This adds `bfd_dplane_echo_negotiate()`, called from that handler and from `bfd_set_echo()` so that enabling echo on an already-established session also negotiates, and sends the negotiated value in `min_echo_tx`.

Two things worth noting for review:

- `min_echo_tx` now carries the negotiated rather than the configured interval. The wire format is unchanged. No data plane can implement echo correctly today, because it never receives the peer's requirement, so there is no working behaviour being changed.

- The fix is inert against a data plane that does not populate `required_echo_rx` in `BFD_STATE_CHANGE`; `remote_timers.required_min_echo` stays 0 and the negotiation is a no-op. Testing bfdd alone will show no change. Verified against a data plane that does report the field: observed echo cadence changes from 50ms to 200ms against a peer advertising 200ms, with no other configuration change.