### PR TITLE
pimd: fix (S,G,rpt) prune cancelling a local receiver on the RP

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -735,12 +735,17 @@ static void on_ifjoin_prune_pending_timer(struct event *t)
 			 * On that scenario, SG entry wouldn't have
 			 * got installed until Prune pending timer
 			 * expired. So install now.
+			 *
+			 * Keep the OIF when the (*,G) on this interface still
+			 * justifies it on its own: the pruning neighbour cannot
+			 * withdraw a local receiver.
 			 */
-			pim_channel_del_oif(
-				ch->upstream->channel_oil, ifp,
-				PIM_OIF_FLAG_PROTO_STAR, __func__);
-			pim_channel_del_oif(ch->upstream->channel_oil, ifp,
-					    PIM_OIF_FLAG_PROTO_PIM, __func__);
+			if (!ch->parent || !pim_macro_chisin_pim_include(ch->parent)) {
+				pim_channel_del_oif(ch->upstream->channel_oil, ifp,
+						    PIM_OIF_FLAG_PROTO_STAR, __func__);
+				pim_channel_del_oif(ch->upstream->channel_oil, ifp,
+						    PIM_OIF_FLAG_PROTO_PIM, __func__);
+			}
 			if (!ch->upstream->channel_oil->installed)
 				pim_upstream_mroute_add(
 					ch->upstream->channel_oil,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1473,7 +1473,11 @@ int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up, struct
 			return 1;
 	}
 
-	if (chrpt)
+	/*
+	 * prunes(S,G,rpt) is subtracted from joins(*,G) only, so a neighbour
+	 * pruning the RPT cannot cancel a local receiver on this interface.
+	 */
+	if (chrpt && !(starch && pim_macro_chisin_pim_include(starch)))
 		return 0;
 	/*
 	 * joins (*,G)

--- a/tests/topotests/pim_rp_as_lhr/dut/frr.conf
+++ b/tests/topotests/pim_rp_as_lhr/dut/frr.conf
@@ -1,0 +1,43 @@
+hostname dut
+!
+! Everything here mirrors the reported sw2 configuration, including protocol
+! timers: the capture shows a 60 second join period, a 210 second join holdtime
+! and default OSPF intervals, and the test's sample offsets are only meaningful
+! against those.  IGMP is pinned to version 2 because the reported
+! "show ip igmp group" output carries V 2 on both SVIs.
+!
+service integrated-vtysh-config
+!
+! vlan100: source ixia1 (11.0.0.1) and receiver ixia3 (11.0.0.3) share this
+! segment, so dut is FHR and LHR on the same interface.  dut is the only PIM
+! router here, so it wins the DR election unopposed.
+interface dut-eth0
+ ip address 11.0.0.2/24
+ ip igmp
+ ip igmp version 2
+ ip pim
+!
+! vlan200: shared with sw3 (the RP) and receiver ixia2.  22.0.0.20 is higher
+! than 22.0.0.2, so the RP wins the DR election here and dut is non-DR.
+! IGMP is enabled here as well, matching the reported state where sw2 sees
+! ixia2's membership on vlan200 despite not being the DR.
+interface dut-eth1
+ ip address 22.0.0.2/24
+ ip igmp
+ ip igmp version 2
+ ip pim
+!
+interface lo
+ ip address 100.100.100.100/32
+ ip pim
+!
+router ospf
+ ospf router-id 100.100.100.100
+ network 11.0.0.0/24 area 0
+ network 22.0.0.0/24 area 0
+ network 100.100.100.100/32 area 0
+!
+router pim
+ no autorp discovery
+ rp 200.200.200.200
+!

--- a/tests/topotests/pim_rp_as_lhr/dut/frr.conf
+++ b/tests/topotests/pim_rp_as_lhr/dut/frr.conf
@@ -1,0 +1,50 @@
+hostname dut
+!
+! Everything PIM here mirrors the reported sw2 configuration, including the
+! default join period and holdtime.  IGMP is pinned to version 2 because the
+! reported "show ip igmp group" output carries V 2 on both SVIs.  OSPF only
+! exists to supply RPF routes, so its network types are chosen to converge
+! quickly rather than to mirror the reported network.
+!
+service integrated-vtysh-config
+!
+! vlan100: source ixia1 (11.0.0.1) and receiver ixia3 (11.0.0.3) share this
+! segment, so dut is FHR and LHR on the same interface.  dut is the only PIM
+! router here, so it wins the DR election unopposed.
+! dut is the only OSPF speaker on this segment, so it is passive: the prefix is
+! advertised straight away instead of after a DR election wait timer.
+interface dut-eth0
+ ip address 11.0.0.2/24
+ ip igmp
+ ip igmp version 2
+ ip ospf passive
+ ip pim
+!
+! vlan200: shared with sw3 (the RP) and receiver ixia2.  22.0.0.20 is higher
+! than 22.0.0.2, so the RP wins the DR election here and dut is non-DR.
+! IGMP is enabled here as well, matching the reported state where sw2 sees
+! ixia2's membership on vlan200 despite not being the DR.
+! The RP is the only OSPF neighbour here, so point-to-point skips the OSPF DR
+! election and its 40 second wait timer.  This is OSPF's own network type and has
+! no bearing on the PIM DR election, which is what the test depends on.
+interface dut-eth1
+ ip address 22.0.0.2/24
+ ip igmp
+ ip igmp version 2
+ ip ospf network point-to-point
+ ip pim
+!
+interface lo
+ ip address 100.100.100.100/32
+ ip pim
+!
+router ospf
+ ospf router-id 100.100.100.100
+ network 11.0.0.0/24 area 0
+ network 22.0.0.0/24 area 0
+ network 100.100.100.100/32 area 0
+!
+router pim
+ no autorp discovery
+ rp 200.200.200.200
+!

--- a/tests/topotests/pim_rp_as_lhr/rp/frr.conf
+++ b/tests/topotests/pim_rp_as_lhr/rp/frr.conf
@@ -1,0 +1,31 @@
+hostname rp
+!
+! Mirrors the reported sw3 configuration; see dut/frr.conf for why protocol
+! timers stay at their defaults and IGMP is pinned to version 2.
+!
+service integrated-vtysh-config
+!
+! vlan200: shared with dut and receiver ixia2.  This router is the RP, the DR
+! on this segment and therefore the LHR that has to serve ixia2.
+! dut is the only OSPF neighbour here; see dut/frr.conf for why this is
+! point-to-point.  The PIM DR election on this segment is unaffected.
+interface rp-eth0
+ ip address 22.0.0.20/24
+ ip igmp
+ ip igmp version 2
+ ip ospf network point-to-point
+ ip pim
+!
+interface lo
+ ip address 200.200.200.200/32
+ ip pim
+!
+router ospf
+ ospf router-id 200.200.200.200
+ network 22.0.0.0/24 area 0
+ network 200.200.200.200/32 area 0
+!
+router pim
+ no autorp discovery
+ rp 200.200.200.200
+!

--- a/tests/topotests/pim_rp_as_lhr/rp/frr.conf
+++ b/tests/topotests/pim_rp_as_lhr/rp/frr.conf
@@ -1,0 +1,28 @@
+hostname rp
+!
+! Mirrors the reported sw3 configuration; see dut/frr.conf for why protocol
+! timers stay at their defaults and IGMP is pinned to version 2.
+!
+service integrated-vtysh-config
+!
+! vlan200: shared with dut and receiver ixia2.  This router is the RP, the DR
+! on this segment and therefore the LHR that has to serve ixia2.
+interface rp-eth0
+ ip address 22.0.0.20/24
+ ip igmp
+ ip igmp version 2
+ ip pim
+!
+interface lo
+ ip address 200.200.200.200/32
+ ip pim
+!
+router ospf
+ ospf router-id 200.200.200.200
+ network 22.0.0.0/24 area 0
+ network 200.200.200.200/32 area 0
+!
+router pim
+ no autorp discovery
+ rp 200.200.200.200
+!

--- a/tests/topotests/pim_rp_as_lhr/test_pim_rp_as_lhr.py
+++ b/tests/topotests/pim_rp_as_lhr/test_pim_rp_as_lhr.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_pim_rp_as_lhr.py
+#
+# Copyright (c) 2025 by Vijayalaxmi Basavaraj, Nvidia Inc.
+#
+
+"""
+test_pim_rp_as_lhr.py: RP acting as the last hop router for a receiver on the
+segment it shares with the first hop router.
+
+dut is the DR on vlan100, so it is the FHR for the source and it also owns h3's
+membership on that same segment.  The RP wins the DR election on vlan200
+(22.0.0.20 > 22.0.0.2), so the RP is the LHR that has to serve h2 and dut must
+not forward there on its own.
+
+dut therefore sends Join(*,G) together with Prune(S,G,rpt) towards the RP.  The
+RP used to drop rp-eth0 from the (S,G) OIL on that prune even though its own
+receiver sits on that segment, which left JoinDesired(S,G) false: it never joined
+the SPT towards the source, sent a register-stop instead, and nothing was left to
+forward the stream.  dut ended up holding an (S,G) with no OIF:
+
+    11.0.0.1  225.1.1.1  SFT  none  vlan100  none  0  --:--:--
+"""
+
+import os
+import sys
+import time
+from functools import partial
+
+import pytest
+
+pytestmark = [pytest.mark.pimd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import step, write_test_footer, write_test_header
+from lib.pim import (
+    McastTesterHelper,
+    clear_mroute,
+    verify_igmp_groups,
+    verify_join_state_and_timer,
+    verify_mroutes,
+    verify_pim_neighbors,
+    verify_sg_traffic,
+    verify_upstream_iif,
+)
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+TOPOLOGY = """
+            vlan100                                  vlan200
+
+  h1 11.0.0.1 --+                                    +-- rp 22.0.0.20
+     (source)   |                                    |      lo 200.200.200.200
+                +-- sw100 -- dut 11.0.0.2 (eth0) -- sw200    (RP, DR, LHR)
+  h3 11.0.0.3 --+            (FHR, DR)  22.0.0.2 (eth1)  |
+     (receiver)              lo 100.100.100.100           +-- h2 22.0.0.10
+                                                                (receiver)
+"""
+
+MCAST_GROUP = "225.1.1.1"
+SOURCE = "11.0.0.1"
+SOURCE_PREFIX = "11.0.0.0/24"
+RP_ADDRESS = "200.200.200.200"
+
+# vlan100 carries the source and a receiver, vlan200 the RP and the receiver the
+# RP has to serve.  dut has one interface on each.
+DUT_VLAN100 = "dut-eth0"
+DUT_VLAN200 = "dut-eth1"
+DUT_VLAN200_ADDR = "22.0.0.2"
+RP_VLAN200 = "rp-eth0"
+RP_VLAN200_ADDR = "22.0.0.20"
+
+# Only the vlan200 segment has a PIM adjacency; dut is the sole router on vlan100.
+PIM_TOPO = {
+    "routers": {
+        "dut": {
+            "links": {
+                "rp": {
+                    "interface": DUT_VLAN200,
+                    "ipv4": "{}/24".format(DUT_VLAN200_ADDR),
+                    "pim": "enable",
+                },
+            }
+        },
+        "rp": {
+            "links": {
+                "dut": {
+                    "interface": RP_VLAN200,
+                    "ipv4": "{}/24".format(RP_VLAN200_ADDR),
+                    "pim": "enable",
+                },
+            }
+        },
+    }
+}
+
+app_helper = McastTesterHelper()
+
+
+def build_topo(tgen):
+    """Build function"""
+
+    tgen.add_router("dut")
+    tgen.add_router("rp")
+
+    # ixia1: source, in vlan100
+    tgen.add_host("h1", ip="11.0.0.1/24", defaultRoute="via 11.0.0.2")
+    # ixia3: receiver sharing vlan100 with the source
+    tgen.add_host("h3", ip="11.0.0.3/24", defaultRoute="via 11.0.0.2")
+    # ixia2: receiver in vlan200, served by the RP as DR of that segment
+    tgen.add_host("h2", ip="22.0.0.10/24", defaultRoute="via 22.0.0.20")
+
+    # vlan100 (11.0.0.0/24): source and a receiver on the same segment as dut
+    sw100 = tgen.add_switch("sw100")
+    sw100.add_link(tgen.gears["h1"])
+    sw100.add_link(tgen.gears["h3"])
+    sw100.add_link(tgen.gears["dut"])
+
+    # vlan200 (22.0.0.0/24): dut, the RP and the second receiver
+    sw200 = tgen.add_switch("sw200")
+    sw200.add_link(tgen.gears["dut"])
+    sw200.add_link(tgen.gears["rp"])
+    sw200.add_link(tgen.gears["h2"])
+
+
+def setup_module(mod):
+    """Sets up the pytest environment"""
+    logger.info("Testsuite start time: %s", time.asctime(time.localtime(time.time())))
+    logger.info("Topology:\n%s", TOPOLOGY)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # The bridges come up with IGMP snooping enabled, which would let L2 decide
+    # what this L3 test measures.  The reported failure happens with snooping
+    # off, so keep both segments flooding.
+    for swname in ("sw100", "sw200"):
+        tgen.gears[swname].cmd(
+            "ip link set dev {} type bridge mcast_snooping 0".format(swname)
+        )
+
+    app_helper.init(tgen)
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_PIM, None),
+                (TopoRouter.RD_OSPF, None),
+            ],
+        )
+
+    tgen.start_router()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    result = verify_pim_neighbors(tgen, PIM_TOPO)
+    assert result is True, "PIM neighbors failed to establish: {}".format(result)
+
+    # Both unicast directions have to be in place before PIM can be blamed for
+    # anything: the RP needs a route back to the source segment to RPF towards
+    # the source, and dut needs a route to the RP address to register at all.
+    for rname, prefix in (
+        ("rp", SOURCE_PREFIX),
+        ("dut", "{}/32".format(RP_ADDRESS)),
+    ):
+        expected = {prefix: [{"protocol": "ospf"}]}
+        test_func = partial(
+            topotest.router_json_cmp,
+            tgen.gears[rname],
+            "show ip route json",
+            expected,
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, "{} has no unicast route to {}: {}".format(
+            rname, prefix, result
+        )
+
+
+def teardown_module():
+    """Teardown the pytest environment"""
+    tgen = get_topogen()
+
+    app_helper.cleanup()
+    tgen.stop_topology()
+
+
+def start_receivers_and_traffic(tgen):
+    """Join the group from both receivers and start the source.
+
+    Both memberships matter to the scenario: h3 is what makes dut a LHR while it
+    is also the FHR, and h2 is the receiver only the RP can serve.
+    """
+    app_helper.stop_all_hosts()
+    clear_mroute(tgen)
+
+    assert app_helper.run_join("h3", MCAST_GROUP, join_intf="h3-eth0") is True
+    assert app_helper.run_join("h2", MCAST_GROUP, join_intf="h2-eth0") is True
+
+    # dut is DR on vlan100 so it owns h3's membership, and it has IGMP enabled on
+    # vlan200 as well, matching the reported state where it sees h2 without being
+    # the DR there.
+    assert verify_igmp_groups(tgen, "dut", DUT_VLAN100, MCAST_GROUP) is True
+    assert verify_igmp_groups(tgen, "rp", RP_VLAN200, MCAST_GROUP) is True
+
+    assert app_helper.run_traffic("h1", MCAST_GROUP, bind_intf="h1-eth0") is True
+
+
+def test_dr_roles_and_fhr_state(request):
+    """Verify the DR outcomes the scenario rests on, and that dut is the FHR.
+
+    dut has to win vlan100 and lose vlan200 for the RP to be the only router that
+    can serve h2.  With the source directly connected on the interface dut is
+    already a LHR for, the (S,G) also has to come up through the FHR path, inbound
+    on the source interface rather than on pimreg.
+    """
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify dut is the DR on vlan100 and the RP is the DR on vlan200")
+    for rname, ifname, dr_addr in (
+        ("dut", DUT_VLAN100, "11.0.0.2"),
+        ("dut", DUT_VLAN200, RP_VLAN200_ADDR),
+        ("rp", RP_VLAN200, RP_VLAN200_ADDR),
+    ):
+        expected = {ifname: {"pimDesignatedRouter": dr_addr}}
+        test_func = partial(
+            topotest.router_json_cmp,
+            tgen.gears[rname],
+            "show ip pim interface json",
+            expected,
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, "{}: {} DR on {} is not {}: {}".format(
+            tc_name, rname, ifname, dr_addr, result
+        )
+
+    step("Join the group from both receivers and start the source")
+    start_receivers_and_traffic(tgen)
+
+    step("Verify dut has an (S,G) inbound on the source interface")
+    result = verify_upstream_iif(tgen, "dut", DUT_VLAN100, SOURCE, MCAST_GROUP)
+    assert result is True, "{}: dut did not take the FHR role: {}".format(
+        tc_name, result
+    )
+
+    write_test_footer(tc_name)
+
+
+def test_rp_as_lhr_forwards_to_local_receiver(request):
+    """Verify the RP joins the SPT despite the (S,G,rpt) prune, so dut forwards.
+
+    The prune dut sends removes the joins(*,G) contribution on vlan200 but not the
+    RP's own receiver, so the RP still has to inherit rp-eth0 into the (S,G) OIL,
+    keep JoinDesired(S,G) true and join the SPT.  That join is what puts vlan200
+    into dut's OIL and gets the stream onto the segment.
+    """
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Join the group from both receivers and start the source")
+    start_receivers_and_traffic(tgen)
+
+    step("Verify the RP learned the source, i.e. registration got through")
+    result = verify_upstream_iif(tgen, "rp", RP_VLAN200, SOURCE, MCAST_GROUP)
+    assert result is True, "{}: RP never learned the source: {}".format(tc_name, result)
+
+    step("Verify the RP joined the SPT and keeps its join timer running")
+    result = verify_join_state_and_timer(tgen, "rp", RP_VLAN200, SOURCE, MCAST_GROUP)
+    assert result is True, (
+        "{}: the RP is not joining the SPT, so dut is never asked to forward "
+        "and the (S,G,rpt) prune has cancelled the RP's own receiver: {}".format(
+            tc_name, result
+        )
+    )
+
+    step("Verify dut forwards the (S,G) natively onto vlan200")
+    result = verify_mroutes(tgen, "dut", SOURCE, MCAST_GROUP, DUT_VLAN100, DUT_VLAN200)
+    assert result is True, "{}: dut has no OIF towards vlan200: {}".format(
+        tc_name, result
+    )
+
+    step("Verify traffic is counted through dut's (S,G)")
+    result = verify_sg_traffic(tgen, "dut", [MCAST_GROUP], SOURCE)
+    assert result is True, "{}: no traffic through dut's (S,G): {}".format(
+        tc_name, result
+    )
+
+    step("Verify h2 receives the stream on vlan200")
+    report = app_helper.collect_receiver_sources(
+        "h2", MCAST_GROUP, "h2-eth0", duration=5, source=SOURCE
+    )
+    received = report.get("sources", {}).get(SOURCE, 0)
+    assert received > 0, "{}: h2 received nothing from {}: {}".format(
+        tc_name, SOURCE, report
+    )
+    logger.info("h2 received %d packets from %s", received, SOURCE)
+
+    write_test_footer(tc_name)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/pim_rp_as_lhr/test_pim_rp_as_lhr.py
+++ b/tests/topotests/pim_rp_as_lhr/test_pim_rp_as_lhr.py
@@ -1,0 +1,845 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_pim_rp_as_lhr.py
+#
+# Copyright (c) 2025 by Vijayalaxmi Basavaraj, Nvidia Inc.
+#
+
+"""
+test_pim_rp_as_lhr.py: FHR co-located with LHR state, RP is also the LHR.
+
+Models the reported "L3 multicast dropping on SVI interfaces" setup, where the
+DUT is the first hop router for a source that shares its segment with a
+receiver, while the RP is the DR, and therefore the last hop router, on the
+segment holding the second receiver.
+
+                        vlan100                        vlan200
+    h1  11.0.0.1 (source ixia1) ----+                +---- rp  22.0.0.20
+                                    |                |         lo 200.200.200.200
+    h3  11.0.0.3 (receiver ixia3) --+-- sw100 -- dut -+-- sw200
+                                        11.0.0.2 (eth0)  |
+                                        22.0.0.2 (eth1)  +---- h2  22.0.0.10
+                                        lo 100.100.100.100      (receiver ixia2)
+
+Mapping to the reported topology: dut is sw2, rp is sw3 and holds the RP
+address, h1/h3 are ixia1/ixia3 in vlan100 behind sw1/sw4, and h2 is ixia2 in
+vlan200.  Addresses match the captured state so the output of this test can be
+diffed against it directly.
+
+Two DR outcomes drive the whole scenario and are asserted before anything else:
+
+- dut is the DR on vlan100, so it is the FHR for h1 and it accepts h3's
+  membership, which gives it a (*,G) and makes it a LHR at the same time.
+- the RP wins the DR election on vlan200 (22.0.0.20 > 22.0.0.2), so dut is
+  non-DR there and must not forward to h2 itself; the RP has to do it.
+
+That leaves the RP as the only router that can serve h2, and it can only do so
+once dut registers the source and the RP pulls the traffic back down.  The
+failure being reproduced is dut ending up with an (S,G) that has no OIF and no
+kernel entry, so nothing reaches h2:
+
+    11.0.0.1  225.1.1.1  SFT  none  vlan100  none  0  --:--:--
+
+The reported symptom is that traffic works and then stops, so a single check
+after convergence would pass and prove nothing.  The state is therefore sampled
+at three offsets from the moment traffic starts (see SAMPLE_OFFSETS), and PIM on
+the dut-rp link is captured for the whole run so the join/prune exchange can be
+read directly rather than inferred from router state.
+"""
+
+import os
+import re
+import sys
+import time
+import pytest
+import functools
+
+pytestmark = [pytest.mark.pimd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.pim import McastTesterHelper
+
+MCAST_GROUP = "225.1.1.1"
+SOURCE = "11.0.0.1"
+RP_ADDRESS = "200.200.200.200"
+
+# The vlan200 segment, where the DUT has to forward natively for h2 to be served
+DUT_VLAN200 = "dut-eth1"
+DUT_VLAN200_ADDR = "22.0.0.2"
+RP_VLAN200 = "rp-eth0"
+RP_VLAN200_ADDR = "22.0.0.20"
+ALL_PIM_ROUTERS = "224.0.0.13"
+
+# Both routers run the default join period and holdtime, matching the capture.
+JOIN_PRUNE_PERIOD = 60
+JOIN_HOLDTIME = 210
+
+# Offsets, in seconds from the start of traffic, at which forwarding state is
+# sampled.  Each one asks a different question:
+#
+#   10s   the FHR is still encapsulating to the RP, so traffic can be flowing
+#         over the register tunnel alone.  Nothing here says the native path
+#         works, but a failure here means it never came up at all.
+#   90s   past the 60 second register-stop suppression window and past one join
+#         refresh period, so the native path has to be standing on its own.
+#   215s  just past the 210 second join holdtime, which is the point where a
+#         join that was sent once and never refreshed has expired.
+SAMPLE_OFFSETS = (10, 90, 215)
+
+# Auto-RP groups that may appear in PIM/IGMP output; ignore them in comparisons
+_IGNORED_MCAST_GROUPS = {"224.0.1.39", "224.0.1.40"}
+
+app_helper = McastTesterHelper()
+
+# Set when traffic starts, so the samples below can be placed relative to it
+traffic_start = None
+
+# tcpdump handle and output path for the PIM capture on the dut-rp link
+pim_capture = None
+pim_capture_path = None
+
+
+def _filter_ignored_mcast_groups(data):
+    """Remove 224.0.1.39 and 224.0.1.40 from parsed JSON at every level."""
+    if isinstance(data, dict):
+        out = {}
+        for key, val in data.items():
+            if key in _IGNORED_MCAST_GROUPS:
+                continue
+            out[key] = _filter_ignored_mcast_groups(val)
+        return out
+    if isinstance(data, list):
+        out = []
+        for item in data:
+            filtered = _filter_ignored_mcast_groups(item)
+            # Drop dicts that represent an ignored group (e.g. {"group": "224.0.1.39"})
+            if (
+                isinstance(filtered, dict)
+                and filtered.get("group") in _IGNORED_MCAST_GROUPS
+            ):
+                continue
+            out.append(filtered)
+        return out
+    return data
+
+
+def _router_json_cmp_no_autorp(router, cmd, expected):
+    """Like router_json_cmp but filters out 224.0.1.39 and 224.0.1.40 from output."""
+    got = router.vtysh_cmd(cmd, isjson=True)
+    filtered = _filter_ignored_mcast_groups(got)
+    return topotest.json_cmp(filtered, expected, exact=False)
+
+
+def _expect_json(router, cmd, expected, assertmsg, count=30, wait=1):
+    test_func = functools.partial(_router_json_cmp_no_autorp, router, cmd, expected)
+    _, result = topotest.run_and_expect(test_func, None, count=count, wait=wait)
+    assert result is None, "{}: {}\n{}".format(router.name, assertmsg, result)
+
+
+# State worth reading side by side with the reported capture.  upstream-join-desired
+# is included because JoinDesired(S,G) is what decides whether a router keeps
+# refreshing its join, and it is the one value the capture does not contain.
+_STATE_CMDS = (
+    "show ip pim upstream",
+    "show ip pim join",
+    "show ip pim upstream-join-desired",
+    "show ip mroute",
+    "show ip igmp groups",
+)
+
+
+def _log_multicast_state(tgen, when):
+    """Dump the state that the reported capture contains, for side by side reading."""
+    for rname in ("dut", "rp"):
+        router = tgen.gears[rname]
+        for cmd in _STATE_CMDS:
+            logger.info("%s: %s (%s):\n%s", rname, cmd, when, router.vtysh_cmd(cmd))
+
+
+def build_topo(tgen):
+    """Build function"""
+
+    tgen.add_router("dut")
+    tgen.add_router("rp")
+
+    # ixia1: source, in vlan100
+    tgen.add_host("h1", ip="11.0.0.1/24", defaultRoute="via 11.0.0.2")
+    # ixia3: receiver sharing vlan100 with the source
+    tgen.add_host("h3", ip="11.0.0.3/24", defaultRoute="via 11.0.0.2")
+    # ixia2: receiver in vlan200, served by the RP as DR of that segment
+    tgen.add_host("h2", ip="22.0.0.10/24", defaultRoute="via 22.0.0.20")
+
+    # vlan100 (11.0.0.0/24): source and a receiver on the same segment as dut
+    sw100 = tgen.add_switch("sw100")
+    sw100.add_link(tgen.gears["h1"])
+    sw100.add_link(tgen.gears["h3"])
+    sw100.add_link(tgen.gears["dut"])
+
+    # vlan200 (22.0.0.0/24): dut, the RP and the second receiver
+    sw200 = tgen.add_switch("sw200")
+    sw200.add_link(tgen.gears["dut"])
+    sw200.add_link(tgen.gears["rp"])
+    sw200.add_link(tgen.gears["h2"])
+
+
+def _start_pim_capture(tgen):
+    """Capture PIM on the dut side of vlan200 for the duration of the run.
+
+    Text output rather than a pcap: what matters is the upstream-neighbor field
+    of each join/prune, and tcpdump already decodes it.  A join that names an
+    address other than the DUT is discarded by the DUT without touching any
+    state, which looks identical to the RP having gone silent.
+    """
+    global pim_capture, pim_capture_path
+
+    dut = tgen.gears["dut"]
+
+    if not dut.run("command -v tcpdump").strip():
+        logger.warning("tcpdump is not available, skipping the PIM capture")
+        return
+
+    pim_capture_path = os.path.join(tgen.logdir, "dut", "pim-vlan200.txt")
+    # -l keeps the decode flushed line by line so the file is readable even if
+    # the run is interrupted; exec replaces the shell so terminate() hits tcpdump.
+    pim_capture = dut.popen(
+        "exec tcpdump -i {} -n -vvv -l ip proto 103 > {} 2>&1".format(
+            DUT_VLAN200, pim_capture_path
+        )
+    )
+    logger.info("capturing PIM on %s into %s", DUT_VLAN200, pim_capture_path)
+
+
+def _stop_pim_capture():
+    """Stop the capture and return its decoded text, or None if there is none."""
+    global pim_capture
+
+    if pim_capture is not None:
+        pim_capture.terminate()
+        try:
+            pim_capture.wait(timeout=5)
+        except Exception:
+            pim_capture.kill()
+        pim_capture = None
+
+    if not pim_capture_path or not os.path.isfile(pim_capture_path):
+        return None
+
+    with open(pim_capture_path) as capfile:
+        return capfile.read()
+
+
+def setup_module(mod):
+    """Sets up the pytest environment"""
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # The bridges come up with IGMP snooping enabled, which would make L2
+    # forwarding decisions part of an L3 test.  The reported failure happens
+    # with snooping off, so keep both segments flooding.
+    for swname in ("sw100", "sw200"):
+        tgen.gears[swname].cmd(
+            "ip link set dev {} type bridge mcast_snooping 0".format(swname)
+        )
+
+    app_helper.init(tgen)
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_PIM, None),
+                (TopoRouter.RD_OSPF, None),
+            ],
+        )
+
+    tgen.start_router()
+
+    # The register and trace debugs record which SPTbit clause the RP takes and
+    # whether it decides join is no longer desired, neither of which shows up in
+    # any show command after the fact.  Deliberately no mroute debugging: the
+    # symptom is data packets being punted to the CPU, so it would log once per
+    # packet for the length of the run.
+    for rname in ("dut", "rp"):
+        tgen.gears[rname].vtysh_cmd(
+            "\n".join(
+                [
+                    "debug pim events",
+                    "debug pim trace",
+                    "debug pim packets joins",
+                    "debug pim packets register",
+                    "debug pim zebra",
+                ]
+            )
+        )
+
+    _start_pim_capture(tgen)
+
+
+def teardown_module():
+    """Teardown the pytest environment"""
+    tgen = get_topogen()
+
+    _stop_pim_capture()
+    app_helper.cleanup()
+
+    tgen.stop_topology()
+
+
+def test_pim_convergence():
+    """Verify PIM neighbors and the unicast path to the RP"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Verifying PIM adjacency on the vlan200 segment")
+
+    expected = {DUT_VLAN200: {RP_VLAN200_ADDR: {"interface": DUT_VLAN200}}}
+    _expect_json(
+        tgen.gears["dut"],
+        "show ip pim neighbor json",
+        expected,
+        "no PIM neighbor towards the RP",
+    )
+
+    expected = {RP_VLAN200: {DUT_VLAN200_ADDR: {"interface": RP_VLAN200}}}
+    _expect_json(
+        tgen.gears["rp"],
+        "show ip pim neighbor json",
+        expected,
+        "no PIM neighbor towards the DUT",
+    )
+
+    # Both unicast directions have to be in place before PIM can be blamed for
+    # anything: the RP needs a route back to the source to RPF towards it, and
+    # the DUT needs a route to the RP address to register at all.  OSPF gets a
+    # wider budget than PIM because default intervals are kept, so the broadcast
+    # segment sits out a 40 second wait timer for DR election before adjacency.
+    expected = {"11.0.0.0/24": [{"protocol": "ospf"}]}
+    _expect_json(
+        tgen.gears["rp"],
+        "show ip route json",
+        expected,
+        "no unicast route to the source segment, cannot RPF towards the source",
+        count=60,
+    )
+
+    expected = {"{}/32".format(RP_ADDRESS): [{"protocol": "ospf"}]}
+    _expect_json(
+        tgen.gears["dut"],
+        "show ip route json",
+        expected,
+        "no unicast route to the RP address, cannot register the source",
+        count=60,
+    )
+
+
+def test_dr_election():
+    """Verify the DR layout the whole scenario depends on"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Verifying dut is DR on vlan100 and non-DR on vlan200")
+
+    # pimDesignatedRouterLocal is only emitted when this router is the DR, so
+    # asking for it to be absent on dut-eth1 is what pins down the non-DR side.
+    expected = {
+        "dut-eth0": {
+            "pimDesignatedRouter": "11.0.0.2",
+            "pimDesignatedRouterLocal": True,
+        },
+        DUT_VLAN200: {
+            "pimDesignatedRouter": RP_VLAN200_ADDR,
+            "pimDesignatedRouterLocal": None,
+        },
+    }
+    _expect_json(
+        tgen.gears["dut"],
+        "show ip pim interface json",
+        expected,
+        "unexpected DR layout, the scenario is not being reproduced",
+    )
+
+    expected = {
+        RP_VLAN200: {
+            "pimDesignatedRouter": RP_VLAN200_ADDR,
+            "pimDesignatedRouterLocal": True,
+        }
+    }
+    _expect_json(
+        tgen.gears["rp"],
+        "show ip pim interface json",
+        expected,
+        "RP is not the DR on the vlan200 segment",
+    )
+
+
+def test_pim_rp_info():
+    """Verify the static RP is known on both routers"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname, i_am_rp in (("dut", False), ("rp", True)):
+        expected = {
+            RP_ADDRESS: [
+                {
+                    "rpAddress": RP_ADDRESS,
+                    "iAmRP": i_am_rp,
+                    "group": "224.0.0.0/4",
+                    "source": "Static",
+                    "groupType": "ASM",
+                }
+            ]
+        }
+        _expect_json(
+            tgen.gears[rname],
+            "show ip pim rp-info json",
+            expected,
+            "RP info not found",
+        )
+
+
+def test_receivers_join():
+    """Verify both receivers register their membership as in the reported state"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Joining %s from h3 (vlan100) and h2 (vlan200)", MCAST_GROUP)
+    assert app_helper.run_join("h3", MCAST_GROUP, join_intf="h3-eth0") is True
+    assert app_helper.run_join("h2", MCAST_GROUP, join_intf="h2-eth0") is True
+
+    # h3 shares the segment with the source, so this membership is what gives
+    # dut its (*,G) and makes it a LHR while it is also the FHR.
+    expected = {MCAST_GROUP: {"*": {"sourceIgmp": True, "group": MCAST_GROUP}}}
+    _expect_json(
+        tgen.gears["dut"],
+        "show ip pim upstream json",
+        expected,
+        "no (*,G) from the vlan100 membership, dut is not a LHR",
+    )
+
+    # The RP is DR on vlan200, so it is the router that owns h2's membership.
+    _expect_json(
+        tgen.gears["rp"],
+        "show ip pim upstream json",
+        expected,
+        "RP did not take h2's membership, it is not acting as LHR",
+    )
+
+
+def test_fhr_role():
+    """Verify dut takes the FHR role for the source sharing its LHR interface"""
+    global traffic_start
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Sending %s traffic from h1", MCAST_GROUP)
+    assert app_helper.run_traffic("h1", MCAST_GROUP, bind_intf="h1-eth0") is True
+    traffic_start = time.time()
+
+    # dut is a LHR for this group but the source is directly connected, so the
+    # (S,G) has to come up as first hop router on the source interface rather
+    # than as a last hop router entry inbound on pimreg.  firstHopRouter with an
+    # inbound interface of dut-eth0 is what separates those two branches of
+    # pim_mroute_msg_wholepkt(), so lastHopRouter is deliberately not asserted
+    # here: dut owns h3's membership on vlan100, so once the RP's (S,G) join
+    # arrives recv_join() legitimately takes a SRC_LHR reference as well.
+    expected = {
+        MCAST_GROUP: {
+            SOURCE: {
+                "firstHopRouter": True,
+                "inboundInterface": "dut-eth0",
+                "source": SOURCE,
+                "group": MCAST_GROUP,
+            }
+        }
+    }
+    _expect_json(
+        tgen.gears["dut"],
+        "show ip pim upstream json",
+        expected,
+        "did not take the FHR role for directly connected {}".format(SOURCE),
+        count=20,
+    )
+
+    _log_multicast_state(tgen, "after traffic start")
+
+
+def test_rp_learns_source():
+    """Verify the RP learns the source, i.e. registration got through"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    expected = {
+        MCAST_GROUP: {
+            SOURCE: {
+                "source": SOURCE,
+                "group": MCAST_GROUP,
+                "inboundInterface": RP_VLAN200,
+            }
+        }
+    }
+    _expect_json(
+        tgen.gears["rp"],
+        "show ip pim upstream json",
+        expected,
+        "never learned source {}, registration did not get through".format(SOURCE),
+        count=20,
+    )
+
+
+def _sg_oifs(mroute_json):
+    """Outgoing interfaces of the (S,G) entry as the mroute JSON reports them.
+
+    The per-source object carries scalars (iif, installed, oilSize) next to an
+    "oil" object holding one entry per outgoing interface, keyed by name.  Muted
+    OIFs are not emitted at all, so an interface that is also the IIF, as on the
+    RP here, correctly does not show up.
+    """
+    sg = mroute_json.get(MCAST_GROUP, {}).get(SOURCE, {})
+    return sorted(
+        name
+        for name, val in sg.get("oil", {}).items()
+        if isinstance(val, dict) and val.get("outboundInterface")
+    )
+
+
+def _join_state(join_json, ifname, source=SOURCE):
+    """ifjoin state of the plain (S,G) channel on one interface, or None if absent.
+
+    NOINFO here is the reported state: it holds no join, so it contributes no
+    OIF, and the transition into it tears down forwarding.
+    """
+    return (
+        join_json.get(ifname, {})
+        .get(MCAST_GROUP, {})
+        .get(source, {})
+        .get("channelJoinName")
+    )
+
+
+def _sg_rpt_state(join_json, ifname, source=SOURCE):
+    """ifjoin state of the (S,G,rpt) channel, which the JSON keys separately.
+
+    Worth reporting on its own: an (S,G,rpt) prune vetoes the interface as an
+    OIF before the (*,G) membership is considered at all, so a router holding
+    one cannot inherit that interface into the (S,G) OIL no matter how healthy
+    the group membership on it is.
+    """
+    return (
+        join_json.get(ifname, {})
+        .get(MCAST_GROUP, {})
+        .get("{},S,Grpt".format(source), {})
+        .get("channelJoinName")
+    )
+
+
+def _wait_until_offset(offset):
+    """Sleep until `offset` seconds after traffic started, and report the actual."""
+    assert traffic_start is not None, "traffic was never started"
+
+    elapsed = time.time() - traffic_start
+    if elapsed < offset:
+        time.sleep(offset - elapsed)
+        elapsed = time.time() - traffic_start
+    elif elapsed > offset + 5:
+        logger.warning(
+            "t+%ds sample is late, earlier checks took %.0fs", offset, elapsed
+        )
+
+    return elapsed
+
+
+def _snapshot(tgen, label):
+    """Record forwarding and join state on both routers at one instant.
+
+    No retrying here: a retry would blur the timing, which is the whole point
+    of sampling.
+    """
+    dut = tgen.gears["dut"]
+    rp = tgen.gears["rp"]
+
+    dut_join = dut.vtysh_cmd("show ip pim join json", isjson=True)
+    rp_join = rp.vtysh_cmd("show ip pim join json", isjson=True)
+
+    snap = {
+        "label": label,
+        "dut_oifs": _sg_oifs(dut.vtysh_cmd("show ip mroute json", isjson=True)),
+        "dut_join": _join_state(dut_join, DUT_VLAN200),
+        "dut_sg_rpt": _sg_rpt_state(dut_join, DUT_VLAN200),
+        "rp_join": _join_state(rp_join, RP_VLAN200),
+        "rp_sg_rpt": _sg_rpt_state(rp_join, RP_VLAN200),
+        "rp_upstream": rp.vtysh_cmd("show ip pim upstream json", isjson=True)
+        .get(MCAST_GROUP, {})
+        .get(SOURCE, {}),
+    }
+
+    logger.info(
+        "%s: dut (S,G) OIFs %s; dut vlan200 join %s, sgrpt %s; "
+        "rp vlan200 join %s, sgrpt %s",
+        label,
+        snap["dut_oifs"] or "none",
+        snap["dut_join"] or "no channel",
+        snap["dut_sg_rpt"] or "no channel",
+        snap["rp_join"] or "no channel",
+        snap["rp_sg_rpt"] or "no channel",
+    )
+    logger.info("%s: rp (S,G) upstream: %s", label, snap["rp_upstream"])
+    _log_multicast_state(tgen, label)
+
+    return snap
+
+
+def test_native_forwarding_is_sustained():
+    """Verify dut keeps vlan200 in the (S,G) OIL, not just right after convergence.
+
+    The reported failure is that traffic runs and then stops once the RP sends
+    its register-stop, so the same state is checked at three offsets and all
+    three have to hold.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    samples = []
+    for offset in SAMPLE_OFFSETS:
+        elapsed = _wait_until_offset(offset)
+        snap = _snapshot(tgen, "t+{}s".format(offset))
+        snap["elapsed"] = elapsed
+        snap["forwarding"] = DUT_VLAN200 in snap["dut_oifs"]
+        samples.append(snap)
+
+    good = [s["label"] for s in samples if s["forwarding"]]
+    bad = [s["label"] for s in samples if not s["forwarding"]]
+
+    if not bad:
+        logger.info("dut forwarded to vlan200 at every sample: %s", good)
+        return
+
+    if not good:
+        verdict = "the native path never came up"
+    else:
+        verdict = (
+            "the native path came up and then collapsed, which is the reported symptom"
+        )
+
+    detail = "\n".join(
+        "  t+{:.0f}s: dut OIFs {}, dut {} join {}/sgrpt {}, "
+        "rp {} join {}/sgrpt {}".format(
+            s["elapsed"],
+            s["dut_oifs"] or "none",
+            DUT_VLAN200,
+            s["dut_join"] or "-",
+            s["dut_sg_rpt"] or "-",
+            RP_VLAN200,
+            s["rp_join"] or "-",
+            s["rp_sg_rpt"] or "-",
+        )
+        for s in samples
+    )
+
+    # An (S,G,rpt) prune on the RP is expected, since the DUT keeps sending
+    # Join(*,G) + Prune(S,G,rpt).  What matters is whether the RP still wants to
+    # join despite it; JoinDesired false alongside the prune is the reported bug,
+    # where the prune cancelled the local membership as well.
+    rp_pruned = [s["label"] for s in samples if s["rp_sg_rpt"]]
+    no_jd = [
+        s["label"]
+        for s in samples
+        if not s["rp_upstream"].get("evaluateJoinDesired")
+    ]
+    if rp_pruned and no_jd:
+        cause = (
+            "The RP holds an (S,G,rpt) channel on {} at {} and JoinDesired(S,G) "
+            "is false at {}. The prune is cancelling the (*,G) membership too, so "
+            "the RP cannot inherit {} into the (S,G) OIL and never joins the SPT "
+            "towards the source, which is why the DUT is never asked to "
+            "forward.".format(RP_VLAN200, rp_pruned, no_jd, RP_VLAN200)
+        )
+    elif no_jd:
+        cause = (
+            "JoinDesired(S,G) is false on the RP at {} with no (S,G,rpt) prune to "
+            "explain it, so look at the (*,G) membership and the RP's RPF towards "
+            "the source.".format(no_jd)
+        )
+    else:
+        cause = (
+            "The RP wants to join (JoinDesired is true), so the break is further "
+            "along: check that its (S,G) join reached the DUT and which upstream "
+            "neighbor it named."
+        )
+
+    assert not bad, "dut has no OIF towards the RP at {}: {}\n{}\n{}".format(
+        bad, verdict, detail, cause
+    )
+
+
+def test_traffic_reaches_vlan200_receiver():
+    """Verify h2 actually gets the stream, not just that the OIL looks right"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Verifying h2 receives %s from %s", MCAST_GROUP, SOURCE)
+    received, report = _receiver_counts("h2", "h2-eth0")
+
+    if not received:
+        _log_multicast_state(tgen, "h2 receiving nothing")
+
+    assert received > 0, "h2 (ixia2) received nothing for {} from {}: {}".format(
+        MCAST_GROUP, SOURCE, report
+    )
+    logger.info("h2 received %d packets from %s", received, SOURCE)
+
+
+def _receiver_counts(host, intf, retries=3, duration=5):
+    """Count datagrams a host gets for the group, retrying while the tree settles."""
+    report = {}
+
+    for _ in range(retries):
+        report = app_helper.collect_receiver_sources(
+            host, MCAST_GROUP, intf, duration=duration
+        )
+        received = report.get("sources", {}).get(SOURCE, 0)
+        if received:
+            return received, report
+
+    return 0, report
+
+
+# tcpdump -vvv prints one join/prune across several lines, so records are split
+# on the timestamp that starts every packet and then searched as a block.
+_PKT_START = re.compile(r"^\d{2}:\d{2}:\d{2}\.\d+ ")
+_SENDER = re.compile(r"(\d+\.\d+\.\d+\.\d+) > (\d+\.\d+\.\d+\.\d+): PIMv2")
+_UPSTREAM = re.compile(r"upstream-neighbor: (\d+\.\d+\.\d+\.\d+)")
+_GROUP = re.compile(r"group #\d+: (\d+\.\d+\.\d+\.\d+)")
+_JOINED_SRC = re.compile(r"joined source #\d+: (\d+\.\d+\.\d+\.\d+)")
+
+
+def _parse_join_prunes(text):
+    """Pull sender, upstream-neighbor, groups and joined sources out of the decode."""
+    records = []
+    current = []
+
+    for line in text.splitlines():
+        if _PKT_START.match(line) and current:
+            records.append("\n".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        records.append("\n".join(current))
+
+    joins = []
+    for record in records:
+        if "Join / Prune" not in record:
+            continue
+
+        sender = _SENDER.search(record)
+        upstream = _UPSTREAM.search(record)
+        joins.append(
+            {
+                "sender": sender.group(1) if sender else None,
+                "upstream": upstream.group(1) if upstream else None,
+                "groups": _GROUP.findall(record),
+                "joined_sources": _JOINED_SRC.findall(record),
+            }
+        )
+
+    return joins
+
+
+def test_rp_refreshes_the_sg_join():
+    """Verify the RP keeps joining the SPT and addresses those joins to the DUT.
+
+    Reading this off the wire separates the two ways the DUT can end up without
+    a join: the RP stopped sending them, or the RP is sending them named at
+    someone other than the DUT, in which case the DUT drops them silently.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    decode = _stop_pim_capture()
+    if decode is None:
+        pytest.skip("no PIM capture was taken")
+
+    joins = _parse_join_prunes(decode)
+    logger.info("%d join/prune messages seen on %s", len(joins), DUT_VLAN200)
+
+    from_rp = [
+        jp
+        for jp in joins
+        if jp["sender"] == RP_VLAN200_ADDR
+        and MCAST_GROUP in jp["groups"]
+        and SOURCE in jp["joined_sources"]
+    ]
+    to_dut = [jp for jp in from_rp if jp["upstream"] == DUT_VLAN200_ADDR]
+    misaddressed = [jp for jp in from_rp if jp["upstream"] != DUT_VLAN200_ADDR]
+
+    logger.info(
+        "RP sent %d (S,G) joins, %d addressed to the DUT, upstream-neighbor values seen: %s",
+        len(from_rp),
+        len(to_dut),
+        sorted({jp["upstream"] for jp in from_rp}) or "none",
+    )
+
+    if misaddressed:
+        logger.warning(
+            "%d (S,G) joins name an upstream neighbor other than %s and are "
+            "therefore discarded by the DUT without creating or refreshing state",
+            len(misaddressed),
+            DUT_VLAN200_ADDR,
+        )
+
+    # The run spans well over three join periods, so a healthy RP sends several.
+    # Exactly one means it joined at flow start and then stopped, which leaves
+    # the DUT holding a channel whose holdtime quietly runs down.
+    assert len(to_dut) >= 2, (
+        "RP sent {} (S,G) join(s) addressed to {} over {} seconds with a {} second "
+        "join period; {} more were addressed elsewhere ({}). A single join means the "
+        "RP stopped refreshing the SPT join after the register-stop.".format(
+            len(to_dut),
+            DUT_VLAN200_ADDR,
+            SAMPLE_OFFSETS[-1],
+            JOIN_PRUNE_PERIOD,
+            len(misaddressed),
+            sorted({jp["upstream"] for jp in misaddressed}) or "none",
+        )
+    )
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
        vlan100                       vlan200
  source   11.0.0.1 --+           +-- rp 22.0.0.20 (RP, DR, has receiver)
                                 +- dut -+
  receiver 11.0.0.3 --+           +-- receiver 22.0.0.10

dut is the DR and FHR on vlan100.  The RP is the DR on vlan200 and has an IGMP receiver of its own on that segment, so it is the LHR that has to serve it.

dut sends Join(*,G) with Prune(S,G,rpt) towards the RP.  The RP dropped the pruned interface from the (S,G) OIL even though its own receiver was on that same segment.  inherited_olist(S,G,rpt) subtracts prunes(S,G,rpt) from joins(*,G) only, so the prune must not cancel the separate pim_include(*,G) term.  With the OIL empty, JoinDesired(S,G) stayed false, so the RP never joined the SPT towards the source and sent a register-stop instead, leaving nothing to forward the stream and the receiver on vlan200 stopped receiving traffic.

Scope the prune to joins(*,G) and keep the OIF when the (*,G) on the interface still has local membership of its own, in both the join-desired evaluation and the SGRpt prune-pending expiry that would otherwise delete the OIF again.