### PR TITLE
ospfd: fix forwarding-address-self for existing external LSAs

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2436,7 +2436,7 @@ struct ospf_lsa *ospf_nssa_lsa_refresh(struct ospf_area *area,
 {
 	struct ospf *ospf = area->ospf;
 	struct ospf_lsa *new;
-	struct as_external_lsa *extlsa_old, *extlsa_new;
+	struct as_external_lsa *extlsa_new;
 
 	/* Delete LSA from neighbor retransmit-list. */
 	ospf_ls_retransmit_delete_nbr_as(ospf, lsa);
@@ -2450,18 +2450,37 @@ struct ospf_lsa *ospf_nssa_lsa_refresh(struct ospf_area *area,
 			zlog_debug(
 				"LSA[Type7:%pI4]: Could not originate NSSA-LSA",
 				&ei->p.prefix);
+		ospf_lsa_flush_area(lsa, area);
 		return NULL;
 	}
 	new->data->type = OSPF_AS_NSSA_LSA;
 	new->data->ls_seqnum = lsa_seqnum_increment(lsa);
 	new->area = area;
 
-	/* Preserve the NP bit and forwarding address. */
+	/* Preserve the NP bit. */
 	if (CHECK_FLAG(lsa->data->options, OSPF_OPTION_NP))
 		SET_FLAG(new->data->options, OSPF_OPTION_NP);
-	extlsa_old = (struct as_external_lsa *)lsa->data;
+
+	/*
+	 * Set forwarding address for NSSA LSA. Per RFC 3101, if the P-bit
+	 * is set and the newly computed address is 0, use an NSSA interface
+	 * address. Without the P-bit, a zero forwarding address is valid.
+	 */
 	extlsa_new = (struct as_external_lsa *)new->data;
-	extlsa_new->e[0].fwd_addr = extlsa_old->e[0].fwd_addr;
+	if (CHECK_FLAG(new->data->options, OSPF_OPTION_NP) &&
+	    extlsa_new->e[0].fwd_addr.s_addr == INADDR_ANY)
+		extlsa_new->e[0].fwd_addr = ospf_get_nssa_ip(area);
+
+	/* P-bit LSAs must have a non-zero forwarding address. */
+	if (CHECK_FLAG(new->data->options, OSPF_OPTION_NP) &&
+	    extlsa_new->e[0].fwd_addr.s_addr == INADDR_ANY) {
+		if (IS_DEBUG_OSPF_NSSA)
+			zlog_debug("LSA[Type-7:%pI4]: Could not refresh, no NSSA interface address",
+				   &new->data->id);
+		ospf_lsa_discard(new);
+		ospf_lsa_flush_area(lsa, area);
+		return NULL;
+	}
 
 	/* Install newly created LSA into Type-7 LSDB. */
 	ospf_lsa_install(ospf, NULL, new);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9745,11 +9745,14 @@ DEFPY (ospf_forwarding_address_self,
        "Set forwarding address to self for external LSAs\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+	bool new_value = !no;
 
-	if (no)
-		ospf->forwarding_address_self = false;
-	else
-		ospf->forwarding_address_self = true;
+	if (ospf->forwarding_address_self != new_value) {
+		ospf->forwarding_address_self = new_value;
+
+		/* Refresh all external LSAs to apply the new config. */
+		ospf_schedule_asbr_redist_update(ospf);
+	}
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Summary
  
  - Refresh external LSAs when forwarding-address-self config changes
  - Fix NSSA Type-7 LSA refresh to use the newly computed forwarding
    address instead of preserving the stale value

Problem

  When forwarding-address-self is configured after redistribute, existing
  external LSAs retain their original forwarding address.

  Additionally, for NSSA areas, ospf_nssa_lsa_refresh() was explicitly
  preserving the old forwarding address from the existing LSA,
  preventing the config change from taking effect on Type-7 LSAs.

Solution

  1. Schedule an ASBR redistribution update when forwarding-address-self
     changes to refresh all external LSAs
  2. Fix ospf_nssa_lsa_refresh() to use the newly computed forwarding
     address, applying the same NSSA logic as origination (per RFC 3101)