### PR TITLE
lib: Deduplicate SRv6 locator JSON output

### DIFF
--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -392,80 +392,7 @@ srv6_locator_chunk_detailed_json(const struct srv6_locator_chunk *chunk)
 	return jo_root;
 }
 
-json_object *srv6_locator_json(const struct srv6_locator *loc)
-{
-	struct listnode *node;
-	struct srv6_locator_chunk *chunk;
-	json_object *jo_root = NULL;
-	json_object *jo_chunk = NULL;
-	json_object *jo_chunks = NULL;
-
-	jo_root = json_object_new_object();
-
-	/* set name */
-	json_object_string_add(jo_root, "name", loc->name);
-
-	/* set prefix */
-	json_object_string_addf(jo_root, "prefix", "%pFX", &loc->prefix);
-
-	if (loc->sid_format) {
-		/* set block_bits_length */
-		json_object_int_add(jo_root, "blockBitsLength",
-				    loc->sid_format->block_len);
-
-		/* set node_bits_length */
-		json_object_int_add(jo_root, "nodeBitsLength",
-				    loc->sid_format->node_len);
-
-		/* set function_bits_length */
-		json_object_int_add(jo_root, "functionBitsLength",
-				    loc->sid_format->function_len);
-
-		/* set argument_bits_length */
-		json_object_int_add(jo_root, "argumentBitsLength",
-				    loc->sid_format->argument_len);
-
-		/* set true if the locator is a Micro-segment (uSID) locator */
-		if (loc->sid_format->type == SRV6_SID_FORMAT_TYPE_USID)
-			json_object_string_add(jo_root, "behavior", "usid");
-	} else {
-		/* set block_bits_length */
-		json_object_int_add(jo_root, "blockBitsLength",
-				    loc->block_bits_length);
-
-		/* set node_bits_length */
-		json_object_int_add(jo_root, "nodeBitsLength",
-				    loc->node_bits_length);
-
-		/* set function_bits_length */
-		json_object_int_add(jo_root, "functionBitsLength",
-				    loc->function_bits_length);
-
-		/* set argument_bits_length */
-		json_object_int_add(jo_root, "argumentBitsLength",
-				    loc->argument_bits_length);
-
-		/* set true if the locator is a Micro-segment (uSID) locator */
-		if (CHECK_FLAG(loc->flags, SRV6_LOCATOR_USID))
-			json_object_string_add(jo_root, "behavior", "usid");
-	}
-
-	/* set status_up */
-	json_object_boolean_add(jo_root, "statusUp",
-				loc->status_up);
-
-	/* set chunks */
-	jo_chunks = json_object_new_array();
-	json_object_object_add(jo_root, "chunks", jo_chunks);
-	for (ALL_LIST_ELEMENTS_RO((struct list *)loc->chunks, node, chunk)) {
-		jo_chunk = srv6_locator_chunk_json(chunk);
-		json_object_array_add(jo_chunks, jo_chunk);
-	}
-
-	return jo_root;
-}
-
-json_object *srv6_locator_detailed_json(const struct srv6_locator *loc)
+static json_object *srv6_locator_json_common(const struct srv6_locator *loc, bool detailed)
 {
 	struct listnode *node;
 	struct srv6_locator_chunk *chunk;
@@ -524,20 +451,35 @@ json_object *srv6_locator_detailed_json(const struct srv6_locator *loc)
 	}
 
 	/* set algonum */
-	json_object_int_add(jo_root, "algoNum", loc->algonum);
+	if (detailed)
+		json_object_int_add(jo_root, "algoNum", loc->algonum);
 
 	/* set status_up */
-	json_object_boolean_add(jo_root, "statusUp", loc->status_up);
+	json_object_boolean_add(jo_root, "statusUp",
+				loc->status_up);
 
 	/* set chunks */
 	jo_chunks = json_object_new_array();
 	json_object_object_add(jo_root, "chunks", jo_chunks);
 	for (ALL_LIST_ELEMENTS_RO((struct list *)loc->chunks, node, chunk)) {
-		jo_chunk = srv6_locator_chunk_detailed_json(chunk);
+		if (detailed)
+			jo_chunk = srv6_locator_chunk_detailed_json(chunk);
+		else
+			jo_chunk = srv6_locator_chunk_json(chunk);
 		json_object_array_add(jo_chunks, jo_chunk);
 	}
 
 	return jo_root;
+}
+
+json_object *srv6_locator_json(const struct srv6_locator *loc)
+{
+	return srv6_locator_json_common(loc, false);
+}
+
+json_object *srv6_locator_detailed_json(const struct srv6_locator *loc)
+{
+	return srv6_locator_json_common(loc, true);
 }
 
 /* clang-format off */


### PR DESCRIPTION
`srv6_locator_json()` and `srv6_locator_detailed_json()` duplicate the same locator-level JSON construction.

Move the shared construction into a common helper while keeping the existing summary and detail entry points as wrappers.