### PR TITLE
zebra: Fix memory leak in EVPN show json commands with empty tables

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2901,8 +2901,11 @@ void zebra_vxlan_print_rmacs_l3vni(struct vty *vty, vni_t l3vni, bool use_json)
 		return;
 	}
 	num_rmacs = hashcount(zl3vni->rmac_table);
-	if (!num_rmacs)
+	if (!num_rmacs) {
+		if (use_json)
+			vty_json_empty(vty, json);
 		return;
+	}
 
 	memset(&wctx, 0, sizeof(wctx));
 	wctx.vty = vty;
@@ -3186,8 +3189,11 @@ void zebra_vxlan_print_neigh_vni(struct vty *vty, struct zebra_vrf *zvrf,
 		return;
 	}
 	num_neigh = zebra_neigh_db_count(zevpn->neigh_table);
-	if (!num_neigh)
+	if (!num_neigh) {
+		if (use_json)
+			vty_json_empty(vty, json);
 		return;
+	}
 
 	/* Since we have IPv6 addresses to deal with which can vary widely in
 	 * size, we try to be a bit more elegant in display by first computing
@@ -3352,8 +3358,11 @@ void zebra_vxlan_print_neigh_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf, v
 		return;
 	}
 	num_neigh = zebra_neigh_db_count(zevpn->neigh_table);
-	if (!num_neigh)
+	if (!num_neigh) {
+		if (use_json)
+			vty_json_empty(vty, json);
 		return;
+	}
 
 	memset(&wctx, 0, sizeof(wctx));
 	wctx.zevpn = zevpn;
@@ -3409,12 +3418,18 @@ void zebra_vxlan_print_neigh_vni_dad(struct vty *vty,
 	}
 
 	num_neigh = zebra_neigh_db_count(zevpn->neigh_table);
-	if (!num_neigh)
+	if (!num_neigh) {
+		if (use_json)
+			vty_json_empty(vty, json);
 		return;
+	}
 
 	num_neigh = num_dup_detected_neighs(zevpn);
-	if (!num_neigh)
+	if (!num_neigh) {
+		if (use_json)
+			vty_json_empty(vty, json);
 		return;
+	}
 
 	/* Since we have IPv6 addresses to deal with which can vary widely in
 	 * size, we try to be a bit more elegant in display by first computing


### PR DESCRIPTION
Randomly discovered while testing https://github.com/FRRouting/frr/pull/22653

`zebra_vxlan_print_rmacs_l3vni`, `zebra_vxlan_print_neigh_vni`, `zebra_vxlan_print_neigh_vni_vtep` and `zebra_vxlan_print_neigh_vni_dad` all have early return paths if the table they want to print is empty.

If JSON output is requested and the table is empty, these function leak the JSON object in the early return path.

Seems like a super long standing bug, introduced 8 years ago. Not sure why it was never noticed before, as it also happens on a clean master branch with valgrind for me, without my PR.

Topotest log:
```
[gw1] linux -- Python 3.13.5 /usr/bin/python3

request = <SubRequest 'module_check_memtest' for <Function test_protocols_convergence>>

    @pytest.fixture(autouse=True, scope="module")
    def module_check_memtest(request):
        yield
        if request.config.option.valgrind_memleaks:
            if get_topogen() is not None:
>               check_for_valgrind_memleaks()

conftest.py:486:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

[...]
        if leaks:
            logger.error("valgrind memleaks found:\n\t%s", "\n\t".join(leaks))
>           pytest.fail("valgrind memleaks found for daemons: " + " ".join(daemons))
E           Failed: valgrind memleaks found for daemons: zebra(1)

conftest.py:327: Failed
---------------------------- Captured log teardown -----------------------------
2026-07-31 14:12:15,110 ERROR: topo: valgrind memleaks found:
        1 in /tmp/topotests/bgp_evpn_rt5.test_bgp_evpn_v6_vtep/r2.valgrind.zebra.32175
-------------------- generated xml file: /tmp/topotests.xml --------------------
=========================== short test summary info ============================
ERROR bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py::test_memory_leak - Failed: valgr...
============== 28 passed, 2 skipped, 1 error in 102.23s (0:01:42) ==============
```

Valgrind log:
```
==33749== Memcheck, a memory error detector
==33749== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==33749== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==33749== Command: /usr/lib/frr/zebra --command-log-always --log file:zebra.log --log-level debug -d
==33749== Parent PID: 33744
==33749==
==33749==
==33749== HEAP SUMMARY:
==33749==     in use at exit: 6,103 bytes in 26 blocks
==33749==   total heap usage: 152,819 allocs, 152,793 frees, 28,579,270 bytes allocated
==33749==
==33749== 5,952 (384 direct, 5,568 indirect) bytes in 8 blocks are definitely lost in loss record 5 of 5
==33749==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==33749==    by 0x4CC0B1E: json_object_new_object (in /usr/lib/x86_64-linux-gnu/libjson-c.so.5.4.0)
==33749==    by 0x26A6E7: zebra_vxlan_print_rmacs_l3vni (zebra_vxlan.c:2887)
==33749==    by 0x2600D5: show_evpn_rmac_vni (zebra_vty.c:3189)
==33749==    by 0x48F8DDD: cmd_execute_command_real (command.c:1014)
==33749==    by 0x48F8F3E: cmd_execute_command (command.c:1073)
==33749==    by 0x48F94A1: cmd_execute (command.c:1239)
==33749==    by 0x49D392A: vty_command (vty.c:593)
==33749==    by 0x49D5580: vty_execute (vty.c:1356)
==33749==    by 0x49D74B0: vtysh_read (vty.c:2302)
==33749==    by 0x49CC92D: event_call (event.c:2744)
==33749==    by 0x493F2A6: frr_run (libfrr.c:1258)
==33749==    by 0x1AEF32: main (main.c:580)
==33749==
==33749== LEAK SUMMARY:
==33749==    definitely lost: 384 bytes in 8 blocks
==33749==    indirectly lost: 5,568 bytes in 16 blocks
==33749==      possibly lost: 0 bytes in 0 blocks
==33749==    still reachable: 63 bytes in 1 blocks
==33749==         suppressed: 88 bytes in 1 blocks
==33749== Reachable blocks (those to which a pointer was found) are not shown.
==33749== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==33749==
==33749== For lists of detected and suppressed errors, rerun with: -s
==33749== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

```
==2322== 5,952 (384 direct, 5,568 indirect) bytes in 8 blocks are definitely lost in loss record 5 of 5
==2322==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==2322==    by 0x4CC0B1E: json_object_new_object (in /usr/lib/x86_64-linux-gnu/libjson-c.so.5.4.0)
==2322==    by 0x26A6E7: zebra_vxlan_print_rmacs_l3vni (zebra_vxlan.c:2887)
==2322==    by 0x2600D5: show_evpn_rmac_vni (zebra_vty.c:3189)
==2322==    by 0x48F8DDD: cmd_execute_command_real (command.c:1014)
==2322==    by 0x48F8F3E: cmd_execute_command (command.c:1073)
==2322==    by 0x48F94A1: cmd_execute (command.c:1239)
==2322==    by 0x49D392A: vty_command (vty.c:593)
==2322==    by 0x49D5580: vty_execute (vty.c:1356)
==2322==    by 0x49D74B0: vtysh_read (vty.c:2302)
==2322==    by 0x49CC92D: event_call (event.c:2744)
==2322==    by 0x493F2A6: frr_run (libfrr.c:1258)
==2322==    by 0x1AEF32: main (main.c:580)
```