### PR TITLE
lib: bound the locator name skip in zapi_srv6_sid_notify_decode

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2399,7 +2399,7 @@ bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
 		}
 	} else if (len > 0) {
 		/* Advance the stream */
-		stream_forward_getp(s, len);
+		STREAM_FORWARD_GETP(s, len);
 	}
 
 	return true;


### PR DESCRIPTION
When the caller does not want the locator name, the decoder skips it with stream_forward_getp(), which returns void.

If the advertised length runs past the end of the stream the skip is refused and the read position stays where it was, but the decoder has no way to see that and carries on, reading the remaining fields from the wrong offset and returning true.

Use STREAM_FORWARD_GETP() so a short stream jumps to stream_failure like every other read in this function already does.