### PR TITLE
bgpd: fix link-bandwidth AS selection in confederations

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -2167,18 +2167,18 @@ const uint8_t *ecommunity_linkbw_present(struct ecommunity *ecom, uint64_t *bw)
 }
 
 
-struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom,
-					     uint64_t cum_bw,
-					     bool disable_ieee_floating,
-					     bool extended)
+struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom, uint64_t cum_bw,
+					     bool disable_ieee_floating, bool extended,
+					     bool ignore_non_transitive)
 {
 	struct ecommunity *new;
 	const uint8_t *eval;
 	uint8_t type;
 	uint64_t cur_bw;
+	bool non_trans;
 
-	/* Nothing to replace if link-bandwidth doesn't exist or
-	 * is non-transitive - just return existing extcommunity.
+	/* Nothing to replace if link-bandwidth doesn't exist - just
+	 * return existing extcommunity.
 	 */
 	new = ecom;
 	if (!ecom || !ecom->size)
@@ -2189,10 +2189,20 @@ struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom,
 		return new;
 
 	type = *eval;
-	if (CHECK_FLAG(type, ECOMMUNITY_FLAG_NON_TRANSITIVE))
+	non_trans = CHECK_FLAG(type, ECOMMUNITY_FLAG_NON_TRANSITIVE);
+	/*
+	 * Non-transitive link-bandwidth is normally left untouched. Some
+	 * callers (e.g. confederation boundary handling) only need to correct
+	 * the encoded AS, not the bandwidth value — they set
+	 * ignore_non_transitive and pass the existing bandwidth value back in
+	 * unchanged as cum_bw, so the re-encode below is a no-op for the
+	 * bandwidth itself.
+	 */
+	if (non_trans && !ignore_non_transitive)
 		return new;
 
-	/* Transitive link-bandwidth exists, replace with the passed
+	/* Link-bandwidth exists and is either transitive, or non-transitive
+	 * with ignore_non_transitive set. Replace with the passed
 	 * (cumulative) bandwidth value. We need to create a new
 	 * extcommunity for this - refer to AS-Path replace function
 	 * for reference.
@@ -2203,14 +2213,14 @@ struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom,
 	if (extended) {
 		struct ecommunity_val_ipv6 lb_eval;
 
-		encode_lb_extended_extcomm(as, cum_bw, false, &lb_eval);
+		encode_lb_extended_extcomm(as, cum_bw, non_trans, &lb_eval);
 		new = ecommunity_dup(ecom);
 		ecommunity_add_val_ipv6(new, &lb_eval, true, true);
 	} else {
 		struct ecommunity_val lb_eval;
 
-		encode_lb_extcomm(as > BGP_AS_MAX ? BGP_AS_TRANS : as, cum_bw,
-				  false, &lb_eval, disable_ieee_floating);
+		encode_lb_extcomm(as > BGP_AS_MAX ? BGP_AS_TRANS : as, cum_bw, non_trans, &lb_eval,
+				  disable_ieee_floating);
 		new = ecommunity_dup(ecom);
 		new->disable_ieee_floating = disable_ieee_floating;
 		ecommunity_add_val(new, &lb_eval, true, true);

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -455,9 +455,9 @@ extern void bgp_remove_ecomm_from_aggregate_hash(
 extern void bgp_aggr_ecommunity_remove(void *arg);
 extern const uint8_t *ecommunity_linkbw_present(struct ecommunity *ecom,
 						uint64_t *bw);
-extern struct ecommunity *
-ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom, uint64_t cum_bw,
-			  bool disable_ieee_floating, bool extended);
+extern struct ecommunity *ecommunity_replace_linkbw(as_t as, struct ecommunity *ecom,
+						    uint64_t cum_bw, bool disable_ieee_floating,
+						    bool extended, bool ignore_non_transitive);
 
 extern bool soo_in_ecom(struct ecommunity *ecom, struct ecommunity *soo);
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3235,25 +3235,77 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	 * the most sense. However, don't modify if the link-bandwidth has
 	 * been explicitly set by user policy.
 	 */
+	struct attr *rmap_src_attr = post_attr ? post_attr : piattr;
+	bool link_bw_was_set = CHECK_FLAG(rmap_src_attr->rmap_change_flags, BATTR_RMAP_LINK_BW_SET);
+
 	if (nh_reset && bgp_path_info_mpath_chkwtd(bgp, pi->net) == BGP_WECMP_BEHAVIOR_LINK_BW &&
-	    (cum_bw = bgp_path_info_mpath_cumbw(pi->net)) != 0 &&
+	    (cum_bw = bgp_path_info_mpath_cumbw(pi->net)) != 0 && !link_bw_was_set &&
 	    !CHECK_FLAG(attr->rmap_change_flags, BATTR_RMAP_LINK_BW_SET)) {
-		if (CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_LINK_BANDWIDTH))
-			bgp_attr_set_ipv6_ecommunity(
-				attr,
-				ecommunity_replace_linkbw(bgp->as,
-							  bgp_attr_get_ipv6_ecommunity(
-								  attr),
-							  cum_bw, false, true));
-		else
-			bgp_attr_set_ecommunity(
-				attr,
-				ecommunity_replace_linkbw(
-					bgp->as, bgp_attr_get_ecommunity(attr),
-					cum_bw,
+		as_t link_bw_as = bgp_local_as_for_peer(peer);
+
+		if (CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_LINK_BANDWIDTH)) {
+			struct ecommunity *old_ecom, *new_ecom;
+
+			old_ecom = bgp_attr_get_ipv6_ecommunity(attr);
+			new_ecom = ecommunity_replace_linkbw(link_bw_as, old_ecom, cum_bw, false,
+							     true, false);
+			bgp_attr_set_ipv6_ecommunity(attr, new_ecom);
+			if (old_ecom && new_ecom != old_ecom && !old_ecom->refcnt)
+				ecommunity_free(&old_ecom);
+		} else {
+			struct ecommunity *old_ecom, *new_ecom;
+			bool disable_ieee = CHECK_FLAG(peer->flags,
+						       PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE);
+
+			old_ecom = bgp_attr_get_ecommunity(attr);
+			new_ecom = ecommunity_replace_linkbw(link_bw_as, old_ecom, cum_bw,
+							     disable_ieee, false, false);
+			bgp_attr_set_ecommunity(attr, new_ecom);
+			if (old_ecom && new_ecom != old_ecom && !old_ecom->refcnt)
+				ecommunity_free(&old_ecom);
+		}
+	}
+
+	/*
+	 * If link-bandwidth was set by a route-map (either at origination or
+	 * per-neighbor), we still need to adjust the AS number based on the
+	 * destination peer type, even though the bandwidth value itself should
+	 * not be changed.
+	 *
+	 * This ensures consistency: external eBGP peers see confederation AS,
+	 * while iBGP and confederation peers see local AS.
+	 */
+	if (link_bw_was_set || CHECK_FLAG(attr->rmap_change_flags, BATTR_RMAP_LINK_BW_SET)) {
+		as_t link_bw_as = bgp_local_as_for_peer(peer);
+		uint64_t bw_val = 0;
+
+		/* Replace AS number in existing link-bandwidth extended community */
+		if (CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_LINK_BANDWIDTH)) {
+			struct ecommunity *old_ecom, *new_ecom;
+
+			old_ecom = bgp_attr_get_ipv6_ecommunity(attr);
+			if (old_ecom && ecommunity_linkbw_present(old_ecom, &bw_val)) {
+				new_ecom = ecommunity_replace_linkbw(link_bw_as, old_ecom, bw_val,
+								     false, true, true);
+				bgp_attr_set_ipv6_ecommunity(attr, new_ecom);
+				if (new_ecom != old_ecom && !old_ecom->refcnt)
+					ecommunity_free(&old_ecom);
+			}
+		} else {
+			struct ecommunity *old_ecom, *new_ecom;
+
+			old_ecom = bgp_attr_get_ecommunity(attr);
+			if (old_ecom && ecommunity_linkbw_present(old_ecom, &bw_val)) {
+				new_ecom = ecommunity_replace_linkbw(
+					link_bw_as, old_ecom, bw_val,
 					CHECK_FLAG(peer->flags,
 						   PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE),
-					false));
+					false, true);
+				bgp_attr_set_ecommunity(attr, new_ecom);
+				if (new_ecom != old_ecom && !old_ecom->refcnt)
+					ecommunity_free(&old_ecom);
+			}
+		}
 	}
 
 	/*

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3560,9 +3560,13 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 	/* Build link bandwidth extended community. The 2-byte (classic)
 	 * encoding below falls back to BGP_AS_TRANS for a 4-byte AS; the
 	 * extended (4-byte) encoding has no such limit and must use the
-	 * real AS.
+	 * real AS. Use confederation ID if configured and sending to
+	 * external eBGP peer, similar to AS_PATH handling. When route-map
+	 * is applied at origination (network command), peer is peer_self.
+	 * The AS number set here will be replaced later in
+	 * subgroup_announce_check() based on the actual destination peer.
 	 */
-	as = peer->bgp->as;
+	as = bgp_local_as_for_peer(peer);
 	if (rels->lb_type == RMAP_ECOMM_LB_SET_VALUE) {
 		bw_bytes = (rels->bw * 1000 * 1000) / 8;
 	} else if (rels->lb_type == RMAP_ECOMM_LB_SET_CUMUL) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -842,6 +842,22 @@ bool bgp_confederation_peers_check(struct bgp *bgp, as_t as)
 	return false;
 }
 
+/*
+ * Return the AS this peer's session should present as our local AS —
+ * the confederation ID for peers outside the confederation, the local
+ * sub-AS for iBGP and confederation-member peers (already tracked in
+ * peer->local_as), or an explicit "neighbor X local-as Y" override
+ * when one is configured and confederation is not. Mirrors the AS
+ * selection in bgp_packet_attribute()'s AS_PATH construction.
+ */
+as_t bgp_local_as_for_peer(struct peer *peer)
+{
+	if (!CHECK_FLAG(peer->bgp->config, BGP_CONFIG_CONFEDERATION) && peer->change_local_as)
+		return peer->change_local_as;
+
+	return peer->local_as;
+}
+
 /* Add an AS to the confederation set.  */
 void bgp_confederation_peers_add(struct bgp *bgp, as_t as, const char *as_str)
 {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2776,6 +2776,7 @@ extern void bgp_confederation_id_set(struct bgp *bgp, as_t as,
 				     const char *as_str);
 extern void bgp_confederation_id_unset(struct bgp *bgp);
 extern bool bgp_confederation_peers_check(struct bgp *bgp, as_t as);
+extern as_t bgp_local_as_for_peer(struct peer *peer);
 
 extern void bgp_confederation_peers_add(struct bgp *bgp, as_t as,
 					const char *as_str);

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r1/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r1/frr.conf
@@ -1,0 +1,161 @@
+!
+interface lo
+ ip address 192.0.2.8/32
+ ipv6 address 2001:db8::8/128
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+ ipv6 address 2001:db8:1::1/64
+!
+interface r1-eth1
+ ip address 10.0.2.1/24
+ ipv6 address 2001:db8:2::1/64
+!
+interface r1-eth2
+ ip address 10.0.3.1/24
+ ipv6 address 2001:db8:3::1/64
+!
+interface r1-eth3
+ ip address 10.0.4.1/24
+ ipv6 address 2001:db8:4::1/64
+!
+interface r1-eth4
+ ip address 10.0.5.1/24
+ ipv6 address 2001:db8:5::1/64
+!
+interface r1-eth5
+ ip address 10.0.6.1/24
+ ipv6 address 2001:db8:6::1/64
+!
+router bgp 65101
+ bgp router-id 192.0.2.101
+ bgp confederation identifier 65100
+ bgp confederation peers 65102 65103
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ !
+ neighbor 10.0.1.2 remote-as 65101
+ neighbor 10.0.1.2 description r2-same-subas-ipv4
+ !
+ neighbor 10.0.2.2 remote-as 65101
+ neighbor 10.0.2.2 description r7-same-subas-ipv4
+ !
+ neighbor 2001:db8:1::2 remote-as 65101
+ neighbor 2001:db8:1::2 description r2-same-subas-ipv6
+ !
+ neighbor 2001:db8:2::2 remote-as 65101
+ neighbor 2001:db8:2::2 description r7-same-subas-ipv6
+ !
+ neighbor 10.0.3.2 remote-as 65102
+ neighbor 10.0.3.2 description r3-confederation-peer-ipv4
+ !
+ neighbor 2001:db8:3::2 remote-as 65102
+ neighbor 2001:db8:3::2 description r3-confederation-peer-ipv6
+ !
+ neighbor 10.0.4.2 remote-as 65103
+ neighbor 10.0.4.2 description r4-confederation-peer-with-routemap-ipv4
+ !
+ neighbor 2001:db8:4::2 remote-as 65103
+ neighbor 2001:db8:4::2 description r4-confederation-peer-with-routemap-ipv6
+ !
+ neighbor 10.0.5.2 remote-as 64001
+ neighbor 10.0.5.2 description r5-external-ebgp-ipv4
+ !
+ neighbor 2001:db8:5::2 remote-as 64001
+ neighbor 2001:db8:5::2 description r5-external-ebgp-ipv6
+ !
+ neighbor 10.0.6.2 remote-as 64002
+ neighbor 10.0.6.2 description r6-external-ebgp-with-routemap-ipv4
+ !
+ neighbor 2001:db8:6::2 remote-as 64002
+ neighbor 2001:db8:6::2 description r6-external-ebgp-with-routemap-ipv6
+ !
+ address-family ipv4 unicast
+  network 192.0.2.8/32 route-map SET_LB_ORIG
+  neighbor 10.0.1.2 activate
+  neighbor 10.0.1.2 next-hop-self
+  !
+  neighbor 10.0.2.2 activate
+  neighbor 10.0.2.2 next-hop-self
+  !
+  neighbor 10.0.3.2 activate
+  neighbor 10.0.3.2 next-hop-self
+  !
+  neighbor 10.0.4.2 activate
+  neighbor 10.0.4.2 next-hop-self
+  neighbor 10.0.4.2 route-map SET_LINKBW out
+  !
+  neighbor 10.0.5.2 activate
+  neighbor 10.0.5.2 next-hop-self
+  !
+  neighbor 10.0.6.2 activate
+  neighbor 10.0.6.2 next-hop-self
+  neighbor 10.0.6.2 route-map SET_LINKBW out
+  !
+  no neighbor 2001:db8:1::2 activate
+  no neighbor 2001:db8:2::2 activate
+  no neighbor 2001:db8:3::2 activate
+  no neighbor 2001:db8:4::2 activate
+  no neighbor 2001:db8:5::2 activate
+  no neighbor 2001:db8:6::2 activate
+  !
+  maximum-paths 64
+  maximum-paths ibgp 64
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  network 2001:db8::8/128 route-map SET_LB_ORIG
+  no neighbor 10.0.1.2 activate
+  no neighbor 10.0.2.2 activate
+  no neighbor 10.0.3.2 activate
+  no neighbor 10.0.4.2 activate
+  no neighbor 10.0.5.2 activate
+  no neighbor 10.0.6.2 activate
+  !
+  neighbor 2001:db8:1::2 activate
+  neighbor 2001:db8:1::2 next-hop-self
+  !
+  neighbor 2001:db8:2::2 activate
+  neighbor 2001:db8:2::2 next-hop-self
+  !
+  neighbor 2001:db8:3::2 activate
+  neighbor 2001:db8:3::2 next-hop-self
+  !
+  neighbor 2001:db8:4::2 activate
+  neighbor 2001:db8:4::2 next-hop-self
+  neighbor 2001:db8:4::2 route-map SET_LINKBW out
+  !
+  neighbor 2001:db8:5::2 activate
+  neighbor 2001:db8:5::2 next-hop-self
+  !
+  neighbor 2001:db8:6::2 activate
+  neighbor 2001:db8:6::2 next-hop-self
+  neighbor 2001:db8:6::2 route-map SET_LINKBW out
+  !
+  maximum-paths 64
+  maximum-paths ibgp 64
+ exit-address-family
+!
+ip prefix-list PL_CUMUL_V4 seq 5 permit 192.0.2.1/32
+ipv6 prefix-list PL_CUMUL_V6 seq 5 permit 2001:db8::1/128
+ip prefix-list PL_NONTRANS_V4 seq 5 permit 192.0.2.2/32
+ipv6 prefix-list PL_NONTRANS_V6 seq 5 permit 2001:db8::2/128
+!
+route-map SET_LINKBW permit 10
+ match ip address prefix-list PL_CUMUL_V4
+ set extcommunity bandwidth cumulative
+route-map SET_LINKBW permit 20
+ match ipv6 address prefix-list PL_CUMUL_V6
+ set extcommunity bandwidth cumulative
+route-map SET_LINKBW permit 30
+ match ip address prefix-list PL_NONTRANS_V4
+ set extcommunity bandwidth 2000 non-transitive
+route-map SET_LINKBW permit 40
+ match ipv6 address prefix-list PL_NONTRANS_V6
+ set extcommunity bandwidth 2000 non-transitive
+route-map SET_LINKBW permit 50
+!
+route-map SET_LB_ORIG permit 10
+ set extcommunity bandwidth 3000
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r2/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r2/frr.conf
@@ -1,0 +1,41 @@
+!
+interface lo
+ ip address 192.0.2.1/32
+ ipv6 address 2001:db8::1/128
+ ip address 192.0.2.2/32
+ ipv6 address 2001:db8::2/128
+!
+interface r2-eth0
+ ip address 10.0.1.2/24
+ ipv6 address 2001:db8:1::2/64
+!
+router bgp 65101
+ bgp router-id 192.0.2.102
+ bgp confederation identifier 65100
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ !
+ neighbor 10.0.1.1 remote-as 65101
+ neighbor 10.0.1.1 description r1-dut-ipv4
+ !
+ neighbor 2001:db8:1::1 remote-as 65101
+ neighbor 2001:db8:1::1 description r1-dut-ipv6
+ !
+ address-family ipv4 unicast
+  network 192.0.2.1/32 route-map SET_LINKBW_1G
+  network 192.0.2.2/32
+  neighbor 10.0.1.1 activate
+  no neighbor 2001:db8:1::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  network 2001:db8::1/128 route-map SET_LINKBW_1G
+  network 2001:db8::2/128
+  no neighbor 10.0.1.1 activate
+  neighbor 2001:db8:1::1 activate
+ exit-address-family
+!
+route-map SET_LINKBW_1G permit 10
+ set extcommunity bandwidth 1000
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r3/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r3/frr.conf
@@ -1,0 +1,28 @@
+!
+interface r3-eth0
+ ip address 10.0.3.2/24
+ ipv6 address 2001:db8:3::2/64
+!
+router bgp 65102
+ bgp router-id 192.0.2.103
+ bgp confederation identifier 65100
+ bgp confederation peers 65101 65103
+ no bgp ebgp-requires-policy
+ !
+ neighbor 10.0.3.1 remote-as 65101
+ neighbor 10.0.3.1 description r1-dut-ipv4
+ !
+ neighbor 2001:db8:3::1 remote-as 65101
+ neighbor 2001:db8:3::1 description r1-dut-ipv6
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.3.1 activate
+  no neighbor 2001:db8:3::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  no neighbor 10.0.3.1 activate
+  neighbor 2001:db8:3::1 activate
+ exit-address-family
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r4/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r4/frr.conf
@@ -1,0 +1,28 @@
+!
+interface r4-eth0
+ ip address 10.0.4.2/24
+ ipv6 address 2001:db8:4::2/64
+!
+router bgp 65103
+ bgp router-id 192.0.2.104
+ bgp confederation identifier 65100
+ bgp confederation peers 65101 65102
+ no bgp ebgp-requires-policy
+ !
+ neighbor 10.0.4.1 remote-as 65101
+ neighbor 10.0.4.1 description r1-dut-ipv4
+ !
+ neighbor 2001:db8:4::1 remote-as 65101
+ neighbor 2001:db8:4::1 description r1-dut-ipv6
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.4.1 activate
+  no neighbor 2001:db8:4::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  no neighbor 10.0.4.1 activate
+  neighbor 2001:db8:4::1 activate
+ exit-address-family
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r5/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r5/frr.conf
@@ -1,0 +1,26 @@
+!
+interface r5-eth0
+ ip address 10.0.5.2/24
+ ipv6 address 2001:db8:5::2/64
+!
+router bgp 64001
+ bgp router-id 192.0.2.105
+ no bgp ebgp-requires-policy
+ !
+ neighbor 10.0.5.1 remote-as 65100
+ neighbor 10.0.5.1 description r1-dut-ipv4
+ !
+ neighbor 2001:db8:5::1 remote-as 65100
+ neighbor 2001:db8:5::1 description r1-dut-ipv6
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.5.1 activate
+  no neighbor 2001:db8:5::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  no neighbor 10.0.5.1 activate
+  neighbor 2001:db8:5::1 activate
+ exit-address-family
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r6/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r6/frr.conf
@@ -1,0 +1,26 @@
+!
+interface r6-eth0
+ ip address 10.0.6.2/24
+ ipv6 address 2001:db8:6::2/64
+!
+router bgp 64002
+ bgp router-id 192.0.2.106
+ no bgp ebgp-requires-policy
+ !
+ neighbor 10.0.6.1 remote-as 65100
+ neighbor 10.0.6.1 description r1-dut-ipv4
+ !
+ neighbor 2001:db8:6::1 remote-as 65100
+ neighbor 2001:db8:6::1 description r1-dut-ipv6
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.6.1 activate
+  no neighbor 2001:db8:6::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  no neighbor 10.0.6.1 activate
+  neighbor 2001:db8:6::1 activate
+ exit-address-family
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/r7/frr.conf
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/r7/frr.conf
@@ -1,0 +1,37 @@
+!
+interface lo
+ ip address 192.0.2.1/32
+ ipv6 address 2001:db8::1/128
+!
+interface r7-eth0
+ ip address 10.0.2.2/24
+ ipv6 address 2001:db8:2::2/64
+!
+router bgp 65101
+ bgp router-id 192.0.2.107
+ bgp confederation identifier 65100
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ !
+ neighbor 10.0.2.1 remote-as 65101
+ neighbor 10.0.2.1 description r1-dut-ipv4
+ !
+ neighbor 2001:db8:2::1 remote-as 65101
+ neighbor 2001:db8:2::1 description r1-dut-ipv6
+ !
+ address-family ipv4 unicast
+  network 192.0.2.1/32 route-map SET_LINKBW_5G
+  neighbor 10.0.2.1 activate
+  no neighbor 2001:db8:2::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  network 2001:db8::1/128 route-map SET_LINKBW_5G
+  no neighbor 10.0.2.1 activate
+  neighbor 2001:db8:2::1 activate
+ exit-address-family
+!
+route-map SET_LINKBW_5G permit 10
+ set extcommunity bandwidth 5000
+!
+

--- a/tests/topotests/bgp_confederation_linkbw_as_test/test_bgp_confederation_linkbw_as.py
+++ b/tests/topotests/bgp_confederation_linkbw_as_test/test_bgp_confederation_linkbw_as.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Srinivasan Koona Lokabiraman <srinivasan@nexthop.ai>
+#
+
+"""
+Test BGP confederation link-bandwidth AS number handling.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+
+pytestmark = [pytest.mark.bgpd]
+
+
+# AS number constants
+LOCAL_AS = "65101"           # Local sub-AS for r1, r2, r7
+CONFEDERATION_AS = "65100"   # Confederation AS
+
+# Standard test prefix, originated by both r2 and r7 (multipath at r1),
+# used by the transitive/automatic link-bandwidth test cases.
+TRANS_PREFIX_V4 = "192.0.2.1/32"
+TRANS_PREFIX_V6 = "2001:db8::1/128"
+
+# Prefix used to test non-transitive link-bandwidth (originated by r2 only,
+# no route-map at origination). r1's SET_LINKBW route-map matches this
+# prefix specifically and sets link-bandwidth as non-transitive, to verify
+# the AS is still corrected for the confederation boundary even though
+# ecommunity_replace_linkbw() must not otherwise touch non-transitive
+# communities.
+NONTRANS_PREFIX_V4 = "192.0.2.2/32"
+NONTRANS_PREFIX_V6 = "2001:db8::2/128"
+
+# Prefix originated by r1 itself via a route-map (network ... route-map),
+# with no per-neighbor outbound route-map on any destination. Verifies the
+# AS still gets corrected for confederation boundaries even when
+# BATTR_RMAP_LINK_BW_SET was only set at origination, not by an outbound
+# route-map on the destination peer.
+ORIG_PREFIX_V4 = "192.0.2.8/32"
+ORIG_PREFIX_V6 = "2001:db8::8/128"
+
+
+# Peer address mapping: [router][peer][address_family]
+# This maps how each router sees its peers
+PEER_ADDRESSES = {
+    "r1": {
+        "r2": {"ipv4": "10.0.1.2", "ipv6": "2001:db8:1::2"},
+        "r7": {"ipv4": "10.0.2.2", "ipv6": "2001:db8:2::2"},
+    },
+    "r3": {
+        "r1": {"ipv4": "10.0.3.1", "ipv6": "2001:db8:3::1"},
+    },
+    "r4": {
+        "r1": {"ipv4": "10.0.4.1", "ipv6": "2001:db8:4::1"},
+    },
+    "r5": {
+        "r1": {"ipv4": "10.0.5.1", "ipv6": "2001:db8:5::1"},
+    },
+    "r6": {
+        "r1": {"ipv4": "10.0.6.1", "ipv6": "2001:db8:6::1"},
+    },
+}
+
+
+def get_peer_address(router_name, peer_name, ipv6=False):
+    """
+    Get the peer address as seen by the router.
+
+    Args:
+        router_name: Router name (e.g., "r1", "r3")
+        peer_name: Peer router name (e.g., "r2", "r1")
+        ipv6: True for IPv6, False for IPv4
+
+    Returns:
+        str: Peer IP address
+
+    Example:
+        get_peer_address("r1", "r2", ipv6=False)  # Returns "10.0.1.2"
+        get_peer_address("r3", "r1", ipv6=True)   # Returns "2001:db8:3::1"
+    """
+    af = "ipv6" if ipv6 else "ipv4"
+
+    if router_name not in PEER_ADDRESSES:
+        raise ValueError("Router {} not found in PEER_ADDRESSES".format(router_name))
+
+    if peer_name not in PEER_ADDRESSES[router_name]:
+        raise ValueError("Peer {} not found for router {}".format(peer_name, router_name))
+
+    return PEER_ADDRESSES[router_name][peer_name][af]
+
+
+def get_bgp_path_from_peer(router, prefix, peer_id, ipv6=False):
+    """
+    Get BGP path information for a specific prefix from a specific peer.
+
+    Args:
+        router: Router object to query
+        prefix: BGP prefix (e.g., "192.0.2.1/32" or "2001:db8::1/128")
+        peer_id: Peer ID to look for (e.g., "10.0.1.2")
+        ipv6: True for IPv6, False for IPv4
+
+    Returns:
+        dict: Path information from the specified peer, or None if not found
+    """
+    if ipv6:
+        cmd = "show bgp ipv6 unicast {} json".format(prefix)
+    else:
+        cmd = "show ip bgp {} json".format(prefix)
+
+    output = router.vtysh_cmd(cmd)
+    data = json.loads(output)
+
+    if "paths" not in data:
+        return None
+
+    # Find the path from the specified peer
+    for path in data["paths"]:
+        if path.get("peer", {}).get("peerId") == peer_id:
+            return path
+
+    return None
+
+
+def validate_linkbw_as(router, peer_router_name, expected_as, peer_type, prefix,
+                       ipv6=False, forbidden_as=None):
+    """
+    Validate that link-bandwidth extended community has the correct AS number.
+
+    Args:
+        router: Router object to query
+        peer_router_name: Peer router name (e.g., "r2", "r1") - address will be auto-looked up
+        expected_as: AS number that should be present (e.g., "65101")
+        peer_type: Description of peer type for error messages (e.g., "iBGP peer r2")
+        prefix: BGP prefix to check (e.g., TRANS_PREFIX_V4, NONTRANS_PREFIX_V6)
+        ipv6: True for IPv6, False for IPv4
+        forbidden_as: AS number that must not appear in LB (e.g., "65100" on iBGP paths)
+
+    Returns:
+        str: Extended community string for logging
+
+    Raises:
+        AssertionError: If validation fails
+    """
+    # Auto-lookup peer address based on router and peer names
+    peer_id = get_peer_address(router.name, peer_router_name, ipv6)
+
+    path = get_bgp_path_from_peer(router, prefix, peer_id, ipv6)
+
+    assert path is not None, "No path found from peer {} ({}) on router {}".format(
+        peer_router_name, peer_id, router.name
+    )
+
+    # Get extended community string
+    extcomm = path.get("extendedCommunity", {}).get("string", "")
+
+    # Validate expected AS is present
+    assert "LB:{}:".format(expected_as) in extcomm, \
+        "Expected AS {} in link-bandwidth for {}, got: {}".format(expected_as, peer_type, extcomm)
+
+    if forbidden_as is not None:
+        assert "LB:{}:".format(forbidden_as) not in extcomm, \
+            "Unexpected AS {} in link-bandwidth for {}, got: {}".format(
+                forbidden_as, peer_type, extcomm
+            )
+
+    return extcomm
+
+
+def build_topo(tgen):
+    """Build the test topology."""
+
+    for routern in range(1, 8):
+        tgen.add_router("r{}".format(routern))
+
+    # r1-r2 (iBGP same sub-AS)
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # r1-r7 (iBGP same sub-AS)
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r7"])
+
+    # r1-r3 (confederation peer)
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    # r1-r4 (confederation peer with route-map)
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r4"])
+
+    # r1-r5 (external eBGP)
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r5"])
+
+    # r1-r6 (external eBGP with route-map)
+    switch = tgen.add_switch("s6")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r6"])
+
+
+def setup_module(mod):
+    """Set up the test environment."""
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    """Tear down the test environment."""
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _test_bgp_convergence(prefix, min_paths=2):
+    """Test BGP convergence."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Waiting for BGP convergence")
+
+    router = tgen.gears["r1"]
+
+    def _bgp_converge(router):
+        output = router.vtysh_cmd("show ip bgp {} json".format(prefix))
+        if not output:
+            return "No output"
+        try:
+            data = json.loads(output)
+            if "paths" in data and len(data["paths"]) >= min_paths:
+                return None
+        except:
+            pass
+        return "Not converged"
+
+    test_func = functools.partial(_bgp_converge, router)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, "BGP did not converge on r1"
+
+    step("BGP converged successfully")
+
+
+def test_bgp_convergence():
+    """Test BGP convergence."""
+    _test_bgp_convergence(TRANS_PREFIX_V4)
+
+
+def test_bgp_convergence_nontransitive():
+    """Test BGP convergence for the non-transitive link-bandwidth test prefix."""
+    _test_bgp_convergence(NONTRANS_PREFIX_V4, min_paths=1)
+
+
+def test_ibgp_peer_linkbw_as():
+    """Test link-bandwidth AS for iBGP peer - check what r1 receives from r2."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for iBGP peer r2 (AS 65101) - what r1 receives")
+
+    router_r1 = tgen.gears["r1"]
+
+    # r2 should send link-bandwidth with local AS 65101
+    # because r2 and r1 are iBGP peers (same AS)
+    extcomm = validate_linkbw_as(
+        router=router_r1,
+        peer_router_name="r2",
+        expected_as=LOCAL_AS,
+        peer_type="iBGP peer r2",
+        prefix=TRANS_PREFIX_V4,
+        ipv6=False,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r2→r1 path extended community: {}".format(extcomm))
+    step("PASS: r2 (iBGP peer AS 65101): Correctly uses local AS 65101 when sending to r1")
+
+
+def test_ibgp_peer_r7_linkbw_as():
+    """Test link-bandwidth AS for iBGP peer r7 - same sub-AS as r1."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for iBGP peer r7 (AS 65101) - what r1 receives")
+
+    router_r1 = tgen.gears["r1"]
+
+    extcomm = validate_linkbw_as(
+        router=router_r1,
+        peer_router_name="r7",
+        expected_as=LOCAL_AS,
+        peer_type="iBGP peer r7",
+        prefix=TRANS_PREFIX_V4,
+        ipv6=False,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r7→r1 path extended community: {}".format(extcomm))
+    step("PASS: r7 (iBGP peer AS 65101): Correctly uses local AS 65101 when sending to r1")
+
+
+def test_confederation_peer_linkbw_as():
+    """Test link-bandwidth AS for confederation peer (r3)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for confederation peer r3 (AS 65102)")
+
+    router_r3 = tgen.gears["r3"]
+
+    # Should use sub-AS 65101
+    # This tests the automatic link-bandwidth code path
+    extcomm = validate_linkbw_as(
+        router=router_r3,
+        peer_router_name="r1",
+        expected_as=LOCAL_AS,
+        peer_type="confederation peer r3",
+        prefix=TRANS_PREFIX_V4,
+        ipv6=False,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r1→r3 path extended community: {}".format(extcomm))
+    step("PASS: r3 (confederation peer AS 65102): Correctly uses sub-AS 65101")
+
+
+def test_confederation_peer_origination_only_linkbw_as():
+    """Test link-bandwidth AS for confederation peer (r3), origination-only route-map."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking origination-only link-bandwidth AS for confederation peer r3 (AS 65102)")
+
+    router_r3 = tgen.gears["r3"]
+
+    # r1 originates ORIG_PREFIX_V4 via "network ... route-map", with no
+    # outbound route-map on r3. Should still use sub-AS 65101.
+    extcomm = validate_linkbw_as(
+        router=router_r3,
+        peer_router_name="r1",
+        expected_as=LOCAL_AS,
+        peer_type="confederation peer r3 (origination-only route-map)",
+        prefix=ORIG_PREFIX_V4,
+        ipv6=False,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r1→r3 origination-only path extended community: {}".format(extcomm))
+    step("PASS: r3 (confederation peer AS 65102, origination-only route-map): "
+         "Correctly uses sub-AS 65101")
+
+
+def _test_confederation_peer_with_routemap_linkbw_as(prefix):
+    """Test link-bandwidth AS for confederation peer with route-map (r4)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for confederation peer r4 (AS 65103) with route-map")
+
+    router_r4 = tgen.gears["r4"]
+
+    # Should use sub-AS 65101 (route-map code path)
+    extcomm = validate_linkbw_as(
+        router=router_r4,
+        peer_router_name="r1",
+        expected_as=LOCAL_AS,
+        peer_type="confederation peer r4 (route-map)",
+        prefix=prefix,
+        ipv6=False,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r1→r4 path extended community: {}".format(extcomm))
+    step("PASS: r4 (confederation peer AS 65103, route-map): Correctly uses sub-AS 65101")
+
+
+def test_confederation_peer_with_routemap_linkbw_as():
+    """Test link-bandwidth AS for confederation peer with route-map (r4)."""
+    _test_confederation_peer_with_routemap_linkbw_as(prefix=TRANS_PREFIX_V4)
+
+
+def test_confederation_peer_with_routemap_nontransitive_linkbw_as():
+    """Test link-bandwidth AS for confederation peer with non-transitive route-map (r4)."""
+    _test_confederation_peer_with_routemap_linkbw_as(prefix=NONTRANS_PREFIX_V4)
+
+
+def test_external_ebgp_peer_linkbw_as():
+    """Test link-bandwidth AS for external eBGP peer (r5)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for external eBGP peer r5 (AS 64001)")
+
+    router_r5 = tgen.gears["r5"]
+
+    # Should use confederation AS 65100 (automatic code path)
+    # This is the KEY test - external peers should see confederation AS
+    extcomm = validate_linkbw_as(
+        router=router_r5,
+        peer_router_name="r1",
+        expected_as=CONFEDERATION_AS,
+        peer_type="external eBGP peer r5",
+        prefix=TRANS_PREFIX_V4,
+        ipv6=False
+    )
+
+    step("r1→r5 path extended community: {}".format(extcomm))
+    step("PASS: r5 (external eBGP AS 64001, no route-map): Correctly uses confederation AS 65100")
+
+
+def test_external_ebgp_peer_origination_only_linkbw_as():
+    """Test link-bandwidth AS for external eBGP peer (r5), origination-only route-map."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking origination-only link-bandwidth AS for external eBGP peer r5 (AS 64001)")
+
+    router_r5 = tgen.gears["r5"]
+
+    # r1 originates ORIG_PREFIX_V4 via "network ... route-map", with no
+    # outbound route-map on r5. This is the key regression check: the AS
+    # correction for route-map-set link-bandwidth must apply here too,
+    # even though the route-map only ran at origination and this specific
+    # destination has no outbound route-map of its own.
+    extcomm = validate_linkbw_as(
+        router=router_r5,
+        peer_router_name="r1",
+        expected_as=CONFEDERATION_AS,
+        peer_type="external eBGP peer r5 (origination-only route-map)",
+        prefix=ORIG_PREFIX_V4,
+        ipv6=False,
+        forbidden_as=LOCAL_AS,
+    )
+
+    step("r1→r5 origination-only path extended community: {}".format(extcomm))
+    step("PASS: r5 (external eBGP AS 64001, origination-only route-map): "
+         "Correctly uses confederation AS 65100")
+
+
+def _test_external_ebgp_peer_with_routemap_linkbw_as(prefix):
+    """Test link-bandwidth AS for external eBGP peer with route-map (r6)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for external eBGP peer r6 (AS 64002) with route-map")
+
+    router_r6 = tgen.gears["r6"]
+
+    # Should use confederation AS 65100 (route-map code path)
+    extcomm = validate_linkbw_as(
+        router=router_r6,
+        peer_router_name="r1",
+        expected_as=CONFEDERATION_AS,
+        peer_type="external eBGP peer r6 (route-map)",
+        prefix=prefix,
+        ipv6=False,
+    )
+
+    step("r1→r6 path extended community: {}".format(extcomm))
+    step("PASS: r6 (external eBGP AS 64002, route-map): Correctly uses confederation AS 65100")
+
+
+def test_external_ebgp_peer_with_routemap_linkbw_as():
+    """Test link-bandwidth AS for external eBGP peer with route-map (r6)."""
+    _test_external_ebgp_peer_with_routemap_linkbw_as(prefix=TRANS_PREFIX_V4)
+
+
+def test_external_ebgp_peer_with_routemap_nontransitive_linkbw_as():
+    """Test link-bandwidth AS for external eBGP peer with non-transitive route-map (r6)."""
+    _test_external_ebgp_peer_with_routemap_linkbw_as(prefix=NONTRANS_PREFIX_V4)
+
+
+def _test_bgp_convergence_ipv6(prefix, min_paths=2):
+    """Test BGP IPv6 convergence."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Waiting for BGP IPv6 convergence")
+
+    router = tgen.gears["r1"]
+
+    def _bgp_converge(router):
+        output = router.vtysh_cmd("show bgp ipv6 unicast {} json".format(prefix))
+        if not output:
+            return "No output"
+        try:
+            data = json.loads(output)
+            if "paths" in data and len(data["paths"]) >= min_paths:
+                return None
+        except:
+            pass
+        return "Not converged"
+
+    test_func = functools.partial(_bgp_converge, router)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, "BGP IPv6 did not converge on r1"
+
+    step("BGP IPv6 converged successfully")
+
+
+def test_bgp_ipv6_convergence():
+    """Test BGP IPv6 convergence."""
+    _test_bgp_convergence_ipv6(TRANS_PREFIX_V6)
+
+
+def test_bgp_convergence_nontransitive_ipv6():
+    """Test BGP convergence for the non-transitive link-bandwidth test prefix (IPv6)."""
+    _test_bgp_convergence_ipv6(NONTRANS_PREFIX_V6, min_paths=1)
+
+
+def test_ibgp_peer_linkbw_as_ipv6():
+    """Test link-bandwidth AS for iBGP peer - check what r1 receives from r2 (IPv6)."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for iBGP peer r2 (AS 65101) - what r1 receives (IPv6)")
+
+    router_r1 = tgen.gears["r1"]
+
+    # r2 should send link-bandwidth with local AS 65101
+    # because r2 and r1 are iBGP peers (same AS)
+    extcomm = validate_linkbw_as(
+        router=router_r1,
+        peer_router_name="r2",
+        expected_as=LOCAL_AS,
+        peer_type="iBGP peer r2 (IPv6)",
+        prefix=TRANS_PREFIX_V6,
+        ipv6=True,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r2→r1 path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r2 (iBGP peer AS 65101, IPv6): Correctly uses local AS 65101 when sending to r1")
+
+
+def test_ibgp_peer_r7_linkbw_as_ipv6():
+    """Test link-bandwidth AS for iBGP peer r7 (IPv6) - same sub-AS as r1."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for iBGP peer r7 (AS 65101) - what r1 receives (IPv6)")
+
+    router_r1 = tgen.gears["r1"]
+
+    extcomm = validate_linkbw_as(
+        router=router_r1,
+        peer_router_name="r7",
+        expected_as=LOCAL_AS,
+        peer_type="iBGP peer r7 (IPv6)",
+        prefix=TRANS_PREFIX_V6,
+        ipv6=True,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r7→r1 path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r7 (iBGP peer AS 65101, IPv6): Correctly uses local AS 65101 when sending to r1")
+
+
+def test_confederation_peer_linkbw_as_ipv6():
+    """Test link-bandwidth AS for confederation peer (r3) - IPv6."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for confederation peer r3 (AS 65102) - IPv6")
+
+    router_r3 = tgen.gears["r3"]
+
+    # Should use sub-AS 65101
+    extcomm = validate_linkbw_as(
+        router=router_r3,
+        peer_router_name="r1",
+        expected_as=LOCAL_AS,
+        peer_type="confederation peer r3 (IPv6)",
+        prefix=TRANS_PREFIX_V6,
+        ipv6=True,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r1→r3 path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r3 (confederation peer AS 65102, IPv6): Correctly uses sub-AS 65101")
+
+
+def test_confederation_peer_origination_only_linkbw_as_ipv6():
+    """Test link-bandwidth AS for confederation peer (r3), origination-only route-map - IPv6."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking origination-only link-bandwidth AS for confederation peer r3 (AS 65102) - IPv6")
+
+    router_r3 = tgen.gears["r3"]
+
+    extcomm = validate_linkbw_as(
+        router=router_r3,
+        peer_router_name="r1",
+        expected_as=LOCAL_AS,
+        peer_type="confederation peer r3 (origination-only route-map, IPv6)",
+        prefix=ORIG_PREFIX_V6,
+        ipv6=True,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r1→r3 origination-only path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r3 (confederation peer AS 65102, origination-only route-map, IPv6): "
+         "Correctly uses sub-AS 65101")
+
+
+def _test_confederation_peer_with_routemap_linkbw_as_ipv6(prefix):
+    """Test link-bandwidth AS for confederation peer with route-map (r4) - IPv6."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for confederation peer r4 (AS 65103) with route-map - IPv6")
+
+    router_r4 = tgen.gears["r4"]
+
+    # Should use sub-AS 65101 (route-map code path)
+    extcomm = validate_linkbw_as(
+        router=router_r4,
+        peer_router_name="r1",
+        expected_as=LOCAL_AS,
+        peer_type="confederation peer r4 (route-map, IPv6)",
+        prefix=prefix,
+        ipv6=True,
+        forbidden_as=CONFEDERATION_AS,
+    )
+
+    step("r1→r4 path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r4 (confederation peer AS 65103, route-map, IPv6): Correctly uses sub-AS 65101")
+
+
+def test_confederation_peer_with_routemap_linkbw_as_ipv6():
+    """Test link-bandwidth AS for confederation peer with route-map (r4) - IPv6."""
+    _test_confederation_peer_with_routemap_linkbw_as_ipv6(prefix=TRANS_PREFIX_V6)
+
+
+def test_confederation_peer_with_routemap_nontransitive_linkbw_as_ipv6():
+    """Test link-bandwidth AS for confederation peer with non-transitive route-map (r4) - IPv6."""
+    _test_confederation_peer_with_routemap_linkbw_as_ipv6(prefix=NONTRANS_PREFIX_V6)
+
+
+def test_external_ebgp_peer_linkbw_as_ipv6():
+    """Test link-bandwidth AS for external eBGP peer (r5) - IPv6."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for external eBGP peer r5 (AS 64001) - IPv6")
+
+    router_r5 = tgen.gears["r5"]
+
+    # Should use confederation AS 65100 (automatic code path)
+    extcomm = validate_linkbw_as(
+        router=router_r5,
+        peer_router_name="r1",
+        expected_as=CONFEDERATION_AS,
+        peer_type="external eBGP peer r5 (IPv6)",
+        prefix=TRANS_PREFIX_V6,
+        ipv6=True
+    )
+
+    step("r1→r5 path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r5 (external eBGP AS 64001, no route-map, IPv6): Correctly uses confederation AS 65100")
+
+
+def test_external_ebgp_peer_origination_only_linkbw_as_ipv6():
+    """Test link-bandwidth AS for external eBGP peer (r5), origination-only route-map - IPv6."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking origination-only link-bandwidth AS for external eBGP peer r5 (AS 64001) - IPv6")
+
+    router_r5 = tgen.gears["r5"]
+
+    extcomm = validate_linkbw_as(
+        router=router_r5,
+        peer_router_name="r1",
+        expected_as=CONFEDERATION_AS,
+        peer_type="external eBGP peer r5 (origination-only route-map, IPv6)",
+        prefix=ORIG_PREFIX_V6,
+        ipv6=True,
+        forbidden_as=LOCAL_AS,
+    )
+
+    step("r1→r5 origination-only path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r5 (external eBGP AS 64001, origination-only route-map, IPv6): "
+         "Correctly uses confederation AS 65100")
+
+
+def _test_external_ebgp_peer_with_routemap_linkbw_as_ipv6(prefix):
+    """Test link-bandwidth AS for external eBGP peer with route-map (r6) - IPv6."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Checking link-bandwidth AS for external eBGP peer r6 (AS 64002) with route-map - IPv6")
+
+    router_r6 = tgen.gears["r6"]
+
+    # Should use confederation AS 65100 (route-map code path)
+    extcomm = validate_linkbw_as(
+        router=router_r6,
+        peer_router_name="r1",
+        expected_as=CONFEDERATION_AS,
+        peer_type="external eBGP peer r6 (route-map, IPv6)",
+        prefix=prefix,
+        ipv6=True,
+    )
+
+    step("r1→r6 path extended community (IPv6): {}".format(extcomm))
+    step("PASS: r6 (external eBGP AS 64002, route-map, IPv6): Correctly uses confederation AS 65100")
+
+
+def test_external_ebgp_peer_with_routemap_linkbw_as_ipv6():
+    """Test link-bandwidth AS for external eBGP peer with route-map (r6) - IPv6."""
+    _test_external_ebgp_peer_with_routemap_linkbw_as_ipv6(prefix=TRANS_PREFIX_V6)
+
+
+def test_external_ebgp_peer_with_routemap_nontransitive_linkbw_as_ipv6():
+    """Test link-bandwidth AS for external eBGP peer with non-transitive route-map (r6) - IPv6."""
+    _test_external_ebgp_peer_with_routemap_linkbw_as_ipv6(prefix=NONTRANS_PREFIX_V6)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))
+

--- a/tests/topotests/bgp_linkbw_local_as_test/r1/frr.conf
+++ b/tests/topotests/bgp_linkbw_local_as_test/r1/frr.conf
@@ -1,0 +1,23 @@
+!
+interface r1-eth0
+ ip address 192.168.20.1/24
+!
+ip prefix-list LB_PFX seq 5 permit 10.20.20.20/32
+!
+route-map lb-out permit 10
+ match ip address prefix-list LB_PFX
+ set extcommunity bandwidth 1000
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.20.2 remote-as 65002
+ neighbor 192.168.20.2 local-as 65099
+ neighbor 192.168.20.2 timers 1 3
+ neighbor 192.168.20.2 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.20.2 activate
+  network 10.20.20.20/32
+  neighbor 192.168.20.2 route-map lb-out out
+ exit-address-family
+!

--- a/tests/topotests/bgp_linkbw_local_as_test/r2/frr.conf
+++ b/tests/topotests/bgp_linkbw_local_as_test/r2/frr.conf
@@ -1,0 +1,13 @@
+!
+interface r2-eth0
+ ip address 192.168.20.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 192.168.20.1 remote-as 65099
+ neighbor 192.168.20.1 timers 1 3
+ neighbor 192.168.20.1 timers connect 1
+ address-family ipv4 unicast
+  neighbor 192.168.20.1 activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_linkbw_local_as_test/test_bgp_linkbw_local_as.py
+++ b/tests/topotests/bgp_linkbw_local_as_test/test_bgp_linkbw_local_as.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026 by
+# Srinivasan Koona Lokabiraman <srinivasan@nexthop.ai>
+#
+
+"""
+Test that bgp_local_as_for_peer() honors "neighbor X local-as Y" when
+selecting the AS to encode in a route-map-set link-bandwidth extended
+community.
+
+Topology
+--------
+
+  r1 (AS 65001, "neighbor r2 local-as 65099") ── eBGP ── r2 (AS 65002)
+
+r1 presents itself to r2 as AS 65099 (the local-as override), not its
+real AS 65001. r1 advertises 10.20.20.20/32 to r2 with an outbound
+route-map setting link-bandwidth, which calls bgp_local_as_for_peer() to
+pick the AS. Before accounting for change_local_as, that function would
+return r1's real AS (65001) instead of the local-as override (65099).
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+PREFIX = "10.20.20.20/32"
+LOCAL_AS_OVERRIDE = "65099"
+REAL_AS = "65001"
+
+_LB_AS_RE = re.compile(r"LB:(\d+):")
+
+
+def lb_as_from_string(lb_string):
+    match = _LB_AS_RE.search(lb_string or "")
+    return match.group(1) if match else None
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_linkbw_local_as_override():
+    """r2 should see the local-as override (65099), not r1's real AS (65001)."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    receiver = tgen.gears["r2"]
+
+    def _check_receiver_lb_as():
+        output = json.loads(receiver.vtysh_cmd("show ip bgp %s json" % PREFIX))
+        paths = output.get("paths", [])
+        if not paths:
+            return "prefix %s not found on r2" % PREFIX
+
+        for path in paths:
+            ec = path.get("extendedCommunity")
+            got_as = lb_as_from_string(ec.get("string") if ec else None)
+            if got_as == LOCAL_AS_OVERRIDE:
+                return None
+
+        got = [
+            lb_as_from_string(p.get("extendedCommunity", {}).get("string"))
+            for p in paths
+        ]
+        return "expected LB AS %s, got %s" % (LOCAL_AS_OVERRIDE, got)
+
+    test_func = functools.partial(_check_receiver_lb_as)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, (
+        "bgp_local_as_for_peer() must honor 'neighbor X local-as %s' instead "
+        "of r1's real AS (%s) in the link-bandwidth encoding: %s"
+        % (LOCAL_AS_OVERRIDE, REAL_AS, result)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
# Summary

Fix incorrect AS numbers in link-bandwidth extended communities when BGP confederations are configured. External eBGP peers should see the **confederation AS** in the link-bandwidth EC; iBGP and confederation peers should see the **local sub-AS** — mirroring confederation AS_PATH semantics.

## Problem

Link-bandwidth extended communities embed an AS number. In a confederation, that AS was wrong in several cases:

1. **Automatic cumulative link-bandwidth** (WECMP) used the local sub-AS when advertising to external eBGP peers.
2. **Route-map `set extcommunity bandwidth`** always used the local sub-AS, with no way to know at route-map-evaluation time which peer the route would ultimately be sent to — so the same (wrong, for external peers) AS was sent to iBGP, confederation, and external peers alike.
3. **Non-transitive** link-bandwidth set via route-map never got an AS rewrite: `ecommunity_replace_linkbw()` returned early for non-transitive communities, so external peers saw the sub-AS instead of the confederation AS.
4. **Origination-only route-maps** (`network … route-map`, no outbound route-map on the destination peer): `BATTR_RMAP_LINK_BW_SET` was cleared during the per-destination attribute reset, so even after adding the per-destination export-time correction (below), it was still skipped for peers with no outbound route-map of their own.

## Solution

### `bgp_link_bw_as_for_peer()`

New helper in `bgpd.c` / `bgpd.h` — centralizes AS selection:

- **Confederation ID** → external eBGP peers (not in confederation peer list)
- **Local sub-AS** → iBGP, confederation peers, and origination (`peer_self`)

### Export-time rewrite in `subgroup_announce_check()`

- **Automatic cumulative link-bandwidth:** use `bgp_link_bw_as_for_peer()` when building/replacing the EC for each destination peer.
- **Route-map-set link-bandwidth:** when `BATTR_RMAP_LINK_BW_SET` is set, rewrite only the AS in the existing EC (bandwidth unchanged), again per destination peer.

### Other fixes

- **`ecommunity_replace_linkbw()`:** add `ignore_non_transitive` parameter so callers that only need an AS correction (not a bandwidth change) can rewrite non-transitive link-bandwidth ECs while preserving the non-transitive flag. WECMP cumulative path keeps existing behavior (`ignore_non_transitive=false`).
- **`BATTR_RMAP_LINK_BW_SET`:** preserve across the per-destination attribute reset so origination-only route-map cases still get export-time AS correction.
- **UAF guard:** only `ecommunity_free(old_ecom)` when `ecommunity_replace_linkbw()` returns a new, unshared object (`new_ecom != old_ecom && !old_ecom->refcnt`) — a no-op replace, or one still referenced elsewhere, must not free the live EC.
- **`route_set_ecommunity_lb()`:** use `bgp_link_bw_as_for_peer()` at origination; AS is still rewritten on export in `subgroup_announce_check()`.

## Topotest

`tests/topotests/bgp_confederation_linkbw_as_test/`

7-router confederation topology (r1 sub-AS 65101, confederation AS 65100). Covers IPv4 and IPv6:

| Scenario | Peers exercised |
|----------|-----------------|
| Automatic transitive cumulative LB | iBGP (r2, r7), confed (r3), external (r5) |
| Route-map outbound LB | confed (r4), external (r6) |
| Non-transitive route-map LB | confed + external |
| Origination-only route-map (`network … route-map`) | confed + external (no per-neighbor outbound RM) |

## Files changed

- `bgpd/bgpd.c`, `bgpd/bgpd.h` — `bgp_link_bw_as_for_peer()`
- `bgpd/bgp_route.c` — export-time AS rewrite, flag preservation
- `bgpd/bgp_routemap.c` — origination path uses helper
- `bgpd/bgp_ecommunity.c`, `bgpd/bgp_ecommunity.h` — `ignore_non_transitive` on `ecommunity_replace_linkbw()`
- `tests/topotests/bgp_confederation_linkbw_as_test/` — new topotest

## Test plan

- [x] `bgp_confederation_linkbw_as_test` (IPv4 + IPv6, automatic / route-map / non-transitive / origination-only)