### PR TITLE
bgpd: Withdraw routes with malformed SRv6 Service TLVs

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3434,8 +3434,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service_data(struct bgp_attr_parser
 		flog_err(EC_BGP_ATTR_LEN,
 			 "Malformed SRv6 Service Data Sub-Sub-TLV attribute - insufficient data (need %zu for attribute header, have %zu in parent TLV, %zu remaining in UPDATE)",
 			 headersz, remaining, STREAM_READABLE(connection->curr));
-		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-					  args->total);
+		return BGP_ATTR_PARSE_WITHDRAW;
 	}
 
 	type = stream_getc(connection->curr);
@@ -3446,8 +3445,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service_data(struct bgp_attr_parser
 		flog_err(EC_BGP_ATTR_LEN,
 			 "Malformed SRv6 Service Data Sub-Sub-TLV attribute - insufficient data (need %hu for attribute data, have %zu in parent TLV, %zu remaining in UPDATE)",
 			 length, remaining, STREAM_READABLE(connection->curr));
-		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-					  args->total);
+		return BGP_ATTR_PARSE_WITHDRAW;
 	}
 
 	if (type == BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_STRUCTURE) {
@@ -3455,9 +3453,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service_data(struct bgp_attr_parser
 			flog_err(EC_BGP_ATTR_LEN,
 				 "Malformed SRv6 Service Data Sub-Sub-TLV attribute - invalid length %hu (expected %u)",
 				 length, BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_STRUCTURE_LENGTH);
-			return bgp_attr_malformed(
-				args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-				args->total);
+			return BGP_ATTR_PARSE_WITHDRAW;
 		}
 
 		loc_block_len = stream_getc(connection->curr);
@@ -3474,8 +3470,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service_data(struct bgp_attr_parser
 			flog_err(EC_BGP_ATTR_LEN,
 				 "Malformed SRv6 Service Data Sub-Sub-TLV attribute - invalid transposition data (len=%u, offset=%u)",
 				 transposition_len, transposition_offset);
-			return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-						  args->total);
+			return BGP_ATTR_PARSE_WITHDRAW;
 		}
 
 		/* Log SRv6 Service Data Sub-Sub-TLV */
@@ -3530,8 +3525,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service(struct bgp_attr_parser_args
 		flog_err(EC_BGP_ATTR_LEN,
 			 "Malformed SRv6 Service Sub-TLV attribute - insufficient data (need %zu for attribute header, have %zu in parent TLV, %zu remaining in UPDATE)",
 			 headersz, remaining, STREAM_READABLE(connection->curr));
-		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-					  args->total);
+		return BGP_ATTR_PARSE_WITHDRAW;
 	}
 
 	type = stream_getc(connection->curr);
@@ -3542,8 +3536,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service(struct bgp_attr_parser_args
 		flog_err(EC_BGP_ATTR_LEN,
 			 "Malformed SRv6 Service Sub-TLV attribute - insufficient data (need %hu for attribute data, have %zu in parent TLV, %zu remaining in UPDATE)",
 			 length, remaining, STREAM_READABLE(connection->curr));
-		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-					  args->total);
+		return BGP_ATTR_PARSE_WITHDRAW;
 	}
 
 	if (type == BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO) {
@@ -3554,8 +3547,7 @@ static enum bgp_attr_parse_ret bgp_attr_srv6_service(struct bgp_attr_parser_args
 			flog_err(EC_BGP_ATTR_LEN,
 				 "Malformed SRv6 Service Sub-TLV attribute - declared length %u is less than minimum %d",
 				 length, BGP_PREFIX_SID_SRV6_L3_SERVICE_SID_INFO_LENGTH);
-			return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-						  args->total);
+			return BGP_ATTR_PARSE_WITHDRAW;
 		}
 
 		start = stream_get_getp(connection->curr);
@@ -3658,6 +3650,13 @@ bgp_attr_psid_sub(uint8_t type, uint16_t length,
 		flog_err(EC_BGP_ATTR_LEN,
 			 "Prefix SID specifies length %hu, but only %zu bytes remain", length,
 			 STREAM_READABLE(connection->curr));
+
+		/* RFC 9252 requires malformed SRv6 Service TLVs, Sub-TLVs,
+		 * and Sub-Sub-TLVs to be handled as treat-as-withdraw.
+		 */
+		if (type == BGP_PREFIX_SID_SRV6_L3_SERVICE)
+			return BGP_ATTR_PARSE_WITHDRAW;
+
 		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
 					  args->total);
 	}
@@ -3794,9 +3793,7 @@ bgp_attr_psid_sub(uint8_t type, uint16_t length,
 			flog_err(
 				EC_BGP_ATTR_LEN,
 				"Prefix SID SRV6 L3 Service not enough data left, it must be at least 1 byte");
-			return bgp_attr_malformed(
-				args, BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
-				args->total);
+			return BGP_ATTR_PARSE_WITHDRAW;
 		}
 
 		start = stream_get_getp(connection->curr);
@@ -3867,6 +3864,14 @@ enum bgp_attr_parse_ret bgp_attr_prefix_sid(struct bgp_attr_parser_args *args)
 			flog_err(EC_BGP_ATTR_LEN,
 				 "Malformed Prefix SID attribute - insufficient data (need %hu for attribute body, have %zu remaining in UPDATE)",
 				 length, STREAM_READABLE(connection->curr));
+
+			/* RFC 9252 requires malformed SRv6 Service TLVs,
+			 * Sub-TLVs, and Sub-Sub-TLVs to be handled as
+			 * treat-as-withdraw.
+			 */
+			if (type == BGP_PREFIX_SID_SRV6_L3_SERVICE)
+				return BGP_ATTR_PARSE_WITHDRAW;
+
 			return bgp_attr_malformed(args,
 						  BGP_NOTIFY_UPDATE_ATTR_LENG_ERR,
 						  args->total);

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -49,6 +49,7 @@ static struct test_segment {
 	int len;
 #define SHOULD_PARSE	0
 #define SHOULD_ERR	-1
+#define SHOULD_WITHDRAW BGP_ATTR_PARSE_WITHDRAW
 	int parses; /* whether it should parse or not */
 } mp_reach_segments[] = {
 	{
@@ -1002,13 +1003,21 @@ static void handle_result(struct peer *peer, struct test_segment *t,
 			  int parse_ret, int nlri_ret)
 {
 	int oldfailed = failed;
+	bool ok;
 
 	printf("mp attr parsed?: %s\n", parse_ret ? "no" : "yes");
 	if (!parse_ret)
 		printf("nrli parsed?:  %s\n", nlri_ret ? "no" : "yes");
 	printf("should parse?:  %s\n", t->parses ? "no" : "yes");
 
-	if ((parse_ret != 0 || nlri_ret != 0) != (t->parses != 0))
+	if (t->parses == SHOULD_ERR)
+		ok = parse_ret != 0 || nlri_ret != 0;
+	else if (t->parses == SHOULD_WITHDRAW)
+		ok = parse_ret == BGP_ATTR_PARSE_WITHDRAW;
+	else
+		ok = parse_ret == 0 && nlri_ret == 0;
+
+	if (!ok)
 		failed++;
 
 

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -992,6 +992,97 @@ static struct test_segment mp_prefix_sid[] = {
 		.len = 56,
 		.parses = SHOULD_PARSE,
 	},
+	{
+		.name = "PREFIX-SID-SRv6-L3-Service-length-overflow",
+		.desc = "PREFIX-SID rejects an overlong SRv6 L3 Service TLV",
+		.data = {
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x19, /* Length exceeds remaining attribute data */
+			0x00,       /* Reserved */
+		},
+		.len = 4,
+		.parses = SHOULD_WITHDRAW,
+	},
+	{
+		.name = "PREFIX-SID-SRv6-L3-Service-missing-reserved",
+		.desc = "PREFIX-SID rejects an SRv6 L3 Service TLV without the reserved byte",
+		.data = {
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x00, /* Length omits the mandatory reserved byte */
+		},
+		.len = 3,
+		.parses = SHOULD_WITHDRAW,
+	},
+	{
+		.name = "PREFIX-SID-SRv6-L3-Service-sid-info-short",
+		.desc = "PREFIX-SID rejects a short SRv6 SID Information Sub-TLV",
+		.data = {
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x18, /* SRv6 L3 Service TLV length */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-TLV type: SID Information */
+			0x00, 0x14, /* Sub-TLV length below the fixed 21 bytes */
+			0x00,       /* Reserved */
+			0xfc, 0xbb, 0xbb, 0xbb, /* SID fcbb:bbbb:1:e000:: */
+			0x00, 0x01, 0xe0, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00,       /* SID flags */
+			0x00, 0x40, /* Endpoint behavior */
+		},
+		.len = 27,
+		.parses = SHOULD_WITHDRAW,
+	},
+	{
+		.name = "PREFIX-SID-SRv6-L3-Service-sid-structure-bad-length",
+		.desc = "PREFIX-SID rejects an SRv6 SID Structure Sub-Sub-TLV with a bad length",
+		.data = {
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x21, /* SRv6 L3 Service TLV length */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-TLV type: SID Information */
+			0x00, 0x1d, /* SID Information plus Sub-Sub-TLV */
+			0x00,       /* Reserved */
+			0xfc, 0xbb, 0xbb, 0xbb, /* SID fcbb:bbbb:1:e000:: */
+			0x00, 0x01, 0xe0, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00,       /* SID flags */
+			0x00, 0x40, /* Endpoint behavior */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-Sub-TLV type: SID Structure */
+			0x00, 0x05, /* Bad SID Structure length */
+			0x20, 0x20, 0x10, 0x00, 0x00,
+		},
+		.len = 36,
+		.parses = SHOULD_WITHDRAW,
+	},
+	{
+		.name = "PREFIX-SID-SRv6-L3-Service-sid-structure-bad-transposition",
+		.desc = "PREFIX-SID rejects an SRv6 SID Structure Sub-Sub-TLV with bad transposition",
+		.data = {
+			0x05,       /* Type 0x05: SRv6 L3 Service */
+			0x00, 0x22, /* SRv6 L3 Service TLV length */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-TLV type: SID Information */
+			0x00, 0x1e, /* SID Information plus Sub-Sub-TLV */
+			0x00,       /* Reserved */
+			0xfc, 0xbb, 0xbb, 0xbb, /* SID fcbb:bbbb:1:e000:: */
+			0x00, 0x01, 0xe0, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00,       /* SID flags */
+			0x00, 0x40, /* Endpoint behavior */
+			0x00,       /* Reserved */
+			0x01,       /* Sub-Sub-TLV type: SID Structure */
+			0x00, 0x06, /* SID Structure length */
+			0x20, 0x20, 0x10, 0x00,
+			0x15,       /* Transposition length greater than 20 */
+			0x00,       /* Transposition offset */
+		},
+		.len = 37,
+		.parses = SHOULD_WITHDRAW,
+	},
 	{NULL, NULL, { 0 }, 0, 0},
 };
 

--- a/tests/bgpd/test_mp_attr.py
+++ b/tests/bgpd/test_mp_attr.py
@@ -52,3 +52,18 @@ TestMpAttr.okfail("PREFIX-SID: PREFIX-SID Test 1")
 TestMpAttr.okfail(
     "PREFIX-SID-SRv6-L3-Service-duplicate: PREFIX-SID ignores duplicate SRv6 L3 Service TLVs"
 )
+TestMpAttr.okfail(
+    "PREFIX-SID-SRv6-L3-Service-length-overflow: PREFIX-SID rejects an overlong SRv6 L3 Service TLV"
+)
+TestMpAttr.okfail(
+    "PREFIX-SID-SRv6-L3-Service-missing-reserved: PREFIX-SID rejects an SRv6 L3 Service TLV without the reserved byte"
+)
+TestMpAttr.okfail(
+    "PREFIX-SID-SRv6-L3-Service-sid-info-short: PREFIX-SID rejects a short SRv6 SID Information Sub-TLV"
+)
+TestMpAttr.okfail(
+    "PREFIX-SID-SRv6-L3-Service-sid-structure-bad-length: PREFIX-SID rejects an SRv6 SID Structure Sub-Sub-TLV with a bad length"
+)
+TestMpAttr.okfail(
+    "PREFIX-SID-SRv6-L3-Service-sid-structure-bad-transposition: PREFIX-SID rejects an SRv6 SID Structure Sub-Sub-TLV with bad transposition"
+)


### PR DESCRIPTION
RFC 9252 Section 7 requires malformed SRv6 Service data in the BGP Prefix-SID attribute to be handled with treat-as-withdraw:

> The treat-as-withdraw action [RFC7606] MUST be performed when at least one malformed SRv6 Service TLV is present in the BGP Prefix-SID attribute.

Source: [RFC 9252, Section 7](https://www.rfc-editor.org/rfc/rfc9252.html#section-7)

The Prefix-SID parser currently reports malformed SRv6 Service TLVs, Sub-TLVs, and Sub-Sub-TLVs through `bgp_attr_malformed()`. For `BGP_ATTR_PREFIX_SID`, that generic path returns `BGP_ATTR_PARSE_PROCEED`, so malformed SRv6 Service data can be skipped instead of withdrawing the affected routes.

Update the SRv6 Service parsing paths to return `BGP_ATTR_PARSE_WITHDRAW` directly for malformed SRv6 Service TLVs, Sub-TLVs, and Sub-Sub-TLVs, while leaving other Prefix-SID TLVs on the existing handling paths.