### PR TITLE
bgpd: fix route_node refcount leak in vpn_leak_to_vrf_update_onevrf()

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -2503,8 +2503,6 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,	/* to */
 
 	community_strip_accept_own(&static_attr);
 
-	bn = bgp_afi_node_get(to_bgp->rib[afi][safi], afi, safi, p, NULL);
-
 	for (bpi = bgp_dest_get_bgp_path_info(bn); bpi; bpi = bpi->next) {
 		if (bpi->extra && bpi->extra->vrfleak &&
 		    bpi->extra->vrfleak->parent == path_vpn)
@@ -2613,6 +2611,7 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,	/* to */
 					to_bgp->vpn_policy[afi]
 						.rmap[BGP_VPN_POLICY_DIR_FROMVPN]
 						->name);
+			bgp_dest_unlock_node(bn);
 			return;
 		}
 		/*


### PR DESCRIPTION
vpn_leak_to_vrf_update_onevrf() acquired the target VRF route node twice via bgp_afi_node_get() but released it at most once, so every leaked route added a reference that could never be dropped.

The second acquire overwrote bn while the first reference was still held, leaving it counted in rn->lock but unreachable. The route-map DENYMATCH path returned without releasing bn at all and leaked both references.

Drop the redundant second acquire (bn from the first is still valid, only attributes are touched in between) and release bn on the DENY return.