### PR TITLE
tests: fix flaky pim autorp topotest under ASAN

### DIFF
--- a/tests/topotests/pim_autorp/test_pim_autorp.py
+++ b/tests/topotests/pim_autorp/test_pim_autorp.py
@@ -1042,7 +1042,19 @@ def test_pim_autorp_discovery_neg_prefixes(request):
           }
         }"""
     )
-    for rtr in ["r1", "r2", "r3", "r4"]:
+    # First verify r1's discovery has the negative prefixes.
+    # Since r1 is the mapping agent, this confirms the updated discovery was sent.
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show ip pim autorp json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, "r1 does not have correct autorp discovery"
+
+    # Now verify the other routers received the discovery.
+    for rtr in ["r2", "r3", "r4"]:
         test_func = partial(
             topotest.router_json_cmp,
             tgen.gears[rtr],


### PR DESCRIPTION
The test test_pim_autorp_discovery_neg_prefixes was flaky under ASAN because discovery entries on remote routers could expire before being refreshed. After the config change adds negative prefixes, the mapping agent (r1) needs to send an updated discovery before the other routers can see the new data.

Fix by verifying r1's discovery first, separately from the other routers. Since r1 is both the mapping agent and a discovery receiver, once r1's discovery shows the negative prefixes, we know the updated discovery has been sent. The other routers should then receive it within one interval (1 second), well within the default polling timeout.