### PR TITLE
lib: zlog_recirculate improvements

### DIFF
--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -108,7 +108,8 @@ struct zlog_msg {
 	size_t stackbufsz;
 	char *text;
 	size_t textlen;
-	size_t hdrlen;
+	/* length of "[XXXXX-XXXXX][EC 0] ", if present */
+	size_t texthdrlen;
 
 	/* for relayed log messages ONLY (cf. zlog_recirculate_live_msg) */
 	intmax_t pid, tid;
@@ -555,7 +556,7 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 			  msg->textlen, len);
 		msg->textlen = len;
 	}
-	msg->hdrlen = MIN(hdr->texthdrlen, msg->textlen);
+	msg->texthdrlen = MIN(hdr->texthdrlen, msg->textlen);
 	msg->text = (char *)data;
 
 	/* caller needs to make sure we have a trailing \n\0, it's not
@@ -600,7 +601,7 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 		msg->fmt = xref_logmsg->fmtstring;
 	} else {
 		/* fake out format string... */
-		msg->fmt = msg->text + msg->hdrlen;
+		msg->fmt = msg->text + msg->texthdrlen;
 	}
 
 	rcu_read_lock();
@@ -827,7 +828,7 @@ const char *zlog_msg_text(struct zlog_msg *msg, size_t *textlen)
 	if (!msg->text) {
 		va_list args;
 		bool do_xid, do_ec;
-		size_t need = 0, hdrlen;
+		size_t need = 0, texthdrlen;
 		struct fbuf fb = {
 			.buf = msg->stackbuf,
 			.pos = msg->stackbuf,
@@ -847,8 +848,8 @@ const char *zlog_msg_text(struct zlog_msg *msg, size_t *textlen)
 		if (need)
 			need += bputch(&fb, ' ');
 
-		msg->hdrlen = hdrlen = need;
-		assert(hdrlen < msg->stackbufsz);
+		msg->texthdrlen = texthdrlen = need;
+		assert(texthdrlen < msg->stackbufsz);
 
 		fb.outpos = msg->argpos;
 		fb.outpos_n = array_size(msg->argpos);
@@ -870,11 +871,11 @@ const char *zlog_msg_text(struct zlog_msg *msg, size_t *textlen)
 		else {
 			msg->text = XMALLOC(MTYPE_LOG_MESSAGE, need);
 
-			memcpy(msg->text, msg->stackbuf, hdrlen);
+			memcpy(msg->text, msg->stackbuf, texthdrlen);
 
 			fb.buf = msg->text;
 			fb.len = need;
-			fb.pos = msg->text + hdrlen;
+			fb.pos = msg->text + texthdrlen;
 			fb.outpos_i = 0;
 
 			va_copy(args, msg->args);
@@ -895,14 +896,14 @@ const char *zlog_msg_text(struct zlog_msg *msg, size_t *textlen)
 	return msg->text;
 }
 
-void zlog_msg_args(struct zlog_msg *msg, size_t *hdrlen, size_t *n_argpos,
+void zlog_msg_args(struct zlog_msg *msg, size_t *texthdrlen, size_t *n_argpos,
 		   const struct fmt_outpos **argpos)
 {
 	if (!msg->text)
 		zlog_msg_text(msg, NULL);
 
-	if (hdrlen)
-		*hdrlen = msg->hdrlen;
+	if (texthdrlen)
+		*texthdrlen = msg->texthdrlen;
 	if (n_argpos)
 		*n_argpos = msg->n_argpos;
 	if (argpos)

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -536,10 +536,10 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 		return;
 
 	hdr = (struct zlog_live_hdr *)data;
-	if (hdr->hdrlen < sizeof(*hdr))
+	if (hdr->hdrlen < sizeof(*hdr) || hdr->hdrlen > len)
 		return;
 	data += hdr->hdrlen;
-	len -= sizeof(*hdr);
+	len -= hdr->hdrlen;
 
 	msg->ts.tv_sec = hdr->ts_sec;
 	msg->ts.tv_nsec = hdr->ts_nsec;
@@ -563,6 +563,7 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 	static_assert(sizeof(msg->argpos[0]) == sizeof(hdr->argpos[0]),
 		      "in-memory struct doesn't match on-wire variant");
 	msg->n_argpos = MIN(hdr->n_argpos, array_size(msg->argpos));
+	msg->n_argpos = MIN(msg->n_argpos, (hdr->hdrlen - sizeof(*hdr)) / sizeof(msg->argpos[0]));
 	memcpy(msg->argpos, hdr->argpos, msg->n_argpos * sizeof(msg->argpos[0]));
 
 	/* This will only work if we're in the same daemon: we received a log

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -547,10 +547,15 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 	msg->tid = hdr->tid;
 	msg->prio = hdr->prio;
 
-	if (hdr->textlen > len)
-		return;
 	msg->textlen = hdr->textlen;
-	msg->hdrlen = hdr->texthdrlen;
+	if (msg->textlen > len) {
+		const char *uid = hdr->uid[0] ? hdr->uid : "<no uid>";
+
+		zlog_warn("log message %s truncated in recirculation (%zu cut off to %zu)", uid,
+			  msg->textlen, len);
+		msg->textlen = len;
+	}
+	msg->hdrlen = MIN(hdr->texthdrlen, msg->textlen);
 	msg->text = (char *)data;
 
 	/* caller needs to make sure we have a trailing \n\0, it's not
@@ -560,6 +565,11 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 	    msg->text[msg->textlen + 1] != '\0')
 		return;
 
+	/* NB: even if the message is truncated, argpos are left intact.  It
+	 * just further mangled a log event that already got mangled, and
+	 * readers/consumers of these values should be resilient against
+	 * invalid offsets anyway
+	 */
 	static_assert(sizeof(msg->argpos[0]) == sizeof(hdr->argpos[0]),
 		      "in-memory struct doesn't match on-wire variant");
 	msg->n_argpos = MIN(hdr->n_argpos, array_size(msg->argpos));
@@ -590,7 +600,7 @@ void zlog_recirculate_live_msg(uint8_t *data, size_t len)
 		msg->fmt = xref_logmsg->fmtstring;
 	} else {
 		/* fake out format string... */
-		msg->fmt = msg->text + hdr->texthdrlen;
+		msg->fmt = msg->text + msg->hdrlen;
 	}
 
 	rcu_read_lock();

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -159,8 +159,8 @@ extern const struct xref_logmsg *zlog_msg_xref(struct zlog_msg *msg);
  */
 extern const char *zlog_msg_text(struct zlog_msg *msg, size_t *textlen);
 
-extern void zlog_msg_args(struct zlog_msg *msg, size_t *hdrlen,
-			  size_t *n_argpos, const struct fmt_outpos **argpos);
+extern void zlog_msg_args(struct zlog_msg *msg, size_t *texthdrlen, size_t *n_argpos,
+			  const struct fmt_outpos **argpos);
 
 /* timestamp formatting control flags */
 

--- a/lib/zlog_5424.c
+++ b/lib/zlog_5424.c
@@ -228,10 +228,11 @@ static size_t zlog_5424_one(struct zlt_5424 *zte, struct zlog_msg *msg,
 		need += bputs(fbuf, "[args@50145");
 
 		for (size_t i = 0; i < n_argpos; i++) {
-			int len = argpos[i].off_end - argpos[i].off_start;
+			unsigned int off_s = MIN(textlen, argpos[i].off_start);
+			unsigned int off_e = MIN(textlen, argpos[i].off_end);
 
-			need += bprintfrr(fbuf, " arg%zu=%*pSQsq", i + 1, len,
-					  text + argpos[i].off_start);
+			need += bprintfrr(fbuf, " arg%zu=%*pSQsq", i + 1, off_e - off_s,
+					  text + off_s);
 		}
 
 		need += bputch(fbuf, ']');
@@ -351,15 +352,16 @@ static size_t zlog_journald_one(struct zlt_5424 *zte, struct zlog_msg *msg,
 
 	if (zte->kw_args && n_argpos) {
 		for (size_t i = 0; i < n_argpos; i++) {
-			int len = argpos[i].off_end - argpos[i].off_start;
+			unsigned int off_s = MIN(textlen, argpos[i].off_start);
+			unsigned int off_e = MIN(textlen, argpos[i].off_end);
 
 			/* rather than escape the value, we could use
 			 * journald's binary encoding, but that seems a bit
 			 * excessive/unnecessary.  99% of things we print here
 			 * will just output 1:1 with %pSE.
 			 */
-			need += bprintfrr(fbuf, "FRR_ARG%zu=%*pSE\n", i + 1,
-					  len, text + argpos[i].off_start);
+			need += bprintfrr(fbuf, "FRR_ARG%zu=%*pSE\n", i + 1, off_e - off_s,
+					  text + off_s);
 		}
 	}
 

--- a/lib/zlog_targets.c
+++ b/lib/zlog_targets.c
@@ -379,12 +379,22 @@ static bool zlog_is_aux;
 
 static int zlt_aux_init(const char *prefix, int prio_min)
 {
-	zlog_is_aux = true;
-
 	zlog_aux_stdout.zt.prio_min = prio_min;
+	if (zlog_is_aux)
+		/* allow easily changing priority (zlog_aux_stdout is private
+		 * and has no associated zlog_cfg_file struct)
+		 *
+		 * this is intended for tests and doesn't make any attempt at
+		 * synchronizing with multiple threads (if that can happen, the
+		 * test shouldn't be using zlog_aux_init)
+		 */
+		return 0;
+
 	zlog_aux_stdout.zt.logfn = zlog_fd;
 	zlog_aux_stdout.zt.logfn_sigsafe = zlog_fd_sigsafe;
 	zlog_aux_stdout.fd = STDOUT_FILENO;
+
+	zlog_is_aux = true;
 
 	zlog_target_replace(NULL, &zlog_aux_stdout.zt);
 	zlog_startup_end();

--- a/tests/lib/test_zlog.c
+++ b/tests/lib/test_zlog.c
@@ -5,9 +5,16 @@
  *                     Quentin Young
  */
 #include <zebra.h>
-#include <memory.h>
-#include "log.h"
-#include "network.h"
+#include <sys/wait.h>
+
+#include "lib/memory.h"
+#include "lib/xref.h"
+#include "lib/log.h"
+#include "lib/network.h"
+#include "lib/zlog_targets.h"
+#include "lib/zlog_live.h"
+#include "lib/zlog_recirculate.h"
+#include "lib/frrevent.h"
 
 /* maximum amount of data to hexdump */
 #define MAXDATA 16384
@@ -34,16 +41,81 @@ static bool test_zlog_hexdump(void)
 	return true;
 }
 
-bool (*tests[])(void) = {
-	test_zlog_hexdump,
+static bool test_zlog_recirculate(void)
+{
+	int sockpair[2];
+	int ret;
+	pid_t child, waited;
+	struct event_loop *loop;
+	struct event evt;
+
+	/* NB: SOCK_DGRAM doesn't give HUP events => use SOCK_SEQPACKET */
+	ret = socketpair(AF_UNIX, SOCK_SEQPACKET, PF_UNSPEC, sockpair);
+	assertf(ret == 0, "socketpair: %m");
+
+	child = fork();
+	assertf(child >= 0, "fork: %m");
+	if (child == 0) {
+		static struct zlog_live_cfg child_log;
+
+		close(sockpair[0]);
+		zlog_live_open_fd(&child_log, LOG_DEBUG, sockpair[1]);
+		zlog_info("test from child");
+		zlog_info("test %-4100s from child", "truncation");
+		exit(0);
+	}
+
+	close(sockpair[1]);
+	zlog_aux_init(NULL, LOG_DEBUG);
+
+	loop = event_master_create(NULL);
+	zlog_recirculate_subscribe(loop, sockpair[0]);
+
+	/* this will exit when no events are left to handle, i.e. the child
+	 * closes the logging socket (hence having to use SOCK_SEQPACKET)
+	 */
+	while (event_fetch(loop, &evt))
+		event_call(&evt);
+
+	event_master_free(loop);
+
+	/* no close(), fd is closed by zlog_live handler when it goes dead */
+
+	waited = waitpid(child, &ret, 0);
+	assertf(waited == child, "waitpid(%jd, &ret, 0) = %jd (errno: %m)", (intmax_t)child,
+		(intmax_t)waited);
+	assertf(WIFEXITED(ret) && WEXITSTATUS(ret) == 0, "ret = %#x", ret);
+
+	return true;
+}
+
+static const struct zlog_test {
+	bool (*testfn)(void);
+	const char *name;
+} tests[] = {
+	{ test_zlog_hexdump, "hexdump" },
+	{ test_zlog_recirculate, "recirculate" },
 };
+
+XREF_SETUP();
 
 int main(int argc, char **argv)
 {
+	int rc = 0;
+
 	zlog_aux_init("NONE: ", ZLOG_DISABLED);
 
-	for (unsigned int i = 0; i < array_size(tests); i++)
-		if (!tests[i]())
-			return 1;
-	return 0;
+	for (unsigned int i = 0; i < array_size(tests); i++) {
+		/* clear back to disabled, in case previous test changed it */
+		zlog_aux_init(NULL, ZLOG_DISABLED);
+
+		if (tests[i].testfn()) {
+			printf("test %s passed\n", tests[i].name);
+		} else {
+			printf("test %s FAILED\n", tests[i].name);
+			rc = 1;
+		}
+		fflush(stdout);
+	}
+	return rc;
 }

--- a/tests/lib/test_zlog.py
+++ b/tests/lib/test_zlog.py
@@ -4,3 +4,10 @@ import frrtest
 
 class TestZlog(frrtest.TestMultiOut):
     program = "./test_zlog"
+
+
+TestZlog.onesimple("test hexdump passed")
+TestZlog.onesimple("test from child")
+TestZlog.onesimple("truncated in recirculation")
+TestZlog.onesimple("test truncation")
+TestZlog.onesimple("test recirculate passed")


### PR DESCRIPTION
* straighten out length handling
* warn about exceeding log message length & continue with truncated message rather than silently dropping
* test the thing in `make check`

Fixes: #22910