### PR TITLE
pathd: check binding sid has label before release

### DIFF
--- a/pathd/path_nb_config.c
+++ b/pathd/path_nb_config.c
@@ -335,8 +335,15 @@ int pathd_srte_policy_binding_sid_modify(struct nb_cb_modify_args *args)
 	case NB_EV_VALIDATE:
 		break;
 	case NB_EV_PREPARE:
-		if (path_zebra_request_label(binding_sid) < 0)
+		if (path_zebra_request_label(binding_sid) < 0) {
+			/*
+			 * The label may be reserved, outside the unreserved label range,
+			 * used by another protocol (SRGB/SRLB), or in a dynamic-block
+			 */
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "Failed to allocate label for %u.", binding_sid);
 			return NB_ERR_RESOURCE;
+		}
 		break;
 	case NB_EV_ABORT:
 		break;

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -361,7 +361,8 @@ void srte_policy_del(struct srte_policy *policy)
 
 	path_zebra_delete_sr_policy(policy);
 
-	path_zebra_release_label(policy->binding_sid);
+	if (policy->binding_sid != MPLS_LABEL_NONE)
+		path_zebra_release_label(policy->binding_sid);
 
 	while (!RB_EMPTY(srte_candidate_head, &policy->candidate_paths)) {
 		candidate =


### PR DESCRIPTION
The current code always calls release label on a SRTE policy delete. RFC9256: 6.1 comments that the path may be defined with a BSID, making them an optional component.  This causes deletions of policies without bsids to log as errors.

The fix, is to check first that the binding sid has a label.  This is already done in the update binding sid function.