### PR TITLE
bgpd: Fix route-map use count for EVPN `no advertise`

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4591,6 +4591,7 @@ DEFUN (no_bgp_evpn_advertise_type5,
 	/* clear the route-map information for advertise ipv4/ipv6 unicast */
 	if (bgp_vrf->adv_cmd_rmap[afi][safi].name) {
 		XFREE(MTYPE_ROUTE_MAP_NAME, bgp_vrf->adv_cmd_rmap[afi][safi].name);
+		route_map_counter_decrement(bgp_vrf->adv_cmd_rmap[afi][safi].map);
 		bgp_vrf->adv_cmd_rmap[afi][safi].name = NULL;
 		bgp_vrf->adv_cmd_rmap[afi][safi].map = NULL;
 	}

--- a/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
+++ b/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
@@ -888,6 +888,27 @@ def test_bgp_evpn_rt5_addpath_route_map():
         result is None
     ), "All paths, including non-best, should be imported in overlay VRF"
 
+    logger.info("Remove advertise route-map and check that it is unused")
+    r1.vtysh_cmd(
+        """
+        conf
+        router bgp 64001 vrf vrf100
+         address-family l2vpn evpn
+          no advertise ipv4 unicast route-map set-pref
+    """
+    )
+
+    def _check_route_map_unused():
+        output = json.loads(r1.vtysh_cmd("show route-map-unused json"))
+        if "set-pref" not in output.get("bgpd", {}):
+            return "set-pref is still in use"
+        return None
+
+    _, result = topotest.run_and_expect(_check_route_map_unused, None, count=20, wait=1)
+    assert result is None, (
+        "set-pref should be unused after removing it from advertise " "ipv4 unicast"
+    )
+
     logger.info("Cleaning up")
     r1.vtysh_cmd(
         """


### PR DESCRIPTION
`no advertise <afi> <safi> route-map` clears `adv_cmd_rmap` without decrementing the route-map use count. Decrement it before clearing the stored pointer so `show route-map-unused` can report the detached map.