### PR TITLE
lib: fix empty result for oper queries with a non-key predicate

### DIFF
--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -1039,6 +1039,30 @@ static bool nb_op_schema_path_has_predicate(struct nb_op_yield_state *ys,
 }
 
 /**
+ * nb_op_pred_needs_siblings() - must this level emit its whole entry?
+ * @ys: the yield state for this tree walk.
+ * @level: the level whose children are about to be walked.
+ *
+ * A predicate naming keys is resolved into a specific entry while walking, but
+ * one naming anything else is not resolvable that way -- it is applied
+ * afterwards, by trimming the returned tree with the query xpath.  That trim
+ * can only keep an entry if the leaves the predicate names are in the tree, so
+ * a level carrying such a predicate has to emit its whole entry rather than
+ * only the node the query descends to.
+ *
+ * The predicates that need this are exactly the ones the walk already failed
+ * to resolve, which it records in @non_specific_predicate before descending.
+ *
+ * Return: true if every child of @level should be walked.
+ */
+static bool nb_op_pred_needs_siblings(struct nb_op_yield_state *ys, int level)
+{
+	if (level < 0 || level > darr_lasti(ys->query_tokens))
+		return false;
+	return ys->non_specific_predicate[level];
+}
+
+/**
  * nb_op_empty_container_ok() - determine if should keep empty container node.
  *
  * Return: true if the empty container should be kept.
@@ -1136,8 +1160,20 @@ static const struct lysc_node *nb_op_sib_next(struct nb_op_yield_state *ys,
 	 * working our way down the specific query path so just return NULL
 	 * (i.e., don't process siblings)
 	 */
-	if (darr_len(ys->schema_path) > darr_len(ys->node_infos))
-		return NULL;
+	if (darr_len(ys->schema_path) > darr_len(ys->node_infos)) {
+		struct nb_op_node_info *last = darr_last(ys->node_infos);
+		int level = darr_lasti(ys->node_infos);
+
+		/*
+		 * When sib is the node on top of the stack we are done with it,
+		 * so the predicate governing its siblings is its parent's.
+		 */
+		if (last && last->schema == sib)
+			level--;
+
+		if (!nb_op_pred_needs_siblings(ys, level))
+			return NULL;
+	}
 	/*
 	 * If sib is on top of the node info stack then
 	 * 1) it's a container node -or-
@@ -1202,7 +1238,8 @@ static const struct lysc_node *nb_op_sib_first(struct nb_op_yield_state *ys,
 	 */
 	if (last != NULL)
 		assert(last->schema == parent);
-	if (darr_lasti(ys->node_infos) < ys->query_base_level)
+	if (darr_lasti(ys->node_infos) < ys->query_base_level &&
+	    !nb_op_pred_needs_siblings(ys, darr_lasti(ys->node_infos)))
 		return ys->schema_path[darr_lasti(ys->node_infos) + 1];
 
 	/* We always skip keys. */

--- a/tests/topotests/mgmt_oper/simple-results/result-intf-vrf-red-state-mtu.json
+++ b/tests/topotests/mgmt_oper/simple-results/result-intf-vrf-red-state-mtu.json
@@ -1,0 +1,24 @@
+{
+  "frr-interface:lib": {
+    "interface": [
+      {
+        "name": "lo-red",
+        "state": {
+          "mtu": "rubout"
+        }
+      },
+      {
+        "name": "r1-eth1",
+        "state": {
+          "mtu": "rubout"
+        }
+      },
+      {
+        "name": "red",
+        "state": {
+          "mtu": "rubout"
+        }
+      }
+    ]
+  }
+}

--- a/tests/topotests/mgmt_oper/test_simple.py
+++ b/tests/topotests/mgmt_oper/test_simple.py
@@ -93,6 +93,16 @@ def test_oper_simple(tgen):
             '/frr-interface:lib/interface[name="r1-eth0"]/state/mtu',
             "simple-results/result-intf-eth0-state-mtu.json",
         ),
+        (
+            # Leaf of container query selected by a NON-key predicate.  The
+            # predicate is applied by trimming the returned tree, so the walk
+            # has to emit 'vrf' even though the query descends to 'state/mtu'
+            # -- otherwise there is nothing for the trim to match and the
+            # answer comes back empty.  'interface' is keyed, so this covers
+            # the case for keyed lists too, not just keyless ones.
+            '/frr-interface:lib/interface[vrf="red"]/state/mtu',
+            "simple-results/result-intf-vrf-red-state-mtu.json",
+        ),
         # VRF
         ("/frr-vrf:lib", "simple-results/result-lib.json"),
         ("/frr-vrf:lib/vrf", "simple-results/result-lib-vrf-nokey.json"),


### PR DESCRIPTION
## Summary

`show mgmt get-data` answers `{}` for any operational query whose predicate names
something other than a list key and which also narrows to a specific leaf or
container.

Using `/frr-interface:lib/interface`, a list keyed by `name`:

```
# show mgmt get-data /frr-interface:lib/interface[vrf="red"]/vrf
... three interfaces ...
# show mgmt get-data /frr-interface:lib/interface[vrf="red"]/state/mtu
{}
```

The predicate alone works, and narrowing to a leaf alone works — only the
combination fails. `interface` is keyed, so this is not about keyless lists, nor
about any one module: it is every model, every non-key predicate.

## Root cause

A predicate naming keys is resolved into a specific list entry while walking:
`nb_op_sib_first()` hands the query token to `lyd_new_path()`, which builds the
entry. libyang can only instantiate a list from its keys, so a predicate naming
an ordinary leaf fails with `LY_EVALID`. The walk records that in
`non_specific_predicate[level]` and walks the list in full.

Such a predicate is applied afterwards instead, by trimming the returned tree
with the query xpath (`yang_lyd_trim_xpath()`, driven from
`txn_get_tree_data_done()`). That trim can only keep an entry whose tree
actually carries the leaves the predicate names.

But while descending the query path, the walk visits only the one node the query
descends to:

```c
if (darr_lasti(ys->node_infos) < ys->query_base_level)
        return ys->schema_path[darr_lasti(ys->node_infos) + 1];
```

So for `interface[vrf="red"]/state/mtu` the walk emits `name` and `state/mtu`,
but never `vrf`. The trim then has nothing to match `[vrf="red"]` against, drops
every entry, and the answer is empty.

The reason this went unnoticed is that a predicate on a *key* has always worked:
YANG guarantees keys are present in the data tree, so the trim always had them
to compare against.

## Fix

Walk the whole entry at a level whose predicate could not be resolved, leaving
the trim to narrow it back down.

A new helper reports whether a level carries such a predicate — exactly the
levels the walk already failed to resolve and recorded before descending:

```c
static bool nb_op_pred_needs_siblings(struct nb_op_yield_state *ys, int level)
{
	if (level < 0 || level > darr_lasti(ys->query_tokens))
		return false;
	return ys->non_specific_predicate[level];
}
```

`nb_op_sib_first()` and `nb_op_sib_next()` both consult it before restricting
the walk to the query path. In `nb_op_sib_next()`, when `sib` is the node on top
of the stack we are done with it, so the predicate governing its siblings is its
parent's.

Only queries that answer nothing today change: the levels this applies to are
exactly the ones already recorded in `non_specific_predicate`, and mgmtd only
trims for the same non-simple xpaths, so a query built from keys alone walks as
before. The widening is confined to the level carrying the unresolved
predicate — deeper levels still follow the query path, so the extra data emitted
is one entry's direct children, not a full subtree.

Oper-state notifications resolve paths from data nodes, which carry key
predicates only, so their walks are unaffected. A subscription selector written
with a non-key predicate is not filtered either way — that path does no
trimming — and is left as it is.

## Test plan

- Added `/frr-interface:lib/interface[vrf="red"]/state/mtu` to
  `tests/topotests/mgmt_oper/test_simple.py`, with the expected result in
  `simple-results/result-intf-vrf-red-state-mtu.json`. It sits beside the
  existing key-predicate queries: the one above it selects with a key and
  narrows to the same leaf, and has always worked.

- Confirmed the case actually covers the bug. With the test applied and the
  `lib/northbound_oper.c` change reverted, `test_oper_simple` fails on that
  query with an empty answer. With the change applied the whole test passes,
  all 31 queries, so the other 30 are unaffected.

- Manual check on the same topology, before the change:

  ```
  # show mgmt get-data /frr-interface:lib/interface[vrf="red"]/vrf
  {"frr-interface:lib":{"interface":[{"name":"lo-red","vrf":"red"},{"name":"r1-eth1","vrf":"red"},{"name":"red","vrf":"red"}]}}
  # show mgmt get-data /frr-interface:lib/interface[vrf="red"]/state/mtu
  {}
  ```

  and after:

  ```
  # show mgmt get-data /frr-interface:lib/interface[vrf="red"]/state/mtu
  {"frr-interface:lib":{"interface":[{"name":"lo-red","state":{"mtu":1500}},{"name":"r1-eth1","state":{"mtu":1500}},{"name":"red","state":{"mtu":65575}}]}}
  ```

  Selecting with a key (`[name="r1-eth0"]/state/mtu`), and a non-key predicate
  that does not narrow past the predicated level (`[vrf="red"]/vrf`), are
  unchanged.

- The result after the fix carries only `name` and `state/mtu` — `vrf` is
  emitted by the walk so the predicate can match, then removed by the trim.