### PR TITLE
tests: fix flaky test_pim6_multiple_groups_same_RP_address_p2

### DIFF
--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -385,9 +385,14 @@ def test_pim6_multiple_groups_same_RP_address_p2(request):
     result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
     assert result is True, ASSERT_MSG.format(tc_name, result)
 
-    step("r2: Verify (S, G) upstream IIF interface")
+    step("r2: Verify (S, G) ip mroutes")
     dut = "r2"
     iif = TOPO["routers"]["r2"]["links"]["r3"]["interface"]
+    oif = "none"
+    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
+    assert result is True, ASSERT_MSG.format(tc_name, result)
+
+    step("r2: Verify (S, G) upstream IIF interface")
     result = verify_upstream_iif(
         tgen, dut, iif, SOURCE_ADDRESS, group_address_list, joinState="NotJoined"
     )
@@ -409,11 +414,6 @@ def test_pim6_multiple_groups_same_RP_address_p2(request):
             tc_name, result
         )
     )
-
-    step("r2: Verify (S, G) ip mroutes")
-    oif = "none"
-    result = verify_mroutes(tgen, dut, SOURCE_ADDRESS, group_address_list, iif, oif)
-    assert result is True, ASSERT_MSG.format(tc_name, result)
 
     step("r1: Delete RP configuration")
     input_dict = {


### PR DESCRIPTION
The test was flaky because it checked r2's (S,G) joinState before verifying that the OIL was empty. After r1 switches to SPT and sends a prune to r2, r2's (S,G) joinState transitions from "Joined" to "NotJoined". However, the timing of this transition depends on prune propagation.

Fix by reordering the verification steps: verify r2's (S,G) mroute has oif="none" first (which has a 120-second retry and waits for the prune to be processed), then verify joinState="NotJoined". Once the OIL is empty, the joinState should already be "NotJoined".