### PR TITLE
bgpd: skip admin-distance step for allowas-in reflected paths

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -985,7 +985,9 @@ int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	bool old_proxy;
 	bool new_proxy;
 	bool new_redist;
+	bool exist_redist;
 	bool new_origin, exist_origin;
+	const struct prefix *p;
 	struct bgp_path_info *bpi_ultimate;
 	struct peer *peer_new, *peer_exist;
 
@@ -1248,10 +1250,37 @@ int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	 */
 	new_redist = (new->peer == bgp->peer_self) && (new->sub_type == BGP_ROUTE_REDISTRIBUTE) &&
 		     bgp_zebra_announce_eligible(exist);
+	exist_redist = (exist->peer == bgp->peer_self) && (exist->sub_type == BGP_ROUTE_REDISTRIBUTE) &&
+		       bgp_zebra_announce_eligible(new);
 
-	if (new_redist ||
-	    ((exist->peer == bgp->peer_self) && (exist->sub_type == BGP_ROUTE_REDISTRIBUTE) &&
-	     bgp_zebra_announce_eligible(new))) {
+	/* Skip the admin-distance step when the competing path is an eBGP
+	 * copy of our own redistributed route reflected back via allowas-in
+	 * (its AS_PATH contains our own AS) AND the admin-distance comparison
+	 * would pick that reflected copy over the locally sourced path (the
+	 * reflected copy has a lower distance). Only then does picking by
+	 * admin distance evict the source from FIB and flap forever as the
+	 * reflection is withdrawn and re-advertised; when the locally
+	 * sourced path already wins on admin distance, keep the original
+	 * behavior so the selection reason stays "Admin Distance". Weight
+	 * (step 1) then decides: the local redistributed path carries
+	 * weight 32768.
+	 */
+	p = bgp_dest_get_prefix(new->net);
+	if (new_redist &&
+	    !((exist->peer != bgp->peer_self) &&
+	      aspath_loop_check(exist->attr->aspath, bgp->as) > 0 &&
+	      bgp_distance_apply(p, exist, afi, safi, bgp) < new->attr->distance)) {
+		ret = bgp_path_info_cmp_distance(bgp, new, exist, debug, pfx_buf, new_buf,
+						 exist_buf, afi, safi, new_redist);
+		if (ret >= 0) {
+			*reason = bgp_path_selection_admin_distance;
+			return ret;
+		}
+	}
+	if (exist_redist &&
+	    !((new->peer != bgp->peer_self) &&
+	      aspath_loop_check(new->attr->aspath, bgp->as) > 0 &&
+	      bgp_distance_apply(p, new, afi, safi, bgp) < exist->attr->distance)) {
 		ret = bgp_path_info_cmp_distance(bgp, new, exist, debug, pfx_buf, new_buf,
 						 exist_buf, afi, safi, new_redist);
 		if (ret >= 0) {

--- a/tests/topotests/bgp_redistribute_allowas_in_flap/leaf12/frr.conf
+++ b/tests/topotests/bgp_redistribute_allowas_in_flap/leaf12/frr.conf
@@ -1,0 +1,22 @@
+!
+interface leaf12-eth0
+ ip address 172.16.1.1/24
+!
+interface leaf12-eth1
+ ip address 172.16.2.1/24
+!
+router bgp 65012
+ no bgp ebgp-requires-policy
+ neighbor 172.16.1.2 remote-as 65201
+ neighbor 172.16.1.2 allowas-in origin
+ neighbor 172.16.1.2 timers 1 3
+ neighbor 172.16.1.2 timers connect 1
+ neighbor 172.16.2.2 remote-as 65201
+ neighbor 172.16.2.2 allowas-in origin
+ neighbor 172.16.2.2 timers 1 3
+ neighbor 172.16.2.2 timers connect 1
+!
+ address-family ipv4
+  redistribute sharp
+ exit-address-family
+!

--- a/tests/topotests/bgp_redistribute_allowas_in_flap/spine11/frr.conf
+++ b/tests/topotests/bgp_redistribute_allowas_in_flap/spine11/frr.conf
@@ -1,0 +1,16 @@
+!
+interface spine11-eth0
+ ip address 172.16.1.2/24
+!
+interface spine11-eth1
+ ip address 172.16.3.1/24
+!
+router bgp 65201
+ no bgp ebgp-requires-policy
+ neighbor 172.16.1.1 remote-as 65012
+ neighbor 172.16.1.1 timers 1 3
+ neighbor 172.16.1.1 timers connect 1
+ neighbor 172.16.3.2 remote-as 65300
+ neighbor 172.16.3.2 timers 1 3
+ neighbor 172.16.3.2 timers connect 1
+!

--- a/tests/topotests/bgp_redistribute_allowas_in_flap/spine12/frr.conf
+++ b/tests/topotests/bgp_redistribute_allowas_in_flap/spine12/frr.conf
@@ -1,0 +1,16 @@
+!
+interface spine12-eth0
+ ip address 172.16.2.2/24
+!
+interface spine12-eth1
+ ip address 172.16.4.1/24
+!
+router bgp 65201
+ no bgp ebgp-requires-policy
+ neighbor 172.16.2.1 remote-as 65012
+ neighbor 172.16.2.1 timers 1 3
+ neighbor 172.16.2.1 timers connect 1
+ neighbor 172.16.4.2 remote-as 65300
+ neighbor 172.16.4.2 timers 1 3
+ neighbor 172.16.4.2 timers connect 1
+!

--- a/tests/topotests/bgp_redistribute_allowas_in_flap/superspine/frr.conf
+++ b/tests/topotests/bgp_redistribute_allowas_in_flap/superspine/frr.conf
@@ -1,0 +1,16 @@
+!
+interface superspine-eth0
+ ip address 172.16.3.2/24
+!
+interface superspine-eth1
+ ip address 172.16.4.2/24
+!
+router bgp 65300
+ no bgp ebgp-requires-policy
+ neighbor 172.16.3.1 remote-as 65201
+ neighbor 172.16.3.1 timers 1 3
+ neighbor 172.16.3.1 timers connect 1
+ neighbor 172.16.4.1 remote-as 65201
+ neighbor 172.16.4.1 timers 1 3
+ neighbor 172.16.4.1 timers connect 1
+!

--- a/tests/topotests/bgp_redistribute_allowas_in_flap/test_bgp_redistribute_allowas_in_flap.py
+++ b/tests/topotests/bgp_redistribute_allowas_in_flap/test_bgp_redistribute_allowas_in_flap.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+When a prefix is (a) locally redistributed into BGP and (b) received back
+from an eBGP neighbor via `allowas-in origin`, the route must not flap.
+
+Regression guard for #23030: the Step-0 admin-distance comparison added in
+PR #20187 made the reflected eBGP copy (distance 20) beat the locally
+redistributed path (distance 150), evicting the source from FIB. The
+withdrawal propagated back through the fabric, the reflected copy vanished,
+the local path won again, and the cycle repeated forever.
+
+With the fix, the admin-distance step skips allowas-in reflected copies
+(AS_PATH contains our own AS), so weight (step 1) decides and the local
+redistributed path (weight 32768) stays the FIB owner.
+"""
+
+import os
+import sys
+import json
+import time
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+
+PREFIX = "77.7.7.1/32"
+
+
+def build_topo(tgen):
+    for router in ("leaf12", "spine11", "spine12", "superspine"):
+        tgen.add_router(router)
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["leaf12"])
+    switch.add_link(tgen.gears["spine11"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["leaf12"])
+    switch.add_link(tgen.gears["spine12"])
+
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["spine11"])
+    switch.add_link(tgen.gears["superspine"])
+
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["spine12"])
+    switch.add_link(tgen.gears["superspine"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for router in router_list.values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_redistribute_allowas_in_no_flap():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # leaf12 (AS 65012), spine11 (AS 65201), spine12 (AS 65201),
+    # superspine (AS 65300)
+    leaf = tgen.gears["leaf12"]
+
+    def _bgp_check_neighbor(router, neighbor):
+        output = json.loads(
+            router.vtysh_cmd("show bgp neighbor {} json".format(neighbor))
+        )
+        expected = {
+            neighbor: {
+                "bgpState": "Established",
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    step("wait for all eBGP sessions on leaf12 to be established")
+    for neighbor in ("172.16.1.2", "172.16.2.2"):
+        test_func = functools.partial(_bgp_check_neighbor, leaf, neighbor)
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert result is None, "neighbor {} failed to establish".format(neighbor)
+
+    step("install the prefix via sharp on leaf12")
+    # nexthop is mandatory in "sharp install routes"; use leaf12's own
+    # connected address so the route is resolved and installed.
+    leaf.vtysh_cmd(
+        "sharp install routes 77.7.7.1 nexthop 172.16.1.1 1")
+
+    def _fib_selected(router, prefix):
+        output = json.loads(
+            router.vtysh_cmd("show ip route {} json".format(prefix))
+        )
+        for entry in output.get(prefix, []):
+            if entry.get("selected"):
+                return entry.get("protocol"), entry.get("distance")
+        return None, None
+
+    def _check_fib_owner_sharp():
+        proto, distance = _fib_selected(leaf, PREFIX)
+        if proto != "sharp" or distance != 150:
+            return "expected sharp/150, got {}/{}".format(proto, distance)
+        return None
+
+    step("FIB owner must be the locally redistributed (sharp) path")
+    _, result = topotest.run_and_expect(_check_fib_owner_sharp, None,
+                                        count=30, wait=1)
+    assert result is None, "FIB owner is not the sharp path: {}".format(result)
+
+    step("FIB owner must stay stable (no flap) for 5 seconds")
+    for _ in range(5):
+        time.sleep(1)
+        proto, distance = _fib_selected(leaf, PREFIX)
+        assert proto == "sharp" and distance == 150, \
+            "route flapped to {}/{}".format(proto, distance)


### PR DESCRIPTION
Fixes: #23030

## Summary

`bgp_path_info_cmp()` Step-0 (admin distance, added in PR #20187) makes a prefix flap forever when it is both locally redistributed into BGP and received back from an eBGP neighbor via `allowas-in origin`: the reflected eBGP copy (distance 20) beats the locally sourced path (distance 150), the source is evicted from FIB, the withdrawal propagates back through the fabric, the reflected copy vanishes, the local path wins again — repeat.

## Problem

The reflected copy is the router's *own* redistributed route coming back through the fabric. Its AS_PATH contains the local AS. Admin-distance-first selection treats it like a real external path, which it is not.

## Solution

Skip the admin-distance step when the competing path is an eBGP copy whose AS_PATH contains our own AS (`aspath_loop_check(aspath, bgp->as)`), so selection falls through to the weight check (step 1). The locally redistributed path carries weight 32768 and stays the FIB owner — matching the pre-#20187 behaviour for this case without reverting the deterministic-redistribution intent for genuine external paths.

## Topotest

New `tests/topotests/bgp_redistribute_allowas_in_flap/`: 4-node topology (leaf + 2 spines + superspine) reproducing the issue topology. Asserts the FIB owner on the leaf stays the sharp path (distance 150) and does not flap over 5 seconds. Note: topotest not run locally (no docker in this environment) — CI runs it; fail-before/pass-after is implied by the flap mechanism described in #23030.

## Test plan

- `./configure && make` (bgpd + sharpd): builds clean.
- Code-path review: the new guard only affects the case where the non-redistributed path is an eBGP path containing the local AS (allowas-in reflection); genuine external paths still go through the admin-distance comparison.