### PR TITLE
*: fix unsigned subtraction in comparator functions

### DIFF
--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -1101,7 +1101,11 @@ static int mon_eth_cmp(const void *a, const void *b)
 	/*
 	 * compare LNIs
 	 */
-	return (m1->logical_net_id - m2->logical_net_id);
+	if (m1->logical_net_id > m2->logical_net_id)
+		return 1;
+	if (m1->logical_net_id < m2->logical_net_id)
+		return -1;
+	return 0;
 }
 
 static void rfapiMonitorEthAttachImport(

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -479,7 +479,7 @@ static int rfapi_info_cmp(struct rfapi_info *a, struct rfapi_info *b)
 		return (a->cost - b->cost);
 
 	if (a->lifetime != b->lifetime)
-		return (a->lifetime - b->lifetime);
+		return (a->lifetime > b->lifetime) ? 1 : -1;
 
 	if ((rc = bgp_tea_options_cmp(a->tea_options, b->tea_options)))
 		return rc;

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -56,7 +56,11 @@ extern struct in_addr router_id_zebra;
 
 int eigrp_master_hash_cmp(const struct eigrp *a, const struct eigrp *b)
 {
-	return a->vrf_id - b->vrf_id;
+	if (a->vrf_id > b->vrf_id)
+		return 1;
+	if (a->vrf_id < b->vrf_id)
+		return -1;
+	return 0;
 }
 
 uint32_t eigrp_master_hash_hash(const struct eigrp *a)

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -1448,7 +1448,11 @@ lde_send_notification_eol_pwid(struct lde_nbr *ln, uint16_t pw_type)
 static __inline int
 lde_nbr_compare(const struct lde_nbr *a, const struct lde_nbr *b)
 {
-	return (a->peerid - b->peerid);
+	if (a->peerid > b->peerid)
+		return 1;
+	if (a->peerid < b->peerid)
+		return -1;
+	return 0;
 }
 
 static struct lde_nbr *

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -116,7 +116,11 @@ nbr_addr_compare(const struct nbr *a, const struct nbr *b)
 static __inline int
 nbr_pid_compare(const struct nbr *a, const struct nbr *b)
 {
-	return (a->peerid - b->peerid);
+	if (a->peerid > b->peerid)
+		return 1;
+	if (a->peerid < b->peerid)
+		return -1;
+	return 0;
 }
 
 int

--- a/lib/netns.c
+++ b/lib/netns.c
@@ -54,7 +54,11 @@ struct ns_map_nsid {
 static inline int ns_map_compare(const struct ns_map_nsid *a,
 				   const struct ns_map_nsid *b)
 {
-	return (a->ns_id - b->ns_id);
+	if (a->ns_id > b->ns_id)
+		return 1;
+	if (a->ns_id < b->ns_id)
+		return -1;
+	return 0;
 }
 
 RB_HEAD(ns_map_nsid_head, ns_map_nsid);
@@ -120,7 +124,11 @@ static int ns_is_enabled(struct ns *ns);
 
 static inline int ns_compare(const struct ns *a, const struct ns *b)
 {
-	return (a->ns_id - b->ns_id);
+	if (a->ns_id > b->ns_id)
+		return 1;
+	if (a->ns_id < b->ns_id)
+		return -1;
+	return 0;
 }
 
 /* Look up a NS by identifier. */

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -73,7 +73,11 @@ struct vrf *vrf_lookup_by_name(const char *name)
 
 static __inline int vrf_id_compare(const struct vrf *a, const struct vrf *b)
 {
-	return (a->vrf_id - b->vrf_id);
+	if (a->vrf_id > b->vrf_id)
+		return 1;
+	if (a->vrf_id < b->vrf_id)
+		return -1;
+	return 0;
 }
 
 static int vrf_name_compare(const struct vrf *a, const struct vrf *b)

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -532,16 +532,18 @@ int ospf6_route_cmp(struct ospf6_route *ra, struct ospf6_route *rb)
 
 	if (ra->path.type == OSPF6_PATH_TYPE_EXTERNAL2) {
 		if (ra->path.u.cost_e2 != rb->path.u.cost_e2)
-			return (ra->path.u.cost_e2 - rb->path.u.cost_e2);
-		else
-			return (ra->path.cost - rb->path.cost);
-	} else {
-		if (ra->path.cost != rb->path.cost)
-			return (ra->path.cost - rb->path.cost);
+			return (ra->path.u.cost_e2 > rb->path.u.cost_e2) ? 1 : -1;
+		if (ra->path.cost > rb->path.cost)
+			return 1;
+		if (ra->path.cost < rb->path.cost)
+			return -1;
+		return 0;
 	}
+	if (ra->path.cost != rb->path.cost)
+		return (ra->path.cost > rb->path.cost) ? 1 : -1;
 
 	if (ra->path.area_id != rb->path.area_id)
-		return (ntohl(ra->path.area_id) - ntohl(rb->path.area_id));
+		return (ntohl(ra->path.area_id) > ntohl(rb->path.area_id)) ? 1 : -1;
 
 	if ((ra->prefix_options & OSPF6_PREFIX_OPTION_LA)
 	    != (rb->prefix_options & OSPF6_PREFIX_OPTION_LA))

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -823,8 +823,11 @@ int ospf_route_cmp(struct ospf *ospf, struct ospf_route *r1,
 		}
 		break;
 	case OSPF_PATH_TYPE2_EXTERNAL:
-		if ((ret = (r1->u.ext.type2_cost - r2->u.ext.type2_cost)))
-			return ret;
+		if (r1->u.ext.type2_cost != r2->u.ext.type2_cost) {
+			if (r1->u.ext.type2_cost > r2->u.ext.type2_cost)
+				return 1;
+			return -1;
+		}
 
 		if (!CHECK_FLAG(ospf->config, OSPF_RFC1583_COMPATIBLE)) {
 			ret = ospf_asbr_route_cmp(ospf, r1->u.ext.asbr,
@@ -836,7 +839,11 @@ int ospf_route_cmp(struct ospf *ospf, struct ospf_route *r1,
 	}
 
 	/* Anyway, compare the costs. */
-	return (r1->cost - r2->cost);
+	if (r1->cost > r2->cost)
+		return 1;
+	if (r1->cost < r2->cost)
+		return -1;
+	return 0;
 }
 
 static int ospf_path_exist(struct list *plist, struct in_addr nexthop,

--- a/tests/ospfd/common.c
+++ b/tests/ospfd/common.c
@@ -43,7 +43,11 @@ int sort_paths(const void **path1, const void **path2)
 	const struct ospf_path *p1 = *path1;
 	const struct ospf_path *p2 = *path2;
 
-	return (p1->nexthop.s_addr - p2->nexthop.s_addr);
+	if (p1->nexthop.s_addr > p2->nexthop.s_addr)
+		return 1;
+	if (p1->nexthop.s_addr < p2->nexthop.s_addr)
+		return -1;
+	return 0;
 }
 
 void print_route_table(struct vty *vty, struct route_table *rt)

--- a/zebra/fpm_listener.c
+++ b/zebra/fpm_listener.c
@@ -98,7 +98,11 @@ struct fpm_nhg {
 /* Comparison function for nexthop groups */
 static int fpm_nhg_cmp(const struct fpm_nhg *a, const struct fpm_nhg *b)
 {
-	return a->id - b->id;
+	if (a->id > b->id)
+		return 1;
+	if (a->id < b->id)
+		return -1;
+	return 0;
 }
 
 /* Hash function for nexthop groups */

--- a/zebra/zebra_nhg_private.h
+++ b/zebra/zebra_nhg_private.h
@@ -30,7 +30,11 @@ struct nhg_connected {
 static int nhg_connected_cmp(const struct nhg_connected *con1,
 			     const struct nhg_connected *con2)
 {
-	return (con1->nhe->id - con2->nhe->id);
+	if (con1->nhe->id > con2->nhe->id)
+		return 1;
+	if (con1->nhe->id < con2->nhe->id)
+		return -1;
+	return 0;
 }
 
 DECLARE_RBTREE_UNIQ(nhg_connected_tree, struct nhg_connected, tree_item,


### PR DESCRIPTION
Multiple comparator functions subtract unsigned 32-bit integers (uint32_t, vrf_id_t, ns_id_t, in_addr_t via ntohl()) and return the result as int. When the difference exceeds INT_MAX, the unsigned subtraction wraps around and the value reinterpreted as signed int can have the wrong sign, causing incorrect ordering in skip-lists, red-black trees, and sorted arrays.