### PR TITLE
zebra: fix route selection tiebreak to preserve existing route

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1230,7 +1230,7 @@ static struct route_entry *rib_choose_best_type(uint8_t route_type,
 		}
 
 		/* Neither are loop or vrf so pick best metric  */
-		if (alternate->metric <= current->metric)
+		if (alternate->metric < current->metric)
 			return alternate;
 
 		return current;
@@ -1280,7 +1280,7 @@ static struct route_entry *rib_choose_best(struct route_entry *current,
 		return current;
 
 	/* metric tie-breaks equal distance */
-	if (alternate->metric <= current->metric)
+	if (alternate->metric < current->metric)
 		return alternate;
 
 	return current;


### PR DESCRIPTION
The route selection logic incorrectly used `<=` instead of `<` when comparing metrics, causing the alternate route to replace the current route even when metrics were equal. This violated the documented tiebreak rule: "last, hence oldest, route wins tie break."

Fix by changing `<=` to `<` so that the alternate route only wins with a strictly lower metric, and equal metrics preserve the current (older) route.