### PR TITLE
tests: reduce join-prune-interval to fix flaky pim6 test

### DIFF
--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -256,9 +256,9 @@ def test_pim6_multiple_groups_same_RP_address_p2(request):
 
     step("Configure shorter join-prune-interval for faster prune propagation")
     input_dict = {
-        "r1": {"pim6": {"join-prune-interval": "10"}},
-        "r2": {"pim6": {"join-prune-interval": "10"}},
-        "r3": {"pim6": {"join-prune-interval": "10"}},
+        "r1": {"pim6": {"join-prune-interval": "5"}},
+        "r2": {"pim6": {"join-prune-interval": "5"}},
+        "r3": {"pim6": {"join-prune-interval": "5"}},
     }
     result = create_pim_config(tgen, TOPO, input_dict)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)


### PR DESCRIPTION
The test test_pim6_multiple_groups_same_RP_address_p2 was failing intermittently because the upstream state verification for 10 multicast groups was timing out at 60 seconds.

From CI failure log:
  2026-07-25 20:32:47,047 INFO: topo: Retry timeout of 60s reached
  ...
  2026-07-25 20:32:53,359 WARNING: topo: RETRY DIAGNOSTIC: SUCCEED after
    FAILED with requested timeout of 60.0s; however, succeeded in 67.0s,
    investigate timeout timing

The test needed 67 seconds to complete, exceeding the 60-second timeout. With join-prune-interval reduced from 10 to 5 seconds, the PIM Join/Prune messages propagate faster, and the test now completes in about 36 seconds.