### PR TITLE
bgpd: parse a route distinguisher of 0:value as AS 0

### DIFF
--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -90,6 +90,7 @@ int str2prefix_rd(const char *str, struct prefix_rd *prd)
 	char *half = NULL;
 	struct in_addr addr;
 	as_t as_val = 0;
+	bool is_as = false;
 
 	prd->family = AF_UNSPEC;
 	prd->prefixlen = 64;
@@ -124,8 +125,21 @@ int str2prefix_rd(const char *str, struct prefix_rd *prd)
 
 	s = stream_new(RD_BYTES);
 
+	/*
+	 * asn_str2asn() rejects AS 0, but 0 is a valid Type 0 RD administrator
+	 * subfield (e.g. "0:3159413647"). A bare decimal number is always an
+	 * AS, never an IPv4 address, so treat a bare "0" as AS 0 here. Without
+	 * this, inet_aton() would misparse "0" as 0.0.0.0 and the 4-byte value
+	 * would be truncated to 2 bytes.
+	 */
+	is_as = asn_str2asn(half, &as_val);
+	if (!is_as && all_digit(half) && strtoull(half, NULL, 10) == 0) {
+		is_as = true;
+		as_val = 0;
+	}
+
 	/* if it is an AS format or an IP */
-	if (asn_str2asn(half, &as_val)) {
+	if (is_as) {
 		if (as_val > UINT16_MAX) {
 			stream_putw(s, RD_TYPE_AS4);
 			stream_putl(s, as_val);

--- a/tests/topotests/bgp_rd_as_zero/r1/frr.conf
+++ b/tests/topotests/bgp_rd_as_zero/r1/frr.conf
@@ -1,0 +1,19 @@
+!
+router bgp 65000
+ bgp router-id 192.0.2.1
+ no bgp ebgp-requires-policy
+ address-family ipv4 vpn
+ exit-address-family
+exit
+!
+router bgp 65000 vrf dummy-vrf
+ bgp router-id 192.0.2.1
+ address-family ipv4 unicast
+  redistribute connected
+  rd vpn export 0:1000000
+  rt vpn both 0:1000000
+  export vpn
+  import vpn
+ exit-address-family
+exit
+!

--- a/tests/topotests/bgp_rd_as_zero/test_bgp_rd_as_zero.py
+++ b/tests/topotests/bgp_rd_as_zero/test_bgp_rd_as_zero.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_rd_as_zero.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by Olasupo Okunaiya
+#
+
+"""
+test_bgp_rd_as_zero.py: a route distinguisher of the form 0:<value>
+must be parsed as a Type 0 RD (AS 0), not as an IPv4 RD.
+
+asn_str2asn() rejects AS 0, so str2prefix_rd() used to fall through to
+inet_aton(), which read the "0" administrator subfield as 0.0.0.0 and
+truncated the value to 16 bits. "0:1000000" was therefore stored as
+"0.0.0.0:16960" (1000000 & 0xffff). This is a regression from the
+introduction of AS-dot notation.
+
+The value stays below 2^31 so it is parsed identically on 32-bit and
+64-bit platforms.
+
+A VRF route is redistributed and exported to the ipv4 vpn table with
+"rd vpn export 0:1000000"; the RD shown for that route must be
+0:1000000.
+"""
+
+import os
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd]
+
+RD = "0:1000000"
+RD_BAD = "0.0.0.0:16960"
+
+
+def build_topo(tgen):
+    "Build function"
+    tgen.add_router("r1")
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1 = tgen.gears["r1"]
+    # A VRF with a connected route to redistribute into the ipv4 vpn table.
+    r1.run("ip link add dummy-vrf type vrf table 1001")
+    r1.run("ip link set dummy-vrf up")
+    r1.run("ip link add dummy0 type dummy")
+    r1.run("ip link set dummy0 master dummy-vrf")
+    r1.run("ip link set dummy0 up")
+    r1.run("ip addr add 192.0.2.100/32 dev dummy0")
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, rname, "frr.conf"))
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _vpn_rds():
+    tgen = get_topogen()
+    out = tgen.gears["r1"].vtysh_cmd("show bgp ipv4 vpn json", isjson=True)
+    return out.get("routes", {}).get("routeDistinguishers", {})
+
+
+def _rd_present():
+    rds = _vpn_rds()
+    if RD in rds:
+        return None
+    return "RD %s not in the vpn table yet (have: %s)" % (RD, list(rds.keys()))
+
+
+def test_bgp_rd_as_zero():
+    "0:<32-bit-value> must be a Type 0 RD, not a truncated IPv4 RD."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("checking the exported route carries RD %s", RD)
+    _, result = topotest.run_and_expect(_rd_present, None, count=30, wait=1)
+    assert result is None, "route distinguisher was not parsed correctly (%s)" % result
+
+    # And it must not have been misparsed to the truncated IPv4 form.
+    rds = _vpn_rds()
+    assert RD_BAD not in rds, "RD was misparsed as %s" % RD_BAD
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Fixes #22749

str2prefix_rd() parses the administrator part of an admin:value route distinguisher with asn_str2asn(), which rejects AS 0. So a bare "0" reached inet_aton() instead and was read as the IPv4 address 0.0.0.0, with the 32 bit value truncated to 16 bits. "0:3159413647" was stored as "0.0.0.0:54159", a Type 1 RD. This is a regression from the introduction of AS dot notation (#12248), and it is inconsistent with route target parsing, which still accepts 0:value.

A bare decimal number is always an AS, never an IPv4 address, so this treats "0" as AS 0 and builds a Type 0 RD.

## Testing

New topotest bgp_rd_as_zero: a VRF route is exported with "rd vpn export 0:3159413647" and the route distinguisher in the vpn table is checked. It fails on the current code (RD 0.0.0.0:54159) and passes with the fix. checkpatch is clean, and the bgp_soo and bgp_route_map_vpn_import tests (IPv4 RDs) still pass.
