### PR TITLE
bfdd: implement demand mode (RFC 5880 section 6.6)

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -91,6 +91,7 @@ static void bfd_profile_set_default(struct bfd_profile *bp)
 	bp->admin_shutdown = false;
 	bp->detection_multiplier = BFD_DEFDETECTMULT;
 	bp->echo_mode = false;
+	bp->demand_mode = false;
 	bp->passive = false;
 	bp->log_session_changes = false;
 	bp->minimum_ttl = BFD_DEF_MHOP_TTL;
@@ -226,6 +227,12 @@ void bfd_session_apply(struct bfd_session *bs)
 		else
 			bs->mh_ttl = bs->peer_profile.minimum_ttl;
 	}
+
+	/* Toggle 'demand-mode' if default value. */
+	if (bs->peer_profile.demand_mode == false)
+		bfd_set_demand(bs, bp->demand_mode);
+	else
+		bfd_set_demand(bs, bs->peer_profile.demand_mode);
 
 	/* Toggle 'passive-mode' if default value. */
 	if (bs->bfd_mode == BFD_MODE_TYPE_BFD) {
@@ -1840,6 +1847,14 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown)
 			bfd_xmttimer_update(bs, bs->xmt_TO);
 		}
 	}
+}
+
+void bfd_set_demand(struct bfd_session *bs, bool demand)
+{
+	if (demand)
+		SET_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND);
+	else
+		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND);
 }
 
 void bfd_set_passive_mode(struct bfd_session *bs, bool passive)

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1854,10 +1854,45 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown)
 
 void bfd_set_demand(struct bfd_session *bs, bool demand)
 {
-	if (demand)
+	if (demand) {
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND))
+			return;
+
 		SET_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND);
-	else
-		UNSET_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND);
+
+		/*
+		 * Stop the detection timer here rather than waiting for
+		 * the next packet: the peer ceases as soon as it sees
+		 * the Demand bit, so there may be no further packet to
+		 * take the receive path.
+		 */
+		if (bs->ses_state == PTM_BFD_UP && bs->remote_ses_state == PTM_BFD_UP)
+			bfd_recvtimer_delete(bs);
+
+		return;
+	}
+
+	if (!CHECK_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND))
+		return;
+
+	UNSET_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND);
+
+	if (bs->ses_state != PTM_BFD_UP)
+		return;
+
+	/*
+	 * Leaving demand mode must restore failure detection without
+	 * waiting for the peer. The detection timer was removed while
+	 * demand mode was active, and if the path is already down no
+	 * packet will arrive to re-arm it.
+	 *
+	 * The peer may still be demanding, in which case our own
+	 * transmission is suppressed and it would never learn that our
+	 * Demand bit is gone. A Poll Sequence is exempt from that
+	 * suppression, so it is what carries the change across.
+	 */
+	bfd_set_polling(bs);
+	bfd_recvtimer_update(bs);
 }
 
 void bfd_set_passive_mode(struct bfd_session *bs, bool passive)

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1385,6 +1385,18 @@ void bfd_set_polling(struct bfd_session *bs)
 		zlog_debug("[%s] Setting polling=1 to negotiate timer change", bs_to_string(bs));
 
 	bs->polling = 1;
+
+	/*
+	 * In demand mode the peer is not transmitting, so the Poll
+	 * Sequence is the only way to verify the path. Arm the
+	 * detection timer so a lost Final brings the session down
+	 * instead of leaving the poll outstanding forever.
+	 *
+	 * RFC 5880, Section 6.6.
+	 */
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND) && bs->ses_state == PTM_BFD_UP &&
+	    bs->remote_ses_state == PTM_BFD_UP)
+		bfd_recvtimer_update(bs);
 }
 
 /*
@@ -1693,15 +1705,6 @@ void bs_final_handler(struct bfd_session *bs)
 	/* Start using our new timers. */
 	bs->cur_timers.desired_min_tx = bs->timers.desired_min_tx;
 	bs->cur_timers.required_min_rx = bs->timers.required_min_rx;
-
-	/*
-	 * TODO: demand mode. See RFC 5880 Section 6.1.
-	 *
-	 * When using demand mode we must disable the detection timer
-	 * for lost control packets.
-	 */
-	if (bs->demand_mode)
-		return;
 
 	/*
 	 * Calculate transmission time based on new timers.

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -788,6 +788,7 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag, bool notify_admin_do
 	bfd->discrs.remote_discr = 0;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
+	bfd->remote_ses_state = PTM_BFD_ADM_DOWN;
 	monotime(&bfd->downtime);
 
 	/*
@@ -883,6 +884,7 @@ void ptm_sbfd_init_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	bfd->local_diag = diag;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
+	bfd->remote_ses_state = PTM_BFD_ADM_DOWN;
 	monotime(&bfd->downtime);
 
 	/*
@@ -932,6 +934,7 @@ void ptm_sbfd_echo_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	bfd->discrs.remote_discr = 0;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
+	bfd->remote_ses_state = PTM_BFD_ADM_DOWN;
 	monotime(&bfd->downtime);
 	/* only signal clients when going from up->down state */
 	if (old_state == PTM_BFD_UP)

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -781,7 +781,6 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag, bool notify_admin_do
 	bfd->discrs.remote_discr = 0;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
-	bfd->demand_mode = 0;
 	monotime(&bfd->downtime);
 
 	/*
@@ -877,7 +876,6 @@ void ptm_sbfd_init_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	bfd->local_diag = diag;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
-	bfd->demand_mode = 0;
 	monotime(&bfd->downtime);
 
 	/*
@@ -927,7 +925,6 @@ void ptm_sbfd_echo_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	bfd->discrs.remote_discr = 0;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
-	bfd->demand_mode = 0;
 	monotime(&bfd->downtime);
 	/* only signal clients when going from up->down state */
 	if (old_state == PTM_BFD_UP)

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -680,6 +680,22 @@ struct key *bfd_keychain_key_find_active(const struct keychain *keychain, bool m
 
 void ptm_bfd_xmt_TO(struct bfd_session *bfd, int fbit)
 {
+	/*
+	 * Periodic transmission ceases while the peer has requested
+	 * Demand mode, both systems are Up and no Poll Sequence is
+	 * in progress.
+	 *
+	 * The timer keeps running so that transmission resumes on
+	 * its own once any of those stop holding.
+	 *
+	 * RFC 5880, Section 6.8.7.
+	 */
+	if (bfd->remote_demand_mode && bfd->ses_state == PTM_BFD_UP &&
+	    bfd->remote_ses_state == PTM_BFD_UP && !bfd->polling && !fbit) {
+		ptm_bfd_start_xmt_timer(bfd, false);
+		return;
+	}
+
 	/* Send the scheduled control packet */
 	ptm_bfd_snd(bfd, fbit);
 
@@ -789,6 +805,7 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag, bool notify_admin_do
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
 	bfd->remote_ses_state = PTM_BFD_ADM_DOWN;
+	bfd->remote_demand_mode = 0;
 	monotime(&bfd->downtime);
 
 	/*
@@ -885,6 +902,7 @@ void ptm_sbfd_init_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
 	bfd->remote_ses_state = PTM_BFD_ADM_DOWN;
+	bfd->remote_demand_mode = 0;
 	monotime(&bfd->downtime);
 
 	/*
@@ -935,6 +953,7 @@ void ptm_sbfd_echo_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
 	bfd->remote_ses_state = PTM_BFD_ADM_DOWN;
+	bfd->remote_demand_mode = 0;
 	monotime(&bfd->downtime);
 	/* only signal clients when going from up->down state */
 	if (old_state == PTM_BFD_UP)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -389,6 +389,7 @@ struct bfd_session {
 	uint8_t remote_detect_mult;
 	uint8_t mh_ttl;
 	uint8_t remote_cbit;
+	uint8_t remote_ses_state;
 
 	/** BFD profile name. */
 	char *profile_name;

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -390,6 +390,7 @@ struct bfd_session {
 	uint8_t mh_ttl;
 	uint8_t remote_cbit;
 	uint8_t remote_ses_state;
+	uint8_t remote_demand_mode;
 
 	/** BFD profile name. */
 	char *profile_name;

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -383,7 +383,6 @@ struct bfd_session {
 	uint8_t ses_state;
 	struct bfd_discrs discrs;
 	uint8_t local_diag;
-	uint8_t demand_mode;
 	uint8_t detect_mult;
 	uint8_t remote_detect_mult;
 	uint8_t mh_ttl;
@@ -495,7 +494,6 @@ struct sbfd_reflector {
 
 /* Various constants */
 /* Retrieved from ptm_timer.h from Cumulus PTM sources. */
-#define BFD_DEF_DEMAND 0
 #define BFD_DEFDETECTMULT 3
 #define BFD_DEFDESIREDMINTX (300 * 1000) /* microseconds. */
 #define BFD_DEFREQUIREDMINRX (300 * 1000) /* microseconds. */

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -260,6 +260,7 @@ enum bfd_session_flags {
 					     * actively
 					     */
 	BFD_SESS_FLAG_MH = 1 << 2,		     /* BFD Multi-hop session */
+	BFD_SESS_FLAG_DEMAND = 1 << 3,		     /* Demand mode configured */
 	BFD_SESS_FLAG_IPV6 = 1 << 4,		     /* BFD IPv6 session */
 	BFD_SESS_FLAG_SEND_EVT_ACTIVE = 1 << 5,	     /* send event timer active */
 	BFD_SESS_FLAG_SEND_EVT_IGNORE = 1 << 6,	     /* ignore send event when timer
@@ -343,6 +344,7 @@ struct bfd_profile {
 
 	/** Echo mode (only applies to single hop). */
 	bool echo_mode;
+	bool demand_mode;
 	/** Desired echo transmission interval (in microseconds). */
 	uint32_t min_echo_tx;
 	/** Minimum required echo receive interval (in microseconds). */
@@ -743,6 +745,7 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown);
  * \param passive the passive mode.
  */
 void bfd_set_passive_mode(struct bfd_session *bs, bool passive);
+void bfd_set_demand(struct bfd_session *bs, bool demand);
 
 /**
  * Set the BFD session to log or not log session changes.

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1399,6 +1399,7 @@ void bfd_recv_cb(struct event *t)
 		bfd->remote_cbit = 0;
 
 	bfd->remote_ses_state = BFD_GETSTATE(cp->flags);
+	bfd->remote_demand_mode = BFD_GETDEMANDBIT(cp->flags) ? 1 : 0;
 
 	/* The initiator handle SBFD reflect packet. */
 	if (bfd->bfd_mode == BFD_MODE_TYPE_SBFD_INIT) {
@@ -1450,8 +1451,20 @@ void bfd_recv_cb(struct event *t)
 		bfd->detect_TO = bfd->remote_detect_mult
 				 * bfd->remote_timers.desired_min_tx;
 
-	/* Apply new receive timer immediately. */
-	bfd_recvtimer_update(bfd);
+	/*
+	 * Apply new receive timer immediately, unless demand mode is
+	 * active: the peer ceases periodic transmission, so there is
+	 * nothing to time out. Liveness is then verified by Poll
+	 * Sequence instead.
+	 *
+	 * RFC 5880, Section 6.6.
+	 */
+	if (!(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_DEMAND) &&
+	      bfd->ses_state == PTM_BFD_UP &&
+	      bfd->remote_ses_state == PTM_BFD_UP))
+		bfd_recvtimer_update(bfd);
+	else
+		bfd_recvtimer_delete(bfd);
 
 	/* Handle echo timers changes. */
 	bs_echo_timer_handler(bfd);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -446,7 +446,14 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
 		BFD_SETCBIT(cp.flags, BFD_CBIT);
 
-	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
+	/*
+	 * The Demand bit is only set once both systems are Up.
+	 *
+	 * RFC 5880, Section 6.8.6.
+	 */
+	BFD_SETDEMANDBIT(cp.flags, CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_DEMAND) &&
+					   bfd->ses_state == PTM_BFD_UP &&
+					   bfd->remote_ses_state == PTM_BFD_UP);
 
 	/* Polling and Final can't be set at the same time.
 	 *
@@ -1390,6 +1397,8 @@ void bfd_recv_cb(struct event *t)
 		bfd->remote_cbit = 1;
 	else
 		bfd->remote_cbit = 0;
+
+	bfd->remote_ses_state = BFD_GETSTATE(cp->flags);
 
 	/* The initiator handle SBFD reflect packet. */
 	if (bfd->bfd_mode == BFD_MODE_TYPE_SBFD_INIT) {

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1459,8 +1459,7 @@ void bfd_recv_cb(struct event *t)
 	 *
 	 * RFC 5880, Section 6.6.
 	 */
-	if (!(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_DEMAND) &&
-	      bfd->ses_state == PTM_BFD_UP &&
+	if (!(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_DEMAND) && bfd->ses_state == PTM_BFD_UP &&
 	      bfd->remote_ses_state == PTM_BFD_UP))
 		bfd_recvtimer_update(bfd);
 	else

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1460,7 +1460,7 @@ void bfd_recv_cb(struct event *t)
 	 * RFC 5880, Section 6.6.
 	 */
 	if (!(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_DEMAND) && bfd->ses_state == PTM_BFD_UP &&
-	      bfd->remote_ses_state == PTM_BFD_UP))
+	      bfd->remote_ses_state == PTM_BFD_UP && !bfd->polling))
 		bfd_recvtimer_update(bfd);
 	else
 		bfd_recvtimer_delete(bfd);

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -878,6 +878,21 @@ void bfd_cli_show_tx(struct vty *vty, const struct lyd_node *dnode,
 }
 
 DEFPY_YANG(
+	bfd_peer_demand, bfd_peer_demand_cmd,
+	"[no] demand-mode",
+	NO_STR
+	"Configure demand mode\n")
+{
+	nb_cli_enqueue_change(vty, "./demand-mode", NB_OP_MODIFY, no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void bfd_cli_show_demand(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	vty_out(vty, "  %sdemand-mode\n", yang_dnode_get_bool(dnode, NULL) ? "" : "no ");
+}
+
+DEFPY_YANG(
 	bfd_peer_echo, bfd_peer_echo_cmd,
 	"[no] echo-mode",
 	NO_STR
@@ -1201,6 +1216,11 @@ ALIAS_YANG(no_bfd_peer_minimum_ttl, no_bfd_profile_minimum_ttl_cmd,
       NO_STR
       "Expect packets with at least this TTL\n")
 
+ALIAS_YANG(bfd_peer_demand, bfd_profile_demand_cmd,
+      "[no] demand-mode",
+      NO_STR
+      "Configure demand mode\n")
+
 ALIAS_YANG(bfd_peer_echo, bfd_profile_echo_cmd,
       "[no] echo-mode",
       NO_STR
@@ -1490,6 +1510,7 @@ bfdd_cli_init(void)
 	install_element(BFD_PEER_NODE, &bfd_peer_rx_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_tx_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_demand_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_interval_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_transmit_interval_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_receive_interval_cmd);
@@ -1515,6 +1536,7 @@ bfdd_cli_init(void)
 	install_element(BFD_PROFILE_NODE, &bfd_profile_rx_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_shutdown_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_cmd);
+	install_element(BFD_PROFILE_NODE, &bfd_profile_demand_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_interval_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_transmit_interval_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_receive_interval_cmd);

--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -91,6 +91,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 				.cli_show = bfd_cli_show_echo,
                         }
                 },
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/profile/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_profile_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand,
+			}
+		},
                 {
                         .xpath = "/frr-bfdd:bfdd/bfd/profile/desired-echo-transmission-interval",
                         .cbs = {
@@ -179,6 +186,20 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_echo_mode_modify,
 				.cli_show = bfd_cli_show_echo,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_multi_hop_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand,
 			}
 		},
 		{

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -26,6 +26,9 @@ int bfdd_bfd_profile_administrative_down_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_passive_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_log_session_changes_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_minimum_ttl_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_demand_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_single_hop_demand_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_multi_hop_demand_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_desired_echo_transmission_interval_modify(
 	struct nb_cb_modify_args *args);
@@ -229,6 +232,7 @@ void bfd_cli_show_rx(struct vty *vty, const struct lyd_node *dnode,
 		     bool show_defaults);
 void bfd_cli_show_shutdown(struct vty *vty, const struct lyd_node *dnode,
 			   bool show_defaults);
+void bfd_cli_show_demand(struct vty *vty, const struct lyd_node *dnode, bool show_defaults);
 void bfd_cli_show_echo(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults);
 void bfd_cli_show_desired_echo_transmission_interval(

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -652,6 +652,28 @@ int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args)
 }
 
 /*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/demand-mode
+ */
+int bfdd_bfd_profile_demand_mode_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+	bool demand;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	demand = yang_dnode_get_bool(args->dnode, NULL);
+	bp = nb_running_get_entry(args->dnode, NULL, true);
+	if (bp->demand_mode == demand)
+		return NB_OK;
+
+	bp->demand_mode = demand;
+	bfd_profile_update(bp);
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-bfdd:bfdd/bfd/profile/desired-echo-transmission-interval
  */
 int bfdd_bfd_profile_desired_echo_transmission_interval_modify(
@@ -1182,6 +1204,60 @@ int bfdd_bfd_sessions_bfd_mode_modify(struct nb_cb_modify_args *args)
 
 int bfdd_bfd_sessions_bfd_mode_destroy(struct nb_cb_destroy_args *args)
 {
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/demand-mode
+ */
+int bfdd_bfd_sessions_single_hop_demand_mode_modify(struct nb_cb_modify_args *args)
+{
+	bool demand = yang_dnode_get_bool(args->dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->peer_profile.demand_mode = demand;
+	bfd_session_apply(bs);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/multi-hop/demand-mode
+ */
+int bfdd_bfd_sessions_multi_hop_demand_mode_modify(struct nb_cb_modify_args *args)
+{
+	bool demand = yang_dnode_get_bool(args->dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->peer_profile.demand_mode = demand;
+	bfd_session_apply(bs);
+
 	return NB_OK;
 }
 

--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -191,13 +191,12 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
 	 *   2. Async without echo
 	 *   3. Demand with echo
 	 *   4. Demand without echo
-	 *
-	 * TODO: support demand mode.
 	 */
-	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
-		detection_mode = 1;
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND) && bs->ses_state == PTM_BFD_UP &&
+	    bs->remote_ses_state == PTM_BFD_UP)
+		detection_mode = CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO) ? 3 : 4;
 	else
-		detection_mode = 2;
+		detection_mode = CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO) ? 1 : 2;
 
 	return yang_data_new_enum(args->xpath, detection_mode);
 }

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -186,6 +186,13 @@ static void _display_peer(struct vty *vty, struct bfd_session *bs)
 		vty_out(vty, "\t\tActive mode\n");
 	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_LOG_SESSION_CHANGES))
 		vty_out(vty, "\t\tLog session changes\n");
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND))
+		vty_out(vty, "\t\tDemand mode: %s\n",
+			bs->ses_state == PTM_BFD_UP && bs->remote_ses_state == PTM_BFD_UP
+				? "active"
+				: "configured");
+	if (bs->remote_demand_mode)
+		vty_out(vty, "\t\tPeer is in demand mode\n");
 	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 		vty_out(vty, "\t\tMinimum TTL: %d\n", bs->mh_ttl);
 	vty_out(vty, "\t\tStatus: ");
@@ -355,6 +362,8 @@ static struct json_object *__display_peer_json(struct bfd_session *bs)
 				CHECK_FLAG(bs->flags, BFD_SESS_FLAG_PASSIVE));
 	json_object_boolean_add(jo, "log-session-changes",
 				CHECK_FLAG(bs->flags, BFD_SESS_FLAG_LOG_SESSION_CHANGES));
+	json_object_boolean_add(jo, "demand-mode", CHECK_FLAG(bs->flags, BFD_SESS_FLAG_DEMAND));
+	json_object_boolean_add(jo, "remote-demand-mode", bs->remote_demand_mode);
 	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 		json_object_int_add(jo, "minimum-ttl", bs->mh_ttl);
 

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -813,6 +813,8 @@ static void _bfd_dplane_session_fill(const struct bfd_session *bs,
 		msg->data.session.flags |= SESSION_ECHO;
 	if (bs->flags & BFD_SESS_FLAG_CBIT)
 		msg->data.session.flags |= SESSION_CBIT;
+	if (bs->flags & BFD_SESS_FLAG_DEMAND)
+		msg->data.session.flags |= SESSION_DEMAND;
 	if (bs->flags & BFD_SESS_FLAG_PASSIVE)
 		msg->data.session.flags |= SESSION_PASSIVE;
 	if (bs->flags & BFD_SESS_FLAG_SHUTDOWN)

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -380,6 +380,12 @@ bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 	bs->remote_diag = state->diagnostics;
 	bs->discrs.remote_discr = ntohl(state->rid);
 	bs->remote_cbit = !!(flags & RBIT_CPI);
+	/*
+	 * Only the peer's Demand bit is recorded here. The data plane
+	 * owns transmission and detection for offloaded sessions, so
+	 * demand mode is reported as configured rather than active.
+	 */
+	bs->remote_demand_mode = !!(flags & RBIT_DEMAND);
 	bs->remote_detect_mult = state->detection_multiplier;
 	bs->remote_timers.desired_min_tx = ntohl(state->desired_tx);
 	bs->remote_timers.required_min_rx = ntohl(state->required_rx);

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -200,6 +200,24 @@ BFD peers and profiles share the same BFD session configuration commands.
    Echo mode is not supported on multi-hop setups (see :rfc:`5883`
    section 3).
 
+.. clicmd:: demand-mode
+
+   Enables or disables demand mode. This mode is disabled by default.
+
+   In demand mode this system asks the peer to cease periodic control
+   packet transmission, on the understanding that connectivity is
+   verified by some other means. The path is then verified only when a
+   Poll Sequence is initiated, which happens when the contents of a
+   control packet would otherwise change.
+
+   Because nothing initiates a Poll Sequence on its own, enabling
+   demand mode on both ends of a connection without `echo-mode` can
+   leave a failed path undetected: neither system transmits and
+   neither runs a detection timer. Pair demand mode with `echo-mode`,
+   or ensure some other mechanism verifies the path.
+
+   Unlike echo mode, demand mode is supported on multi-hop setups.
+
 .. clicmd:: shutdown
 
    Enables or disables the peer. When the peer is disabled an

--- a/tests/topotests/bfd_demand_topo1/r1/frr.conf
+++ b/tests/topotests/bfd_demand_topo1/r1/frr.conf
@@ -1,0 +1,11 @@
+!
+interface r1-eth0
+ ip address 192.168.1.1/24
+!
+bfd
+ peer 192.168.1.2
+  transmit-interval 1000
+  receive-interval 1000
+ exit
+exit
+!

--- a/tests/topotests/bfd_demand_topo1/r2/frr.conf
+++ b/tests/topotests/bfd_demand_topo1/r2/frr.conf
@@ -1,0 +1,11 @@
+!
+interface r2-eth0
+ ip address 192.168.1.2/24
+!
+bfd
+ peer 192.168.1.1
+  transmit-interval 1000
+  receive-interval 1000
+ exit
+exit
+!

--- a/tests/topotests/bfd_demand_topo1/test_bfd_demand_topo1.py
+++ b/tests/topotests/bfd_demand_topo1/test_bfd_demand_topo1.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_bfd_demand_topo1.py
+#
+# Copyright (c) 2026 by Abdul Wasey
+#
+
+"""
+test_bfd_demand_topo1.py: BFD demand mode (RFC 5880 section 6.6).
+
+r1 and r2 run a single hop session.  Demand mode is enabled on r1 only,
+so r1 sets the Demand bit and r2 is expected to cease periodic control
+packet transmission while keeping the session up.
+
+The session must survive that silence: a system in demand mode does not
+run its detection timer, because there is nothing left to time out.
+Liveness is verified by Poll Sequence instead, so a path failure is
+detected only once a poll is initiated.
+"""
+
+import os
+import sys
+from functools import partial
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bfdd]
+
+R1_ADDR = "192.168.1.1"
+R2_ADDR = "192.168.1.2"
+
+# Long enough that a transmitting peer would emit many packets at the
+# configured 100ms interval, so a zero delta is unambiguous.
+QUIET_SECS = 10
+
+# With no poll outstanding the detection timer is not running, so r1 must
+# stay up across this window even though r2 is unreachable.
+UNDETECTED_SECS = 5
+
+
+def build_topo(tgen):
+    "Two routers on a single link."
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _peer_entry(entries, peer):
+    for entry in entries:
+        if entry.get("peer") == peer:
+            return entry
+    return None
+
+
+def _check_peer(router, peer, expected):
+    output = router.vtysh_cmd("show bfd peers json", isjson=True)
+    entry = _peer_entry(output, peer)
+    if entry is None:
+        return "peer {} not found on {}".format(peer, router.name)
+    return topotest.json_cmp(entry, expected)
+
+
+def _counter(router, peer, name):
+    counters = router.vtysh_cmd("show bfd peers counters json", isjson=True)
+    entry = _peer_entry(counters, peer)
+    assert entry is not None, "peer {} not found on {}".format(peer, router.name)
+    return entry.get(name, 0)
+
+
+def _shutdown(router, peer, enable):
+    router.vtysh_cmd(
+        "configure terminal\nbfd\npeer {}\n{}shutdown\nend".format(
+            peer, "" if enable else "no "
+        )
+    )
+
+
+def _wait_quiet(router, peer):
+    """
+    Block until the router stops sending control packets.
+
+    Poll and Final exchanges keep flowing for a while after a configuration
+    change, and how long depends on the negotiated interval, so waiting for
+    the counter to stop advancing is more reliable than sleeping a fixed
+    time and hoping the exchange has drained.
+    """
+    state = {"last": None}
+
+    def _moving():
+        now = _counter(router, peer, "control-packet-output")
+        if state["last"] is not None and now == state["last"]:
+            return None
+        state["last"] = now
+        return "{} is still transmitting".format(router.name)
+
+    _, result = topotest.run_and_expect(_moving, None, count=30, wait=2)
+    return result
+
+
+def _set_demand(router, peer, enable):
+    router.vtysh_cmd(
+        "configure terminal\nbfd\npeer {}\n{}demand-mode\nend".format(
+            peer, "" if enable else "no "
+        )
+    )
+
+
+def test_bfd_demand_session_up():
+    "Both ends must reach up before demand mode is enabled."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for router, peer in ((tgen.gears["r1"], R2_ADDR), (tgen.gears["r2"], R1_ADDR)):
+        test_func = partial(_check_peer, router, peer, {"status": "up"})
+        _, result = topotest.run_and_expect(test_func, None, count=32, wait=1)
+        assert result is None, "{} did not reach up with {}".format(router.name, peer)
+
+
+def test_bfd_demand_reported():
+    "Enabling demand mode must be visible on both ends, differently."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _set_demand(tgen.gears["r1"], R2_ADDR, True)
+
+    # r1 knows it is demanding; r2 knows its peer is.  The two keys report
+    # different facts and must not be conflated.
+    test_func = partial(
+        _check_peer,
+        tgen.gears["r1"],
+        R2_ADDR,
+        {"status": "up", "demand-mode": True, "remote-demand-mode": False},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+    assert result is None, "r1 does not report itself in demand mode"
+
+    test_func = partial(
+        _check_peer,
+        tgen.gears["r2"],
+        R1_ADDR,
+        {"status": "up", "demand-mode": False, "remote-demand-mode": True},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+    assert result is None, "r2 did not observe r1's Demand bit"
+
+
+def test_bfd_demand_transmission_ceases():
+    "r2 must stop transmitting, r1 must not, and the session must survive."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1, r2 = tgen.gears["r1"], tgen.gears["r2"]
+
+    assert _wait_quiet(r2, R1_ADDR) is None, "r2 never ceased transmitting"
+
+    # Sampled before the wait: the session was reconfigured during this run,
+    # so only deltas are meaningful.
+    r1_tx = _counter(r1, R2_ADDR, "control-packet-output")
+    r2_tx = _counter(r2, R1_ADDR, "control-packet-output")
+    r1_down = _counter(r1, R2_ADDR, "session-down")
+    r2_down = _counter(r2, R1_ADDR, "session-down")
+
+    topotest.sleep(QUIET_SECS, "waiting to see whether r2 keeps transmitting")
+
+    for router, peer, before in ((r1, R2_ADDR, r1_down), (r2, R1_ADDR, r2_down)):
+        flaps = _counter(router, peer, "session-down") - before
+        assert flaps == 0, (
+            "{} recorded {} down events with {}: the detection timer is "
+            "still running in demand mode".format(router.name, flaps, peer)
+        )
+
+    r2_sent = _counter(r2, R1_ADDR, "control-packet-output") - r2_tx
+    assert r2_sent == 0, (
+        "r2 sent {} control packets while r1 was in demand mode: "
+        "the Demand bit is not being honoured".format(r2_sent)
+    )
+
+    r1_sent = _counter(r1, R2_ADDR, "control-packet-output") - r1_tx
+    assert r1_sent > 0, (
+        "r1 stopped transmitting: a system in demand mode ceases only when "
+        "its peer asks it to, and r2 is not demanding"
+    )
+
+
+def test_bfd_demand_poll_detects_failure():
+    "A failed path is detected once a Poll Sequence is initiated."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1, r2 = tgen.gears["r1"], tgen.gears["r2"]
+
+    # Break the path silently.  Stopping the router would let r2 signal the
+    # session down, which is a different diagnostic than the one under test.
+    r2.run("ip link set r2-eth0 down")
+
+    topotest.sleep(UNDETECTED_SECS, "checking that the failure goes unnoticed")
+
+    result = _check_peer(r1, R2_ADDR, {"status": "up"})
+    assert result is None, (
+        "r1 detected the failure without a Poll Sequence: the detection timer "
+        "should not be running while demand mode is active"
+    )
+
+    # Changing a negotiated interval forces a Poll Sequence, which is the only
+    # in band verification available in demand mode.
+    r1.vtysh_cmd(
+        "configure terminal\nbfd\npeer {}\ntransmit-interval 300\nend".format(R2_ADDR)
+    )
+
+    test_func = partial(
+        _check_peer,
+        r1,
+        R2_ADDR,
+        {"status": "down", "diagnostic": "control detection time expired"},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+    assert result is None, "r1 did not detect the failure after a Poll Sequence"
+
+
+def test_bfd_demand_disable_restores_detection():
+    "Leaving demand mode must restore detection even if the peer is already gone."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1, r2 = tgen.gears["r1"], tgen.gears["r2"]
+
+    # Bring the session back with the link and demand mode restored, so this
+    # test starts from a working demanding session rather than the previous
+    # test's leftovers.
+    r2.run("ip link set r2-eth0 up")
+    _set_demand(r1, R2_ADDR, False)
+
+    test_func = partial(_check_peer, r1, R2_ADDR, {"status": "up"})
+    _, result = topotest.run_and_expect(test_func, None, count=32, wait=1)
+    assert result is None, "session did not recover before the test"
+
+    _set_demand(r1, R2_ADDR, True)
+    test_func = partial(_check_peer, r1, R2_ADDR, {"demand-mode": True})
+    _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+    assert result is None, "r1 did not re-enter demand mode"
+
+    # Confirm r2 has actually ceased before breaking the path: if it is
+    # still transmitting, r1's detection timer was never deleted and this
+    # test would pass without exercising the restore at all.
+    assert _wait_quiet(r2, R1_ADDR) is None, "r2 never ceased transmitting"
+
+    r2_tx = _counter(r2, R1_ADDR, "control-packet-output")
+    r1_rx = _counter(r1, R2_ADDR, "control-packet-input")
+    topotest.sleep(5, "checking that r2 stays ceased")
+    assert _counter(r2, R1_ADDR, "control-packet-output") - r2_tx == 0, (
+        "r2 is still transmitting, so r1's detection timer was never deleted "
+        "and this test would not exercise the restore"
+    )
+    assert (
+        _counter(r1, R2_ADDR, "control-packet-input") - r1_rx == 0
+    ), "r1 is still receiving, so nothing here depends on the timer restore"
+
+    # Break the path while the detection timer is disabled, so nothing will
+    # arrive to re-arm it once demand mode is turned off again.
+    r2.run("ip link set r2-eth0 down")
+    topotest.sleep(3, "letting the failure go unnoticed")
+
+    _set_demand(r1, R2_ADDR, False)
+
+    test_func = partial(
+        _check_peer,
+        r1,
+        R2_ADDR,
+        {"status": "down", "diagnostic": "control detection time expired"},
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+    assert result is None, (
+        "r1 stayed up after leaving demand mode: the detection timer was not "
+        "restored, so a dead path goes unnoticed indefinitely"
+    )
+
+
+def test_bfd_demand_both_ends_disable():
+    "Leaving demand mode must reach a peer that is also demanding."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1, r2 = tgen.gears["r1"], tgen.gears["r2"]
+
+    r2.run("ip link set r2-eth0 up")
+    _set_demand(r1, R2_ADDR, False)
+    _set_demand(r2, R1_ADDR, False)
+
+    test_func = partial(_check_peer, r1, R2_ADDR, {"status": "up"})
+    _, result = topotest.run_and_expect(test_func, None, count=32, wait=1)
+    assert result is None, "session did not recover before the test"
+
+    # Both ends demanding. Configure it while the session is down: the
+    # Demand bit is only set once both systems are Up, so bringing the
+    # session up with both ends already configured lets each learn the
+    # other's bit before either has ceased transmitting.
+    _shutdown(r1, R2_ADDR, True)
+    _shutdown(r2, R1_ADDR, True)
+    topotest.sleep(2, "letting both ends go down")
+    _set_demand(r1, R2_ADDR, True)
+    _set_demand(r2, R1_ADDR, True)
+    _shutdown(r1, R2_ADDR, False)
+    _shutdown(r2, R1_ADDR, False)
+
+    for router, peer in ((r1, R2_ADDR), (r2, R1_ADDR)):
+        test_func = partial(
+            _check_peer,
+            router,
+            peer,
+            {"status": "up", "demand-mode": True, "remote-demand-mode": True},
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=32, wait=1)
+        assert result is None, "{} is not mutually demanding".format(router.name)
+
+    down_before = _counter(r1, R2_ADDR, "session-down")
+
+    _set_demand(r1, R2_ADDR, False)
+
+    topotest.sleep(10, "checking that the healthy session survives")
+
+    result = _check_peer(r1, R2_ADDR, {"status": "up", "diagnostic": "ok"})
+    assert result is None, (
+        "r1 went down after leaving demand mode on a healthy path: its "
+        "transmission is still suppressed by the peer's Demand bit"
+    )
+    flaps = _counter(r1, R2_ADDR, "session-down") - down_before
+    assert flaps == 0, "r1 recorded {} down events on a healthy path".format(flaps)
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -257,6 +257,19 @@ module frr-bfdd {
     }
   }
 
+  grouping session-demand {
+    description "BFD session demand settings";
+
+    leaf demand-mode {
+      type boolean;
+      default false;
+      description
+        "Operate in demand mode: cease periodic control packet
+         transmission once the session is up, relying on an
+         independent means of verifying connectivity.";
+    }
+  }
+
   grouping session-multi-hop {
     description "BFD session multi hop settings.";
 
@@ -471,6 +484,7 @@ module frr-bfdd {
         uses session-common;
         uses session-echo;
         uses session-multi-hop;
+        uses session-demand;
 
         container profile-authentication {
           leaf authentication-key-chain {
@@ -520,6 +534,7 @@ module frr-bfdd {
 
           uses session-common;
           uses session-echo;
+          uses session-demand;
           uses auth-config;
 
 
@@ -557,6 +572,7 @@ module frr-bfdd {
 
           uses session-common;
           uses session-multi-hop;
+          uses session-demand;
           uses auth-config;
 
           container stats {


### PR DESCRIPTION
Demand mode has been declared but dead in bfdd. `bfd->demand_mode` is assigned `0` in three places and never `1`. `BFD_DEF_DEMAND` is `0`, so the Demand bit is always cleared on transmit. `frr-bfdd.yang` declares `demand-with-echo` and `demand-without-echo` detection modes that nothing can report. Two `TODO: demand mode` comments sit in `bs_final_handler()` and `bfdd_nb_state.c`. This series implements it.

Section 6.6 says a system may use demand mode when it has some other way of verifying connectivity, and leaves what that is to the implementation. bfdd cannot determine that, so the knob is the operator asserting it.

Discussed with @rzalamena beforehand. He confirmed it should be a session/profile configuration and asked for a documentation note about the both-ends case. Both are in the series.

## Commits

| Commit | What it does |
| --- | --- |
| `bfdd: add demand mode configuration` | `demand-mode` at peer and profile level, through YANG, northbound and CLI into a new `BFD_SESS_FLAG_DEMAND`. Nothing reads the flag yet. |
| `bfdd: set the Demand bit when configured` | Records the remote session state from incoming packets and sets the Demand bit on transmit when demand mode is configured and both systems are Up, per section 6.8.6. |
| `bfdd: don't run the detection timer in demand mode` | The peer ceases periodic transmission, so there is nothing to time out. |
| `bfdd: cease periodic transmission on a received Demand bit` | Records the peer's Demand bit and stops sending while it is set, both systems are Up, and no Poll Sequence is in progress. |
| `bfdd: verify the path with a Poll Sequence in demand mode` | Keeps the detection timer running while a poll is outstanding, so a lost Final brings the session down instead of leaving the poll outstanding forever. |
| `bfdd: report demand mode and pass it to the data plane` | Fills in the two demand detection modes, sets `SESSION_DEMAND` in the data plane session flags, reports demand mode in `show bfd peers` and its JSON, and documents the command. |
| `tests: add a topotest for BFD demand mode` | `tests/topotests/bfd_demand_topo1/`. |
| `bfdd: record the peer's Demand bit from the data plane` | Honours `RBIT_DEMAND` in the data plane state change the way `RBIT_CPI` already is. Reporting only. |

## Three departures from the design I circulated

Each is explained in the commit message of the commit that makes it. Collected here because they are the parts most likely to draw disagreement.

### Transmission is suppressed at the send point, not by removing the transmit timer

Deleting the transmit timer does not work here.

`ptm_bfd_xmt_TO()` sends and then re-arms via `ptm_bfd_start_xmt_timer()`, and `bfd_xmt_cb()` is its only driver, so the timer is self-perpetuating and deleting it needs somewhere to restart it from. There is no such place. `bs_up_handler()` is a no-op for the Up-to-Up case, which is the transition that matters here.

It also deadlocks when both ends operate in demand mode. Under section 6.8.7 a system ceases transmission because the peer set the Demand bit. If both set it, both stop, and neither can clear its own Demand bit, because clearing it requires sending a packet. The escape is that a content change forces a Poll Sequence and section 6.8.7 exempts a poll in progress from the suppression, which requires the transmit path to still be reachable.

So `ptm_bfd_xmt_TO()` re-arms the timer and returns without sending while `remote_demand_mode && Up && remote Up && !polling && !fbit` holds. No new state, and the poll exemption stays reachable.

### The commit order is deliberate

The detection timer guard lands before the commit that ceases transmission. The other way round leaves a bisect point where enabling `demand-mode` takes the session down with `control detection time expired`, because the peer goes quiet while the local detection timer is still running. Guard-first is inert on its own, since nothing yet honours the Demand bit, so the peer keeps transmitting and we stop timing it out.

### `bs_final_handler()`'s demand mode guard is deleted rather than repaired

The function contained:

```c
	/*
	 * TODO: demand mode. See RFC 5880 Section 6.1.
	 *
	 * When using demand mode we must disable the detection timer
	 * for lost control packets.
	 */
	if (bs->demand_mode)
		return;
```

It tests `bs->demand_mode`, which nothing sets to `1`, so it has never fired. Pointing it at the real flag would be wrong: it skips the transmission interval recalculation, and a system in demand mode still transmits and must honour the negotiated interval. The detection timer is handled on the receive path instead, so the guard and its TODO are removed.

## Documentation

`doc/user/bfd.rst` notes that enabling demand mode on both ends without echo mode can leave a failed path undetected: neither system transmits, neither runs a detection timer, and nothing initiates a Poll Sequence on its own. It recommends pairing demand mode with echo mode, or ensuring some other mechanism verifies the path.

This is easy to hit. While testing, restarting bfdd on the non-demanding end went undetected every time. The demanding end has no detection timer, so it stays in Up with a stale discriminator, while the restarted end comes up in Down, and under section 6.8.6 a system in Down that receives Up makes no transition. Both ends then reject each other until the session is bounced by hand.

## Testing

Tested FRR to FRR on a two node lab, one session per end, each claim checked on the wire.

Demand bit: with demand mode enabled five seconds into a capture, 74 frames from the configured end carried the bit and 19 did not, with none from the peer. The last clear frame precedes the first Demand frame.

Cease and detection: with demand mode on one end only, the peer's last frame lands at the moment the knob is flipped and it then goes silent, while the configured end keeps transmitting for the remaining 25 seconds of the capture. Both ends stay up with uptime climbing.

Resume: after `no demand-mode`, both ends transmit again symmetrically with no Demand bit anywhere, and the session does not flap.

Poll Sequence: a forced poll gets its Final back within 144 microseconds and the session stays up. With the peer killed, a forced poll brings the session down in about four seconds with `control detection time expired`.

The topotest covers the same ground under CI. Both ends reach up, each end reports demand mode differently in JSON, the peer's `control-packet-output` delta is zero over a ten second window while the other end's climbs, neither end records a down event, and downing the link goes unnoticed until a Poll Sequence is forced. Each assertion was checked against a build with the relevant commit neutered, and each fails with its own message.

## Caveats

No interoperability testing against another vendor. I do not have vendor gear. The closest data point is that one end of the lab ran FRR 10.5.1, which has no demand mode support: it ignored the Demand bit rather than rejecting the packets, and the session stayed up for over two minutes across 74 frames carrying it. That says the bit is safely ignored by an implementation that does not support it, which is not the same as the mode interoperating.

The data plane commit is not reproducible with upstream FRR. `RBIT_DEMAND` handling was verified against my own XDP based data plane, which needed changes of its own before it reported the flag correctly. There is no upstream data plane to check it against.

Multihop is permitted but untested. Unlike echo mode, demand mode is not restricted to single hop, so the leaf is available on multihop sessions and the CLI accepts it there. The lab and the topotest are both single hop.
