### PR TITLE
pceplib: increase sub-objects in RO object to 128

### DIFF
--- a/pceplib/pcep_msg_encoding.h
+++ b/pceplib/pcep_msg_encoding.h
@@ -55,6 +55,11 @@ struct pcep_versioning {
  * received */
 #define MAX_ITERATIONS 10
 
+/* RO objects may carry many sub-objects. For SR-TE, each segment is a
+ * sub-object.
+ */
+#define MAX_RO_ITERATIONS 128
+
 struct pcep_versioning *create_default_pcep_versioning(void);
 void destroy_pcep_versioning(struct pcep_versioning *versioning);
 

--- a/pceplib/pcep_msg_objects_encoding.c
+++ b/pceplib/pcep_msg_objects_encoding.c
@@ -1551,7 +1551,7 @@ struct pcep_object_header *pcep_decode_obj_ro(struct pcep_object_header *hdr,
 		hdr->encoded_object_length - OBJECT_HEADER_LENGTH;
 
 	while ((obj_body_length - read_count) > OBJECT_RO_SUBOBJ_HEADER_LENGTH
-	       && num_sub_objects < MAX_ITERATIONS) {
+	       && num_sub_objects <= MAX_RO_ITERATIONS) {
 		num_sub_objects++;
 		/* Read the Sub-Object Header */
 		bool flag_l = (obj_buf[read_count] & 0x80);
@@ -1975,6 +1975,13 @@ struct pcep_object_header *pcep_decode_obj_ro(struct pcep_object_header *hdr,
 		if (err_p)
 			break;
 	}
+
+	/* Warn user when sub-objects have not been decoded */
+	if (!err_p && (obj_body_length - read_count) > 0)
+		pcep_log(LOG_WARNING,
+			 "%s: RO object truncated at %d sub-objects, %d bytes left undecoded",
+			 __func__, num_sub_objects - 1,
+			 obj_body_length - read_count);
 
 	if (err_p) {
 		pcep_obj_free_object((struct pcep_object_header *)obj);


### PR DESCRIPTION
The current implementation uses 10 (MAX_ITERATIONS) as the maximum number of sub-objects allowed in an RO object.  When an RO object exceeds 9 sub-objects (counter starts at 1), the RO is truncated and the remaining sub-objects are not evaluated, and there is no log message reporting the truncation.

The modifications increase this limit to 128.  The decode loop already terminates on the RO's encoded byte length. The prevention of reading corrupted data is now increased from 10 to 128, but still maintained as a boundary. Also included is a warning statement for when truncation does occur. Now a PCE-initiated path using SR-TE can exceed 9 segments.