### PR TITLE
zebra: fix use-after-free in EVPN neigh-MAC linkage on gateway MACIP takeover

### DIFF
--- a/tests/topotests/bgp_evpn_svi_anycast_gw/leaf1/frr.conf
+++ b/tests/topotests/bgp_evpn_svi_anycast_gw/leaf1/frr.conf
@@ -1,0 +1,24 @@
+!
+interface lo
+ ip address 10.10.10.10/32
+!
+interface leaf1-eth0
+ ip address 10.20.1.1/24
+!
+!
+ip route 10.30.30.30/32 10.20.1.2
+!
+!
+router bgp 65000
+ timers bgp 3 9
+ bgp router-id 10.10.10.10
+ no bgp default ipv4-unicast
+ neighbor 10.30.30.30 remote-as 65000
+ neighbor 10.30.30.30 update-source lo
+ neighbor 10.30.30.30 timers 3 10
+ address-family l2vpn evpn
+  neighbor 10.30.30.30 activate
+  advertise-all-vni
+  advertise-default-gw
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_svi_anycast_gw/leaf2/frr.conf
+++ b/tests/topotests/bgp_evpn_svi_anycast_gw/leaf2/frr.conf
@@ -1,0 +1,23 @@
+!
+interface lo
+ ip address 10.30.30.30/32
+!
+interface leaf2-eth0
+ ip address 10.20.1.2/24
+!
+!
+ip route 10.10.10.10/32 10.20.1.1
+!
+!
+router bgp 65000
+ timers bgp 3 9
+ bgp router-id 10.30.30.30
+ no bgp default ipv4-unicast
+ neighbor 10.10.10.10 remote-as 65000
+ neighbor 10.10.10.10 update-source lo
+ neighbor 10.10.10.10 timers 3 10
+ address-family l2vpn evpn
+  neighbor 10.10.10.10 activate
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_svi_anycast_gw/test_anycast_gw_neigh_linkage.py
+++ b/tests/topotests/bgp_evpn_svi_anycast_gw/test_anycast_gw_neigh_linkage.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_anycast_gw_neigh_linkage.py
+#
+# Copyright (c) 2026 Robin Christ for partimus GmbH
+#
+
+"""
+test_anycast_gw_neigh_linkage.py:
+
+Regression test for zebra's EVPN neigh-MAC linkage on gateway MACIP
+takeover.
+
+Two VTEPs share an anycast gateway subnet, each with its own gateway
+MAC (no macvlan, no EVPN-MH). leaf1 carries the anycast gateway IPs
+on its SVIs and runs advertise-default-gw from the start. leaf2
+starts without the anycast addresses, so it installs leaf1's
+default-gw MAC+IP binding (which leaf1 advertises as Route Type 2 with 
+Default Gateway Extended Community) as an ordinary remote neighbor.
+The test is built so that it should also be valid later when FRR gains
+proper support for RFC 7432 "Default Gateway Extended Community"
+on received routes (basically MAC aliasing of remote default-gw MACs),
+which at the time of writing this text is not the case.
+
+The test works through the following steps:
+
+1. leaf1 configures the anycast addresses on its SVIs and has
+   advertise-default-gw enabled in its startup config. It will thus
+   advertise Route Type 2 with Default Gateway Extended Community
+   for those anycast addresses, which leaf2 installs as ordinary
+   remote neighbors (leaf2 does NOT yet have the anycast addresses
+   configured or advertise-default-gw enabled)
+   
+2. leaf2 configures the anycast addresses on its SVIs and then
+   enables advertise-default-gw while the anycast addresses advertised
+   by leaf1 are installed as ordinary remote neighbors.
+   zebra's zebra_evpn_neigh_gw_macip_add reuses the existing neighbor
+   entry and rewrites its MAC binding.
+
+3. leaf1 issues "no advertise-default-gw" and thus withdraws the
+   Route Type 2 with the anycast gateway MACIP bindings and the
+   Default Gateway Extended Community.
+   zebra's zebra_evpn_neigh_del on leaf2 deletes the reused neighbor.
+
+zebra used to rewrite n->emac in step 2 without re-parenting the
+neighbor onto the gateway MAC, so step 3 freed the neighbor while the
+old MAC's neigh_list still pointed at it. This results in a
+heap-use-after-free in remote_neigh_count, which under ASAN will
+make zebra abort while processing the withdrawal.
+
+The test runs the sequence twice and checks that leaf2 processes the
+withdrawal and stays alive.
+"""
+
+import json
+import os
+import sys
+from functools import partial
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.evpn import evpn_verify_bgp_vni_state, evpn_verify_vni_remote_vteps
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd]
+
+VNIS = [100, 200]
+GW_IPS = {100: "10.0.100.1", 200: "10.0.200.1"}
+GW_PLEN = 24
+LEAF_LO = {"leaf1": "10.10.10.10", "leaf2": "10.30.30.30"}
+LEAF_MACS = {
+    "leaf1": "00:be:ef:00:00:01",
+    "leaf2": "00:be:ef:00:00:02",
+}
+
+
+def build_topo(tgen):
+    "Two leaves back to back over the underlay, no hosts needed."
+    tgen.add_router("leaf1")
+    tgen.add_router("leaf2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["leaf1"])
+    switch.add_link(tgen.gears["leaf2"])
+
+
+def config_leaf_dataplane(leaf, name, svi_mac, with_gw_addrs):
+    """
+    Set up the VTEP dataplane on one leaf: vlan-aware bridge, a single
+    vxlan device carrying every VNI, and one SVI per vlan. With
+    with_gw_addrs the SVI carries the anycast gateway address directly.
+    svi_mac is used for the bridge and every SVI of this leaf, so each
+    leaf owns the shared gateway IPs with its own MAC.
+
+    The vlan to VNI mapping lives on the single vxlan device as per-vlan
+    tunnel_info, so vlan N carries VNI N.
+    """
+    lo_ip = LEAF_LO[name]
+
+    leaf.run("ip link add dev bridge type bridge stp_state 0")
+    leaf.run("ip link set dev bridge type bridge vlan_filtering 1")
+    leaf.run("ip link set dev bridge type bridge mcast_snooping 0")
+    leaf.run("ip link set dev bridge address %s" % svi_mac)
+    leaf.run("ip link set dev bridge up")
+
+    leaf.run(
+        "ip link add dev vxlan0 type vxlan dstport 4789 local %s nolearning external"
+        % lo_ip
+    )
+    leaf.run("ip link set dev vxlan0 master bridge")
+    leaf.run("/sbin/bridge link set dev vxlan0 vlan_tunnel on")
+    leaf.run("/sbin/bridge link set dev vxlan0 neigh_suppress on")
+    leaf.run("/sbin/bridge link set dev vxlan0 learning off")
+    leaf.run("/sbin/bridge vlan del vid 1 dev vxlan0")
+    leaf.run("ip link set dev vxlan0 up")
+
+    for vni in VNIS:
+        leaf.run("/sbin/bridge vlan add vid %d dev vxlan0" % vni)
+        leaf.run(
+            "/sbin/bridge vlan add vid %d dev vxlan0 tunnel_info id %d" % (vni, vni)
+        )
+
+        leaf.run("/sbin/bridge vlan add vid %d dev bridge self" % vni)
+        svi = "vlan%d" % vni
+        leaf.run(
+            "ip link add link bridge name %s type vlan id %d protocol 802.1q"
+            % (svi, vni)
+        )
+        leaf.run("ip link set dev %s address %s" % (svi, svi_mac))
+        if with_gw_addrs:
+            leaf.run("ip addr add %s/%d dev %s" % (GW_IPS[vni], GW_PLEN, svi))
+        leaf.run("ip link set dev %s up" % svi)
+
+    leaf.run("/sbin/sysctl -w net.ipv4.ip_forward=1")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # only leaf1 owns the anycast addresses from the start; leaf2 gains
+    # them at runtime right before it advertises (see module docstring)
+    config_leaf_dataplane(tgen.gears["leaf1"], "leaf1", LEAF_MACS["leaf1"], True)
+    config_leaf_dataplane(tgen.gears["leaf2"], "leaf2", LEAF_MACS["leaf2"], False)
+
+    # only leaf1 starts with advertise-default-gw; see module docstring
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            daemons=["zebra", "staticd", "bgpd"],
+        )
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def set_advertise_default_gw(leaf, enable):
+    cfg = "" if enable else "no "
+    leaf.vtysh_cmd(
+        "conf t\nrouter bgp 65000\naddress-family l2vpn evpn\n"
+        "%sadvertise-default-gw" % cfg
+    )
+
+
+def set_gw_addrs(leaf, present):
+    "add or remove the anycast gateway addresses on the leaf's SVIs"
+    op = "add" if present else "del"
+    for vni in VNIS:
+        leaf.run("ip addr %s %s/%d dev vlan%d" % (op, GW_IPS[vni], GW_PLEN, vni))
+
+
+def check_zebra_gw_addrs(leaf, expect_present):
+    """
+    run_and_expect-compatible: zebra's view of every SVI does (not)
+    carry the anycast gateway address. The tests order address changes
+    against advertisement changes, so they must wait until zebra has
+    processed the netlink address event.
+    """
+    for vni in VNIS:
+        out = leaf.vtysh_cmd("show interface vlan%d json" % vni, isjson=True)
+        info = out.get("vlan%d" % vni, {})
+        addrs = [c.get("address") for c in info.get("ipAddresses", [])]
+        present = "%s/%d" % (GW_IPS[vni], GW_PLEN) in addrs
+        if present != expect_present:
+            return "vni %d: %s" % (vni, json.dumps(addrs))
+    return None
+
+
+def _tgen_or_skip():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    return tgen
+
+
+#
+# EVPN / BGP state helpers
+#
+
+
+def get_vni_rd(leaf, vni):
+    out = leaf.vtysh_cmd("show bgp l2vpn evpn vni %d json" % vni, isjson=True)
+    return out["rd"]
+
+
+def bgp_macip_route(dut, rd, mac, ip=None):
+    """
+    Look up a type-2 route in the global EVPN table under the origin's RD.
+    Returns the parsed JSON dict, or None when the route is absent.
+    Imported routes are not visible in the per-VNI table, hence the
+    RD-based lookup.
+    """
+    cmd = "show bgp l2vpn evpn route rd %s mac %s" % (rd, mac)
+    if ip:
+        cmd += " ip %s" % ip
+    out = dut.vtysh_cmd(cmd + " json")
+    try:
+        parsed = json.loads(out)
+    except ValueError:
+        # "% Network not in table" and friends
+        return None
+    return parsed or None
+
+
+def check_bgp_macip(dut, origin, vni, mac, ip, expect_present):
+    """
+    run_and_expect-compatible: None on success, offending output otherwise.
+    """
+    try:
+        rd = get_vni_rd(origin, vni)
+    except (KeyError, ValueError):
+        return "no rd for vni %d on %s" % (vni, origin.name)
+    route = bgp_macip_route(dut, rd, mac, ip)
+    present = route is not None
+    if present == expect_present:
+        return None
+    return "rd %s mac %s ip %s: %s" % (rd, mac, ip, json.dumps(route))
+
+
+def zebra_mac_entry(leaf, vni, mac):
+    "zebra's view of one EVPN MAC entry, or None when absent"
+    out = leaf.vtysh_cmd("show evpn mac vni %d mac %s json" % (vni, mac))
+    try:
+        parsed = json.loads(out)
+    except ValueError:
+        return None
+    return parsed or None
+
+
+def check_zebra_mac(leaf, vni, mac, expect_present, expect_type=None):
+    """
+    run_and_expect-compatible: None on success, offending output otherwise.
+    """
+    entry = zebra_mac_entry(leaf, vni, mac)
+    present = entry is not None
+    if present != expect_present:
+        return "vni %d mac %s: %s" % (vni, mac, json.dumps(entry))
+    if present and expect_type:
+        # entry may be keyed by the MAC or flat
+        info = entry.get(mac, entry)
+        if info.get("type") != expect_type:
+            return "vni %d mac %s type %s != %s" % (
+                vni,
+                mac,
+                info.get("type"),
+                expect_type,
+            )
+    return None
+
+
+def zebra_neigh_entry(leaf, vni, ip):
+    "zebra's view of one EVPN neighbor entry, or None when absent"
+    out = leaf.vtysh_cmd("show evpn arp-cache vni %d ip %s json" % (vni, ip))
+    try:
+        parsed = json.loads(out)
+    except ValueError:
+        # the command prints nothing at all when the entry is absent
+        return None
+    return parsed or None
+
+
+def check_gw_neigh_binding(leaf, mac, neigh_type):
+    """
+    run_and_expect-compatible: the neighbor entry for the anycast
+    gateway IP of every VNI is bound to `mac` and has type
+    `neigh_type`.
+    """
+    for vni in VNIS:
+        entry = zebra_neigh_entry(leaf, vni, GW_IPS[vni])
+        if entry is None:
+            return "vni %d ip %s: no neighbor entry" % (vni, GW_IPS[vni])
+        if entry.get("mac") != mac or entry.get("type") != neigh_type:
+            return "vni %d ip %s: %s/%s != %s/%s" % (
+                vni,
+                GW_IPS[vni],
+                entry.get("type"),
+                entry.get("mac"),
+                neigh_type,
+                mac,
+            )
+    return None
+
+
+def check_own_gw_mac(leaf, expect_present):
+    """
+    run_and_expect-compatible: the leaf's own gateway MAC is (not) a
+    local MAC of every VNI. zebra creates that MAC entry as part of the
+    gateway MACIP add, in the same event that rebinds the anycast
+    neighbors, and unlike the neighbors it stays put.
+    """
+    mac = LEAF_MACS[leaf.name]
+    for vni in VNIS:
+        result = check_zebra_mac(
+            leaf, vni, mac, expect_present, "local" if expect_present else None
+        )
+        if result is not None:
+            return result
+    return None
+
+
+def check_vni_remote_vteps(tgen):
+    """
+    run_and_expect-compatible convergence check: each leaf sees exactly
+    the other leaf as remote VTEP on every VNI, in zebra and in the
+    bridge FDB. The single vxlan device makes the HREP entries carry a
+    src_vni, which is what the library helper matches on.
+    """
+    for lname, peer in (("leaf1", "leaf2"), ("leaf2", "leaf1")):
+        result = evpn_verify_vni_remote_vteps(tgen.gears[lname], VNIS, [LEAF_LO[peer]])
+        if result is not None:
+            return "%s: %s" % (lname, result)
+    return None
+
+
+def check_leaf1_gw_bindings_on_leaf2(tgen, expect_present):
+    """
+    run_and_expect-compatible: leaf1's gateway MAC is (not) a remote
+    MAC in leaf2's zebra and its MAC+IP route is (not) in leaf2's BGP
+    table, for every VNI.
+    """
+    leaf1 = tgen.gears["leaf1"]
+    leaf2 = tgen.gears["leaf2"]
+    mac = LEAF_MACS["leaf1"]
+
+    for vni in VNIS:
+        result = check_zebra_mac(
+            leaf2, vni, mac, expect_present, "remote" if expect_present else None
+        )
+        if result is not None:
+            return "zebra: %s" % result
+        result = check_bgp_macip(leaf2, leaf1, vni, mac, GW_IPS[vni], expect_present)
+        if result is not None:
+            return "bgp: %s" % result
+    return None
+
+
+#
+# Tests
+#
+
+
+def test_evpn_convergence():
+    "Both leaves see each other as remote VTEP on both VNIs"
+    tgen = _tgen_or_skip()
+    test_fn = partial(check_vni_remote_vteps, tgen)
+    _, result = topotest.run_and_expect(test_fn, None, count=60, wait=1)
+    assert result is None, "EVPN did not converge: %s" % result
+
+
+def test_gw_bindings_installed_on_peer():
+    """
+    leaf1 advertises its SVI MAC + anycast IP per VNI as a default-gw
+    type-2 route and leaf2 installs the binding: leaf1's gateway MAC
+    is a remote MAC in leaf2's zebra. This is the remote neighbor
+    state the takeover in the next test builds on.
+    """
+    tgen = _tgen_or_skip()
+    test_fn = partial(check_leaf1_gw_bindings_on_leaf2, tgen, True)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+    assert result is None, "leaf1 gateway bindings missing on leaf2: %s" % result
+
+
+def test_gw_withdraw_after_local_takeover():
+    """
+    leaf2 configures the anycast addresses and enables
+    advertise-default-gw while leaf1's gateway binding for the anycast
+    IP is installed as a remote neighbor, then leaf1 withdraws its
+    gateway bindings. leaf2 must process the withdrawal and stay
+    alive. zebra used to free the taken-over neighbor while it was
+    still linked on the old MAC's neigh_list, which aborts leaf2's
+    zebra under ASAN right here. The addresses arrive only now so that
+    the remote neighbor install above stays valid under the RFC 7432
+    coexistence guards, which refuse to displace an already configured
+    gateway binding.
+    """
+    tgen = _tgen_or_skip()
+    leaf1 = tgen.gears["leaf1"]
+    leaf2 = tgen.gears["leaf2"]
+
+    for cycle in (1, 2):
+        logger.info("takeover/withdraw cycle %d", cycle)
+
+        # leaf1's gateway bindings are installed on leaf2
+        test_fn = partial(check_leaf1_gw_bindings_on_leaf2, tgen, True)
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert (
+            result is None
+        ), "cycle %d: leaf1 gateway bindings missing on leaf2: %s" % (cycle, result)
+
+        # the shared anycast IPs are remote neighbors bound to leaf1's
+        # gateway MAC. These are the entries the gateway MACIP add on
+        # leaf2 reuses.
+        test_fn = partial(check_gw_neigh_binding, leaf2, LEAF_MACS["leaf1"], "remote")
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert (
+            result is None
+        ), "cycle %d: anycast IPs are not remote neighbors of leaf1: %s" % (
+            cycle,
+            result,
+        )
+
+        # leaf2 has not run a gateway MACIP add yet, so its own gateway
+        # MAC is not in the VNIs
+        test_fn = partial(check_own_gw_mac, leaf2, False)
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert result is None, "cycle %d: leaf2 gateway MAC already present: %s" % (
+            cycle,
+            result,
+        )
+
+        # leaf2 now gains the anycast addresses. The advertisement knob
+        # is still off, so nothing is advertised yet and the remote
+        # neighbors stay put.
+        set_gw_addrs(leaf2, True)
+        test_fn = partial(check_zebra_gw_addrs, leaf2, True)
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert result is None, "cycle %d: zebra did not pick up the addresses: %s" % (
+            cycle,
+            result,
+        )
+
+        # Enabling the gateway advertisement rebinds those neighbors to
+        # leaf2's own gateway MAC. The rebinding itself is not a state
+        # that can be polled for: leaf1's route is still there and wins
+        # the anycast IP back within the same second. Poll instead for
+        # leaf2's own gateway MAC, which the same event creates and
+        # which stays, so it tells us the rebinding has happened.
+        set_advertise_default_gw(leaf2, True)
+
+        # bgpd has taken the knob (it is set globally, so the per-VNI
+        # state reads "Active"). This only says the configuration
+        # arrived, the zebra-side effect is checked right after.
+        test_fn = partial(
+            evpn_verify_bgp_vni_state,
+            leaf2,
+            VNIS,
+            expected_fields={"advertiseGatewayMacip": "Active"},
+        )
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert result is None, "cycle %d: leaf2 did not enable gateway MACIP: %s" % (
+            cycle,
+            result,
+        )
+
+        test_fn = partial(check_own_gw_mac, leaf2, True)
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert (
+            result is None
+        ), "cycle %d: leaf2 did not process the gateway MACIP add: %s" % (
+            cycle,
+            result,
+        )
+
+        # leaf1 withdraws; the remote MACIP del on leaf2 deletes the
+        # reused neighbor. This step used to be the use-after-free.
+        set_advertise_default_gw(leaf1, False)
+
+        test_fn = partial(check_leaf1_gw_bindings_on_leaf2, tgen, False)
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert result is None, (
+            "cycle %d: leaf1 gateway bindings still on leaf2 after "
+            "withdrawal: %s" % (cycle, result)
+        )
+
+        assert (
+            not tgen.routers_have_failure()
+        ), "cycle %d: a daemon died processing the withdrawal: %s" % (
+            cycle,
+            tgen.errors,
+        )
+
+        # Restore the initial single-advertiser state for the next
+        # cycle. leaf1 must only re-advertise after zebra on leaf2 has
+        # processed the address removal: a gateway route that arrives
+        # while the address is still known would be treated as a claim
+        # of a configured gateway binding and never become the remote
+        # neighbor the next cycle builds on.
+        set_advertise_default_gw(leaf2, False)
+        set_gw_addrs(leaf2, False)
+        test_fn = partial(check_zebra_gw_addrs, leaf2, False)
+        _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+        assert result is None, "cycle %d: zebra kept the removed addresses: %s" % (
+            cycle,
+            result,
+        )
+        set_advertise_default_gw(leaf1, True)
+
+    # leaf2's zebra is still fully responsive
+    test_fn = partial(check_vni_remote_vteps, tgen)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=1)
+    assert result is None, "EVPN state gone after the churn: %s" % result
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -285,9 +285,6 @@ int zebra_evpn_del_macip_for_intf(struct interface *ifp,
 				  struct zebra_evpn *zevpn)
 {
 	struct connected *c = NULL;
-	struct ethaddr macaddr;
-
-	memcpy(&macaddr.octet, ifp->hw_addr, ETH_ALEN);
 
 	frr_each_safe (if_connected, ifp->connected, c) {
 		struct ipaddr ip;
@@ -383,9 +380,6 @@ int zebra_evpn_advertise_subnet(struct zebra_evpn *zevpn, struct interface *ifp,
 				int advertise)
 {
 	struct connected *c = NULL;
-	struct ethaddr macaddr;
-
-	memcpy(&macaddr.octet, ifp->hw_addr, ETH_ALEN);
 
 	frr_each (if_connected, ifp->connected, c) {
 		struct prefix p;
@@ -449,7 +443,7 @@ int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 		return 0;
 
 	/* mac entry should be present */
-	mac = zebra_evpn_mac_lookup(zevpn, &n->emac);
+	mac = n->mac;
 	if (!mac) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("MAC %pEA doesn't exist for neigh %pIA on VNI %u",
@@ -475,9 +469,8 @@ int zebra_evpn_gw_macip_del(struct interface *ifp, struct zebra_evpn *zevpn,
 	/* Delete this neighbor entry. */
 	zebra_evpn_neigh_del(zevpn, n);
 
-	/* see if the mac needs to be deleted as well*/
-	if (mac)
-		zebra_evpn_deref_ip2mac(zevpn, mac);
+	/* see if the mac needs to be deleted as well */
+	zebra_evpn_deref_ip2mac(zevpn, mac);
 
 	return 0;
 }

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1912,7 +1912,7 @@ static bool zebra_evpn_local_mac_update_fwd_info(struct zebra_mac *mac,
 	return es_change;
 }
 
-/* Notify Local MACs to the clienti, skips GW MAC */
+/* Notify Local MACs to the client, skips GW MAC */
 static void zebra_evpn_send_mac_hash_entry_to_client(struct hash_bucket *bucket,
 						     void *arg)
 {

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -148,6 +148,13 @@ static void zebra_evpn_local_neigh_ref_mac(struct zebra_neigh *n,
 	bool old_static;
 	bool new_static;
 
+	/* The neighbor must be unlinked from its previous MAC first;
+	 * relinking without an unlink leaves the neighbor on the old
+	 * MAC's neigh_list, which is later freed from under it.
+	 */
+	assert(!n->mac);
+	assert(!mac || !memcmp(macaddr, &mac->macaddr, ETH_ALEN));
+
 	memcpy(&n->emac, macaddr, ETH_ALEN);
 	n->mac = mac;
 
@@ -155,6 +162,7 @@ static void zebra_evpn_local_neigh_ref_mac(struct zebra_neigh *n,
 	if (!mac)
 		return;
 
+	assert(!listnode_lookup(mac->neigh_list, n));
 	listnode_add_sort(mac->neigh_list, n);
 	if (n->flags & ZEBRA_NEIGH_ALL_PEER_FLAGS) {
 		old_static = zebra_evpn_mac_is_static(mac);
@@ -251,9 +259,8 @@ int zebra_evpn_neigh_send_add_to_client(vni_t vni, const struct ipaddr *ip,
 	if (CHECK_FLAG(neigh_flags, ZEBRA_NEIGH_SVI_IP))
 		SET_FLAG(flags, ZEBRA_MACIP_TYPE_SVI_IP);
 
-	return zebra_evpn_macip_send_msg_to_client(vni, macaddr, ip, flags, seq,
-						   ZEBRA_NEIGH_ACTIVE, zmac->es,
-						   ZEBRA_MACIP_ADD);
+	return zebra_evpn_macip_send_msg_to_client(vni, macaddr, ip, flags, seq, ZEBRA_NEIGH_ACTIVE,
+						   zmac ? zmac->es : NULL, ZEBRA_MACIP_ADD);
 }
 
 /*
@@ -399,11 +406,13 @@ static inline void zebra_evpn_neigh_start_hold_timer(struct zebra_neigh *n)
 			zmh_info->neigh_hold_time, &n->hold_timer);
 }
 
-static void zebra_evpn_local_neigh_deref_mac(struct zebra_neigh *n,
-					     bool send_mac_update)
+/* Unlink the neighbor from its MAC: sync-ref accounting and neigh_list
+ * membership. Does not drop the ip2mac reference; use
+ * zebra_evpn_local_neigh_deref_mac for that.
+ */
+static void zebra_evpn_local_neigh_unlink_mac(struct zebra_neigh *n, bool send_mac_update)
 {
 	struct zebra_mac *mac = n->mac;
-	struct zebra_evpn *zevpn = n->zevpn;
 	bool old_static;
 	bool new_static;
 
@@ -428,7 +437,16 @@ static void zebra_evpn_local_neigh_deref_mac(struct zebra_neigh *n,
 	}
 
 	listnode_delete(mac->neigh_list, n);
-	zebra_evpn_deref_ip2mac(zevpn, mac);
+}
+
+static void zebra_evpn_local_neigh_deref_mac(struct zebra_neigh *n, bool send_mac_update)
+{
+	struct zebra_mac *mac = n->mac;
+	struct zebra_evpn *zevpn = n->zevpn;
+
+	zebra_evpn_local_neigh_unlink_mac(n, send_mac_update);
+	if (mac)
+		zebra_evpn_deref_ip2mac(zevpn, mac);
 }
 
 bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn,
@@ -504,6 +522,12 @@ static struct zebra_neigh *zebra_evpn_neigh_add(struct zebra_evpn *zevpn,
 	if (!n) {
 		n = zebra_evpn_neigh_alloc(&tmp_n);
 		zebra_neigh_db_add(zevpn->neigh_table, n);
+	} else {
+		/* Callers create only after a failed lookup, but if an
+		 * existing entry is ever reused it must be unlinked from
+		 * its old MAC before the flags are reset below.
+		 */
+		zebra_evpn_local_neigh_deref_mac(n, false /* send_mac_update */);
 	}
 
 	n->state = ZEBRA_NEIGH_INACTIVE;
@@ -526,8 +550,7 @@ static struct zebra_neigh *zebra_evpn_neigh_add(struct zebra_evpn *zevpn,
  */
 int zebra_evpn_neigh_del(struct zebra_evpn *zevpn, struct zebra_neigh *n)
 {
-	if (n->mac)
-		listnode_delete(n->mac->neigh_list, n);
+	zebra_evpn_local_neigh_unlink_mac(n, false /* send_mac_update */);
 
 	/* Cancel auto recovery */
 	event_cancel(&n->dad_ip_auto_recovery_timer);
@@ -1790,7 +1813,7 @@ void zebra_evpn_print_neigh(const struct zebra_neigh *n, void *ctxt, json_object
 						      n->hold_timer));
 	}
 	if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_REMOTE)) {
-		if (n->mac->es) {
+		if (n->mac && n->mac->es) {
 			if (json)
 				json_object_string_add(json, "remoteEs",
 						       n->mac->es->esi_str);
@@ -1933,22 +1956,22 @@ void zebra_evpn_print_neigh_hash(struct neigh_walk_ctx *wctx, const struct zebra
 			    && (wctx->count == 0))
 				zebra_evpn_print_neigh_hdr(vty, addr_width, r_vtep_width);
 
-			if (n->mac->es == NULL)
+			if (!n->mac || n->mac->es == NULL)
 				ipaddr2str(&n->r_vtep_ip, addr_buf, sizeof(addr_buf));
 
 			vty_out(vty, "%*s %-6s %-5s %-8s %-17s %*s %u/%u\n", -addr_width, buf2,
 				"remote",
 				zebra_evpn_print_neigh_flags(n, flags_buf, sizeof(flags_buf)),
 				state_str, buf1, -r_vtep_width,
-				n->mac->es ? n->mac->es->esi_str : addr_buf, n->loc_seq,
-				n->rem_seq);
+				(n->mac && n->mac->es) ? n->mac->es->esi_str : addr_buf,
+				n->loc_seq, n->rem_seq);
 		} else {
 			json_row = json_object_new_object();
 
 			json_object_string_add(json_row, "type", "remote");
 			json_object_string_add(json_row, "state", state_str);
 			json_object_string_add(json_row, "mac", buf1);
-			if (n->mac->es)
+			if (n->mac && n->mac->es)
 				json_object_string_add(json_row, "remoteEs",
 						       n->mac->es->esi_str);
 			else
@@ -2087,17 +2110,13 @@ void zebra_evpn_neigh_remote_macip_add(struct zebra_evpn *zevpn, struct zebra_vr
 				   sizeof(struct ethaddr))
 			    != 0) {
 				/* update neigh list for macs */
-				old_mac =
-					zebra_evpn_mac_lookup(zevpn, &n->emac);
-				if (old_mac) {
-					is_old_mac_dup = CHECK_FLAG(old_mac->flags, ZEBRA_MAC_DUPLICATE);
-					listnode_delete(old_mac->neigh_list, n);
-					n->mac = NULL;
-					zebra_evpn_deref_ip2mac(zevpn, old_mac);
-				}
-				n->mac = mac;
-				listnode_add_sort(mac->neigh_list, n);
-				memcpy(&n->emac, &mac->macaddr, ETH_ALEN);
+				old_mac = n->mac;
+				if (old_mac)
+					is_old_mac_dup = CHECK_FLAG(old_mac->flags,
+								    ZEBRA_MAC_DUPLICATE);
+				zebra_evpn_local_neigh_deref_mac(n, false /* send_mac_update */);
+				zebra_evpn_local_neigh_ref_mac(n, &mac->macaddr, mac,
+							       false /* send_mac_update */);
 
 				/* Check Neigh's current state is local
 				 * (this is the case where neigh/host has  moved
@@ -2161,15 +2180,31 @@ int zebra_evpn_neigh_gw_macip_add(struct interface *ifp,
 	assert(mac);
 
 	n = zebra_evpn_neigh_lookup(zevpn, ip);
-	if (!n)
+	if (!n) {
 		n = zebra_evpn_neigh_add(zevpn, ip, &mac->macaddr, mac, 0);
-	else
+	} else {
 		n->gr_refresh_time = monotime(NULL);
+
+		/* The neighbor may exist bound to another MAC, e.g. as a
+		 * remote neighbor created from a peer's route for the same
+		 * (anycast) IP. Re-link it to the gateway MAC and reclaim
+		 * it as local.
+		 */
+		if (n->mac != mac) {
+			zebra_evpn_local_neigh_deref_mac(n, false /* send_mac_update */);
+			zebra_evpn_local_neigh_ref_mac(n, &mac->macaddr, mac,
+						       false /* send_mac_update */);
+		}
+		if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_REMOTE)) {
+			zebra_evpn_neigh_uninstall(zevpn, n);
+			UNSET_FLAG(n->flags, ZEBRA_NEIGH_REMOTE);
+			memset(&n->r_vtep_ip.ip.addr, 0, sizeof(n->r_vtep_ip.ip));
+		}
+	}
 
 	/* Set "local" forwarding info. */
 	SET_FLAG(n->flags, ZEBRA_NEIGH_LOCAL);
 	ZEBRA_NEIGH_SET_ACTIVE(n);
-	memcpy(&n->emac, &mac->macaddr, ETH_ALEN);
 	n->ifindex = ifp->ifindex;
 
 	/* Only advertise in BGP if the knob is enabled */

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -171,7 +171,10 @@ static inline bool zebra_evpn_neigh_is_ready_for_bgp(struct zebra_neigh *n)
 	bool mac_ready;
 	bool neigh_ready;
 
-	mac_ready = !!(n->mac->flags & ZEBRA_MAC_LOCAL);
+	/* A neighbor that is not linked to a MAC (transiently, while
+	 * being re-linked) is not advertisable.
+	 */
+	mac_ready = n->mac && (n->mac->flags & ZEBRA_MAC_LOCAL);
 	neigh_ready =
 		((n->flags & ZEBRA_NEIGH_LOCAL) && IS_ZEBRA_NEIGH_ACTIVE(n)
 		 && (!(n->flags & ZEBRA_NEIGH_LOCAL_INACTIVE)

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5953,7 +5953,10 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 
 		zvrf->advertise_gw_macip = advertise;
 
-		if (advertise_gw_macip_enabled(zevpn))
+		/* zevpn is NULL in the global branch; the walkers re-check
+		 * the per-EVPN override themselves.
+		 */
+		if (advertise_gw_macip_enabled(NULL))
 			hash_iterate(zvrf->evpn_table,
 				     zebra_evpn_gw_macip_add_for_evpn_hash,
 				     NULL);


### PR DESCRIPTION
This fix was extracted from a larger PR series on EVPN anycast gateways that is currently being worked on on request of @donaldsharp 

zebra maintains the neigh-MAC relationship (`n->mac`, `n->emac`, `mac->neigh_list`) in four independent code paths.
Unfortunately, two of them disagree.
The remote MACIP add path unlinks a reused neighbor via a MAC lookup on `n->emac`, which can be stale, and the gateway MACIP add path rewrites `n->emac` without re-parenting the neighbor onto the new MAC.

This failure occurs e.g. with two VTEPs carrying the same anycast gateway IP directly on their SVIs, but each with its own gateway MAC (a valid scenario under RFC7432, that's why the "Default Gateway Extended Community" exists)
When the second VTEP enables `advertise-default-gw` while the first VTEP's default-gw route is installed as a remote neighbor (created by `zebra_evpn_neigh_remote_macip_add()`), `zebra_evpn_neigh_gw_macip_add()` (via `zebra_evpn_gw_macip_add()`) reuses that neighbor entry and rewrites `n->emac` without re-parenting the neighbor.
When the first VTEP then withdraws its gateway bindings, `zebra_evpn_rem_macip_del()` frees the neighbor via `zebra_evpn_neigh_remote_uninstall()` -> `zebra_evpn_neigh_del()`, which unlinks it from the wrong MAC's `neigh_list`. The subsequent `zebra_evpn_rem_mac_del()` call in the same `zebra_evpn_rem_macip_del()` run then walks the old MAC's `neigh_list` in `remote_neigh_count()` and reads the freed neighbor.

The fix routes all neigh-MAC link and unlink operations through the existing ref/deref helper pair, and adds `assert`s for the linkage invariant to `zebra_evpn_local_neigh_ref_mac()` (the neighbor must be unlinked before relinking (`assert(!n->mac)`, the new MAC must match the address being bound (`assert(!mac || !memcmp(macaddr, &mac->macaddr, ETH_ALEN))`), and the neighbor must not already be on the MAC's `neigh_list` (`assert(!listnode_lookup(mac->neigh_list, n))`), so future violations fail very obviously instead of corrupting the list.

The first commit adds a topotest to demonstrate the issue which fails without the fix, the second test is the actual fix (topotest passes after that). The third commit is some further cleanup work...

Note: EVPN "Default Gateway Extended Community" (RFC7432, specifically section 10.1) is currently very broken in FRR, which is part of the PR mentioned above. I tried to build the test so that the test does not assert on currently wrong FRR behaviour and stays valid even after the behaviour fixes.


ASAN Output from the failing test:
```
leaf2: zebra triggered an exception by AddressSanitizer
AddressSanitizer error in topotest `test_anycast_gw_neigh_linkage.py`, test `test_gw_withdraw_after_local_takeover`, router `leaf2`

ERROR: AddressSanitizer: heap-use-after-free on address 0x51000001e98c at pc 0x561df5a36128 bp 0x7ffdfc71cb50 sp 0x7ffdfc71cb48
READ of size 4 at 0x51000001e98c thread T0
    #0 0x561df5a36127 in remote_neigh_count zebra/zebra_evpn_neigh.c:86
    #1 0x561df5a2f374 in zebra_evpn_rem_mac_del zebra/zebra_evpn_mac.c:1959
    #2 0x561df5a233ed in zebra_evpn_rem_macip_del zebra/zebra_evpn.c:1644
    #3 0x561df5ab5a6e in process_subq_evpn zebra/zebra_rib.c:2436
    #4 0x561df5ab5a6e in process_subq zebra/zebra_rib.c:3176
    #5 0x561df5ab5a6e in meta_queue_process zebra/zebra_rib.c:3235
    #6 0x7f1c4a4cecfe in work_queue_run lib/workqueue.c:279
    #7 0x7f1c4a4b717f in event_call lib/event.c:2744
    #8 0x7f1c4a3d2b66 in frr_run lib/libfrr.c:1258
    #9 0x561df59a8b52 in main zebra/main.c:580
    #10 0x7f1c49e16ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7f1c49e16d64 in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x561df597bca0 in _start (/usr/lib/frr/zebra+0x1acca0) (BuildId: 6cc371d6a87188d9b5da0874bf5ea161b01d120a)

0x51000001e98c is located 76 bytes inside of 184-byte region [0x51000001e940,0x51000001e9f8)
freed by thread T0 here:
    #0 0x7f1c4a86b8f8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7f1c4a3f80de in qfree lib/memory.c:136
    #2 0x561df5a37346 in zebra_evpn_neigh_del zebra/zebra_evpn_neigh.c:540
    #3 0x561df5a415ce in zebra_evpn_neigh_remote_uninstall zebra/zebra_evpn_neigh.c:2238
    #4 0x561df5a22f57 in zebra_evpn_rem_macip_del zebra/zebra_evpn.c:1621
    #5 0x561df5ab5a6e in process_subq_evpn zebra/zebra_rib.c:2436
    #6 0x561df5ab5a6e in process_subq zebra/zebra_rib.c:3176
    #7 0x561df5ab5a6e in meta_queue_process zebra/zebra_rib.c:3235
    #8 0x7f1c4a4cecfe in work_queue_run lib/workqueue.c:279
    #9 0x7f1c4a4b717f in event_call lib/event.c:2744
    #10 0x7f1c4a3d2b66 in frr_run lib/libfrr.c:1258
    #11 0x561df59a8b52 in main zebra/main.c:580
    #12 0x7f1c49e16ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

previously allocated by thread T0 here:
    #0 0x7f1c4a86c610 in calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7f1c4a3f77eb in qcalloc lib/memory.c:111
    #2 0x561df5a34863 in zebra_evpn_neigh_alloc zebra/zebra_evpn_neigh.c:137
    #3 0x561df5a34863 in zebra_evpn_neigh_add zebra/zebra_evpn_neigh.c:505
    #4 0x561df5a40e51 in zebra_evpn_neigh_remote_macip_add zebra/zebra_evpn_neigh.c:2057
    #5 0x561df5a229cb in zebra_evpn_rem_macip_add zebra/zebra_evpn.c:1533
    #6 0x561df5ab5a0c in process_subq_evpn zebra/zebra_rib.c:2433
    #7 0x561df5ab5a0c in process_subq zebra/zebra_rib.c:3176
    #8 0x561df5ab5a0c in meta_queue_process zebra/zebra_rib.c:3235
    #9 0x7f1c4a4cecfe in work_queue_run lib/workqueue.c:279
    #10 0x7f1c4a4b717f in event_call lib/event.c:2744
    #11 0x7f1c4a3d2b66 in frr_run lib/libfrr.c:1258
    #12 0x561df59a8b52 in main zebra/main.c:580
    #13 0x7f1c49e16ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: heap-use-after-free zebra/zebra_evpn_neigh.c:86 in remote_neigh_count
Shadow bytes around the buggy address:
  0x51000001e700: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x51000001e780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x51000001e800: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x51000001e880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x51000001e900: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x51000001e980: fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fa
  0x51000001ea00: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x51000001ea80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x51000001eb00: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x51000001eb80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x51000001ec00: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```