### PR TITLE
zebra: Fix SRv6 source-address config output

### DIFF
--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -1762,10 +1762,10 @@ static int zebra_sr_config(struct vty *vty)
 			vty_out(vty, "  exit\n");
 			vty_out(vty, "  !\n");
 		}
-		vty_out(vty, " exit\n");
-		vty_out(vty, " !\n");
 	}
 	if (display_source_srv6 || zebra_srv6_is_enable()) {
+		vty_out(vty, " exit\n");
+		vty_out(vty, " !\n");
 		vty_out(vty, "exit\n");
 		vty_out(vty, "!\n");
 	}


### PR DESCRIPTION
When only an SRv6 encapsulation source address is configured, `zebra_sr_config()` opens both the `segment-routing` and `srv6` nodes but only writes one closing `exit`:

```
  segment-routing
   srv6
    encapsulation
     source-address fc00:0:1::1
    exit
  exit
```

The missing `srv6`-level exit happens because that exit was emitted only from the locator config path. With no locator configured, the final exit leaves the parser in `segment-routing` mode, so any following top-level configuration can be emitted under the wrong node.

After the fix, `zebra_sr_config()` writes both closing exits:

```
  segment-routing
   srv6
    encapsulation
     source-address fc00:0:1::1
    exit
   exit
  exit
```