### PR TITLE
tests: Fix test_zebra_multiple_connected.py

### DIFF
--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -445,6 +445,49 @@ def test_zebra_metaq_early_route_table_discriminator():
     router.run(f"ip link add {ifname} type dummy")
     router.run(f"ip link set {ifname} up")
 
+    step("Wait for zebra to finish handling dummy0 up")
+
+    def _dummy0_up_handled():
+        # IPv6 link-local install after link-up is asynchronous. Wait until zebra
+        # has the connected route installed (early-route work for up is done) and
+        # the early-route metaQ is empty before plugging it.
+        try:
+            routes = json.loads(router.vtysh_cmd("show ipv6 route connected json"))
+        except (json.JSONDecodeError, TypeError) as err:
+            return "failed to parse ipv6 connected routes: {}".format(err)
+
+        found_ll = False
+        for route_prefix, entries in routes.items():
+            if not route_prefix.startswith("fe80:"):
+                continue
+            for entry in entries:
+                for nh in entry.get("nexthops", []):
+                    if nh.get("interfaceName") == ifname:
+                        found_ll = True
+                        break
+                if found_ll:
+                    break
+            if found_ll:
+                break
+        if not found_ll:
+            return "waiting for zebra IPv6 link-local connected route on {}".format(
+                ifname
+            )
+
+        count = _get_early_route_metaq_current(router)
+        if count is None:
+            return "failed to read early-route metaq"
+        if count != 0:
+            return (
+                "early-route metaq still draining after dummy0 up, current={}".format(
+                    count
+                )
+            )
+        return None
+
+    _, result = topotest.run_and_expect(_dummy0_up_handled, None, count=20, wait=1)
+    assert result is None, result
+
     step("Plug the meta queue so early routes remain visible")
     router.vtysh_cmd("zebra test metaq disable")
 


### PR DESCRIPTION
Under heavy system load the bring up of dummy0 would place items into the metaQ for processing, but we would immediately go into the next step which would be adding data to the metaQ to ensure things are handled appropriately.  Let's just make sure that the dummy0 bring up is finished before plugging the metaQ to do the next test.