### PR TITLE
ospfd: fix MEMSET_SIZE_MISMATCH on ospf_te_delete_ext_link()

### DIFF
--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -3203,7 +3203,7 @@ static int ospf_te_delete_ext_link(struct ls_ted *ted, struct ospf_lsa *lsa)
 	atr = edge->attributes;
 	UNSET_FLAG(atr->flags, LS_ATTR_ADJ_SID);
 	UNSET_FLAG(atr->flags, LS_ATTR_BCK_ADJ_SID);
-	memset(atr->adj_sid, 0, 2 * sizeof(struct ls_sid));
+	memset(atr->adj_sid, 0, 2 * sizeof(atr->adj_sid[0]));
 	edge->status = UPDATE;
 
 	/* Edge has been updated: export it */


### PR DESCRIPTION
Hi!

It seems a bit mixed up here. The function is supposed to clear the first two elements of the array, but only the first one is being cleared. We need to clear `Primary` and `Backup` elements for `IPv4` socket.

MEMSET_SIZE_MISMATCH Function 'memset' used to fill a block of memory pointed by 'atr->adj_sid', whose element type 'struct ls_adjacency' (16 B) has different size than the sizeof operand type 'struct ls_sid' (8 B).

Found by the static analyzer Svace (ISP RAS).