### PR TITLE
zebra: Fix SRv6 locator delete after no prefix (backport #22882)

### DIFF
--- a/tests/topotests/srv6_locator/expected_locators7.json
+++ b/tests/topotests/srv6_locator/expected_locators7.json
@@ -1,0 +1,9 @@
+{
+  "locators":[
+    {
+      "name": "loc1",
+      "prefix": "fcbb:bbbb:1::/48",
+      "statusUp": true
+    }
+  ]
+}

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -39,6 +39,32 @@ def open_json_file(filename):
         assert False, "Could not read file {}".format(filename)
 
 
+def _check_sharpd_chunk(router, expected_chunk_file):
+    logger.info("checking sharpd locator chunk status")
+    output = json.loads(router.vtysh_cmd("show sharp segment-routing srv6 json"))
+    expected = open_json_file("{}/{}".format(CWD, expected_chunk_file))
+    return topotest.json_cmp(output, expected)
+
+
+def _check_srv6_locator(router, expected_locator_file):
+    logger.info("checking zebra locator status")
+    output = json.loads(router.vtysh_cmd("show segment-routing srv6 locator json"))
+    expected = open_json_file("{}/{}".format(CWD, expected_locator_file))
+    return topotest.json_cmp(output, expected)
+
+
+def check_srv6_locator(router, expected_file):
+    func = functools.partial(_check_srv6_locator, router, expected_file)
+    _, result = topotest.run_and_expect(func, None, count=15, wait=1)
+    assert result is None, "Failed"
+
+
+def check_sharpd_chunk(router, expected_file):
+    func = functools.partial(_check_sharpd_chunk, router, expected_file)
+    _, result = topotest.run_and_expect(func, None, count=15, wait=1)
+    assert result is None, "Failed"
+
+
 def setup_module(mod):
     tgen = Topogen({None: "r1"}, mod.__name__)
     tgen.start_topology()
@@ -66,28 +92,6 @@ def test_srv6():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
     router = tgen.gears["r1"]
-
-    def _check_srv6_locator(router, expected_locator_file):
-        logger.info("checking zebra locator status")
-        output = json.loads(router.vtysh_cmd("show segment-routing srv6 locator json"))
-        expected = open_json_file("{}/{}".format(CWD, expected_locator_file))
-        return topotest.json_cmp(output, expected)
-
-    def _check_sharpd_chunk(router, expected_chunk_file):
-        logger.info("checking sharpd locator chunk status")
-        output = json.loads(router.vtysh_cmd("show sharp segment-routing srv6 json"))
-        expected = open_json_file("{}/{}".format(CWD, expected_chunk_file))
-        return topotest.json_cmp(output, expected)
-
-    def check_srv6_locator(router, expected_file):
-        func = functools.partial(_check_srv6_locator, router, expected_file)
-        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
-        assert result is None, "Failed"
-
-    def check_sharpd_chunk(router, expected_file):
-        func = functools.partial(_check_sharpd_chunk, router, expected_file)
-        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
-        assert result is None, "Failed"
 
     # FOR DEVELOPER:
     # If you want to stop some specific line and start interactive shell,

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -150,6 +150,51 @@ def test_srv6():
     check_sharpd_chunk(router, "expected_chunks6.json")
 
 
+def test_srv6_no_locator():
+    """Delete a locator after removing its prefix."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            locator loc1
+             prefix fcbb:bbbb:1::/48
+             format usid-f3216
+        """
+    )
+    check_srv6_locator(router, "expected_locators7.json")
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            no locator loc1
+        """
+    )
+    assert router.check_router_running() == ""
+    check_srv6_locator(router, "expected_locators6.json")
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           locators
+            locator loc1
+             prefix fcbb:bbbb:1::/48
+        """
+    )
+    check_srv6_locator(router, "expected_locators7.json")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -830,26 +830,24 @@ DEFUN (no_srv6_locator,
 	}
 
 	block = locator->sid_block;
-	frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, ctx) {
-		if (!ctx->sid)
-			continue;
-
-		frr_each_safe (zebra_srv6_sid_entry_list, &ctx->sid->entries, entry)
-			if (entry->locator == locator) {
-				zebra_srv6_sid_entry_list_del(&ctx->sid->entries, entry);
-				zebra_srv6_sid_entry_free(entry);
-			}
-
-		if (zebra_srv6_sid_entry_list_count(&ctx->sid->entries) == 0) {
-			zebra_srv6_sid_free(ctx->sid);
-
-			zebra_srv6_sid_ctx_list_del(&block->sids, ctx);
-			zebra_srv6_sid_ctx_free(ctx);
-		}
-	}
-
-	block = locator->sid_block;
 	if (block) {
+		frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, ctx) {
+			if (!ctx->sid)
+				continue;
+
+			frr_each_safe (zebra_srv6_sid_entry_list, &ctx->sid->entries, entry)
+				if (entry->locator == locator) {
+					zebra_srv6_sid_entry_list_del(&ctx->sid->entries, entry);
+					zebra_srv6_sid_entry_free(entry);
+				}
+
+			if (zebra_srv6_sid_entry_list_count(&ctx->sid->entries) == 0) {
+				zebra_srv6_sid_free(ctx->sid);
+
+				zebra_srv6_sid_ctx_list_del(&block->sids, ctx);
+				zebra_srv6_sid_ctx_free(ctx);
+			}
+		}
 		block->refcnt--;
 		if (block->refcnt == 0) {
 			frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, ctx) {


### PR DESCRIPTION
Manual backport of https://github.com/FRRouting/frr/pull/22882 for FRR 10.5

Replaces https://github.com/FRRouting/frr/pull/22901