### PR TITLE
ospfd: fix MEMORY_LEAK in show_lsa_detail_adv_router()

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7048,9 +7048,6 @@ static void show_lsa_detail_adv_router(struct vty *vty, struct ospf *ospf,
 	json_object *json_areas = NULL;
 	json_object *json_lsa_array = NULL;
 
-	if (json)
-		json_lsa_type = json_object_new_object();
-
 	switch (type) {
 	case OSPF_AS_EXTERNAL_LSA:
 	case OSPF_OPAQUE_AS_LSA:
@@ -7092,6 +7089,7 @@ static void show_lsa_detail_adv_router(struct vty *vty, struct ospf *ospf,
 		}
 
 		if (json) {
+			json_lsa_type = json_object_new_object();
 			json_object_object_add(json_lsa_type, "areas",
 					       json_areas);
 			json_object_object_add(json,


### PR DESCRIPTION
Hi!

When `type` equal `OSPF_AS_EXTERNAL_LSA` or `OSPF_OPAQUE_AS_LSA` json object `json_lsa_type` leaked.  In this case, `json_lsa_type` is not passed anywhere and is not freed. Moved it to the default branch. The same is done in the `show_lsa_detail()` function.

Dynamic memory, referenced by 'json_lsa_type', is allocated at ospf_vty.c:6957 by calling function 'json_object_new_object' and lost at ospf_vty.c:6974.

Found by the static analyzer Svace (ISP RAS).