### PR TITLE
nhrpd: fix hub NHS treating Code 4 Registration Reply as ACK

### DIFF
--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -64,9 +64,8 @@ static void nhrp_reg_reply(struct nhrp_reqid *reqid, void *arg)
 				: &p->src_proto;
 		debugf(NHRP_DEBUG_COMMON, "NHS: CIE registration: %pSU: %d",
 		       proto, cie->code);
-		if (!((cie->code == NHRP_CODE_SUCCESS)
-		      || (cie->code == NHRP_CODE_ADMINISTRATIVELY_PROHIBITED
-			  && nhs->hub)))
+		/* Per RFC 2332 §5.2.4: any non-zero CIE code is a NAK. */
+		if (cie->code != NHRP_CODE_SUCCESS)
 			ok = 0;
 		mtu = ntohs(cie->mtu);
 		debugf(NHRP_DEBUG_COMMON, "NHS: CIE MTU: %d", mtu);


### PR DESCRIPTION
## Summary

nhrp_reg_reply() accepted Code 4 (Administratively Prohibited) as a successful registration reply when the NHS is configured as a hub. RFC 2332 Section 5.2.4 specifies that any non-zero CIE code in a Registration Reply indicates a NAK — Code 4 explicitly means administratively prohibited.

## Impact

When a hub NHS receives an administratively prohibited registration reply, the exception causes FRR to treat it as successful: the registration timer is refreshed, the NHS adjacency is maintained, and the failure is silently masked from the operator. This can lead to persistent misconfiguration without any indication that the registration is being rejected.

## Fix

Remove the hub-specific exception. Treat all non-zero CIE codes as failure per RFC 2332 Section 5.2.4.

## References

- RFC 2332 Section 5.2.4 (Registration Reply)
- RFCAudit Bug 13 (RFCBin)

Signed-off-by: zhuxu <185172534zxxx@gmail.com>