### PR TITLE
bgpd: fix BAD_COPY_PASTE in bgp_path_info_cmp()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1584,11 +1584,9 @@ int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	     new_sub_sort == BGP_PEER_EBGP_OAD)) {
 		*reason = bgp_path_selection_peer;
 		if (debug)
-			zlog_debug("%s: %s loses to %s due to %s peer < eBGP peer",
-				   pfx_buf, new_buf, exist_buf,
-				   (exist_sub_sort == BGP_PEER_EBGP_OAD)
-					   ? "eBGP-OAD"
-					   : "iBGP");
+			zlog_debug("%s: %s loses to %s due to %s peer < eBGP peer", pfx_buf,
+				   new_buf, exist_buf,
+				   (new_sub_sort == BGP_PEER_EBGP_OAD) ? "eBGP-OAD" : "iBGP");
 		if (!CHECK_FLAG(bgp->flags, BGP_FLAG_PEERTYPE_MULTIPATH_RELAX))
 			return 0;
 		peer_sort_ret = 0;


### PR DESCRIPTION
Hello again!

There is a copy-paste error here from the previous code block. As a result, the log output is incorrect.

Based on the condition `new_sub_sort == BGP_PEER_EBGP_OAD`, the log output should show a similar comparison.

In function 'bgp_path_info_cmp': Value 'exist_sub_sort' might be 'new_sub_sort'.

Found by the static analyzer Svace (ISP RAS).