### PR TITLE
bgpd: fix RD route_node refcount leak in bgp_safi_node_lookup()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -322,6 +322,7 @@ struct bgp_dest *bgp_safi_node_lookup(struct bgp_table *table, safi_t safi,
 		}
 
 		table = bgp_dest_get_bgp_table_info(pdest);
+		bgp_dest_unlock_node(pdest);
 	}
 
 	dest = bgp_node_lookup(table, p);


### PR DESCRIPTION
bgp_safi_node_lookup() locks the RD node via bgp_node_lookup() but never releases it on the success path, leaking one route_node lock per call.
It is reached once per withdraw from vpn_leak_from_vrf_withdraw() and the EVPN delete paths, so under sustained MAC-mobility churn a single RD node accumulates references until the unsigned lock counter reaches MAX value.
Once reaches MAX value, anyone does lock(Max value to 0) and unlock (0 to -1) will cause the crash.

**Fix**: unlock the node


**Coredump:**
```

#0 0×00007fc1557c9eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1 0×00007fc15577afb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2 0×00007fc155b00d6c in core_handler (signo=6, siginfo=0×7ffcbfcf2cb0, context=) at ../lib/sigevent.c:261
#3
#4 0×00007fc1557c9eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#5 0×00007fc15577afb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#6 0×00007fc155765472 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#7 0×00007fc155b32529 in zlog_assert_failed (xref=xref@entry=0×565020a1ec60 <_xref.1>, extra=extra@entry=0×0) at ../lib/zlog.c:672
#8 0×0000565020897870 in route_unlock_node (node=0×56502cc6cc40) at ../lib/table.h:239
#9 bgp_dest_unlock_node (dest=, dest@entry=0×56502d03fca0) at ../bgpd/bgp_table.c:95
#10 0×0000565020864b76 in bgp_afi_node_get (table=0×56502b7c63c0, afi=afi@entry=AFI_IP, safi=safi@entry=SAFI_MPLS_VPN, p=p@entry=0×565030bdaeb0, prd=) at ../bgpd/bgp_route.c:193
#11 0×000056502083f174 in vpn_leak_from_vrf_update (to_bgp=0×56502b7be5b0, from_bgp=from_bgp@entry=0×56502d0747b0, path_vrf=path_vrf@entry=0×56502c18ed40) at ../bgpd/bgp_mplsvpn.c:1899
#12 0×00005650208007ff in install_evpn_route_entry_in_vrf (bgp_vrf=bgp_vrf@entry=0×56502d0747b0, evp=evp@entry=0×7ffcbfcf3d90, parent_pi=parent_pi@entry=0×56502c691aa0) at ../bgpd/bgp_evpn.c:3225
#13 0×0000565020805685 in install_uninstall_route_in_vrfs (bgp_def=bgp_def@entry=0×56502b7be5b0, evp=evp@entry=0×7ffcbfcf3d90, pi=pi@entry=0×56502c691aa0, vrfs=, install=install@entry=1, safi=SAFI_EVPN, afi=AFI_L2VPN) at ../bgpd/bgp_evpn.c:4265
#14 0×0000565020805976 in bgp_evpn_install_uninstall_table (bgp=bgp@entry=0×56502b7be5b0, afi=afi@entry=AFI_L2VPN, safi=safi@entry=SAFI_EVPN, p=p@entry=0×7ffcbfcf3d90, pi=pi@entry=0×56502c691aa0, import=import@entry=1, in_vrf_rt=, in_vni_rt=) at ../bgpd/bgp_evpn.c:4448
#15 0×000056502080a24b in install_uninstall_evpn_route (import=1, pi=pi@entry=0×56502c691aa0, p=p@entry=0×7ffcbfcf3d90, safi=safi@entry=SAFI_EVPN, afi=afi@entry=AFI_L2VPN, bgp=bgp@entry=0×56502b7be5b0) at ../bgpd/bgp_evpn.c:4476
#16 0×000056502087351a in bgp_update (peer=peer@entry=0×56502b7f6c70, p=p@entry=0×7ffcbfcf3d90, addpath_id=addpath_id@entry=0, attr=attr@entry=0×7ffcbfcf3e90, afi=afi@entry=AFI_L2VPN, safi=, safi@entry=SAFI_EVPN, type=, sub_type=, prd=, label=, num_labels=, soft_reconfig=, evpn=) at ../bgpd/bgp_route.c:5938
#17 0×0000565020808b0e in process_type2_route (addpath_id=0, psize=40, pfx=0×7fc14406c1c6 "", attr=0×7ffcbfcf3e90, safi=SAFI_EVPN, afi=AFI_L2VPN, peer=0×56502b7f6c70) at ../bgpd/bgp_evpn.c:4955
#18 bgp_nlri_parse_evpn (peer=peer@entry=0×56502b7f6c70, attr=attr@entry=0×7ffcbfcf3e90, packet=, withdraw=withdraw@entry=false) at ../bgpd/bgp_evpn.c:6334
#19 0×000056502084cc26 in bgp_nlri_parse (peer=peer@entry=0×56502b7f6c70, attr=attr@entry=0×7ffcbfcf3e90, packet=packet@entry=0×7ffcbfcf3e70, mp_withdraw=mp_withdraw@entry=false) at ../bgpd/bgp_packet.c:352
#20 0×000056502084cf31 in bgp_update_receive (connection=connection@entry=0×56502b7f67b0, peer=peer@entry=0×56502b7f6c70, size=size@entry=120) at ../bgpd/bgp_packet.c:2476
#21 0×0000565020852ed4 in bgp_process_packet (thread=) at ../bgpd/bgp_packet.c:3911
#22 0×00007fc155b13211 in event_call (thread=thread@entry=0×7ffcbfcf41b0) at ../lib/event.c:2034
#23 0×00007fc155abcc10 in frr_run (master=0×56502b08ab70) at ../lib/libfrr.c:1242
#24 0×00005650207e12e6 in main (argc=, argv=0×7ffcbfcf4468) at ../bgpd/bgp_main.c:561
#25 0×00007fc15576624a in ?? () from /lib/x8664-linux-gnu/libc.so.6
#26 0×00007fc155766305 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#27 0×00005650207e49a1 in _start ()
```