### PR TITLE
bfdd: keep remote discriminator and demand mode on session down

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -778,11 +778,24 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag, bool notify_admin_do
 	int old_state = bfd->ses_state;
 
 	bfd->local_diag = diag;
-	bfd->discrs.remote_discr = 0;
 	bfd->ses_state = PTM_BFD_DOWN;
 	bfd->polling = 0;
-	bfd->demand_mode = 0;
 	monotime(&bfd->downtime);
+
+	/*
+	 * RFC 5880, Section 6.8.1: RemoteDiscr must only be cleared
+	 * after a full Detection Time without valid packets.  A Down
+	 * or AdminDown message from the peer is a valid packet, so the
+	 * discriminator must be kept to allow a quick restart.  Only a
+	 * local failure (control/echo timeout, path down) proves that
+	 * no valid packets arrived for a full Detection Time.
+	 *
+	 * DemandMode is local configuration and must survive session
+	 * flaps: it is not a temporary state cancelled by a Down
+	 * transition.
+	 */
+	if (diag != BD_NEIGHBOR_DOWN)
+		bfd->discrs.remote_discr = 0;
 
 	/*
 	 * Only attempt to send if we have a valid socket:


### PR DESCRIPTION
## Summary

`ptm_bfd_sess_dn()` unconditionally cleared `RemoteDiscr` and `DemandMode` on every transition to Down. RFC 5880 Section 6.8.1 requires `RemoteDiscr` to be kept for at least one Detection Time after the last valid packet; a Down or AdminDown message from the peer is itself a valid packet, so the discriminator should be kept to allow a quick restart. `DemandMode` is local configuration and must not be reset by a session flap.

## Changes

- Stop clearing `RemoteDiscr` when the Down transition is caused by a peer Down/AdminDown message (`BD_NEIGHBOR_DOWN`)
- Only clear it on local failures (control/echo timeout, path down) which prove no valid packets arrived for a full Detection Time
- Stop resetting `DemandMode` on Down transitions entirely — it is configuration, not transient state

## Impact

After a short flap the session lost its demand mode preference and the remote discriminator too early, falling back to the address/interface demultiplexing path for subsequent packets. Keeping `RemoteDiscr` across a peer-initiated Down allows the session to restart quickly when the peer comes back.