### PR TITLE
pathd: accept IPv6 endpoints for pce in pathd

### DIFF
--- a/pathd/path_pcep_config.c
+++ b/pathd/path_pcep_config.c
@@ -358,7 +358,7 @@ int path_pcep_config_update_path(struct path *path)
 {
 	assert(path != NULL);
 	assert(path->nbkey.preference != 0);
-	assert(path->nbkey.endpoint.ipa_type == IPADDR_V4);
+	assert(!IS_IPADDR_NONE(&path->nbkey.endpoint));
 
 	int number_of_sid_clashed = 0;
 	struct path_hop *hop;


### PR DESCRIPTION
Allows ipv6 endpoint for pce-initiate calls.  Matches elsewhere in the code where ipv6 is allowed, asserts instead that there exists an address (ipv4 or ipv6).