### PR TITLE
bgpd: fix Coverity issues in BGP UPA code

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11582,8 +11582,11 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 
 	/* Aggregate address insert into BGP routing table. */
 	if (!bgp_aggregate_route(bgp, &p, afi, safi, aggregate)) {
+		/* Keep table state consistent and avoid stale aggregate pointer. */
+		bgp_dest_set_bgp_aggregate_info(dest, NULL);
 		bgp_aggregate_free(aggregate);
 		bgp_dest_unlock_node(dest);
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	/* Handle UPA origination/withdrawal based on configuration change */
@@ -20250,7 +20253,7 @@ DEFUN(show_bgp_upa_statistics, show_bgp_upa_statistics_cmd,
 	} else {
 		vty_out(vty, "UPA Statistics for AFI %s, SAFI %s:\n\n",
 			afi == AFI_IP ? "IPv4" : "IPv6",
-			safi == SAFI_UNICAST ? "unicast" : "other");
+			"unicast");
 		vty_out(vty, "  Global UPA originate-all:      %s\n",
 			global_enabled ? "Enabled" : "Disabled");
 		vty_out(vty, "  Active UPA routes:             %u\n", total_upa_routes);


### PR DESCRIPTION
Address two Coverity findings in the BGP UPA (Unreachable Prefix Announcement) aggregate code:

- CID 1672994 (USE_AFTER_FREE): in bgp_aggregate_set(), when bgp_aggregate_route() fails the aggregate was freed but execution fell through and the freed pointer could be passed to bgp_upa_originate_all(). Clear the stale aggregate pointer from the dest, free it, unlock the node and return early on failure.

- CID 1672995 (DEADCODE): in show_bgp_upa_statistics() the SAFI is always SAFI_UNICAST, so the ternary selecting "other" was unreachable. Print "unicast" directly.

Logs:
_____________________________________________________________________________________________
*** CID 1672995:         Control flow issues  (DEADCODE)
/bgpd/bgp_route.c: 20251             in show_bgp_upa_statistics()
20245     		json_object_int_add(json, "activeUpaRoutes", total_upa_routes);
20246     		json_object_int_add(json, "globalTrackedRoutes", tracked_count);
20247     		json_object_int_add(json, "maxRoutesLimit", max_routes ? max_routes : 0);
20248     		json_object_boolean_add(json, "dropBitEnabled", d_bit);
20249     		vty_json(vty, json);
20250     	} else {
>>>     CID 1672995:         Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression ""other"" inside this statement: "vty_out(vty, "UPA Statistic...".
20251     		vty_out(vty, "UPA Statistics for AFI %s, SAFI %s:\n\n",
20252     			afi == AFI_IP ? "IPv4" : "IPv6",
20253     			safi == SAFI_UNICAST ? "unicast" : "other");
20254     		vty_out(vty, "  Global UPA originate-all:      %s\n",
20255     			global_enabled ? "Enabled" : "Disabled");
20256     		vty_out(vty, "  Active UPA routes:             %u\n", total_upa_routes);

** CID 1672994:         (USE_AFTER_FREE)
/bgpd/bgp_route.c: 11595           in bgp_aggregate_set()


_____________________________________________________________________________________________
*** CID 1672994:           (USE_AFTER_FREE)
/bgpd/bgp_route.c: 11595             in bgp_aggregate_set()
11589     	/* Handle UPA origination/withdrawal based on configuration change */
11590     	if (upa_enabled && !old_upa_enabled) {
11591     		/* UPA was just enabled - originate for existing unreachable prefixes */
11592     		if (BGP_DEBUG(upa, UPA))
11593     			zlog_debug("%s: UPA enabled on aggregate %pFX, originating UPA routes",
11594     				   __func__, &p);
>>>     CID 1672994:           (USE_AFTER_FREE)
>>>     Calling "bgp_upa_originate_all" dereferences freed pointer "aggregate".
11595     		bgp_upa_originate_all(bgp, &p, afi, safi, aggregate);
11596     	} else if (!upa_enabled && old_upa_enabled) {
11597     		/* UPA was just disabled - withdraw all active UPA routes */
11598     		if (BGP_DEBUG(upa, UPA))
11599     			zlog_debug("%s: UPA disabled on aggregate %pFX, withdrawing UPA routes",
11600     				   __func__, &p);
/bgpd/bgp_route.c: 11595             in bgp_aggregate_set()
11589     	/* Handle UPA origination/withdrawal based on configuration change */
11590     	if (upa_enabled && !old_upa_enabled) {
11591     		/* UPA was just enabled - originate for existing unreachable prefixes */
11592     		if (BGP_DEBUG(upa, UPA))
11593     			zlog_debug("%s: UPA enabled on aggregate %pFX, originating UPA routes",
11594     				   __func__, &p);
>>>     CID 1672994:           (USE_AFTER_FREE)
>>>     Passing freed pointer "aggregate" as an argument to "bgp_upa_originate_all".
11595     		bgp_upa_originate_all(bgp, &p, afi, safi, aggregate);
11596     	} else if (!upa_enabled && old_upa_enabled) {
11597     		/* UPA was just disabled - withdraw all active UPA routes */
11598     		if (BGP_DEBUG(upa, UPA))
11599     			zlog_debug("%s: UPA disabled on aggregate %pFX, withdrawing UPA routes",
11600     				   __func__, &p);
