### PR TITLE
zebra: implement 64-bit interface statistics via Netlink

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -13,6 +13,10 @@
 #include "hook.h"
 #include "admin_group.h"
 
+#ifdef GNU_LINUX
+#include <linux/if_link.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -310,9 +314,9 @@ struct interface {
 	char ptm_status;
 
 /* Statistics fields. */
-#ifdef HAVE_PROC_NET_DEV
-	struct if_stats stats;
-#endif /* HAVE_PROC_NET_DEV */
+#ifdef HAVE_NETLINK
+	struct rtnl_link_stats64 stats;
+#endif /* HAVE_NETLINK */
 #ifdef HAVE_NET_RT_IFLIST
 	struct if_data stats;
 #endif /* HAVE_NET_RT_IFLIST */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -808,6 +808,47 @@ static uint8_t netlink_parse_lacp_bypass(struct rtattr **linkinfo)
 	return bypass;
 }
 
+static int netlink_parse_ifstat(struct nlmsghdr *h, ns_id_t ns_id, int startup, void *arg)
+{
+	struct ifinfomsg *ifi;
+	struct rtattr *tb[IFLA_MAX + 1];
+	struct rtnl_link_stats64 *stats_rtnl;
+	struct interface *ifp;
+	int len;
+
+	if (h->nlmsg_type != RTM_NEWLINK) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: wrong kernel message %s", __func__,
+				   nl_msg_type_to_str(h->nlmsg_type));
+
+		frrtrace(3, frr_zebra, netlink_msg_err, nl_msg_type_to_str(h->nlmsg_type), 0, 7);
+
+		return 0;
+	}
+
+	ifi = NLMSG_DATA(h);
+
+	len = h->nlmsg_len - NLMSG_LENGTH(sizeof(*ifi));
+	if (len < 0) {
+		flog_err(EC_ZEBRA_NETLINK_LENGTH_ERROR,
+			 "%s: Message received from netlink is of a broken size %d %zu", __func__,
+			 h->nlmsg_len, (size_t)NLMSG_LENGTH(sizeof(*ifi)));
+		return -1;
+	}
+
+	ifp = if_lookup_by_index_per_nsid(ns_id, ifi->ifi_index);
+	if (!ifp)
+		return 0;
+
+	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
+	if (tb[IFLA_STATS64]) {
+		stats_rtnl = (struct rtnl_link_stats64 *)RTA_DATA(tb[IFLA_STATS64]);
+		memcpy(&ifp->stats, stats_rtnl, sizeof(ifp->stats));
+	}
+
+	return 0;
+}
+
 /* Request for specific interface or address information from the kernel */
 static int netlink_request_intf_addr(struct nlsock *netlink_cmd, int family,
 				     int type, uint32_t filter_mask)
@@ -833,6 +874,46 @@ static int netlink_request_intf_addr(struct nlsock *netlink_cmd, int family,
 		return -1;
 
 	return netlink_request(netlink_cmd, &req);
+}
+
+/*
+ * Request link statistics from the kernel for a specific interface
+ * or for all interfaces if ifp is NULL.
+ */
+int netlink_request_ifstat(const struct interface *ifp)
+{
+	struct zebra_vrf *zvrf;
+	struct zebra_ns *zns = NULL;
+	struct {
+		struct nlmsghdr n;
+		struct ifinfomsg ifi;
+		char buf[64];
+	} req;
+
+	if (ifp && ifp->vrf) {
+		zvrf = ifp->vrf->info;
+		if (zvrf)
+			zns = zvrf->zns;
+	}
+
+	if (!zns)
+		zns = zebra_ns_lookup(NS_DEFAULT);
+
+	memset(&req, 0, sizeof(req));
+	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+	req.n.nlmsg_type = RTM_GETLINK;
+	req.n.nlmsg_flags = NLM_F_REQUEST;
+	req.ifi.ifi_family = AF_UNSPEC;
+
+	if (ifp) {
+		req.ifi.ifi_index = ifp->ifindex;
+	} else {
+		req.n.nlmsg_flags |= NLM_F_DUMP;
+		req.ifi.ifi_index = 0;
+	}
+
+	return netlink_talk(netlink_parse_ifstat, &req.n, &zns->netlink_cmd, zns, false, NULL,
+			    NULL);
 }
 
 enum netlink_msg_status

--- a/zebra/if_netlink.h
+++ b/zebra/if_netlink.h
@@ -18,6 +18,8 @@ extern "C" {
  */
 int netlink_interface_addr_dplane(struct nlmsghdr *h, ns_id_t ns_id, int startup, void *arg);
 
+int netlink_request_ifstat(const struct interface *ifp);
+
 extern int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup, void *arg);
 extern int interface_lookup_netlink(struct zebra_ns *zns);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -3127,35 +3127,29 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 	for (ALL_LIST_ELEMENTS_RO(ifp->nbr_connected, node, nbr_connected))
 		nbr_connected_dump_vty(vty, NULL, nbr_connected);
 
-#ifdef HAVE_PROC_NET_DEV
-	/* Statistics print out using proc file system. */
-	vty_out(vty,
-		"    %lu input packets (%lu multicast), %lu bytes, %lu dropped\n",
-		ifp->stats.rx_packets, ifp->stats.rx_multicast,
-		ifp->stats.rx_bytes, ifp->stats.rx_dropped);
+#ifdef HAVE_NETLINK
+	vty_out(vty, "    %llu input packets (%llu multicast), %llu bytes, %llu dropped\n",
+		ifp->stats.rx_packets, ifp->stats.multicast, ifp->stats.rx_bytes,
+		ifp->stats.rx_dropped);
 
-	vty_out(vty,
-		"    %lu input errors, %lu length, %lu overrun, %lu CRC, %lu frame\n",
-		ifp->stats.rx_errors, ifp->stats.rx_length_errors,
-		ifp->stats.rx_over_errors, ifp->stats.rx_crc_errors,
-		ifp->stats.rx_frame_errors);
+	vty_out(vty, "    %llu input errors, %llu length, %llu overrun, %llu CRC, %llu frame\n",
+		ifp->stats.rx_errors, ifp->stats.rx_length_errors, ifp->stats.rx_over_errors,
+		ifp->stats.rx_crc_errors, ifp->stats.rx_frame_errors);
 
-	vty_out(vty, "    %lu fifo, %lu missed\n", ifp->stats.rx_fifo_errors,
+	vty_out(vty, "    %llu fifo, %llu missed\n", ifp->stats.rx_fifo_errors,
 		ifp->stats.rx_missed_errors);
 
-	vty_out(vty, "    %lu output packets, %lu bytes, %lu dropped\n",
-		ifp->stats.tx_packets, ifp->stats.tx_bytes,
-		ifp->stats.tx_dropped);
+	vty_out(vty, "    %llu output packets, %llu bytes, %llu dropped\n", ifp->stats.tx_packets,
+		ifp->stats.tx_bytes, ifp->stats.tx_dropped);
 
 	vty_out(vty,
-		"    %lu output errors, %lu aborted, %lu carrier, %lu fifo, %lu heartbeat\n",
-		ifp->stats.tx_errors, ifp->stats.tx_aborted_errors,
-		ifp->stats.tx_carrier_errors, ifp->stats.tx_fifo_errors,
-		ifp->stats.tx_heartbeat_errors);
+		"    %llu output errors, %llu aborted, %llu carrier, %llu fifo, %llu heartbeat\n",
+		ifp->stats.tx_errors, ifp->stats.tx_aborted_errors, ifp->stats.tx_carrier_errors,
+		ifp->stats.tx_fifo_errors, ifp->stats.tx_heartbeat_errors);
 
-	vty_out(vty, "    %lu window, %lu collisions\n",
-		ifp->stats.tx_window_errors, ifp->stats.collisions);
-#endif /* HAVE_PROC_NET_DEV */
+	vty_out(vty, "    %llu window, %llu collisions\n", ifp->stats.tx_window_errors,
+		ifp->stats.collisions);
+#endif /* HAVE_NETLINK */
 
 #ifdef HAVE_NET_RT_IFLIST
 	/* Statistics print out using sysctl (). */
@@ -3230,6 +3224,7 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 	char buf[BUFSIZ];
 	json_object *json_if;
 	json_object *json_addrs;
+	json_object *json_stats;
 
 	json_if = json_object_new_object();
 	json_object_object_add(json, ifp->name, json_if);
@@ -3542,42 +3537,33 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 					       nbr_connected);
 	}
 
-#ifdef HAVE_PROC_NET_DEV
-	json_object_int_add(json_if, "inputPackets", stats.rx_packets);
-	json_object_int_add(json_if, "inputBytes", ifp->stats.rx_bytes);
-	json_object_int_add(json_if, "inputDropped", ifp->stats.rx_dropped);
-	json_object_int_add(json_if, "inputMulticastPackets",
-			    ifp->stats.rx_multicast);
-	json_object_int_add(json_if, "inputErrors", ifp->stats.rx_errors);
-	json_object_int_add(json_if, "inputLengthErrors",
-			    ifp->stats.rx_length_errors);
-	json_object_int_add(json_if, "inputOverrunErrors",
-			    ifp->stats.rx_over_errors);
-	json_object_int_add(json_if, "inputCrcErrors",
-			    ifp->stats.rx_crc_errors);
-	json_object_int_add(json_if, "inputFrameErrors",
-			    ifp->stats.rx_frame_errors);
-	json_object_int_add(json_if, "inputFifoErrors",
-			    ifp->stats.rx_fifo_errors);
-	json_object_int_add(json_if, "inputMissedErrors",
-			    ifp->stats.rx_missed_errors);
-	json_object_int_add(json_if, "outputPackets", ifp->stats.tx_packets);
-	json_object_int_add(json_if, "outputBytes", ifp->stats.tx_bytes);
-	json_object_int_add(json_if, "outputDroppedPackets",
-			    ifp->stats.tx_dropped);
-	json_object_int_add(json_if, "outputErrors", ifp->stats.tx_errors);
-	json_object_int_add(json_if, "outputAbortedErrors",
-			    ifp->stats.tx_aborted_errors);
-	json_object_int_add(json_if, "outputCarrierErrors",
-			    ifp->stats.tx_carrier_errors);
-	json_object_int_add(json_if, "outputFifoErrors",
-			    ifp->stats.tx_fifo_errors);
-	json_object_int_add(json_if, "outputHeartbeatErrors",
-			    ifp->stats.tx_heartbeat_errors);
-	json_object_int_add(json_if, "outputWindowErrors",
-			    ifp->stats.tx_window_errors);
-	json_object_int_add(json_if, "collisions", ifp->stats.collisions);
-#endif /* HAVE_PROC_NET_DEV */
+#ifdef HAVE_NETLINK
+	json_stats = json_object_new_object();
+
+	json_object_int_add(json_stats, "inputPackets", ifp->stats.rx_packets);
+	json_object_int_add(json_stats, "inputBytes", ifp->stats.rx_bytes);
+	json_object_int_add(json_stats, "inputDropped", ifp->stats.rx_dropped);
+	json_object_int_add(json_stats, "inputMulticastPackets", ifp->stats.multicast);
+	json_object_int_add(json_stats, "inputErrors", ifp->stats.rx_errors);
+	json_object_int_add(json_stats, "inputLengthErrors", ifp->stats.rx_length_errors);
+	json_object_int_add(json_stats, "inputOverrunErrors", ifp->stats.rx_over_errors);
+	json_object_int_add(json_stats, "inputCrcErrors", ifp->stats.rx_crc_errors);
+	json_object_int_add(json_stats, "inputFrameErrors", ifp->stats.rx_frame_errors);
+	json_object_int_add(json_stats, "inputFifoErrors", ifp->stats.rx_fifo_errors);
+	json_object_int_add(json_stats, "inputMissedErrors", ifp->stats.rx_missed_errors);
+	json_object_int_add(json_stats, "outputPackets", ifp->stats.tx_packets);
+	json_object_int_add(json_stats, "outputBytes", ifp->stats.tx_bytes);
+	json_object_int_add(json_stats, "outputDroppedPackets", ifp->stats.tx_dropped);
+	json_object_int_add(json_stats, "outputErrors", ifp->stats.tx_errors);
+	json_object_int_add(json_stats, "outputAbortedErrors", ifp->stats.tx_aborted_errors);
+	json_object_int_add(json_stats, "outputCarrierErrors", ifp->stats.tx_carrier_errors);
+	json_object_int_add(json_stats, "outputFifoErrors", ifp->stats.tx_fifo_errors);
+	json_object_int_add(json_stats, "outputHeartbeatErrors", ifp->stats.tx_heartbeat_errors);
+	json_object_int_add(json_stats, "outputWindowErrors", ifp->stats.tx_window_errors);
+	json_object_int_add(json_stats, "collisions", ifp->stats.collisions);
+
+	json_object_object_add(json_if, "statistics", json_stats);
+#endif /* HAVE_NETLINK */
 
 #ifdef HAVE_NET_RT_IFLIST
 	json_object_int_add(json_if, "inputPackets", ifp->stats.ifi_ipackets);
@@ -3596,13 +3582,11 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 	json_object_int_add(json_if, "carrierChanges", zebra_if->carrier_changes);
 }
 
-static void interface_update_stats(void)
+static void interface_update_stats(const struct interface *ifp)
 {
-#ifdef HAVE_PROC_NET_DEV
-	/* If system has interface statistics via proc file system, update
-	   statistics. */
-	ifstat_update_proc();
-#endif /* HAVE_PROC_NET_DEV */
+#ifdef HAVE_NETLINK
+	netlink_request_ifstat(ifp);
+#endif /* HAVE_NETLINK */
 #ifdef HAVE_NET_RT_IFLIST
 	ifstat_update_sysctl();
 #endif /* HAVE_NET_RT_IFLIST */
@@ -3622,8 +3606,6 @@ DEFPY(show_interface, show_interface_cmd,
 	struct interface *ifp;
 	json_object *json = NULL;
 
-	interface_update_stats();
-
 	vrf = vrf_lookup_by_name(vrf_name);
 	if (!vrf) {
 		if (uj)
@@ -3642,6 +3624,7 @@ DEFPY(show_interface, show_interface_cmd,
 		else
 			ifs_dump_brief_vty(vty, vrf);
 	} else {
+		interface_update_stats(NULL);
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (json)
 				if_dump_vty_json(vty, ifp, json);
@@ -3671,8 +3654,6 @@ DEFPY (show_interface_vrf_all,
 	struct interface *ifp;
 	json_object *json = NULL;
 
-	interface_update_stats();
-
 	if (uj)
 		json = json_object_new_object();
 
@@ -3684,6 +3665,7 @@ DEFPY (show_interface_vrf_all,
 			else
 				ifs_dump_brief_vty(vty, vrf);
 		} else {
+			interface_update_stats(NULL);
 			FOR_ALL_INTERFACES (vrf, ifp) {
 				if (json)
 					if_dump_vty_json(vty, ifp, json);
@@ -3714,8 +3696,6 @@ DEFPY (show_interface_name_vrf,
 	struct vrf *vrf;
 	json_object *json = NULL;
 
-	interface_update_stats();
-
 	vrf = vrf_lookup_by_name(vrf_name);
 	if (!vrf) {
 		if (uj)
@@ -3736,6 +3716,8 @@ DEFPY (show_interface_name_vrf,
 
 	if (uj)
 		json = json_object_new_object();
+
+	interface_update_stats(ifp);
 
 	if (json)
 		if_dump_vty_json(vty, ifp, json);
@@ -3763,8 +3745,6 @@ DEFPY (show_interface_name_vrf_all,
 	struct vrf *vrf;
 	json_object *json = NULL;
 	int count = 0;
-
-	interface_update_stats();
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 		ifptmp = if_lookup_by_name_vrf(ifname, vrf);
@@ -3797,6 +3777,8 @@ DEFPY (show_interface_name_vrf_all,
 
 	if (uj)
 		json = json_object_new_object();
+
+	interface_update_stats(ifp);
 
 	if (json)
 		if_dump_vty_json(vty, ifp, json);

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -344,9 +344,6 @@ extern const char *zebra_protodown_rc_str(uint32_t protodown_rc, char *pd_buf,
 					  uint32_t pd_buf_len);
 void zebra_if_dplane_result(struct zebra_dplane_ctx *ctx);
 
-#ifdef HAVE_PROC_NET_DEV
-extern void ifstat_update_proc(void);
-#endif /* HAVE_PROC_NET_DEV */
 #ifdef HAVE_NET_RT_IFLIST
 extern void ifstat_update_sysctl(void);
 


### PR DESCRIPTION
Interface statistics in Zebra are currently non-functional on Linux. The legacy path relied on `/proc/net/dev`, but was not implemented.

This commit implement `netlink_request_ifstats()` and `netlink_parse_ifstats()` to update link statistics from the kernel.