### PR TITLE
zebra: don't fall back to the vxlan interface walk on vlan-aware bridges

### DIFF
--- a/tests/topotests/zebra_evpn_l3vni_svi_resolve/r1/frr.conf
+++ b/tests/topotests/zebra_evpn_l3vni_svi_resolve/r1/frr.conf
@@ -1,0 +1,16 @@
+frr defaults datacenter
+!
+interface lo
+ ip address 10.10.10.10/32
+!
+vrf vrf-red
+ vni 5000
+exit-vrf
+!
+router bgp 65000
+ bgp router-id 10.10.10.10
+ no bgp default ipv4-unicast
+ address-family l2vpn evpn
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/zebra_evpn_l3vni_svi_resolve/r1/setup.sh
+++ b/tests/topotests/zebra_evpn_l3vni_svi_resolve/r1/setup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# VLAN-aware bridge. VLAN 3745 maps to VNI 5000; VLAN 12 maps to NOTHING.
+# Both SVIs live in the same VRF, which is what lets a bug in SVI resolution
+# bind the L3VNI to the wrong one.
+
+ip link add vrf-red type vrf table 1000
+ip link set vrf-red up
+
+ip link add name bridge type bridge stp_state 0 vlan_filtering 1
+ip link set bridge type bridge vlan_default_pvid 0
+ip link set dev bridge up
+
+ip link add vxlan5000 type vxlan id 5000 dstport 4789 local 10.10.10.10 nolearning
+ip link set dev vxlan5000 master bridge
+ip link set up dev vxlan5000
+
+# VLAN 12 -- present on the bridge, in the same VRF, but has NO VNI mapping.
+#
+# Order matters: resolution is "last SVI up wins", so Vlan12 is brought up
+# FIRST and Vlan3745 second. That gives a correct baseline, which is what
+# lets the flap test below isolate the regression instead of tripping over
+# an already-wrong initial state.
+bridge vlan add vid 12 dev bridge self
+ip link add link bridge name Vlan12 type vlan id 12
+ip link set dev Vlan12 master vrf-red
+ip addr add 1.12.1.100/16 dev Vlan12
+ip link set dev Vlan12 up
+
+# VLAN 3745 <-> VNI 5000  (the correct L3VNI SVI)
+bridge vlan add vid 3745 dev bridge self
+bridge vlan del vid 1 dev vxlan5000
+bridge vlan add vid 3745 dev vxlan5000 pvid untagged
+ip link add link bridge name Vlan3745 type vlan id 3745
+ip link set dev Vlan3745 master vrf-red
+ip link set dev Vlan3745 up

--- a/tests/topotests/zebra_evpn_l3vni_svi_resolve/test_zebra_evpn_l3vni_svi_resolve.py
+++ b/tests/topotests/zebra_evpn_l3vni_svi_resolve/test_zebra_evpn_l3vni_svi_resolve.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_zebra_evpn_l3vni_svi_resolve.py
+#
+# Copyright (c) 2026 by the FRRouting project
+#
+"""
+An L3VNI's SVI must be resolved from the VLAN-VNI map of a VLAN-aware bridge,
+not from an unrelated SVI that happens to sit on the same bridge.
+
+zl3vni_from_svi() looks the SVI's VLAN up in the bridge's VLAN-VNI map. On a
+miss it falls through to zl3vni_from_svi_ns(), a walk that matches on
+"is a VXLAN interface, is operative, same bridge" and ignores the VLAN
+entirely. So bringing up any SVI on the bridge -- including one with no VNI
+mapping at all -- rebinds the L3VNI to it.
+
+Topology (single VTEP, no peering required; `advertise-all-vni` alone is
+enough to enable EVPN in zebra):
+
+    bridge (VLAN-aware)
+      +-- vxlan5000   VNI 5000, access VLAN 3745
+      +-- Vlan3745    SVI in vrf-red   <- the correct L3VNI SVI
+      +-- Vlan12      SVI in vrf-red   <- NO VNI mapping
+
+Flapping Vlan12 must not move the L3VNI's SVI off Vlan3745.
+"""
+
+import os
+import sys
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    tgen.start_router()
+    tgen.gears["r1"].run(f"/bin/bash {CWD}/r1/setup.sh")
+
+
+def teardown_module(mod):
+    get_topogen().stop_topology()
+
+
+def _svi_of_l3vni(r1):
+    """Return the L3-SVI zebra currently has bound to VNI 5000, or None."""
+    out = r1.vtysh_cmd("show vrf vni json", isjson=True)
+    for vrf in out.get("vrfs", []):
+        if str(vrf.get("vni")) == "5000":
+            return vrf.get("sviIntf")
+    return None
+
+
+def test_l3vni_svi_is_vlan3745():
+    """Baseline: the L3VNI must resolve to Vlan3745, the SVI of its own VLAN."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    def _check():
+        svi = _svi_of_l3vni(r1)
+        return None if svi == "Vlan3745" else f"L3-SVI is {svi}, expected Vlan3745"
+
+    _, result = topotest.run_and_expect(functools.partial(_check), None, count=30, wait=2)
+    assert result is None, f"L3VNI 5000 did not come up on Vlan3745: {result}"
+
+
+def test_unrelated_svi_flap_does_not_steal_l3vni():
+    """Flapping Vlan12 -- which has no VNI mapping -- must not rebind the L3VNI."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    def _link_ups(ifname):
+        """zebra's own count of up-events it has processed for this interface."""
+        out = r1.vtysh_cmd(f"show interface {ifname} json", isjson=True)
+        return out.get(ifname, {}).get("linkUps", 0)
+
+    before = _link_ups("Vlan12")
+
+    r1.run("ip link set dev Vlan12 down")
+    r1.run("ip link set dev Vlan12 up")
+
+    # Wait for zebra to have actually processed the up-event rather than for a
+    # fixed interval. A fixed sleep lets a slow machine finish the check before
+    # zebra runs the resolution, so the test would pass against the unchanged
+    # pre-flap binding without ever exercising the regression.
+    def _flap_processed():
+        now = _link_ups("Vlan12")
+        return None if now > before else f"linkUps still {now}, expected > {before}"
+
+    _, result = topotest.run_and_expect(
+        functools.partial(_flap_processed), None, count=30, wait=1
+    )
+    assert result is None, f"zebra never processed the Vlan12 up-event: {result}"
+
+    svi = _svi_of_l3vni(r1)
+    assert svi == "Vlan3745", (
+        f"L3VNI 5000 SVI moved to {svi} after flapping unrelated SVI Vlan12; "
+        "expected it to stay on Vlan3745"
+    )
+
+
+def test_l3vni_svi_recovers_after_own_svi_flap():
+    """Flapping the L3VNI's own SVI must still resolve back to Vlan3745."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+
+    r1.run("ip link set dev Vlan3745 down")
+    topotest.sleep(2, "waiting for Vlan3745 down to be processed")
+    r1.run("ip link set dev Vlan3745 up")
+
+    def _check():
+        svi = _svi_of_l3vni(r1)
+        return None if svi == "Vlan3745" else f"L3-SVI is {svi}, expected Vlan3745"
+
+    _, result = topotest.run_and_expect(functools.partial(_check), None, count=30, wait=2)
+    assert result is None, f"L3VNI 5000 did not recover onto Vlan3745: {result}"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/zebra_evpn_mac_vlan_map/r1/frr.conf
+++ b/tests/topotests/zebra_evpn_mac_vlan_map/r1/frr.conf
@@ -1,0 +1,12 @@
+frr defaults datacenter
+!
+interface lo
+ ip address 10.10.10.10/32
+!
+router bgp 65000
+ bgp router-id 10.10.10.10
+ no bgp default ipv4-unicast
+ address-family l2vpn evpn
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/zebra_evpn_mac_vlan_map/r1/setup.sh
+++ b/tests/topotests/zebra_evpn_mac_vlan_map/r1/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# VLAN-aware bridge with an L2VNI. VLAN 3745 maps to VNI 5000; VLAN 12 does
+# not map to anything. r1-eth0 carries VLAN 3745, r1-eth1 carries VLAN 12, so
+# a MAC can be learned on each and attribution can be compared.
+#
+# NOTE: no `vrf ... vni 5000`. That would make 5000 an L3VNI, and
+# zebra_evpn_map_vlan() resolves the L2 EVPN table -- `show evpn mac vni 5000`
+# would answer "VNI does not exist" and the test would prove nothing.
+
+ip link add name bridge type bridge stp_state 0 vlan_filtering 1
+ip link set bridge type bridge vlan_default_pvid 0
+ip link set dev bridge up
+
+ip link add vxlan5000 type vxlan id 5000 dstport 4789 local 10.10.10.10 nolearning
+ip link set dev vxlan5000 master bridge
+ip link set up dev vxlan5000
+
+# VLAN 3745 <-> VNI 5000
+bridge vlan add vid 3745 dev bridge self
+bridge vlan del vid 1 dev vxlan5000
+bridge vlan add vid 3745 dev vxlan5000 pvid untagged
+ip link add link bridge name Vlan3745 type vlan id 3745
+ip addr add 10.37.0.1/24 dev Vlan3745
+ip link set dev Vlan3745 up
+
+# VLAN 12 -- no VNI mapping
+bridge vlan add vid 12 dev bridge self
+ip link add link bridge name Vlan12 type vlan id 12
+ip addr add 10.12.0.1/24 dev Vlan12
+ip link set dev Vlan12 up
+
+# Bridge ports: eth0 on the mapped VLAN, eth1 on the unmapped one.
+ip addr flush dev r1-eth0 2>/dev/null
+ip link set dev r1-eth0 master bridge
+bridge vlan del vid 1 dev r1-eth0
+bridge vlan add vid 3745 dev r1-eth0 pvid untagged
+ip link set dev r1-eth0 up
+
+ip addr flush dev r1-eth1 2>/dev/null
+ip link set dev r1-eth1 master bridge
+bridge vlan del vid 1 dev r1-eth1
+bridge vlan add vid 12 dev r1-eth1 pvid untagged
+ip link set dev r1-eth1 up

--- a/tests/topotests/zebra_evpn_mac_vlan_map/r2/frr.conf
+++ b/tests/topotests/zebra_evpn_mac_vlan_map/r2/frr.conf
@@ -1,0 +1,2 @@
+frr defaults datacenter
+!

--- a/tests/topotests/zebra_evpn_mac_vlan_map/r3/frr.conf
+++ b/tests/topotests/zebra_evpn_mac_vlan_map/r3/frr.conf
@@ -1,0 +1,2 @@
+frr defaults datacenter
+!

--- a/tests/topotests/zebra_evpn_mac_vlan_map/test_zebra_evpn_mac_vlan_map.py
+++ b/tests/topotests/zebra_evpn_mac_vlan_map/test_zebra_evpn_mac_vlan_map.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_zebra_evpn_mac_vlan_map.py
+#
+# Copyright (c) 2026 by the FRRouting project
+#
+"""
+A locally learned MAC must only be attributed to an EVPN when its (port, VLAN)
+actually maps to a VNI.
+
+zebra_evpn_map_vlan() looks the VLAN up in the VLAN-VNI map of a VLAN-aware
+bridge. On a miss it falls through to zebra_evpn_map_vlan_ns(), a walk that
+matches on "is a VXLAN interface, is operative, same bridge" and ignores the
+VLAN. Every MAC on every VLAN of that bridge is therefore attributed to
+whichever VNI the bridge's VXLAN interface carries -- and with
+`advertise-all-vni` it is advertised as an EVPN type-2 route.
+
+Topology:
+
+    r2 --- r1-eth0 --+                bridge (VLAN-aware)
+                     |                  +-- vxlan5000  VNI 5000, VLAN 3745
+    r3 --- r1-eth1 --+                  +-- r1-eth0    VLAN 3745  (mapped)
+                                        +-- r1-eth1    VLAN 12    (NOT mapped)
+
+r2's MAC must appear in VNI 5000; r3's MAC must not.
+"""
+
+import os
+import re
+import sys
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2"), "s2": ("r1", "r3")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    tgen.start_router()
+    tgen.gears["r1"].run(f"/bin/bash {CWD}/r1/setup.sh")
+
+    # r2 sits on the mapped VLAN, r3 on the unmapped one.
+    tgen.gears["r2"].run("ip addr add 10.37.0.2/24 dev r2-eth0")
+    tgen.gears["r3"].run("ip addr add 10.12.0.2/24 dev r3-eth0")
+
+    # Traffic so the bridge learns a MAC on each VLAN.
+    tgen.gears["r2"].run("ping -c 3 -W 1 10.37.0.1")
+    tgen.gears["r3"].run("ping -c 3 -W 1 10.12.0.1")
+
+
+def teardown_module(mod):
+    get_topogen().stop_topology()
+
+
+def _mac_of(tgen, rname):
+    out = tgen.gears[rname].run(f"cat /sys/class/net/{rname}-eth0/address")
+    return out.strip().lower()
+
+
+def _macs_in_vni(r1, vni=5000):
+    out = r1.vtysh_cmd(f"show evpn mac vni {vni} json", isjson=True)
+    return {m.lower() for m in out.get("macs", {}).keys()}
+
+
+def test_mac_on_mapped_vlan_is_in_vni():
+    """Positive control: a MAC on VLAN 3745 must be learned into VNI 5000."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+    r2_mac = _mac_of(tgen, "r2")
+
+    def _check():
+        macs = _macs_in_vni(r1)
+        if r2_mac in macs:
+            return None
+        return f"{r2_mac} not in VNI 5000 (have: {sorted(macs)})"
+
+    _, result = topotest.run_and_expect(functools.partial(_check), None, count=30, wait=2)
+    assert result is None, f"MAC on mapped VLAN 3745 was not learned into VNI 5000: {result}"
+
+
+def test_mac_on_unmapped_vlan_is_not_in_vni():
+    """A MAC on VLAN 12, which maps to no VNI, must not be attributed to VNI 5000."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    r1 = tgen.gears["r1"]
+    r3_mac = _mac_of(tgen, "r3")
+
+    # The kernel must actually have learned it, or this test proves nothing.
+    # Match the MAC and the VLAN within a SINGLE fdb record: searching the whole
+    # multiline output independently would let two unrelated entries satisfy the
+    # two checks, and the negative assertion below would then pass without the
+    # r3 MAC ever having been learned on the unmapped VLAN.
+    fdb = r1.run("bridge fdb show br bridge")
+    learned_on_vlan12 = any(
+        r3_mac in line.lower() and re.search(r"\bvlan\s+12\b", line.lower())
+        for line in fdb.splitlines()
+    )
+    assert learned_on_vlan12, (
+        f"precondition failed: no single fdb entry has {r3_mac} on vlan 12; "
+        f"fdb:\n{fdb}"
+    )
+
+    macs = _macs_in_vni(r1)
+    assert r3_mac not in macs, (
+        f"MAC {r3_mac} learned on VLAN 12 (which has no VNI mapping) was "
+        f"attributed to VNI 5000; macs in VNI 5000: {sorted(macs)}"
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -690,6 +690,7 @@ struct zebra_evpn *zebra_evpn_map_vlan(struct interface *ifp,
 		vni_id = zebra_l2_bridge_if_vni_find(zif, vid);
 		if (vni_id)
 			return zebra_evpn_lookup(vni_id);
+		return NULL;
 	}
 
 	in_param.vid = vid;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2354,6 +2354,7 @@ static struct zebra_l3vni *zl3vni_from_svi(struct interface *ifp,
 		vni_id = zebra_l2_bridge_if_vni_find(br_zif, in_param.vid);
 		if (vni_id)
 			return zl3vni_lookup(vni_id);
+		return NULL;
 	}
 
 	/* See if this interface (or interface plus VLAN Id) maps to a VxLAN */


### PR DESCRIPTION
On a vlan-aware bridge, `zl3vni_from_svi()` and `zebra_evpn_map_vlan()` both look
the VLAN up in the bridge's vlan-vni map, return if they find a VNI, and then fall
through to an interface walk if they don't. That walk is the problem. It matches
only on "is a vxlan interface, is operative, and is on this bridge" and never looks
at the VLAN, resolving the VNI with `zebra_vxlan_if_access_vlan_vni_find()`, which
says in its own comment that it is expected to be called only for vlan-unaware
bridges. So on a vlan-aware bridge every VLAN ends up inheriting whatever VNI the
bridge's vxlan interface happens to carry, including VLANs that have no vni mapping
at all.

For `zl3vni_from_svi()` this shows up as the L3VNI binding to the wrong SVI. With
two SVIs in a VRF where only one of them has a vni mapping, bringing the other one
up moves the L3VNI onto it. The L3VNI stays up and stays advertised, just bound to
an interface that has nothing to do with it:

```
# vlan 3745 is mapped to vni 5000, vlan 12 is mapped to nothing
VRF      VNI   VxLAN IF   L3-SVI     State
Vrf_RED  5000  vxlan5000  Vlan3745   Up      <- before flapping Vlan12
Vrf_RED  5000  vxlan5000  Vlan12     Up      <- after
```

For `zebra_evpn_map_vlan()` it shows up in local mac learning. It is called from
`zebra_vxlan_local_mac_add_update()`, which says it is interested in MACs only on
ports or (port, VLAN) that map to an EVPN, and expects a NULL back when they don't.
Instead a MAC learned on an unmapped VLAN is attributed to the bridge's VNI, and
with `advertise-all-vni` configured it gets advertised as a type-2 route:

```
# vethbr is on vlan 12, which has no vni mapping
MAC                Type   Intf     VLAN
c6:c2:4c:71:22:f9  local  vethbr2  3745
ce:e9:d1:e3:9c:b6  local  vethbr   12
```

Return NULL from the vlan-aware branch in both, so only vlan-unaware bridges reach
the walk. On a vlan-aware bridge the vlan-vni map is the authoritative answer and a
miss means there is no VNI for that VLAN. `zebra_evpn_from_svi()` in the same file
already does exactly this, with a "Don't need to search in this case" comment on its
vlan-aware branch, so this brings the other two in line with it.

Both fast paths came in with 8353cf5d4c ("zebra: use new per-NS ifp iterators in
vxlan code"), which added the vlan-aware lookup in front of the existing walk but
did not terminate the branch. Before that commit the walk was the only path for
either kind of bridge.

**Testing:**

Two topotests are added, one per commit. Unpatched they fail, with the L3VNI landing
on the wrong SVI and the vlan-12 MAC showing up in vni 5000. Patched they pass.

I also built the two patches separately to check they are independent. Patch 1 fixes
the SVI resolution and leaves the MAC attribution wrong, patch 2 does the reverse, and
neither disturbs the other's positive control - an SVI that is correctly mapped still
resolves, and a MAC on the mapped VLAN is still learned into the VNI. So both are
needed and neither is rejecting more than it should.

Fixes: #23028