### PR TITLE
bfdd: Immediately honor faster RemoteMinRx interval per RFC 5880

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1386,6 +1386,22 @@ void bfd_recv_cb(struct event *t)
 		ntohl(cp->timers.required_min_echo);
 	bfd->remote_detect_mult = cp->detect_mult;
 
+	/* RFC 5880 Section 6.8.3: when remote RequiredMinRxInterval
+	 * decreases (remote can receive faster), the local system
+	 * MUST begin transmitting at the new shorter interval
+	 * immediately, not just during Poll Sequence.
+	 */
+	if (!bfd->demand_mode) {
+		uint64_t new_xmt_TO = bfd->timers.desired_min_tx;
+
+		if (bfd->remote_timers.required_min_rx > new_xmt_TO)
+			new_xmt_TO = bfd->remote_timers.required_min_rx;
+
+		if (new_xmt_TO < bfd->xmt_TO) {
+			bfd->xmt_TO = new_xmt_TO;
+			ptm_bfd_start_xmt_timer(bfd, false);
+		}
+	}
 	if (BFD_GETCBIT(cp->flags))
 		bfd->remote_cbit = 1;
 	else


### PR DESCRIPTION
## Summary

When the remote side reduces its Required Min RX Interval, RFC 5880 Section 6.8.3 requires the local system to begin transmitting at the new shorter interval immediately. FRR updated the stored value but only recalculated xmt_TO inside bs_final_handler(), which only runs during Poll/Final negotiation.

## RFC Violation

**RFC 5880 Section 6.8.3**: When bfd.RemoteMinRxInterval is decreased and the remote system is not in Demand mode, the local system MUST begin transmitting at the new shorter interval immediately.

## Impact

Without this fix, if the remote tightens its receive interval mid-session, the local side may continue sending at the old slower rate until the next Poll Sequence. If the old interval exceeds the new remote Detection Time, the remote may falsely timeout the session, causing spurious Down events and route flapping.

## Fix

After updating remote_timers.required_min_rx in bfd_recv_cb(), immediately recalculate xmt_TO = max(desired_min_tx, required_min_rx) per RFC 5880 Section 6.8.7 (slowest rate wins). If the new value is shorter, update xmt_TO and restart the transmission timer.

## References

- RFC 5880 Section 6.8.3 (Reception of BFD Control Packets)
- RFC 5880 Section 6.8.7 (Calculating the Transmission Interval)
- RFCAudit Bug 16 (RFCBin): remote min_rx immediate honor

Signed-off-by: zhuxu <185172534zxxx@gmail.com>