### PR TITLE
bgpd: fix link-bandwidth AS truncation in route-map for extended encoding

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3557,8 +3557,12 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 	if (!peer || !peer->bgp)
 		return RMAP_ERROR;
 
-	/* Build link bandwidth extended community */
-	as = (peer->bgp->as > BGP_AS_MAX) ? BGP_AS_TRANS : peer->bgp->as;
+	/* Build link bandwidth extended community. The 2-byte (classic)
+	 * encoding below falls back to BGP_AS_TRANS for a 4-byte AS; the
+	 * extended (4-byte) encoding has no such limit and must use the
+	 * real AS.
+	 */
+	as = peer->bgp->as;
 	if (rels->lb_type == RMAP_ECOMM_LB_SET_VALUE) {
 		bw_bytes = (rels->bw * 1000 * 1000) / 8;
 	} else if (rels->lb_type == RMAP_ECOMM_LB_SET_CUMUL) {
@@ -3605,7 +3609,8 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 	} else {
 		struct ecommunity_val lb_eval;
 
-		encode_lb_extcomm(as, bw_bytes, rels->non_trans, &lb_eval,
+		encode_lb_extcomm(as > BGP_AS_MAX ? BGP_AS_TRANS : as, bw_bytes,
+				  rels->non_trans, &lb_eval,
 				  CHECK_FLAG(peer->flags,
 					     PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE));
 

--- a/tests/topotests/bgp_linkbw_routemap_as_truncation/r1/frr.conf
+++ b/tests/topotests/bgp_linkbw_routemap_as_truncation/r1/frr.conf
@@ -1,0 +1,23 @@
+!
+interface r1-eth0
+ ip address 192.168.12.1/24
+!
+ip prefix-list LB_PFX seq 5 permit 10.10.10.10/32
+!
+route-map lb-out permit 10
+ match ip address prefix-list LB_PFX
+ set extcommunity bandwidth 1000
+!
+router bgp 400000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.12.2 remote-as 65000
+ neighbor 192.168.12.2 extended-link-bandwidth
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.2 activate
+  network 10.10.10.10/32
+  neighbor 192.168.12.2 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_linkbw_routemap_as_truncation/r2/frr.conf
+++ b/tests/topotests/bgp_linkbw_routemap_as_truncation/r2/frr.conf
@@ -1,0 +1,13 @@
+!
+interface r2-eth0
+ ip address 192.168.12.2/24
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ neighbor 192.168.12.1 remote-as 400000
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.12.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_linkbw_routemap_as_truncation/test_bgp_linkbw_routemap_as_truncation.py
+++ b/tests/topotests/bgp_linkbw_routemap_as_truncation/test_bgp_linkbw_routemap_as_truncation.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Srinivasan Koona Lokabiraman <srinivasan@nexthop.ai>
+#
+
+"""
+Test that route_set_ecommunity_lb() does not truncate a 4-byte AS to
+BGP_AS_TRANS when encoding the extended (4-byte AS) link-bandwidth
+extended community via a route-map.
+
+Topology
+--------
+
+  r1 (AS 400000) ── eBGP ── r2 (AS 65000)
+
+r1's local AS (400000) exceeds BGP_AS_MAX (65535), so it can only be
+represented in the extended (4-byte AS / IPv6 ecommunity) link-bandwidth
+encoding, never in the classic 2-byte encoding. r1 advertises 10.10.10.10/32
+to r2 with "extended-link-bandwidth" enabled and an outbound route-map
+setting link-bandwidth, which exercises route_set_ecommunity_lb().
+
+Before the fix, route_set_ecommunity_lb() truncated any AS above
+BGP_AS_MAX to BGP_AS_TRANS (23456) before choosing between the extended
+and classic encodings, so r2 would see "LB:23456:..." instead of the
+real "LB:400000:...".
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+PREFIX = "10.10.10.10/32"
+R1_AS = "400000"
+BGP_AS_TRANS = "23456"
+
+_LB_AS_RE = re.compile(r"LB:(\d+):")
+
+
+def lb_as_from_string(lb_string):
+    match = _LB_AS_RE.search(lb_string or "")
+    return match.group(1) if match else None
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_linkbw_extended_as_not_truncated():
+    """r2 should see the real 4-byte AS (400000), not BGP_AS_TRANS (23456)."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    receiver = tgen.gears["r2"]
+
+    def _check_receiver_lb_as():
+        output = json.loads(receiver.vtysh_cmd("show ip bgp %s json" % PREFIX))
+        paths = output.get("paths", [])
+        if not paths:
+            return "prefix %s not found on r2" % PREFIX
+
+        for path in paths:
+            ec = path.get("extendedIpv6Community")
+            got_as = lb_as_from_string(ec.get("string") if ec else None)
+            if got_as == R1_AS:
+                return None
+
+        got = [
+            lb_as_from_string(p.get("extendedIpv6Community", {}).get("string"))
+            for p in paths
+        ]
+        return "expected LB AS %s, got %s" % (R1_AS, got)
+
+    test_func = functools.partial(_check_receiver_lb_as)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "route_set_ecommunity_lb() must not truncate a 4-byte AS (%s) to "
+        "BGP_AS_TRANS (%s) in the extended link-bandwidth encoding: %s"
+        % (R1_AS, BGP_AS_TRANS, result)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary

Fix incorrect AS truncation in `route_set_ecommunity_lb()` when the extended (4-byte AS / IPv6 ecommunity) link-bandwidth encoding is used.

## Problem

`route_set_ecommunity_lb()` currently does this before choosing extended vs classic encoding:

```c
as = (peer->bgp->as > BGP_AS_MAX) ? BGP_AS_TRANS : peer->bgp->as;
```

For a BGP instance with a **4-byte AS** (e.g. 400000), that always reduces the AS to **BGP_AS_TRANS (23456)** — even when the peer has **`extended-link-bandwidth`** configured and the extended encoding can carry the full AS.

Result: an outbound route-map such as `set extcommunity bandwidth …` advertises **`LB:23456:…`** instead of **`LB:400000:…`**.

The clamp is correct only for the **classic 2-byte** link-bandwidth encoding, which cannot represent a full 4-byte AS. The extended encoding has no such limit. `ecommunity_replace_linkbw()` already keeps the real AS for extended encoding; this aligns `route_set_ecommunity_lb()` with that behavior.

## Solution

- Use the originator's real AS when building the extended link-bandwidth EC.
- Apply the `BGP_AS_TRANS` fallback **only** in the classic `encode_lb_extcomm()` path:

```c
encode_lb_extcomm(as > BGP_AS_MAX ? BGP_AS_TRANS : as, ...)
```

## Topotest

`tests/topotests/bgp_linkbw_routemap_as_truncation/`

- **r1** — AS **400000**, eBGP to r2, `extended-link-bandwidth` on the neighbor, outbound route-map `set extcommunity bandwidth 1000` for `10.10.10.10/32`
- **r2** — receives the route and checks the link-bandwidth EC shows AS **400000**, not **23456**

Verified: test fails on master (sees 23456) and passes with this fix.

## Files changed

- `bgpd/bgp_routemap.c` — `route_set_ecommunity_lb()`
- `tests/topotests/bgp_linkbw_routemap_as_truncation/` — new topotest

## Test plan

- [x] New topotest `bgp_linkbw_routemap_as_truncation` (fail-before / pass-after confirmed locally)
- [ ] CI / NetDEF Basic Tests