### PR TITLE
ospfd: flush the received instance of an unwanted self-originated LSA

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2050,19 +2050,58 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 				 * must take special action. ... the router must then advance the LSA's LS
 				 * sequence number one past the received LS sequence number, and
 				 * originate a new instance of the LSA.
+				 *
+				 * Unless we no longer wish to originate it, in which case the
+				 * received instance is the one that has to be flushed.  A
+				 * database copy already sitting at MaxAge is how we know that:
+				 * it was flushed locally when we stopped wanting to originate
+				 * it, one of Section 13.4's examples being a network-LSA for a
+				 * network we are no longer Designated Router for.
 				 */
+				struct ospf_lsa *ls_req;
+
 				if (IS_DEBUG_OSPF(lsa, LSA))
 					zlog_debug("%s: Link State Update[%s]: router-id is local, but has higher seq num",
 						   __func__, dump_lsa_key(lsa));
-				current->data->ls_seqnum = lsa->data->ls_seqnum;
-				ospf_lsa_checksum(current->data);
-				ospf_lsa_refresh(oi->ospf, current);
-				/* Discarding without ACK may cause neighbor to retransmit the stale LSA
-				 * until the refreshed LSA arrives, make sure that doesn't happen.
+
+				/* Ack immediately, otherwise the neighbor keeps
+				 * retransmitting the stale instance while we re-originate or
+				 * flush it.
 				 */
 				ospf_ls_ack_send_direct(nbr, lsa);
-				DISCARD_LSA(lsa, 10);
-				continue;
+
+				/* The received LSA satisfies any request still outstanding
+				 * for it.  Without this the neighbor never leaves Loading.
+				 */
+				ls_req = ospf_ls_request_lookup(nbr, lsa);
+				if (ls_req != NULL) {
+					ospf_ls_request_delete(nbr, ls_req);
+					ospf_check_nbr_loading(nbr);
+				}
+
+				if (IS_LSA_MAXAGE(current)) {
+					/* Section 14.1: flush by setting the received LSA's LS
+					 * age to MaxAge and reflooding it, leaving its sequence
+					 * number alone.  Step (5) below does the reflooding.
+					 *
+					 * Reflooding our own database copy instead cannot flush
+					 * anything: it carries the same sequence number as the
+					 * received instance but different contents, so the
+					 * Section 13.1 checksum comparison makes the instance the
+					 * rest of the domain holds more recent, and the two get
+					 * exchanged back and forth forever.
+					 */
+					LS_AGE_SET(lsa, OSPF_LSA_MAXAGE);
+				} else {
+					/* ospf_lsa_refresh() increments the sequence number as it
+					 * re-originates, which lands it one past the received one.
+					 */
+					current->data->ls_seqnum = lsa->data->ls_seqnum;
+					ospf_lsa_checksum(current->data);
+					ospf_lsa_refresh(oi->ospf, current);
+					DISCARD_LSA(lsa, 10);
+					continue;
+				}
 			}
 		}
 


### PR DESCRIPTION
RFC 2328 Section 13.4 covers receiving a self-originated LSA that is newer than the instance the router last originated, which happens when instances originated before a restart are still in the routing domain. It prescribes two different remedies:

  In most cases, the router must then advance the LSA's LS sequence
  number one past the received LS sequence number, and originate a new
  instance of the LSA.

  It may be the case the router no longer wishes to originate the
  received LSA.  Possible examples include: ... 2) the LSA is a
  network-LSA but the router is no longer Designated Router for the
  network ... In all these cases, instead of updating the LSA, the LSA
  should be flushed from the routing domain by incrementing the
  received LSA's LS age to MaxAge and reflooding (see Section 14.1).

ospf_ls_upd() only implemented the first remedy.  For the second case it still called ospf_lsa_refresh(), which for a network-LSA on a link where we are no longer DR ends up in ospf_network_lsa_refresh() flushing our own database copy instead of the received one.

That cannot flush anything.  Our copy can carry the same sequence number as the received instance while holding different contents, and Section 13.1 compares the checksum before it looks at MaxAge:

  o  If the two instances have different LS checksums, then the instance
     having the larger LS checksum (when considered as a 16-bit unsigned
     integer) is considered more recent.

  o  Else, if only one of the instances has its LS age field set to
     MaxAge, the instance of age MaxAge is considered to be more recent.

So a neighbour holding the larger checksum treats its own copy as the more recent one, hits step (8) of Section 13 and sends it straight back, and we flush it at the neighbour again.  Neither side ever wins.  The two instances are then exchanged at packet rate for as long as the adjacency lives, leaking an LSA reference and a flooding queue entry every round.  A four router topotest reached an LSA lock count of 873306 and 17k LS Updates per interface in under three minutes.

Flush the instance the RFC says to flush.  A database copy already at MaxAge is how we know we no longer wish to originate the LSA, since a self-originated LSA only reaches MaxAge because something deliberately flushed it - ospf_lsa_maxage_walker_remover() skips self-originated LSAs so they never age out on their own.  In that case set the received LSA's age to MaxAge, leaving its sequence number alone as Section 14.1 requires, and let step (5) below reflood it.  Its sequence number and checksum then match what every neighbour holds, the Section 13.1 MaxAge rule makes it more recent for all of them, and the flush is accepted in one round.

Also remove the LSA from the neighbour's Link state request list here. Both remedies satisfy an outstanding request, but the re-origination path returns before step (5), skipping the removal that ospf_flood_through_interface() would otherwise have done.  Without it the adjacency stays in Loading forever, which is how this first showed up: ospf_basic_functionality/test_ospf_authentication.py failing intermittently with "OSPF is not Converged" on a neighbour the test never touches.