### PR TITLE
zebra: Fix northbound rib iteration skips link-locals

### DIFF
--- a/tests/topotests/mgmt_oper/oper.py
+++ b/tests/topotests/mgmt_oper/oper.py
@@ -63,7 +63,41 @@ def disable_debug(router):
     router.vtysh_cmd("no debug northbound callbacks configuration")
 
 
+def is_link_local(prefix):
+    if not prefix or ":" not in prefix:
+        return False
+    return ipaddress.ip_network(prefix, strict=False).network_address.is_link_local
+
+
+def rm_link_local_routes(j):
+    """Drop IPv6 link-local routes from any RIB in a `get-data` result.
+
+    Every interface carries a link-local address, so a RIB holds one
+    fe80::/64 route with a connected route-entry per interface.  Zebra
+    learns those interfaces in whatever order it gets them, and that order
+    is not stable from one topology setup to the next: both the order of
+    the entries and which one of them wins route selection move around, so
+    the entry carrying "selected" and "internal-flags" is a different one
+    on different runs.  Stored results are compared exactly, keys included,
+    so they cannot pin any of that down.  test_oper_link_local() covers the
+    link-locals directly instead, comparing entry counts per prefix.
+    """
+    if j is None:
+        return j
+    for vrf in (j.get("frr-vrf:lib") or {}).get("vrf") or []:
+        zebra = vrf.get("frr-zebra:zebra")
+        if not isinstance(zebra, dict):
+            continue
+        for rib in (zebra.get("ribs") or {}).get("rib") or []:
+            routes = rib.get("route")
+            if routes is None:
+                continue
+            rib["route"] = [x for x in routes if not is_link_local(x.get("prefix"))]
+    return j
+
+
 def clean_json(j):
+    j = rm_link_local_routes(copy.deepcopy(j))
     if (
         j is None
         or not isinstance(j.get("frr-interface:lib"), dict)
@@ -71,7 +105,6 @@ def clean_json(j):
     ):
         return j
     rm_if_re = r"span|gre|sit|tnl|tun|vti"
-    j = copy.deepcopy(j)
     try:
         iflist = j["frr-interface:lib"]["interface"]
     except KeyError:
@@ -211,6 +244,33 @@ def check_kernel(r1, super_prefix, count, add, is_blackhole, vrf, matchvia):
                 "proto (static|196) metric 20"
             )
         assert re.search(route, kernel), f"Failed to find \n'{route}'\n in \n'{kernel}'"
+
+
+@retry(retry_timeout=60, initial_wait=0.1)
+def check_link_local_routes(r1, vrf):
+    """Every link-local route the CLI shows must also come back from the NB."""
+    vrfstr = "" if vrf == "default" else f" vrf {vrf}"
+    cli = json.loads(r1.cmd_raises(f"vtysh -c 'show ipv6 route{vrfstr} json'"))
+    expect = {p: len(e) for p, e in cli.items() if is_link_local(p)}
+    assert expect, f"vrf {vrf}: 'show ipv6 route' has no link-local routes"
+
+    query = f'/frr-vrf:lib/vrf[name="{vrf}"]/frr-zebra:zebra/ribs/rib'
+    nb = json.loads(r1.cmd_raises(f"vtysh -c 'show mgmt get-data {query}'"))
+
+    got = {}
+    for lvrf in nb["frr-vrf:lib"]["vrf"]:
+        for rib in lvrf["frr-zebra:zebra"]["ribs"]["rib"]:
+            if rib["afi-safi-name"] != "frr-routing:ipv6-unicast":
+                continue
+            for route in rib.get("route", []):
+                if not is_link_local(route["prefix"]):
+                    continue
+                nentries = len(route.get("route-entry", []))
+                got[route["prefix"]] = max(got.get(route["prefix"], 0), nentries)
+
+    assert (
+        got == expect
+    ), f"vrf {vrf}: northbound link-local routes {got} differ from cli {expect}"
 
 
 def addrgen(a, count, step=1):

--- a/tests/topotests/mgmt_oper/test_oper.py
+++ b/tests/topotests/mgmt_oper/test_oper.py
@@ -15,7 +15,12 @@ import math
 
 import pytest
 from lib.topogen import Topogen
-from oper import check_kernel_32, check_kernel_net, do_oper_test
+from oper import (
+    check_kernel_32,
+    check_kernel_net,
+    check_link_local_routes,
+    do_oper_test,
+)
 
 pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
 
@@ -106,6 +111,22 @@ def test_oper(tgen):
     check_kernel_net(r1, "2004:4444::/64", "red")
 
     do_oper_test(tgen, query_results)
+
+
+def test_oper_link_local(tgen):
+    """The northbound RIB walk must not hide IPv6 link-local routes.
+
+    A router holds one connected link-local route per interface, all of them
+    under the single fe80::/64 route node, so this also covers a route node
+    carrying several entries owned by the same protocol.
+    """
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"].net
+
+    check_link_local_routes(r1, "default")
+    check_link_local_routes(r1, "red")
 
 
 to_gen_new_results = """

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -411,15 +411,8 @@ lib_vrf_zebra_ribs_rib_route_get_next(struct nb_cb_get_next_args *args)
 		rn = route_top(zrt->table);
 	else
 		rn = srcdest_route_next(rn);
-	/*
-	 * Skip empty route nodes and link-local IPv6 routes. Link-locals are
-	 * excluded because the multiple connected link-local routes a router
-	 * holds (one per interface) collapse to identical YANG keys
-	 * (route[prefix='fe80::/64']/route-entry[protocol='connected']), which
-	 * breaks key-based resume of the async walk.
-	 */
-	while (rn && (rn->info == NULL ||
-		      (rn->p.family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL(&rn->p.u.prefix6))))
+	/* Optimization: skip empty route nodes. */
+	while (rn && rn->info == NULL)
 		rn = route_next(rn);
 
 	return rn;


### PR DESCRIPTION
### Summary

`lib_vrf_zebra_ribs_rib_route_get_next()` skipped every IPv6 link-local route
node, so the northbound never returned `fe80::/64` even though `show ipv6 route`
lists it. This drops the filter, so everything the CLI can display is reachable
through the northbound as well.

On the `mgmt_oper` topology, before:

```
munet> r1 show ipv6 route
C>* fe80::/64 is directly connected, r1-eth0, weight 1, 00:01:06
C * fe80::/64 is directly connected, r1-eth1, weight 1, 00:01:06

munet> r1 show mgmt get-data /frr-vrf:lib/vrf[name="default"]/frr-zebra:zebra/ribs/\
rib[afi-safi-name="frr-routing:ipv6-unicast"][table-id="254"]/route
... "route":[ {"prefix":"::/0"},
              {"prefix":"2001:1111::/64", ...},
              {"prefix":"2001:1111::1/128", ...},
              {"prefix":"2002:2222::/64", ...},
              {"prefix":"2002:2222::1/128", ...} ]        <-- no fe80::/64
```

and after, with both of its entries:

```
{"prefix":"fe80::/64","route-entry":[
   {"protocol":"connected", ... "interface":"r1-eth1" ...},
   {"protocol":"connected", ... "interface":"r1-eth0" ...}]}
```

### Why the filter's stated reason does not hold

The comment said the multiple connected link-local routes a router holds (one
per interface) collapse to identical YANG keys
(`route[prefix='fe80::/64']/route-entry[protocol='connected']`), and that this
breaks key-based resume of the asynchronous walk. It does not:

* `route-entry` registers no `lookup_next()` callback in `zebra_nb.c`.
* `nb_op_ys_finalize_node_info()` computes
  `ni->lookup_next_ok = yield_ok && ni->has_lookup_next && ni[-1].lookup_next_ok`,
  so the `route-entry` level is never yield-capable, and neither is anything
  below it, since `lookup_next_ok` propagates down from the parent.
* `_walk()` only yields at a list node whose `lookup_next_ok` is set. The
  deepest list on the node-info stack at yield time is therefore `route`, which
  is keyed by prefix and unique within a table.
* `nb_op_resume_data_tree()` walks that stack and re-looks-up each list node
  from its saved keys — route nodes only. It never sees a route entry.

Duplicate `route-entry` keys consequently cannot affect resume.

They are also not specific to link-locals. `rib_compare_routes()` deliberately
keeps several connected entries under one route node:

```c
	/* We support multiple connected routes: this supports multiple
	 * v6 link-locals, and we also support multiple addresses in the same
	 * subnet on a single interface.
	 */
```

and likewise several kernel entries that differ only in metric. Two IPv4
interfaces addressed in the same subnet already produce two
`route-entry[protocol='connected']` under a single prefix, and that already
comes back from the walk today. Link-locals were the only case being singled
out.

The underlying YANG wart is real but separate: `route-entry` is keyed by
`protocol` alone, which zebra cannot guarantee to be unique for any address
family. Fixing that means either a second key or a keyless list, and both are
backward-incompatible model changes that also cost query forms the topotests
rely on today (a keyless list makes libyang reject
`route-entry[protocol="connected"]` in a path context, which
`mgmt_oper/test_simple.py` asserts on). That is left alone here.

### Testing

`tests/topotests/mgmt_oper` passes in full (7 tests). The new
`test_oper_link_local()` checks the northbound against `show ipv6 route` in both
the default and `red` VRFs; it fails without the zebra change:

```
vrf default: northbound link-local routes {} differ from cli {'fe80::/64': 2}
```

Checked by hand against a 15363-route IPv6 RIB, large enough for the walk to
yield repeatedly at its 50 ms batch interval: the northbound returns every
prefix the CLI does, with no duplicated or dropped prefixes, and `fe80::/64`
comes back carrying all of its entries.

### Note on the stored oper results

The stored `mgmt_oper` results are compared exactly, keys included, and the
link-local entries are not reproducible enough to be stored. Zebra learns
interfaces in whatever order it gets them, and across two setups of the same
topology the two `fe80::/64` entries swapped places — and route selection
swapped with them:

```
setup A:  C>* fe80::/64 ... r1-eth0        setup B:  C>* fe80::/64 ... r1-eth1
          C * fe80::/64 ... r1-eth1                  C * fe80::/64 ... r1-eth0
```

That moves `selected` and `internal-flags` onto the other entry, and neither is
rubbed out before the comparison. So `clean_json()` drops link-local routes
before comparing, and `test_oper_link_local()` covers them directly instead,
comparing entry counts per prefix rather than an order that is not stable.

### Related Issue

Fixes https://github.com/FRRouting/frr/issues/22535

### Components

zebra, tests