### PR TITLE
staticd: assert route info before initialization

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -83,6 +83,7 @@ struct route_node *static_add_route(afi_t afi, safi_t safi, struct prefix *p,
 
 	/* Lookup static route prefix. */
 	rn = srcdest_rnode_get(stable, p, src_p);
+	assert(!rn->info);
 
 	si = XCALLOC(MTYPE_STATIC_ROUTE, sizeof(struct static_route_info));
 


### PR DESCRIPTION
The northbound route-list lifecycle guarantees that `static_add_route()` is called only once for each route-list instance. Child path-list creation retrieves the existing route node through its parent's running entry and does not *recreate* the route.

Make it explicit by asserting that the route node does not already contain static route information before initializing it. This catches duplicate initialization introduced by future callers before it can overwrite `rn->info`.