### PR TITLE
babeld: Fix premature route flush in expire_routes()

### DIFF
--- a/babeld/route.c
+++ b/babeld/route.c
@@ -1045,12 +1045,17 @@ void expire_routes(void)
 		r = routes[i];
 		while (r) {
 			/* Protect against clock being stepped. */
-			if (r->time > babel_now.tv_sec || route_old(r)) {
+			if (r->time > babel_now.tv_sec) {
 				flush_route(r);
 				goto again;
 			}
 
 			update_route_metric(r);
+
+			if (route_expired(r)) {
+				flush_route(r);
+				goto again;
+			}
 
 			if (r->installed && r->refmetric < INFINITY) {
 				if (route_old(r))


### PR DESCRIPTION
## Summary

`expire_routes()` used `route_old()` (`hold_time * 7/8`) as the flush threshold, causing routes to be flushed before they were fully expired. This bypassed two RFC 8966 requirements:

1. **RFC 8966 §3.5.3**: finite-metric routes that expire must first set metric to infinity and reset the expiry timer. Instead, routes were directly flushed, skipping the `update_route_metric()` retraction path.

2. **RFC 8966 §3.8.2.3**: before a selected route expires, the node should send a unicast Route Request to the original neighbour. This was dead code because `route_old()` routes were already flushed on line 1048.

## Fix

Change the flush condition from `route_old()` to `route_expired()` (full `hold_time`), so that:

- Only truly expired routes are flushed immediately
- `route_old()` routes (7/8 hold_time) fall through to `update_route_metric()` for normal metric processing  
- The pre-expiry unicast Route Request on installed finite routes becomes reachable

## References

- RFC 8966 §3.5.3 (Route Acquisition)
- RFC 8966 §3.5.4 (Hold Time)  
- RFC 8966 §3.8.2.3 (Preventing Routes from Expiring)
- RFCAudit Bug 13 (RFCBin): route expiry premature flush

Signed-off-by: zhuxu <185172534zxxx@gmail.com>