### PR TITLE
pbrd: fix table id leak on individual nexthop removal

### DIFF
--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -645,6 +645,8 @@ static void pbr_nht_release_individual_nexthop(struct pbr_map_sequence *pbrms)
 	pbr_nht_uninstall_nexthop_group(pnhgc, *pbrms->nhg, nh_type);
 	pbr_map_check_nh_group_change(pnhgc->name);
 
+	hash_release(pbr_nhg_allocated_id_hash, pnhgc);
+	pbr_nht_update_next_unallocated_table_id();
 	hash_release(pbr_nhg_hash, pnhgc);
 	pbr_nhgc_delete(pnhgc);
 


### PR DESCRIPTION
When a pbr-map sequence with a single set nexthop is removed, pbr_nht_release_individual_nexthop() frees the nexthop-group cache without releasing its allocated table id from pbr_nhg_allocated_id_hash or recalculating pbr_next_unallocated_table_id. Each add/remove cycle leaks one table id, so the configured pbr table range is eventually exhausted and new rules fail with "Exhausted all table identifiers; cannot create nexthop-group cache".

Release the table id and recompute the next unallocated id before deleting the cache, matching what pbr_nht_delete_group() does.Fixes #23042