### PR TITLE
bfdd: set demand bit and poll on demand mode changes per RFC 5880

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -384,6 +384,10 @@ struct bfd_session {
 	struct bfd_discrs discrs;
 	uint8_t local_diag;
 	uint8_t demand_mode;
+	/* Last session state reported by the remote peer. */
+	uint8_t remote_state;
+	/* Last demand bit value sent to the remote peer. */
+	uint8_t last_sent_demand;
 	uint8_t detect_mult;
 	uint8_t remote_detect_mult;
 	uint8_t mh_ttl;
@@ -495,7 +499,6 @@ struct sbfd_reflector {
 
 /* Various constants */
 /* Retrieved from ptm_timer.h from Cumulus PTM sources. */
-#define BFD_DEF_DEMAND 0
 #define BFD_DEFDETECTMULT 3
 #define BFD_DEFDESIREDMINTX (300 * 1000) /* microseconds. */
 #define BFD_DEFREQUIREDMINRX (300 * 1000) /* microseconds. */

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -457,7 +457,28 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
 		BFD_SETCBIT(cp.flags, BFD_CBIT);
 
-	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
+	/*
+	 * The demand bit may only be set when we want to use demand
+	 * mode and both ends of the session are up.
+	 *
+	 * RFC 5880, Section 6.8.7.
+	 */
+	bool demand = bfd->demand_mode && bfd->ses_state == PTM_BFD_UP &&
+		      bfd->remote_state == PTM_BFD_UP;
+
+	/*
+	 * Any change to the demand bit must be confirmed with a poll
+	 * sequence, as the peer has no other way to acknowledge the
+	 * demand mode transition.
+	 *
+	 * RFC 5880, Section 6.6.
+	 */
+	if (demand != bfd->last_sent_demand) {
+		bfd->polling = 1;
+		bfd->last_sent_demand = demand;
+	}
+
+	BFD_SETDEMANDBIT(cp.flags, demand);
 
 	/* Polling and Final can't be set at the same time.
 	 *
@@ -1424,6 +1445,12 @@ void bfd_recv_cb(struct event *t)
 
 		return;
 	}
+
+	/* Save last remote state: needed for demand bit computation.
+	 *
+	 * RFC 5880, Section 6.8.7.
+	 */
+	bfd->remote_state = BFD_GETSTATE(cp->flags);
 
 	/* State switch from section 6.2. */
 	bs_state_handler(bfd, BFD_GETSTATE(cp->flags));


### PR DESCRIPTION
## Summary

`ptm_bfd_snd()` hardcoded the demand bit to zero, so the D bit was never set on the wire even when demand mode was requested. RFC 5880 Section 6.8.7 requires the D bit to be set only when the local system wants demand mode **and** both ends of the session are Up; Section 6.6 requires any change to the D bit to be confirmed with a poll sequence.

## Changes

- Save the last remote session state in `struct bfd_session` on packet reception
- Set the D bit in `ptm_bfd_snd()` only when `demand_mode` is enabled and both local and remote state are Up
- Track the last D bit value sent; start a poll sequence whenever it changes so the peer can acknowledge the demand mode transition with a Final

## Impact

Without this fix, demand mode could never be activated: the D bit was always 0 regardless of configuration or session state. With the poll-on-change logic, a peer that changes its demand mode gets a confirmation exchange instead of the two ends diverging on whether periodic control packets are still being sent.