### PR TITLE
nhrpd: gate source binding cache on S-bit and holding time per RFC2332

### DIFF
--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -521,6 +521,25 @@ static void nhrp_handle_resolution_req(struct nhrp_packet_parser *pp)
 		debugf(NHRP_DEBUG_COMMON,
 		       "shortcut res_rep: holdtime is %u (if 0, using %u)",
 		       holdtime, pp->if_ad->holdtime);
+
+		/* RFC 2332 §6.2.1: source binding from a Resolution Request
+		 * MUST only be cached when the S-bit is set AND the CIE
+		 * Holding Time is greater than zero.  Skip caching if
+		 * either condition is not met.
+		 */
+		if (!(pp->hdr->flags
+		      & htons(NHRP_FLAG_RESOLUTION_SOURCE_STABLE))
+		    || !cie->holding_time) {
+			debugf(NHRP_DEBUG_COMMON,
+			       "shortcut res_rep: skipping source binding cache"
+			       " (S-bit=%u, holding_time=%u)",
+			       !!(pp->hdr->flags &
+				  htons(NHRP_FLAG_RESOLUTION_SOURCE_STABLE)),
+			       htons(cie->holding_time));
+			cie->code = NHRP_CODE_SUCCESS;
+			continue;
+		}
+
 		if (!holdtime)
 			holdtime = pp->if_ad->holdtime;
 


### PR DESCRIPTION
## Summary

nhrp_handle_resolution_req() unconditionally caches the source binding
from every Resolution Request CIE, ignoring two conditions mandated by
RFC 2332 Section 6.2.1:

1. The S-bit (NHRP_FLAG_RESOLUTION_SOURCE_STABLE) must be set - without
   it, the binding is temporary and MUST NOT be retained.

2. The CIE Holding Time must be greater than zero. A zero holding time
   means the binding should not be stored. The code also silently replaced
   zero with the interface default holdtime.

## Impact

Transit/responder NHS nodes accumulate stale or unauthorized source
bindings, leading to incorrect shortcut paths, forwarding to wrong
NBMA addresses, or serving expired mappings.

## Fix

Add an explicit gate before nhrp_cache_update_binding(): if the S-bit is
unset OR the original holding_time is zero, skip creating or updating the
cache entry for this CIE.

## References

- RFC 2332 Section 6.2.1
- RFCAudit Bug 11 (RFCBin)

Signed-off-by: zhuxu <185172534zxxx@gmail.com>
