### PR TITLE
ospfd: allow virtual-link configuration before ABR state

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1108,12 +1108,6 @@ ospf_find_vl_data(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 	vty = vl_config->vty;
 	area_id = vl_config->area_id;
 
-	if (!CHECK_FLAG(ospf->flags, OSPF_FLAG_ABR)) {
-		vty_out(vty,
-			"Configuring VLs on non-ABRs is not allowed\n");
-		return NULL;
-	}
-
 	if (area_id.s_addr == OSPF_AREA_BACKBONE) {
 		vty_out(vty,
 			"Configuring VLs over the backbone is not allowed\n");


### PR DESCRIPTION
This is a revert of #20213

OSPF_FLAG_ABR represents derived operational state rather than persistent configuration. During startup, interfaces may not yet be active and an abr-type change is processed by the delayed ABR task. Consequently, a valid virtual-link command immediately following "ospf abr-type standard" can be rejected. Reapplying the configuration after the ABR task succeeds.

Remove the operational ABR check from virtual-link configuration. It is safe to configure a virtual link before the router becomes an ABR because configuration does not make the link immediately operational. During SPF, virtual links are initially unapproved and are brought up only when the remote endpoint is reachable through the configured transit area. Unapproved links remain shut down.

Validation preventing backbone, stub, and NSSA areas from being used as transit areas remains unchanged.

Fixes: #22937
Fixes: 4257c1dc28e7 ("ospfd: fix bug allowing vlink creation on non-ABRs")