### PR TITLE
mgmtd, lib, zebra, staticd, tests: Distinguish YANG "explicit values that happen to match the default value" from implicit default values

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1413,7 +1413,13 @@ static void vty_print_redistribute(struct vty *vty, const struct lyd_node *dnode
 		vty_out(vty, " redistribute %s %s ", family, protocol);
 	}
 	vty_out(vty, "%s", level);
-	if (show_defaults || !yang_dnode_is_default(dnode, "metric"))
+	/*
+	 * "metric" lives in a case of the "protocol-type" choice. When neither
+	 * metric nor route-map is configured, the case has no members, so the
+	 * schema default is not instantiated and the leaf is absent entirely.
+	 */
+	if (yang_dnode_exists(dnode, "metric") &&
+	    (show_defaults || !yang_dnode_is_default(dnode, "metric")))
 		vty_out(vty, " metric %s", yang_dnode_get_string(dnode, "%s", "metric"));
 
 	if (yang_dnode_exists(dnode, "route-map"))

--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -293,6 +293,11 @@ static int logging_file_level_modify(struct nb_cb_modify_args *args)
 		fname = yang_dnode_get_string(args->dnode, "../filename");
 	if (!fname)
 		fname = zt_file.filename;
+	/* A level without any file configured has nothing to apply; the
+	 * filename callback picks the level up once a file is set.
+	 */
+	if (!fname)
+		return NB_OK;
 	level = _get_level_value(args->dnode, NULL);
 	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS)
 		return NB_ERR_INCONSISTENCY;
@@ -342,7 +347,12 @@ static int logging_filtered_file_level_modify(struct nb_cb_modify_args *args)
 	if (yang_dnode_exists(args->dnode, "../filename"))
 		fname = yang_dnode_get_string(args->dnode, "../filename");
 	if (!fname)
-		fname = zt_file.filename;
+		fname = zt_filterfile.parent.filename;
+	/* A level without any file configured has nothing to apply; the
+	 * filename callback picks the level up once a file is set.
+	 */
+	if (!fname)
+		return NB_OK;
 	level = _get_level_value(args->dnode, NULL);
 	if (set_log_file(&zt_filterfile.parent, NULL, fname, level) != CMD_SUCCESS)
 		return NB_ERR_INCONSISTENCY;

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -507,7 +507,20 @@ void nb_config_diff_created(const struct lyd_node *dnode, uint32_t *seq,
 	switch (dnode->schema->nodetype) {
 	case LYS_LEAF:
 	case LYS_LEAFLIST:
-		if (lyd_is_default(dnode))
+		/*
+		 * Skip implicit defaults only. A leaf explicitly set to its
+		 * default value is real config: it must be committed so the
+		 * datastore records it as explicit, and its callback is
+		 * invoked even though the value is unchanged. This keeps
+		 * create/destroy callbacks paired (its later removal is a
+		 * real change too), matches the legacy CLI where entering a
+		 * command always ran the handler, and forces convergence if
+		 * a daemon's built-in initial value drifts from the YANG
+		 * default. Cost: same-value side effects of non-idempotent
+		 * callbacks become observable on implicit-to-explicit
+		 * transitions.
+		 */
+		if (CHECK_FLAG(dnode->flags, LYD_DEFAULT))
 			break;
 
 		if (nb_cb_operation_is_valid(NB_CB_CREATE, dnode->schema))
@@ -584,6 +597,26 @@ static int nb_lyd_diff_get_op(const struct lyd_node *dnode)
 	return 'n';
 }
 
+/*
+ * Check whether an op "none" diff node records a default-flag-only change:
+ * same value on both sides, but implicit default on one side and explicitly
+ * configured on the other. lyd_diff() marks exactly this case (and only this
+ * case, for op "none" term nodes) with an "orig-default" metadata annotation
+ * when invoked with LYD_DIFF_DEFAULTS.
+ */
+static bool nb_lyd_diff_is_dflt_only_change(const struct lyd_node *dnode)
+{
+	const struct lyd_meta *meta;
+
+	LY_LIST_FOR (dnode->meta, meta) {
+		if (strcmp(meta->name, "orig-default") ||
+		    strcmp(meta->annotation->module->name, "yang"))
+			continue;
+		return true;
+	}
+	return false;
+}
+
 #if 0 /* Used below in nb_config_diff inside normally disabled code */
 static inline void nb_config_diff_dnode_log_path(const char *context,
 						 const char *path,
@@ -617,8 +650,7 @@ static inline void nb_config_diff_dnode_log(const char *context,
  * the DB being compared against 'config1'. Typically 'config1'
  * should be the Running DB and 'config2' is the Candidate DB.
  */
-void nb_config_diff(const struct nb_config *config1,
-		    const struct nb_config *config2,
+void nb_config_diff(const struct nb_config *config1, const struct nb_config *config2,
 		    struct nb_config_cbs *changes)
 {
 	struct lyd_node *diff = NULL;
@@ -645,15 +677,13 @@ void nb_config_diff(const struct nb_config *config1,
 	}
 #endif
 
-	err = lyd_diff_siblings(config1->dnode, config2->dnode,
-				LYD_DIFF_DEFAULTS, &diff);
+	err = lyd_diff_siblings(config1->dnode, config2->dnode, LYD_DIFF_DEFAULTS, &diff);
 	assert(!err);
 
 	if (diff && DEBUG_MODE_CHECK(&nb_dbg_cbs_config, DEBUG_MODE_ALL)) {
 		char *s;
 
-		if (!lyd_print_mem(&s, diff, LYD_JSON,
-				   LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL)) {
+		if (!lyd_print_mem(&s, diff, LYD_JSON, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL)) {
 			zlog_debug("%s: %s", __func__, s);
 			free(s);
 		}
@@ -705,10 +735,30 @@ void nb_config_diff(const struct nb_config *config1,
 				/* either moving an entry or changing a value */
 				target = yang_dnode_get(config2->dnode, path);
 				assert(target);
-				nb_config_diff_add_change(changes, NB_CB_MODIFY,
-							  &seq, target);
+				nb_config_diff_add_change(changes, NB_CB_MODIFY, &seq, target);
 				break;
 			case 'n': /* none */
+				/*
+				 * A default-flag-only change: the value is
+				 * unchanged but the leaf switched between
+				 * implicitly-default and explicitly
+				 * configured. The datastores differ, so the
+				 * commit must go through (otherwise the
+				 * explicitness would be lost with "no
+				 * changes"), and the modify callback fires
+				 * with the unchanged value, which is what the
+				 * legacy CLI did when a command was re-entered
+				 * or negated back to its default.
+				 */
+				if (CHECK_FLAG(dnode->schema->nodetype, LYS_LEAF) &&
+				    nb_lyd_diff_is_dflt_only_change(dnode) &&
+				    nb_cb_operation_is_valid(NB_CB_MODIFY, dnode->schema)) {
+					target = yang_dnode_get(config2->dnode, path);
+					assert(target);
+					nb_config_diff_add_change(changes, NB_CB_MODIFY, &seq,
+								  target);
+				}
+				break;
 			default:
 				break;
 			}
@@ -1176,10 +1226,22 @@ enum nb_change_result nb_candidate_edit_config_change(struct nb_config *candidat
 		return NB_CHANGE_ERR;
 	}
 
-	/* If the value is not set, get the default if it exists. */
-	/* XXX what about presence containers? */
-	if (value == NULL)
+	/*
+	 * A modify without a value on a leaf carrying a schema default means
+	 * "return to the default" (the common CLI 'no' handler idiom). Under
+	 * RFC 7950 strict default handling that is a destroy: the leaf goes
+	 * back to being an implicit default instead of being explicitly set
+	 * to the default value. Handlers that want the leaf to be explicitly
+	 * configured at its default value must pass the value string.
+	 */
+	if (value == NULL && operation == NB_OP_MODIFY && nb_node->snode->nodetype == LYS_LEAF &&
+	    yang_snode_get_default(nb_node->snode)) {
+		operation = NB_OP_DESTROY;
+	} else if (value == NULL) {
+		/* If the value is not set, get the default if it exists. */
+		/* XXX what about presence containers? */
 		value = yang_snode_get_default(nb_node->snode);
+	}
 
 	/*
 	 * Ignore "not found" errors when editing the candidate configuration.
@@ -1223,8 +1285,8 @@ void nb_candidate_edit_config_changes(struct nb_config *candidate_config,
 		}
 		strlcat(xpath, change_xpath, sizeof(xpath));
 
-		result = nb_candidate_edit_config_change(candidate_config, change->operation, xpath,
-							 change->value, in_backend);
+		result = nb_candidate_edit_config_change(candidate_config, change->operation,
+							 xpath, change->value, in_backend);
 		if (result != NB_CHANGE_OK)
 			*error = true;
 		if (result == NB_CHANGE_ERR)

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -711,7 +711,12 @@ static int nb_cli_show_config_libyang(struct vty *vty, LYD_FORMAT format,
 	if (with_defaults)
 		SET_FLAG(options, LYD_PRINT_WD_ALL);
 	else
-		SET_FLAG(options, LYD_PRINT_WD_TRIM);
+		/*
+		 * "As configured": keep leaves explicitly set to their default
+		 * value, drop only implicit defaults. WD_TRIM would drop by
+		 * value comparison, losing the explicitly configured ones.
+		 */
+		SET_FLAG(options, LYD_PRINT_WD_EXPLICIT);
 
 	if (lyd_print_mem(&strp, dnode, format, options) == 0 && strp) {
 		vty_out(vty, "%s", strp);

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -591,7 +591,6 @@ uint32_t yang_dnode_count(const struct lyd_node *dnode, const char *xpath_fmt,
 bool yang_dnode_is_default(const struct lyd_node *dnode, const char *xpath)
 {
 	const struct lysc_node *snode;
-	struct lysc_node_leaf *sleaf;
 
 	if (xpath)
 		dnode = yang_dnode_get(dnode, xpath);
@@ -600,13 +599,16 @@ bool yang_dnode_is_default(const struct lyd_node *dnode, const char *xpath)
 	snode = dnode->schema;
 	switch (snode->nodetype) {
 	case LYS_LEAF:
-		sleaf = (struct lysc_node_leaf *)snode;
-		if (sleaf->type->basetype == LY_TYPE_EMPTY)
-			return false;
-		return lyd_is_default(dnode);
 	case LYS_LEAFLIST:
-		/* TODO: check leaf-list default values */
-		return false;
+		/*
+		 * Only implicit defaults count as "default" (RFC 7950 7.6.1):
+		 * a leaf explicitly set to its default value exists in the
+		 * data tree in its own right (libyang clears LYD_DEFAULT) and
+		 * must be treated as configured, e.g. emitted on
+		 * "show running-config". Do NOT compare the value against the
+		 * schema default here (that is what lyd_is_default() does).
+		 */
+		return CHECK_FLAG(dnode->flags, LYD_DEFAULT);
 	case LYS_CONTAINER:
 		if (CHECK_FLAG(snode->flags, LYS_PRESENCE))
 			return false;

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -454,8 +454,11 @@ uint32_t yang_dnode_count(const struct lyd_node *dnode, const char *xpath_fmt,
 			  ...) PRINTFRR(2, 3);
 
 /*
- * Check if the libyang data node contains a default value. Non-presence
- * containers are assumed to always contain a default value.
+ * Check if the libyang data node is an implicit default, i.e. was never
+ * explicitly configured. A leaf explicitly set to its default value is NOT
+ * considered default here (RFC 7950 7.6.1 treats explicit and implicit
+ * presence as distinct). Non-presence containers are assumed to always
+ * contain a default value.
  *
  * dnode
  *    Base libyang data node to operate on.
@@ -465,7 +468,7 @@ uint32_t yang_dnode_count(const struct lyd_node *dnode, const char *xpath_fmt,
  *    data node to operate on in the same data tree.
  *
  * Returns:
- *    true if the data node contains the default value, false otherwise.
+ *    true if the data node is an implicit default, false otherwise.
  */
 extern bool yang_dnode_is_default(const struct lyd_node *dnode,
 				  const char *xpath);

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -280,16 +280,26 @@ struct nb_config_cbs mgmt_be_adapter_get_config(struct mgmt_be_client_adapter *a
 
 	LY_LIST_FOR (running_config->dnode, root) {
 		LYD_TREE_DFS_BEGIN (root, dnode) {
-			if (lysc_is_key(dnode->schema))
-				goto walk_cont;
-
-			xpath = lyd_path(dnode, LYD_PATH_STD, NULL, 0);
-			if (be_client_wants_cfg(xpath, adapter->id))
-				nb_config_diff_add_change(&changes, NB_CB_CREATE, &seq, dnode);
-			else
-				LYD_TREE_DFS_continue = 1; /* skip any subtree */
-			free(xpath);
-walk_cont:
+			/*
+			 * Implicit defaults are not configuration: the backend
+			 * re-materializes them from the schema on validation.
+			 * Pushing them would make every default-valued leaf
+			 * explicitly set on the backend side. An implicit node
+			 * can only carry implicit descendants (libyang clears
+			 * the parent's default flag when an explicit child is
+			 * inserted), so the whole subtree can be skipped.
+			 */
+			if (CHECK_FLAG(dnode->flags, LYD_DEFAULT)) {
+				LYD_TREE_DFS_continue = 1;
+			} else if (!lysc_is_key(dnode->schema)) {
+				xpath = lyd_path(dnode, LYD_PATH_STD, NULL, 0);
+				if (be_client_wants_cfg(xpath, adapter->id))
+					nb_config_diff_add_change(&changes, NB_CB_CREATE, &seq,
+								  dnode);
+				else
+					LYD_TREE_DFS_continue = 1; /* skip any subtree */
+				free(xpath);
+			}
 			LYD_TREE_DFS_END(root, dnode);
 		}
 	}

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -53,26 +53,27 @@ static struct mgmt_master *mgmt_ds_mm;
 static struct mgmt_ds_ctx running, candidate, oper;
 
 /* Dump the data tree of the specified format in the file pointed by the path */
-static int mgmt_ds_dump_in_memory(struct mgmt_ds_ctx *ds_ctx,
-				  const char *base_xpath, LYD_FORMAT format,
-				  struct ly_out *out)
+static int mgmt_ds_dump_in_memory(struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
+				  LYD_FORMAT format, struct ly_out *out)
 {
 	struct lyd_node *root;
 	uint32_t options = 0;
 
 	if (base_xpath[0] == '\0')
-		root = ds_ctx->config_ds ? ds_ctx->root.cfg_root->dnode
-					  : ds_ctx->root.dnode_root;
+		root = ds_ctx->config_ds ? ds_ctx->root.cfg_root->dnode : ds_ctx->root.dnode_root;
 	else
-		root = yang_dnode_get(ds_ctx->config_ds
-					      ? ds_ctx->root.cfg_root->dnode
-					      : ds_ctx->root.dnode_root,
+		root = yang_dnode_get(ds_ctx->config_ds ? ds_ctx->root.cfg_root->dnode
+							: ds_ctx->root.dnode_root,
 				      base_xpath);
 	if (!root)
 		return -1;
 
-	options = ds_ctx->config_ds ? LYD_PRINT_WD_TRIM :
-		LYD_PRINT_WD_EXPLICIT;
+	/*
+	 * WD_EXPLICIT for config datastores too: a leaf explicitly set to its
+	 * default value is configuration and must survive the dump; only
+	 * implicit defaults are omitted. WD_TRIM would drop both.
+	 */
+	options = LYD_PRINT_WD_EXPLICIT;
 
 	if (base_xpath[0] == '\0')
 		lyd_print_all(out, root, format, options);

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -111,17 +111,11 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	char buf_prefix[PREFIX_STRLEN];
 	char buf_src_prefix[PREFIX_STRLEN] = "::/0";
 	char buf_nh_type[PREFIX_STRLEN] = {};
-	char buf_distance[PREFIX_STRLEN];
-	char buf_tag[PREFIX_STRLEN];
-	char buf_metric[PREFIX_STRLEN];
 	uint8_t label_stack_id = 0;
 	uint8_t segs_stack_id = 0;
 	char *orig_label = NULL, *orig_seg = NULL;
 	const char *buf_gate_str;
 	struct ipaddr gate_ip;
-	uint8_t distance = ZEBRA_STATIC_DISTANCE_DEFAULT;
-	route_tag_t tag = 0;
-	uint32_t metric = 0;
 	uint32_t table_id = 0;
 	const struct lyd_node *dnode;
 	const struct lyd_node *vrf_dnode;
@@ -218,18 +212,6 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 			type = STATIC_IPV6_GATEWAY;
 	}
 
-	/* Administrative distance. */
-	if (args->distance)
-		distance = strtol(args->distance, NULL, 10);
-
-	/* tag */
-	if (args->tag)
-		tag = strtoul(args->tag, NULL, 10);
-
-	/* metric */
-	if (args->metric)
-		metric = strtoul(args->metric, NULL, 10);
-
 	/* TableID */
 	if (args->table)
 		table_id = strtol(args->table, NULL, 10);
@@ -252,24 +234,23 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		if (!dnode)
 			nb_cli_enqueue_change(vty, xpath_prefix, NB_OP_CREATE, NULL);
 
-		/* Distance processing */
+		/*
+		 * Distance/tag/metric: pass the user's string through, or NULL
+		 * when the token was not given. A NULL modify returns the leaf
+		 * to its (implicit) schema default, so only values the user
+		 * actually typed become explicit configuration.
+		 */
 		strlcpy(ab_xpath, xpath_prefix, sizeof(ab_xpath));
 		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_DISTANCE_XPATH, sizeof(ab_xpath));
-		snprintf(buf_distance, sizeof(buf_distance), "%u", distance);
-		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_distance);
+		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, args->distance);
 
-		/* Tag processing */
-		snprintf(buf_tag, sizeof(buf_tag), "%u", tag);
 		strlcpy(ab_xpath, xpath_prefix, sizeof(ab_xpath));
-		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_TAG_XPATH,
-			sizeof(ab_xpath));
-		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_tag);
+		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_TAG_XPATH, sizeof(ab_xpath));
+		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, args->tag);
 
-		/* Metric processing */
-		snprintf(buf_metric, sizeof(buf_metric), "%u", metric);
 		strlcpy(ab_xpath, xpath_prefix, sizeof(ab_xpath));
 		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_METRIC_XPATH, sizeof(ab_xpath));
-		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_metric);
+		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, args->metric);
 
 		/* The path-list entry is the nexthop; xpath_nexthop == xpath_prefix. */
 		strlcpy(xpath_nexthop, xpath_prefix, sizeof(xpath_nexthop));
@@ -1780,18 +1761,18 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 
 	if (yang_dnode_exists(path, "tag")) {
 		tag = yang_dnode_get_uint32(path, "tag");
-		if (tag != 0 || show_defaults)
+		if (!yang_dnode_is_default(path, "tag") || show_defaults)
 			vty_out(vty, " tag %" PRIu32, tag);
 	}
 
 	distance = yang_dnode_get_uint8(path, "distance");
-	if (distance != ZEBRA_STATIC_DISTANCE_DEFAULT || show_defaults)
+	if (!yang_dnode_is_default(path, "distance") || show_defaults)
 		vty_out(vty, " %" PRIu8, distance);
 
 	if (yang_dnode_exists(path, "metric")) {
 		uint32_t metric = yang_dnode_get_uint32(path, "metric");
 
-		if (metric != 0 || show_defaults)
+		if (!yang_dnode_is_default(path, "metric") || show_defaults)
 			vty_out(vty, " metric %" PRIu32, metric);
 	}
 

--- a/tests/topotests/mgmt_explicit_defaults/r1/frr.conf
+++ b/tests/topotests/mgmt_explicit_defaults/r1/frr.conf
@@ -1,0 +1,6 @@
+log timestamp precision 3
+!
+router rip
+ default-metric 1
+ timers basic 30 180 120
+exit

--- a/tests/topotests/mgmt_explicit_defaults/test_explicit_defaults.py
+++ b/tests/topotests/mgmt_explicit_defaults/test_explicit_defaults.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# Copyright (C) 2026 Robin Christ for partimus GmbH
+#
+
+"""
+Test RFC 7950 default-leaf strictness in the northbound/mgmtd stack.
+
+A leaf explicitly set to its schema default value is configuration in its
+own right (RFC 7950 7.6.1): it must survive the commit (not collapse into
+"no changes"), be stored explicitly in the running datastore, and be
+emitted by "show running-config" and saved configurations. A leaf whose
+default merely applies implicitly must NOT be emitted (except in the
+with-defaults view).
+
+Exercised with ripd, whose frr-ripd model carries plain YANG defaults
+(default-metric 1, timers basic 30/180/120).
+"""
+
+import json
+import os
+
+import pytest
+from lib.topogen import Topogen
+
+pytestmark = [pytest.mark.mgmtd, pytest.mark.ripd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    "Setup/Teardown the environment and provide tgen argument to tests"
+
+    topodef = {"s1": ("r1",)}
+
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for router in router_list.values():
+        router.load_frr_config()
+
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+def _rip_block(r1, args=""):
+    out = r1.vtysh_cmd("show running-config %s" % args)
+    lines = out.splitlines()
+    try:
+        start = next(i for i, l in enumerate(lines) if l.startswith("router rip"))
+    except StopIteration:
+        return []
+    block = []
+    for line in lines[start:]:
+        block.append(line)
+        if line.strip() in ("exit", "!") and len(block) > 1:
+            break
+    return block
+
+
+def test_explicit_defaults_survive_load(tgen):
+    "Explicitly configured default values must appear in show running-config."
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    block = _rip_block(r1)
+    assert " default-metric 1" in block, "explicit default-metric 1 lost: %s" % block
+    assert " timers basic 30 180 120" in block, (
+        "explicit timers basic 30 180 120 lost: %s" % block
+    )
+
+
+def test_implicit_default_not_emitted(tgen):
+    "Removing the config line must return the leaf to (non-emitted) default."
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("conf t\nrouter rip\nno default-metric\n")
+    block = _rip_block(r1)
+    assert not any("default-metric" in l for l in block), (
+        "implicit default-metric emitted: %s" % block
+    )
+
+
+def test_explicit_set_to_default_commits(tgen):
+    """Setting a leaf to its default value on a running system is a real
+    commit (previously collapsed into 'no changes') and must re-appear."""
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("conf t\nrouter rip\ndefault-metric 1\n")
+    block = _rip_block(r1)
+    assert " default-metric 1" in block, (
+        "explicit set-to-default did not commit/emit: %s" % block
+    )
+
+
+def test_with_defaults_view(tgen):
+    """The as-configured view must contain only explicitly configured leaves;
+    the with-defaults (effective) view materializes the implicit defaults."""
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("conf t\nrouter rip\nno timers basic\n")
+    block = _rip_block(r1)
+    assert not any("timers basic" in l for l in block), (
+        "implicit timers emitted in plain view: %s" % block
+    )
+
+    cmd = "show mgmt get-data /frr-ripd:ripd datastore running only-config %sjson"
+    plain = json.loads(r1.vtysh_cmd(cmd % ""))
+    effective = json.loads(r1.vtysh_cmd(cmd % "with-defaults all "))
+
+    plain_inst = plain["frr-ripd:ripd"]["instance"][0]
+    effective_inst = effective["frr-ripd:ripd"]["instance"][0]
+
+    assert "timers" not in plain_inst, (
+        "implicit timers in as-configured data: %s" % plain_inst
+    )
+    assert plain_inst.get("default-metric") == 1, (
+        "explicit default-metric missing from as-configured data: %s" % plain_inst
+    )
+    assert effective_inst.get("timers", {}).get("update-interval") == 30, (
+        "implicit timers missing from effective data: %s" % effective_inst
+    )
+
+    # The CLI rendering of both views, from mgmtd (which owns the
+    # datastore); vtysh's grammar requires the trailing daemon name.
+    plain_cli = r1.vtysh_cmd("show configuration running mgmtd")
+    effective_cli = r1.vtysh_cmd("show configuration running with-defaults mgmtd")
+    assert " default-metric 1" in plain_cli.splitlines(), (
+        "explicit default-metric missing from plain CLI view"
+    )
+    assert not any(
+        "timers basic" in l for l in plain_cli.splitlines()
+    ), "implicit timers in plain CLI view"
+    assert " timers basic 30 180 120" in effective_cli.splitlines(), (
+        "implicit timers missing from with-defaults CLI view"
+    )
+
+
+def test_explicit_default_round_trips_restart(tgen):
+    "An explicitly configured default survives write memory and a restart."
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_cmd("conf t\nrouter rip\ndefault-metric 1\n")
+    r1.vtysh_cmd("write memory")
+
+    saved = r1.cmd("cat /etc/frr/frr.conf")
+    assert " default-metric 1" in saved.splitlines(), (
+        "explicit default-metric missing from saved config:\n%s" % saved
+    )
+    assert not any(
+        l.strip().startswith("timers basic") for l in saved.splitlines()
+    ), "implicit timers leaked into saved config:\n%s" % saved
+
+
+if __name__ == "__main__":
+    args = ["-s"] + [__file__]
+    ret = pytest.main(args)
+    exit(ret)

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -196,7 +196,7 @@ static void zebra_import_kernel_table_cli_write(struct vty *vty, const struct ly
 	if (safi == SAFI_MULTICAST)
 		vty_out(vty, " mrib");
 
-	if (distance != ZEBRA_TABLE_DISTANCE_DEFAULT)
+	if (!yang_dnode_is_default(dnode, "distance") || show_defaults)
 		vty_out(vty, " distance %u", distance);
 
 	if (rmap)
@@ -324,7 +324,7 @@ DEFPY_YANG (ip_zebra_import_table_distance,
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 
 	snprintfrr(xpath_child, sizeof(xpath_child), "%s/distance", xpath);
-	nb_cli_enqueue_change(vty, xpath_child, NB_OP_MODIFY, distance_str ? distance_str : "15");
+	nb_cli_enqueue_change(vty, xpath_child, NB_OP_MODIFY, distance_str);
 
 	snprintfrr(xpath_child, sizeof(xpath_child), "%s/route-map", xpath);
 	nb_cli_enqueue_change(vty, xpath_child, rmap ? NB_OP_MODIFY : NB_OP_DESTROY, rmap);
@@ -378,7 +378,7 @@ DEFPY_YANG (ipv6_zebra_import_table_distance,
 		return nb_cli_apply_changes(vty, NULL);
 
 	snprintfrr(xpath_child, sizeof(xpath_child), "%s/distance", xpath);
-	nb_cli_enqueue_change(vty, xpath_child, NB_OP_MODIFY, distance_str ? distance_str : "15");
+	nb_cli_enqueue_change(vty, xpath_child, NB_OP_MODIFY, distance_str);
 
 	snprintfrr(xpath_child, sizeof(xpath_child), "%s/route-map", xpath);
 	nb_cli_enqueue_change(vty, xpath_child, rmap ? NB_OP_MODIFY : NB_OP_DESTROY, rmap);
@@ -2583,13 +2583,15 @@ static void lib_vrf_zebra_resolve_via_default_cli_write(
 {
 	bool resolve_via_default = yang_dnode_get_bool(dnode, NULL);
 
-	if (resolve_via_default != SAVE_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT ||
-	    show_defaults) {
-		zebra_vrf_indent_cli_write(vty, dnode);
+	/*
+	 * The leaf has no schema default (the effective default is
+	 * profile-dependent), so it only exists when explicitly configured
+	 * and must then always be rendered, even at the profile's default
+	 * value.
+	 */
+	zebra_vrf_indent_cli_write(vty, dnode);
 
-		vty_out(vty, "%sip nht resolve-via-default\n",
-			resolve_via_default ? "" : "no ");
-	}
+	vty_out(vty, "%sip nht resolve-via-default\n", resolve_via_default ? "" : "no ");
 }
 
 DEFPY_YANG (ipv6_nht_default_route,
@@ -2615,13 +2617,12 @@ static void lib_vrf_zebra_ipv6_resolve_via_default_cli_write(
 {
 	bool resolve_via_default = yang_dnode_get_bool(dnode, NULL);
 
-	if (resolve_via_default != SAVE_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT ||
-	    show_defaults) {
-		zebra_vrf_indent_cli_write(vty, dnode);
+	/* No schema default (profile-dependent), same rationale as the
+	 * IPv4 variant above: explicit config always renders.
+	 */
+	zebra_vrf_indent_cli_write(vty, dnode);
 
-		vty_out(vty, "%sipv6 nht resolve-via-default\n",
-			resolve_via_default ? "" : "no ");
-	}
+	vty_out(vty, "%sipv6 nht resolve-via-default\n", resolve_via_default ? "" : "no ");
 }
 
 DEFPY_YANG (mpls_fec_nexthop_resolution, mpls_fec_nexthop_resolution_cmd,


### PR DESCRIPTION
`mgmtd`'s YANG logic currently does not distinguish between "explicit values that happen to match the default value" and implicit default values.

If you set a value that happens to match the implicit default value from the YANG schema, `mgmtd` will basically just ignore that. If you explicitly set a value, and later the schema default changes, your configured value is gone and changes to the new schema default value, because it was simply never recorded.

RFC 7950 section 7.6.1 distinguishes a leaf explicitly set to its default value from a leaf whose default merely applies.


Example startup config:
```
log timestamp precision 3
!
router rip
 default-metric 1
 timers basic 30 180 120
exit
```

Pre-PR:
```
$ vtysh -c 'show running-config'
Building configuration...

Current configuration:
!
frr version 10.8.0-dev-topotests
frr defaults traditional
hostname r1
log commands
log timestamp precision 3
service integrated-vtysh-config
!
router rip
exit
!
end
```
Both explicitly configured lines are gone.

With PR:
```
$ vtysh -c 'show running-config'
Building configuration...

Current configuration:
!
frr version 10.8.0-dev-topotests
frr defaults traditional
hostname r1
log commands
log timestamp precision 3
service integrated-vtysh-config
!
router rip
 default-metric 1
 timers basic 30 180 120
exit
!
end
```

I can provide some more examples, but I think the examples are sufficiently obvious.

The new topotest `mgmt_explicit_defaults` covers:
- explicit defaults surviving config load, `show running-config` and `write memory`
- negation returning to the non-emitted implicit default
- set-to-default on a running system being a real commit
- the as-configured vs effective split via mgmt get-data and the mgmtd CLI views



Note:
While testing this PR, I discovered a crash caused by init push: `logging_file_level_modify()` and `logging_filtered_file_level_modify()` dereference a `NULL` filename when a file log level is applied with no log file configured (ASAN: `SEGV in set_log_file()`, `reachable via /frr-logging:logging/file/level`). They now no-op. The filename callback picks the level up later. The filtered variant also read `zt_file`'s filename instead of `zt_filterfile`'s.

Repro:
```
# --log stdout on purpose: leaves zt_file / zt_filterfile completely
# unconfigured, i.e. filename == NULL.
/usr/lib/frr/mgmtd -d -u root -g root --log stdout --log-level debug
```
ASAN gives:
```
====================================================================
########## /tmp/repro-out/asan.1760 ##########
=================================================================
==1760==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7faaafdf49f8 bp 0x7ffe5abdbd70 sp 0x7ffe5abd9ae0 T0)
==1760==The signal is caused by a READ memory access.
==1760==Hint: address points to the zero page.
    #0 0x7faaafdf49f8 in set_log_file lib/log_nb.c:50
    #1 0x7faaafdf5d7f in logging_file_level_modify lib/log_nb.c:297
    #2 0x7faaafe2e6bd in nb_callback_modify lib/northbound.c:1634
    #3 0x7faaafe2e6bd in nb_callback_configuration lib/northbound.c:2004
    #4 0x7faaafe2f922 in nb_transaction_process lib/northbound.c:2133
    #5 0x7faaafe3009f in nb_candidate_commit_apply lib/northbound.c:1445
    #6 0x556336be1ddc in txn_cfg_send_cfg_apply mgmtd/mgmt_txn_cfg.c:466
    #7 0x556336be2a1c in txn_cfg_next_phase mgmtd/mgmt_txn_cfg.c:630
    #8 0x556336be2a1c in txn_cfg_adapter_acked mgmtd/mgmt_txn_cfg.c:667
    #9 0x556336be5264 in txn_cfg_make_and_send_cfg_req mgmtd/mgmt_txn_cfg.c:427
    #10 0x556336be5909 in txn_cfg_send_config_changes mgmtd/mgmt_txn_cfg.c:711
    #11 0x556336be8639 in mgmt_txn_send_commit_config_req mgmtd/mgmt_txn_cfg.c:1072
    #12 0x556336bd3739 in fe_session_handle_commit mgmtd/mgmt_fe_adapter.c:872
    #13 0x556336bd3739 in fe_adapter_process_msg mgmtd/mgmt_fe_adapter.c:1798
    #14 0x7faaafe0ae8e in mgmt_msg_procbufs lib/mgmt_msg.c:175
    #15 0x7faaafe0b012 in msg_conn_proc_msgs lib/mgmt_msg.c:491
    #16 0x7faaafeba17f in event_call lib/event.c:2744
    #17 0x7faaafdd5b66 in frr_run lib/libfrr.c:1258
    #18 0x556336bc32e3 in main mgmtd/mgmt_main.c:283
    #19 0x7faaaf74bca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #20 0x7faaaf74bd64 in __libc_start_main_impl ../csu/libc-start.c:360
    #21 0x556336bc2de0 in _start (/usr/lib/frr/mgmtd+0x3fde0) (BuildId: 1fb3eea501627a36b8f44b95bef4cd9394e2cf43)
```