### PR TITLE
zebra: seg6 encap with vrf lookup consistency

### DIFF
--- a/doc/user/about.rst
+++ b/doc/user/about.rst
@@ -242,6 +242,20 @@ The indicators have the following semantics:
 Known Kernel Issues
 -------------------
 
+- Linux < 7.3
+
+  SRv6 (seg6) Lookup Table - Kernels before 7.3 do not perform SID lookup
+  consistently after the encapsulation. For forwarded traffic, the kernel looks
+  up the SID in the current VRF context. For locally generated traffic, the
+  kernel looks up the SID in the default VRF (main table). This breaks VPN use
+  cases where forwarded traffic needs to resolve the SID in the default VRF
+  (e.g., veth-based VRF cross-connect). Since kernel 7.3, FRRouting ensures
+  consistent behavior across both paths by automatically using the netlink
+  attribute ``SEG6_IPTUNNEL_TABLE``. This feature explicitly tells the kernel
+  which routing table must be used for the post-encapsulation SID lookup. It is
+  silently ignored by kernels with no support, which simply fall back to the
+  default (i.e., inconsistent) behavior.
+
 - Linux 6.19 – 7.1.5 (fixed in 7.1.6+ and 7.2-rc5+)
 
   MPLS ECMP - Adding an MPLS route with multiple nexthops can mark the route

--- a/include/linux/seg6_iptunnel.h
+++ b/include/linux/seg6_iptunnel.h
@@ -21,6 +21,7 @@ enum {
 	SEG6_IPTUNNEL_UNSPEC,
 	SEG6_IPTUNNEL_SRH,
 	SEG6_IPTUNNEL_SRC, /* struct in6_addr */
+	SEG6_IPTUNNEL_TABLE, /* __u32 FIB table for post-encap SID lookup */
 	__SEG6_IPTUNNEL_MAX,
 };
 #define SEG6_IPTUNNEL_MAX (__SEG6_IPTUNNEL_MAX - 1)

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -730,7 +730,7 @@ void nexthop_del_srv6_seg6local(struct nexthop *nexthop)
 
 void nexthop_add_srv6_seg6(struct nexthop *nexthop, const struct in6_addr *segs, int num_segs,
 			   enum srv6_headend_behavior encap_behavior,
-			   const struct in6_addr *encap_source)
+			   const struct in6_addr *encap_source, uint32_t lookup_table)
 {
 	int i;
 
@@ -762,6 +762,8 @@ void nexthop_add_srv6_seg6(struct nexthop *nexthop, const struct in6_addr *segs,
 
 	if (encap_source)
 		nexthop->nh_srv6->seg6_segs->encap_source = *encap_source;
+
+	nexthop->nh_srv6->seg6_segs->lookup_table = lookup_table;
 }
 
 void nexthop_del_srv6_seg6(struct nexthop *nexthop)
@@ -970,7 +972,8 @@ void nexthop_copy_no_recurse(struct nexthop *copy,
 			nexthop_add_srv6_seg6(copy, &nexthop->nh_srv6->seg6_segs->seg[0],
 					      nexthop->nh_srv6->seg6_segs->num_segs,
 					      nexthop->nh_srv6->seg6_segs->encap_behavior,
-					      &nexthop->nh_srv6->seg6_segs->encap_source);
+					      &nexthop->nh_srv6->seg6_segs->encap_source,
+					      nexthop->nh_srv6->seg6_segs->lookup_table);
 	}
 }
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1462,6 +1462,9 @@ void nexthop_json_helper(json_object *json_nexthop, const struct nexthop *nextho
 					    &in6addr_any))
 				json_object_string_addf(json_nexthop, "srv6EncapSource", "%pI6",
 							&nexthop->nh_srv6->seg6_segs->encap_source);
+			if (nexthop->nh_srv6->seg6_segs->lookup_table)
+				json_object_int_add(json_nexthop, "srv6LookupTable",
+						    nexthop->nh_srv6->seg6_segs->lookup_table);
 		} else {
 			if (nexthop->nh_srv6->seg6_segs) {
 				json_segs = json_object_new_array();
@@ -1489,6 +1492,10 @@ void nexthop_json_helper(json_object *json_nexthop, const struct nexthop *nextho
 								"%pI6",
 								&nexthop->nh_srv6->seg6_segs
 									 ->encap_source);
+				if (nexthop->nh_srv6->seg6_segs->lookup_table)
+					json_object_int_add(json_nexthop, "srv6LookupTable",
+							    nexthop->nh_srv6->seg6_segs
+								->lookup_table);
 			}
 		}
 	}
@@ -1632,6 +1639,9 @@ void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,
 					    &in6addr_any))
 				vty_out(vty, ", encap source %pI6",
 					&nexthop->nh_srv6->seg6_segs->encap_source);
+			if (nexthop->nh_srv6->seg6_segs->lookup_table)
+				vty_out(vty, ", lookup table %u",
+					nexthop->nh_srv6->seg6_segs->lookup_table);
 		}
 	}
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -100,6 +100,12 @@ static int _nexthop_srv6_cmp(const struct nexthop *nh1,
 	if (ret != 0)
 		return ret;
 
+	if (nh1->nh_srv6->seg6_segs->lookup_table > nh2->nh_srv6->seg6_segs->lookup_table)
+		return 1;
+
+	if (nh1->nh_srv6->seg6_segs->lookup_table < nh2->nh_srv6->seg6_segs->lookup_table)
+		return -1;
+
 	if (nh1->nh_srv6->seg6_segs->num_segs < nh2->nh_srv6->seg6_segs->num_segs)
 		return -1;
 
@@ -918,6 +924,7 @@ uint32_t nexthop_hash(const struct nexthop *nexthop)
 				key = jhash_1word(nexthop->nh_srv6->seg6_segs->encap_behavior, key);
 				key = jhash(&nexthop->nh_srv6->seg6_segs->encap_source,
 					    sizeof(struct in6_addr), key);
+				key = jhash_1word(nexthop->nh_srv6->seg6_segs->lookup_table, key);
 			}
 		}
 	}

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -209,7 +209,7 @@ void nexthop_add_srv6_seg6local(struct nexthop *nexthop, uint32_t action,
 void nexthop_del_srv6_seg6local(struct nexthop *nexthop);
 void nexthop_add_srv6_seg6(struct nexthop *nexthop, const struct in6_addr *seg, int num_segs,
 			   enum srv6_headend_behavior encap_behavior,
-			   const struct in6_addr *encap_source);
+			   const struct in6_addr *encap_source, uint32_t lookup_table);
 void nexthop_del_srv6_seg6(struct nexthop *nexthop);
 
 /*

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -116,6 +116,9 @@ struct seg6_seg_stack {
 	/* optional encapsulation source address */
 	struct in6_addr encap_source;
 
+	/* optional post-encap lookup table */
+	uint32_t lookup_table;
+
 	uint8_t num_segs;
 	struct in6_addr seg[0]; /* 1 or more segs */
 };

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2459,7 +2459,7 @@ struct nexthop *nexthop_from_zapi_nexthop(const struct zapi_nexthop *znh)
 
 	if (znh->seg_num && !sid_zero_ipv6(znh->seg6_segs))
 		nexthop_add_srv6_seg6(n, &znh->seg6_segs[0], znh->seg_num,
-				      znh->srv6_encap_behavior, &znh->srv6_encap_source);
+				      znh->srv6_encap_behavior, &znh->srv6_encap_source, 0);
 
 	return n;
 }

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -459,7 +459,7 @@ DEFPY (install_seg6_routes,
 	sg.r.nhop.gate.ipv6 = seg6_nh6;
 	sg.r.nhop.vrf_id = vrf->vrf_id;
 	sg.r.nhop_group.nexthop = &sg.r.nhop;
-	nexthop_add_srv6_seg6(&sg.r.nhop, &seg6_seg, 1, SRV6_HEADEND_BEHAVIOR_H_ENCAPS, NULL);
+	nexthop_add_srv6_seg6(&sg.r.nhop, &seg6_seg, 1, SRV6_HEADEND_BEHAVIOR_H_ENCAPS, NULL, 0);
 
 	sg.r.vrf_id = vrf->vrf_id;
 	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, 0, &sg.r.nhop_group,
@@ -559,7 +559,7 @@ DEFPY(install_seg6local_segs_routes, install_seg6local_segs_routes_cmd,
 	sg.r.nhop_group.nexthop = &sg.r.nhop;
 	seg_list[0] = seg6_seg1;
 	seg_list[1] = seg6_seg2;
-	nexthop_add_srv6_seg6(&sg.r.nhop, p_seg_list, 2, SRV6_HEADEND_BEHAVIOR_H_ENCAPS, NULL);
+	nexthop_add_srv6_seg6(&sg.r.nhop, p_seg_list, 2, SRV6_HEADEND_BEHAVIOR_H_ENCAPS, NULL, 0);
 
 	sg.r.vrf_id = vrf->vrf_id;
 	sharp_install_routes_helper(&sg.r.orig_prefix, sg.r.vrf_id, sg.r.inst, 0, &sg.r.nhop_group,

--- a/tests/topotests/zebra_seg6_lookup_table/r1/fib_v4.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/fib_v4.json
@@ -1,0 +1,44 @@
+[
+	{
+		"dst": "1.1.1.0/24",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"]
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "2.2.2.0/24",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"],
+			"lookup": "main"
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "3.3.3.0/24",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec1::ff"],
+			"lookup": "1001"
+		},
+		"dev": "eth1"
+	},
+
+	{
+		"dst": "4.4.4.0/24",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"],
+			"lookup": "main"
+		},
+		"dev": "eth0"
+	}
+]

--- a/tests/topotests/zebra_seg6_lookup_table/r1/fib_v4_vrfA.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/fib_v4_vrfA.json
@@ -1,0 +1,27 @@
+[
+	{
+		"dst": "5.5.5.0/24",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"],
+			"lookup": "main"
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "6.6.6.0/24",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec1::ff"],
+			"lookup": "1001"
+		},
+		"via": {
+			"family": "inet6",
+			"host": "fec1::2"
+		},
+		"dev": "eth1"
+	}
+]

--- a/tests/topotests/zebra_seg6_lookup_table/r1/fib_v6.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/fib_v6.json
@@ -1,0 +1,49 @@
+[
+	{
+		"dst": "2001:db8:1::/48",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"]
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "2001:db8:2::/48",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"],
+			"lookup": "main"
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "2001:db8:3::/48",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec1::ff"],
+			"lookup": "1001"
+		},
+		"dev": "eth1"
+	},
+
+	{
+		"dst": "2001:db8:4::/48",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"],
+			"lookup": "main"
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "fec0::/64",
+		"dev": "eth0"
+	}
+]

--- a/tests/topotests/zebra_seg6_lookup_table/r1/fib_v6_vrfA.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/fib_v6_vrfA.json
@@ -1,0 +1,39 @@
+[
+	{
+		"dst": "2001:db8:5::/48",
+		"encap": {
+			"encap_type": "seg6",
+			"mode": "encap",
+			"segs": ["fec0::ff"],
+			"lookup": "main"
+		},
+		"dev": "eth0"
+	},
+
+	{
+		"dst": "2001:db8:6::/48",
+		"nexthops": [
+			{
+				"encap": {
+					"encap_type": "seg6",
+					"mode": "encap",
+					"segs": ["fec1::ff"],
+					"lookup": "1001"
+				},
+				"gateway": "fec1::2",
+				"dev": "eth1"
+			}
+		]
+	},
+
+	{
+		"type": "local",
+		"dst": "fec1::1",
+		"dev": "eth1"
+	},
+
+	{
+		"dst": "fec1::/64",
+		"dev": "eth1"
+	}
+]

--- a/tests/topotests/zebra_seg6_lookup_table/r1/frr.conf
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/frr.conf
@@ -1,0 +1,21 @@
+!
+hostname r1
+!
+vrf vrfA
+exit-vrf
+!
+interface eth0
+  ipv6 address fec0::1/64
+exit
+!
+interface eth1 vrf vrfA
+  ipv6 address fec1::1/64
+exit
+!
+ip route 4.4.4.0/24 eth0 segments fec0::ff
+ip route 5.5.5.0/24 eth0 segments fec0::ff table 1001
+ip route 6.6.6.0/24 fec1::2 segments fec1::ff nexthop-vrf vrfA table 1001
+ipv6 route 2001:db8:4::/48 eth0 segments fec0::ff
+ipv6 route 2001:db8:5::/48 eth0 segments fec0::ff table 1001
+ipv6 route 2001:db8:6::/48 fec1::2 segments fec1::ff nexthop-vrf vrfA table 1001
+!

--- a/tests/topotests/zebra_seg6_lookup_table/r1/rib_v4.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/rib_v4.json
@@ -1,0 +1,101 @@
+{
+	"1.1.1.0/24": [
+		{
+			"protocol": "kernel",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "1.1.1.0/24",
+			"prefixLen": 24,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps"
+				}
+			]
+		}
+	],
+
+	"2.2.2.0/24": [
+		{
+			"protocol": "kernel",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2.2.2.0/24",
+			"prefixLen": 24,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 254
+				}
+			]
+		}
+	],
+
+	"3.3.3.0/24": [
+		{
+			"protocol": "kernel",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "3.3.3.0/24",
+			"prefixLen": 24,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth1",
+					"vrf": "vrfA",
+					"active": true,
+					"seg6": {
+						"segs": "fec1::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 1001
+				}
+			]
+		}
+	],
+
+	"4.4.4.0/24": [
+		{
+			"protocol": "static",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "4.4.4.0/24",
+			"prefixLen": 24,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 254
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/zebra_seg6_lookup_table/r1/rib_v4_vrfA.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/rib_v4_vrfA.json
@@ -1,0 +1,53 @@
+{
+	"5.5.5.0/24": [
+		{
+			"protocol": "static",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "5.5.5.0/24",
+			"prefixLen": 24,
+			"table": 1001,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 254
+				}
+			]
+		}
+	],
+
+	"6.6.6.0/24": [
+		{
+			"protocol": "static",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "6.6.6.0/24",
+			"prefixLen": 24,
+			"table": 1001,
+			"nexthops": [
+				{
+					"fib": true,
+					"ip": "fec1::2",
+					"afi": "ipv6",
+					"interfaceName": "eth1",
+					"vrf": "vrfA",
+					"active": true,
+					"seg6": {
+						"segs": "fec1::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 1001
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/zebra_seg6_lookup_table/r1/rib_v6.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/rib_v6.json
@@ -1,0 +1,141 @@
+{
+	"2001:db8:1::/48": [
+		{
+			"protocol": "kernel",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2001:db8:1::/48",
+			"prefixLen": 48,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps"
+				}
+			]
+		}
+	],
+
+	"2001:db8:2::/48": [
+		{
+			"protocol": "kernel",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2001:db8:2::/48",
+			"prefixLen": 48,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 254
+				}
+			]
+		}
+	],
+
+	"2001:db8:3::/48": [
+		{
+			"protocol": "kernel",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2001:db8:3::/48",
+			"prefixLen": 48,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth1",
+					"vrf": "vrfA",
+					"active": true,
+					"seg6": {
+						"segs": "fec1::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 1001
+				}
+			]
+		}
+	],
+
+	"2001:db8:4::/48": [
+		{
+			"protocol": "static",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2001:db8:4::/48",
+			"prefixLen": 48,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 254
+				}
+			]
+		}
+	],
+
+	"fec0::/64": [
+		{
+			"protocol": "connected",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "fec0::/64",
+			"prefixLen": 64,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true
+				}
+			]
+		}
+	],
+
+	"fec0::1/128": [
+		{
+			"protocol": "local",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "fec0::1/128",
+			"prefixLen": 128,
+			"table": 254,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/zebra_seg6_lookup_table/r1/rib_v6_vrfA.json
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/rib_v6_vrfA.json
@@ -1,0 +1,93 @@
+{
+	"2001:db8:5::/48": [
+		{
+			"protocol": "static",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2001:db8:5::/48",
+			"prefixLen": 48,
+			"table": 1001,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth0",
+					"active": true,
+					"seg6": {
+						"segs": "fec0::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 254
+				}
+			]
+		}
+	],
+
+	"2001:db8:6::/48": [
+		{
+			"protocol": "static",
+			"selected": true,
+			"installed": true,
+			"vrfId": 0,
+			"prefix": "2001:db8:6::/48",
+			"prefixLen": 48,
+			"table": 1001,
+			"nexthops": [
+				{
+					"fib": true,
+					"ip": "fec1::2",
+					"afi": "ipv6",
+					"interfaceName": "eth1",
+					"vrf": "vrfA",
+					"active": true,
+					"seg6": {
+						"segs": "fec1::ff"
+					},
+					"srv6EncapBehavior": "H.Encaps",
+					"srv6LookupTable": 1001
+				}
+			]
+		}
+	],
+
+	"fec1::/64": [
+		{
+			"protocol": "connected",
+			"selected": true,
+			"installed": true,
+			"vrfName": "vrfA",
+			"prefix": "fec1::/64",
+			"prefixLen": 64,
+			"table": 1001,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth1",
+					"active": true
+				}
+			]
+		}
+	],
+
+	"fec1::1/128": [
+		{
+			"protocol": "local",
+			"selected": true,
+			"installed": true,
+			"vrfName": "vrfA",
+			"prefix": "fec1::1/128",
+			"prefixLen": 128,
+			"table": 1001,
+			"nexthops": [
+				{
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "eth1",
+					"active": true
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/zebra_seg6_lookup_table/r1/setup.sh
+++ b/tests/topotests/zebra_seg6_lookup_table/r1/setup.sh
@@ -1,0 +1,17 @@
+ip link add eth0 type dummy
+ip link set eth0 up
+
+ip link add vrfA type vrf table 1001
+ip link set dev vrfA up
+
+ip link add eth1 type dummy
+ip link set dev eth1 master vrfA
+ip link set eth1 up
+
+ip r a 1.1.1.0/24 encap seg6 mode encap segs fec0::ff dev eth0
+ip r a 2.2.2.0/24 encap seg6 mode encap segs fec0::ff lookup 254 dev eth0
+ip r a 3.3.3.0/24 encap seg6 mode encap segs fec1::ff lookup 1001 dev eth1
+
+ip -6 r a 2001:db8:1::/48 encap seg6 mode encap segs fec0::ff dev eth0
+ip -6 r a 2001:db8:2::/48 encap seg6 mode encap segs fec0::ff lookup 254 dev eth0
+ip -6 r a 2001:db8:3::/48 encap seg6 mode encap segs fec1::ff lookup 1001 dev eth1

--- a/tests/topotests/zebra_seg6_lookup_table/test_zebra_seg6_encap_lookup.py
+++ b/tests/topotests/zebra_seg6_lookup_table/test_zebra_seg6_encap_lookup.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright 2026 6WIND S.A.
+# Justin Iurman <justin.iurman@6wind.com>
+#
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import required_linux_kernel_version
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+
+def open_json_file(filename):
+    try:
+        with open(filename, "r") as f:
+            return json.load(f)
+    except IOError:
+        assert False, "Could not read file {}".format(filename)
+
+
+def setup_module(mod):
+    result = required_linux_kernel_version("7.3")
+    if result is not True:
+        pytest.skip("SRv6 lookup table: kernel version should be >=7.3")
+
+    topodef = {None: ("r1")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, (rname, router) in enumerate(router_list.items()):
+        router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+
+def teardown_module():
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_zebra_seg6_lookup_table():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _check_rib(router, cmd, expected_file):
+        logger.info("checking the RIB: {}".format(cmd))
+        output = json.loads(router.vtysh_cmd(cmd))
+        expected = open_json_file("{}/{}".format(CWD, expected_file))
+        return topotest.json_cmp(output, expected)
+
+    def check_rib(router, cmd, expected_file):
+        func = functools.partial(_check_rib, router, cmd, expected_file)
+        _, result = topotest.run_and_expect(func, None, count=10, wait=2)
+        assert result is None, "Failed"
+
+    def _check_fib(router, cmd, expected_file):
+        logger.info("checking the FIB: {}".format(cmd))
+        output = json.loads(router.cmd(cmd))
+        expected = open_json_file("{}/{}".format(CWD, expected_file))
+        return topotest.json_cmp(output, expected)
+
+    def check_fib(router, cmd, expected_file):
+        func = functools.partial(_check_fib, router, cmd, expected_file)
+        _, result = topotest.run_and_expect(func, None, count=10, wait=2)
+        assert result is None, "Failed"
+
+    router = tgen.gears["r1"]
+    logger.info("Test for SRv6 lookup table")
+
+    check_rib(router, "show ip route json", "r1/rib_v4.json")
+    check_rib(router, "show ip route vrf vrfA json", "r1/rib_v4_vrfA.json")
+    check_rib(router, "show ipv6 route json", "r1/rib_v6.json")
+    check_rib(router, "show ipv6 route vrf vrfA json", "r1/rib_v6_vrfA.json")
+
+    check_fib(router, "ip -j route show", "r1/fib_v4.json")
+    check_fib(router, "ip -j route show table 1001", "r1/fib_v4_vrfA.json")
+    check_fib(router, "ip -j -6 route show", "r1/fib_v6.json")
+    check_fib(router, "ip -j -6 route show table 1001", "r1/fib_v6_vrfA.json")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -644,7 +644,8 @@ parse_nexthop_unicast(ns_id_t ns_id, struct rtmsg *rtm, struct rtattr **tb,
 		nexthop_add_srv6_seg6local(&nh, seg6l_act, &seg6l_ctx);
 
 	if (num_segs)
-		nexthop_add_srv6_seg6(&nh, segs, num_segs, srv6_encap_behavior, &srv6_encap_source);
+		nexthop_add_srv6_seg6(&nh, segs, num_segs, srv6_encap_behavior, &srv6_encap_source,
+				      srv6_lookup_table);
 
 	return nh;
 }
@@ -765,7 +766,7 @@ static uint16_t parse_multipath_nexthops_unicast(ns_id_t ns_id, struct nexthop_g
 
 			if (num_segs)
 				nexthop_add_srv6_seg6(nh, segs, num_segs, srv6_encap_behavior,
-						      &srv6_encap_source);
+						      &srv6_encap_source, srv6_lookup_table);
 
 			if (rtnh->rtnh_flags & RTNH_F_ONLINK)
 				SET_FLAG(nh->flags, NEXTHOP_FLAG_ONLINK);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -493,7 +493,7 @@ parse_encap_seg6local(struct rtattr *tb,
 
 static int parse_encap_seg6(struct rtattr *tb, struct in6_addr *segs,
 			    enum srv6_headend_behavior *encap_behavior,
-			    struct in6_addr *encap_source)
+			    struct in6_addr *encap_source, uint32_t *lookup_table)
 {
 	struct rtattr *tb_encap[SEG6_IPTUNNEL_MAX + 1] = {};
 	struct seg6_iptunnel_encap *ipt = NULL;
@@ -530,6 +530,11 @@ static int parse_encap_seg6(struct rtattr *tb, struct in6_addr *segs,
 			memset(encap_source, 0, sizeof(struct in6_addr));
 		}
 
+		if (tb_encap[SEG6_IPTUNNEL_TABLE])
+			*lookup_table = *(uint32_t *)RTA_DATA(tb_encap[SEG6_IPTUNNEL_TABLE]);
+		else
+			*lookup_table = 0;
+
 		ind_seg6 = ipt->srh[0].first_segment;
 		if (ind_seg6 >= SRV6_MAX_SIDS) {
 			ind_seg6 = SRV6_MAX_SIDS - 1;
@@ -564,6 +569,7 @@ parse_nexthop_unicast(ns_id_t ns_id, struct rtmsg *rtm, struct rtattr **tb,
 	int num_segs = 0;
 	enum srv6_headend_behavior srv6_encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
 	struct in6_addr srv6_encap_source = {};
+	uint32_t srv6_lookup_table = 0;
 
 	vrf_id_t nh_vrf_id = vrf_id;
 	size_t sz = (afi == AFI_IP) ? 4 : 16;
@@ -612,7 +618,7 @@ parse_nexthop_unicast(ns_id_t ns_id, struct rtmsg *rtm, struct rtattr **tb,
 	    && *(uint16_t *)RTA_DATA(tb[RTA_ENCAP_TYPE])
 		       == LWTUNNEL_ENCAP_SEG6) {
 		num_segs = parse_encap_seg6(tb[RTA_ENCAP], segs, &srv6_encap_behavior,
-					    &srv6_encap_source);
+					    &srv6_encap_source, &srv6_lookup_table);
 	}
 
 	if (rtm->rtm_flags & RTNH_F_ONLINK)
@@ -660,6 +666,7 @@ static uint16_t parse_multipath_nexthops_unicast(ns_id_t ns_id, struct nexthop_g
 	enum srv6_headend_behavior srv6_encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
 	struct rtattr *rtnh_tb[RTA_MAX + 1] = {};
 	struct in6_addr srv6_encap_source = {};
+	uint32_t srv6_lookup_table = 0;
 
 	int len = RTA_PAYLOAD(tb[RTA_MULTIPATH]);
 	vrf_id_t nh_vrf_id = vrf_id;
@@ -714,7 +721,7 @@ static uint16_t parse_multipath_nexthops_unicast(ns_id_t ns_id, struct nexthop_g
 				       == LWTUNNEL_ENCAP_SEG6) {
 				num_segs = parse_encap_seg6(rtnh_tb[RTA_ENCAP], segs,
 							    &srv6_encap_behavior,
-							    &srv6_encap_source);
+							    &srv6_encap_source, &srv6_lookup_table);
 			}
 		}
 
@@ -1925,6 +1932,10 @@ static bool _netlink_nexthop_encode_seg6_info(struct nlmsghdr *nlmsg, size_t buf
 	if (!sid_zero_ipv6(&segs->encap_source) &&
 	    !nl_attr_put(nlmsg, buflen, SEG6_IPTUNNEL_SRC, &segs->encap_source,
 			 sizeof(struct in6_addr)))
+		return false;
+
+	if (segs->lookup_table &&
+	    !nl_attr_put32(nlmsg, buflen, SEG6_IPTUNNEL_TABLE, segs->lookup_table))
 		return false;
 
 	return true;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1850,6 +1850,7 @@ static bool zapi_read_nexthops(struct zserv *client, struct prefix *p,
 		char nhbuf[NEXTHOP_STRLEN];
 		char labelbuf[MPLS_LABEL_STRLEN];
 		struct zapi_nexthop *api_nh = &nhops[i];
+		struct zebra_vrf *zvrf;
 
 		/* Convert zapi nexthop */
 		nexthop = nexthop_from_zapi(api_nh, flags, p, backup_nh_num);
@@ -1917,9 +1918,12 @@ static bool zapi_read_nexthops(struct zserv *client, struct prefix *p,
 			if (IS_ZEBRA_DEBUG_RECV)
 				zlog_debug("%s: adding seg6", __func__);
 
+			zvrf = zebra_vrf_lookup_by_id(nexthop->vrf_id);
+
 			nexthop_add_srv6_seg6(nexthop, &api_nh->seg6_segs[0], api_nh->seg_num,
 					      api_nh->srv6_encap_behavior,
-					      &api_nh->srv6_encap_source);
+					      &api_nh->srv6_encap_source,
+					      zvrf ? zvrf->table_id : rt_table_main_id);
 		}
 
 		if (IS_ZEBRA_DEBUG_RECV) {

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2069,7 +2069,8 @@ static struct nexthop *nexthop_set_resolved(afi_t afi, const struct nexthop *new
 			nexthop_add_srv6_seg6(resolved_hop, &nexthop->nh_srv6->seg6_segs->seg[0],
 					      nexthop->nh_srv6->seg6_segs->num_segs,
 					      nexthop->nh_srv6->seg6_segs->encap_behavior,
-					      &nexthop->nh_srv6->seg6_segs->encap_source);
+					      &nexthop->nh_srv6->seg6_segs->encap_source,
+					      nexthop->nh_srv6->seg6_segs->lookup_table);
 	}
 
 	/* Handle evpn nexthop - capture that info also */


### PR DESCRIPTION
The kernel's seg6 lwtunnel had inconsistent vrf lookups: forwarded traffic used the overlay VRF, while (output) local traffic used the main table. A shared cache between the two paths caused state overwrites, which has been fixed and backported since then. Now, the seg6 lwtunnel (seg6_iptunnel) uses two caches: one for the input path (forward) and one for the output path. Because of this fix, some use cases that were working previously ("by chance") are not working anymore.                                                              

Fortunately, a new SEG6_IPTUNNEL_TABLE netlink attribute has been introduced to explicitly define the post-encap fib table, which also happens to maintain consistency between the two paths. Without this attribute, several SRv6 scenarios now break in the forwarding (input) path. For example, if an overlay route in vrfA (table 10) encapsulates traffic to SID 2001:db8:dead:beef::ff, the kernel strictly performs the post-encap lookup in table 10 (for forwarded packets). If the underlay route is installed inside the main table (254), the lookup fails and traffic is dropped.            

This patch implicitly binds the seg6 lookup to the nexthop's vrf table and installs routes accordingly. Kernels with no support (< 7.3) would simply ignore it and automatically fallback on old behavior.