### PR TITLE
bgpd: add enforce-as4 for EVPN Route Targets

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5829,13 +5829,23 @@ static bool bgp_evpn_vrf_should_generate_export_auto_rt(struct bgp *bgp_vrf)
  * VNIs but the same across routers (in the same AS) for a particular
  * VNI.
  */
-static void bgp_evpn_vrf_form_auto_rt_eval(struct bgp *bgp_vrf, struct ecommunity_val *eval)
+static bool bgp_evpn_vrf_form_auto_rt_eval(struct bgp *bgp_vrf, struct ecommunity_val *eval)
 {
 	vni_t vni = bgp_vrf->l3vni;
 
+	if (bgp_vrf->autort_enforce_as4_export) {
+		if (vni > 0xFFFF) {
+			zlog_warn("VRF L3VNI %u exceeds 16-bit limit, cannot auto-derive RT with enforce-as4",
+				  vni);
+			return false;
+		}
+		encode_route_target_as4(bgp_vrf->as, (uint16_t)(vni & 0xFFFF), eval, true);
+		return true;
+	}
 	if (bgp_vrf->autort_rfc8365_export)
 		SET_FLAG(vni, EVPN_AUTORT_VXLAN);
 	encode_route_target_as((bgp_vrf->as & 0xFFFF), vni, eval, true);
+	return true;
 }
 
 /* Encode a fully qualified user configured route target into an
@@ -5899,15 +5909,24 @@ static void bgp_evpn_vrf_regenerate_effective_import_rts(struct bgp *bgp_vrf)
 
 	if (bgp_vrf->l3vni && bgp_evpn_vrf_should_generate_import_auto_rt(bgp_vrf)) {
 		vni_t vni = bgp_vrf->l3vni;
+		bool skip = false;
 
-		if (bgp_vrf->autort_rfc8365_import)
+		if (bgp_vrf->autort_enforce_as4_import) {
+			if (vni > 0xFFFF) {
+				zlog_warn("VRF L3VNI %u exceeds 16-bit limit, cannot auto-derive import RT with enforce-as4",
+					  vni);
+				skip = true;
+			}
+			vni = (vni & 0xFFFF);
+		} else if (bgp_vrf->autort_rfc8365_import)
 			SET_FLAG(vni, EVPN_AUTORT_VXLAN);
 
 		/* The auto import route target is a wildcard route
 		 * target: it matches any route target carrying the VNI
 		 * as local admin value, regardless of the AS.
 		 */
-		bgp_evpn_vrf_add_effective_wildcard_import_rt(bgp_vrf, htonl(vni));
+		if (!skip)
+			bgp_evpn_vrf_add_effective_wildcard_import_rt(bgp_vrf, htonl(vni));
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_import, cfgd_rt) {
@@ -5941,10 +5960,12 @@ static void bgp_evpn_vrf_regenerate_effective_export_rts(struct bgp *bgp_vrf)
 	bgp_evpn_effective_fq_rt_list_flush(&bgp_vrf->effective_fq_export_rts);
 
 	if (bgp_vrf->l3vni && bgp_evpn_vrf_should_generate_export_auto_rt(bgp_vrf)) {
-		bgp_evpn_vrf_form_auto_rt_eval(bgp_vrf, &eval);
-		fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
-		if (bgp_evpn_effective_fq_rt_slu_add(&bgp_vrf->effective_fq_export_rts, fq_rt))
-			bgp_evpn_effective_fq_rt_free(fq_rt); /* duplicate */
+		if (bgp_evpn_vrf_form_auto_rt_eval(bgp_vrf, &eval)) {
+			fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
+			if (bgp_evpn_effective_fq_rt_slu_add(&bgp_vrf->effective_fq_export_rts,
+							     fq_rt))
+				bgp_evpn_effective_fq_rt_free(fq_rt); /* duplicate */
+		}
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_export, cfgd_rt) {
@@ -6016,14 +6037,24 @@ static bool bgp_evpn_l2vni_should_generate_export_auto_rt(struct bgpevpn *vpn)
  * VNIs but the same across routers (in the same AS) for a particular
  * VNI.
  */
-static void bgp_evpn_l2vni_form_auto_rt_eval(struct bgp *bgp, struct bgpevpn *vpn,
+static bool bgp_evpn_l2vni_form_auto_rt_eval(struct bgp *bgp, struct bgpevpn *vpn,
 					     struct ecommunity_val *eval)
 {
 	vni_t vni = vpn->vni;
 
+	if (bgp->autort_enforce_as4_export) {
+		if (vni > 0xFFFF) {
+			zlog_warn("L2VNI %u exceeds 16-bit limit, cannot auto-derive RT with enforce-as4",
+				  vni);
+			return false;
+		}
+		encode_route_target_as4(bgp->as, (uint16_t)(vni & 0xFFFF), eval, true);
+		return true;
+	}
 	if (bgp->autort_rfc8365_export)
 		SET_FLAG(vni, EVPN_AUTORT_VXLAN);
 	encode_route_target_as((bgp->as & 0xFFFF), vni, eval, true);
+	return true;
 }
 
 /* Add an effective wildcard import route target to the L2VNI */
@@ -6057,11 +6088,20 @@ void bgp_evpn_l2vni_regenerate_effective_import_rts(struct bgp *bgp, struct bgpe
 
 	if (bgp_evpn_l2vni_should_generate_import_auto_rt(vpn)) {
 		vni_t vni = vpn->vni;
+		bool skip = false;
 
-		if (bgp->autort_rfc8365_import)
+		if (bgp->autort_enforce_as4_import) {
+			if (vni > 0xFFFF) {
+				zlog_warn("L2VNI %u exceeds 16-bit limit, cannot auto-derive import RT with enforce-as4",
+					  vni);
+				skip = true;
+			}
+			vni = (vni & 0xFFFF);
+		} else if (bgp->autort_rfc8365_import)
 			SET_FLAG(vni, EVPN_AUTORT_VXLAN);
 
-		bgp_evpn_l2vni_add_effective_wildcard_import_rt(vpn, htonl(vni));
+		if (!skip)
+			bgp_evpn_l2vni_add_effective_wildcard_import_rt(vpn, htonl(vni));
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_import, cfgd_rt) {
@@ -6093,10 +6133,11 @@ void bgp_evpn_l2vni_regenerate_effective_export_rts(struct bgp *bgp, struct bgpe
 	bgp_evpn_effective_fq_rt_list_flush(&vpn->effective_fq_export_rts);
 
 	if (bgp_evpn_l2vni_should_generate_export_auto_rt(vpn)) {
-		bgp_evpn_l2vni_form_auto_rt_eval(bgp, vpn, &eval);
-		fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
-		if (bgp_evpn_effective_fq_rt_slu_add(&vpn->effective_fq_export_rts, fq_rt))
-			bgp_evpn_effective_fq_rt_free(fq_rt);
+		if (bgp_evpn_l2vni_form_auto_rt_eval(bgp, vpn, &eval)) {
+			fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
+			if (bgp_evpn_effective_fq_rt_slu_add(&vpn->effective_fq_export_rts, fq_rt))
+				bgp_evpn_effective_fq_rt_free(fq_rt);
+		}
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_export, cfgd_rt) {

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5820,22 +5820,54 @@ static bool bgp_evpn_vrf_should_generate_export_auto_rt(struct bgp *bgp_vrf)
 	return !bgp_evpn_vrf_has_manual_export_rt_cfgd(bgp_vrf);
 }
 
+enum bgp_evpn_vni_type {
+	BGP_EVPN_VNI_TYPE_L2,
+	BGP_EVPN_VNI_TYPE_L3,
+};
+
 /*
- * Create the auto export RT extended community value for the VRF, of
+ * Create the auto export RT extended community value for the VRF or L2VNI, of
  * the form AS:VNI. Only the export direction uses this fully qualified
  * form; the auto import route target is a wildcard route target.
  * NOTE: We use only the lower 16 bits of the AS. This is sufficient as
  * the need is to get a RT value that will be unique across different
  * VNIs but the same across routers (in the same AS) for a particular
  * VNI.
+ *
+ * Returns: true if the RT was successfully derived and placed in eval,
+ *          false if the generation was aborted (e.g. VNI > 16-bit limit).
  */
-static void bgp_evpn_vrf_form_auto_rt_eval(struct bgp *bgp_vrf, struct ecommunity_val *eval)
+static inline bool bgp_evpn_derive_auto_rt_export_eval(struct bgp *bgp, vni_t vni,
+						       struct ecommunity_val *eval,
+						       enum bgp_evpn_vni_type vni_type)
 {
-	vni_t vni = bgp_vrf->l3vni;
-
-	if (bgp_vrf->autort_rfc8365_export)
+	if (bgp->autort_enforce_as4_export) {
+		if (vni > 0xFFFF) {
+			zlog_warn("%s %u exceeds 16-bit limit, cannot auto-derive RT with enforce-as4",
+				  vni_type == BGP_EVPN_VNI_TYPE_L2 ? "L2VNI" : "VRF L3VNI", vni);
+			return false;
+		}
+		encode_route_target_as4(bgp->as, (uint16_t)(vni & 0xFFFF), eval, true);
+		return true;
+	}
+	if (bgp->autort_rfc8365_export)
 		SET_FLAG(vni, EVPN_AUTORT_VXLAN);
-	encode_route_target_as((bgp_vrf->as & 0xFFFF), vni, eval, true);
+	encode_route_target_as((bgp->as & 0xFFFF), vni, eval, true);
+	return true;
+}
+
+static inline bool bgp_evpn_derive_auto_rt_import_local_admin(struct bgp *bgp, vni_t *vni,
+							      enum bgp_evpn_vni_type vni_type)
+{
+	if (bgp->autort_enforce_as4_import) {
+		if (*vni > 0xFFFF) {
+			zlog_warn("%s %u exceeds 16-bit limit, cannot auto-derive import RT with enforce-as4",
+				  vni_type == BGP_EVPN_VNI_TYPE_L2 ? "L2VNI" : "VRF L3VNI", *vni);
+			return false;
+		}
+	} else if (bgp->autort_rfc8365_import)
+		SET_FLAG(*vni, EVPN_AUTORT_VXLAN);
+	return true;
 }
 
 /* Encode a fully qualified user configured route target into an
@@ -5899,15 +5931,12 @@ static void bgp_evpn_vrf_regenerate_effective_import_rts(struct bgp *bgp_vrf)
 
 	if (bgp_vrf->l3vni && bgp_evpn_vrf_should_generate_import_auto_rt(bgp_vrf)) {
 		vni_t vni = bgp_vrf->l3vni;
-
-		if (bgp_vrf->autort_rfc8365_import)
-			SET_FLAG(vni, EVPN_AUTORT_VXLAN);
-
 		/* The auto import route target is a wildcard route
 		 * target: it matches any route target carrying the VNI
 		 * as local admin value, regardless of the AS.
 		 */
-		bgp_evpn_vrf_add_effective_wildcard_import_rt(bgp_vrf, htonl(vni));
+		if (bgp_evpn_derive_auto_rt_import_local_admin(bgp_vrf, &vni, BGP_EVPN_VNI_TYPE_L3))
+			bgp_evpn_vrf_add_effective_wildcard_import_rt(bgp_vrf, htonl(vni));
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_import, cfgd_rt) {
@@ -5941,10 +5970,13 @@ static void bgp_evpn_vrf_regenerate_effective_export_rts(struct bgp *bgp_vrf)
 	bgp_evpn_effective_fq_rt_list_flush(&bgp_vrf->effective_fq_export_rts);
 
 	if (bgp_vrf->l3vni && bgp_evpn_vrf_should_generate_export_auto_rt(bgp_vrf)) {
-		bgp_evpn_vrf_form_auto_rt_eval(bgp_vrf, &eval);
-		fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
-		if (bgp_evpn_effective_fq_rt_slu_add(&bgp_vrf->effective_fq_export_rts, fq_rt))
-			bgp_evpn_effective_fq_rt_free(fq_rt); /* duplicate */
+		if (bgp_evpn_derive_auto_rt_export_eval(bgp_vrf, bgp_vrf->l3vni, &eval,
+							BGP_EVPN_VNI_TYPE_L3)) {
+			fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
+			if (bgp_evpn_effective_fq_rt_slu_add(&bgp_vrf->effective_fq_export_rts,
+							     fq_rt))
+				bgp_evpn_effective_fq_rt_free(fq_rt); /* duplicate */
+		}
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_export, cfgd_rt) {
@@ -6005,27 +6037,6 @@ static bool bgp_evpn_l2vni_should_generate_export_auto_rt(struct bgpevpn *vpn)
 	return !bgp_evpn_l2vni_has_manual_export_rt_cfgd(vpn);
 }
 
-/*
- * Create the auto export RT extended community value for the L2VNI, of
- * the form AS:VNI. The AS and the RFC 8365 export setting are taken
- * from the EVPN instance. Only the export direction uses this fully
- * qualified form; the auto import route target is a wildcard route
- * target.
- * NOTE: We use only the lower 16 bits of the AS. This is sufficient as
- * the need is to get a RT value that will be unique across different
- * VNIs but the same across routers (in the same AS) for a particular
- * VNI.
- */
-static void bgp_evpn_l2vni_form_auto_rt_eval(struct bgp *bgp, struct bgpevpn *vpn,
-					     struct ecommunity_val *eval)
-{
-	vni_t vni = vpn->vni;
-
-	if (bgp->autort_rfc8365_export)
-		SET_FLAG(vni, EVPN_AUTORT_VXLAN);
-	encode_route_target_as((bgp->as & 0xFFFF), vni, eval, true);
-}
-
 /* Add an effective wildcard import route target to the L2VNI */
 static void bgp_evpn_l2vni_add_effective_wildcard_import_rt(struct bgpevpn *vpn,
 							    uint32_t local_admin_nbo)
@@ -6058,10 +6069,8 @@ void bgp_evpn_l2vni_regenerate_effective_import_rts(struct bgp *bgp, struct bgpe
 	if (bgp_evpn_l2vni_should_generate_import_auto_rt(vpn)) {
 		vni_t vni = vpn->vni;
 
-		if (bgp->autort_rfc8365_import)
-			SET_FLAG(vni, EVPN_AUTORT_VXLAN);
-
-		bgp_evpn_l2vni_add_effective_wildcard_import_rt(vpn, htonl(vni));
+		if (bgp_evpn_derive_auto_rt_import_local_admin(bgp, &vni, BGP_EVPN_VNI_TYPE_L2))
+			bgp_evpn_l2vni_add_effective_wildcard_import_rt(vpn, htonl(vni));
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_import, cfgd_rt) {
@@ -6093,10 +6102,12 @@ void bgp_evpn_l2vni_regenerate_effective_export_rts(struct bgp *bgp, struct bgpe
 	bgp_evpn_effective_fq_rt_list_flush(&vpn->effective_fq_export_rts);
 
 	if (bgp_evpn_l2vni_should_generate_export_auto_rt(vpn)) {
-		bgp_evpn_l2vni_form_auto_rt_eval(bgp, vpn, &eval);
-		fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
-		if (bgp_evpn_effective_fq_rt_slu_add(&vpn->effective_fq_export_rts, fq_rt))
-			bgp_evpn_effective_fq_rt_free(fq_rt);
+		if (bgp_evpn_derive_auto_rt_export_eval(bgp, vpn->vni, &eval,
+							BGP_EVPN_VNI_TYPE_L2)) {
+			fq_rt = bgp_evpn_effective_fq_rt_new(&eval);
+			if (bgp_evpn_effective_fq_rt_slu_add(&vpn->effective_fq_export_rts, fq_rt))
+				bgp_evpn_effective_fq_rt_free(fq_rt);
+		}
 	}
 
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_export, cfgd_rt) {

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3744,10 +3744,14 @@ static void evpn_set_autort_rfc8365(struct bgp *bgp, bool import, bool export)
 
 	if (import && !bgp->autort_rfc8365_import) {
 		bgp->autort_rfc8365_import = true;
+		/* Mutually exclusive with enforce-as4 */
+		bgp->autort_enforce_as4_import = false;
 		changed = true;
 	}
 	if (export && !bgp->autort_rfc8365_export) {
 		bgp->autort_rfc8365_export = true;
+		/* Mutually exclusive with enforce-as4 */
+		bgp->autort_enforce_as4_export = false;
 		changed = true;
 	}
 
@@ -3768,6 +3772,51 @@ static void evpn_unset_autort_rfc8365(struct bgp *bgp, bool import, bool export)
 	}
 	if (export && bgp->autort_rfc8365_export) {
 		bgp->autort_rfc8365_export = false;
+		changed = true;
+	}
+
+	if (changed)
+		bgp_evpn_handle_autort_change(bgp);
+}
+
+/*
+ * EVPN - enforce AS4 (32-bit) encoding for auto-derived RT
+ * Mutually exclusive with RFC 8365 mode.
+ */
+static void evpn_set_autort_enforce_as4(struct bgp *bgp, bool import, bool export)
+{
+	bool changed = false;
+
+	if (import && !bgp->autort_enforce_as4_import) {
+		bgp->autort_enforce_as4_import = true;
+		/* Mutually exclusive with rfc8365 */
+		bgp->autort_rfc8365_import = false;
+		changed = true;
+	}
+	if (export && !bgp->autort_enforce_as4_export) {
+		bgp->autort_enforce_as4_export = true;
+		/* Mutually exclusive with rfc8365 */
+		bgp->autort_rfc8365_export = false;
+		changed = true;
+	}
+
+	if (changed)
+		bgp_evpn_handle_autort_change(bgp);
+}
+
+/*
+ * EVPN - stop enforcing AS4 encoding for auto-derived RT
+ */
+static void evpn_unset_autort_enforce_as4(struct bgp *bgp, bool import, bool export)
+{
+	bool changed = false;
+
+	if (import && bgp->autort_enforce_as4_import) {
+		bgp->autort_enforce_as4_import = false;
+		changed = true;
+	}
+	if (export && bgp->autort_enforce_as4_export) {
+		bgp->autort_enforce_as4_export = false;
 		changed = true;
 	}
 
@@ -4071,6 +4120,37 @@ DEFPY_ATTR(no_bgp_evpn_advertise_autort_rfc8365,
 		"%% \"no autort rfc8365-compatible\" is deprecated, use \"no auto-route-target both rfc8365-compatible\"\n");
 
 	evpn_unset_autort_rfc8365(bgp, true, true);
+	return CMD_SUCCESS;
+}
+
+DEFPY (bgp_evpn_autort_enforce_as4,
+       bgp_evpn_autort_enforce_as4_cmd,
+       "autort enforce-as4",
+       "Auto-derivation of RT\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
+{
+	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
+
+	if (!bgp)
+		return CMD_WARNING;
+
+	evpn_set_autort_enforce_as4(bgp, true, true);
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_bgp_evpn_autort_enforce_as4,
+       no_bgp_evpn_autort_enforce_as4_cmd,
+       "no autort enforce-as4",
+       NO_STR
+       "Auto-derivation of RT\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
+{
+	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
+
+	if (!bgp)
+		return CMD_WARNING;
+
+	evpn_unset_autort_enforce_as4(bgp, true, true);
 	return CMD_SUCCESS;
 }
 
@@ -7312,7 +7392,7 @@ static enum bgp_evpn_autort_cfgd bgp_evpn_autort_mode_from_str(const char *mode)
 
 DEFPY (bgp_evpn_vrf_auto_rt,
        bgp_evpn_vrf_auto_rt_cmd,
-       "auto-route-target <both|import|export>$type <add-always|add-never|add-if-no-manual|rfc8365-compatible>$mode",
+       "auto-route-target <both|import|export>$type <add-always|add-never|add-if-no-manual|rfc8365-compatible|enforce-as4>$mode",
        "Automatic route-target configuration\n"
        "Import and export\n"
        "Import\n"
@@ -7320,7 +7400,8 @@ DEFPY (bgp_evpn_vrf_auto_rt,
        "Always add the automatic route-target, even when manual route-targets are configured\n"
        "Never add the automatic route-target\n"
        "Add the automatic route-target only when no manual route-target is configured (default)\n"
-       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n")
+       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
 	bool do_import, do_export;
@@ -7332,11 +7413,14 @@ DEFPY (bgp_evpn_vrf_auto_rt,
 	do_import = strmatch(type, "import") || strmatch(type, "both");
 	do_export = strmatch(type, "export") || strmatch(type, "both");
 
-	/* rfc8365-compatible is orthogonal to the add-mode: it only affects
-	 * how the automatic route-target is encoded.
+	/* rfc8365-compatible and enforce-as4 are orthogonal to the add-mode:
+	 * they only affect how the automatic route-target is encoded.
+	 * They are mutually exclusive with each other.
 	 */
 	if (strmatch(mode, "rfc8365-compatible")) {
 		evpn_set_autort_rfc8365(bgp, do_import, do_export);
+	} else if (strmatch(mode, "enforce-as4")) {
+		evpn_set_autort_enforce_as4(bgp, do_import, do_export);
 	} else {
 		enum bgp_evpn_autort_cfgd autort = bgp_evpn_autort_mode_from_str(mode);
 
@@ -7445,7 +7529,7 @@ DEFPY (no_bgp_evpn_vrf_rt,
 
 DEFPY (no_bgp_evpn_vrf_auto_rt,
        no_bgp_evpn_vrf_auto_rt_cmd,
-       "no auto-route-target [<both|import|export>$type [<add-always|add-never|add-if-no-manual|rfc8365-compatible>$mode]]",
+       "no auto-route-target [<both|import|export>$type [<add-always|add-never|add-if-no-manual|rfc8365-compatible|enforce-as4>$mode]]",
        NO_STR
        "Automatic route-target configuration\n"
        "Import and export\n"
@@ -7454,13 +7538,15 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
        "Always add the automatic route-target, even when manual route-targets are configured\n"
        "Never add the automatic route-target\n"
        "Add the automatic route-target only when no manual route-target is configured (default)\n"
-       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n")
+       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
 	struct bgp_evpn_rt_config *rt_config;
 	bool do_import, do_export;
 	bool clear_add_import, clear_add_export;
 	bool clear_rfc_import, clear_rfc_export;
+	bool clear_as4_import, clear_as4_export;
 
 	if (!bgp)
 		return CMD_WARNING_CONFIG_FAILED;
@@ -7483,6 +7569,21 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
 		}
 
 		evpn_unset_autort_rfc8365(bgp, clear_import, clear_export);
+		return CMD_SUCCESS;
+	}
+
+	if (mode && strmatch(mode, "enforce-as4")) {
+		/* Clear the (orthogonal) enforce-as4 setting, exact match. */
+		bool clear_import = do_import && bgp->autort_enforce_as4_import;
+		bool clear_export = do_export && bgp->autort_enforce_as4_export;
+
+		if (!clear_import && !clear_export) {
+			vty_out(vty,
+				"%% Enforce-as4 automatic route-target is not configured for this VRF\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		evpn_unset_autort_enforce_as4(bgp, clear_import, clear_export);
 		return CMD_SUCCESS;
 	}
 
@@ -7509,15 +7610,18 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
 		return CMD_SUCCESS;
 	}
 
-	/* Without a mode, clear both the add-mode and the rfc8365 setting for
-	 * the direction(s).
+	/* Without a mode, clear the add-mode, rfc8365 and enforce-as4
+	 * settings for the direction(s).
 	 */
 	clear_add_import = do_import && rt_config->autort_cfgd_import != BGP_EVPN_AUTORT_NOT_CFGD;
 	clear_add_export = do_export && rt_config->autort_cfgd_export != BGP_EVPN_AUTORT_NOT_CFGD;
 	clear_rfc_import = do_import && bgp->autort_rfc8365_import;
 	clear_rfc_export = do_export && bgp->autort_rfc8365_export;
+	clear_as4_import = do_import && bgp->autort_enforce_as4_import;
+	clear_as4_export = do_export && bgp->autort_enforce_as4_export;
 
-	if (!clear_add_import && !clear_add_export && !clear_rfc_import && !clear_rfc_export) {
+	if (!clear_add_import && !clear_add_export && !clear_rfc_import && !clear_rfc_export &&
+	    !clear_as4_import && !clear_as4_export) {
 		vty_out(vty, "%% Automatic route-target is not configured for this VRF\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
@@ -7527,6 +7631,7 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
 	if (clear_add_export)
 		bgp_evpn_unconfigure_export_auto_rt_for_vrf(bgp);
 	evpn_unset_autort_rfc8365(bgp, clear_rfc_import, clear_rfc_export);
+	evpn_unset_autort_enforce_as4(bgp, clear_as4_import, clear_as4_export);
 
 	return CMD_SUCCESS;
 }
@@ -8121,6 +8226,8 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi, saf
 		vty_out(vty, "  auto-route-target import %s\n", autort_mode_str);
 	if (bgp->autort_rfc8365_import)
 		vty_out(vty, "  auto-route-target import rfc8365-compatible\n");
+	if (bgp->autort_enforce_as4_import)
+		vty_out(vty, "  auto-route-target import enforce-as4\n");
 
 	/* export route-target */
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_export, cfgd_rt) {
@@ -8134,6 +8241,8 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi, saf
 		vty_out(vty, "  auto-route-target export %s\n", autort_mode_str);
 	if (bgp->autort_rfc8365_export)
 		vty_out(vty, "  auto-route-target export rfc8365-compatible\n");
+	if (bgp->autort_enforce_as4_export)
+		vty_out(vty, "  auto-route-target export enforce-as4\n");
 }
 
 void bgp_ethernetvpn_init(void)
@@ -8160,6 +8269,8 @@ void bgp_ethernetvpn_init(void)
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_all_vni_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_autort_rfc8365_cmd);
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_autort_rfc8365_cmd);
+	install_element(BGP_EVPN_NODE, &bgp_evpn_autort_enforce_as4_cmd);
+	install_element(BGP_EVPN_NODE, &no_bgp_evpn_autort_enforce_as4_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_default_gw_cmd);
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_default_gw_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_svi_ip_cmd);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3738,9 +3738,20 @@ static void bgp_evpn_set_unset_resolve_overlay_index(struct bgp *bgp, bool set)
 /*
  * EVPN - use RFC8365 to auto-derive RT
  */
-static void evpn_set_autort_rfc8365(struct bgp *bgp, bool import, bool export)
+static int evpn_set_autort_rfc8365(struct vty *vty, struct bgp *bgp, bool import, bool export)
 {
 	bool changed = false;
+
+	if (import && bgp->autort_enforce_as4_import) {
+		vty_out(vty,
+			"%% Cannot configure rfc8365-compatible and enforce-as4 simultaneously for import\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+	if (export && bgp->autort_enforce_as4_export) {
+		vty_out(vty,
+			"%% Cannot configure rfc8365-compatible and enforce-as4 simultaneously for export\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	if (import && !bgp->autort_rfc8365_import) {
 		bgp->autort_rfc8365_import = true;
@@ -3753,6 +3764,8 @@ static void evpn_set_autort_rfc8365(struct bgp *bgp, bool import, bool export)
 
 	if (changed)
 		bgp_evpn_handle_autort_change(bgp);
+
+	return CMD_SUCCESS;
 }
 
 /*
@@ -3768,6 +3781,96 @@ static void evpn_unset_autort_rfc8365(struct bgp *bgp, bool import, bool export)
 	}
 	if (export && bgp->autort_rfc8365_export) {
 		bgp->autort_rfc8365_export = false;
+		changed = true;
+	}
+
+	if (changed)
+		bgp_evpn_handle_autort_change(bgp);
+}
+
+static void evpn_autort_as4_count_oversized_vni(struct hash_bucket *bucket, void *arg)
+{
+	struct bgpevpn *vpn = bucket->data;
+	unsigned int *count = arg;
+
+	if (vpn->vni > 0xFFFF)
+		(*count)++;
+}
+
+/* Count the VNIs owned by bgp (its L3VNI, if any, plus all its L2VNIs)
+ * that exceed the 16-bit local admin available in enforce-as4 mode:
+ * auto route-target generation is skipped for these.
+ */
+static unsigned int evpn_autort_as4_oversized_vni_count(struct bgp *bgp)
+{
+	unsigned int count = 0;
+
+	if (bgp->l3vni > 0xFFFF)
+		count++;
+	if (bgp->vnihash)
+		hash_iterate(bgp->vnihash,
+			     (void (*)(struct hash_bucket *,
+				       void *))evpn_autort_as4_count_oversized_vni,
+			     &count);
+
+	return count;
+}
+
+/*
+ * EVPN - enforce AS4 (32-bit) encoding for auto-derived RT
+ * Mutually exclusive with RFC 8365 mode.
+ */
+static int evpn_set_autort_enforce_as4(struct vty *vty, struct bgp *bgp, bool import, bool export)
+{
+	bool changed = false;
+
+	if (import && bgp->autort_rfc8365_import) {
+		vty_out(vty,
+			"%% Cannot configure enforce-as4 and rfc8365-compatible simultaneously for import\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+	if (export && bgp->autort_rfc8365_export) {
+		vty_out(vty,
+			"%% Cannot configure enforce-as4 and rfc8365-compatible simultaneously for export\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (import && !bgp->autort_enforce_as4_import) {
+		bgp->autort_enforce_as4_import = true;
+		changed = true;
+	}
+	if (export && !bgp->autort_enforce_as4_export) {
+		bgp->autort_enforce_as4_export = true;
+		changed = true;
+	}
+
+	if (changed) {
+		unsigned int oversized = evpn_autort_as4_oversized_vni_count(bgp);
+
+		bgp_evpn_handle_autort_change(bgp);
+
+		if (oversized)
+			vty_out(vty,
+				"%% %u VNI(s) exceed the 16-bit limit for enforce-as4; automatic route-target generation skipped for them (see log)\n",
+				oversized);
+	}
+
+	return CMD_SUCCESS;
+}
+
+/*
+ * EVPN - stop enforcing AS4 encoding for auto-derived RT
+ */
+static void evpn_unset_autort_enforce_as4(struct bgp *bgp, bool import, bool export)
+{
+	bool changed = false;
+
+	if (import && bgp->autort_enforce_as4_import) {
+		bgp->autort_enforce_as4_import = false;
+		changed = true;
+	}
+	if (export && bgp->autort_enforce_as4_export) {
+		bgp->autort_enforce_as4_export = false;
 		changed = true;
 	}
 
@@ -4050,8 +4153,7 @@ DEFPY_ATTR(bgp_evpn_advertise_autort_rfc8365,
 	vty_out(vty,
 		"%% \"autort rfc8365-compatible\" is deprecated, use \"auto-route-target both rfc8365-compatible\"\n");
 
-	evpn_set_autort_rfc8365(bgp, true, true);
-	return CMD_SUCCESS;
+	return evpn_set_autort_rfc8365(vty, bgp, true, true);
 }
 
 DEFPY_ATTR(no_bgp_evpn_advertise_autort_rfc8365,
@@ -4071,6 +4173,36 @@ DEFPY_ATTR(no_bgp_evpn_advertise_autort_rfc8365,
 		"%% \"no autort rfc8365-compatible\" is deprecated, use \"no auto-route-target both rfc8365-compatible\"\n");
 
 	evpn_unset_autort_rfc8365(bgp, true, true);
+	return CMD_SUCCESS;
+}
+
+DEFPY (bgp_evpn_autort_enforce_as4,
+       bgp_evpn_autort_enforce_as4_cmd,
+       "autort enforce-as4",
+       "Auto-derivation of RT\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
+{
+	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
+
+	if (!bgp)
+		return CMD_WARNING;
+
+	return evpn_set_autort_enforce_as4(vty, bgp, true, true);
+}
+
+DEFPY (no_bgp_evpn_autort_enforce_as4,
+       no_bgp_evpn_autort_enforce_as4_cmd,
+       "no autort enforce-as4",
+       NO_STR
+       "Auto-derivation of RT\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
+{
+	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
+
+	if (!bgp)
+		return CMD_WARNING;
+
+	evpn_unset_autort_enforce_as4(bgp, true, true);
 	return CMD_SUCCESS;
 }
 
@@ -7312,7 +7444,7 @@ static enum bgp_evpn_autort_cfgd bgp_evpn_autort_mode_from_str(const char *mode)
 
 DEFPY (bgp_evpn_vrf_auto_rt,
        bgp_evpn_vrf_auto_rt_cmd,
-       "auto-route-target <both|import|export>$type <add-always|add-never|add-if-no-manual|rfc8365-compatible>$mode",
+       "auto-route-target <both|import|export>$type <add-always|add-never|add-if-no-manual|rfc8365-compatible|enforce-as4>$mode",
        "Automatic route-target configuration\n"
        "Import and export\n"
        "Import\n"
@@ -7320,7 +7452,8 @@ DEFPY (bgp_evpn_vrf_auto_rt,
        "Always add the automatic route-target, even when manual route-targets are configured\n"
        "Never add the automatic route-target\n"
        "Add the automatic route-target only when no manual route-target is configured (default)\n"
-       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n")
+       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
 	bool do_import, do_export;
@@ -7332,11 +7465,14 @@ DEFPY (bgp_evpn_vrf_auto_rt,
 	do_import = strmatch(type, "import") || strmatch(type, "both");
 	do_export = strmatch(type, "export") || strmatch(type, "both");
 
-	/* rfc8365-compatible is orthogonal to the add-mode: it only affects
-	 * how the automatic route-target is encoded.
+	/* rfc8365-compatible and enforce-as4 are orthogonal to the add-mode:
+	 * they only affect how the automatic route-target is encoded.
+	 * They are mutually exclusive with each other.
 	 */
 	if (strmatch(mode, "rfc8365-compatible")) {
-		evpn_set_autort_rfc8365(bgp, do_import, do_export);
+		return evpn_set_autort_rfc8365(vty, bgp, do_import, do_export);
+	} else if (strmatch(mode, "enforce-as4")) {
+		return evpn_set_autort_enforce_as4(vty, bgp, do_import, do_export);
 	} else {
 		enum bgp_evpn_autort_cfgd autort = bgp_evpn_autort_mode_from_str(mode);
 
@@ -7445,7 +7581,7 @@ DEFPY (no_bgp_evpn_vrf_rt,
 
 DEFPY (no_bgp_evpn_vrf_auto_rt,
        no_bgp_evpn_vrf_auto_rt_cmd,
-       "no auto-route-target [<both|import|export>$type [<add-always|add-never|add-if-no-manual|rfc8365-compatible>$mode]]",
+       "no auto-route-target [<both|import|export>$type [<add-always|add-never|add-if-no-manual|rfc8365-compatible|enforce-as4>$mode]]",
        NO_STR
        "Automatic route-target configuration\n"
        "Import and export\n"
@@ -7454,13 +7590,15 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
        "Always add the automatic route-target, even when manual route-targets are configured\n"
        "Never add the automatic route-target\n"
        "Add the automatic route-target only when no manual route-target is configured (default)\n"
-       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n")
+       "Encode the automatic route-target as RFC 8365 compatible (set the VXLAN encapsulation bits in the local admin field)\n"
+       "Force AS4 (32-bit AS) encoding for auto-derived route targets\n")
 {
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
 	struct bgp_evpn_rt_config *rt_config;
 	bool do_import, do_export;
 	bool clear_add_import, clear_add_export;
 	bool clear_rfc_import, clear_rfc_export;
+	bool clear_as4_import, clear_as4_export;
 
 	if (!bgp)
 		return CMD_WARNING_CONFIG_FAILED;
@@ -7483,6 +7621,21 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
 		}
 
 		evpn_unset_autort_rfc8365(bgp, clear_import, clear_export);
+		return CMD_SUCCESS;
+	}
+
+	if (mode && strmatch(mode, "enforce-as4")) {
+		/* Clear the (orthogonal) enforce-as4 setting, exact match. */
+		bool clear_import = do_import && bgp->autort_enforce_as4_import;
+		bool clear_export = do_export && bgp->autort_enforce_as4_export;
+
+		if (!clear_import && !clear_export) {
+			vty_out(vty,
+				"%% Enforce-as4 automatic route-target is not configured for this VRF\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		evpn_unset_autort_enforce_as4(bgp, clear_import, clear_export);
 		return CMD_SUCCESS;
 	}
 
@@ -7509,15 +7662,18 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
 		return CMD_SUCCESS;
 	}
 
-	/* Without a mode, clear both the add-mode and the rfc8365 setting for
-	 * the direction(s).
+	/* Without a mode, clear the add-mode, rfc8365 and enforce-as4
+	 * settings for the direction(s).
 	 */
 	clear_add_import = do_import && rt_config->autort_cfgd_import != BGP_EVPN_AUTORT_NOT_CFGD;
 	clear_add_export = do_export && rt_config->autort_cfgd_export != BGP_EVPN_AUTORT_NOT_CFGD;
 	clear_rfc_import = do_import && bgp->autort_rfc8365_import;
 	clear_rfc_export = do_export && bgp->autort_rfc8365_export;
+	clear_as4_import = do_import && bgp->autort_enforce_as4_import;
+	clear_as4_export = do_export && bgp->autort_enforce_as4_export;
 
-	if (!clear_add_import && !clear_add_export && !clear_rfc_import && !clear_rfc_export) {
+	if (!clear_add_import && !clear_add_export && !clear_rfc_import && !clear_rfc_export &&
+	    !clear_as4_import && !clear_as4_export) {
 		vty_out(vty, "%% Automatic route-target is not configured for this VRF\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
@@ -7527,6 +7683,7 @@ DEFPY (no_bgp_evpn_vrf_auto_rt,
 	if (clear_add_export)
 		bgp_evpn_unconfigure_export_auto_rt_for_vrf(bgp);
 	evpn_unset_autort_rfc8365(bgp, clear_rfc_import, clear_rfc_export);
+	evpn_unset_autort_enforce_as4(bgp, clear_as4_import, clear_as4_export);
 
 	return CMD_SUCCESS;
 }
@@ -8121,6 +8278,8 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi, saf
 		vty_out(vty, "  auto-route-target import %s\n", autort_mode_str);
 	if (bgp->autort_rfc8365_import)
 		vty_out(vty, "  auto-route-target import rfc8365-compatible\n");
+	if (bgp->autort_enforce_as4_import)
+		vty_out(vty, "  auto-route-target import enforce-as4\n");
 
 	/* export route-target */
 	frr_each (bgp_evpn_cfgd_rt_slu, &rt_config->cfgd_export, cfgd_rt) {
@@ -8134,6 +8293,8 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi, saf
 		vty_out(vty, "  auto-route-target export %s\n", autort_mode_str);
 	if (bgp->autort_rfc8365_export)
 		vty_out(vty, "  auto-route-target export rfc8365-compatible\n");
+	if (bgp->autort_enforce_as4_export)
+		vty_out(vty, "  auto-route-target export enforce-as4\n");
 }
 
 void bgp_ethernetvpn_init(void)
@@ -8160,6 +8321,8 @@ void bgp_ethernetvpn_init(void)
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_all_vni_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_autort_rfc8365_cmd);
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_autort_rfc8365_cmd);
+	install_element(BGP_EVPN_NODE, &bgp_evpn_autort_enforce_as4_cmd);
+	install_element(BGP_EVPN_NODE, &no_bgp_evpn_autort_enforce_as4_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_default_gw_cmd);
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_default_gw_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_svi_ip_cmd);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1009,6 +1009,10 @@ struct bgp {
 	bool autort_rfc8365_import;
 	bool autort_rfc8365_export;
 
+	/* EVPN - force AS4 (32-bit) encoding for auto-derived RT */
+	bool autort_enforce_as4_import;
+	bool autort_enforce_as4_export;
+
 	/*
 	 * Flooding mechanism for BUM packets for VxLAN-EVPN.
 	 */
@@ -3470,5 +3474,4 @@ struct srv6_locator *bgp_srv6_locator_lookup(struct bgp *bgp_vrf, struct bgp *bg
 	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_ADV) &&                                       \
 	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_RCV) &&                                       \
 	 IN6_IS_ADDR_LINKLOCAL(&_peer->nexthop.v6_local))
-
 #endif /* _QUAGGA_BGPD_H */

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4219,7 +4219,7 @@ notably Route Type 2 and Route Type 3 (IMET).
        exit-address-family
       exit
 
-.. clicmd:: auto-route-target <import|export|both> <add-always|add-never|add-if-no-manual|rfc8365-compatible>
+.. clicmd:: auto-route-target <import|export|both> <add-always|add-never|add-if-no-manual|rfc8365-compatible|enforce-as4>
 
    Control the automatic route-target of the given direction(s) of the
    IP-VRF or EVI / L2VNI (see :ref:`evpn-automatic-route-targets` for
@@ -4244,6 +4244,15 @@ notably Route Type 2 and Route Type 3 (IMET).
    local admin field, as described in :rfc:`8365`. It is off by default,
    configured at the instance level (the tenant VRF for the L3VNI, the
    EVPN underlay VRF for all its L2VNIs) and cannot be set per-L2VNI.
+
+   ``enforce-as4`` is similarly an orthogonal per-direction setting: it
+   forces the automatic route-target to be encoded in the Type 0x02 format
+   (AS4), regardless of whether the AS is a 2-byte or 4-byte AS. The VNI
+   is truncated to its lower 16 bits. A warning is generated and auto-RT
+   creation is skipped for VNIs larger than 65535 when this is enabled,
+   as the truncation would lead to route target collisions. It is off by default.
+   It cannot be configured simultaneously with ``rfc8365-compatible`` for
+   the same direction.
 
    ``both`` applies the setting to import and export.
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4219,7 +4219,7 @@ notably Route Type 2 and Route Type 3 (IMET).
        exit-address-family
       exit
 
-.. clicmd:: auto-route-target <import|export|both> <add-always|add-never|add-if-no-manual|rfc8365-compatible>
+.. clicmd:: auto-route-target <import|export|both> <add-always|add-never|add-if-no-manual|rfc8365-compatible|enforce-as4>
 
    Control the automatic route-target of the given direction(s) of the
    IP-VRF or EVI / L2VNI (see :ref:`evpn-automatic-route-targets` for
@@ -4244,6 +4244,18 @@ notably Route Type 2 and Route Type 3 (IMET).
    local admin field, as described in :rfc:`8365`. It is off by default,
    configured at the instance level (the tenant VRF for the L3VNI, the
    EVPN underlay VRF for all its L2VNIs) and cannot be set per-L2VNI.
+
+   ``enforce-as4`` is similarly an orthogonal per-direction setting: it
+   forces the automatic route-target to be encoded in the Type 0x02 format
+   (AS4), regardless of whether the AS is a 2-byte or 4-byte AS. The VNI
+   is truncated to its lower 16 bits, so auto-RT creation is skipped for
+   VNIs larger than 65535 when this is enabled, as the truncation would
+   lead to route target collisions; a warning is logged for each such VNI,
+   and enabling the setting while any of the instance's existing VNIs
+   already exceed 65535 also warns immediately on the vty. It is off by
+   default.
+   It cannot be configured simultaneously with ``rfc8365-compatible`` for
+   the same direction.
 
    ``both`` applies the setting to import and export.
 

--- a/doc/user/evpn.rst
+++ b/doc/user/evpn.rst
@@ -220,6 +220,14 @@ type is encoded in the upper byte of the local administrator field, in
 front of the VNI. On the import side the wildcard then matches this RFC
 8365 encoded local administrator value instead.
 
+To force a 32-bit AS encoding of the automatic Route Target, the
+``auto-route-target <import|export|both> enforce-as4`` command can be used.
+This uses a Type 0x02 (AS4) route target, placing the full AS number in the
+Global Administrator field and truncating the VNI to the lower 16 bits in the
+Local Administrator field. VNIs larger than 65535 will skip auto-RT generation
+to prevent collisions. It cannot be configured simultaneously with
+``rfc8365-compatible`` for the same direction.
+
 
 .. _evpn-linux-vxlan-dataplane:
 

--- a/doc/user/evpn.rst
+++ b/doc/user/evpn.rst
@@ -220,6 +220,13 @@ type is encoded in the upper byte of the local administrator field, in
 front of the VNI. On the import side the wildcard then matches this RFC
 8365 encoded local administrator value instead.
 
+To force a 32-bit AS encoding of the automatic Route Target, the
+``auto-route-target <import|export|both> enforce-as4`` command can be used.
+This uses a Type 0x02 (AS4) route target, placing the full AS number in the
+Global Administrator field and truncating the VNI to the lower 16 bits in the
+Local Administrator field. VNIs larger than 65535 will skip auto-RT generation
+to prevent collisions.
+
 
 .. _evpn-linux-vxlan-dataplane:
 

--- a/tests/topotests/bgp_evpn_rt_wildcard_matching/test_bgp_evpn_rt_wildcard_matching.py
+++ b/tests/topotests/bgp_evpn_rt_wildcard_matching/test_bgp_evpn_rt_wildcard_matching.py
@@ -54,6 +54,7 @@ pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 # 4200000001 & 0xFFFF - the AS2-truncated form of r2's AS used in its
 # auto route targets.
+R2_AS = 4200000001
 R2_AS_TRUNCATED = 59905
 
 R1_TYPE5_PREFIX = "[5]:[0]:[32]:[10.0.101.1]"
@@ -230,8 +231,8 @@ def _check_vni_route_absent(router, vni, prefix):
     return None
 
 
-def _expect(test_func, msg):
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+def _expect(test_func, msg, count=30, wait=1):
+    _, result = topotest.run_and_expect(test_func, None, count=count, wait=wait)
     assert result is None, msg
 
 
@@ -336,12 +337,14 @@ def test_as4_encoded_rt():
 
     # Replace r2's auto export RT with a manual, AS4-encoded RT that
     # keeps the VNI as the local admin.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 4200000001:101
-""")
+"""
+    )
 
     test_func = partial(
         _check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:4200000001:101"
@@ -356,13 +359,15 @@ router bgp 4200000001 vrf vrf-101
     )
 
     # Move the local admin away from the VNI; r1 must stop importing.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 4200000001:999
   no route-target export 4200000001:101
-""")
+"""
+    )
 
     test_func = partial(
         _check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:4200000001:999"
@@ -374,12 +379,14 @@ router bgp 4200000001 vrf vrf-101
 
     # A fully-qualified import RT must match the AS4-encoded RT on the
     # exact encoded value.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import 4200000001:999
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -388,13 +395,15 @@ router bgp 65001 vrf vrf-101
 
     # A wildcard import RT must match the AS4-encoded RT on its 2-byte
     # local admin.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import 4200000001:999
   route-target import *:999
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -402,18 +411,22 @@ router bgp 65001 vrf vrf-101
     )
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:999
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 4200000001:999
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -435,12 +448,14 @@ def test_ip_encoded_rt():
     r1 = tgen.gears["r1"]
     r2 = tgen.gears["r2"]
 
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 192.0.2.2:101
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:192.0.2.2:101")
     _expect(test_func, "r1: r2's type-5 route does not carry the IP-encoded RT")
@@ -455,12 +470,14 @@ router bgp 4200000001 vrf vrf-101
     # Disable the auto import RT; without any import RT the route must
     # no longer be imported (even though the local admin equals the
     # VNI).
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   auto-route-target import add-never
-""")
+"""
+    )
 
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(
@@ -469,12 +486,14 @@ router bgp 65001 vrf vrf-101
 
     # A fully-qualified import RT must match the IP-encoded RT
     # exactly.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import 192.0.2.2:101
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -484,13 +503,15 @@ router bgp 65001 vrf vrf-101
     # An import RT with the same local admin but a different IP must
     # NOT match (fully-qualified matching is on the exact encoded
     # bytes and the wildcard matching is disabled here).
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import 192.0.2.2:101
   route-target import 192.0.2.9:101
-""")
+"""
+    )
 
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(
@@ -499,19 +520,23 @@ router bgp 65001 vrf vrf-101
     )
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import 192.0.2.9:101
   no auto-route-target import add-never
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 192.0.2.2:101
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -534,12 +559,14 @@ def test_wildcard_keying_as2_full_local_admin():
     r1 = tgen.gears["r1"]
     r2 = tgen.gears["r2"]
 
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 65002:65637
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:65002:65637")
     _expect(test_func, "r1: r2's type-5 route does not carry RT 65002:65637")
@@ -553,12 +580,14 @@ router bgp 4200000001 vrf vrf-101
     )
 
     # A wildcard on the full 4-byte local admin must match.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import *:65637
-""")
+"""
+    )
 
     expected = {"*:65637": {"rt": "*:65637"}}
     test_func = partial(
@@ -575,23 +604,27 @@ router bgp 65001 vrf vrf-101
     )
 
     # Removing the wildcard again must uninstall the route.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:65637
-""")
+"""
+    )
 
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(test_func, "r1: type-5 route still imported after removing '*:65637'")
 
     # Cleanup: back to auto RTs.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 65002:65637
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -617,12 +650,14 @@ def test_multiple_rts_any_match():
     # share the AS and differ only in the local admin; both must
     # survive (regression: the effective-RT dedup once compared AS4
     # local admins at the wrong offset and collapsed them).
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 65002:999 192.0.2.2:888 4200000001:777 4200000001:778
-""")
+"""
+    )
 
     for rt in [
         "RT:65002:999",
@@ -634,54 +669,64 @@ router bgp 4200000001 vrf vrf-101
         _expect(test_func, "r1: r2's type-5 route does not carry {}".format(rt))
 
     # Matching the AS4-encoded RT alone must be enough ...
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import *:777
-""")
+"""
+    )
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
         "r1: type-5 route not imported although '*:777' matches one of its RTs",
     )
 
     # ... as must matching the IP-encoded RT alone ...
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:777
   route-target import *:888
-""")
+"""
+    )
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
         "r1: type-5 route not imported although '*:888' matches one of its RTs",
     )
 
     # ... while a wildcard matching none of the RTs must not import.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:888
   route-target import *:666
-""")
+"""
+    )
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(test_func, "r1: type-5 route imported although none of its RTs match")
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:666
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 65002:999 192.0.2.2:888 4200000001:777 4200000001:778
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -714,13 +759,15 @@ def test_l2vni_rt_encoding():
 
     # AS4-encoded export RT with the VNI as local admin: r1's auto
     # import RT must still match (2-byte local admin extraction).
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001
  address-family l2vpn evpn
   vni 201
    route-target export 4200000001:201
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_IMET_PREFIX, "RT:4200000001:201")
     _expect(test_func, "r1: r2's IMET route does not carry the AS4-encoded RT")
@@ -732,14 +779,16 @@ router bgp 4200000001
 
     # AS2-encoded RT with a 4-byte local admin whose low 16 bits equal
     # the VNI: must NOT match r1's auto import RT.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001
  address-family l2vpn evpn
   vni 201
    no route-target export 4200000001:201
    route-target export 65002:65737
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_IMET_PREFIX, "RT:65002:65737")
     _expect(test_func, "r1: r2's IMET route does not carry RT 65002:65737")
@@ -752,14 +801,16 @@ router bgp 4200000001
 
     # A wildcard on the full 4-byte local admin must match, and must
     # show up in the VNI import RT table.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001
  address-family l2vpn evpn
   vni 201
    auto-route-target import add-always
    route-target import *:65737
-""")
+"""
+    )
 
     expected = {"*:65737": {"rt": "*:65737", "vnis": [201]}}
     test_func = partial(
@@ -776,21 +827,25 @@ router bgp 65001
     )
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001
  address-family l2vpn evpn
   vni 201
    no route-target import *:65737
    no auto-route-target import add-always
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001
  address-family l2vpn evpn
   vni 201
    no route-target export 65002:65737
-""")
+"""
+    )
 
     _expect(
         _check_vni_route_present(r1, 201, R2_IMET_PREFIX),
@@ -825,12 +880,14 @@ def test_rfc8365_compatible_encoding():
 
     # Enable RFC 8365 compatible encoding on r2's export direction; the
     # VXLAN bit (0x10000000) is OR'd into the local admin.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   auto-route-target export rfc8365-compatible
-""")
+"""
+    )
 
     rfc8365_local_admin = 0x10000000 + 101
     _expect(
@@ -851,12 +908,14 @@ router bgp 4200000001 vrf vrf-101
     )
 
     # Matching the encoding on r1's import direction restores the import.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   auto-route-target import rfc8365-compatible
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -870,22 +929,237 @@ router bgp 65001 vrf vrf-101
     ), "r2: 'auto-route-target export rfc8365-compatible' not in running config"
 
     # Cleanup: back to the plain auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no auto-route-target import rfc8365-compatible
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no auto-route-target export rfc8365-compatible
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
         "r1: type-5 route not re-imported after clearing the RFC 8365 encoding",
+    )
+
+
+def test_enforce_as4_encoding():
+    """
+    "auto-route-target export enforce-as4" forces the AS4 encoding for auto
+    route targets, placing the 32-bit AS in the global admin field and truncating
+    the VNI to its lower 16 bits in the local admin field.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Baseline: r2's L3VNI and L2VNI auto export RTs are <as-truncated>:<vni> on the wire.
+    _expect(
+        partial(
+            _check_global_route_rt,
+            r1,
+            R2_TYPE5_PREFIX,
+            "RT:{}:101".format(R2_AS_TRUNCATED),
+        ),
+        "r1: r2's type-5 route does not carry the plain auto export RT",
+    )
+    _expect(
+        partial(
+            _check_global_route_rt,
+            r1,
+            R2_IMET_PREFIX,
+            "RT:{}:201".format(R2_AS_TRUNCATED),
+        ),
+        "r1: r2's type-3 route does not carry the plain auto export RT",
+    )
+
+    # Enable enforce-as4 on r2's export direction for both L3VNI and L2VNI.
+    r2.vtysh_cmd(
+        """
+configure terminal
+router bgp 4200000001
+ address-family l2vpn evpn
+  auto-route-target export enforce-as4
+  exit
+ exit
+router bgp 4200000001 vrf vrf-101
+ address-family l2vpn evpn
+  auto-route-target export enforce-as4
+"""
+    )
+
+    _expect(
+        partial(
+            _check_global_route_rt,
+            r1,
+            R2_TYPE5_PREFIX,
+            "RT:{}:101".format(R2_AS),
+        ),
+        "r1: r2's type-5 route does not carry the enforce-as4 encoded auto export RT",
+    )
+    _expect(
+        partial(
+            _check_global_route_rt,
+            r1,
+            R2_IMET_PREFIX,
+            "RT:{}:201".format(R2_AS),
+        ),
+        "r1: r2's type-3 route does not carry the enforce-as4 encoded auto export RT",
+    )
+
+    # r1's plain auto import RT (wildcard on local admin) successfully matches
+    # the AS4 encoded RT's 16-bit local admin.
+    _expect(
+        _check_vrf_route_present(r1, "10.0.101.2/32"),
+        "r1: type-5 route not imported despite matching local admin in enforce-as4 encoded RT",
+    )
+    _expect(
+        _check_vni_route_present(r1, 201, R2_IMET_PREFIX),
+        "r1: type-3 route not imported despite matching local admin in enforce-as4 encoded RT",
+    )
+
+    # Configuring enforce-as4 on r1's import direction should maintain the import.
+    r1.vtysh_cmd(
+        """
+configure terminal
+router bgp 65001
+ address-family l2vpn evpn
+  auto-route-target import enforce-as4
+  exit
+ exit
+router bgp 65001 vrf vrf-101
+ address-family l2vpn evpn
+  auto-route-target import enforce-as4
+"""
+    )
+
+    _expect(
+        _check_vrf_route_present(r1, "10.0.101.2/32"),
+        "r1: type-5 route not imported with matching enforce-as4 import encoding",
+    )
+    _expect(
+        _check_vni_route_present(r1, 201, R2_IMET_PREFIX),
+        "r1: type-3 route not imported with matching enforce-as4 import encoding",
+    )
+
+    # The per-direction setting round-trips in the running config.
+    running_r2 = r2.vtysh_cmd("show running-config", isjson=False)
+    assert (
+        "auto-route-target export enforce-as4" in running_r2
+    ), "r2: 'auto-route-target export enforce-as4' not in running config"
+
+    # Cleanup: back to the plain auto RTs on both sides.
+    r1.vtysh_cmd(
+        """
+configure terminal
+router bgp 65001
+ address-family l2vpn evpn
+  no auto-route-target import enforce-as4
+  exit
+ exit
+router bgp 65001 vrf vrf-101
+ address-family l2vpn evpn
+  no auto-route-target import enforce-as4
+"""
+    )
+    r2.vtysh_cmd(
+        """
+configure terminal
+router bgp 4200000001
+ address-family l2vpn evpn
+  no auto-route-target export enforce-as4
+  exit
+ exit
+router bgp 4200000001 vrf vrf-101
+ address-family l2vpn evpn
+  no auto-route-target export enforce-as4
+"""
+    )
+
+    _expect(
+        _check_vrf_route_present(r1, "10.0.101.2/32"),
+        "r1: type-5 route not re-imported after clearing the enforce-as4 encoding",
+    )
+    _expect(
+        _check_vni_route_present(r1, 201, R2_IMET_PREFIX),
+        "r1: type-3 route not re-imported after clearing the enforce-as4 encoding",
+    )
+
+
+def test_enforce_as4_oversized_vni_skipped():
+    """
+    "auto-route-target <import|export> enforce-as4" cannot fit a VNI
+    above 0xFFFF into the 2-byte local admin of the AS4 route-target
+    encoding. Automatic route-target generation must be skipped for
+    such a VNI (rather than silently truncating it into a colliding
+    route target), and enabling enforce-as4 while an oversized VNI is
+    already configured must warn immediately on the vty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    oversized_vni = 700000
+
+    # A standalone L2VNI config entry (no live VXLAN device needed) is
+    # enough to exercise auto route-target derivation.
+    output = r2.vtysh_cmd(
+        """
+configure terminal
+router bgp 4200000001
+ address-family l2vpn evpn
+  vni {vni}
+  exit
+  auto-route-target export enforce-as4
+  auto-route-target import enforce-as4
+""".format(
+            vni=oversized_vni
+        )
+    )
+
+    assert "exceed the 16-bit limit for enforce-as4" in output, (
+        "r2: no immediate vty warning when enabling enforce-as4 while VNI {} "
+        "(> 0xFFFF) is configured".format(oversized_vni)
+    )
+
+    show = r2.vtysh_cmd(
+        "show bgp l2vpn evpn vni {} json".format(oversized_vni), isjson=True
+    )
+    assert show.get("exportRts") == [], (
+        "r2: an export route-target was auto-derived for VNI {}, above the "
+        "16-bit enforce-as4 limit".format(oversized_vni)
+    )
+    assert show.get("importRts") == [], (
+        "r2: an import route-target was auto-derived for VNI {}, above the "
+        "16-bit enforce-as4 limit".format(oversized_vni)
+    )
+
+    # Cleanup: drop the oversized VNI and the enforce-as4 setting.
+    r2.vtysh_cmd(
+        """
+configure terminal
+router bgp 4200000001
+ address-family l2vpn evpn
+  no vni {vni}
+  no auto-route-target export enforce-as4
+  no auto-route-target import enforce-as4
+""".format(
+            vni=oversized_vni
+        )
     )
 
 

--- a/tests/topotests/bgp_evpn_rt_wildcard_matching/test_bgp_evpn_rt_wildcard_matching.py
+++ b/tests/topotests/bgp_evpn_rt_wildcard_matching/test_bgp_evpn_rt_wildcard_matching.py
@@ -54,6 +54,7 @@ pytestmark = [pytest.mark.bgpd, pytest.mark.evpn]
 
 # 4200000001 & 0xFFFF - the AS2-truncated form of r2's AS used in its
 # auto route targets.
+R2_AS = 4200000001
 R2_AS_TRUNCATED = 59905
 
 R1_TYPE5_PREFIX = "[5]:[0]:[32]:[10.0.101.1]"
@@ -336,12 +337,14 @@ def test_as4_encoded_rt():
 
     # Replace r2's auto export RT with a manual, AS4-encoded RT that
     # keeps the VNI as the local admin.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 4200000001:101
-""")
+"""
+    )
 
     test_func = partial(
         _check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:4200000001:101"
@@ -356,13 +359,15 @@ router bgp 4200000001 vrf vrf-101
     )
 
     # Move the local admin away from the VNI; r1 must stop importing.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 4200000001:999
   no route-target export 4200000001:101
-""")
+"""
+    )
 
     test_func = partial(
         _check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:4200000001:999"
@@ -374,12 +379,14 @@ router bgp 4200000001 vrf vrf-101
 
     # A fully-qualified import RT must match the AS4-encoded RT on the
     # exact encoded value.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import 4200000001:999
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -388,13 +395,15 @@ router bgp 65001 vrf vrf-101
 
     # A wildcard import RT must match the AS4-encoded RT on its 2-byte
     # local admin.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import 4200000001:999
   route-target import *:999
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -402,18 +411,22 @@ router bgp 65001 vrf vrf-101
     )
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:999
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 4200000001:999
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -435,12 +448,14 @@ def test_ip_encoded_rt():
     r1 = tgen.gears["r1"]
     r2 = tgen.gears["r2"]
 
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 192.0.2.2:101
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:192.0.2.2:101")
     _expect(test_func, "r1: r2's type-5 route does not carry the IP-encoded RT")
@@ -455,12 +470,14 @@ router bgp 4200000001 vrf vrf-101
     # Disable the auto import RT; without any import RT the route must
     # no longer be imported (even though the local admin equals the
     # VNI).
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   auto-route-target import add-never
-""")
+"""
+    )
 
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(
@@ -469,12 +486,14 @@ router bgp 65001 vrf vrf-101
 
     # A fully-qualified import RT must match the IP-encoded RT
     # exactly.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import 192.0.2.2:101
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -484,13 +503,15 @@ router bgp 65001 vrf vrf-101
     # An import RT with the same local admin but a different IP must
     # NOT match (fully-qualified matching is on the exact encoded
     # bytes and the wildcard matching is disabled here).
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import 192.0.2.2:101
   route-target import 192.0.2.9:101
-""")
+"""
+    )
 
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(
@@ -499,19 +520,23 @@ router bgp 65001 vrf vrf-101
     )
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import 192.0.2.9:101
   no auto-route-target import add-never
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 192.0.2.2:101
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -534,12 +559,14 @@ def test_wildcard_keying_as2_full_local_admin():
     r1 = tgen.gears["r1"]
     r2 = tgen.gears["r2"]
 
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 65002:65637
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_TYPE5_PREFIX, "RT:65002:65637")
     _expect(test_func, "r1: r2's type-5 route does not carry RT 65002:65637")
@@ -553,12 +580,14 @@ router bgp 4200000001 vrf vrf-101
     )
 
     # A wildcard on the full 4-byte local admin must match.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import *:65637
-""")
+"""
+    )
 
     expected = {"*:65637": {"rt": "*:65637"}}
     test_func = partial(
@@ -575,23 +604,27 @@ router bgp 65001 vrf vrf-101
     )
 
     # Removing the wildcard again must uninstall the route.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:65637
-""")
+"""
+    )
 
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(test_func, "r1: type-5 route still imported after removing '*:65637'")
 
     # Cleanup: back to auto RTs.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 65002:65637
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -617,12 +650,14 @@ def test_multiple_rts_any_match():
     # share the AS and differ only in the local admin; both must
     # survive (regression: the effective-RT dedup once compared AS4
     # local admins at the wrong offset and collapsed them).
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   route-target export 65002:999 192.0.2.2:888 4200000001:777 4200000001:778
-""")
+"""
+    )
 
     for rt in [
         "RT:65002:999",
@@ -634,54 +669,64 @@ router bgp 4200000001 vrf vrf-101
         _expect(test_func, "r1: r2's type-5 route does not carry {}".format(rt))
 
     # Matching the AS4-encoded RT alone must be enough ...
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   route-target import *:777
-""")
+"""
+    )
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
         "r1: type-5 route not imported although '*:777' matches one of its RTs",
     )
 
     # ... as must matching the IP-encoded RT alone ...
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:777
   route-target import *:888
-""")
+"""
+    )
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
         "r1: type-5 route not imported although '*:888' matches one of its RTs",
     )
 
     # ... while a wildcard matching none of the RTs must not import.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:888
   route-target import *:666
-""")
+"""
+    )
     test_func = partial(_check_vrf_route_absent, r1, "10.0.101.2/32")
     _expect(test_func, "r1: type-5 route imported although none of its RTs match")
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no route-target import *:666
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no route-target export 65002:999 192.0.2.2:888 4200000001:777 4200000001:778
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -714,13 +759,15 @@ def test_l2vni_rt_encoding():
 
     # AS4-encoded export RT with the VNI as local admin: r1's auto
     # import RT must still match (2-byte local admin extraction).
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001
  address-family l2vpn evpn
   vni 201
    route-target export 4200000001:201
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_IMET_PREFIX, "RT:4200000001:201")
     _expect(test_func, "r1: r2's IMET route does not carry the AS4-encoded RT")
@@ -732,14 +779,16 @@ router bgp 4200000001
 
     # AS2-encoded RT with a 4-byte local admin whose low 16 bits equal
     # the VNI: must NOT match r1's auto import RT.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001
  address-family l2vpn evpn
   vni 201
    no route-target export 4200000001:201
    route-target export 65002:65737
-""")
+"""
+    )
 
     test_func = partial(_check_global_route_rt, r1, R2_IMET_PREFIX, "RT:65002:65737")
     _expect(test_func, "r1: r2's IMET route does not carry RT 65002:65737")
@@ -752,14 +801,16 @@ router bgp 4200000001
 
     # A wildcard on the full 4-byte local admin must match, and must
     # show up in the VNI import RT table.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001
  address-family l2vpn evpn
   vni 201
    auto-route-target import add-always
    route-target import *:65737
-""")
+"""
+    )
 
     expected = {"*:65737": {"rt": "*:65737", "vnis": [201]}}
     test_func = partial(
@@ -776,21 +827,25 @@ router bgp 65001
     )
 
     # Cleanup: back to auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001
  address-family l2vpn evpn
   vni 201
    no route-target import *:65737
    no auto-route-target import add-always
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001
  address-family l2vpn evpn
   vni 201
    no route-target export 65002:65737
-""")
+"""
+    )
 
     _expect(
         _check_vni_route_present(r1, 201, R2_IMET_PREFIX),
@@ -825,12 +880,14 @@ def test_rfc8365_compatible_encoding():
 
     # Enable RFC 8365 compatible encoding on r2's export direction; the
     # VXLAN bit (0x10000000) is OR'd into the local admin.
-    r2.vtysh_cmd("""
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   auto-route-target export rfc8365-compatible
-""")
+"""
+    )
 
     rfc8365_local_admin = 0x10000000 + 101
     _expect(
@@ -851,12 +908,14 @@ router bgp 4200000001 vrf vrf-101
     )
 
     # Matching the encoding on r1's import direction restores the import.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   auto-route-target import rfc8365-compatible
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
@@ -870,22 +929,122 @@ router bgp 65001 vrf vrf-101
     ), "r2: 'auto-route-target export rfc8365-compatible' not in running config"
 
     # Cleanup: back to the plain auto RTs on both sides.
-    r1.vtysh_cmd("""
+    r1.vtysh_cmd(
+        """
 configure terminal
 router bgp 65001 vrf vrf-101
  address-family l2vpn evpn
   no auto-route-target import rfc8365-compatible
-""")
-    r2.vtysh_cmd("""
+"""
+    )
+    r2.vtysh_cmd(
+        """
 configure terminal
 router bgp 4200000001 vrf vrf-101
  address-family l2vpn evpn
   no auto-route-target export rfc8365-compatible
-""")
+"""
+    )
 
     _expect(
         _check_vrf_route_present(r1, "10.0.101.2/32"),
         "r1: type-5 route not re-imported after clearing the RFC 8365 encoding",
+    )
+
+
+def test_enforce_as4_encoding():
+    """
+    "auto-route-target export enforce-as4" forces the AS4 encoding for auto
+    route targets, placing the 32-bit AS in the global admin field and truncating
+    the VNI to its lower 16 bits in the local admin field.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Baseline: r2's L3VNI auto export RT is <as-truncated>:101 on the wire.
+    _expect(
+        partial(
+            _check_global_route_rt,
+            r1,
+            R2_TYPE5_PREFIX,
+            "RT:{}:101".format(R2_AS_TRUNCATED),
+        ),
+        "r1: r2's type-5 route does not carry the plain auto export RT",
+    )
+
+    # Enable enforce-as4 on r2's export direction.
+    r2.vtysh_cmd(
+        """
+configure terminal
+router bgp 4200000001 vrf vrf-101
+ address-family l2vpn evpn
+  auto-route-target export enforce-as4
+"""
+    )
+
+    _expect(
+        partial(
+            _check_global_route_rt,
+            r1,
+            R2_TYPE5_PREFIX,
+            "RT:{}:101".format(R2_AS),
+        ),
+        "r1: r2's type-5 route does not carry the enforce-as4 encoded auto export RT",
+    )
+
+    # r1's plain auto import RT (wildcard on local admin 101) successfully matches
+    # the AS4 encoded RT's 16-bit local admin (which is also 101).
+    _expect(
+        _check_vrf_route_present(r1, "10.0.101.2/32"),
+        "r1: type-5 route not imported despite matching local admin in enforce-as4 encoded RT",
+    )
+
+    # Configuring enforce-as4 on r1's import direction should maintain the import.
+    r1.vtysh_cmd(
+        """
+configure terminal
+router bgp 65001 vrf vrf-101
+ address-family l2vpn evpn
+  auto-route-target import enforce-as4
+"""
+    )
+
+    _expect(
+        _check_vrf_route_present(r1, "10.0.101.2/32"),
+        "r1: type-5 route not imported with matching enforce-as4 import encoding",
+    )
+
+    # The per-direction setting round-trips in the running config.
+    running_r2 = r2.vtysh_cmd("show running-config", isjson=False)
+    assert (
+        "auto-route-target export enforce-as4" in running_r2
+    ), "r2: 'auto-route-target export enforce-as4' not in running config"
+
+    # Cleanup: back to the plain auto RTs on both sides.
+    r1.vtysh_cmd(
+        """
+configure terminal
+router bgp 65001 vrf vrf-101
+ address-family l2vpn evpn
+  no auto-route-target import enforce-as4
+"""
+    )
+    r2.vtysh_cmd(
+        """
+configure terminal
+router bgp 4200000001 vrf vrf-101
+ address-family l2vpn evpn
+  no auto-route-target export enforce-as4
+"""
+    )
+
+    _expect(
+        _check_vrf_route_present(r1, "10.0.101.2/32"),
+        "r1: type-5 route not re-imported after clearing the enforce-as4 encoding",
     )
 
 


### PR DESCRIPTION
By default, auto-derived Route Targets truncate 32-bit ASNs to 16 bits (Type 0x00) to allow for 24-bit VXLAN VNIs per RFC 8365. This breaks native EVPN auto-RT compatibility with hardware VTEPs that use Type 0x02.

This patch introduces the enforce-as4 command under the L2VPN EVPN address family. It forces the auto-derivation to use the full local 32-bit AS (Type 0x02 encoding), with the explicit trade-off that VNIs are constrained to 16 bits (max 65535).

It allows native compatibility automatically with such switch like Arista.