### PR TITLE
pathd: compare originators by value, not address

### DIFF
--- a/pathd/path_pcep_config.c
+++ b/pathd/path_pcep_config.c
@@ -326,8 +326,8 @@ int path_pcep_config_initiate_path(struct path *path)
 			SET_FLAG(candidate->flags, F_CANDIDATE_NEW);
 		} else {
 			policy = candidate->policy;
-			if ((path->originator != candidate->originator)
-			    || (path->originator != policy->originator)) {
+			if (strcmp(path->originator, candidate->originator)
+			    || strcmp(path->originator, policy->originator)) {
 				/* There is already an initiated path from
 				 * another PCE, show a warning and regect the
 				 * initiated path */

--- a/pathd/path_pcep_config.c
+++ b/pathd/path_pcep_config.c
@@ -326,8 +326,8 @@ int path_pcep_config_initiate_path(struct path *path)
 			SET_FLAG(candidate->flags, F_CANDIDATE_NEW);
 		} else {
 			policy = candidate->policy;
-			if ((path->originator != candidate->originator)
-			    || (path->originator != policy->originator)) {
+			if (strcmp(path->originator, candidate->originator) ||
+			    strcmp(path->originator, policy->originator)) {
 				/* There is already an initiated path from
 				 * another PCE, show a warning and regect the
 				 * initiated path */


### PR DESCRIPTION
The current implementation compares addresses of path->originator and candidate->originator (and policy->originator).  The path->originator is a const char*, while the other two are char[64]. This means that it evaluates as always true as the addresses are never the same, but the values could be the same, causing all re-initiate to be rejected as being owned by another PCE.

The fix is to compare values via strcmp instead of addresses.