### PR TITLE
isis: handle redistributed route source replacement

### DIFF
--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -73,6 +73,11 @@ static struct route_table *get_ext_info(struct isis *i, int family)
 	return i->ext_info[protocol];
 }
 
+static bool isis_redist_info_matches(const struct isis_ext_info *info, int type, uint16_t table)
+{
+	return info->origin == type && info->table == table;
+}
+
 static struct isis_redist *isis_redist_lookup(struct isis_area *area,
 					      int family, int type, int level,
 					      uint16_t table)
@@ -247,6 +252,7 @@ static void isis_redist_ensure_default(struct isis *isis, int family)
 	info->origin = DEFAULT_ROUTE;
 	info->distance = 254;
 	info->metric = MAX_WIDE_PATH_METRIC;
+	info->table = 0;
 }
 
 static int _isis_redist_table_is_present(const struct lyd_node *dnode, void *arg)
@@ -319,17 +325,33 @@ void isis_redist_add(struct isis *isis, int type, struct prefix *p,
 	}
 
 	ei_node = srcdest_rnode_get(ei_table, p, src_p);
-	if (ei_node->info)
+	if (ei_node->info) {
+		info = ei_node->info;
+		/*
+		 * Zebra uses replace semantics for redistribution: when the
+		 * selected source changes, the new ADD isn't preceded by a DEL.
+		 * Remove reachability derived from the old source before replacing
+		 * the shared external information entry.
+		 */
+		if (!isis_redist_info_matches(info, type, table)) {
+			frr_each (isis_area_list, &isis->area_list, area)
+				for (level = ISIS_LEVEL1; level <= ISIS_LEVEL2; level++) {
+					if (!get_ext_reach(area, family, level))
+						continue;
+					isis_redist_uninstall(area, level, p, src_p);
+				}
+		}
 		route_unlock_node(ei_node);
-	else
-		ei_node->info = XCALLOC(MTYPE_ISIS_EXT_INFO,
-					sizeof(struct isis_ext_info));
+	} else {
+		ei_node->info = XCALLOC(MTYPE_ISIS_EXT_INFO, sizeof(struct isis_ext_info));
+	}
 
 	info = ei_node->info;
 	info->origin = type;
 	info->distance = distance;
 	info->metric = metric;
 	info->tag = tag;
+	info->table = table;
 
 	if (is_default_prefix(p)
 	    && (!src_p || !src_p->prefixlen)) {
@@ -361,17 +383,6 @@ void isis_redist_delete(struct isis *isis, int type, struct prefix *p,
 	zlog_debug("%s: Removing route %pFX from %s.", __func__, p,
 		   zebra_route_string(type));
 
-	if (is_default_prefix(p)
-	    && (!src_p || !src_p->prefixlen)) {
-		/* Don't remove default route but add synthetic route for use
-		 * by "default-information originate always". Areas without the
-		 * "always" setting will ignore routes with origin
-		 * DEFAULT_ROUTE. */
-		isis_redist_add(isis, DEFAULT_ROUTE, p, NULL, 254,
-				MAX_WIDE_PATH_METRIC, 0, table);
-		return;
-	}
-
 	if (!ei_table) {
 		zlog_warn("%s: External information table not initialized.",
 			  __func__);
@@ -385,6 +396,22 @@ void isis_redist_delete(struct isis *isis, int type, struct prefix *p,
 			__func__, zebra_route_string(type), p);
 		if (ei_node)
 			route_unlock_node(ei_node);
+		return;
+	}
+	if (!isis_redist_info_matches(ei_node->info, type, table)) {
+		zlog_debug("%s: Ignoring delete for replaced %s route %pFX table %u.", __func__,
+			   zebra_route_string(type), p, table);
+		route_unlock_node(ei_node);
+		return;
+	}
+
+	if (is_default_prefix(p) && (!src_p || !src_p->prefixlen)) {
+		/* Don't remove default route but add synthetic route for use
+		 * by "default-information originate always". Areas without the
+		 * "always" setting will ignore routes with origin
+		 * DEFAULT_ROUTE. */
+		route_unlock_node(ei_node);
+		isis_redist_add(isis, DEFAULT_ROUTE, p, NULL, 254, MAX_WIDE_PATH_METRIC, 0, table);
 		return;
 	}
 	route_unlock_node(ei_node);
@@ -465,7 +492,7 @@ void isis_redist_update(struct isis_area *area, int level, int family, int type,
 				continue;
 			}
 		} else {
-			if (info->origin != type)
+			if (!isis_redist_info_matches(info, type, table))
 				continue;
 		}
 
@@ -522,7 +549,7 @@ void isis_redist_set(struct isis_area *area, int level, int family, int type,
 				continue;
 			}
 		} else {
-			if (info->origin != type)
+			if (!isis_redist_info_matches(info, type, table))
 				continue;
 		}
 
@@ -572,7 +599,7 @@ void isis_redist_unset(struct isis_area *area, int level, int family, int type,
 				continue;
 			}
 		} else {
-			if (info->origin != type)
+			if (!isis_redist_info_matches(info, type, table))
 				continue;
 		}
 

--- a/isisd/isis_redist.h
+++ b/isisd/isis_redist.h
@@ -19,6 +19,7 @@ struct isis_ext_info {
 	uint32_t metric;
 	uint8_t distance;
 	route_tag_t tag;
+	uint16_t table;
 };
 
 struct isis_redist {

--- a/tests/topotests/isis_redist_source_replace/r1/frr.conf
+++ b/tests/topotests/isis_redist_source_replace/r1/frr.conf
@@ -1,0 +1,45 @@
+hostname r1
+!
+interface r1-eth0
+ ip address 10.0.12.1/24
+ ip router isis TEST
+ isis circuit-type level-1
+ isis hello-interval 1
+!
+interface r1-eth1
+ ip address 10.0.13.1/24
+ ip router isis TEST
+ isis circuit-type level-2-only
+ isis hello-interval 1
+!
+interface r1-eth2
+ ip address 10.0.14.1/24
+!
+route-map RM-BGP-L1 permit 10
+ set metric 101
+!
+route-map RM-BGP-L2 permit 10
+ set metric 202
+!
+route-map RM-KERNEL-L1 permit 10
+ set metric 303
+!
+router isis TEST
+ net 49.0001.0000.0000.0001.00
+ metric-style wide
+ lsp-gen-interval 1
+ spf-interval 1
+ redistribute ipv4 bgp level-1 route-map RM-BGP-L1
+ redistribute ipv4 bgp level-2 route-map RM-BGP-L2
+ redistribute ipv4 kernel level-1 route-map RM-KERNEL-L1
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 10.0.14.4 remote-as 65004
+ neighbor 10.0.14.4 timers 1 3
+ neighbor 10.0.14.4 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.14.4 activate
+ exit-address-family
+!

--- a/tests/topotests/isis_redist_source_replace/r2/frr.conf
+++ b/tests/topotests/isis_redist_source_replace/r2/frr.conf
@@ -1,0 +1,15 @@
+hostname r2
+!
+interface r2-eth0
+ ip address 10.0.12.2/24
+ ip router isis TEST
+ isis circuit-type level-1
+ isis hello-interval 1
+!
+router isis TEST
+ is-type level-1
+ net 49.0001.0000.0000.0002.00
+ metric-style wide
+ lsp-gen-interval 1
+ spf-interval 1
+!

--- a/tests/topotests/isis_redist_source_replace/r3/frr.conf
+++ b/tests/topotests/isis_redist_source_replace/r3/frr.conf
@@ -1,0 +1,15 @@
+hostname r3
+!
+interface r3-eth0
+ ip address 10.0.13.3/24
+ ip router isis TEST
+ isis circuit-type level-2-only
+ isis hello-interval 1
+!
+router isis TEST
+ is-type level-2-only
+ net 49.0001.0000.0000.0003.00
+ metric-style wide
+ lsp-gen-interval 1
+ spf-interval 1
+!

--- a/tests/topotests/isis_redist_source_replace/r4/frr.conf
+++ b/tests/topotests/isis_redist_source_replace/r4/frr.conf
@@ -1,0 +1,19 @@
+hostname r4
+!
+interface lo
+ ip address 172.31.0.1/16
+!
+interface r4-eth0
+ ip address 10.0.14.4/24
+!
+router bgp 65004
+ no bgp ebgp-requires-policy
+ neighbor 10.0.14.1 remote-as 65001
+ neighbor 10.0.14.1 timers 1 3
+ neighbor 10.0.14.1 timers connect 1
+ !
+ address-family ipv4 unicast
+  network 172.31.0.0/16
+  neighbor 10.0.14.1 activate
+ exit-address-family
+!

--- a/tests/topotests/isis_redist_source_replace/test_isis_redist_source_replace.py
+++ b/tests/topotests/isis_redist_source_replace/test_isis_redist_source_replace.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (C) 2026 Proxmox Server Solutions GmbH
+#                    Gabriel Goller
+#
+
+"""Test replacement of a route redistributed into different IS-IS levels."""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import step
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
+
+PREFIX = "172.31.0.0/16"
+
+
+def build_topo(tgen):
+    """Build L1/L2 neighbors and a BGP peer around the DUT."""
+    for router in ("r1", "r2", "r3", "r4"):
+        tgen.add_router(router)
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module():
+    get_topogen().stop_topology()
+
+
+def _route_check(router, protocol, metric=None):
+    routes = json.loads(router.vtysh_cmd("show ip route {} json".format(PREFIX)))
+    for route in routes.get(PREFIX, []):
+        if route.get("protocol") != protocol or not route.get("selected", False):
+            continue
+        if metric is not None and route.get("metric") != metric:
+            continue
+        return None
+    return "{} selected route not found in {}".format(protocol, routes)
+
+
+def _route_absent(router, protocol):
+    routes = json.loads(router.vtysh_cmd("show ip route {} json".format(PREFIX)))
+    if any(route.get("protocol") == protocol for route in routes.get(PREFIX, [])):
+        return "{} route is still present in {}".format(protocol, routes)
+    return None
+
+
+def test_initial_bgp_redistribution():
+    """The BGP route must be advertised into both IS-IS levels."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+    r3 = tgen.gears["r3"]
+
+    step("Wait for the BGP route to become selected on r1")
+    test_func = functools.partial(_route_check, r1, "bgp")
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, result
+
+    step("Verify BGP redistribution through the Level-1 adjacency")
+    test_func = functools.partial(_route_check, r2, "isis", 111)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, result
+
+    step("Verify BGP redistribution through the Level-2 adjacency")
+    test_func = functools.partial(_route_check, r3, "isis", 212)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, result
+
+
+def test_kernel_replaces_bgp():
+    """Replacing BGP with KERNEL must withdraw the old Level-2 route."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+    r3 = tgen.gears["r3"]
+
+    step("Install a lower-distance KERNEL route on r1")
+    r1.run("ip route add blackhole {}".format(PREFIX))
+
+    step("Verify that the KERNEL route replaces BGP in the r1 RIB")
+    test_func = functools.partial(_route_check, r1, "kernel")
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert result is None, result
+
+    step("Verify that Level-1 is updated with the KERNEL metric")
+    test_func = functools.partial(_route_check, r2, "isis", 313)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, result
+
+    step("Verify that the old BGP-derived Level-2 route is withdrawn")
+    test_func = functools.partial(_route_absent, r3, "isis")
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Track the protocol and routing table of redistributed routes so isis correctly handles zebra route replacement semantics. When a route changes source, stale reachability is removed from previously advertised levels before the new route is installed.
Add a topotest covering replacement of a bgp route with a kernel route across Level-1 and Level-2.

Fixes: #23009 