### PR TITLE
pimd: re-evaluate upstream RPF when neighbor secondary addresses change

### DIFF
--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -747,12 +747,51 @@ static void delete_from_neigh_addr(struct interface *ifp,
 	} /* scan addr list */
 }
 
+/*
+ * Compare two prefix lists for equality.
+ * Returns true if the lists have the same prefixes (in any order).
+ */
+static bool prefix_list_equal(struct list *list1, struct list *list2)
+{
+	struct listnode *node1, *node2;
+	struct prefix *p1, *p2;
+	bool found;
+
+	/* Both NULL means equal (no secondary addresses) */
+	if (!list1 && !list2)
+		return true;
+
+	/* One NULL and one not means not equal */
+	if (!list1 || !list2)
+		return false;
+
+	/* Different lengths means not equal */
+	if (listcount(list1) != listcount(list2))
+		return false;
+
+	/* Check that every prefix in list1 exists in list2 */
+	for (ALL_LIST_ELEMENTS_RO(list1, node1, p1)) {
+		found = false;
+		for (ALL_LIST_ELEMENTS_RO(list2, node2, p2)) {
+			if (prefix_same(p1, p2)) {
+				found = true;
+				break;
+			}
+		}
+		if (!found)
+			return false;
+	}
+
+	return true;
+}
+
 void pim_neighbor_update(struct pim_neighbor *neigh,
 			 pim_hello_options hello_options, uint16_t holdtime,
 			 uint32_t dr_priority, struct list *addr_list)
 {
 	struct pim_interface *pim_ifp = neigh->interface->info;
 	uint32_t old, new;
+	bool secondary_addr_changed = false;
 
 	/* Received holdtime ? */
 	if (PIM_OPTION_IS_SET(hello_options, PIM_OPTION_MASK_HOLDTIME)) {
@@ -779,6 +818,15 @@ void pim_neighbor_update(struct pim_neighbor *neigh,
 				__func__, (void *)addr_list);
 		}
 	} else {
+		/*
+		 * Check if the secondary addresses actually changed.
+		 * We compare list contents, not pointers, because each
+		 * hello message allocates a new addr_list even when
+		 * the addresses are unchanged.
+		 */
+		if (!prefix_list_equal(neigh->prefix_list, addr_list))
+			secondary_addr_changed = true;
+
 		/* Delete existing secondary address list */
 		delete_prefix_list(neigh);
 	}
@@ -806,4 +854,12 @@ void pim_neighbor_update(struct pim_neighbor *neigh,
 	  Copy flags
 	 */
 	neigh->hello_options = hello_options;
+
+	/*
+	 * When neighbor secondary addresses change, upstreams that depend on
+	 * this neighbor for RPF (via secondary address matching) may now be
+	 * resolvable. Re-evaluate upstreams that don't have a valid RPF path.
+	 */
+	if (secondary_addr_changed)
+		pim_upstream_find_new_rpf(pim_ifp->pim);
 }


### PR DESCRIPTION
When a PIM neighbor's secondary addresses are updated via hello message,
upstreams that depend on this neighbor for RPF resolution (via secondary
address matching) may now be resolvable.

This primarily affects IPv6 PIM where neighbors use link-local addresses
as their primary address, while static routes use global addresses as
nexthops. The RPF lookup must match the global nexthop against the
neighbor's secondary address list. If the neighbor's initial hello
arrives before global addresses are assigned to the interface, those
addresses won't be in the secondary list, causing RPF lookup to fail.

Previously, pim_neighbor_update() did not trigger RPF re-evaluation
when secondary addresses changed, so upstreams would remain in NotJoined
state with inboundInterface=Unknown indefinitely.

This fix calls pim_upstream_find_new_rpf() when secondary addresses
change, which re-evaluates all upstreams that don't have a valid RPF
path.

Note: The secondary address comparison checks actual content equality,
not just pointer equality, since each hello message allocates a new
address list even if the addresses haven't changed.

The issue was exposed by flaky pim6_mld_join_toggle topotest
(test_baseline_join).