### PR TITLE
bgpd: fix wrong comparision for rfapi

### DIFF
--- a/bgpd/rfapi/rfapi_nve_addr.c
+++ b/bgpd/rfapi/rfapi_nve_addr.c
@@ -76,7 +76,7 @@ int rfapi_nve_addr_cmp(const void *k1, const void *k2)
 		}
 	} else if (a->un.addr_family == AF_INET6) {
 		ret = IPV6_ADDR_CMP(&a->un.addr.v6, &b->un.addr.v6);
-		if (ret == 0) {
+		if (ret != 0) {
 #if DEBUG_NVE_ADDR
 			logdifferent("diff: UN addr", a, b);
 #endif
@@ -103,7 +103,7 @@ int rfapi_nve_addr_cmp(const void *k1, const void *k2)
 		}
 	} else if (a->vn.addr_family == AF_INET6) {
 		ret = IPV6_ADDR_CMP(&a->vn.addr.v6, &b->vn.addr.v6);
-		if (ret == 0) {
+		if (ret != 0) {
 #if DEBUG_NVE_ADDR
 			logdifferent("diff: VN addr", a, b);
 #endif

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2761,7 +2761,7 @@ static int nve_addr_cmp(const void *k1, const void *k2)
 			return ret;
 	} else if (a->vn.addr_family == AF_INET6) {
 		ret = IPV6_ADDR_CMP(&a->vn.addr.v6, &b->vn.addr.v6);
-		if (ret == 0) {
+		if (ret != 0) {
 			return ret;
 		}
 	} else {


### PR DESCRIPTION
I happened to come across this wrong comparision of `IPV6_ADDR_CMP()`, their usage logic should be same as that of IPV4 case.