### PR TITLE
babeld: Ignore same-source unfeasible update for installed routes

### DIFF
--- a/babeld/route.c
+++ b/babeld/route.c
@@ -772,6 +772,11 @@ struct babel_route *update_route(const unsigned char *router_id, const unsigned 
 			if (src != route->src) {
 				uninstall_route(route);
 				lost = 1;
+			} else {
+				/* Same source, unfeasible update: per RFC 8966 §3.5.3,
+				 * ignore this update if the source has not changed.
+				 */
+				return route;
 			}
 		}
 


### PR DESCRIPTION
## Summary

`update_route()` has a comment stating *"If the source remains the same, we ignore the update"* when handling unfeasible updates to installed routes. However, the code only skipped uninstalling the route — it continued to apply the new seqno, metric, and other fields via `change_route_metric()` and `route_changed()`. If no better feasible route existed, this now-unfeasible entry could remain installed.

## RFC Violation

**RFC 8966 §3.5.3** states: if a node decides to accept an unfeasible update for an existing entry with the same router-id, the now-unfeasible entry **MUST be immediately unselected**.

The current code violates this by:
1. Not unselecting when source is unchanged (the `src != route->src` guard)
2. Calling `route_changed()` which, without a better alternative, retains the now-unfeasible route as installed

## Fix

Add an `else` clause to actually ignore the update when source is unchanged — matching what the existing comment already says. When `!feasible && route->installed && src == route->src`, return immediately without modifying the route entry.

## Impact

Without this fix, a same-source unfeasible update can leave a now-unfeasible route installed, extending the window for blackholes or routing loops. The installed route continues to be used for forwarding and readvertisement despite no longer satisfying the feasibility condition.

## References

- RFC 8966 §3.5.3 (Route Acquisition)
- RFC 8966 §3.8.2.2 (Dealing with Unfeasible Updates)
- RFCAudit Bug 15 (RFCBin): unfeasible update not unselected

Signed-off-by: zhuxu <185172534zxxx@gmail.com>