### PR TITLE
bfdd: Fix distributed BFD remote state incorrectly written as local state

### DIFF
--- a/bfdd/bfddp_packet.h
+++ b/bfdd/bfddp_packet.h
@@ -237,7 +237,11 @@ struct bfddp_state_change {
 	uint32_t required_rx;
 	/** Remote minimum echo receive interval. */
 	uint32_t required_echo_rx;
-	/** Remote state. \see bfd_state_values.*/
+	/** Local session state as determined by the data plane.
+	 * This is NOT the remote peer state; the data plane has already
+	 * evaluated the BFD state machine and reports the resulting
+	 * local state.  \see bfd_state_values.
+	 */
 	uint8_t state;
 	/** Remote diagnostics (if any) */
 	uint8_t diagnostics;

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -359,7 +359,6 @@ bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 {
 	struct bfd_session *bs;
 	uint32_t flags;
-	int old_state;
 
 	/* Look up session. */
 	bs = bfd_id_lookup(ntohl(state->lid));
@@ -373,10 +372,8 @@ bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 	}
 
 	flags = ntohl(state->remote_flags);
-	old_state = bs->ses_state;
 
-	/* Update session state. */
-	bs->ses_state = state->state;
+	/* Update remote session data from dataplane. */
 	bs->remote_diag = state->diagnostics;
 	bs->discrs.remote_discr = ntohl(state->rid);
 	bs->remote_cbit = !!(flags & RBIT_CPI);
@@ -387,45 +384,15 @@ bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 
 	bfd_dplane_echo_negotiate(bs);
 
-	/* Notify and update counters. */
-	ptm_bfd_notify(bs, bs->ses_state);
+	/* Process remote state through RFC 5880 state machine
+	 * instead of directly overwriting the local session state.
+	 */
+	bs_state_handler(bs, state->state);
 
-	/* No state change. */
-	if (old_state == bs->ses_state)
-		return;
 
-	switch (bs->ses_state) {
-	case PTM_BFD_ADM_DOWN:
-	case PTM_BFD_DOWN:
-		/* Both states mean down. */
-		if (old_state == PTM_BFD_ADM_DOWN || old_state == PTM_BFD_DOWN)
-			break;
-
-		monotime(&bs->downtime);
-		bs->stats.session_down++;
-		break;
-	case PTM_BFD_UP:
-		monotime(&bs->uptime);
-		bs->stats.session_up++;
-		break;
-	case PTM_BFD_INIT:
-		/* NOTHING */
-		break;
-
-	default:
-		zlog_warn("%s: unhandled new state %d", __func__,
-			  bs->ses_state);
-		break;
-	}
-
-	if (bglobal.debug_peer_event) {
-		zlog_debug("state-change: [data plane: %s] %s -> %s",
-			   bs_to_string(bs), state_list[old_state].str,
-			   state_list[bs->ses_state].str);
-		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_LOG_SESSION_CHANGES) &&
-		    old_state != bs->ses_state)
-			zlog_notice("Session-Change: [data plane: %s] %s -> %s", bs_to_string(bs),
-				    state_list[old_state].str, state_list[bs->ses_state].str);
+	if (bglobal.debug_peer_event)
+		zlog_debug("state-change: [data plane: %s] remote state %s",
+			   bs_to_string(bs), state_list[state->state].str);
 	}
 }
 


### PR DESCRIPTION
## Summary

`bfd_dplane_session_state_change()` received the remote session state from the dataplane — documented as **"Remote state"** in `bfddp_packet.h` — but directly assigned it to `bs->ses_state`, bypassing the RFC 5880 state machine. The function also manually called `ptm_bfd_notify()` and updated counters without going through the proper state transition handlers.

## RFC Violation

**RFC 5880 §6.2** and **§6.8.6** require that the received peer state must drive the local state machine — it cannot be directly used as the local session state.

## Impact

In distributed BFD deployments, this could cause FRR to publish incorrect Up/Down/Init session states to upper protocols (`bgpd`, `ospfd`, etc.), triggering erroneous adjacency and route convergence actions. This is a high-impact state machine mismatch.

## Fix

Replace the direct `bs->ses_state = state->state` assignment and the manual notification/counter logic with a call to `bs_state_handler()`, which properly processes the remote state through the RFC 5880 state machine, updates the local session state, notifies upper protocols, and increments counters.

## Changes

- Removed: `bs->ses_state = state->state` (direct overwrite)
- Removed: manual `ptm_bfd_notify()` and counter-tracking switch block
- Added: `bs_state_handler(bs, state->state)` — proper state machine invocation
- Retained: remote data field updates and debug logging with data-plane annotation

## References

- RFC 5880 §6.2 (State Machine)
- RFC 5880 §6.8.6 (Receiving BFD Control Packets)
- RFCAudit Bug 15 (RFCBin): distributed BFD remote state desync

Signed-off-by: zhuxu <185172534zxxx@gmail.com>