### PR TITLE
tests: fix flaky pim_nocache_forward ECMP test

### DIFF
--- a/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
+++ b/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
@@ -361,6 +361,8 @@ def test_nocache_ecmp_prefer_kernel_ingress(request):
 
     step("Flush MFC on LHR to force NOCACHE with ECMP RPF ambiguity")
     clear_mroute(tgen, "l1")
+    # clear_mroute deletes IGMP groups; re-join to restore OIL (not IIF being tested)
+    app_helper.run_join("h_recv", group, join_intf="h_recv-eth0")
 
     step("Verify (S,G) reinstalled with RP-facing IIF after NOCACHE")
     result = verify_mroutes(tgen, "l1", SOURCE, group, L1_TO_RP, L1_TO_RECV)


### PR DESCRIPTION
The test_nocache_ecmp_prefer_kernel_ingress test is flaky because clear_mroute() deletes IGMP group memberships along with the MFC. This causes the mroute to be reinstalled with an empty OIL, dropping traffic until IGMP state recovers (up to 125 seconds for the next query).

Fix by re-triggering the IGMP join after clear_mroute to immediately restore group membership. This only affects the OIL (receiver side) and does not interfere with the NOCACHE IIF selection being tested.