### PR TITLE
tests: fix flaky test_BGP_GR_15_p2 by restoring extended timeout

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
@@ -1193,9 +1193,10 @@ def test_BGP_GR_15_p2(request):
         result = verify_bgp_rib(tgen, addr_type, "r1", input_dict_2)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
-        # Verifying BGP RIB routes (r2's 102.x via r1) on r6
+        # Verifying BGP RIB routes (r2's 102.x via r1) on r6.
+        # Use extended timeout as R1->R6 propagation can be slow under ASAN.
         dut = "r6"
-        result = verify_bgp_rib(tgen, addr_type, dut, input_dict_2)
+        result = verify_bgp_rib(tgen, addr_type, dut, input_dict_2, retry_timeout=60)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
         # Verifying RIB routes before shutting down BGPd daemon


### PR DESCRIPTION
Commit b7a866b4d6 added verification of R2's routes on R1 before checking R6, but inadvertently removed the extended retry_timeout for the R6 check. Both are needed: the R1 check ensures proper sequencing (R2->R1), while the extended timeout handles the additional delay for R1 to advertise those routes to R6.

Under ASAN builds, the default 30-second timeout is insufficient for the full propagation chain (R2->R1->R6) to complete.