### PR TITLE
staticd: fix wrong bfd json output

### DIFF
--- a/staticd/static_bfd.c
+++ b/staticd/static_bfd.c
@@ -406,33 +406,36 @@ static void static_bfd_show_path_json(struct vty *vty, struct json_object *jo,
 
 static void static_bfd_show_json(struct vty *vty)
 {
-	struct json_object *jo, *jo_path, *jo_afi_safi;
+	struct json_object *jo, *jo_path;
+	struct json_object *jo_ipv4_unicast, *jo_ipv4_multicast;
+	struct json_object *jo_ipv6_unicast;
 	struct static_vrf *svrf;
 
 	jo = json_object_new_object();
 	jo_path = json_object_new_object();
+	jo_ipv4_unicast = json_object_new_array();
+	jo_ipv4_multicast = json_object_new_array();
+	jo_ipv6_unicast = json_object_new_array();
 
 	json_object_object_add(jo, "path-list", jo_path);
+	json_object_object_add(jo_path, "ipv4-unicast", jo_ipv4_unicast);
+	json_object_object_add(jo_path, "ipv4-multicast", jo_ipv4_multicast);
+	json_object_object_add(jo_path, "ipv6-unicast", jo_ipv6_unicast);
+
 	RB_FOREACH (svrf, svrf_name_head, &svrfs) {
 		struct route_table *rt;
 
-		jo_afi_safi = json_object_new_array();
-		json_object_object_add(jo_path, "ipv4-unicast", jo_afi_safi);
 		rt = svrf->stable[AFI_IP][SAFI_UNICAST];
 		if (rt)
-			static_bfd_show_path_json(vty, jo_afi_safi, rt);
+			static_bfd_show_path_json(vty, jo_ipv4_unicast, rt);
 
-		jo_afi_safi = json_object_new_array();
-		json_object_object_add(jo_path, "ipv4-multicast", jo_afi_safi);
 		rt = svrf->stable[AFI_IP][SAFI_MULTICAST];
 		if (rt)
-			static_bfd_show_path_json(vty, jo_afi_safi, rt);
+			static_bfd_show_path_json(vty, jo_ipv4_multicast, rt);
 
-		jo_afi_safi = json_object_new_array();
-		json_object_object_add(jo_path, "ipv6-unicast", jo_afi_safi);
 		rt = svrf->stable[AFI_IP6][SAFI_UNICAST];
 		if (rt)
-			static_bfd_show_path_json(vty, jo_afi_safi, rt);
+			static_bfd_show_path_json(vty, jo_ipv6_unicast, rt);
 	}
 
 	vty_out(vty, "%s\n", json_object_to_json_string_ext(jo, 0));


### PR DESCRIPTION
`static_bfd_show_json()` creates AFI/SAFI arrays while iterating over static VRFs, but adds every array to the same "path-list" object. So it retains only the routes from the final VRF.

Config:
```
vrf blue
 ip route 1.1.1.0/24 192.0.2.2 bfd
exit-vrf
!
vrf red
 ip route 2.2.2.0/24 193.0.2.2 bfd
exit-vrf
```

Before: ( show bfd static route json )
```

{"path-list":{"ipv4-unicast":[{"prefix":"2.2.2.0\/24","vrf":"red","installed":false,"peer":"193.0.2.2"}],"ipv4-multicast":[],"ipv6-unicast":[]}}
```

After:
```
{"path-list":{"ipv4-unicast":[{"prefix":"1.1.1.0\/24","vrf":"blue","installed":false,"peer":"192.0.2.2"},{"prefix":"2.2.2.0\/24","vrf":"red","installed":false,"peer":"193.0.2.2"}],"ipv4-multicast":[],"ipv6-unicast":[]}}
```