### PR TITLE
zebra: backport stale ifp cleanup PRs to 10.5 (second try)

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -227,6 +227,8 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		zebra_evpn_if_cleanup(zebra_if);
 		zebra_evpn_mac_ifp_del(ifp);
 
+		zebra_l2_unmap_slave_from_bond(zebra_if);
+
 		if_nhg_dependents_release(ifp);
 		nhg_connected_tree_free(&zebra_if->nhg_dependents);
 
@@ -239,6 +241,8 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		XFREE(MTYPE_ZINFO, zebra_if);
 	}
 
+	zebra_vxlan_if_ref_cleanup(ifp);
+
 	/* walk over all zebra interfaces; unref link pointer */
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 		FOR_ALL_INTERFACES (vrf, p_ifp) {
@@ -250,6 +254,15 @@ static int if_zebra_delete_hook(struct interface *ifp)
 				zebra_if->link_ifindex = IFINDEX_INTERNAL;
 				zebra_if->link_nsid = NS_UNKNOWN;
 			}
+			/*
+			 * Master pointers are caches of an ifp that is about
+			 * to be freed; the ifindex stays as-is so that the
+			 * linkage is re-established if the master reappears.
+			 */
+			if (zebra_if->brslave_info.br_if == ifp)
+				zebra_if->brslave_info.br_if = NULL;
+			if (zebra_if->bondslave_info.bond_if == ifp)
+				zebra_if->bondslave_info.bond_if = NULL;
 		}
 	}
 	return 0;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -200,6 +200,8 @@ static int if_zebra_delete_hook(struct interface *ifp)
 {
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_bond *bond;
+	struct vrf *vrf;
+	struct interface *p_ifp;
 
 	if (ifp->info) {
 		zebra_if = ifp->info;
@@ -237,6 +239,19 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		XFREE(MTYPE_ZINFO, zebra_if);
 	}
 
+	/* walk over all zebra interfaces; unref link pointer */
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		FOR_ALL_INTERFACES (vrf, p_ifp) {
+			if (p_ifp->info == NULL)
+				continue;
+			zebra_if = p_ifp->info;
+			if (zebra_if->link == ifp) {
+				zebra_if->link = NULL;
+				zebra_if->link_ifindex = IFINDEX_INTERNAL;
+				zebra_if->link_nsid = NS_UNKNOWN;
+			}
+		}
+	}
 	return 0;
 }
 

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -409,11 +409,16 @@ int zebra_evpn_gw_macip_add(struct interface *ifp, struct zebra_evpn *zevpn,
 	struct zebra_if *zif = NULL;
 	struct zebra_vxlan_vni *vni;
 
+	if (!zevpn->vxlan_if)
+		return -1;
+
 	zif = zevpn->vxlan_if->info;
 	if (!zif)
 		return -1;
 
 	vni = zebra_vxlan_if_vni_find(zif, zevpn->vni);
+	if (!vni)
+		return -1;
 
 	zebra_evpn_mac_gw_macip_add(ifp, zevpn, ip, &mac, macaddr,
 				    vni->access_vlan, true);
@@ -1269,6 +1274,13 @@ int zebra_evpn_vtep_del_all(struct zebra_evpn *zevpn, int uninstall)
  */
 int zebra_evpn_vtep_install(struct zebra_evpn *zevpn, struct zebra_vtep *zvtep)
 {
+	if (!zevpn->vxlan_if) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("VNI %u hash %p couldn't be installed - no intf", zevpn->vni,
+				   zevpn);
+		return -1;
+	}
+
 	if (is_vxlan_flooding_head_end() &&
 	    (zvtep->flood_control == VXLAN_FLOOD_HEAD_END_REPL)) {
 		if (ZEBRA_DPLANE_REQUEST_FAILURE ==

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1169,6 +1169,24 @@ void zebra_evpn_if_init(struct zebra_if *zif)
 	zebra_evpn_local_es_update(zif);
 }
 
+static void zebra_evpn_acc_vl_ref_cleanup_cb(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_evpn_access_bd *acc_bd = bucket->data;
+	const struct zebra_if *zif = arg;
+
+	/*
+	 * These are caches of an interface that is going away. Both are
+	 * optional and are re-derived when the SVI/vxlan device reappears,
+	 * so simply dropping the reference is enough - and it is required,
+	 * since zebra_evpn_acc_bd_svi_set() only clears vlan_zif while the
+	 * SVI still has a parent bridge to look up.
+	 */
+	if (acc_bd->vlan_zif == zif)
+		acc_bd->vlan_zif = NULL;
+	if (acc_bd->vxlan_zif == zif)
+		acc_bd->vxlan_zif = NULL;
+}
+
 /* handle deletion of an access port by removing it from all associated
  * broadcast domains.
  */
@@ -1190,6 +1208,9 @@ void zebra_evpn_if_cleanup(struct zebra_if *zif)
 	es = zif->es_info.es;
 	if (es)
 		zebra_evpn_local_es_del(&es);
+
+	if (zmh_info && zmh_info->evpn_vlan_table)
+		hash_iterate(zmh_info->evpn_vlan_table, zebra_evpn_acc_vl_ref_cleanup_cb, zif);
 }
 
 /*****************************************************************************

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5043,7 +5043,7 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 			zevpn->vrf_id = VRF_DEFAULT;
 
 			/* update the tenant vrf in BGP */
-			if (if_is_operative(zevpn->vxlan_if))
+			if (zevpn->vxlan_if && if_is_operative(zevpn->vxlan_if))
 				zebra_evpn_send_add_to_client(zevpn);
 		}
 	}
@@ -5206,6 +5206,49 @@ void zebra_vxlan_macvlan_up(struct interface *ifp)
 		if (is_l3vni_oper_up(zl3vni))
 			zebra_vxlan_process_l3vni_oper_up(zl3vni);
 	}
+}
+
+static void zl3vni_ifp_ref_cleanup_cb(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_l3vni *zl3vni = bucket->data;
+	const struct interface *ifp = arg;
+
+	if (zl3vni->vxlan_if == ifp)
+		zl3vni->vxlan_if = NULL;
+	if (zl3vni->svi_if == ifp)
+		zl3vni->svi_if = NULL;
+	if (zl3vni->mac_vlan_if == ifp)
+		zl3vni->mac_vlan_if = NULL;
+	if (zl3vni->bridge_if == ifp) {
+		zl3vni->bridge_if = NULL;
+		zl3vni->vid = 0;
+	}
+}
+
+static void zevpn_ifp_ref_cleanup_cb(struct hash_bucket *bucket, void *arg)
+{
+	struct zebra_evpn *zevpn = bucket->data;
+	const struct interface *ifp = arg;
+
+	if (zevpn->vxlan_if == ifp)
+		zevpn->vxlan_if = NULL;
+	if (zevpn->svi_if == ifp)
+		zevpn->svi_if = NULL;
+	if (zevpn->bridge_if == ifp) {
+		zevpn->bridge_if = NULL;
+		zevpn->vid = 0;
+	}
+}
+
+void zebra_vxlan_if_ref_cleanup(struct interface *ifp)
+{
+	struct zebra_vrf *zvrf = zebra_vrf_get_evpn();
+
+	if (zvrf && zvrf->evpn_table)
+		hash_iterate(zvrf->evpn_table, zevpn_ifp_ref_cleanup_cb, ifp);
+
+	if (zrouter.l3vni_table)
+		hash_iterate(zrouter.l3vni_table, zl3vni_ifp_ref_cleanup_cb, ifp);
 }
 
 void zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -178,6 +178,7 @@ extern int zebra_vxlan_if_add(struct interface *ifp);
 extern int zebra_vxlan_if_update(struct interface *ifp,
 				 struct zebra_vxlan_if_update_ctx *ctx);
 extern int zebra_vxlan_if_del(struct interface *ifp);
+extern void zebra_vxlan_if_ref_cleanup(struct interface *ifp);
 extern void zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 					    int filter, int add);
 extern void zebra_vxlan_init_tables(struct zebra_vrf *zvrf);


### PR DESCRIPTION
This PR backports #22024  and #22858  - these clean up several paths where stale interface pointers could be left in various zebra data structs.
