### PR TITLE
tests: ospf_rfc4222_r4: harden LSA-delivery timing against redistribution latency

### DIFF
--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_broadcast_lsa_pacing.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_broadcast_lsa_pacing.py
@@ -61,17 +61,14 @@ def tgen(request):
     tgen.start_topology()
 
     for rname, router in tgen.routers().items():
-        router.load_frr_config(os.path.join(CWD, "{}_broadcast".format(rname), "frr.conf"))
+        router.load_frr_config(
+            os.path.join(CWD, "{}_broadcast".format(rname), "frr.conf")
+        )
 
     tgen.start_router()
 
     r1 = tgen.gears["r1"]
-    r1.vtysh_cmd(
-        "configure terminal\n"
-        "router ospf\n"
-        "redistribute static\n"
-        "end"
-    )
+    r1.vtysh_cmd("configure terminal\n" "router ospf\n" "redistribute static\n" "end")
 
     time.sleep(12)
 
@@ -158,15 +155,16 @@ def _wait_all_full(tgen, routers=None, timeout_s=30):
 def _count_external_lsas(router):
     out = router.vtysh_cmd("show ip ospf database external")
     return sum(
-        1 for line in out.splitlines()
-        if "Link State ID" in line and PREFIX_TAG in line
+        1 for line in out.splitlines() if "Link State ID" in line and PREFIX_TAG in line
     )
 
 
 def _wait_all_receivers(expected, receivers, timeout_s):
     deadline = time.time() + timeout_s
     while time.time() < deadline:
-        counts = {name: _count_external_lsas(router) for name, router in receivers.items()}
+        counts = {
+            name: _count_external_lsas(router) for name, router in receivers.items()
+        }
         if all(count == expected for count in counts.values()):
             return counts
         time.sleep(0.2)
@@ -207,12 +205,12 @@ def _enable_dynamic_adjacency_pacing(r1):
         "end"
     )
     cfg = r1.vtysh_cmd("show running-config")
-    assert "ip ospf adjacency-pacing dynamic" in cfg, (
-        "R5 adjacency-pacing dynamic missing from running-config"
-    )
-    assert "ip ospf adjacency-pacing dynamic thresholds 20 6" in cfg, (
-        "R5 adjacency-pacing dynamic thresholds missing from running-config"
-    )
+    assert (
+        "ip ospf adjacency-pacing dynamic" in cfg
+    ), "R5 adjacency-pacing dynamic missing from running-config"
+    assert (
+        "ip ospf adjacency-pacing dynamic thresholds 20 6" in cfg
+    ), "R5 adjacency-pacing dynamic thresholds missing from running-config"
 
 
 def _add_routes(r1):
@@ -254,23 +252,48 @@ def _exercise_lsa_pacing(tgen, constrained):
     step("Inject external LSAs through redistributed static routes")
     _add_routes(r1)
 
-    first = _wait_receiver_at_least(r2, 1, timeout_s=4)
+    # Wait for the first LSA at r2 -- may be delayed by 1s LSA throttle
+    # plus whatever redistribution/zebra takes. Floored at 15s per
+    # topotest convention rather than the previous tight 4s. This
+    # check (and the negative one right after it) is anchored to the
+    # first-arrival event, not to a fixed deadline from when the
+    # routes were added, so widening it is safe: R4 only starts
+    # spacing sends apart once an LSA is actually queued, so "first
+    # arrival, then still incomplete" holds regardless of how long
+    # redistribution took to get that first LSA originated. Adding an
+    # R1-side precondition wait here instead would risk it completing
+    # only after pacing had already fully drained, defeating the
+    # "still queued" check below for a reason unrelated to pacing.
+    first = _wait_receiver_at_least(r2, 1, timeout_s=15)
     assert first >= 1, "No Type-5 LSA reached r2 after enabling broadcast LSA pacing"
 
     count_now = _count_external_lsas(r2)
-    assert count_now < NUM_ROUTES, (
-        "Broadcast LSA pacing did not gate the flood: r2 already has {}/{} LSAs".format(
-            count_now, NUM_ROUTES
-        )
+    assert (
+        count_now < NUM_ROUTES
+    ), "Broadcast LSA pacing did not gate the flood: r2 already has {}/{} LSAs".format(
+        count_now, NUM_ROUTES
+    )
+
+    # Precondition: confirm r1 itself actually originated all
+    # NUM_ROUTES external LSAs before timing delivery to every LAN
+    # receiver below. This is a redistribution/zebra step, not part of
+    # what's under test -- a failure in the final convergence check
+    # without this would be ambiguous between "redistribution was
+    # slow" and "broadcast flooding/pacing across LAN receivers is
+    # broken".
+    origin_counts = _wait_all_receivers(NUM_ROUTES, {"r1": r1}, timeout_s=15)
+    assert origin_counts["r1"] == NUM_ROUTES, (
+        "r1 only originated {}/{} external LSAs within 15s of adding "
+        "the routes. This is a redistribution/zebra issue, not "
+        "broadcast LSA pacing.".format(origin_counts["r1"], NUM_ROUTES)
     )
 
     receivers = {name: tgen.gears[name] for name in LAN_NEIGHBORS}
-    timeout_s = 12
+    timeout_s = 15
     counts = _wait_all_receivers(NUM_ROUTES, receivers, timeout_s=timeout_s)
     assert all(count == NUM_ROUTES for count in counts.values()), (
-        "Not all receivers learned all Type-5 LSAs within {}s: {}".format(
-            timeout_s, counts
-        )
+        "r1 originated all {} LSAs but not all receivers learned them "
+        "within {}s: {}".format(NUM_ROUTES, timeout_s, counts)
     )
 
     # Log check is informational only: it depends on 'debug ospf lsa flooding'
@@ -303,6 +326,22 @@ def _exercise_adj_and_lsa_pacing(tgen, constrained):
     step("Inject external LSAs while flapping three DROther neighbors")
     _add_routes(r1)
 
+    # Precondition: confirm r1 itself actually originated all
+    # NUM_ROUTES external LSAs before flapping neighbors and timing
+    # convergence below. This is a redistribution/zebra step, not part
+    # of what's under test -- without it, a failure in the final
+    # convergence check would be ambiguous between "redistribution was
+    # slow" and "combined R4/R5 broadcast pacing is broken". No
+    # transient/negative property is being tested here (unlike
+    # _exercise_lsa_pacing's "still queued" check), so it's safe to
+    # wait on this precondition unconditionally before anything else.
+    origin_counts = _wait_all_receivers(NUM_ROUTES, {"r1": r1}, timeout_s=15)
+    assert origin_counts["r1"] == NUM_ROUTES, (
+        "r1 only originated {}/{} external LSAs within 15s of adding "
+        "the routes. This is a redistribution/zebra issue, not "
+        "combined R4/R5 broadcast pacing.".format(origin_counts["r1"], NUM_ROUTES)
+    )
+
     for rname in ["r3", "r4", "r5"]:
         tgen.net[rname].cmd("ip link set {}-eth0 down".format(rname))
     time.sleep(1)
@@ -315,9 +354,8 @@ def _exercise_adj_and_lsa_pacing(tgen, constrained):
     timeout_s = 20
     counts = _wait_all_receivers(NUM_ROUTES, receivers, timeout_s=timeout_s)
     assert all(count == NUM_ROUTES for count in counts.values()), (
-        "Combined R4/R5 broadcast pacing did not deliver all Type-5 LSAs: {}".format(
-            counts
-        )
+        "r1 originated all {} LSAs but combined R4/R5 broadcast pacing "
+        "did not deliver them to all receivers: {}".format(NUM_ROUTES, counts)
     )
 
     # Log checks are informational only — see note in _exercise_lsa_pacing.

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_congested.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_congested.py
@@ -113,22 +113,22 @@ TEST_PREFIXES = ["10.88.{}.0/24".format(i) for i in range(1, NUM_ROUTES + 1)]
 PREFIX_TAG = "10.88."
 
 # Pacing parameters for the congested tests
-GAP_MS = 200          # 200 ms inter-LSU gap — well above the ~8 ms LSU tx time
-MAX_LSAS = 1          # one LSA per LSU — clean 1:1 timing
-ADJINT_MS = 60000     # freeze gap adjuster
+GAP_MS = 200  # 200 ms inter-LSU gap — well above the ~8 ms LSU tx time
+MAX_LSAS = 1  # one LSA per LSU — clean 1:1 timing
+ADJINT_MS = 60000  # freeze gap adjuster
 
 # Link shaping — 100 Kbps
 LINK_RATE = "100kbit"
 LINK_BURST = "4kb"
 LINK_LATENCY = "100ms"
-R1_ETH1 = "eth1"   # interface name inside R1's network namespace
+R1_ETH1 = "eth1"  # interface name inside R1's network namespace
 
 # Heavy-load / duplicate-suppression test (test 5) parameters
-NUM_ROUTES_HEAVY = 20      # heavier burst than the other congested tests
-HEAVY_GAP_MS = 500         # 500 ms gap -> 10 s drain for 20 LSAs
-HEAVY_RXMT_S = 3           # retransmit interval well below drain time
-HEAVY_DEAD_S = 60          # survive the ACK blackout without dead-timer expiry
-BLACKOUT_S = 13            # > 4 retransmit intervals of ACK loss
+NUM_ROUTES_HEAVY = 20  # heavier burst than the other congested tests
+HEAVY_GAP_MS = 500  # 500 ms gap -> 10 s drain for 20 LSAs
+HEAVY_RXMT_S = 3  # retransmit interval well below drain time
+HEAVY_DEAD_S = 60  # survive the ACK blackout without dead-timer expiry
+BLACKOUT_S = 13  # > 4 retransmit intervals of ACK loss
 HEAVY_PREFIXES = ["10.99.{}.0/24".format(i) for i in range(1, NUM_ROUTES_HEAVY + 1)]
 HEAVY_TAG = "10.99."
 
@@ -140,6 +140,7 @@ PM = None
 # Topology
 # ---------------------------------------------------------------------------
 
+
 def build_topo(tgen):
     """Two-router topology: R1 (sender) — R2 (observer)."""
     r1 = tgen.add_router("r1")
@@ -150,6 +151,7 @@ def build_topo(tgen):
 # ---------------------------------------------------------------------------
 # Module-level setup / teardown
 # ---------------------------------------------------------------------------
+
 
 def teardown_module():
     """Placeholder — topology is destroyed per test in teardown_function."""
@@ -175,15 +177,15 @@ def _setup_topology(test_name):
             R1_ETH1, LINK_RATE, LINK_BURST, LINK_LATENCY
         )
     )
-    logger.info("R1 %s shaped to %s (burst=%s latency=%s)",
-                R1_ETH1, LINK_RATE, LINK_BURST, LINK_LATENCY)
-
-    r1.vtysh_cmd(
-        "configure terminal\n"
-        "router ospf\n"
-        "redistribute static\n"
-        "end"
+    logger.info(
+        "R1 %s shaped to %s (burst=%s latency=%s)",
+        R1_ETH1,
+        LINK_RATE,
+        LINK_BURST,
+        LINK_LATENCY,
     )
+
+    r1.vtysh_cmd("configure terminal\n" "router ospf\n" "redistribute static\n" "end")
 
     global PM
     PM = PerInterfacePcapManager(outdir="pcaps", tag="congested")
@@ -223,6 +225,7 @@ def teardown_function():
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _enable_pacing(r1):
     r1.vtysh_cmd(
         "configure terminal\n"
@@ -235,16 +238,14 @@ def _enable_pacing(r1):
         "end".format(gap=GAP_MS, max_lsas=MAX_LSAS, adjint=ADJINT_MS)
     )
     cfg = r1.vtysh_cmd("show running-config")
-    assert "ip ospf lsa-pacing" in cfg, \
-        "lsa-pacing did not appear in running-config — vtysh command failed"
+    assert (
+        "ip ospf lsa-pacing" in cfg
+    ), "lsa-pacing did not appear in running-config — vtysh command failed"
 
 
 def _disable_pacing(r1):
     r1.vtysh_cmd(
-        "configure terminal\n"
-        "interface eth1\n"
-        "no ip ospf lsa-pacing\n"
-        "end"
+        "configure terminal\n" "interface eth1\n" "no ip ospf lsa-pacing\n" "end"
     )
 
 
@@ -267,8 +268,7 @@ def _remove_routes(r1):
 def _count_external_lsas(router):
     out = router.vtysh_cmd("show ip ospf database external")
     return sum(
-        1 for line in out.splitlines()
-        if "Link State ID" in line and PREFIX_TAG in line
+        1 for line in out.splitlines() if "Link State ID" in line and PREFIX_TAG in line
     )
 
 
@@ -292,9 +292,7 @@ def _wait_at_least(router, minimum, timeout_s):
 
 def _rxmt_list_count(r1, neighbor_id="2.2.2.2"):
     """Return R1's LS retransmission list length toward neighbor_id, or -1."""
-    out = r1.vtysh_cmd(
-        "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
-    )
+    out = r1.vtysh_cmd("show ip ospf neighbor {} json".format(neighbor_id), isjson=True)
     nbr_list = out.get("default", {}).get(neighbor_id)
     if not nbr_list:
         return -1
@@ -304,16 +302,22 @@ def _rxmt_list_count(r1, neighbor_id="2.2.2.2"):
 def _count_heavy_lsas(router):
     out = router.vtysh_cmd("show ip ospf database external")
     return sum(
-        1 for line in out.splitlines()
-        if "Link State ID" in line and HEAVY_TAG in line
+        1 for line in out.splitlines() if "Link State ID" in line and HEAVY_TAG in line
     )
+
+
+def _wait_heavy_lsas(router, expected, timeout_s):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _count_heavy_lsas(router) == expected:
+            return expected
+        time.sleep(0.2)
+    return _count_heavy_lsas(router)
 
 
 def _adjacency_is_full(r1, neighbor_id="2.2.2.2"):
     """Return True if R1's adjacency with neighbor_id is Full."""
-    out = r1.vtysh_cmd(
-        "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
-    )
+    out = r1.vtysh_cmd("show ip ospf neighbor {} json".format(neighbor_id), isjson=True)
     nbr_list = out.get("default", {}).get(neighbor_id)
     if not nbr_list:
         return False
@@ -333,9 +337,7 @@ def _wait_adjacency_full(r1, timeout_s=20, neighbor_id="2.2.2.2"):
 def _dead_timer_due_ms(r1, neighbor_id="2.2.2.2"):
     """Return the remaining ms on R1's inactivity (dead) timer for
     neighbor_id, or -1 if unavailable."""
-    out = r1.vtysh_cmd(
-        "show ip ospf neighbor {} json".format(neighbor_id), isjson=True
-    )
+    out = r1.vtysh_cmd("show ip ospf neighbor {} json".format(neighbor_id), isjson=True)
     nbr_list = out.get("default", {}).get(neighbor_id)
     if not nbr_list:
         return -1
@@ -363,6 +365,7 @@ def _wait_dead_timer_above(r1, min_ms, timeout_s, neighbor_id="2.2.2.2"):
 # Test 1: baseline — no pacing, adjacency survives burst on congested link
 # ---------------------------------------------------------------------------
 
+
 def test_congested_no_pacing_adjacency_stable():
     """
     Baseline: without pacing, all LSAs are sent as a burst on the 100 Kbps
@@ -375,7 +378,25 @@ def test_congested_no_pacing_adjacency_stable():
     off.  The shaped link adds real queuing delay but not enough to drop
     the adjacency for a moderate burst size.
 
-    If this test fails the link shaping or Hello timing needs adjustment.
+    Verified in two independent phases so a failure is unambiguous
+    about where the problem is:
+
+      Phase 1 - precondition: R1 must actually originate all
+      NUM_ROUTES external LSAs after redistribute-static picks up the
+      injected routes. This is a redistribution/zebra step, unrelated
+      to the legacy flood path being tested here.
+
+      Phase 2 - the actual behavior under test: once R1 has all
+      NUM_ROUTES LSAs, the legacy (unpaced) flood path must deliver
+      them all to R2.
+
+    Both phases use max(computed, 15s) rather than a tight computed
+    budget, per topotest convention -- a loaded CI host gives no
+    guarantee that either step finishes quickly even when everything
+    is working correctly.
+
+    If this test fails at Phase 2 the link shaping or Hello timing
+    needs adjustment.
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -389,16 +410,29 @@ def test_congested_no_pacing_adjacency_stable():
     # No pacing — legacy flood path
     _add_routes(r1)
 
-    # All LSAs should arrive quickly (burst within throttle + link delay)
-    # Budget: 1s throttle + NUM_ROUTES * 8ms per LSU at 100Kbps + 2s margin
-    timeout_s = 1 + NUM_ROUTES * 0.05 + 2
-    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+    # Theoretical timeline: 1s throttle headroom + NUM_ROUTES * 50ms
+    # per-LSU margin (conservative vs. the ~8ms actually measured at
+    # 100Kbps) + 2s margin. Floored at 15s per topotest convention.
+    pacing_time_total = 1 + NUM_ROUTES * 0.05 + 2
+    timeout_s = max(pacing_time_total, 15)
 
+    # Phase 1: confirm the precondition on R1 itself before timing the
+    # legacy flood path.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} external LSAs within {:.1f}s of "
+        "adding the routes. This is a redistribution/zebra issue "
+        "(static route -> RIB -> kernel install -> redistribute), "
+        "not the legacy flood path.".format(origin_count, NUM_ROUTES, timeout_s)
+    )
+
+    # Phase 2: now time the thing actually under test -- the legacy
+    # flood path delivering to R2.
+    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
     assert count == NUM_ROUTES, (
-        "Baseline: only {}/{} LSAs arrived within {:.1f}s without pacing "
-        "on 100Kbps link. Check link shaping parameters.".format(
-            count, NUM_ROUTES, timeout_s
-        )
+        "R1 originated all {} LSAs but only {}/{} arrived at R2 "
+        "within {:.1f}s without pacing on 100Kbps link. Check link "
+        "shaping parameters.".format(NUM_ROUTES, count, NUM_ROUTES, timeout_s)
     )
 
     # Adjacency must still be Full after the burst
@@ -416,6 +450,7 @@ def test_congested_no_pacing_adjacency_stable():
 # Test 2: pacing intercepts flood on congested link
 # ---------------------------------------------------------------------------
 
+
 def test_congested_pacing_slows_flood():
     """
     With pacing active (G=200ms, max-lsas=1) on the 100Kbps link:
@@ -428,6 +463,21 @@ def test_congested_pacing_slows_flood():
     The shaped link makes the timing more realistic — LSUs take ~8ms to
     transmit at 100Kbps, so the 200ms gap is meaningfully larger than the
     wire time, giving clear separation between packets in the pcap.
+
+    This test asserts a negative, transient property ("not all LSAs
+    have arrived yet"), unlike the other tests in this file. That
+    property is checked immediately after the *first* LSA is observed
+    at R2, not after a fixed wall-clock deadline from when the routes
+    were added -- so widening the wait for that first arrival is safe
+    and does not weaken the test: R4 only starts spacing sends apart
+    once an LSA is actually queued, so "first arrival, then still
+    incomplete" holds regardless of how long redistribution took to
+    get that first LSA originated. (Contrast this with the other
+    congested-link tests, where a precondition wait on R1 was added
+    before timing R2 -- doing that here instead would risk the whole
+    15s precondition wait completing only after R4's ~1.8s drain had
+    already finished, which would make the "still queued" assertion
+    fail for a reason unrelated to pacing.)
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -441,10 +491,12 @@ def test_congested_pacing_slows_flood():
     _enable_pacing(r1)
     _add_routes(r1)
 
-    # Wait for the first LSA — may be delayed by 1s LSA throttle
-    first = _wait_at_least(r2, 1, timeout_s=4)
+    # Wait for the first LSA -- may be delayed by 1s LSA throttle plus
+    # whatever redistribution/zebra takes. Floored at 15s per topotest
+    # convention rather than the previous tight 4s.
+    first = _wait_at_least(r2, 1, timeout_s=15)
     assert first >= 1, (
-        "No LSA arrived at R2 within 4s on shaped link with pacing. "
+        "No LSA arrived at R2 within 15s on shaped link with pacing. "
         "Check adjacency and redistribution."
     )
 
@@ -466,6 +518,7 @@ def test_congested_pacing_slows_flood():
 # Test 3: pacing delivers all LSAs on congested link
 # ---------------------------------------------------------------------------
 
+
 def test_congested_pacing_delivers_all():
     """
     Correctness: all NUM_ROUTES LSAs reach R2 when pacing is active on
@@ -476,14 +529,30 @@ def test_congested_pacing_delivers_all():
       t+0.2s: LSA-2  sent
       ...
       t+1.8s: LSA-10 sent
-      Checked at: 1s throttle + (NUM_ROUTES-1)*0.2s + 2s margin
 
-    The shaped link adds ~8ms per packet at 100Kbps, which is well within
-    the 200ms gap so timing is still predictable.
+    Verified in two independent phases so a failure is unambiguous
+    about where the problem is:
 
-    A failure here (count < NUM_ROUTES) means the send timer stopped
-    re-arming or the queue was incorrectly flushed — check
-    ospf_r4_nbr_send_timer() and the re-arm logic.
+      Phase 1 - precondition: R1 must actually originate all
+      NUM_ROUTES external LSAs after redistribute-static picks up the
+      injected routes. This step is entirely outside R4 pacing
+      (static route -> zebra RIB -> kernel dataplane confirmation ->
+      redistribute -> ospf_external_lsa_originate()) and its timing
+      is not governed by GAP_MS at all. A failure here points at
+      redistribution/zebra, not at R4 pacing.
+
+      Phase 2 - the actual behavior under test: once R1 has all
+      NUM_ROUTES LSAs queued, R4 pacing must drain them to R2. A
+      failure here, with Phase 1 already confirmed, points at
+      ospf_r4_nbr_send_timer() and the re-arm logic.
+
+    Both phases use max(pacing_time_total, 15s) rather than timing to
+    the computed best case: the 15s floor matches the project's
+    general "look for state generously" topotest convention, since a
+    CI host running many tests in parallel gives no guarantee that a
+    given step finishes inside a tight window even when everything is
+    working correctly. The shaped link adds ~8ms per packet at
+    100Kbps, folded into pacing_time_total's margin term.
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -497,16 +566,32 @@ def test_congested_pacing_delivers_all():
     _enable_pacing(r1)
     _add_routes(r1)
 
-    # Budget: throttle(1s) + (NUM_ROUTES-1)*GAP_MS + link_delay + margin
-    timeout_s = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
-    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+    # Theoretical pacing timeline: 1s throttle headroom + (NUM_ROUTES-1)
+    # gaps of GAP_MS + 2s margin/link-delay. Floored at 15s per
+    # topotest convention -- a computed "just enough" budget doesn't
+    # survive a loaded CI host.
+    pacing_time_total = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    timeout_s = max(pacing_time_total, 15)
 
+    # Phase 1: confirm the precondition on R1 itself before timing
+    # anything pacing-related.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} external LSAs within {:.1f}s of "
+        "adding the routes. This is a redistribution/zebra issue "
+        "(static route -> RIB -> kernel install -> redistribute), "
+        "not R4 pacing -- ospf_r4_nbr_send_timer() never had a "
+        "chance to run.".format(origin_count, NUM_ROUTES, timeout_s)
+    )
+
+    # Phase 2: now time the thing actually under test -- R4 pacing
+    # draining the queue to R2.
+    count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
     assert count == NUM_ROUTES, (
-        "Only {}/{} LSAs reached R2 in {:.1f}s with pacing on 100Kbps link. "
-        "Expected all {} delivered at {}ms intervals. "
-        "Check ospf_r4_nbr_send_timer() re-arm logic.".format(
-            count, NUM_ROUTES, timeout_s, NUM_ROUTES, GAP_MS
-        )
+        "R1 originated all {} LSAs but only {}/{} reached R2 within "
+        "{:.1f}s with pacing on the 100Kbps link (expected delivery "
+        "at {}ms intervals). Check ospf_r4_nbr_send_timer() re-arm "
+        "logic.".format(NUM_ROUTES, count, NUM_ROUTES, timeout_s, GAP_MS)
     )
 
     # Cleanup
@@ -518,6 +603,7 @@ def test_congested_pacing_delivers_all():
 # ---------------------------------------------------------------------------
 # Test 4: adjacency survives while pacing drains queue on congested link
 # ---------------------------------------------------------------------------
+
 
 def test_congested_adjacency_survives_pacing():
     """
@@ -532,13 +618,30 @@ def test_congested_adjacency_survives_pacing():
     Scenario
     --------
     1. Enable pacing with G=200ms (slow drain) and inject NUM_ROUTES LSAs.
-    2. While the queue is draining (takes ~2s), poll the adjacency state.
+    2. Poll the adjacency state continuously from the moment the routes
+       are added, for long enough to cover both a possibly-slow
+       redistribution round trip and the subsequent pacing drain.
+       R4 starts pacing and sending each LSA as soon as *that one*
+       originates, not once all NUM_ROUTES exist -- so if redistribution
+       staggers origination, watching only starts after a separate
+       precondition wait could let the real congestion happen entirely
+       before monitoring begins, passing the test without observing
+       anything. Watching continuously from t=0 avoids that gap.
     3. The adjacency must remain Full throughout — dead-interval is 4s,
        so even one missed Hello cycle (1s) must not drop the adjacency.
+    4. Separately confirm R1 actually originated all NUM_ROUTES LSAs
+       (this is a redistribution/zebra concern, not a Hello-starvation
+       one) and that they all reached R2.
 
     If the adjacency drops it means Hellos are being delayed behind LSUs
     in either oi->obuf or the kernel socket send buffer — indicating the
     Hello priority mechanism is not working under the shaped link.
+
+    The origination precondition and the final delivery check both use
+    max(computed, 15s) rather than a tight computed budget, per
+    topotest convention -- a loaded CI host gives no guarantee that
+    either step finishes quickly even when everything is working
+    correctly.
     """
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -552,14 +655,21 @@ def test_congested_adjacency_survives_pacing():
     _enable_pacing(r1)
     _add_routes(r1)
 
-    # Poll adjacency state while LSAs are being drained.
-    # The drain takes approximately (NUM_ROUTES-1) * GAP_MS = 1.8s.
-    # Poll every 200ms for 4s total — if it ever goes non-Full, fail.
+    # Theoretical pacing timeline, floored at 15s per topotest convention.
+    pacing_time_total = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    timeout_s = max(pacing_time_total, 15)
+
+    # Monitor adjacency continuously from the moment the routes are
+    # added, for timeout_s (covering a possibly-slow redistribution
+    # round trip) plus the pacing drain duration -- rather than waiting
+    # for an origination precondition first and watching a separate
+    # window afterward, which could let the real congestion finish
+    # entirely before monitoring ever starts.
     drain_duration = (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 1.0
-    poll_end = time.time() + drain_duration
+    monitor_end = time.time() + timeout_s + drain_duration
     adjacency_dropped = False
 
-    while time.time() < poll_end:
+    while time.time() < monitor_end:
         if not _adjacency_is_full(r1):
             adjacency_dropped = True
             break
@@ -574,12 +684,25 @@ def test_congested_adjacency_survives_pacing():
         )
     )
 
-    # Also verify all LSAs arrived correctly
-    timeout_s = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    # Confirm R1 actually originated everything -- the monitor loop
+    # above already spanned timeout_s, so this should already be true;
+    # a distinct failure here points at redistribution/zebra, not
+    # Hello starvation.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s=1)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} external LSAs even after {:.1f}s of "
+        "monitoring. This is a redistribution/zebra issue, not a "
+        "Hello-starvation problem.".format(
+            origin_count, NUM_ROUTES, timeout_s + drain_duration
+        )
+    )
+
+    # Also verify all LSAs arrived correctly at R2.
     count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
     assert count == NUM_ROUTES, (
-        "Only {}/{} LSAs delivered even though adjacency survived.".format(
-            count, NUM_ROUTES
+        "R1 originated all {} LSAs and the adjacency survived, but only "
+        "{}/{} reached R2 within {:.1f}s.".format(
+            NUM_ROUTES, count, NUM_ROUTES, timeout_s
         )
     )
 
@@ -592,6 +715,7 @@ def test_congested_adjacency_survives_pacing():
 # ---------------------------------------------------------------------------
 # Test 5: heavy load + ACK blackout — no duplicate paced retransmits
 # ---------------------------------------------------------------------------
+
 
 def test_congested_heavy_load_no_duplicate_retransmits():
     """
@@ -609,10 +733,21 @@ def test_congested_heavy_load_no_duplicate_retransmits():
     2. Enable pacing with a fixed 500ms gap, one LSA per LSU.
     3. Drop all inbound OSPF on R1 (iptables): R2 still receives and
        ACKs R1's LSUs, but the ACKs never reach R1.
-    4. Inject NUM_ROUTES_HEAVY=20 routes. Draining takes ~10s; every
-       transmitted LSA stays unacknowledged on R1's retransmission
-       list, and the retransmit timer fires 4+ times during the 13s
-       blackout.
+    4. Inject NUM_ROUTES_HEAVY=20 routes, then confirm R1 has actually
+       originated all of them before the 13s blackout clock starts.
+       This origination step is a redistribution/zebra precondition,
+       not part of what's under test: if it were left unverified and
+       ran long, it could eat into BLACKOUT_S uncounted, leaving too
+       little unacked load built up (or in the worst case none at
+       all) for the retransmit timer to ever stress the
+       duplicate-suppression path this test exists to exercise --
+       while the test still reported a pass. Draining takes ~10s;
+       every transmitted LSA stays unacknowledged on R1's
+       retransmission list, and the retransmit timer fires 4+ times
+       during the 13s blackout. A tripwire just before lifting the
+       blackout confirms the retransmission list is actually
+       non-empty, so a future regression here fails loudly instead of
+       silently passing the convergence check below.
     5. Lift the blackout and measure convergence on R1: the LS
        retransmission list toward R2 must drain to 0 (sustained).
 
@@ -664,9 +799,7 @@ def test_congested_heavy_load_no_duplicate_retransmits():
     assert _wait_dead_timer_above(r1, min_ms=30000, timeout_s=10), (
         "R1's inactivity timer was not re-armed with the new {}s "
         "dead-interval within 10s (needs one accepted Hello after the "
-        "config change) — cannot start the ACK blackout safely.".format(
-            HEAVY_DEAD_S
-        )
+        "config change) — cannot start the ACK blackout safely.".format(HEAVY_DEAD_S)
     )
 
     r1.vtysh_cmd(
@@ -699,6 +832,25 @@ def test_congested_heavy_load_no_duplicate_retransmits():
             + "end"
         )
 
+        # Confirm R1 actually originated all NUM_ROUTES_HEAVY external
+        # LSAs before starting the blackout clock. This is a
+        # redistribution/zebra precondition, not part of what's under
+        # test: if it's slow and eats into BLACKOUT_S uncounted, fewer
+        # (or in the worst case zero) LSAs would ever be sent-and-stuck
+        # unacked during the remaining blackout window, so the
+        # retransmit timer would never see sustained unacked load and
+        # the duplicate-suppression path this test exists to exercise
+        # would go untested -- with the test still reporting a pass.
+        origin_count = _wait_heavy_lsas(r1, NUM_ROUTES_HEAVY, timeout_s=15)
+        assert origin_count == NUM_ROUTES_HEAVY, (
+            "R1 only originated {}/{} heavy-load external LSAs within "
+            "15s of adding the routes. This is a redistribution/zebra "
+            "issue, not a pacing/retransmit problem -- the ACK "
+            "blackout stress window was never entered.".format(
+                origin_count, NUM_ROUTES_HEAVY
+            )
+        )
+
         blackout_end = time.time() + BLACKOUT_S
         while time.time() < blackout_end:
             assert _adjacency_is_full(r1), (
@@ -708,6 +860,20 @@ def test_congested_heavy_load_no_duplicate_retransmits():
                 )
             )
             time.sleep(1)
+
+        # Tripwire: confirm the blackout actually produced sustained
+        # unacked load before declaring the stress condition exercised.
+        # This catches (loudly, here) any future regression that lets
+        # LSAs slip through unqueued -- rather than the test silently
+        # passing the convergence check below because there was never
+        # anything to converge.
+        pre_lift_rxmt = _rxmt_list_count(r1)
+        assert pre_lift_rxmt > 0, (
+            "R1's LS retransmission list toward R2 was empty just "
+            "before lifting the ACK blackout -- no unacked load was "
+            "ever built up, so the duplicate-suppression path this "
+            "test exists to exercise was never actually stressed."
+        )
     finally:
         # -- 5. Lift the blackout.
         r1.cmd("iptables -D INPUT -i {} -p 89 -j DROP".format(R1_ETH1))
@@ -753,15 +919,14 @@ def test_congested_heavy_load_no_duplicate_retransmits():
     # All LSAs must have reached R2 (R2 received them during the
     # blackout — only the ACKs were dropped).
     count = _count_heavy_lsas(r2)
-    assert count == NUM_ROUTES_HEAVY, (
-        "Only {}/{} heavy-load LSAs present in R2's LSDB after "
-        "convergence.".format(count, NUM_ROUTES_HEAVY)
+    assert (
+        count == NUM_ROUTES_HEAVY
+    ), "Only {}/{} heavy-load LSAs present in R2's LSDB after " "convergence.".format(
+        count, NUM_ROUTES_HEAVY
     )
 
     # Adjacency must have survived the whole exercise.
-    assert _adjacency_is_full(r1), (
-        "Adjacency not Full after blackout recovery."
-    )
+    assert _adjacency_is_full(r1), "Adjacency not Full after blackout recovery."
 
     # Cleanup
     r1.vtysh_cmd(
@@ -774,4 +939,5 @@ def test_congested_heavy_load_no_duplicate_retransmits():
 
 if __name__ == "__main__":
     import sys
+
     sys.exit(pytest.main(["-s", __file__]))

--- a/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_functional.py
+++ b/tests/topotests/ospf_rfc4222_r4/test_ospf_lsa_pacing_functional.py
@@ -1,4 +1,4 @@
-    #!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 eval: (blacken-mode 1) -*-
 # SPDX-License-Identifier: ISC
 #
@@ -111,14 +111,15 @@ TEST_PREFIXES = ["10.99.{}.0/24".format(i) for i in range(1, NUM_ROUTES + 1)]
 PREFIX_TAG = "10.99."  # substring used to filter these LSAs in 'show' output
 
 # Pacing parameters — large gap so timing is reliable on a loaded test host.
-GAP_MS = 1000      # 1 s between LSU batches
-MAX_LSAS = 1       # 1 LSA per LSU — clean 1:1 timing, no batching ambiguity
+GAP_MS = 1000  # 1 s between LSU batches
+MAX_LSAS = 1  # 1 LSA per LSU — clean 1:1 timing, no batching ambiguity
 ADJINT_MS = 60000  # freeze gap adjuster so G stays fixed during the test
 
 
 # ---------------------------------------------------------------------------
 # Topology
 # ---------------------------------------------------------------------------
+
 
 def build_topo(tgen):
     """Two-router topology: R1 (sender) — R2 (observer)."""
@@ -130,6 +131,7 @@ def build_topo(tgen):
 # ---------------------------------------------------------------------------
 # Per-test fixture — fresh topology for every test function
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="function")
 def tgen(request):
@@ -149,12 +151,7 @@ def tgen(request):
 
     # Enable redistribution of static routes into OSPF so that blackhole
     # routes added per-test become AS-External (Type-5) LSAs.
-    r1.vtysh_cmd(
-        "configure terminal\n"
-        "router ospf\n"
-        "redistribute static\n"
-        "end"
-    )
+    r1.vtysh_cmd("configure terminal\n" "router ospf\n" "redistribute static\n" "end")
 
     # hello-interval 1 s / dead-interval 4 s — adjacency normally reaches
     # Full in < 10 s; allow 12 s for a loaded test host.
@@ -168,6 +165,7 @@ def tgen(request):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _enable_pacing(r1):
     """Configure R1 eth1 with a fixed gap and frozen adjuster.
@@ -187,18 +185,16 @@ def _enable_pacing(r1):
         "end".format(gap=GAP_MS, max_lsas=MAX_LSAS, adjint=ADJINT_MS)
     )
     cfg = r1.vtysh_cmd("show running-config")
-    assert "ip ospf lsa-pacing" in cfg, \
-        "lsa-pacing did not appear in R1 running-config after _enable_pacing() — " \
+    assert "ip ospf lsa-pacing" in cfg, (
+        "lsa-pacing did not appear in R1 running-config after _enable_pacing() — "
         "vtysh command may have failed silently."
+    )
 
 
 def _disable_pacing(r1):
     """Remove all pacing config from R1 eth1."""
     r1.vtysh_cmd(
-        "configure terminal\n"
-        "interface eth1\n"
-        "no ip ospf lsa-pacing\n"
-        "end"
+        "configure terminal\n" "interface eth1\n" "no ip ospf lsa-pacing\n" "end"
     )
 
 
@@ -221,8 +217,7 @@ def _count_external_lsas(router):
     """
     out = router.vtysh_cmd("show ip ospf database external")
     return sum(
-        1 for line in out.splitlines()
-        if "Link State ID" in line and PREFIX_TAG in line
+        1 for line in out.splitlines() if "Link State ID" in line and PREFIX_TAG in line
     )
 
 
@@ -256,6 +251,7 @@ def _wait_at_least(router, minimum, timeout_s):
 # Test 1: pacing slows down the flood
 # ---------------------------------------------------------------------------
 
+
 def test_pacing_slows_flood(tgen):
     """
     Prove pacing is active: after the first LSA arrives at R2, the remaining
@@ -282,6 +278,17 @@ def test_pacing_slows_flood(tgen):
     Polling until count >= 1 means we only start the race after R1 has
     actually sent the first packet — the subsequent check is then purely
     about the gap timer, not the throttle.
+
+    This check (and the negative one right after it) is anchored to the
+    first-arrival event, not to a fixed deadline from when the routes
+    were added, so a generous 15s wait here is safe: R4 only starts
+    spacing sends apart once an LSA is actually queued, so "first
+    arrival, then still incomplete" holds regardless of how long
+    redistribution took to get that first LSA originated. This is
+    also why no precondition wait on R1's own LSDB is added here --
+    doing that instead would risk it completing only after the gap
+    timer had already fully drained, defeating the "still queued"
+    check below for a reason unrelated to pacing.
     """
 
     if tgen.routers_have_failure():
@@ -293,10 +300,11 @@ def test_pacing_slows_flood(tgen):
     _enable_pacing(r1)
     _add_routes(r1)
 
-    # Wait up to (throttle_max + first_packet_travel) for LSA-1 to appear.
-    first = _wait_at_least(r2, 1, timeout_s=4)
+    # Wait for LSA-1 to appear. Floored at 15s per topotest convention
+    # rather than the previous tight 4s.
+    first = _wait_at_least(r2, 1, timeout_s=15)
     assert first >= 1, (
-        "No LSA arrived at R2 within 4 s. "
+        "No LSA arrived at R2 within 15 s. "
         "Check that OSPF adjacency is Full and redistribution is active."
     )
 
@@ -319,6 +327,7 @@ def test_pacing_slows_flood(tgen):
 # Test 2: pacing delivers all LSAs eventually
 # ---------------------------------------------------------------------------
 
+
 def test_pacing_delivers_all(tgen):
     """
     Correctness: every injected LSA reaches R2, just spaced over time.
@@ -336,6 +345,11 @@ def test_pacing_delivers_all(tgen):
     lsu_sent_for_dst() advances nbr->next_send_ms by sent_count * GAP_MS.
     The timer re-arms with that exact delay so the next batch fires on
     schedule.  The queue drains completely; no LSA is dropped or skipped.
+
+    Verified in two phases: first confirm R1 itself originated all
+    NUM_ROUTES LSAs (a redistribution/zebra precondition, unrelated to
+    the send-timer/re-arm logic actually under test), then time
+    delivery to R2. Both floored at 15s per topotest convention.
     """
 
     if tgen.routers_have_failure():
@@ -349,14 +363,27 @@ def test_pacing_delivers_all(tgen):
 
     # LSA throttle can delay first origination by up to 1 s, then the queue
     # drains one LSA per GAP_MS.  Total budget:
-    #   throttle_max(1s) + (NUM_ROUTES-1)*GAP_MS + 2s margin
-    timeout_s = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    #   throttle_max(1s) + (NUM_ROUTES-1)*GAP_MS + 2s margin,
+    # floored at 15s per topotest convention.
+    pacing_time_total = 1 + (NUM_ROUTES - 1) * (GAP_MS / 1000.0) + 2
+    timeout_s = max(pacing_time_total, 15)
+
+    # Precondition: confirm R1 itself originated all NUM_ROUTES LSAs
+    # before timing delivery to R2.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} external LSAs within {:.1f}s of "
+        "adding the routes. This is a redistribution/zebra issue, "
+        "not the send timer/re-arm logic.".format(origin_count, NUM_ROUTES, timeout_s)
+    )
+
     final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
 
     assert final_count == NUM_ROUTES, (
-        "Only {}/{} external LSAs reached R2 after {:.1f} s with pacing. "
+        "R1 originated all {} LSAs but only {}/{} reached R2 within "
+        "{:.1f} s with pacing. "
         "Check ospf_r4_nbr_send_timer() queue drain and re-arm logic.".format(
-            final_count, NUM_ROUTES, timeout_s
+            NUM_ROUTES, final_count, NUM_ROUTES, timeout_s
         )
     )
 
@@ -364,6 +391,7 @@ def test_pacing_delivers_all(tgen):
 # ---------------------------------------------------------------------------
 # Test 3: without pacing all LSAs arrive quickly
 # ---------------------------------------------------------------------------
+
 
 def test_no_pacing_fast_delivery(tgen):
     """
@@ -378,6 +406,12 @@ def test_no_pacing_fast_delivery(tgen):
 
     With no pacing configured, rec4_gap_pacing == 0 and the existing
     multicast/unicast send path runs unchanged.
+
+    Verified in two phases: first confirm R1 itself originated all
+    NUM_ROUTES LSAs (a redistribution/zebra precondition, unrelated to
+    the legacy flood path actually under test), then time delivery to
+    R2. Both floored at 15s per topotest convention rather than the
+    previous flat 3s.
     """
 
     if tgen.routers_have_failure():
@@ -389,20 +423,32 @@ def test_no_pacing_fast_delivery(tgen):
     # No _enable_pacing() call — legacy path only.
     _add_routes(r1)
 
-    # LSA throttle (up to 1 s) + propagation; all LSAs flood immediately
-    # so 3 s total is a generous budget.
-    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s=3)
+    timeout_s = 15
+
+    # Precondition: confirm R1 itself originated all NUM_ROUTES LSAs
+    # before timing delivery to R2.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} external LSAs within {}s of adding "
+        "the routes. This is a redistribution/zebra issue, not the "
+        "legacy flood path.".format(origin_count, NUM_ROUTES, timeout_s)
+    )
+
+    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
 
     assert final_count == NUM_ROUTES, (
-        "Without pacing only {}/{} external LSAs reached R2 within 3 s. "
-        "The legacy flood path may be broken, or LSA/SPF timers are too "
-        "conservative for this host.".format(final_count, NUM_ROUTES)
+        "R1 originated all {} LSAs but only {}/{} reached R2 within "
+        "{}s without pacing. The legacy flood path may be broken, or "
+        "LSA/SPF timers are too conservative for this host.".format(
+            NUM_ROUTES, final_count, NUM_ROUTES, timeout_s
+        )
     )
 
 
 # ---------------------------------------------------------------------------
 # Test 4: dynamic enable / disable mid-session
 # ---------------------------------------------------------------------------
+
 
 def test_pacing_enable_disable_mid_session(tgen):
     """
@@ -413,7 +459,7 @@ def test_pacing_enable_disable_mid_session(tgen):
       (count < NUM_ROUTES immediately after first arrival).
 
     Phase B — pacing toggled OFF (same adjacency, routes removed first):
-      Inject the same routes again.  All arrive within 3 s.
+      Inject the same routes again.  All arrive within a generous budget.
 
     What the code does for the disable path
     ----------------------------------------
@@ -421,6 +467,14 @@ def test_pacing_enable_disable_mid_session(tgen):
     ospf_rec4_recompute_effective() setting oi->rec4_gap_pacing = 0, then
     walks existing neighbors calling ospf_nbr_apply_rec4_params() to reset
     their runtime state.  The next flood falls through to the legacy path.
+
+    Phase A's checks are anchored to the first-arrival event (like
+    test_pacing_slows_flood), so widening that wait is safe and no R1
+    precondition is added there. Phase B has no transient property to
+    protect -- it only asserts eventual delivery -- so it gets the
+    standard fix: confirm R1 itself originated all NUM_ROUTES LSAs
+    before timing delivery to R2, both floored at 15s per topotest
+    convention.
     """
 
     if tgen.routers_have_failure():
@@ -433,8 +487,8 @@ def test_pacing_enable_disable_mid_session(tgen):
     _enable_pacing(r1)
     _add_routes(r1)
 
-    first = _wait_at_least(r2, 1, timeout_s=4)
-    assert first >= 1, "Phase A: no LSA arrived within 4 s — check adjacency."
+    first = _wait_at_least(r2, 1, timeout_s=15)
+    assert first >= 1, "Phase A: no LSA arrived within 15 s — check adjacency."
 
     count_paced = _count_external_lsas(r2)
     assert count_paced < NUM_ROUTES, (
@@ -455,12 +509,23 @@ def test_pacing_enable_disable_mid_session(tgen):
     _disable_pacing(r1)
     _add_routes(r1)
 
-    count_unpaced = _wait_lsas(r2, NUM_ROUTES, timeout_s=3)
+    # Precondition: confirm R1 itself originated all NUM_ROUTES LSAs
+    # before timing delivery to R2 -- a redistribution/zebra issue
+    # here would otherwise be misattributed to the disable path.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s=15)
+    assert origin_count == NUM_ROUTES, (
+        "Phase B: R1 only originated {}/{} external LSAs within 15s "
+        "of re-adding the routes. This is a redistribution/zebra "
+        "issue, not the pacing disable path.".format(origin_count, NUM_ROUTES)
+    )
+
+    count_unpaced = _wait_lsas(r2, NUM_ROUTES, timeout_s=15)
     assert count_unpaced == NUM_ROUTES, (
-        "Phase B: only {}/{} LSAs arrived within 3 s after disabling pacing. "
-        "Check that ospf_if_update_params_all() correctly clears "
+        "Phase B: R1 originated all {} LSAs but only {}/{} arrived at "
+        "R2 within 15 s after disabling pacing. Check that "
+        "ospf_if_update_params_all() correctly clears "
         "oi->rec4_gap_pacing on the live interface.".format(
-            count_unpaced, NUM_ROUTES
+            NUM_ROUTES, count_unpaced, NUM_ROUTES
         )
     )
 
@@ -468,6 +533,7 @@ def test_pacing_enable_disable_mid_session(tgen):
 # ---------------------------------------------------------------------------
 # Test 5: gap adjuster speedup — U < L causes G to halve toward min-gap
 # ---------------------------------------------------------------------------
+
 
 def test_gap_adjuster_speedup(tgen):
     """
@@ -491,17 +557,30 @@ def test_gap_adjuster_speedup(tgen):
       adjust-interval = 1 ms  effectively no rate-limit
       max-lsas    = 1
 
-    Expected delivery timeline (from first LSA sent):
-      call 1: U<100 → G 2000→1000ms  LSA-1 sent,  next_send += 1000ms
-      call 2: U<100 → G 1000→ 500ms  LSA-2 sent,  next_send +=  500ms
-      call 3: U<100 → G  500→ 250→200ms(min)  LSA-3 sent,  next_send += 200ms
-      call 4: U<100 → G stays 200ms  LSA-4 sent
-      Total ≈ 1000+500+200 = 1700ms from first send
+    Expected delivery timeline (from first LSA sent)
+    -------------------------------------------------
+    ospf_r4_nbr_send_timer() calls ospf_ls_upd_queue_send() -- which
+    schedules the *next* send using whatever lsu_gap_ms already is --
+    before calling pace_maybe_adjust_gap() to compute the new value.
+    Each adjustment therefore lags one call behind: the halved gap
+    computed after sending LSA-N governs the wait before LSA-(N+1),
+    never the wait that just elapsed. Accounting for that lag:
 
-    Without speedup (fixed G=2000ms):
+      call 1: send LSA-1 using G=2000 (initial); next_send += 2000
+              post-adjust: G 2000→1000
+      call 2 (t=2000): send LSA-2 using G=1000;   next_send += 1000
+              post-adjust: G 1000→500
+      call 3 (t=3000): send LSA-3 using G=500;    next_send += 500
+              post-adjust: G 500→250
+      call 4 (t=3500): send LSA-4 (last one)
+      Total ≈ 2000+1000+500 = 3500ms from first send
+
+    Without speedup (fixed G=2000ms throughout, no one-call lag to
+    account for since G never changes):
       LSA-2 at 2000ms, LSA-3 at 4000ms, LSA-4 at 6000ms — total ≈ 6000ms
 
-    The 4s timeout discriminates: speedup completes in ~2.7s; without it ~7s.
+    The remaining-LSA budget discriminates: speedup completes in
+    ~3.5s from first arrival; without it, ~6.0s from first arrival.
 
     What the code does
     ------------------
@@ -509,8 +588,24 @@ def test_gap_adjuster_speedup(tgen):
         } else if (U < L) {
             G = max(G / F, Gmin);   ← this branch fires on every call
         }
-    lsu_sent_for_dst() then uses the updated G to advance next_send_ms,
-    so each subsequent timer arms with the reduced delay.
+    ospf_ls_upd_queue_send() uses the *current* (pre-adjustment)
+    lsu_gap_ms to advance next_send_ms; pace_maybe_adjust_gap() runs
+    immediately after and only affects the following call's schedule
+    -- see the one-call lag above.
+
+    Why this test is timed differently from the others in this file
+    -----------------------------------------------------------------
+    Unlike the other tests here, the timeout value IS the assertion:
+    it has to be short enough to reject the no-speedup outcome (~6.0s
+    remaining) while still admitting the speedup outcome (~3.5s
+    remaining). Flooring it at 15s like the other tests would make
+    both outcomes pass, silently discarding the coverage this test
+    exists to provide. Instead, the clock starts at *first arrival*
+    (a generous, separately-floored wait that absorbs redistribution
+    jitter, since that has nothing to do with the gap timer's
+    behavior after LSA-1 is sent) rather than at _add_routes() time,
+    so a slow redistribution round-trip can no longer eat into the
+    discriminating margin and false-fail a working implementation.
     """
 
     if tgen.routers_have_failure():
@@ -533,24 +628,42 @@ def test_gap_adjuster_speedup(tgen):
     )
 
     cfg = r1.vtysh_cmd("show running-config")
-    assert "ip ospf lsa-pacing initial-gap 2000" in cfg, \
-        "initial-gap 2000 not in running-config — vtysh command failed."
+    assert (
+        "ip ospf lsa-pacing initial-gap 2000" in cfg
+    ), "initial-gap 2000 not in running-config — vtysh command failed."
 
     _add_routes(r1)
 
-    # Budget: 1s throttle + ~1.7s actual + 1.3s margin = 4s.
-    # Without speedup the same 4 LSAs need ~7s (1s throttle + 6s at G=2000ms).
-    # Passing within 4s proves speedup fired.
-    timeout_s = 4.0
-    final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
+    # Anchor on first arrival -- generous, since redistribution/
+    # origination timing has nothing to do with what this test
+    # discriminates (the gap timer's behavior *after* LSA-1 is sent).
+    # Widening this wait is safe.
+    first = _wait_at_least(r2, 1, timeout_s=15)
+    assert first >= 1, (
+        "No LSA arrived at R2 within 15s. "
+        "Check that OSPF adjacency is Full and redistribution is active."
+    )
+
+    # From first arrival, the remaining (NUM_ROUTES-1) LSAs must land
+    # within the speedup timeline (~3.5s, accounting for the one-call
+    # lag in ospf_r4_nbr_send_timer() -- see the docstring) + margin,
+    # discriminating against the no-speedup timeline (~6.0s for the
+    # same remaining LSAs). This window MUST stay tight -- it is the
+    # actual assertion under test, not a safety margin, so it is NOT
+    # floored at 15s like the other tests in this file.
+    remaining_budget_s = 3.5 + 1.0  # 4.5s
+    final_count = _wait_lsas(r2, NUM_ROUTES, remaining_budget_s)
 
     assert final_count == NUM_ROUTES, (
-        "Speedup did not reduce delivery time: only {}/{} LSAs arrived in {:.0f}s. "
-        "With initial-gap=2000ms and low-watermark=100, G should halve on every "
-        "send cycle reaching min-gap=200ms quickly. "
-        "Without speedup all {} LSAs need ~7s. "
+        "Speedup did not reduce delivery time: only {}/{} LSAs arrived "
+        "within {:.1f}s of the first one. "
+        "With initial-gap=2000ms and low-watermark=100, G should halve on "
+        "every send cycle reaching min-gap=200ms quickly (expected ~3.5s "
+        "for the remaining {} LSAs, accounting for the one-call lag "
+        "before an adjustment takes effect). Without speedup the same "
+        "LSAs need ~6.0s. "
         "Check the U < L branch in pace_maybe_adjust_gap().".format(
-            final_count, NUM_ROUTES, timeout_s, NUM_ROUTES
+            final_count, NUM_ROUTES, remaining_budget_s, NUM_ROUTES - 1
         )
     )
 
@@ -558,6 +671,7 @@ def test_gap_adjuster_speedup(tgen):
 # ---------------------------------------------------------------------------
 # Test 6: gap adjuster backoff — aggressive config still delivers all LSAs
 # ---------------------------------------------------------------------------
+
 
 def test_gap_adjuster_backoff(tgen):
     """
@@ -595,6 +709,11 @@ def test_gap_adjuster_backoff(tgen):
       Worst case (G maxes at 500ms for all remaining LSAs after first):
         1s throttle + (NUM_ROUTES-1) * 500ms + 2s margin
       This is the upper bound regardless of how many times backoff fires.
+      Unlike test_gap_adjuster_speedup, this budget is a pure upper
+      bound with no discrimination against a "backoff didn't fire"
+      case baked into the timing -- so it can safely be floored at 15s
+      per topotest convention, and preceded by a precondition check
+      confirming R1 itself originated all NUM_ROUTES LSAs first.
     """
 
     if tgen.routers_have_failure():
@@ -617,23 +736,37 @@ def test_gap_adjuster_backoff(tgen):
     )
 
     cfg = r1.vtysh_cmd("show running-config")
-    assert "ip ospf lsa-pacing initial-gap 100" in cfg, \
-        "initial-gap 100 not in running-config — vtysh command failed."
+    assert (
+        "ip ospf lsa-pacing initial-gap 100" in cfg
+    ), "initial-gap 100 not in running-config — vtysh command failed."
 
     _add_routes(r1)
 
     # Worst case: G maxes at 500ms for every inter-LSA gap.
-    # Budget: 1s throttle + (NUM_ROUTES-1)*500ms + 2s margin.
-    timeout_s = 1 + (NUM_ROUTES - 1) * 0.5 + 2
+    # Budget: 1s throttle + (NUM_ROUTES-1)*500ms + 2s margin, floored
+    # at 15s per topotest convention.
+    pacing_time_total = 1 + (NUM_ROUTES - 1) * 0.5 + 2
+    timeout_s = max(pacing_time_total, 15)
+
+    # Precondition: confirm R1 itself originated all NUM_ROUTES LSAs
+    # before timing delivery to R2.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} external LSAs within {:.1f}s of "
+        "adding the routes. This is a redistribution/zebra issue, "
+        "not the backoff path.".format(origin_count, NUM_ROUTES, timeout_s)
+    )
+
     final_count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
 
     assert final_count == NUM_ROUTES, (
-        "Only {}/{} LSAs delivered with aggressive backoff config in {:.1f}s. "
+        "R1 originated all {} LSAs but only {}/{} were delivered with "
+        "aggressive backoff config in {:.1f}s. "
         "With initial-gap=100ms, max-gap=500ms and factor=3, all {} LSAs must "
         "still be delivered even if G backs off to max-gap. "
         "Check the U > H branch in pace_maybe_adjust_gap() and the "
         "send timer re-arm logic under increasing G.".format(
-            final_count, NUM_ROUTES, timeout_s, NUM_ROUTES
+            NUM_ROUTES, final_count, NUM_ROUTES, timeout_s, NUM_ROUTES
         )
     )
 
@@ -641,6 +774,7 @@ def test_gap_adjuster_backoff(tgen):
 # ---------------------------------------------------------------------------
 # Fixture: pacing pre-configured in frr.conf (active before adjacency forms)
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="function")
 def tgen_pacing(request):
@@ -659,12 +793,7 @@ def tgen_pacing(request):
     tgen.start_router()
 
     r1 = tgen.gears["r1"]
-    r1.vtysh_cmd(
-        "configure terminal\n"
-        "router ospf\n"
-        "redistribute static\n"
-        "end"
-    )
+    r1.vtysh_cmd("configure terminal\n" "router ospf\n" "redistribute static\n" "end")
 
     time.sleep(12)
 
@@ -676,6 +805,7 @@ def tgen_pacing(request):
 # ---------------------------------------------------------------------------
 # Test 7: Router-LSA paced via pre-configured frr.conf
 # ---------------------------------------------------------------------------
+
 
 def test_router_lsa_paced_from_config(tgen_pacing):
     """
@@ -709,29 +839,42 @@ def test_router_lsa_paced_from_config(tgen_pacing):
 
     # Verify pacing is active from config — no _enable_pacing() call needed
     cfg = r1.vtysh_cmd("show running-config")
-    assert "ip ospf lsa-pacing" in cfg, \
-        "Pacing not active from frr_pacing.conf — check fixture config load"
+    assert (
+        "ip ospf lsa-pacing" in cfg
+    ), "Pacing not active from frr_pacing.conf — check fixture config load"
 
     # Trigger Type-1 Router-LSA re-origination via cost change
-    r1.vtysh_cmd(
-        "configure terminal\n"
-        "interface eth1\n"
-        "ip ospf cost 100\n"
-        "end"
-    )
+    r1.vtysh_cmd("configure terminal\n" "interface eth1\n" "ip ospf cost 100\n" "end")
 
     # Inject Type-5 LSAs — these and the Type-1 share the same R4 queue
     _add_routes(r1)
 
-    # Budget: 1s LSA throttle + (NUM_ROUTES + 1 Type-1) gaps + 2s margin
-    timeout_s = 1 + (NUM_ROUTES + 1) * 1.0 + 2
+    # Budget: 1s LSA throttle + (NUM_ROUTES + 1 Type-1) gaps + 2s margin,
+    # floored at 15s per topotest convention.
+    pacing_time_total = 1 + (NUM_ROUTES + 1) * 1.0 + 2
+    timeout_s = max(pacing_time_total, 15)
+
+    # Precondition: confirm R1 itself originated all NUM_ROUTES Type-5
+    # LSAs before timing delivery to R2. This is a redistribution/zebra
+    # step, unrelated to whether the R4 queue correctly mixes Type-1
+    # and Type-5 LSAs -- the thing actually under test below.
+    origin_count = _wait_lsas(r1, NUM_ROUTES, timeout_s)
+    assert origin_count == NUM_ROUTES, (
+        "R1 only originated {}/{} Type-5 external LSAs within {:.1f}s "
+        "of adding the routes. This is a redistribution/zebra issue, "
+        "not the mixed Type-1/Type-5 R4 queue path.".format(
+            origin_count, NUM_ROUTES, timeout_s
+        )
+    )
+
     count = _wait_lsas(r2, NUM_ROUTES, timeout_s)
 
     assert count == NUM_ROUTES, (
-        "Only {}/{} Type-5 LSAs arrived within {}s. "
+        "R1 originated all {} Type-5 LSAs but only {}/{} arrived at R2 "
+        "within {:.1f}s. "
         "Expected Type-1 and Type-5 to share the R4 queue and be delivered "
         "at 1000ms intervals. Check R4: flood enqueue lines in ospfd.log "
-        "for [Type1:] entries.".format(count, NUM_ROUTES, timeout_s)
+        "for [Type1:] entries.".format(NUM_ROUTES, count, NUM_ROUTES, timeout_s)
     )
 
 


### PR DESCRIPTION
## Summary

A real CI failure of `test_congested_pacing_delivers_all` (support bundle showing R1 with "Number of external LSA 0" while `staticd.log`/`zebra.log` were silent for the whole test window) traced back to a step none of these tests budgeted any time for: zebra only notifies ospfd of a new route (`ZEBRA_REDISTRIBUTE_ROUTE_ADD`) after its dataplane thread gets a **kernel install confirmation** (`rib_process_result()` → `redistribute_update()`, gated on `ROUTE_ENTRY_INSTALLED`) — not merely when the route is accepted into zebra's RIB. That round-trip through mgmtd/staticd/zebra's dplane worker is unrelated to R4 pacing itself, but every affected test assumed it was instantaneous.

This is not an R4 code bug — `ospf_r4_nbr_send_timer()` and the paced queue never had anything to act on, because no LSA had been originated yet by the time the test's tight deadline expired.

## Changes

Across `test_ospf_lsa_pacing_congested.py`, `test_ospf_broadcast_lsa_pacing.py`, and `test_ospf_lsa_pacing_functional.py`:

- **Pure eventual-delivery checks**: added a precondition wait confirming the sender itself originated all expected external LSAs before timing delivery to the receiver(s), and floored the timeout at 15s per topotest convention instead of a tightly computed "just enough" budget. This also makes failures unambiguous — precondition failure points at redistribution/zebra, delivery-check failure points at R4 pacing.
- **Transient/negative-property checks** (e.g. "first LSA arrived, rest still queued"): only widened the first-arrival wait to 15s; left the transient check itself untouched. Adding a precondition wait ahead of these would risk it completing only after the pacing gap timer had already fully drained, defeating the "still queued" assertion for an unrelated reason.

Two additional, more specific fixes:

- `test_congested_adjacency_survives_pacing` needed a different fix again: R4 starts pacing and sending each LSA as soon as *that one* originates, not once all of them exist, so a precondition wait for full origination before starting the Hello-starvation watch could let the entire congestion window finish in the background while still waiting, leaving the watch to observe a quiet period and pass without checking anything. It now monitors adjacency continuously from the moment the routes are added, for a duration covering both the redistribution budget and the pacing drain, then separately confirms origination and delivery counts.
- `test_congested_heavy_load_no_duplicate_retransmits` had a related but distinct gap: the 13s ACK-blackout clock started before confirming the 20 heavy-load LSAs were originated, so a slow redistribution round-trip could eat into the blackout and leave too little sustained unacked load for the retransmit timer to ever stress the duplicate-suppression path under test, while still reporting a pass. Unlike the adjacency test above, the blackout is already active for this whole sequence, so anchoring the precondition before the blackout clock starts is sufficient here. Added that precondition, plus a tripwire assertion just before lifting the blackout confirming the retransmission list actually built up non-zero load.

`test_gap_adjuster_speedup` is a special case, deliberately handled differently: its timeout is not a safety margin but the assertion itself (discriminating "speedup fired" from "it didn't"). Flooring it at 15s would make both outcomes pass. The clock starts at first LSA arrival (widened to 15s, safe since redistribution timing has nothing to do with gap-timer behavior after the first send), and the discriminating budget for the remaining LSAs stays tight and unfloored — corrected to 4.5s (was 3.0s) after tracing `ospf_r4_nbr_send_timer()`: it schedules each send using the pre-adjustment gap and only applies `pace_maybe_adjust_gap()`'s result to the following call, a one-call lag the original budget didn't account for. With that lag, a working speedup delivers the remaining LSAs in ~3.5s, not ~1.7s; the no-speedup baseline is unaffected at ~6.0s since G never changes in that case.

`test_ospf_lsa_pacing_cli.py` and `test_ospf_lsa_pacing_opaque.py` were checked and need no changes — neither exercises `redistribute static`/external LSAs, and the opaque test's existing timeouts already clear 15s.

## Testing

Each modified test was run individually and confirmed passing locally before being folded into this commit.
