### PR TITLE
tests: Fixup frr_load_config to be correct for 10.5 branch

### DIFF
--- a/tests/topotests/bgp_link_bandwidth_cumulative/test_bgp_link_bandwidth_cumulative.py
+++ b/tests/topotests/bgp_link_bandwidth_cumulative/test_bgp_link_bandwidth_cumulative.py
@@ -118,8 +118,9 @@ def setup_module(mod):
     tgen = Topogen(topodef, mod.__name__)
     tgen.start_topology()
 
-    for router in tgen.routers().values():
-        router.load_frr_config()
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
 
     tgen.start_router()
 

--- a/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/test_bgp_link_bandwidth_cumulative_disable_ieee.py
+++ b/tests/topotests/bgp_link_bandwidth_cumulative_disable_ieee/test_bgp_link_bandwidth_cumulative_disable_ieee.py
@@ -63,8 +63,9 @@ def setup_module(mod):
     tgen = Topogen(topodef, mod.__name__)
     tgen.start_topology()
 
-    for router in tgen.routers().values():
-        router.load_frr_config()
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
 
     tgen.start_router()
 

--- a/tests/topotests/bgp_linkbw_routemap_as_truncation/test_bgp_linkbw_routemap_as_truncation.py
+++ b/tests/topotests/bgp_linkbw_routemap_as_truncation/test_bgp_linkbw_routemap_as_truncation.py
@@ -60,8 +60,9 @@ def setup_module(mod):
     tgen = Topogen(topodef, mod.__name__)
     tgen.start_topology()
 
-    for router in tgen.routers().values():
-        router.load_frr_config()
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
 
     tgen.start_router()
 


### PR DESCRIPTION
The usage of frr_load_config has evolved on master, 10.5 does not have this change.  Fixup to allow these tests to run.