### PR TITLE
bgpd: carry reception time at microsecond precision in BMP adj-in

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -168,7 +168,9 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 		    uint32_t addpath_id, struct bgp_labels *labels)
 {
 	struct bgp_adj_in *adj;
+	struct timeval now;
 
+	monotime(&now);
 	for (adj = dest->adj_in; adj; adj = adj->next) {
 		if (adj->peer == peer && adj->addpath_rx_id == addpath_id) {
 			if (!attrhash_cmp(adj->attr, attr)) {
@@ -179,14 +181,16 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 				bgp_labels_unintern(&adj->labels);
 				adj->labels = bgp_labels_intern(labels);
 			}
-			adj->uptime = monotime(NULL);
+			adj->uptime = now.tv_sec;
+			adj->uptime_usec = now.tv_usec;
 			return;
 		}
 	}
 	adj = XCALLOC(MTYPE_BGP_ADJ_IN, sizeof(struct bgp_adj_in));
 	adj->peer = peer_lock(peer); /* adj_in peer reference */
 	adj->attr = bgp_attr_intern(attr);
-	adj->uptime = monotime(NULL);
+	adj->uptime = now.tv_sec;
+	adj->uptime_usec = now.tv_usec;
 	adj->addpath_rx_id = addpath_id;
 	adj->labels = bgp_labels_intern(labels);
 	BGP_ADJ_IN_ADD(dest, adj);

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -100,6 +100,7 @@ struct bgp_adj_in {
 
 	/* timestamp (monotime) */
 	time_t uptime;
+	uint32_t uptime_usec;
 
 	/* Addpath identifier */
 	uint32_t addpath_rx_id;

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1335,15 +1335,12 @@ static struct stream *bmp_withdraw(const struct prefix *p,
 	return s;
 }
 
-static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
-			uint8_t peer_type_flag, const struct prefix *p,
-			struct prefix_rd *prd, struct attr *attr,
-			struct bgp_path_info *path, afi_t afi,
-			safi_t safi, time_t uptime, mpls_label_t *label,
-			uint32_t num_labels)
+static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags, uint8_t peer_type_flag,
+			const struct prefix *p, struct prefix_rd *prd, struct attr *attr,
+			struct bgp_path_info *path, afi_t afi, safi_t safi,
+			const struct timeval *uptime, mpls_label_t *label, uint32_t num_labels)
 {
 	struct stream *hdr, *msg;
-	struct timeval tv = { .tv_sec = uptime, .tv_usec = 0 };
 	struct timeval uptime_real;
 
 	uint64_t peer_distinguisher = 0;
@@ -1354,7 +1351,8 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 		return;
 	}
 
-	monotime_to_realtime(&tv, &uptime_real);
+	if (uptime)
+		monotime_to_realtime(uptime, &uptime_real);
 	if (attr)
 		msg = bmp_update(p, prd, peer, attr, path, afi, safi, label,
 				 num_labels);
@@ -1367,7 +1365,7 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 	hdr = stream_new(BGP_MAX_PACKET_SIZE);
 	bmp_common_hdr(hdr, BMP_VERSION_3, BMP_TYPE_ROUTE_MONITORING);
 	bmp_per_peer_hdr(hdr, peer->bgp, peer, flags, peer_type_flag, peer_distinguisher,
-			 uptime == (time_t)(-1L) ? NULL : &uptime_real);
+			 uptime ? &uptime_real : NULL);
 
 	stream_putl_at(hdr, BMP_LENGTH_POS,
 			stream_get_endp(hdr) + stream_get_endp(msg));
@@ -1647,28 +1645,32 @@ afibreak:
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_SELECTED) &&
 	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
-		bmp_monitor(bmp, bpi->peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
-			    bn_p, prd, bpi->attr, bpi, afi, safi,
-			    bpi && bpi->extra ? bpi->extra->bgp_rib_uptime
-					      : (time_t)(-1L),
-			    bpi_num_labels ? bpi->extra->labels->label : NULL,
-			    bpi_num_labels);
+		struct timeval tv = { .tv_sec = bpi->extra ? bpi->extra->bgp_rib_uptime : 0 };
+
+		bmp_monitor(bmp, bpi->peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE, bn_p, prd,
+			    bpi->attr, bpi, afi, safi,
+			    bpi->extra && bpi->extra->bgp_rib_uptime != (time_t)(-1L) ? &tv : NULL,
+			    bpi_num_labels ? bpi->extra->labels->label : NULL, bpi_num_labels);
 	}
 
 	if (bpi)
 		peer_type_flag = bmp_get_peer_type(bpi->peer);
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_VALID) &&
-	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY))
+	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY)) {
+		struct timeval tv = { .tv_sec = bpi->uptime };
+
 		bmp_monitor(bmp, bpi->peer, BMP_PEER_FLAG_L, peer_type_flag, bn_p, prd, bpi->attr,
-			    bpi, afi, safi, bpi->uptime,
-			    bpi_num_labels ? bpi->extra->labels->label : NULL, bpi_num_labels);
+			    bpi, afi, safi, &tv, bpi_num_labels ? bpi->extra->labels->label : NULL,
+			    bpi_num_labels);
+	}
 
 	if (adjin) {
+		struct timeval tv = { .tv_sec = adjin->uptime, .tv_usec = adjin->uptime_usec };
+
 		adjin_num_labels = adjin->labels ? adjin->labels->num_labels : 0;
 		bmp_monitor(bmp, adjin->peer, 0, peer_type_flag, bn_p, prd, adjin->attr, NULL, afi,
-			    safi, adjin->uptime,
-			    adjin_num_labels ? &adjin->labels->label[0] : NULL,
+			    safi, &tv, adjin_num_labels ? &adjin->labels->label[0] : NULL,
 			    adjin_num_labels);
 	}
 
@@ -1782,12 +1784,12 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 
 	bpi_num_labels = BGP_PATH_INFO_NUM_LABELS(bpi);
 
+	struct timeval tv = { .tv_sec = bpi && bpi->extra ? bpi->extra->bgp_rib_uptime : 0 };
+
 	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE, &bqe->p, prd,
 		    bpi ? bpi->attr : NULL, bpi, afi, safi,
-		    bpi && bpi->extra ? bpi->extra->bgp_rib_uptime
-				      : (time_t)(-1L),
-		    bpi_num_labels ? bpi->extra->labels->label : NULL,
-		    bpi_num_labels);
+		    bpi && bpi->extra && bpi->extra->bgp_rib_uptime != (time_t)(-1L) ? &tv : NULL,
+		    bpi_num_labels ? bpi->extra->labels->label : NULL, bpi_num_labels);
 	written = true;
 
 out:
@@ -1854,6 +1856,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 
 	if (CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY)) {
 		struct bgp_path_info *bpi;
+		struct timeval tv = {};
 
 		for (bpi = bgp_dest_get_bgp_path_info(bn); bpi;
 		     bpi = bpi->next) {
@@ -1863,11 +1866,15 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 				break;
 		}
 
+		if (bpi)
+			tv.tv_sec = bpi->uptime;
+		else
+			monotime(&tv);
+
 		bpi_num_labels = BGP_PATH_INFO_NUM_LABELS(bpi);
 
 		bmp_monitor(bmp, peer, BMP_PEER_FLAG_L, peer_type_flag, &bqe->p, prd,
-			    bpi ? bpi->attr : NULL, bpi, afi, safi,
-			    bpi ? bpi->uptime : monotime(NULL),
+			    bpi ? bpi->attr : NULL, bpi, afi, safi, &tv,
 			    bpi_num_labels ? bpi->extra->labels->label : NULL, bpi_num_labels);
 		written = true;
 	}
@@ -1875,15 +1882,24 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 	if (CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_PREPOLICY) &&
 	    bgp_adj_in_needed(peer, afi, safi)) {
 		struct bgp_adj_in *adjin;
+		struct timeval tv = {};
 
 		for (adjin = bn ? bn->adj_in : NULL; adjin;
 		     adjin = adjin->next) {
 			if (adjin->peer == peer)
 				break;
 		}
+
+		if (adjin) {
+			tv.tv_sec = adjin->uptime;
+			tv.tv_usec = adjin->uptime_usec;
+		} else {
+			monotime(&tv);
+		}
+
 		adjin_num_labels = adjin && adjin->labels ? adjin->labels->num_labels : 0;
 		bmp_monitor(bmp, peer, 0, peer_type_flag, &bqe->p, prd, adjin ? adjin->attr : NULL,
-			    NULL, afi, safi, adjin ? adjin->uptime : monotime(NULL),
+			    NULL, afi, safi, &tv,
 			    adjin_num_labels ? &adjin->labels->label[0] : NULL, adjin_num_labels);
 		written = true;
 	}

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_timestamps.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_timestamps.py
@@ -32,12 +32,18 @@ Checks:
   already-known prefix (same prefix, changed attribute) must carry the
   reception time of the re-announcement, not the time the prefix was
   first received.
+* pre-policy route-monitoring timestamps must carry genuine
+  microsecond precision: the microsecond components of updates
+  received seconds apart must differ, not all sit at the boot-constant
+  sub-second offset that monotime_to_realtime() fabricates from a
+  seconds-only monotonic timestamp.
 """
 
 import os
 import sys
 import pytest
 from datetime import datetime
+from itertools import combinations
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -469,6 +475,87 @@ def test_prepolicy_reannouncement_timestamp():
             second_timestamp,
             delta,
         )
+    )
+
+
+def test_prepolicy_microsecond_timestamps():
+    """
+    The previous subtest left WATCHED_PREFIX announced through
+    route-map RM-TS (community 65502:77) and produced two pre-policy
+    updates >= 5s apart.  Drive three further re-announcements by
+    changing only the route-map community, each spaced by the 5s
+    route-map delay timer, and collect the microsecond component of
+    all five updates' timestamps.  Genuine reception times of events
+    seconds apart have effectively random microseconds; the fabricated
+    ones are the boot-constant CLOCK_REALTIME-CLOCK_MONOTONIC
+    sub-second offset, identical (within ~20us of clock-read jitter)
+    for every message.  Assert the samples spread out: maximum
+    pairwise circular distance above 100us -- 5x the observed jitter
+    cluster, with a ~1e-8 false-failure probability on fixed code.
+    """
+    tgen = get_topogen()
+
+    # Deliberately no bmp_update_seq() here: the baseline set at the
+    # start of the previous subtest keeps its two updates visible.
+    def _update_with_community(community, min_seq):
+        msgs = [
+            m
+            for m in _route_messages("pre-policy", "update", WATCHED_PREFIX)
+            if m["seq"] > min_seq and m.get("communities") == community
+        ]
+        return msgs[0] if msgs else None
+
+    samples = {}
+    last_seq = 0
+
+    # The two updates the previous subtest already verified.
+    for community in ("65502:11", "65502:77"):
+        msg = _update_with_community(community, last_seq)
+        assert msg, (
+            "pre-policy update with community {} from the previous "
+            "subtest not found in the BMP log".format(community)
+        )
+        samples[community] = _parse_bmp_timestamp(msg["timestamp"]).microsecond
+        last_seq = msg["seq"]
+
+    # Three more re-announcements, each an in-place attribute change
+    # spaced by the 5s route-map delay timer.
+    for community in ("65502:101", "65502:102", "65502:103"):
+        tgen.gears["r2ts"].vtysh_cmd(
+            "configure terminal\n"
+            "route-map RM-TS permit 10\n"
+            " set community {}\n".format(community)
+        )
+
+        def _update_seen():
+            if _update_with_community(community, last_seq):
+                return True
+            return "pre-policy update with community {} not logged yet".format(
+                community
+            )
+
+        success, res = topotest.run_and_expect(_update_seen, True, count=60, wait=1)
+        assert success, (
+            "no pre-policy update carrying community {} for the "
+            "re-announcement of {}: {}".format(community, WATCHED_PREFIX, res)
+        )
+        msg = _update_with_community(community, last_seq)
+        samples[community] = _parse_bmp_timestamp(msg["timestamp"]).microsecond
+        last_seq = msg["seq"]
+
+    def _circular_distance(a, b):
+        d = abs(a - b)
+        return min(d, 1000000 - d)
+
+    max_spread = max(
+        _circular_distance(a, b) for a, b in combinations(samples.values(), 2)
+    )
+    assert max_spread > 100, (
+        "the microsecond components of {} pre-policy updates received "
+        "seconds apart all sit within {}us of each other ({}) -- bgpd "
+        "fabricated them from the boot-constant sub-second offset "
+        "between CLOCK_REALTIME and CLOCK_MONOTONIC instead of "
+        "carrying the genuine reception time".format(len(samples), max_spread, samples)
     )
 
 


### PR DESCRIPTION
BMP Route Monitoring per-peer header timestamps are reconstituted from a
seconds-only monotonic time_t, so monotime_to_realtime() fills the
microsecond field with the sub-second offset between CLOCK_REALTIME and
CLOCK_MONOTONIC -- a boot-constant value, identical in every RM message
until the host reboots.

For the pre-policy (Adj-RIB-In) feed full precision is free: the
reception time lives in struct bgp_adj_in, written in one place and read
only by BMP. Store the microseconds in the struct's padding hole (no
size growth on LP64), stamp both fields from one clock read in
bgp_adj_in_set(), and pass bmp_monitor() a monotonic struct timeval,
NULL meaning "time unavailable" in place of the (time_t)(-1L) sentinel.

Post-policy, Loc-RIB and peer-state timestamps intentionally stay
second-precision: their sources are shared time_t fields used across
bgpd.

Includes a topotest asserting that the microsecond components of
pre-policy updates received seconds apart actually differ.
