### PR TITLE
bgpd: Replace `strncat` with `strlcat` in peer JSON output

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -15886,31 +15886,26 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 			char comm_attri_sent_to_nbr[BGP_SEND_COMMUNITY_STR_SIZE] = { 0 };
 
 			if (CHECK_FLAG(p->af_flags[afi][safi], PEER_FLAG_SEND_COMMUNITY)) {
-				strncat(comm_attri_sent_to_nbr, "standard",
-					sizeof(comm_attri_sent_to_nbr) -
-						strlen(comm_attri_sent_to_nbr) - 1);
+				strlcat(comm_attri_sent_to_nbr, "standard",
+					sizeof(comm_attri_sent_to_nbr));
 			}
 
 			if (CHECK_FLAG(p->af_flags[afi][safi], PEER_FLAG_SEND_EXT_COMMUNITY)) {
 				if (strlen(comm_attri_sent_to_nbr) > 0) {
-					strncat(comm_attri_sent_to_nbr, "And",
-						sizeof(comm_attri_sent_to_nbr) -
-							strlen(comm_attri_sent_to_nbr) - 1);
+					strlcat(comm_attri_sent_to_nbr, "And",
+						sizeof(comm_attri_sent_to_nbr));
 				}
-				strncat(comm_attri_sent_to_nbr, "extended",
-					sizeof(comm_attri_sent_to_nbr) -
-						strlen(comm_attri_sent_to_nbr) - 1);
+				strlcat(comm_attri_sent_to_nbr, "extended",
+					sizeof(comm_attri_sent_to_nbr));
 			}
 
 			if (CHECK_FLAG(p->af_flags[afi][safi], PEER_FLAG_SEND_LARGE_COMMUNITY)) {
 				if (strlen(comm_attri_sent_to_nbr) > 0) {
-					strncat(comm_attri_sent_to_nbr, "And",
-						sizeof(comm_attri_sent_to_nbr) -
-							strlen(comm_attri_sent_to_nbr) - 1);
+					strlcat(comm_attri_sent_to_nbr, "And",
+						sizeof(comm_attri_sent_to_nbr));
 				}
-				strncat(comm_attri_sent_to_nbr, "large",
-					sizeof(comm_attri_sent_to_nbr) -
-						strlen(comm_attri_sent_to_nbr) - 1);
+				strlcat(comm_attri_sent_to_nbr, "large",
+					sizeof(comm_attri_sent_to_nbr));
 			}
 
 			json_object_string_add(json_addr, "commAttriSentToNbr",


### PR DESCRIPTION
The existing `strncat()` usage is bounded correctly and does not appear to have an overflow bug. However, checkpatch reports:

```
WARNING: strncat() is error-prone; please use strlcat() if possible#15889: FILE: bgpd/bgp_vty.c:15889:
+				strncat(comm_attri_sent_to_nbr, "standard",

WARNING: strncat() is error-prone; please use strlcat() if possible#15896: FILE: bgpd/bgp_vty.c:15896:
+					strncat(comm_attri_sent_to_nbr, "And",

WARNING: strncat() is error-prone; please use strlcat() if possible#15900: FILE: bgpd/bgp_vty.c:15900:
+				strncat(comm_attri_sent_to_nbr, "extended",

WARNING: strncat() is error-prone; please use strlcat() if possible#15907: FILE: bgpd/bgp_vty.c:15907:
+					strncat(comm_attri_sent_to_nbr, "And",

WARNING: strncat() is error-prone; please use strlcat() if possible#15911: FILE: bgpd/bgp_vty.c:15911:
+				strncat(comm_attri_sent_to_nbr, "large",
```

Update the five flagged calls to use `strlcat()`.