### PR TITLE
babeld: Remove spurious seqno gap threshold for local Seqno Request handling

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -2062,13 +2062,8 @@ void handle_request(struct neighbour *neigh, const unsigned char *prefix, unsign
 
 	if (xroute && (!route || xroute->metric <= kernel_metric)) {
 		if (hop_count > 0 && memcmp(id, myid, 8) == 0) {
-			if (seqno_compare(seqno, myseqno) > 0) {
-				if (seqno_minus(seqno, myseqno) > 100) {
-					/* Hopelessly out-of-date request */
-					return;
-				}
+			if (seqno_compare(seqno, myseqno) > 0)
 				update_myseqno();
-			}
 		}
 		send_update(neigh->ifp, 1, prefix, plen);
 		return;


### PR DESCRIPTION
## Summary

RFC 8966 §3.8.1.2 requires that when a Seqno Request targets the local router-id and the requested seqno is larger, the node **MUST** increase its own seqno by 1 and send an Update. A single request **MUST NOT** cause the seqno to increase by more than 1.

FRR additionally enforced `seqno_minus(seqno, myseqno) > 100` as a rejection threshold in `handle_request()`, silently dropping requests whose seqno was more than 100 ahead of the local seqno. RFC 8966 permits no such threshold — dropping these requests violates the MUST requirement.

## Fix

Remove the `seqno_minus(seqno, myseqno) > 100` guard in `handle_request()` (`babeld/message.c:2048-2051`).

Since `update_myseqno()` already increments by exactly 1 (`seqno_plus(myseqno, 1)`), removing the threshold restores RFC-compliant behavior without risk of excessive seqno jumps.

## References

- RFC 8966 §3.8.1.2 (Seqno Requests)
- RFCAudit Bug 12 (RFCBin): local seqno request gap drop

Signed-off-by: zhuxu <185172534zxxx@gmail.com>