### PR TITLE
isisd: backport #22234 (per-AF adjacency usability / SPF nexthop gating) to stable/10.7

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -946,3 +946,28 @@ int isis_adj_usage2levels(enum isis_adj_usage usage)
 	assert(!"Reached end of function where we are not expecting to");
 	return -1;
 }
+
+/*
+ * Compute (fresh, never cached) whether this adjacency currently has a
+ * usable IPv4/IPv6 nexthop: the local circuit must have an address in
+ * that address family, and the neighbor must have advertised one too.
+ */
+bool isis_adj_ipv4_usable(const struct isis_adjacency *adj)
+{
+	struct isis_circuit *circuit = adj->circuit;
+
+	if (!circuit)
+		return false;
+
+	return (fabricd_ip_addrs(circuit) && adj->ipv4_address_count);
+}
+
+bool isis_adj_ipv6_usable(const struct isis_adjacency *adj)
+{
+	struct isis_circuit *circuit = adj->circuit;
+
+	if (!circuit)
+		return false;
+
+	return (listcount(circuit->ipv6_link) && adj->ll_ipv6_count);
+}

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -146,4 +146,6 @@ void isis_adj_build_up_list(struct list *adjdb, struct list *list);
 int isis_adj_usage2levels(enum isis_adj_usage usage);
 void isis_bfd_startup_timer(struct event *event);
 const char *isis_adj_name(const struct isis_adjacency *adj);
+bool isis_adj_ipv4_usable(const struct isis_adjacency *adj);
+bool isis_adj_ipv6_usable(const struct isis_adjacency *adj);
 #endif /* ISIS_ADJACENCY_H */

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -49,6 +49,7 @@
 #include "isisd/isis_tx_queue.h"
 #include "isisd/isis_nb.h"
 #include "isisd/isis_ldp_sync.h"
+#include "isisd/isis_spf.h"
 
 DEFINE_MTYPE_STATIC(ISISD, ISIS_CIRCUIT, "ISIS circuit");
 
@@ -278,6 +279,26 @@ struct isis_circuit *circuit_scan_by_ifp(struct interface *ifp)
 DEFINE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
 	    (circuit));
 
+/*
+ * A local IP address was added or removed on this circuit. Re-evaluate
+ * which address families each adjacency can still be used for (we need a
+ * local address in that AF to reach the neighbor's nexthop), then
+ * re-originate our LSP and re-run SPF so any route whose nexthop is no
+ * longer usable is withdrawn. IPv6 adjacencies keep working across an
+ * IPv4 address removal and vice versa.
+ */
+static void isis_circuit_ip_addr_change_update(struct isis_circuit *circuit)
+{
+	if (circuit->area == NULL)
+		return;
+
+	lsp_regenerate_schedule(circuit->area, circuit->is_type, 0);
+	if (circuit->is_type & IS_LEVEL_1)
+		isis_spf_schedule(circuit->area, IS_LEVEL_1);
+	if (circuit->is_type & IS_LEVEL_2)
+		isis_spf_schedule(circuit->area, IS_LEVEL_2);
+}
+
 void isis_circuit_add_addr(struct isis_circuit *circuit,
 			   struct connected *connected)
 {
@@ -308,9 +329,7 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 			SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR);
 		}
 
-		if (circuit->area)
-			lsp_regenerate_schedule(circuit->area, circuit->is_type,
-						0);
+		isis_circuit_ip_addr_change_update(circuit);
 
 #ifdef EXTREME_DEBUG
 		if (IS_DEBUG_EVENTS)
@@ -348,9 +367,7 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 				SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR6);
 			}
 		}
-		if (circuit->area)
-			lsp_regenerate_schedule(circuit->area, circuit->is_type,
-						0);
+		isis_circuit_ip_addr_change_update(circuit);
 
 #ifdef EXTREME_DEBUG
 		if (IS_DEBUG_EVENTS)
@@ -386,9 +403,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 		if (ip) {
 			listnode_delete(circuit->ip_addrs, ip);
 			prefix_ipv4_free(&ip);
-			if (circuit->area)
-				lsp_regenerate_schedule(circuit->area,
-							circuit->is_type, 0);
+			isis_circuit_ip_addr_change_update(circuit);
 		} else {
 			zlog_warn(
 				"Nonexistent ip address %pFX removal attempt from circuit %s",
@@ -449,9 +464,8 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 						  ip6))
 				zlog_warn("  %pFX", (struct prefix *)ip6);
 			zlog_warn("End of addresses");
-		} else if (circuit->area)
-			lsp_regenerate_schedule(circuit->area, circuit->is_type,
-						0);
+		} else
+			isis_circuit_ip_addr_change_update(circuit);
 
 		prefix_ipv6_free(&ipv6);
 	}

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1141,6 +1141,10 @@ static struct spf_adj_ref *adj_find(struct spf_adj_list_head *adj_list, const ui
 		if (mtid == ISIS_MT_IPV4_UNICAST &&
 		    !speaks(adj->nlpids.nlpids, adj->nlpids.count, family))
 			continue;
+		if (family == AF_INET && !isis_adj_ipv4_usable(adj))
+			continue;
+		if (family == AF_INET6 && !isis_adj_ipv6_usable(adj))
+			continue;
 		return ref;
 	}
 


### PR DESCRIPTION
Clean backport of #22234 ("isisd: track per-AF adjacency usability, gate SPF nexthops on it", merged to `master` at 07bae1d800f4 / 89e1123f2dd3, 2026-07-21) to `stable/10.7`.

**Why:** the bug this fixes is live-confirmed in a production dual-stack, multi-topology IS-IS deployment (P2P circuits, IPv4+IPv6 MT). Without per-AF adjacency-usability tracking, isisd can compute and install SPF nexthops for a node that's only reachable via one address family's adjacency and reuse that nexthop for the other AF, producing silent IPv6 route-reachability failures while the IPv4 topology looks healthy. This matches FRR's own bugfix-backport policy (applied to the two most recent releases; `10.7` and `10.6` currently) — filing since #22234 doesn't yet carry a backport label for `stable/10.7`.

**Testing done:** cherry-picked `07bae1d800f4` onto `stable/10.7` tip (`6ca4534fb415`, 2026-08-07) — applies with zero conflicts, and the resulting diff is byte-for-byte identical to the original PR's diff (4 files, +57/-12: `isisd/isis_adjacency.c`, `isisd/isis_adjacency.h`, `isisd/isis_circuit.c`, `isisd/isis_spf.c`). None of these files have been touched by any commit landed on `stable/10.7` since the `frr-10.7.0` tag, so there's no semantic drift to account for versus the original change.

Happy to provide more detail on the field symptom if useful to reviewers — it was found and confirmed via source-level code review plus live isisd/SPF state inspection on affected routers, not just log-reading.