### PR TITLE
zebra: clean l3vni remote state on vlan deletion

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2743,6 +2743,18 @@ static void zl3vni_del_nh_hash_entry(struct l3vni_walk_ctx *wctx, struct zebra_n
 	zl3vni_nh_del(zl3vni, n);
 }
 
+void zebra_vxlan_l3vni_rmac_cleanup(struct zebra_l3vni *zl3vni)
+{
+	struct l3vni_walk_ctx wctx = {
+		.zl3vni = zl3vni,
+	};
+
+	if (!zl3vni)
+		return;
+
+	hash_iterate(zl3vni->rmac_table, zl3vni_del_rmac_hash_entry, &wctx);
+}
+
 /* re-add remote rmac if needed */
 static int zebra_vxlan_readd_remote_rmac(struct zebra_l3vni *zl3vni,
 					 struct ethaddr *rmac)

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -163,6 +163,11 @@ static int zebra_vxlan_if_del_vni(struct interface *ifp,
 		/* process oper-down for l3-vni */
 		zebra_vxlan_process_l3vni_oper_down(zl3vni);
 
+		/* RMAC uninstall needs the VXLAN and VLAN associations below,
+		 * so clean it up before detaching the VNI.
+		 */
+		zebra_vxlan_l3vni_rmac_cleanup(zl3vni);
+
 		/* remove the association with vxlan_if */
 		memset(&zl3vni->local_vtep_ip, 0, sizeof(zl3vni->local_vtep_ip));
 		zl3vni->vxlan_if = NULL;

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -215,6 +215,7 @@ extern struct interface *zl3vni_map_to_svi_if(struct zebra_l3vni *zl3vni);
 extern struct interface *zl3vni_map_to_mac_vlan_if(struct zebra_l3vni *zl3vni);
 extern struct zebra_l3vni *zl3vni_lookup(vni_t vni);
 extern vni_t vni_id_from_svi(struct interface *ifp, struct interface *br_if);
+extern void zebra_vxlan_l3vni_rmac_cleanup(struct zebra_l3vni *zl3vni);
 
 DECLARE_HOOK(zebra_rmac_update,
 	     (struct zebra_mac * rmac, struct zebra_l3vni *zl3vni, bool delete,


### PR DESCRIPTION
```
2026/08/17 04:28:29 ZEBRA: [KZXKD-3PRAJ] l3vni 300 del nexthop: rmac 52:54:dd:ee:ff:01 vtep-ip 7.7.7.7
2026/08/17 04:28:29 ZEBRA: [W0Q6Q-6EMPH] RMAC 52:54:dd:ee:ff:01 on L3-VNI 300 hash 0x55a3ac446330 couldn't be uninstalled - no vxlan_if
2026/08/17 04:28:29 ZEBRA: [Z6Z7F-6VGP8] L3VNI 300 RMAC 52:54:dd:ee:ff:01 vtep_ip 7.7.7.7 delete
```

Removing a bridge VLAN associated with an SVD-backed L3VNI can leave remote RMAC entries installed: (After "bridge vlan del dev vxlan0 vid 300" on vni 300)
```
52:54:dd:ee:ff:01 dev vxlan0 vlan 300 extern_learn master br0
52:54:dd:ee:ff:01 dev vxlan0 dst 7.7.7.7 src_vni 300 self extern_learn
```

The L3VNI delete path of `zebra_vxlan_if_del_vni` finally enters `zl3vni_rmac_uninstall()` via "ZEBRA_L3VNI_DEL", and `zl3vni_rmac_uninstall()`'s returned value is not checked. At that time "zl3vni->vxlan_if" had already been cleared in `zebra_vxlan_if_del_vni`, so `zl3vni_rmac_uninstall` can't clean fdb entries of rmac.

Just clean fdb entries of rmac before the vlan deletion.