### PR TITLE
tests: fix flaky test_BGP_GR_15_p2 by reducing connect timer

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
@@ -1036,14 +1036,28 @@ def test_BGP_GR_15_p2(request):
                     "ipv4": {
                         "unicast": {
                             "neighbor": {
-                                "r2": {"dest_link": {"r1": {"graceful-restart": True}}}
+                                "r2": {
+                                    "dest_link": {
+                                        "r1": {
+                                            "graceful-restart": True,
+                                            "connecttimer": 10,
+                                        }
+                                    }
+                                }
                             }
                         }
                     },
                     "ipv6": {
                         "unicast": {
                             "neighbor": {
-                                "r2": {"dest_link": {"r1": {"graceful-restart": True}}}
+                                "r2": {
+                                    "dest_link": {
+                                        "r1": {
+                                            "graceful-restart": True,
+                                            "connecttimer": 10,
+                                        }
+                                    }
+                                }
                             }
                         }
                     },
@@ -1058,7 +1072,10 @@ def test_BGP_GR_15_p2(request):
                             "neighbor": {
                                 "r1": {
                                     "dest_link": {
-                                        "r2": {"graceful-restart-helper": True}
+                                        "r2": {
+                                            "graceful-restart-helper": True,
+                                            "connecttimer": 10,
+                                        }
                                     }
                                 }
                             }
@@ -1069,7 +1086,10 @@ def test_BGP_GR_15_p2(request):
                             "neighbor": {
                                 "r1": {
                                     "dest_link": {
-                                        "r2": {"graceful-restart-helper": True}
+                                        "r2": {
+                                            "graceful-restart-helper": True,
+                                            "connecttimer": 10,
+                                        }
                                     }
                                 }
                             }
@@ -1098,9 +1118,13 @@ def test_BGP_GR_15_p2(request):
         result = verify_rib(tgen, addr_type, dut, input_dict_1)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 
-        # Verifying BGP RIB routes
-        dut = "r6"
+        # First verify R1 has received R2's routes after the session clear.
         input_dict_2 = {key: topo["routers"][key] for key in ["r2"]}
+        result = verify_bgp_rib(tgen, addr_type, "r1", input_dict_2)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+        # Verifying BGP RIB routes (r2's routes via r1) on r6.
+        dut = "r6"
         result = verify_bgp_rib(tgen, addr_type, dut, input_dict_2)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
 


### PR DESCRIPTION
The test_BGP_GR_15_p2 test fails intermittently because after the BGP session between R1 and R2 is cleared with ADMIN_RESET notification, the default connect retry timer (30 seconds) can cause the session re-establishment to exceed the 30-second verification timeout.

When clear bgp is executed, both sides send ADMIN_RESET notifications and clear their routes. After the session goes to Idle state, the connect timer (v_connect) defaults to 30 seconds. If the first TCP connection attempt fails due to the race between both sides clearing, the peer waits up to 30 seconds before retrying, causing the route propagation from R2 through R1 to R6 to exceed the timeout.

Fix by configuring "timers connect 10" for the R1-R2 peering, reducing the worst-case reconnection time from ~32 seconds to ~12 seconds.

Also fix the verification order to check R1 has R2's routes before checking R6, ensuring proper sequencing of route propagation checks.