### PR TITLE
zebra: Fix SRv6 locator delete after no prefix

### DIFF
--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -251,6 +251,63 @@ def test_srv6_no_prefix_explicit():
     check_sharpd_chunk(router, "expected_chunks6.json")
 
 
+def test_srv6_no_locator():
+    """Delete a locator after removing its prefix."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            locator loc1
+             prefix fcbb:bbbb:1::/48
+             format usid-f3216
+        """
+    )
+    check_srv6_locator(router, "expected_locators7.json")
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            locator loc1
+             no prefix
+        """
+    )
+    check_srv6_locator(router, "expected_locators8.json")
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            no locator loc1
+        """
+    )
+    assert router.check_router_running() == ""
+    check_srv6_locator(router, "expected_locators6.json")
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            locator loc1
+             prefix fcbb:bbbb:1::/48
+        """
+    )
+    check_srv6_locator(router, "expected_locators7.json")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -836,26 +836,24 @@ DEFUN (no_srv6_locator,
 	}
 
 	block = locator->sid_block;
-	frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, ctx) {
-		if (!ctx->sid)
-			continue;
-
-		frr_each_safe (zebra_srv6_sid_entry_list, &ctx->sid->entries, entry)
-			if (entry->locator == locator) {
-				zebra_srv6_sid_entry_list_del(&ctx->sid->entries, entry);
-				zebra_srv6_sid_entry_free(entry);
-			}
-
-		if (zebra_srv6_sid_entry_list_count(&ctx->sid->entries) == 0) {
-			zebra_srv6_sid_free(ctx->sid);
-
-			zebra_srv6_sid_ctx_list_del(&block->sids, ctx);
-			zebra_srv6_sid_ctx_free(ctx);
-		}
-	}
-
-	block = locator->sid_block;
 	if (block) {
+		frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, ctx) {
+			if (!ctx->sid)
+				continue;
+
+			frr_each_safe (zebra_srv6_sid_entry_list, &ctx->sid->entries, entry)
+				if (entry->locator == locator) {
+					zebra_srv6_sid_entry_list_del(&ctx->sid->entries, entry);
+					zebra_srv6_sid_entry_free(entry);
+				}
+
+			if (zebra_srv6_sid_entry_list_count(&ctx->sid->entries) == 0) {
+				zebra_srv6_sid_free(ctx->sid);
+
+				zebra_srv6_sid_ctx_list_del(&block->sids, ctx);
+				zebra_srv6_sid_ctx_free(ctx);
+			}
+		}
 		block->refcnt--;
 		if (block->refcnt == 0) {
 			frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, ctx) {


### PR DESCRIPTION
A locator can be configured with a prefix:

```
segment-routing
 srv6
  locators
   locator MAIN
    prefix fcbb:bbbb:1::/48
```

Then the prefix can be removed while leaving the locator configured:

```
segment-routing
 srv6
  locators
   locator MAIN
    no prefix
```

Deleting the locator after that crashes zebra:

```
segment-routing
 srv6
  locators
   no locator MAIN
```

This triggers a NULL dereference:

```
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000048
    #0 zebra_srv6_sid_ctx_list_const_first zebra/zebra_srv6.h:232
    #1 zebra_srv6_sid_ctx_list_first zebra/zebra_srv6.h:232
    #2 no_srv6_locator zebra/zebra_srv6_vty.c:837
```

`no prefix` releases `locator->sid_block`, but
`no_srv6_locator_cmd()` walked `block->sids` before checking whether the locator still had a SID block.

Guard the SID entry cleanup with the existing SID block check before deleting the locator.