### PR TITLE
zebra: route EVPN-MH FDB nexthops through the dplane

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1068,6 +1068,8 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 		break;
 
 	/* Un-handled by FPM at this time. */
+	case DPLANE_OP_NH_FDB_INSTALL:
+	case DPLANE_OP_NH_FDB_DELETE:
 	case DPLANE_OP_PW_INSTALL:
 	case DPLANE_OP_PW_UNINSTALL:
 	case DPLANE_OP_ADDR_INSTALL:

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1486,6 +1486,10 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_MAC_DELETE:
 		return netlink_put_mac_update_msg(bth, ctx);
 
+	case DPLANE_OP_NH_FDB_INSTALL:
+	case DPLANE_OP_NH_FDB_DELETE:
+		return netlink_put_nh_fdb_update_msg(bth, ctx);
+
 	case DPLANE_OP_NEIGH_INSTALL:
 	case DPLANE_OP_NEIGH_UPDATE:
 	case DPLANE_OP_NEIGH_DELETE:

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1685,6 +1685,12 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 			res = ZEBRA_DPLANE_REQUEST_SUCCESS;
 			break;
 
+		/* EVPN-MH FDB nexthops are a netlink-only feature - no-op here */
+		case DPLANE_OP_NH_FDB_INSTALL:
+		case DPLANE_OP_NH_FDB_DELETE:
+			res = ZEBRA_DPLANE_REQUEST_SUCCESS;
+			break;
+
 		case DPLANE_OP_INTF_NETCONFIG:
 			res = kernel_intf_netconf_update(ctx);
 			break;

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -93,11 +93,6 @@ extern void kernel_read_neigh(struct zebra_dplane_ctx *ctx);
 extern void kernel_read_tc_qdisc(struct zebra_dplane_ctx *ctx);
 extern void kernel_read_intf_speed(struct zebra_dplane_ctx *ctx);
 extern void route_read(struct zebra_ns *zns);
-extern int kernel_upd_mac_nh(uint32_t nh_id, struct ipaddr *vtep_ip);
-extern int kernel_del_mac_nh(uint32_t nh_id);
-extern int kernel_upd_mac_nhg(uint32_t nhg_id, uint32_t nh_cnt,
-		struct nh_grp *nh_ids);
-extern int kernel_del_mac_nhg(uint32_t nhg_id);
 
 /*
  * Message batching interface.

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -5177,168 +5177,118 @@ ssize_t netlink_mpls_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 	return NLMSG_ALIGN(req->n.nlmsg_len);
 }
 
-/****************************************************************************
-* This code was developed in a branch that didn't have dplane APIs for
-* MAC updates. Hence the use of the legacy style. It will be moved to
-* the new dplane style pre-merge to master. XXX
-*/
-static int netlink_fdb_nh_update(uint32_t nh_id, struct ipaddr *vtep_ip)
+/*
+ * Encode an EVPN-MH FDB (L2) nexthop / nexthop-group update from a dplane ctx.
+ *
+ * A single encoder covers both DPLANE_OP_NH_FDB_INSTALL and
+ * DPLANE_OP_NH_FDB_DELETE, and within install both the single-nexthop and the
+ * nexthop-group case (distinguished by the fdb-nh grp count):
+ *   - DELETE            -> RTM_DELNEXTHOP with NHA_ID
+ *   - INSTALL, cnt == 0 -> RTM_NEWNEXTHOP with NHA_FDB + NHA_GATEWAY
+ *   - INSTALL, cnt  > 0 -> RTM_NEWNEXTHOP with NHA_FDB + NHA_GROUP
+ */
+static ssize_t netlink_fdb_nh_msg_encode(struct zebra_dplane_ctx *ctx, void *buf, size_t buflen)
 {
 	struct {
 		struct nlmsghdr n;
 		struct nhmsg nhm;
-		char buf[256];
-	} req;
-	int cmd = RTM_NEWNEXTHOP;
-	struct zebra_vrf *zvrf;
-	struct zebra_ns *zns;
+		char buf[];
+	} *req = buf;
+	int cmd;
+	uint32_t nh_id = dplane_ctx_get_fdb_nh_id(ctx);
+	uint16_t nh_cnt = dplane_ctx_get_fdb_nh_grp_count(ctx);
+	const struct nh_grp *nh_ids = nh_cnt ? dplane_ctx_get_fdb_nh_grp(ctx) : NULL;
+	const struct ipaddr *vtep_ip = NULL;
+	enum dplane_op_e op = dplane_ctx_get_op(ctx);
 
-	zvrf = zebra_vrf_get_evpn();
-	zns = zvrf->zns;
+	if (buflen < sizeof(*req))
+		return 0;
 
-	memset(&req, 0, sizeof(req));
+	/* Defensive: never write past the on-stack group array below. */
+	if (nh_cnt > ES_VTEP_MAX_CNT)
+		nh_cnt = ES_VTEP_MAX_CNT;
 
-	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg));
-	req.n.nlmsg_flags = NLM_F_REQUEST;
-	req.n.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
-	req.n.nlmsg_type = cmd;
-	req.nhm.nh_family = ipaddr_family(vtep_ip);
-	req.nhm.nh_protocol = RTPROT_ZEBRA;
+	memset(req, 0, sizeof(*req));
 
-	if (!nl_attr_put32(&req.n, sizeof(req), NHA_ID, nh_id))
-		return -1;
-	if (!nl_attr_put(&req.n, sizeof(req), NHA_FDB, NULL, 0))
-		return -1;
-	if (req.nhm.nh_family == AF_INET) {
-		if (!nl_attr_put(&req.n, sizeof(req), NHA_GATEWAY, &vtep_ip->ipaddr_v4,
-				 IPV4_MAX_BYTELEN))
-			return -1;
-	} else {
-		if (!nl_attr_put(&req.n, sizeof(req), NHA_GATEWAY, &vtep_ip->ipaddr_v6,
-				 IPV6_MAX_BYTELEN))
-			return -1;
-	}
+	req->n.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg));
+	req->n.nlmsg_flags = NLM_F_REQUEST;
 
-	if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH)
-		zlog_debug("Tx %s fdb-nh 0x%x %pIA", nl_msg_type_to_str(cmd), nh_id, vtep_ip);
-
-	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns, false, NULL, NULL);
-}
-
-static int netlink_fdb_nh_del(uint32_t nh_id)
-{
-	struct {
-		struct nlmsghdr n;
-		struct nhmsg nhm;
-		char buf[256];
-	} req;
-	int cmd = RTM_DELNEXTHOP;
-	struct zebra_vrf *zvrf;
-	struct zebra_ns *zns;
-
-	zvrf = zebra_vrf_get_evpn();
-	zns = zvrf->zns;
-
-	memset(&req, 0, sizeof(req));
-
-	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg));
-	req.n.nlmsg_flags = NLM_F_REQUEST;
-	req.n.nlmsg_type = cmd;
-	req.nhm.nh_family = AF_UNSPEC;
-
-	if (!nl_attr_put32(&req.n, sizeof(req), NHA_ID, nh_id))
-		return -1;
-
-	if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH) {
-		zlog_debug("Tx %s fdb-nh 0x%x",
-			   nl_msg_type_to_str(cmd), nh_id);
-	}
-
-	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns, false, NULL, NULL);
-}
-
-static int netlink_fdb_nhg_update(uint32_t nhg_id, uint32_t nh_cnt,
-		struct nh_grp *nh_ids)
-{
-	struct {
-		struct nlmsghdr n;
-		struct nhmsg nhm;
-		char buf[256];
-	} req;
-	int cmd = RTM_NEWNEXTHOP;
-	struct zebra_vrf *zvrf;
-	struct zebra_ns *zns;
-	struct nexthop_grp grp[nh_cnt];
-	uint32_t i;
-
-	zvrf = zebra_vrf_get_evpn();
-	zns = zvrf->zns;
-
-	memset(&req, 0, sizeof(req));
-
-	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg));
-	req.n.nlmsg_flags = NLM_F_REQUEST;
-	req.n.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
-	req.n.nlmsg_type = cmd;
-	req.nhm.nh_family = AF_UNSPEC;
-	req.nhm.nh_protocol = RTPROT_ZEBRA;
-
-	if (!nl_attr_put32(&req.n, sizeof(req), NHA_ID, nhg_id))
-		return -1;
-	if (!nl_attr_put(&req.n, sizeof(req), NHA_FDB, NULL, 0))
-		return -1;
-	memset(&grp, 0, sizeof(grp));
-	for (i = 0; i < nh_cnt; ++i) {
-		grp[i].id = nh_ids[i].id;
-		grp[i].weight = nh_ids[i].weight;
-	}
-	if (!nl_attr_put(&req.n, sizeof(req), NHA_GROUP,
-			grp, nh_cnt * sizeof(struct nexthop_grp)))
-		return -1;
-
-
-	if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH) {
-		char vtep_str[ES_VTEP_LIST_STR_SZ];
-		char nh_buf[16];
-
-		vtep_str[0] = '\0';
-		for (i = 0; i < nh_cnt; ++i) {
-			snprintf(nh_buf, sizeof(nh_buf), "%u ",
-					grp[i].id);
-			strlcat(vtep_str, nh_buf, sizeof(vtep_str));
+	if (op == DPLANE_OP_NH_FDB_INSTALL) {
+		cmd = RTM_NEWNEXTHOP;
+		req->n.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
+		req->nhm.nh_protocol = RTPROT_ZEBRA;
+		if (nh_cnt) {
+			/* nexthop-group install: family is unspec */
+			req->nhm.nh_family = AF_UNSPEC;
+		} else {
+			/* single-nexthop install: family from the VTEP IP */
+			vtep_ip = dplane_ctx_get_fdb_nh_vtep_ip(ctx);
+			req->nhm.nh_family = ipaddr_family(vtep_ip);
 		}
+	} else {
+		cmd = RTM_DELNEXTHOP;
+		req->nhm.nh_family = AF_UNSPEC;
+	}
+	req->n.nlmsg_type = cmd;
 
-		zlog_debug("Tx %s fdb-nhg 0x%x %s",
-			   nl_msg_type_to_str(cmd), nhg_id, vtep_str);
+	if (!nl_attr_put32(&req->n, buflen, NHA_ID, nh_id))
+		return 0;
+
+	if (cmd == RTM_NEWNEXTHOP) {
+		if (!nl_attr_put(&req->n, buflen, NHA_FDB, NULL, 0))
+			return 0;
+		if (nh_cnt) {
+			struct nexthop_grp grp[ES_VTEP_MAX_CNT];
+			uint16_t i;
+
+			/* memset zeroes the reserved fields not set below */
+			memset(grp, 0, sizeof(grp));
+			for (i = 0; i < nh_cnt; ++i) {
+				grp[i].id = nh_ids[i].id;
+				grp[i].weight = nh_ids[i].weight;
+			}
+			if (!nl_attr_put(&req->n, buflen, NHA_GROUP, grp,
+					 nh_cnt * sizeof(struct nexthop_grp)))
+				return 0;
+		} else if (req->nhm.nh_family == AF_INET) {
+			if (!nl_attr_put(&req->n, buflen, NHA_GATEWAY, &vtep_ip->ipaddr_v4,
+					 IPV4_MAX_BYTELEN))
+				return 0;
+		} else {
+			if (!nl_attr_put(&req->n, buflen, NHA_GATEWAY, &vtep_ip->ipaddr_v6,
+					 IPV6_MAX_BYTELEN))
+				return 0;
+		}
 	}
 
-	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns, false, NULL, NULL);
+	if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_EVPN_MH_NH) {
+		if (nh_cnt) {
+			char vtep_str[ES_VTEP_LIST_STR_SZ];
+			char nh_buf[16];
+			uint16_t i;
+
+			vtep_str[0] = '\0';
+			for (i = 0; i < nh_cnt; ++i) {
+				snprintf(nh_buf, sizeof(nh_buf), "%u ", nh_ids[i].id);
+				strlcat(vtep_str, nh_buf, sizeof(vtep_str));
+			}
+			zlog_debug("Tx %s fdb-nhg 0x%x %s", nl_msg_type_to_str(cmd), nh_id,
+				   vtep_str);
+		} else if (vtep_ip) {
+			zlog_debug("Tx %s fdb-nh 0x%x %pIA", nl_msg_type_to_str(cmd), nh_id,
+				   vtep_ip);
+		} else {
+			zlog_debug("Tx %s fdb-nh 0x%x", nl_msg_type_to_str(cmd), nh_id);
+		}
+	}
+
+	return NLMSG_ALIGN(req->n.nlmsg_len);
 }
 
-static int netlink_fdb_nhg_del(uint32_t nhg_id)
+enum netlink_msg_status netlink_put_nh_fdb_update_msg(struct nl_batch *bth,
+						      struct zebra_dplane_ctx *ctx)
 {
-	return netlink_fdb_nh_del(nhg_id);
-}
-
-int kernel_upd_mac_nh(uint32_t nh_id, struct ipaddr *vtep_ip)
-{
-	return netlink_fdb_nh_update(nh_id, vtep_ip);
-}
-
-int kernel_del_mac_nh(uint32_t nh_id)
-{
-	return netlink_fdb_nh_del(nh_id);
-}
-
-int kernel_upd_mac_nhg(uint32_t nhg_id, uint32_t nh_cnt,
-		struct nh_grp *nh_ids)
-{
-	return netlink_fdb_nhg_update(nhg_id, nh_cnt, nh_ids);
-}
-
-int kernel_del_mac_nhg(uint32_t nhg_id)
-{
-	return netlink_fdb_nhg_del(nhg_id);
+	return netlink_batch_add_msg(bth, ctx, netlink_fdb_nh_msg_encode, false);
 }
 
 #endif /* HAVE_NETLINK */

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -92,9 +92,10 @@ netlink_put_nexthop_update_msg(struct nl_batch *bth,
 			       struct zebra_dplane_ctx *ctx);
 extern enum netlink_msg_status
 netlink_put_mac_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
-extern enum netlink_msg_status
-netlink_put_neigh_update_msg(struct nl_batch *bth,
-			     struct zebra_dplane_ctx *ctx);
+extern enum netlink_msg_status netlink_put_nh_fdb_update_msg(struct nl_batch *bth,
+							     struct zebra_dplane_ctx *ctx);
+extern enum netlink_msg_status netlink_put_neigh_update_msg(struct nl_batch *bth,
+							    struct zebra_dplane_ctx *ctx);
 extern enum netlink_msg_status
 netlink_put_lsp_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
 extern enum netlink_msg_status

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -389,25 +389,4 @@ void kernel_read_intf_speed(struct zebra_dplane_ctx *ctx)
 	dplane_ctx_set_ifp_speed_set(ctx, false);
 }
 
-int kernel_upd_mac_nh(uint32_t nh_id, struct ipaddr *vtep_ip)
-{
-	return 0;
-}
-
-int kernel_del_mac_nh(uint32_t nh_id)
-{
-	return 0;
-}
-
-int kernel_upd_mac_nhg(uint32_t nhg_id, uint32_t nh_cnt,
-		struct nh_grp *nh_ids)
-{
-	return 0;
-}
-
-int kernel_del_mac_nhg(uint32_t nhg_id)
-{
-	return 0;
-}
-
 #endif /* !HAVE_NETLINK */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -49,7 +49,7 @@ DEFINE_MTYPE(ZEBRA, VLAN_CHANGE_ARR, "Vlan Change Array");
  * are made. The minor version (at least) should be updated when new APIs
  * are introduced.
  */
-static uint32_t zdplane_version = MAKE_FRRVERSION(4, 0, 0);
+static uint32_t zdplane_version = MAKE_FRRVERSION(4, 1, 0);
 
 /* Control for collection of extra interface info with route updates; a plugin
  * can enable the extra info via a dplane api.
@@ -91,6 +91,20 @@ struct dplane_nexthop_info {
 
 	struct nexthop_group ng;
 	struct nh_grp nh_grp[MULTIPATH_NUM];
+	uint16_t nh_grp_count;
+};
+
+/*
+ * EVPN-MH FDB (L2) nexthop / nexthop-group info for the dataplane.
+ *
+ * A single FDB nexthop carries the remote VTEP ip (NHA_GATEWAY); an FDB
+ * nexthop-group carries the member nh ids (NHA_GROUP). Both use a single
+ * kernel id space, stored in 'id'. This payload is POD - nothing to free.
+ */
+struct dplane_fdb_nh_info {
+	uint32_t id;
+	struct ipaddr vtep_ip;
+	struct nh_grp nh_grp[ES_VTEP_MAX_CNT];
 	uint16_t nh_grp_count;
 };
 
@@ -492,6 +506,7 @@ struct zebra_dplane_ctx {
 		struct dplane_intf_info intf;
 		struct dplane_vlan_info vlan_info;
 		struct dplane_mac_info macinfo;
+		struct dplane_fdb_nh_info fdb_nh;
 		struct dplane_neigh_info neigh;
 		struct dplane_rule_info rule;
 		struct dplane_tc_qdisc_info tc_qdisc;
@@ -648,6 +663,9 @@ static struct zebra_dplane_globals {
 
 	_Atomic uint32_t dg_nexthops_in;
 	_Atomic uint32_t dg_nexthop_errors;
+
+	_Atomic uint32_t dg_nh_fdb_in;
+	_Atomic uint32_t dg_nh_fdb_errors;
 
 	_Atomic uint32_t dg_lsps_in;
 	_Atomic uint32_t dg_lsp_errors;
@@ -926,6 +944,8 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 
 	case DPLANE_OP_MAC_INSTALL:
 	case DPLANE_OP_MAC_DELETE:
+	case DPLANE_OP_NH_FDB_INSTALL:
+	case DPLANE_OP_NH_FDB_DELETE:
 	case DPLANE_OP_NEIGH_INSTALL:
 	case DPLANE_OP_NEIGH_UPDATE:
 	case DPLANE_OP_NEIGH_DELETE:
@@ -1170,6 +1190,11 @@ const char *dplane_op2str(enum dplane_op_e op)
 		return "NH_UPDATE";
 	case DPLANE_OP_NH_DELETE:
 		return "NH_DELETE";
+
+	case DPLANE_OP_NH_FDB_INSTALL:
+		return "NH_FDB_INSTALL";
+	case DPLANE_OP_NH_FDB_DELETE:
+		return "NH_FDB_DELETE";
 
 	case DPLANE_OP_LSP_INSTALL:
 		return "LSP_INSTALL";
@@ -2520,6 +2545,31 @@ uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 	return ctx->u.rinfo.nhe.nh_grp_count;
+}
+
+/* Accessors for EVPN-MH FDB (L2) nexthop / nexthop-group information */
+uint32_t dplane_ctx_get_fdb_nh_id(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.fdb_nh.id;
+}
+
+const struct ipaddr *dplane_ctx_get_fdb_nh_vtep_ip(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &ctx->u.fdb_nh.vtep_ip;
+}
+
+const struct nh_grp *dplane_ctx_get_fdb_nh_grp(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.fdb_nh.nh_grp;
+}
+
+uint16_t dplane_ctx_get_fdb_nh_grp_count(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.fdb_nh.nh_grp_count;
 }
 
 /* Accessors for LSP information */
@@ -5265,6 +5315,84 @@ enum zebra_dplane_result dplane_nexthop_delete(struct nhg_hash_entry *nhe)
 }
 
 /*
+ * Common helper to enqueue an EVPN-MH FDB (L2) nexthop / nexthop-group op.
+ */
+static enum zebra_dplane_result fdb_nh_update_common(enum dplane_op_e op, uint32_t id,
+						     const struct ipaddr *vtep_ip, uint32_t nh_cnt,
+						     const struct nh_grp *nh_ids)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	struct zebra_dplane_ctx *ctx;
+	struct zebra_vrf *zvrf;
+	struct zebra_ns *zns;
+	int ret;
+
+	/* ctx is zero-initialized by dplane_ctx_alloc()'s XCALLOC. */
+	ctx = dplane_ctx_alloc();
+	ctx->zd_op = op;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	/* EVPN-MH FDB nexthops live in the EVPN vrf's namespace. */
+	zvrf = zebra_vrf_get_evpn();
+	zns = zvrf ? zvrf->zns : zebra_ns_lookup(NS_DEFAULT);
+	dplane_ctx_ns_init(ctx, zns, false);
+
+	ctx->u.fdb_nh.id = id;
+	if (vtep_ip)
+		ctx->u.fdb_nh.vtep_ip = *vtep_ip;
+	if (nh_cnt > ES_VTEP_MAX_CNT)
+		nh_cnt = ES_VTEP_MAX_CNT;
+	if (nh_cnt)
+		memcpy(ctx->u.fdb_nh.nh_grp, nh_ids, nh_cnt * sizeof(struct nh_grp));
+	ctx->u.fdb_nh.nh_grp_count = nh_cnt;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
+		zlog_debug("init fdb-nh ctx %s: id 0x%x cnt %u", dplane_op2str(op), id, nh_cnt);
+
+	ret = dplane_update_enqueue(ctx);
+
+	atomic_fetch_add_explicit(&zdplane_info.dg_nh_fdb_in, 1, memory_order_relaxed);
+
+	if (ret == AOK)
+		result = ZEBRA_DPLANE_REQUEST_QUEUED;
+	else {
+		atomic_fetch_add_explicit(&zdplane_info.dg_nh_fdb_errors, 1, memory_order_relaxed);
+		dplane_ctx_free(&ctx);
+	}
+
+	return result;
+}
+
+/*
+ * Enqueue an EVPN-MH FDB (L2) single-nexthop add/update.
+ */
+enum zebra_dplane_result dplane_nh_fdb_add(uint32_t nh_id, const struct ipaddr *vtep_ip)
+{
+	return fdb_nh_update_common(DPLANE_OP_NH_FDB_INSTALL, nh_id, vtep_ip, 0, NULL);
+}
+
+/*
+ * Enqueue an EVPN-MH FDB (L2) nexthop / nexthop-group delete. A delete is
+ * id-only, so a single entry point covers both the single-nexthop and the
+ * nexthop-group case (both live in the same kernel id space).
+ */
+enum zebra_dplane_result dplane_nh_fdb_del(uint32_t id)
+{
+	return fdb_nh_update_common(DPLANE_OP_NH_FDB_DELETE, id, NULL, 0, NULL);
+}
+
+/*
+ * Enqueue an EVPN-MH FDB (L2) nexthop-group add/update. This shares the
+ * install op with the single-nexthop case; a non-zero nh_cnt selects the
+ * group (NHA_GROUP) encoding.
+ */
+enum zebra_dplane_result dplane_nhg_fdb_add(uint32_t nhg_id, uint32_t nh_cnt,
+					    const struct nh_grp *nh_ids)
+{
+	return fdb_nh_update_common(DPLANE_OP_NH_FDB_INSTALL, nhg_id, NULL, nh_cnt, nh_ids);
+}
+
+/*
  * Enqueue LSP add for the dataplane.
  */
 enum zebra_dplane_result dplane_lsp_add(struct zebra_lsp *lsp)
@@ -6735,6 +6863,11 @@ int dplane_show_helper(struct vty *vty, bool detailed)
 	vty_out(vty, "Nexthop updates:          %" PRIu64 "\n", incoming);
 	vty_out(vty, "Nexthop update errors:    %" PRIu64 "\n", errs);
 
+	incoming = atomic_load_explicit(&zdplane_info.dg_nh_fdb_in, memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_nh_fdb_errors, memory_order_relaxed);
+	vty_out(vty, "FDB nexthop updates:      %" PRIu64 "\n", incoming);
+	vty_out(vty, "FDB nexthop update errs:  %" PRIu64 "\n", errs);
+
 	vty_out(vty, "Other errors       :      %"PRIu64"\n", other_errs);
 	vty_out(vty, "Route update queue limit: %"PRIu64"\n", limit);
 	vty_out(vty, "Route update queue depth: %"PRIu64"\n", queued);
@@ -7287,6 +7420,14 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 			   dplane_op2str(dplane_ctx_get_op(ctx)));
 		break;
 
+	case DPLANE_OP_NH_FDB_INSTALL:
+	case DPLANE_OP_NH_FDB_DELETE:
+		zlog_debug("ID (0x%x) Dplane fdb-nh update ctx %p op %s cnt %u",
+			   dplane_ctx_get_fdb_nh_id(ctx), ctx,
+			   dplane_op2str(dplane_ctx_get_op(ctx)),
+			   dplane_ctx_get_fdb_nh_grp_count(ctx));
+		break;
+
 	case DPLANE_OP_LSP_INSTALL:
 	case DPLANE_OP_LSP_UPDATE:
 	case DPLANE_OP_LSP_DELETE:
@@ -7518,6 +7659,13 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 			atomic_fetch_add_explicit(
 				&zdplane_info.dg_nexthop_errors, 1,
 				memory_order_relaxed);
+		break;
+
+	case DPLANE_OP_NH_FDB_INSTALL:
+	case DPLANE_OP_NH_FDB_DELETE:
+		if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
+			atomic_fetch_add_explicit(&zdplane_info.dg_nh_fdb_errors, 1,
+						  memory_order_relaxed);
 		break;
 
 	case DPLANE_OP_LSP_INSTALL:

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -226,6 +226,10 @@ enum dplane_op_e {
 	/* Traffic control qdisc read */
 	DPLANE_OP_TC_QDISC_READ,
 	DPLANE_OP_TC_QDISC_NOTIFY,
+
+	/* EVPN-MH FDB (L2) nexthop update */
+	DPLANE_OP_NH_FDB_INSTALL,
+	DPLANE_OP_NH_FDB_DELETE,
 };
 
 /* Operational status of Bridge Ports */
@@ -668,6 +672,12 @@ const struct nh_grp *
 dplane_ctx_get_nhe_nh_grp(const struct zebra_dplane_ctx *ctx);
 uint16_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx);
 
+/* Accessors for EVPN-MH FDB (L2) nexthop / nexthop-group information */
+uint32_t dplane_ctx_get_fdb_nh_id(const struct zebra_dplane_ctx *ctx);
+const struct ipaddr *dplane_ctx_get_fdb_nh_vtep_ip(const struct zebra_dplane_ctx *ctx);
+const struct nh_grp *dplane_ctx_get_fdb_nh_grp(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_get_fdb_nh_grp_count(const struct zebra_dplane_ctx *ctx);
+
 /* Accessors for LSP information */
 
 /* Init the internal LSP data struct - necessary before adding to it.
@@ -1095,6 +1105,17 @@ void dplane_mac_init(struct zebra_dplane_ctx *ctx, const struct interface *ifp,
 		     const struct interface *br_ifp, vlanid_t vid, const struct ethaddr *mac,
 		     vni_t vni, struct ipaddr *vtep_ip, bool sticky, uint32_t nhg_id,
 		     uint32_t update_flags);
+
+/*
+ * Enqueue EVPN-MH FDB (L2) nexthop / nexthop-group operations for the
+ * dataplane. These program the per-VTEP FDB nexthops and per-ES nexthop
+ * groups used for EVPN multihoming fast failover.
+ */
+enum zebra_dplane_result dplane_nh_fdb_add(uint32_t nh_id, const struct ipaddr *vtep_ip);
+enum zebra_dplane_result dplane_nhg_fdb_add(uint32_t nhg_id, uint32_t nh_cnt,
+					    const struct nh_grp *nh_ids);
+/* Deletes are id-only and shared by the single-nexthop and group cases. */
+enum zebra_dplane_result dplane_nh_fdb_del(uint32_t id);
 
 /*
  * Enqueue evpn neighbor updates for the dataplane.

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -1486,7 +1486,7 @@ static void zebra_evpn_nhg_update(struct zebra_evpn_es *es)
 				   es->nhg_id, nh_str);
 		}
 
-		kernel_upd_mac_nhg(es->nhg_id, nh_cnt, nh_ids);
+		dplane_nhg_fdb_add(es->nhg_id, nh_cnt, nh_ids);
 		if (!(es->flags & ZEBRA_EVPNES_NHG_ACTIVE)) {
 			es->flags |= ZEBRA_EVPNES_NHG_ACTIVE;
 			/* add backup NHG to the br-port */
@@ -1506,7 +1506,7 @@ static void zebra_evpn_nhg_update(struct zebra_evpn_es *es)
 				zebra_evpn_es_br_port_dplane_update(es,
 								    __func__);
 			zebra_evpn_nhg_mac_update(es);
-			kernel_del_mac_nhg(es->nhg_id);
+			dplane_nh_fdb_del(es->nhg_id);
 		}
 	}
 
@@ -1523,6 +1523,8 @@ static void zebra_evpn_es_l2_nh_show_entry(struct zebra_evpn_l2_nh *nh,
 		json_object_string_addf(json, "vtep", "%pIA", &nh->vtep_ip);
 		json_object_int_add(json, "nhId", nh->nh_id);
 		json_object_int_add(json, "refCnt", nh->ref_cnt);
+		json_object_boolean_add(json, "installed",
+					!!(nh->flags & ZEBRA_EVPN_L2_NH_INSTALLED));
 
 		json_object_array_add(json_array, json);
 	} else {
@@ -1559,7 +1561,7 @@ void zebra_evpn_l2_nh_show(struct vty *vty, bool uj)
 		vty_json(vty, json_array);
 }
 
-static struct zebra_evpn_l2_nh *zebra_evpn_l2_nh_find(struct ipaddr *vtep_ip)
+static struct zebra_evpn_l2_nh *zebra_evpn_l2_nh_find(const struct ipaddr *vtep_ip)
 {
 	struct zebra_evpn_l2_nh *nh;
 	struct zebra_evpn_l2_nh tmp;
@@ -1586,7 +1588,7 @@ static struct zebra_evpn_l2_nh *zebra_evpn_l2_nh_alloc(struct ipaddr *vtep_ip)
 	}
 
 	/* install the NH in the dataplane */
-	kernel_upd_mac_nh(nh->nh_id, &nh->vtep_ip);
+	dplane_nh_fdb_add(nh->nh_id, &nh->vtep_ip);
 
 	return nh;
 }
@@ -1594,11 +1596,91 @@ static struct zebra_evpn_l2_nh *zebra_evpn_l2_nh_alloc(struct ipaddr *vtep_ip)
 static void zebra_evpn_l2_nh_free(struct zebra_evpn_l2_nh *nh)
 {
 	/* delete the NH from the dataplane */
-	kernel_del_mac_nh(nh->nh_id);
+	dplane_nh_fdb_del(nh->nh_id);
 
 	zebra_evpn_nhid_free(nh->nh_id, NULL);
 	hash_release(zmh_info->nh_ip_table, nh);
 	XFREE(MTYPE_L2_NH, nh);
+}
+
+/* Record the async result of a per-VTEP L2 NH install. */
+static void zebra_evpn_l2_nh_install_result(struct zebra_dplane_ctx *ctx, uint32_t id,
+					    enum zebra_dplane_result status)
+{
+	const struct ipaddr *vtep_ip = dplane_ctx_get_fdb_nh_vtep_ip(ctx);
+	struct zebra_evpn_l2_nh *nh;
+
+	nh = zebra_evpn_l2_nh_find(vtep_ip);
+	/* The NH may have been released - or replaced by a new NH for the same
+	 * VTEP - while this op was in flight; match on the id to be sure.
+	 */
+	if (!nh || nh->nh_id != id) {
+		if (IS_ZEBRA_DEBUG_EVPN_MH_NH)
+			zlog_debug("l2-nh %u (%pIA) install result %s: no longer present", id,
+				   vtep_ip, dplane_res2str(status));
+		return;
+	}
+
+	if (status == ZEBRA_DPLANE_REQUEST_SUCCESS) {
+		nh->flags |= ZEBRA_EVPN_L2_NH_INSTALLED;
+		return;
+	}
+
+	nh->flags &= ~ZEBRA_EVPN_L2_NH_INSTALLED;
+	flog_err(EC_ZEBRA_DP_INSTALL_FAIL,
+		 "Failed to install EVPN-MH L2 nexthop %u (%pIA) in the kernel", id, vtep_ip);
+}
+
+/* Record the async result of a per-ES NHG install. */
+static void zebra_evpn_nhg_install_result(uint32_t id, enum zebra_dplane_result status)
+{
+	struct zebra_evpn_es *es;
+
+	if (status == ZEBRA_DPLANE_REQUEST_SUCCESS)
+		return;
+
+	es = zebra_evpn_nhg_find(id);
+	if (es)
+		flog_err(EC_ZEBRA_DP_INSTALL_FAIL,
+			 "Failed to install EVPN-MH NHG %u for es %s in the kernel", id,
+			 es->esi_str);
+	else
+		flog_err(EC_ZEBRA_DP_INSTALL_FAIL,
+			 "Failed to install EVPN-MH NHG %u in the kernel", id);
+}
+
+/* Handle the dataplane result of an EVPN-MH FDB nexthop / nexthop-group
+ * install or delete: confirm the install state and flag failures.
+ */
+void zebra_evpn_l2_nh_dplane_result(struct zebra_dplane_ctx *ctx)
+{
+	enum dplane_op_e op = dplane_ctx_get_op(ctx);
+	enum zebra_dplane_result status = dplane_ctx_get_status(ctx);
+	uint32_t id = dplane_ctx_get_fdb_nh_id(ctx);
+
+	if (IS_ZEBRA_DEBUG_EVPN_MH_NH || IS_ZEBRA_DEBUG_DPLANE_DETAIL)
+		zlog_debug("EVPN-MH FDB nh dplane ctx %p op %s nh id %u result %s", ctx,
+			   dplane_op2str(op), id, dplane_res2str(status));
+
+	if (op == DPLANE_OP_NH_FDB_DELETE) {
+		/* The per-VTEP NH is freed (and the per-ES NHG may be
+		 * transitioning) by the time the delete result lands, so there
+		 * is nothing to update - just flag a failure.
+		 */
+		if (status != ZEBRA_DPLANE_REQUEST_SUCCESS)
+			flog_err(EC_ZEBRA_DP_DELETE_FAIL,
+				 "Failed to uninstall EVPN-MH FDB nexthop ID (%u) from the kernel",
+				 id);
+		return;
+	}
+
+	/* Install/update: a group op (grp_count > 0) targets a per-ES NHG,
+	 * otherwise it is a per-VTEP L2 NH.
+	 */
+	if (dplane_ctx_get_fdb_nh_grp_count(ctx) > 0)
+		zebra_evpn_nhg_install_result(id, status);
+	else
+		zebra_evpn_l2_nh_install_result(ctx, id, status);
 }
 
 static void zebra_evpn_l2_nh_es_vtep_ref(struct zebra_evpn_es_vtep *es_vtep)
@@ -2115,7 +2197,7 @@ static void zebra_evpn_es_free(struct zebra_evpn_es **esp)
 	/* If the NHG is still installed uninstall it and free the id */
 	if (es->flags & ZEBRA_EVPNES_NHG_ACTIVE) {
 		es->flags &= ~ZEBRA_EVPNES_NHG_ACTIVE;
-		kernel_del_mac_nhg(es->nhg_id);
+		dplane_nh_fdb_del(es->nhg_id);
 	}
 	zebra_evpn_nhid_free(es->nhg_id, es);
 

--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -135,6 +135,10 @@ struct zebra_evpn_l2_nh {
 
 	/* es_vtep entries using this nexthop */
 	uint32_t ref_cnt;
+
+	uint16_t flags;
+	/* NH has been confirmed installed by the dataplane */
+#define ZEBRA_EVPN_L2_NH_INSTALLED (1 << 0)
 };
 
 PREDECL_SORTLIST_UNIQ(mh_vtep_list);
@@ -339,6 +343,7 @@ extern void zebra_evpn_mh_init(void);
 extern void zebra_evpn_mh_terminate(void);
 extern void zebra_evpn_mh_reserve_stale_nhid(uint32_t nh_id);
 extern void zebra_evpn_mh_release_stale_nhid(uint32_t nh_id);
+extern void zebra_evpn_l2_nh_dplane_result(struct zebra_dplane_ctx *ctx);
 extern bool zebra_evpn_is_if_es_capable(struct zebra_if *zif);
 extern void zebra_evpn_if_init(struct zebra_if *zif);
 extern void zebra_evpn_if_cleanup(struct zebra_if *zif);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5281,6 +5281,11 @@ static void rib_process_dplane_results(struct event *event)
 				zebra_vxlan_handle_result(ctx);
 				break;
 
+			case DPLANE_OP_NH_FDB_INSTALL:
+			case DPLANE_OP_NH_FDB_DELETE:
+				zebra_evpn_l2_nh_dplane_result(ctx);
+				break;
+
 			case DPLANE_OP_RULE_ADD:
 			case DPLANE_OP_RULE_DELETE:
 			case DPLANE_OP_RULE_UPDATE:

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -422,6 +422,8 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_TC_FILTER_ADD:
 	case DPLANE_OP_TC_FILTER_DELETE:
 	case DPLANE_OP_TC_FILTER_UPDATE:
+	case DPLANE_OP_NH_FDB_INSTALL:
+	case DPLANE_OP_NH_FDB_DELETE:
 		/* Not currently handled */
 	case DPLANE_OP_INTF_NETCONFIG: /*NYI*/
 	case DPLANE_OP_INTF_SPEED_GET:


### PR DESCRIPTION
EVPN-MH Ethernet-Segment FDB (L2) nexthop and nexthop-group programming was the last MH kernel operation still using a synchronous netlink_talk() from the main thread, bypassing the zebra_dplane abstraction.

Add two dataplane ops, DPLANE_OP_NH_FDB_INSTALL and _DELETE, so this programming flows through the dataplane thread like every other kernel write. A single op covers both the single-nexthop and nexthop-group case (distinguished by nh_grp_count), mirroring DPLANE_OP_NH_INSTALL/_DELETE. zebra_evpn_mh.c is switched to the new async API.