### PR TITLE
linux: sync NTF_E_MH_PEER_SYNC flag with what's in kernel

### DIFF
--- a/include/linux/neighbour.h
+++ b/include/linux/neighbour.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+// SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
 #ifndef __LINUX_NEIGHBOUR_H
 #define __LINUX_NEIGHBOUR_H
 
@@ -52,7 +52,7 @@ enum {
 
 /* Neighbor Cache Entry extended flags, part of NDA_EXT_FLAGS attribute */
 #define NTF_E_WEAK_OVERRIDE_STATE 0x01
-#define NTF_E_MH_PEER_SYNC 0x02
+#define NTF_E_MH_PEER_SYNC	  0x04
 
 /*
  *	Neighbor Cache Entry States.


### PR DESCRIPTION
NTF_E_MH_PEER_SYNC landed as NTF_EXT_VALIDATED in kernel in commit 03dc03fa0432 ("neighbor: Add NTF_EXT_VALIDATED flag for externally validated entries"), [link](https://lore.kernel.org/netdev/20250626073111.244534-1-idosch@nvidia.com/).

This fixes #15253, which is still an issue on master with exact same messages and behavior.

Thanks @zcayou for hints. 