### PR TITLE
bgpd: emit a zero BMP timestamp for never-established peers

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -466,13 +466,22 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 	struct stream *s;
 	size_t len;
 	struct timeval uptime, uptime_real;
+	struct timeval *uptime_tv = NULL;
 	uint8_t peer_type;
 	bool is_locrib = false;
 	uint64_t peer_distinguisher = 0;
 
-	uptime.tv_sec = peer->uptime;
-	uptime.tv_usec = 0;
-	monotime_to_realtime(&uptime, &uptime_real);
+	/* peer->uptime is monotonic and is 0 when the session has never
+	 * established; converting 0 to realtime would yield the machine's
+	 * boot time.  RFC 7854 says a zero timestamp means the time is
+	 * unavailable, which bmp_per_peer_hdr emits for a NULL timeval.
+	 */
+	if (peer->uptime) {
+		uptime.tv_sec = peer->uptime;
+		uptime.tv_usec = 0;
+		monotime_to_realtime(&uptime, &uptime_real);
+		uptime_tv = &uptime_real;
+	}
 
 	peer_type = bmp_get_peer_type(peer);
 	if (peer_type == BMP_PEER_TYPE_LOC_RIB_INSTANCE)
@@ -493,7 +502,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_UP_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, peer_distinguisher, &uptime_real);
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, peer_distinguisher, uptime_tv);
 
 		/* Local Address (16 bytes) */
 		if (is_locrib)
@@ -558,7 +567,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_DOWN_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, peer_distinguisher, &uptime_real);
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, peer_distinguisher, uptime_tv);
 
 		type_pos = stream_get_endp(s);
 		stream_putc(s, 0);	/* placeholder for down reason */

--- a/tests/topotests/bgp_bmp/r1ts/frr.conf
+++ b/tests/topotests/bgp_bmp/r1ts/frr.conf
@@ -18,8 +18,10 @@ router bgp 65501
  no bgp ebgp-requires-policy
  neighbor 192.168.0.2 remote-as 65502
  neighbor 192.168.0.2 timers delayopen 5
+ neighbor 192.168.0.66 remote-as 65503
 !
  address-family ipv4 unicast
   neighbor 192.168.0.2 activate
+  neighbor 192.168.0.66 activate
  exit-address-family
 !

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_timestamps.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_timestamps.py
@@ -14,10 +14,20 @@ test_bgp_bmp_timestamps.py: BMP per-peer header timestamps.
     |          |            |          |               |          |
     +----------+            +----------+               +----------+
 
-Checks that a pre-policy route-monitoring message for a re-announcement
-of an already-known prefix (same prefix, changed attribute) carries the
-reception time of the re-announcement, not the time the prefix was
-first received.
+r1ts additionally has a configured neighbor at an unreachable address
+(192.168.0.66) whose session can never establish.
+
+Checks:
+
+* peer-state (Peer Up/Down) messages for a peer that has never established
+  since bgpd start must carry a per-peer header timestamp of 0 -- RFC 7854
+  section 4.2 "time unavailable" -- not a wall-clock time fabricated from
+  the peer's zero monotonic uptime (which decodes to the machine's boot
+  time);
+* a pre-policy route-monitoring message for a re-announcement of an
+  already-known prefix (same prefix, changed attribute) must carry the
+  reception time of the re-announcement, not the time the prefix was
+  first received.
 """
 
 import os
@@ -40,6 +50,7 @@ from lib.topolog import logger
 pytestmark = [pytest.mark.bgpd]
 
 WATCHED_PREFIX = "203.0.113.1/32"
+NEVER_ESTABLISHED_PEER = "192.168.0.66"
 
 bmp_seq_context = BMPSequenceContext()
 
@@ -108,9 +119,28 @@ def _route_messages(policy, bmp_log_type, prefix):
     ]
 
 
+def _never_established_peer_state_messages():
+    """
+    Return the peer-state (Peer Up/Down) messages logged for the neighbor
+    that can never establish, oldest first.
+    """
+    tgen = get_topogen()
+    messages = get_bmp_messages(tgen.gears["bmp1ts"], _bmp_log_file())
+    return sorted(
+        (
+            m
+            for m in messages
+            if m.get("peer_ip") == NEVER_ESTABLISHED_PEER
+            and m.get("bmp_log_type") in ("peer up", "peer down")
+        ),
+        key=lambda m: m["seq"],
+    )
+
+
 def test_bgp_convergence():
     """
-    Wait for the r1ts--r2ts session to establish.
+    Wait for the r1ts--r2ts session to establish.  The 192.168.0.66 neighbor
+    is unreachable by design and must NOT be waited for.
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -143,6 +173,42 @@ def test_bmp_server_logging():
 
     success, _ = topotest.run_and_expect(check_for_log_file, True, count=30, wait=1)
     assert success, "The BMP server is not logging"
+
+
+def test_peerstate_timestamp_never_established():
+    """
+    When the BMP session starts, bgpd dumps the state of every configured
+    peer; a peer that has never established is reported with a Peer Down
+    message.  Per RFC 7854 section 4.2 its per-peer header timestamp must
+    be 0 ("time unavailable"), since there is no session whose reception
+    time could be reported.
+    """
+    tgen = get_topogen()
+
+    def _peer_state_seen():
+        if _never_established_peer_state_messages():
+            return True
+        return "no peer-state message for {} logged yet".format(
+            NEVER_ESTABLISHED_PEER
+        )
+
+    success, res = topotest.run_and_expect(_peer_state_seen, True, count=60, wait=1)
+    assert success, (
+        "bgpd never sent a peer-state message for the never-established "
+        "neighbor {}: {}".format(NEVER_ESTABLISHED_PEER, res)
+    )
+
+    msg = _never_established_peer_state_messages()[0]
+    timestamp = _parse_bmp_timestamp(msg["timestamp"])
+    epoch = datetime.fromtimestamp(0)
+    assert timestamp == epoch, (
+        "the peer-state message (seq {}) for the never-established neighbor "
+        "{} must carry timestamp 0 ('time unavailable', decoding to {}), "
+        "but carries {} -- bgpd converted the peer's zero monotonic uptime "
+        "to wall clock, fabricating the machine's boot time".format(
+            msg["seq"], NEVER_ESTABLISHED_PEER, epoch, timestamp
+        )
+    )
 
 
 def test_prepolicy_reannouncement_timestamp():


### PR DESCRIPTION
Two bugs in the per-peer header timestamps of the Peer Up/Peer Down BMP messages frr produces:

* a peer whose `peer->uptime` was never written (one that never established since bgpd started, or the loc-rib pseudo-peer) gets its zero monotonic uptime converted to wall clock, so the timestamp carries the machine's *boot time* (**the zero-uptime bug**);
* the live Peer Up at establishment is built before `bgp_establish()` refreshes `peer->uptime`, so it carries the previous value: 0 on a first establish, the previous session's disconnect time on a re-establish (**the stale-uptime bug**).

The full matrix of every scenario, before and after the zero-uptime fix: https://gist.github.com/tobez/2970f30ad0f113c12c0414cdb9ae36ed

This PR fixes the zero-uptime bug only: `bmp_peerstate()` now passes a NULL timeval to `bmp_per_peer_hdr()` when `peer->uptime` is 0, emitting the RFC 7854 section 4.2 zero "time unavailable" timestamp. I intend to submit a stale-uptime fix separately; it is an FSM ordering change and harder to reason about. The two are complementary (never-established peers and the loc-rib pseudo-peer need the zero path regardless of hook ordering), and the zero-uptime fix alone is strictly better than no fix: every fabricated boot time becomes an honest zero.

The second commit extends the bgp_bmp timestamps topotest with a neighbor that can never establish and checks that its peer-state message carries the zero timestamp.
