### PR TITLE
tests: fix flaky pim_nocache_forward ECMP test with retry logic

### DIFF
--- a/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
+++ b/tests/topotests/pim_nocache_forward/test_pim_nocache_forward.py
@@ -243,12 +243,15 @@ def verify_upstream_json(tgen, dut, source, group, expected_fields):
     return result
 
 
-def verify_receiver_traffic(host, group, recv_intf, source, min_pkts=1):
-    report = app_helper.collect_receiver_sources(
-        host, group, recv_intf, duration=3, source=source
-    )
-    count = report.get("sources", {}).get(source, 0)
-    return count >= min_pkts, report
+def verify_receiver_traffic(host, group, recv_intf, source, min_pkts=1, retries=3):
+    for _ in range(retries):
+        report = app_helper.collect_receiver_sources(
+            host, group, recv_intf, duration=3, source=source
+        )
+        count = report.get("sources", {}).get(source, 0)
+        if count >= min_pkts:
+            return True, report
+    return False, report
 
 
 def verify_mroute_json(router, expected, count=30, wait=1):


### PR DESCRIPTION
The previous fix (ed3d2a6807) addressed the IGMP group membership being deleted by clear_mroute() by re-triggering the IGMP join. However, the test remains flaky because verify_receiver_traffic() only collects traffic for 3 seconds without retries.

After MFC flush and IGMP re-join, there is a timing window where the mroute may be reinstalled (verified in STEP 5) but the data path has not fully resumed. The single 3-second collection window can miss traffic if it starts during this transient period.

Fix by adding retry logic to verify_receiver_traffic(). The function now attempts up to 3 collections (9 seconds total) before reporting failure, matching the retry pattern used by other verification functions like verify_mroutes().