### PR TITLE
build: assorted clippy improvements, + "mechanical commit" tool

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -281,6 +281,9 @@ struct cmd_node {
 			    struct cmd_token *argv[] __attribute__((unused)))
 
 /* DEFPY variants */
+/* please update lib/defun_lex.l when adding or removing macros here
+ * (just needs the macro name in the list, nothing else)
+ */
 
 #define DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
 	static DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr, 0)  \
@@ -307,6 +310,7 @@ struct cmd_node {
 		   CMD_ATTR_YANG | CMD_ATTR_NOSH)
 
 /* DEFUN variants */
+/* as above, please update lib/defun_lex.l when adding/removing macros here */
 
 #define DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
 	DEFUN_CMD_FUNC_DECL(funcname)                                          \
@@ -323,6 +327,8 @@ struct cmd_node {
 	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
 /* DEFUN_NOSH for commands that vtysh should ignore */
+/* as above, please update lib/defun_lex.l when adding/removing macros here */
+
 #define DEFUN_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
 	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_NOSH)
 
@@ -335,6 +341,8 @@ struct cmd_node {
 		   CMD_ATTR_YANG | CMD_ATTR_NOSH)
 
 /* DEFSH for vtysh. */
+/* (these do NOT go in lib/defun_lex.l since they are vtysh only) */
+
 #define DEFSH_ATTR(daemon, cmdname, cmdstr, helpstr, attr)                     \
 	DEFUN_CMD_ELEMENT(NULL, cmdname, cmdstr, helpstr, attr, daemon)
 
@@ -345,6 +353,7 @@ struct cmd_node {
 	DEFSH_ATTR(daemon, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN)
 
 /* DEFUN + DEFSH */
+
 #define DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr, attr)         \
 	DEFUN_CMD_FUNC_DECL(funcname)                                          \
 	static DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr,     \
@@ -359,6 +368,8 @@ struct cmd_node {
 		     CMD_ATTR_HIDDEN)
 
 /* ALIAS macro which define existing command's alias. */
+/* as above, please update lib/defun_lex.l when adding/removing macros here */
+
 #define ALIAS_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
 	static DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr, 0)
 

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -71,6 +71,8 @@ static void extendbuf(char **what, const char *arg)
 
 #ifndef __clang_analyzer__
 
+#define YY_USER_INIT BEGIN(linestart)
+
 %}
 
 ID		[A-Za-z0-9_]+
@@ -91,9 +93,8 @@ SPECIAL		[(),]
 %x linecomment
 %x preproc
 %x rstring
-%%
-				BEGIN(linestart);
 
+%%
 \n				BEGIN(linestart);
 
 <INITIAL,linestart,preproc>"/*"	comment_link = YY_START; extend(yytext); BEGIN(comment);
@@ -107,7 +108,7 @@ SPECIAL		[(),]
 <linecomment>\n			BEGIN((comment_link == INITIAL) ? linestart : comment_link); return COMMENT;
 
 <linestart>#			BEGIN(preproc);
-<preproc>\n			BEGIN(INITIAL); return PREPROC;
+<preproc>\n			BEGIN(linestart); return PREPROC;
 <preproc>[^\n\\]+		extend(yytext);
 <preproc>\\\n			extend(yytext);
 <preproc>\\+[^\n]		extend(yytext);
@@ -149,7 +150,7 @@ SPECIAL		[(),]
 "VTYSH_TARGETS"			value = strdup(yytext); return AUXILIARY;
 "VTYSH_NODESWITCH"		value = strdup(yytext); return AUXILIARY;
 
-[ \t\n]+			/* ignore */
+[ \t]+				/* ignore */
 \\				/* ignore */
 {ID}				BEGIN(INITIAL); value = strdup(yytext); return ID;
 {OPERATOR}			BEGIN(INITIAL); value = strdup(yytext); return OPERATOR;

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -158,8 +158,12 @@ SPECIAL		[(),]
 <rstring>[^\\\"\'\n]+		extend(yytext);
 
 "DEFUN"				value = strdup(yytext); return DEFUNNY;
+"DEFUN_ATTR"			value = strdup(yytext); return DEFUNNY;
 "DEFUN_NOSH"			value = strdup(yytext); return DEFUNNY;
 "DEFUN_HIDDEN"			value = strdup(yytext); return DEFUNNY;
+"DEFUN_YANG"			value = strdup(yytext); return DEFUNNY;
+"DEFUN_YANG_NOSH"		value = strdup(yytext); return DEFUNNY;
+"DEFUN_YANG_HIDDEN"		value = strdup(yytext); return DEFUNNY;
 "DEFPY"				value = strdup(yytext); return DEFUNNY;
 "DEFPY_NOSH"			value = strdup(yytext); return DEFUNNY;
 "DEFPY_ATTR"			value = strdup(yytext); return DEFUNNY;
@@ -168,7 +172,10 @@ SPECIAL		[(),]
 "DEFPY_YANG_HIDDEN"		value = strdup(yytext); return DEFUNNY;
 "DEFPY_YANG_NOSH"		value = strdup(yytext); return DEFUNNY;
 "ALIAS"				value = strdup(yytext); return DEFUNNY;
+"ALIAS_ATTR"			value = strdup(yytext); return DEFUNNY;
 "ALIAS_HIDDEN"			value = strdup(yytext); return DEFUNNY;
+"ALIAS_DEPRECATED"		value = strdup(yytext); return DEFUNNY;
+"ALIAS_YANG"			value = strdup(yytext); return DEFUNNY;
 
 "install_element"		value = strdup(yytext); return INSTALL;
 

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -35,6 +35,7 @@
 #include <Python.h>
 #include <string.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "command_graph.h"
 #include "clippy.h"
@@ -55,6 +56,7 @@ char string_end;
 
 char *value;
 static const char *yyfilename;
+static size_t input_pos;
 
 static void extendbuf(char **what, const char *arg)
 {
@@ -70,6 +72,26 @@ static void extendbuf(char **what, const char *arg)
 #define extend(x) extendbuf(&value, x)
 
 #ifndef __clang_analyzer__
+
+static int def_do_input(char *buf, int max_size, FILE *filep)
+{
+	ssize_t result;
+
+	assert(max_size > 0);
+
+	result = fread(buf, 1, (size_t)max_size, filep);
+	if (result >= 0)
+		input_pos += result;
+
+	return result;
+}
+
+#define YY_INPUT(buf, result, max_size)                                                           \
+	do {                                                                                      \
+		result = def_do_input(buf, max_size, yyin);                                       \
+		if (result < 0)                                                                   \
+			YY_FATAL_ERROR("input in flex scanner failed");                           \
+	} while (0)
 
 #define YY_USER_INIT BEGIN(linestart)
 
@@ -164,15 +186,18 @@ extern int def_yylex(void);
 extern int def_yylex_destroy(void);
 #endif /* __clang_analyzer__ */
 
-static int yylex_clr(char **retbuf)
+static int yylex_clr(char **retbuf, ssize_t *retpos)
 {
 	int rv = def_yylex();
+	char *yy_ch_buf = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+
+	*retpos = input_pos - yy_n_chars + (yy_c_buf_p - yy_ch_buf);
 	*retbuf = value;
 	value = NULL;
 	return rv;
 }
 
-static PyObject *get_args(const char *filename, int lineno)
+static PyObject *get_args(const char *filename, int lineno, ssize_t *off_end)
 {
 	PyObject *pyObj = PyList_New(0);
 	PyObject *pyArg = NULL;
@@ -181,7 +206,7 @@ static PyObject *get_args(const char *filename, int lineno)
 	int depth = 1;
 	int token;
 
-	while ((token = yylex_clr(&tval)) != YY_NULL) {
+	while ((token = yylex_clr(&tval, off_end)) != YY_NULL) {
 		if (token == SPECIAL && tval[0] == '(') {
 			free(tval);
 			break;
@@ -194,7 +219,7 @@ static PyObject *get_args(const char *filename, int lineno)
 		exit(1);
 	}
 
-	while ((token = yylex_clr(&tval)) != YY_NULL) {
+	while ((token = yylex_clr(&tval, off_end)) != YY_NULL) {
 		if (token == COMMENT) {
 			free(tval);
 			continue;
@@ -249,23 +274,29 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 
 	char *tval;
 	int token;
+
 	yyin = fd;
 	value = NULL;
 	yyfilename = filename;
+	input_pos = 0;
 
 	PyObject *pyCont = PyDict_New();
 	PyObject *pyObj = PyList_New(0);
 	PyDict_SetItemString(pyCont, "filename", PyUnicode_FromString(filename));
 	PyDict_SetItemString(pyCont, "data", pyObj);
 
-	while ((token = yylex_clr(&tval)) != YY_NULL) {
+	ssize_t off_start, off_end;
+
+	while ((token = yylex_clr(&tval, &off_start)) != YY_NULL) {
 		int lineno = yylineno;
 		PyObject *pyItem = NULL, *pyArgs;
 		switch (token) {
 		case DEFUNNY:
 		case INSTALL:
 		case AUXILIARY:
-			pyArgs = get_args(filename, lineno);
+			off_start -= strlen(tval);
+
+			pyArgs = get_args(filename, lineno, &off_end);
 			if (!pyArgs) {
 				free(tval);
 				Py_DECREF(pyCont);
@@ -274,6 +305,8 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 			}
 			pyItem = PyDict_New();
 			PyDict_SetItemString(pyItem, "type", PyUnicode_FromString(tval));
+			PyDict_SetItemString(pyItem, "start", PyLong_FromLongLong(off_start));
+			PyDict_SetItemString(pyItem, "end", PyLong_FromLongLong(off_end));
 			PyDict_SetItemString(pyItem, "args", pyArgs);
 			break;
 		case COMMENT:

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -39,16 +39,16 @@
 #include "command_graph.h"
 #include "clippy.h"
 
-#define ID		258
-#define PREPROC		259
-#define OPERATOR	260
-#define STRING		261
-#define COMMENT		262
-#define SPECIAL		263
+#define ID	 258
+#define PREPROC	 259
+#define OPERATOR 260
+#define STRING	 261
+#define COMMENT	 262
+#define SPECIAL	 263
 
-#define DEFUNNY		270
-#define INSTALL		271
-#define AUXILIARY	272
+#define DEFUNNY	  270
+#define INSTALL	  271
+#define AUXILIARY 272
 
 int comment_link;
 char string_end;
@@ -202,8 +202,8 @@ static PyObject *get_args(const char *filename, int lineno)
 			free(tval);
 			Py_DECREF(pyObj);
 			return PyErr_Format(PyExc_ValueError,
-					"%s:%d: cannot process CPP directive within argument list",
-					filename, lineno);
+					    "%s:%d: cannot process CPP directive within argument list",
+					    filename, lineno);
 		}
 		if (token == SPECIAL) {
 			if (depth == 1 && (tval[0] == ',' || tval[0] == ')')) {
@@ -224,8 +224,8 @@ static PyObject *get_args(const char *filename, int lineno)
 		}
 		if (!tval)
 			return PyErr_Format(PyExc_ValueError,
-					"%s:%d: invalid token in DEFPY parameters",
-					filename, lineno);
+					    "%s:%d: invalid token in DEFPY parameters", filename,
+					    lineno);
 		if (!pyArg)
 			pyArg = PyList_New(0);
 		PyList_Append(pyArg, PyUnicode_FromString(tval));
@@ -241,7 +241,7 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 	const char *filename;
 	if (!PyArg_ParseTuple(args, "s", &filename))
 		return NULL;
-	
+
 	FILE *fd = fopen(filename, "r");
 	if (!fd)
 		return PyErr_SetFromErrnoWithFilename(PyExc_IOError, filename);
@@ -258,7 +258,7 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 	PyDict_SetItemString(pyCont, "data", pyObj);
 
 	while ((token = yylex_clr(&tval)) != YY_NULL) {
-                int lineno = yylineno;
+		int lineno = yylineno;
 		PyObject *pyItem = NULL, *pyArgs;
 		switch (token) {
 		case DEFUNNY:
@@ -276,8 +276,8 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 			PyDict_SetItemString(pyItem, "args", pyArgs);
 			break;
 		case COMMENT:
-                        if (strncmp(tval, "//~", 3) && strncmp(tval, "/*~", 3))
-                                break;
+			if (strncmp(tval, "//~", 3) && strncmp(tval, "/*~", 3))
+				break;
 			pyItem = PyDict_New();
 			PyDict_SetItemString(pyItem, "type", PyUnicode_FromString("COMMENT"));
 			PyDict_SetItemString(pyItem, "line", PyUnicode_FromString(tval));

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -54,8 +54,9 @@
 
 int comment_link;
 char string_end;
+int lno_offs;
 
-char *value;
+char *value, *val_comment;
 static const char *yyfilename;
 static size_t input_pos;
 
@@ -70,7 +71,8 @@ static void extendbuf(char **what, const char *arg)
 		(*what)[vall + argl] = '\0';
 	}
 }
-#define extend(x) extendbuf(&value, x)
+#define extend(x)     extendbuf(&value, x)
+#define extendcomm(x) extendbuf(&val_comment, x)
 
 #ifndef __clang_analyzer__
 
@@ -118,21 +120,24 @@ SPECIAL		[(),]
 %x rstring
 
 %%
-\n				BEGIN(linestart);
 
-<INITIAL,linestart,preproc>"/*"	comment_link = YY_START; extend(yytext); BEGIN(comment);
-<comment>[^*\n]*		extend(yytext);
-<comment>"*"+[^*/\n]*		extend(yytext);
-<comment>\n			extend(yytext);
-<comment>"*"+"/"		extend(yytext); BEGIN(comment_link); return COMMENT;
+<INITIAL,linestart,preproc>"/*"	comment_link = YY_START; extendcomm(yytext); BEGIN(comment);
+<comment>[^*\n]*		extendcomm(yytext);
+<comment>"*"+[^*/\n]*		extendcomm(yytext);
+<comment>\n			extendcomm(yytext);
+<comment>"*"+"/"		extendcomm(yytext); BEGIN(comment_link); if (value) extend(" "); return COMMENT;
 
-<INITIAL,linestart,preproc>"//"	comment_link = YY_START; extend(yytext); BEGIN(linecomment);
-<linecomment>[^\n]*		extend(yytext);
-<linecomment>\n			BEGIN((comment_link == INITIAL) ? linestart : comment_link); return COMMENT;
+<INITIAL,linestart>"//"		extendcomm(yytext); BEGIN(linecomment);
+<linecomment>[^\n\\]*		extendcomm(yytext);
+<linecomment>\\\n		extendcomm(yytext);
+<linecomment>\\			extendcomm(yytext);
+<linecomment>\n			BEGIN(linestart); lno_offs = -1; return COMMENT;
 
 <linestart>#			BEGIN(preproc);
 <preproc>\n			BEGIN(linestart); return PREPROC;
-<preproc>[^\n\\]+		extend(yytext);
+<preproc>"//"			extendcomm(yytext); BEGIN(linecomment); lno_offs = 1; return PREPROC;
+<preproc>[^\n\\/]+		extend(yytext);
+<preproc>"/"			extend(yytext);
 <preproc>\\\n			extend(yytext);
 <preproc>\\+[^\n]		extend(yytext);
 
@@ -189,11 +194,13 @@ SPECIAL		[(),]
 "DEFINE_KOOH"			value = strdup(yytext); return HOOK;
 "DECLARE_KOOH"			value = strdup(yytext); return HOOK;
 
+<INITIAL,linestart>\\\n		/* ignore */
 [ \t]+				/* ignore */
-\\				/* ignore */
 {ID}				BEGIN(INITIAL); value = strdup(yytext); return ID;
 {OPERATOR}			BEGIN(INITIAL); value = strdup(yytext); return OPERATOR;
 {SPECIAL}			BEGIN(INITIAL); value = strdup(yytext); return SPECIAL;
+\n				BEGIN(linestart);
+
 .				/* printf("-- '%s' in init\n", yytext); */ BEGIN(INITIAL); return yytext[0];
 
 %%
@@ -203,14 +210,22 @@ extern int def_yylex(void);
 extern int def_yylex_destroy(void);
 #endif /* __clang_analyzer__ */
 
-static int yylex_clr(char **retbuf, ssize_t *retpos)
+static int yylex_clr(char **retbuf, int *lineno, ssize_t *retpos)
 {
 	int rv = def_yylex();
 	char *yy_ch_buf = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 
 	*retpos = input_pos - yy_n_chars + (yy_c_buf_p - yy_ch_buf);
-	*retbuf = value;
-	value = NULL;
+	if (rv == COMMENT) {
+		*retbuf = val_comment;
+		val_comment = NULL;
+	} else {
+		*retbuf = value;
+		value = NULL;
+	}
+	if (lineno)
+		*lineno = yylineno + lno_offs;
+	lno_offs = 0;
 	return rv;
 }
 
@@ -223,7 +238,7 @@ static PyObject *get_args(const char *filename, int lineno, ssize_t *off_end)
 	int depth = 1;
 	int token;
 
-	while ((token = yylex_clr(&tval, off_end)) != YY_NULL) {
+	while ((token = yylex_clr(&tval, NULL, off_end)) != YY_NULL) {
 		if (token == SPECIAL && tval[0] == '(') {
 			free(tval);
 			break;
@@ -236,7 +251,7 @@ static PyObject *get_args(const char *filename, int lineno, ssize_t *off_end)
 		exit(1);
 	}
 
-	while ((token = yylex_clr(&tval, off_end)) != YY_NULL) {
+	while ((token = yylex_clr(&tval, NULL, off_end)) != YY_NULL) {
 		if (token == COMMENT) {
 			free(tval);
 			continue;
@@ -294,6 +309,7 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 
 	yyin = fd;
 	value = NULL;
+	val_comment = NULL;
 	yyfilename = filename;
 	input_pos = 0;
 
@@ -303,9 +319,9 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 	PyDict_SetItemString(pyCont, "data", pyObj);
 
 	ssize_t off_start, off_end;
+	int lineno;
 
-	while ((token = yylex_clr(&tval, &off_start)) != YY_NULL) {
-		int lineno = yylineno;
+	while ((token = yylex_clr(&tval, &lineno, &off_start)) != YY_NULL) {
 		const char *type;
 
 		PyObject *pyItem = NULL, *pyArgs;

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -50,6 +50,7 @@
 #define DEFUNNY	  270
 #define INSTALL	  271
 #define AUXILIARY 272
+#define HOOK	  273
 
 int comment_link;
 char string_end;
@@ -168,9 +169,18 @@ SPECIAL		[(),]
 "DEFPY_YANG_NOSH"		value = strdup(yytext); return DEFUNNY;
 "ALIAS"				value = strdup(yytext); return DEFUNNY;
 "ALIAS_HIDDEN"			value = strdup(yytext); return DEFUNNY;
+
 "install_element"		value = strdup(yytext); return INSTALL;
+
 "VTYSH_TARGETS"			value = strdup(yytext); return AUXILIARY;
 "VTYSH_NODESWITCH"		value = strdup(yytext); return AUXILIARY;
+
+"DO_HOOK"			value = strdup(yytext); return HOOK;
+"DEFINE_HOOK"			value = strdup(yytext); return HOOK;
+"DECLARE_HOOK"			value = strdup(yytext); return HOOK;
+"DO_KOOH"			value = strdup(yytext); return HOOK;
+"DEFINE_KOOH"			value = strdup(yytext); return HOOK;
+"DECLARE_KOOH"			value = strdup(yytext); return HOOK;
 
 [ \t]+				/* ignore */
 \\				/* ignore */
@@ -289,11 +299,23 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 
 	while ((token = yylex_clr(&tval, &off_start)) != YY_NULL) {
 		int lineno = yylineno;
+		const char *type;
+
 		PyObject *pyItem = NULL, *pyArgs;
 		switch (token) {
 		case DEFUNNY:
+			if (!(type = "DEFUNNY"))
+				/* fallthru */
 		case INSTALL:
+			if (!(type = "INSTALL"))
+				/* fallthru */
 		case AUXILIARY:
+			if (!(type = "AUXILIARY"))
+				/* fallthru */
+		case HOOK:
+			if (!(type = "HOOK"))
+				(void)0;
+
 			off_start -= strlen(tval);
 
 			pyArgs = get_args(filename, lineno, &off_end);
@@ -304,9 +326,10 @@ PyObject *clippy_parse(PyObject *self, PyObject *args)
 				return NULL;
 			}
 			pyItem = PyDict_New();
-			PyDict_SetItemString(pyItem, "type", PyUnicode_FromString(tval));
+			PyDict_SetItemString(pyItem, "value", PyUnicode_FromString(tval));
 			PyDict_SetItemString(pyItem, "start", PyLong_FromLongLong(off_start));
 			PyDict_SetItemString(pyItem, "end", PyLong_FromLongLong(off_end));
+			PyDict_SetItemString(pyItem, "type", PyUnicode_FromString(type));
 			PyDict_SetItemString(pyItem, "args", pyArgs);
 			break;
 		case COMMENT:

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -289,13 +289,19 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
     cond_stack = []
 
     for entry in filedata["data"]:
+        errors += process_one(fn, entry, cond_stack, ofd, dumpfd, all_defun, macros)
+
+    return errors
+
+def process_one(fn, entry, cond_stack, ofd, dumpfd, all_defun, macros) -> int:
+    try:
         if entry["type"] == "PREPROC":
             line = entry["line"].lstrip()
             tokens = line.split(maxsplit=1)
             line = "#" + line + "\n"
 
             if not tokens:
-                continue
+                return 0
 
             if tokens[0] in ["if", "ifdef", "ifndef"]:
                 cond_stack.append(line)
@@ -309,7 +315,7 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
                     macros.load_preproc(fn, entry)
                 elif len(cond_stack) == 1 and cond_stack[0] == "#ifdef CLIPPY\n":
                     macros.load_preproc(fn, entry)
-            continue
+            return 0
         if entry["type"] == "DEFUNNY" and (
             entry["value"].startswith("DEFPY") or all_defun
         ):
@@ -318,8 +324,7 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
                     "%s:%d: DEFPY function name not parseable (%r)\n"
                     % (fn, entry["lineno"], entry["args"][0])
                 )
-                errors += 1
-                continue
+                return 1
 
             cmddef = entry["args"][2]
             cmddefx = []
@@ -334,11 +339,7 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
                     "%s:%d: DEFPY command string not parseable (%r)\n"
                     % (fn, entry["lineno"], cmddef)
                 )
-                errors += 1
-                cmddefx = None
-                break
-            if cmddefx is None:
-                continue
+                return 1
             cmddef = "".join([i for i in cmddefx])
 
             graph = clippy.Graph(cmddef)
@@ -439,8 +440,12 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
             params["nonempty"] = len(argblocks)
             params["argassert"] = "".join(argassert)
             ofd.write(templ.substitute(params))
+    except Exception as e:
+        tokeninfo = entry.get("value", entry.get("type"))
+        e.add_note(f"{fn}:{entry['lineno']}: at token {tokeninfo!r}")
+        raise e
 
-    return errors
+    return 0
 
 
 if __name__ == "__main__":

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -43,12 +43,10 @@ class StringHandler(RenderHandler):
 class Int64Handler(RenderHandler):
     argtype = "int64_t"
     decl = Template("int64_t $varname = 0;")
-    code = Template(
-        """\
+    code = Template("""\
 char *_end;
 $varname = strtoll(argv[_i]->arg, &_end, 10);
-_fail = (_end == argv[_i]->arg) || (*_end != '\\0');"""
-    )
+_fail = (_end == argv[_i]->arg) || (*_end != '\\0');""")
 
 
 class AsDotHandler(RenderHandler):
@@ -124,8 +122,7 @@ class IPGenHandler(IPBase):
     decl = Template(
         """union sockunion s__$varname = { .sa.sa_family = AF_UNSPEC }, *$varname = NULL;"""
     )
-    code = Template(
-        """\
+    code = Template("""\
 if (argv[_i]->text[0] == 'X') {
 	s__$varname.sa.sa_family = AF_INET6;
 	_fail = !inet_pton(AF_INET6, argv[_i]->arg, &s__$varname.sin6.sin6_addr);
@@ -134,8 +131,7 @@ if (argv[_i]->text[0] == 'X') {
 	s__$varname.sa.sa_family = AF_INET;
 	_fail = !inet_aton(argv[_i]->arg, &s__$varname.sin.sin_addr);
 	$varname = &s__$varname;
-}"""
-    )
+}""")
     canassert = True
 
 
@@ -166,8 +162,7 @@ handlers = {
 # the "#if $..." bits are there to keep this template unified into one
 # common form, without requiring a more advanced template engine (e.g.
 # jinja2)
-templ = Template(
-    """$cond_begin/* $fnname => "$cmddef" */
+templ = Template("""$cond_begin/* $fnname => "$cmddef" */
 DEFUN_CMD_FUNC_DECL($fnname)
 #define funcdecl_$fnname static int ${fnname}_magic(\\
 	const struct cmd_element *self __attribute__ ((unused)),\\
@@ -206,16 +201,13 @@ $argassert
 	return ${fnname}_magic(self, vty, argc, argv$arglist);
 }
 $cond_end
-"""
-)
+""")
 
 # invoked for each named parameter
-argblock = Template(
-    """
+argblock = Template("""
 		if (!strcmp(argv[_i]->varname, \"$varname\")) {$strblock
 			$code
-		}"""
-)
+		}""")
 
 
 def get_always_args(token, always_args, args=[], stack=[]):
@@ -292,6 +284,7 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
         errors += process_one(fn, entry, cond_stack, ofd, dumpfd, all_defun, macros)
 
     return errors
+
 
 def process_one(fn, entry, cond_stack, ofd, dumpfd, all_defun, macros) -> int:
     try:
@@ -382,13 +375,10 @@ def process_one(fn, entry, cond_stack, ofd, dumpfd, all_defun, macros) -> int:
                 )
                 arglist.append(", %s%s" % (handler.deref, varname))
                 if basename in always_args and handler.canassert:
-                    argassert.append(
-                        """\tif (!%s) {
+                    argassert.append("""\tif (!%s) {
 \t\tvty_out(vty, "Internal CLI error [%%s]\\n", "%s");
 \t\treturn CMD_WARNING;
-\t}\n"""
-                        % (varname, varname)
-                    )
+\t}\n""" % (varname, varname))
                 if attr == "":
                     at = handler.argtype
                     if not at.startswith("const "):

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -310,8 +310,8 @@ def process_file(fn, ofd, dumpfd, all_defun, macros):
                 elif len(cond_stack) == 1 and cond_stack[0] == "#ifdef CLIPPY\n":
                     macros.load_preproc(fn, entry)
             continue
-        if entry["type"].startswith("DEFPY") or (
-            all_defun and entry["type"].startswith("DEFUN")
+        if entry["type"] == "DEFUNNY" and (
+            entry["value"].startswith("DEFPY") or all_defun
         ):
             if len(entry["args"][0]) != 1:
                 sys.stderr.write(
@@ -451,7 +451,7 @@ if __name__ == "__main__":
         "--all-defun",
         action="store_const",
         const=True,
-        help="process DEFUN() statements in addition to DEFPY()",
+        help="process DEFUN() and ALIAS() statements in addition to DEFPY()",
     )
     argp.add_argument(
         "--show",

--- a/tools/mechanicommit.py
+++ b/tools/mechanicommit.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2017  David Lamparter for NetDEF, Inc.
+"""
+Tool to re-run/re-create "mechanical" commits resulting from automated changes.
+
+The point of this is that when you rebase a branch with such mechanical
+changes, these commits can simply be recreated rather than fixing merge
+conflicts.
+
+This tool is intended to be used primarily *during* a rebase.  It does need
+to be run in a clean worktree, to support adding changed files but also for
+general safety.
+"""
+
+import sys
+import os
+from subprocess import Popen, PIPE, CalledProcessError
+import argparse
+import re
+from pathlib import Path
+
+
+def git(*gitargs: str) -> str:
+    proc = Popen(["git"] + list(gitargs), stdout=PIPE, encoding="UTF-8")
+    rv = proc.communicate("")[0]
+    proc.wait()
+    if proc.returncode != 0:
+        raise CalledProcessError(proc.returncode, ["git"] + list(gitargs))
+    return rv.removesuffix("\n")
+
+
+def main() -> None:
+    argp = argparse.ArgumentParser(
+        description="mechanical git commit reapplication/verification tool"
+    )
+    argp.add_argument(
+        "--allow-dirty",
+        action="store_const",
+        const=True,
+        help="bypass dirty tree check (DANGEROUS)",
+    )
+
+    args = argp.parse_args()
+
+    topdir = Path(git("rev-parse", "--show-toplevel"))
+    gitdir = Path(git("rev-parse", "--git-dir"))
+
+    r_merge = gitdir / "rebase-merge"
+    r_apply = gitdir / "rebase-apply"
+
+    topmost = git("rev-parse", "HEAD")
+    use_commit = None
+    base = None
+    allow_dirty = False
+
+    if r_merge.exists():
+        sys.stderr.write("§ currently in rebase-merge\n")
+
+        with open(r_merge / "done", "r") as fd:
+            done = fd.readlines()
+
+        verb = None
+        while done:
+            while done and done[-1].strip() == "":
+                done.pop(-1)
+            while done and done[-1].lstrip().startswith("#"):
+                done.pop(-1)
+            assert len(done)
+            cmd = done[-1].split(maxsplit=1)
+            verb = cmd[0]
+            if verb in ["l", "label"]:
+                done.pop(-1)
+                continue
+            break
+
+        if verb not in ["b", "break", "e", "edit", "p", "pick"]:
+            sys.stderr.write(f"unsupported rebase verb: {verb}\n")
+            sys.exit(1)
+
+        if verb in ["b", "break", "e", "edit"]:
+            sys.stderr.write("§ stopped in normal state, using topmost commit\n")
+            use_commit = topmost
+        else:
+            use_commit = cmd[1].split()[0]
+            sys.stderr.write(f"§ using commit {use_commit} from rebase pick\n")
+            base = topmost
+            allow_dirty = True
+
+    else:
+        use_commit = topmost
+
+    if use_commit is None:
+        sys.stderr.write("§ unknown mode, aborting\n")
+        sys.exit(1)
+    if base is None:
+        parents = git("show", "-s", "--pretty=format:%P", use_commit).split()
+        if len(parents) != 1:
+            sys.stderr.write("§ cannot work with a merge commit\n")
+            sys.exit(1)
+        base = parents[0]
+
+    if not allow_dirty:
+        status = git("status", "--porcelain", "-u")
+        if status != "":
+            if args.allow_dirty:
+                sys.stderr.write(
+                    "§ working tree contains changes or untracked files.  continuing anyway.\n"
+                )
+            else:
+                sys.stderr.write(
+                    "§ working tree contains changes or untracked files.  refusing work.\n"
+                )
+                sys.exit(1)
+
+    commitmsg = git("show", "-s", "--pretty=format:%B", use_commit)
+    m = re.search(
+        r"""^\$cmds:\$\n(.*?)^\$:cmds\$""", commitmsg, re.MULTILINE | re.DOTALL
+    )
+    if m is None:
+        sys.stderr.write("§ commit message does not contain commands?\n")
+        sys.exit(1)
+
+    cmds = m.group(1)
+    sys.stderr.write(f"§ commands:\n{cmds}")
+
+    os.chdir(topdir)
+    git("checkout", base, "--", ".")
+
+    env: dict[str, str] = {}
+    env.update(os.environ)
+    env["BASE"] = base
+
+    shell = Popen(["/bin/sh", "-e", "-x"], stdin=PIPE, env=env, encoding="UTF-8")
+    assert shell.stdin
+    shell.stdin.write(cmds)
+    shell.stdin.close()
+    shell.wait()
+    assert shell.returncode == 0
+
+    git("add", "-A")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* the newline handling for C code was slightly b0rked (didn't affect anything it seems, impact was primarily around malformed preprocessor stuff which the compiler would've rejected anyway)
* tracks file offset now (about to use that for another tool)
* extracts `HOOK` bits now (for same tool)
* comments are removed from midway through other things (can actually handle comments in DEFUNs now)
* slightly better error reporting in the python code
* some reformatting

The "mechanical commit" tool is for bulk changes that can be done with sed / coccinelle / python / etc., it helps during rebases by just rerunning the commands instead of fixing merge conflicts.