### PR TITLE
bgpd, zebra: Fix unnecessary zlog_warn

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1608,12 +1608,23 @@ bgp_evpn_es_vtep_add(struct bgp *bgp, struct bgp_evpn_es *es,
 			   &es_vtep->vtep_ip, esr ? "esr" : "ead", df_alg, df_pref);
 
 	if (esr) {
+		bool had_esr = CHECK_FLAG(es_vtep->flags, BGP_EVPNES_VTEP_ESR);
+
 		SET_FLAG(es_vtep->flags, BGP_EVPNES_VTEP_ESR);
 		if ((es_vtep->df_pref != df_pref)
 		    || (es_vtep->df_alg != df_alg)) {
 			param_change = true;
 			es_vtep->df_pref = df_pref;
 			es_vtep->df_alg = df_alg;
+		}
+		/* FRR only implements preference-based DF election */
+		if (df_alg != EVPN_MH_DF_ALG_PREF && (!had_esr || param_change)) {
+			char alg_buf[EVPN_DF_ALG_STR_LEN];
+
+			zlog_warn("es %s vtep %pIA Type-4 ESR df_alg %s (%u); only preference (%u) is supported",
+				  es->esi_str, &vtep_ip,
+				  evpn_es_df_alg2str(df_alg, alg_buf, sizeof(alg_buf)), df_alg,
+				  EVPN_MH_DF_ALG_PREF);
 		}
 	} else {
 		++es_vtep->evi_cnt;

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2755,10 +2755,6 @@ int zebra_evpn_remote_es_add(const esi_t *esi, struct ipaddr *vtep_ip, bool esr_
 		}
 	}
 
-	if (df_alg != EVPN_MH_DF_ALG_PREF)
-		zlog_warn("remote es %s vtep %pIA add %s with unsupported df_alg %d",
-			  esi_to_str(esi, buf, sizeof(buf)), vtep_ip, esr_rxed ? "esr" : "", df_alg);
-
 	zebra_evpn_es_vtep_add(es, vtep_ip, esr_rxed, df_alg, df_pref);
 	zebra_evpn_es_remote_info_re_eval(&es);
 


### PR DESCRIPTION
Zebra is frequently putting out this warning:

026-07-17T09:46:33.634092-05:00 SMS-LFS-201 zebra[24596]: [VB5HM-D56CP] remote es 03:12:d3:4f:8a:36:ad:7b:24:f0 vtep 198.19.39.214 add with unsupported df_alg 0
2026-07-17T11:03:45.472308-05:00 SMS-LFS-201 zebra[24596]: [VB5HM-D56CP] remote es 03:12:d3:4f:d6:5e:e2:68:25:8a vtep 198.19.39.214 add with unsupported df_alg 0
2026-07-17T12:25:17.911831-05:00 SMS-LFS-201 zebra[24596]: [VB5HM-D56CP] remote es 03:12:d3:4f:d6:5e:e2:68:25:8a vtep 198.19.39.214 add with unsupported df_alg 0

Upon investigation, this warning is to allow the operator to know that FRR has received a df_algorithm that it does not currently support.  The problem is, is that the df_alg is specified in a type 4 route, yet a type 1 route received can cause the creation of the remote es in zebra.  the type 1 evpn route does not carry what to do with bum traffic, it just says forward for this unicast neighbor in isolation.  The type 4 evpn route specifies how to handle bum traffic.  As such BGP is receiving the type 1 route first, installing the remote es to handle the unicast traffic.  Zebra is then warning about the bum traffic problem when we have made no decision about what to do with bum traffic at this point.  Then when the type 4 route is received we specify the df algorithm.

Let's move the warning from zebra into bgp itself, with an actual warning on the reception of the type 4 route with a df_alg that is not supported currently.  That way the spurious error is no longer received.