### PR TITLE
pimd: don't restart KAT from a freshly installed mroute's lastused value when no data traffic

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2439,18 +2439,35 @@ static bool pim_upstream_sg_running_proc(struct pim_upstream *up)
 
 	pim_mroute_update_counters(up->channel_oil);
 
-	// Have we seen packets?
-	if ((up->channel_oil->cc.oldpktcnt >= up->channel_oil->cc.pktcnt)
-	    && (up->channel_oil->cc.lastused / 100 > 30)) {
-		if (PIM_DEBUG_PIM_TRACE) {
-			zlog_debug(
-				"%s[%s]: %s old packet count is equal or lastused is greater than 30, (%ld,%ld,%lld)",
-				__func__, up->sg_str, pim->vrf->name,
-				up->channel_oil->cc.oldpktcnt,
-				up->channel_oil->cc.pktcnt,
-				up->channel_oil->cc.lastused / 100);
+	/* Have we seen packets?
+	 *
+	 * The kernel sets lastused when the mroute is installed, so on a
+	 * freshly (re-)installed entry it is the age of the entry and not the
+	 * time since a packet was forwarded.  Only trust it when a source
+	 * stream is already active.
+	 */
+	if (PIM_UPSTREAM_FLAG_TEST_SRC_STREAM(up->flags)) {
+		if ((up->channel_oil->cc.oldpktcnt >= up->channel_oil->cc.pktcnt) &&
+		    (up->channel_oil->cc.lastused / 100 > 30)) {
+			if (PIM_DEBUG_PIM_TRACE) {
+				zlog_debug("%s[%s]: %s old packet count is equal or lastused is greater than 30, (%ld,%ld,%lld)",
+					   __func__, up->sg_str, pim->vrf->name,
+					   up->channel_oil->cc.oldpktcnt,
+					   up->channel_oil->cc.pktcnt,
+					   up->channel_oil->cc.lastused / 100);
+			}
+			return rv;
 		}
-		return rv;
+	} else {
+		if (up->channel_oil->cc.oldpktcnt >= up->channel_oil->cc.pktcnt) {
+			if (PIM_DEBUG_PIM_TRACE) {
+				zlog_debug("%s[%s]: %s old packet count is equal, (%ld,%ld)",
+					   __func__, up->sg_str, pim->vrf->name,
+					   up->channel_oil->cc.oldpktcnt,
+					   up->channel_oil->cc.pktcnt);
+			}
+			return rv;
+		}
 	}
 
 	if (pim_upstream_kat_start_ok(up)) {


### PR DESCRIPTION
Issue:
    An FHR keeps register-encapsulating an (S,G) after KeepaliveTimer has
    cleanly expired.  On the next 30 second poll pimd restarts KAT, sets the
    FHR flag again and re-adds pimreg to the OIL, even though the source has
    stopped sending.
    
Rootcause:
    pim_upstream_sg_running_proc() treats a lastused below 30 seconds as
    recent forwarding activity even when the packet counter has not moved.
    The kernel sets mfc_un.res.lastuse when the MFC entry is created, so on
    a freshly installed entry lastused is the age of the entry and not the
    time since a packet was forwarded.
    
Issue sequence is as below:
     1. The source stops sending.  The packet counter stops advancing and
        lastused grows past 30 seconds, so pim_upstream_sg_running_proc()
        correctly declines to restart KAT on each 30 second poll.
    
     2. KAT expires.  pim_upstream_fhr_kat_expiry() sets reg_state to
        PIM_REG_NOINFO, clears PIM_UPSTREAM_FLAG_FHR and removes pimreg
        from the OIL.  The stream reference is released, but the upstream
        survives because the downstream ifchannel still holds a reference.
    
     3. A downstream Prune(S,G) arrives, ifjoin_to_noinfo() clears the
        ifchannel reference and the last reference on the upstream goes
        away, so the upstream is freed and MRT_DEL_MFC is issued.
    
     4. The group still has receivers, so (*,G) inheritance re-creates the
        (S,G) immediately and pim_upstream_update_use_rpt() installs a
        fresh mroute.  The kernel sets mfc_un.res.lastuse when it creates
        the MFC entry, so the new entry reports a small lastused while its
        packet counter is still zero.  No source stream is active yet.
    
     5. On the next poll pim_upstream_sg_running_proc() sees a lastused
        below 30 seconds and concludes traffic was forwarded, even though
        the packet counter has not moved:
    
            if ((cc.oldpktcnt >= cc.pktcnt) && (cc.lastused / 100 > 30))
                    return rv;
    
     6. pim_upstream_kat_start_ok() therefore succeeds.  A source stream
        reference is taken, PIM_UPSTREAM_FLAG_FHR is set again,
        pim_register_join() puts pimreg back on the OIL and KAT is armed
        for another keep alive period.
    
     7. The FHR is encapsulating again with no source traffic.  Later polls
        do see lastused above 30 seconds, but by then KAT is running and
        pimreg is back on the OIL, so the register encapsulation persists.
    
  Fix:
    Only consult lastused when a source stream is already active, where the
    entry has necessarily existed at least as long as the stream.  Otherwise
    require the packet counter to advance.  Behaviour is unchanged when
    PIM_UPSTREAM_FLAG_SRC_STREAM is set, and a genuinely active source still
    arms KAT because its packet counter advances.
    
  Note: Issue is not seen consistently because it is race.