### PR TITLE
babeld: Fix non-wildcard retraction lookup ignoring RFC nexthop rule

### DIFF
--- a/babeld/route.c
+++ b/babeld/route.c
@@ -739,6 +739,24 @@ struct babel_route *update_route(const unsigned char *router_id, const unsigned 
 
 	route = find_route(prefix, plen, neigh, nexthop);
 
+	/* For retractions, RFC 8966 §4.6.9 says nexthop is not used.
+	 * If the primary lookup missed, try matching by neighbour only.
+	 */
+	if (!route && refmetric >= INFINITY) {
+		int rt_slot = find_route_slot(prefix, plen, NULL);
+
+		if (rt_slot >= 0) {
+			struct babel_route *rt = routes[rt_slot];
+
+			while (rt) {
+				if (rt->neigh == neigh) {
+					route = rt;
+					break;
+				}
+				rt = rt->next;
+			}
+		}
+		}
 	if (route && memcmp(route->src->id, router_id, 8) == 0)
 		/* Avoid scanning the source table. */
 		src = route->src;


### PR DESCRIPTION
## Summary

`update_route()` calls `find_route(prefix, plen, neigh, nexthop)` for ALL Updates — including retractions. However, **RFC 8966 §4.6.9** explicitly states that for retractions (metric = INFINITY), the router-id, next hop, and seqno **are not used**.

When a retraction arrived with a different nexthop than the originally recorded route (e.g., explicit Next Hop TLV vs. default source-address nexthop), the primary lookup would miss. The code then treated it as *"a route we never saw"* and silently ignored the retraction — the stale route persisted.

## Impact

A stale route that should have been withdrawn continues to be used for forwarding. This breaks convergence: a prefix can remain installed even after the originator has explicitly retracted it. In worst case, this creates a blackhole where traffic is forwarded toward a neighbour that no longer has the route.

## Fix

Add a secondary lookup for retractions: when the primary nexthop-based `find_route()` fails and `refmetric >= INFINITY`, search the prefix slot by neighbour only (matching what RFC requires). If found, the existing route-update logic handles uninstallation and retraction correctly.

## References

- RFC 8966 §4.6.9 (Update TLV — retraction semantics)
- RFCAudit Bug 16 (RFCBin): non-wildcard retraction lookup

Signed-off-by: zhuxu <185172534zxxx@gmail.com>