### PR TITLE
bgpd: fix self nexthop overwrite in unnumbered interfaces setup

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -447,7 +447,8 @@ static int bgp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 			if (addr->family == AF_INET)
 				continue;
 
-			if (!IN6_IS_ADDR_LINKLOCAL(&addr->u.prefix6) &&
+			if (peer->nexthop.ifp == ifc->ifp &&
+			    !IN6_IS_ADDR_LINKLOCAL(&addr->u.prefix6) &&
 			    memcmp(&peer->nexthop.v6_global, &addr->u.prefix6, IPV6_MAX_BYTELEN) ==
 				    0) {
 				/*


### PR DESCRIPTION
In the case where the same IPV6 address is assigned to multiple addresses and this address is the one used as the self nexthop from the source interface, if that address is suppressed from an interface that is not the source one, all self-originated or using self nexthop routes are updated again with an invalid nexthop address.

The global nexthop address of peer is erased and replaced by another address assigned to the altered interface instead of keeping an actual address from the interface used for connection.