### PR TITLE
ripd/ripngd: fix wrong checking metric 0 for route-map

### DIFF
--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -55,11 +55,7 @@ static void *route_match_metric_compile(const char *arg)
 	metric = XMALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(uint32_t));
 	*metric = atoi(arg);
 
-	if (*metric > 0)
-		return metric;
-
-	XFREE(MTYPE_ROUTE_MAP_COMPILED, metric);
-	return NULL;
+	return metric;
 }
 
 /* Free route map's compiled `match metric' value. */

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -48,11 +48,7 @@ static void *route_match_metric_compile(const char *arg)
 	metric = XMALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(uint32_t));
 	*metric = atoi(arg);
 
-	if (*metric > 0)
-		return metric;
-
-	XFREE(MTYPE_ROUTE_MAP_COMPILED, metric);
-	return NULL;
+	return metric;
 }
 
 /* Free route map's compiled `match metric' value. */


### PR DESCRIPTION
```
anlan(config)# route-map x permit 10
anlan(config-route-map)# match metric 0
% Configuration applied with notes:
RIPD: % [RIP] Argument form is unsupported or malformed.
```

`route_match_metric_compile()` rejects metric value 0 as invalid by returning NULL when `*metric > 0` is false. However, metric 0 is a perfectly valid value (e.g., directly connected routes).

Just remove the incorrect `> 0` check and always return the compiled metric value.