### PR TITLE
tests: edit bgp_evpn_rt5_addpath to pass on 10.5 branch

### DIFF
--- a/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
+++ b/tests/topotests/bgp_evpn_rt5_addpath/test_bgp_evpn_rt5_addpath.py
@@ -797,17 +797,6 @@ def test_bgp_evpn_rt5_addpath_route_map():
     """
     )
 
-    def _check_route_map_unused():
-        output = json.loads(r1.vtysh_cmd("show route-map-unused json"))
-        if "set-pref" not in output.get("bgpd", {}):
-            return "set-pref is still in use"
-        return None
-
-    _, result = topotest.run_and_expect(_check_route_map_unused, None, count=20, wait=1)
-    assert result is None, (
-        "set-pref should be unused after removing it from advertise " "ipv4 unicast"
-    )
-
     logger.info("Cleaning up")
     r1.vtysh_cmd("""
         conf


### PR DESCRIPTION
The bgp_evpn_rt5_addpath topotest uses a cli that ... does not exist in 10.5. Excise that one test case, to allow the full test to run.
