### PR TITLE
babeld: Refresh timers for retained unfeasible routes

### DIFF
--- a/babeld/route.c
+++ b/babeld/route.c
@@ -776,7 +776,8 @@ struct babel_route *update_route(const unsigned char *router_id, const unsigned 
 		}
 
 		route->src = retain_source(src);
-		if ((feasible || keep_unfeasible) && refmetric < INFINITY)
+		if ((feasible || keep_unfeasible || !route->installed) &&
+		    refmetric < INFINITY)
 			route->time = babel_now.tv_sec;
 		route->seqno = seqno;
 


### PR DESCRIPTION
RFC 8966 Section 3.5.3 requires an existing route entry updated with a finite advertised metric to have its expiry timer reset. It permits an unfeasible Update to be ignored when the route is currently selected and has the same router-id.

With `keep_unfeasible=0`, `update_route()` currently retains and updates an existing unselected route after a finite unfeasible Update, but does not refresh `route->time`. The entry therefore keeps its old expiry anchor and can expire despite receiving fresh finite Updates.

Add `!route->installed` to the timer condition. At this point, an existing unselected route has `installed == 0`; a selected route that switched sources and was uninstalled also has `installed == 0`. Feasible updates and `keep_unfeasible` behavior remain unchanged.

The narrower condition deliberately leaves the selected, same-source, unfeasible case unchanged. RFC 8966 Section 3.5.3 permits that case to be ignored, and preserving its timestamp also preserves the existing `route_old()`-based forced Seqno Request behavior.

I verified the relevant state matrix at function level:

- existing, unselected, finite, unfeasible: timer is refreshed;
- finite feasible update: unchanged;
- infinite retraction: timer is not refreshed;
- selected, same-source, finite, unfeasible: existing timer/request behavior is preserved;
- new-route handling: unchanged.

This was checked against FRRouting master commit `01ca85721c8b9fb9e4bf1ac5545a08a6c63de74e`. I have not run a full network-topology reproduction.

This finding originated from an academic source-level RFC consistency review.