### PR TITLE
lib, isisd: fix some broken `HOOK` declarations

### DIFF
--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -570,11 +570,12 @@ DECLARE_HOOK(isis_hook_authentication_failure,
 	     (circuit, raw_pdu, raw_pdu_len));
 DECLARE_HOOK(isis_hook_adj_state_change, (const struct isis_adjacency *adj), (adj));
 DECLARE_HOOK(isis_hook_reject_adjacency,
-	     (const struct isis_circuit *circuit, const char *pdu, size_t pdu_len),
-	     (circuit, pdu, pdu_len));
+	     (const struct isis_circuit *circuit, const char *raw_pdu,
+	      size_t raw_pdu_len),
+	     (circuit, raw_pdu, raw_pdu_len));
 DECLARE_HOOK(isis_hook_area_mismatch,
 	     (const struct isis_circuit *circuit, const char *raw_pdu, size_t raw_pdu_len),
-	     (circuit));
+	     (circuit, raw_pdu, raw_pdu_len));
 DECLARE_HOOK(isis_hook_id_len_mismatch,
 	     (const struct isis_circuit *circuit, uint8_t rcv_id_len, const char *raw_pdu,
 	      size_t raw_pdu_len),
@@ -582,11 +583,11 @@ DECLARE_HOOK(isis_hook_id_len_mismatch,
 DECLARE_HOOK(isis_hook_version_skew,
 	     (const struct isis_circuit *circuit, uint8_t version, const char *raw_pdu,
 	      size_t raw_pdu_len),
-	     (circuit));
+	     (circuit, version, raw_pdu, raw_pdu_len));
 DECLARE_HOOK(isis_hook_lsp_error,
 	     (const struct isis_circuit *circuit, const uint8_t *lsp_id, const char *raw_pdu,
 	      size_t raw_pdu_len),
-	     (circuit));
+	     (circuit, lsp_id, raw_pdu, raw_pdu_len));
 DECLARE_HOOK(isis_hook_seqno_skipped, (const struct isis_circuit *circuit, const uint8_t *lsp_id),
 	     (circuit, lsp_id));
 DECLARE_HOOK(isis_hook_own_lsp_purge, (const struct isis_circuit *circuit, const uint8_t *lsp_id),

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -333,7 +333,7 @@ extern void zebra_main_router_started(void);
 /* zebra_northbound.c */
 extern const struct frr_yang_module_info frr_zebra_info;
 
-DECLARE_HOOK(nos_initialize_data, (struct zebra_architectural_values *), (zav));
+DECLARE_HOOK(nos_initialize_data, (struct zebra_architectural_values *zav), (zav));
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_srv6.h
+++ b/zebra/zebra_srv6.h
@@ -260,7 +260,7 @@ DECLARE_HOOK(srv6_manager_get_chunk,
 	      struct zserv *client,
 	      const char *locator_name,
 	      vrf_id_t vrf_id),
-	     (mc, client, keep, size, base, vrf_id));
+	     (loc, client, locator_name, vrf_id));
 DECLARE_HOOK(srv6_manager_release_chunk,
 	     (struct zserv *client,
 	      const char *locator_name,


### PR DESCRIPTION
Not all of the `DECLARE_HOOK` is used (its parameters are the same as for `DEFINE_HOOK` for the sake of simplicity.) Unfortunately that means errors won't be flagged.

And, well, I was tinkering around with tooling that _does_ flag errors :)