### PR TITLE
bgpd: emit NEXT_HOP when reflecting a labeled-unicast route to a unicast peer

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -5730,6 +5730,22 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
 						     NULL);
 			stream_putc(s, 4);
 			stream_put_ipv4(s, 0);
+		} else if (attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV4) {
+			/*
+			 * The path carries a valid IPv4 next hop that arrived
+			 * in an MP_REACH_NLRI rather than the legacy NEXT_HOP
+			 * attribute, for example a route reflected from an
+			 * ipv4 labeled-unicast peer to an ipv4 unicast-only
+			 * client. NEXT_HOP is mandatory for a unicast NLRI, so
+			 * emit it from the stored next hop instead of dropping
+			 * the attribute and producing a malformed UPDATE.
+			 */
+			stream_putc(s, BGP_ATTR_FLAG_TRANS);
+			stream_putc(s, BGP_ATTR_NEXT_HOP);
+			bpacket_attr_vec_arr_set_vec(vecarr, BGP_ATTR_VEC_NH, s,
+						     attr);
+			stream_putc(s, 4);
+			stream_put_ipv4(s, attr->mp_nexthop_global_in.s_addr);
 		}
 	}
 

--- a/tests/topotests/bgp_rr_lu_to_unicast/r1/frr.conf
+++ b/tests/topotests/bgp_rr_lu_to_unicast/r1/frr.conf
@@ -1,0 +1,32 @@
+!
+interface lo
+ ip address 10.0.0.13/32
+!
+interface r1-eth0
+ ip address 10.1.12.1/24
+!
+router ospf
+ ospf router-id 10.0.0.13
+ network 10.0.0.13/32 area 0
+ network 10.1.12.0/24 area 0
+ passive-interface lo
+exit
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ no bgp network import-check
+ neighbor 10.0.0.10 remote-as 65001
+ neighbor 10.0.0.10 update-source lo
+ neighbor 10.0.0.10 timers 1 3
+ neighbor 10.0.0.10 timers connect 1
+ !
+ address-family ipv4 unicast
+  network 10.0.0.13/32
+ exit-address-family
+ !
+ address-family ipv4 labeled-unicast
+  neighbor 10.0.0.10 activate
+ exit-address-family
+exit
+!

--- a/tests/topotests/bgp_rr_lu_to_unicast/r2/frr.conf
+++ b/tests/topotests/bgp_rr_lu_to_unicast/r2/frr.conf
@@ -1,0 +1,43 @@
+!
+interface lo
+ ip address 10.0.0.10/32
+!
+interface r2-eth0
+ ip address 10.1.12.2/24
+!
+interface r2-eth1
+ ip address 10.2.23.2/24
+!
+router ospf
+ ospf router-id 10.0.0.10
+ network 10.0.0.10/32 area 0
+ network 10.1.12.0/24 area 0
+ network 10.2.23.0/24 area 0
+ passive-interface lo
+exit
+!
+router bgp 65001
+ bgp router-id 10.0.0.10
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ no bgp network import-check
+ neighbor 10.0.0.13 remote-as 65001
+ neighbor 10.0.0.13 update-source lo
+ neighbor 10.0.0.13 timers 1 3
+ neighbor 10.0.0.13 timers connect 1
+ neighbor 10.0.0.12 remote-as 65001
+ neighbor 10.0.0.12 update-source lo
+ neighbor 10.0.0.12 timers 1 3
+ neighbor 10.0.0.12 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.0.12 activate
+  neighbor 10.0.0.12 route-reflector-client
+ exit-address-family
+ !
+ address-family ipv4 labeled-unicast
+  neighbor 10.0.0.13 activate
+  neighbor 10.0.0.13 route-reflector-client
+ exit-address-family
+exit
+!

--- a/tests/topotests/bgp_rr_lu_to_unicast/r3/frr.conf
+++ b/tests/topotests/bgp_rr_lu_to_unicast/r3/frr.conf
@@ -1,0 +1,30 @@
+!
+interface lo
+ ip address 10.0.0.12/32
+!
+interface r3-eth0
+ ip address 10.2.23.3/24
+!
+router ospf
+ ospf router-id 10.0.0.12
+ network 10.0.0.12/32 area 0
+ network 10.2.23.0/24 area 0
+ passive-interface lo
+exit
+!
+router bgp 65001
+ bgp router-id 10.0.0.12
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ no bgp network import-check
+ neighbor 10.0.0.10 remote-as 65001
+ neighbor 10.0.0.10 update-source lo
+ neighbor 10.0.0.10 timers 1 3
+ neighbor 10.0.0.10 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.0.10 activate
+  neighbor 10.0.0.10 soft-reconfiguration inbound
+ exit-address-family
+exit
+!

--- a/tests/topotests/bgp_rr_lu_to_unicast/test_bgp_rr_lu_to_unicast.py
+++ b/tests/topotests/bgp_rr_lu_to_unicast/test_bgp_rr_lu_to_unicast.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_rr_lu_to_unicast.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by Olasupo Okunaiya
+#
+
+"""
+test_bgp_rr_lu_to_unicast.py: a route reflector that learns a prefix over an
+ipv4 labeled-unicast (SAFI 4) session must reflect it to an ipv4 unicast-only
+(SAFI 1) client with the mandatory NEXT_HOP path attribute present.
+
+The next hop of a labeled path arrives in the MP_REACH_NLRI, so the legacy
+NEXT_HOP (type 3) attribute flag is never set on the stored path. When the
+route was reflected out of the ipv4 unicast address-family the serializer
+dropped NEXT_HOP entirely, producing an UPDATE that the unicast client
+rejected as "Missing well-known attribute NEXT_HOP", so the prefix never
+installed.
+
+Topology (single AS 65001, iBGP, loopback reachability via OSPF):
+
+    r1 ---(ipv4 labeled-unicast)--- r2 ---(ipv4 unicast)--- r3
+  10.0.0.13                       10.0.0.10               10.0.0.12
+  originates                    route reflector        unicast-only client
+  10.0.0.13/32
+"""
+
+import os
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    # r1 --- s1 --- r2 --- s2 --- r3
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_sessions_up():
+    "The two iBGP sessions on the route reflector must reach Established."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _sessions_up():
+        out = tgen.gears["r2"].vtysh_cmd("show bgp summary json", isjson=True)
+        expected = {
+            "ipv4Unicast": {"peers": {"10.0.0.12": {"state": "Established"}}},
+            "ipv4LabeledUnicast": {"peers": {"10.0.0.13": {"state": "Established"}}},
+        }
+        return topotest.json_cmp(out, expected)
+
+    _, result = topotest.run_and_expect(_sessions_up, None, count=60, wait=1)
+    assert result is None, "iBGP sessions did not come up: {}".format(result)
+
+
+def test_rr_advertises_nexthop_to_unicast_client():
+    "The RR Adj-RIB-Out for the unicast client must carry the next hop."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _advertised():
+        out = tgen.gears["r2"].vtysh_cmd(
+            "show bgp ipv4 unicast neighbors 10.0.0.12 advertised-routes json",
+            isjson=True,
+        )
+        expected = {"advertisedRoutes": {"10.0.0.13/32": {"nextHop": "10.0.0.13"}}}
+        return topotest.json_cmp(out, expected)
+
+    _, result = topotest.run_and_expect(_advertised, None, count=60, wait=1)
+    assert result is None, "RR advertised no next hop: {}".format(result)
+
+
+def test_unicast_client_installs_route_with_nexthop():
+    "The unicast-only client must accept the reflected route with NEXT_HOP set."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _installed():
+        out = tgen.gears["r3"].vtysh_cmd(
+            "show bgp ipv4 unicast 10.0.0.13/32 json", isjson=True
+        )
+        expected = {
+            "prefix": "10.0.0.13/32",
+            "paths": [{"valid": True, "nexthops": [{"ip": "10.0.0.13"}]}],
+        }
+        return topotest.json_cmp(out, expected)
+
+    _, result = topotest.run_and_expect(_installed, None, count=60, wait=1)
+    assert result is None, "unicast client did not install route: {}".format(result)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Fixes #22569

When a route reflector learns a prefix over ipv4 labeled-unicast (SAFI 4) and reflects it to a client activated only for ipv4 unicast (SAFI 1), the next hop of the labeled path is held in the MP_REACH_NLRI, so the legacy NEXT_HOP (type 3) attribute flag is never set on the stored path. The unicast egress serializer in `bgp_packet_attribute()` only wrote NEXT_HOP for the flagged case or the ENHE/IPv6 case, so it emitted nothing here. The resulting UPDATE carried a unicast NLRI with no NEXT_HOP, which is malformed per RFC 4271, and the client rejected it with "Missing well-known attribute NEXT_HOP".

The next hop is already correct in the reflector's Adj-RIB-Out; only the serialization dropped it. This emits NEXT_HOP from the stored IPv4 next hop when the path has an IPv4 MP_REACH next hop but no legacy NEXT_HOP attribute.

Includes a topotest (`bgp_rr_lu_to_unicast`) with a labeled-unicast client, a route reflector, and a unicast-only client. The client must install the prefix with the correct next hop; the test fails without the fix (the client never installs the route) and passes with it.
