### PR TITLE
ospfd: fix memory leak of OSPF crypt keys at shutdown

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -549,6 +549,10 @@ void ospf_if_stream_unset(struct ospf_interface *oi)
 	ospf_if_reset_stats(oi);
 }
 
+static void ospf_crypt_key_free(void *val)
+{
+	XFREE(MTYPE_OSPF_CRYPT_KEY, val);
+}
 
 static struct ospf_if_params *ospf_new_if_params(void)
 {
@@ -579,6 +583,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, dscp_low_control);
 
 	oip->auth_crypt = list_new();
+	oip->auth_crypt->del = ospf_crypt_key_free;
 
 	oip->network_lsa_seqnum = htonl(OSPF_INITIAL_SEQUENCE_NUMBER);
 	oip->is_v_wait_set = false;


### PR DESCRIPTION
The auth_crypt list in ospf_if_params was created with list_new() without setting a delete callback. When list_delete() was called during interface cleanup, only the list container was freed, but the crypt_key elements remained allocated.

This caused ospf_basic_functionality/test_ospf_authentication.py to fail at teardown with:

  ospfd has memory leaks:
    ## showing active allocations in memory group ospfd
    OSPF crypt key                :      1 *         18

Fix by adding a delete callback (ospf_crypt_key_free) that properly frees each crypt_key element when the list is deleted.