### PR TITLE
bgpd: Anchor parsed attr in bgp_nlri_parse_evpn to preserve PMSI attribute

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6980,8 +6980,14 @@ void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
 	}
 }
 
-int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
-			struct bgp_nlri *packet, bool withdraw)
+/*
+ * Walks the EVPN NLRIs in the MP_REACH/MP_UNREACH attribute from "packet"
+ * and hands each route (type 1-5) to its per-type processor, which runs
+ * bgp_update() / bgp_withdraw() against the shared parent attr.
+ * Returns BGP_NLRI_PARSE_OK or an error code on malformed input.
+ */
+static int _bgp_nlri_parse_evpn_internal(struct peer *peer, struct attr *attr,
+					 const struct bgp_nlri *packet, bool withdraw)
 {
 	uint8_t *pnt;
 	uint8_t *lim;
@@ -7099,6 +7105,42 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 		return BGP_NLRI_PARSE_ERROR_PACKET_LENGTH;
 
 	return BGP_NLRI_PARSE_OK;
+}
+
+/*
+ * Wrapper function for _bgp_nlri_parse_evpn_internal().
+ * Walks the EVPN NLRIs in the MP_REACH/MP_UNREACH attribute from "packet"
+ * and hands each route (type 1-5) to its per-type processor.
+ * Anchors the parent attr for the duration of the parse (see below),
+ * then delegates to _bgp_nlri_parse_evpn_internal().
+ * Without the anchor, the first bgp_attr_intern() of the parent attr
+ * (e.g. via bgp_adj_in_set() with soft-reconfiguration inbound) would
+ * see bgp_attr_owns_extra() true and strip attr->extra, losing the
+ * PMSI tunnel attribute for the routes processed after it.
+ */
+int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr, const struct bgp_nlri *packet,
+			bool withdraw)
+{
+	int ret;
+
+	/* Self-anchor the parsed parent attr so bgp_attr_owns_extra() does
+	 * not treat it as transient and steal or discard attr->extra (which
+	 * carries pmsi_tnl_type/tunn_id) on the first intern, the NLRI loop
+	 * passes this attr to bgp_update() once per prefix. Mirrors
+	 * bgp_nlri_parse_ip()/bgp_nlri_parse_vpn().
+	 */
+	if (attr) {
+		memset(&attr->attr_intern_reuse, 0, sizeof(attr->attr_intern_reuse));
+		attr->attr_intern_reuse.parsed_attr = attr;
+	}
+
+	ret = _bgp_nlri_parse_evpn_internal(peer, attr, packet, withdraw);
+
+	/* Reset the attr_intern_reuse cache */
+	if (attr)
+		memset(&attr->attr_intern_reuse, 0, sizeof(attr->attr_intern_reuse));
+
+	return ret;
 }
 
 /*

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -136,8 +136,8 @@ extern void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
 				   mpls_label_t *label, uint8_t num_labels,
 				   struct attr *attr, bool addpath_capable,
 				   uint32_t addpath_tx_id);
-extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
-			       struct bgp_nlri *packet, bool withdraw);
+extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr, const struct bgp_nlri *packet,
+			       bool withdraw);
 extern int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
 				 const struct prefix *p,
 				 struct bgp_path_info *ri);

--- a/tests/topotests/bgp_evpn_pmsi_attr_intern/r1/frr.conf
+++ b/tests/topotests/bgp_evpn_pmsi_attr_intern/r1/frr.conf
@@ -1,0 +1,15 @@
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+router bgp 65000
+ bgp router-id 10.10.10.1
+ bgp log-neighbor-changes
+ no bgp default ipv4-unicast
+ neighbor 10.0.0.2 remote-as 65000
+ !
+ address-family l2vpn evpn
+  neighbor 10.0.0.2 activate
+  neighbor 10.0.0.2 soft-reconfiguration inbound
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_pmsi_attr_intern/r2/frr.conf
+++ b/tests/topotests/bgp_evpn_pmsi_attr_intern/r2/frr.conf
@@ -1,0 +1,15 @@
+interface r2-eth0
+ ip address 10.0.0.2/24
+!
+router bgp 65000
+ bgp router-id 10.10.10.2
+ bgp log-neighbor-changes
+ no bgp default ipv4-unicast
+ neighbor 10.0.0.1 remote-as 65000
+ !
+ address-family l2vpn evpn
+  neighbor 10.0.0.1 activate
+  neighbor 10.0.0.1 soft-reconfiguration inbound
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_pmsi_attr_intern/test_bgp_evpn_pmsi_attr_intern.py
+++ b/tests/topotests/bgp_evpn_pmsi_attr_intern/test_bgp_evpn_pmsi_attr_intern.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_evpn_pmsi_attr_intern.py
+#
+# Copyright (c) 2026 Robin Christ for partimus GmbH
+#
+
+"""
+Regression test: the PMSI Tunnel attribute of EVPN type-3 (IMET) routes
+must survive attribute interning on the receiving side.
+
+pmsi_tnl_type/tunn_id live in the lazily allocated attr->extra
+("struct attr_extra", allocated by bgp_attr_extra_get() when
+bgp_attr_pmsi_tunnel() stores the parsed PMSI).
+
+The parent attr "struct attr attr" lives on the stack of bgp_update_receive(),
+where it is filled by bgp_attr_parse() once per UPDATE message.
+The EVPN NLRI parser gets this "parent attr" and passes it to bgp_update() once
+per EVPN NLRI.
+Unless the parser self-anchors that attr (attr->attr_intern_reuse.parsed_attr),
+bgp_attr_owns_extra() treats it as transient and the intern path may
+steal its attr->extra.
+
+The trigger is "soft-reconfiguration inbound" on the EVPN session
+(configured below - without it the bug does not manifest):
+
+  bgp_update_receive()
+    bgp_attr_parse(&attr, ...)  one "struct attr attr" per UPDATE (the
+                                parent), the type-3 parse puts PMSI into
+                                attr.extra, a heap-allocated
+                                "struct attr_extra" (bgp_attr_pmsi_tunnel())
+    bgp_nlri_parse(peer, NLRI_ATTR_ARG, &nlris[i], 0)
+                                per-AFI/SAFI dispatcher switch
+      bgp_nlri_parse_evpn(peer, attr, packet, withdraw)
+                                loops over the NLRIs of this attribute
+                                block. The fix self-anchors
+                                attr->attr_intern_reuse.parsed_attr =
+                                attr here for the loop's duration
+        process_type3_route(..., attr, ...)
+          bgp_update(..., attr, ...)
+            bgp_adj_in_set(dest, peer, attr, ...)
+                                only with soft-reconfig inbound
+              adj->attr = bgp_attr_intern(attr)
+                                first arrival: attrhash miss
+                bgp_attr_hash_alloc(val)   val == attr (the parent)!
+                                bgp_attr_owns_extra(val) is true for an
+                                unanchored parent -> TRANSFERS val->extra
+                                to the hashed copy, val->extra = NULL
+            new_attr = *attr    RIB working copy: new_attr.extra == NULL
+            attr_new = bgp_attr_intern(&new_attr)
+                                RIB attr interned without PMSI
+            evpn_zebra_install()
+                                remote VTEP added with
+                                flood_control = VXLAN_FLOOD_DISABLED
+
+This bug is deterministic and not a memory error, so ASAN does not
+report it.
+A re-delivery of the same route heals it, because bgp_adj_in_set()
+then finds the stored adj-in attr equal to the incoming one and skips
+the intern).
+This is the reason why this failure mode was noticed on clean restarts.
+
+The receiver then holds the type-3 route without its
+Ingress-Replication PMSI marker.
+As a consequence, zebra installs the remote VTEP with flood control disabled
+("flood": "-" instead of "HER"), no head-end replication FDB entries are
+programmed and all BUM traffic in the VNI blackholes.
+
+This bug is verifiable by inspecting zebra's per-VNI per-remote-VTEP
+flood mode, which is directly derived from the PMSI value bgpd retained.
+"""
+
+import os
+import sys
+from functools import partial
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
+
+VNIS = list(range(101, 111))
+
+ROUTERS = {
+    "r1": {"vtep": "10.0.0.1", "peer": "10.0.0.2"},
+    "r2": {"vtep": "10.0.0.2", "peer": "10.0.0.1"},
+}
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    cmds_vxlan = [
+        "ip link add name bridge-{vni} up type bridge stp_state 0",
+        "ip link set dev bridge-{vni} up",
+        "ip link add name vxlan-{vni} type vxlan id {vni} dstport 4789 "
+        "dev {rname}-eth0 local {vtep}",
+        "ip link set dev vxlan-{vni} master bridge-{vni}",
+        "ip link set vxlan-{vni} up type bridge_slave "
+        "learning off flood off mcast_flood off",
+    ]
+
+    for rname, params in ROUTERS.items():
+        router = tgen.gears[rname]
+        for vni in VNIS:
+            for cmd in cmds_vxlan:
+                formatted = cmd.format(rname=rname, vni=vni, vtep=params["vtep"])
+                logger.info("cmd to {}: {}".format(rname, formatted))
+                router.cmd_raises(formatted)
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    "Assert the EVPN session comes up."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname, params in ROUTERS.items():
+        router = tgen.gears[rname]
+        expected = {"peers": {params["peer"]: {"state": "Established"}}}
+
+        test_func = partial(
+            topotest.router_json_cmp,
+            router,
+            "show bgp l2vpn evpn summary json",
+            expected,
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, '"{}" BGP EVPN session did not establish'.format(rname)
+
+
+def _check_flood_her(rname):
+    """
+    Every VNI's remote VTEP must be installed with head-end replication
+    ("HER"). With the PMSI attribute lost in interning, zebra reports
+    "-" (flood disabled) instead.
+    """
+    tgen = get_topogen()
+    router = tgen.gears[rname]
+    peer = ROUTERS[rname]["peer"]
+
+    for vni in VNIS:
+        expected = {
+            "vni": vni,
+            "type": "L2",
+            "numRemoteVteps": 1,
+            "remoteVteps": [{"ip": peer, "flood": "HER"}],
+        }
+
+        test_func = partial(
+            topotest.router_json_cmp,
+            router,
+            "show evpn vni {} json".format(vni),
+            expected,
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, (
+            '"{}" VNI {}: remote VTEP {} not installed with flood "HER" '
+            "(PMSI Tunnel attribute lost?)".format(rname, vni, peer)
+        )
+
+
+def test_evpn_flood_her_initial():
+    "Initial exchange: all VNIs must have HER flood entries on both VTEPs."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ROUTERS:
+        _check_flood_her(rname)
+
+
+def test_evpn_flood_her_after_soft_clear():
+    """
+    Re-parse all routes in one burst (this is the post-restart convergence
+    pattern that most reliably trips the lost-attr->extra bug) and verify
+    the PMSI marker still survives.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ROUTERS:
+        tgen.gears[rname].vtysh_cmd("clear bgp l2vpn evpn * soft in")
+
+    for rname in ROUTERS:
+        _check_flood_her(rname)
+
+
+def test_memory_leak():
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
EVPN type-3 (IMET) routes can lose their PMSI Tunnel attribute on the receiving side when `soft-reconfiguration inbound` is configured on the EVPN session.
The route is installed, but without the Ingress Replication marker zebra programs the remote VTEP with flooding disabled:
```
testbox1# show evpn vni 16001285 
VNI: 16001285
 Type: L2
[...]
 Remote VTEPs for this VNI:
  10.151.10.13 flood: -
  10.151.10.33 flood: -
[...]
```
Therefore no head-end replication FDB entries are created and all BUM traffic in the VNI is blackholed.

The consequence is e.g. that ARP requests never reach the remote VTEP and hosts in the L2VPN cannot reach each other.


This bug is deterministic ( on the first delivery of a route) and not a memory error, so ASAN does not report it.
A re-delivery of the same route heals it, because `bgp_adj_in_set()` then finds the stored adj-in attr equal to the incoming one and skips the intern).
This is the reason why this failure mode was first noticed on clean restarts.

From the regression topotest that documents it:
```
pmsi_tnl_type/tunn_id live in the lazily allocated attr->extra ("struct attr_extra", allocated by bgp_attr_extra_get() when bgp_attr_pmsi_tunnel() stores the parsed PMSI).

The parent attr "struct attr attr" lives on the stack of bgp_update_receive(), where it is filled by bgp_attr_parse() once per UPDATE message.
The EVPN NLRI parser gets this "parent attr" and passes it to bgp_update() once per EVPN NLRI.

Unless the parser self-anchors that attr (attr->attr_intern_reuse.parsed_attr), bgp_attr_owns_extra() treats it as transient and the intern path may steal its attr->extra.

The trigger is "soft-reconfiguration inbound" on the EVPN session, without it the bug does not manifest.

Call chain:

  bgp_update_receive()
    bgp_attr_parse(&attr, ...)  one "struct attr attr" per UPDATE (the
                                parent), the type-3 parse puts PMSI into
                                attr.extra, a heap-allocated
                                "struct attr_extra" (bgp_attr_pmsi_tunnel())
    bgp_nlri_parse(peer, NLRI_ATTR_ARG, &nlris[i], 0)
                                per-AFI/SAFI dispatcher switch
      bgp_nlri_parse_evpn(peer, attr, packet, withdraw)
                                loops over the NLRIs of this attribute
                                block. The fix self-anchors
                                attr->attr_intern_reuse.parsed_attr =
                                attr here for the loop's duration
        process_type3_route(..., attr, ...)
          bgp_update(..., attr, ...)
            bgp_adj_in_set(dest, peer, attr, ...)
                                only with soft-reconfig inbound
              adj->attr = bgp_attr_intern(attr)
                                first arrival: attrhash miss
                bgp_attr_hash_alloc(val)   val == attr (the parent)!
                                bgp_attr_owns_extra(val) is true for an
                                unanchored parent -> TRANSFERS val->extra
                                to the hashed copy, val->extra = NULL
            new_attr = *attr    RIB working copy: new_attr.extra == NULL
            attr_new = bgp_attr_intern(&new_attr)
                                RIB attr interned without PMSI
            evpn_zebra_install()
                                remote VTEP added with
                                flood_control = VXLAN_FLOOD_DISABLED
```


`bgp_nlri_parse_ip()` has the anchor and `bgp_nlri_parse_vpn()` gained it in commit d2a0fbc5aa8.
`bgp_nlri_parse_evpn()` was missed, and PMSI loss does not break route install, only flooding, so it went unnoticed.

The fix is mirroring the anchoring of the other two parsers. `bgp_nlri_parse_evpn()` became a small wrapper that self-anchors the parent attr. It delegates the unchanged parse loop to `_bgp_nlri_parse_evpn_internal()` and
clears the anchor on every exit path.

The regression was likely caused by the commit series around aa5f17271 (PR #21859)


The PR includes a regression topotest that reliably fails (tested 20 runs) without the patch and reliably passes (tested 20 runs) with the patch.
