### PR TITLE
nhrpd: enforce RFC2332 Section 5.2.7 Error Indication rules

### DIFF
--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -1151,6 +1151,16 @@ static int nhrp_packet_send_error(struct nhrp_packet_parser *pp,
 	struct nhrp_packet_header *hdr;
 	struct zbuf *zb;
 
+	/* RFC 2332, Section 5.2.7: an Error Indication SHALL NEVER be
+	 * generated in response to another Error Indication, and in no
+	 * case should more than one Error Indication be generated for a
+	 * single packet.
+	 */
+	if (pp->error_sent
+	    || pp->hdr->type == NHRP_PACKET_ERROR_INDICATION)
+		return 0;
+	pp->error_sent = true;
+
 	src_proto = pp->src_proto;
 	dst_proto = pp->dst_proto;
 	if (packet_types[pp->hdr->type].type != PACKET_REPLY) {
@@ -1330,17 +1340,25 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
 	nhrp_packet_debug(zb, "Recv");
 	if (nifp->auth_token) {
 		if (!nhrp_connection_authorized(&pp)) {
-			if (!(hdr->type == NHRP_PACKET_ERROR_INDICATION &&
-			      hdr->u.error.code ==
-				      htons(NHRP_ERROR_AUTHENTICATION_FAILURE)))
-				nhrp_packet_send_error(
-					&pp,
-					NHRP_ERROR_AUTHENTICATION_FAILURE,
-					0);
+			/* nhrp_packet_send_error() itself suppresses the
+			 * reply when the offending packet is an Error
+			 * Indication (RFC 2332, Section 5.2.7).
+			 */
+			nhrp_packet_send_error(
+				&pp, NHRP_ERROR_AUTHENTICATION_FAILURE, 0);
 			info = "authentication failure";
 			goto drop;
 		}
 	}
+
+	/* RFC 2332, Section 5.2.7: if a transiting Error Indication
+	 * carries our own NBMA and Protocol addresses as its source,
+	 * the Error Indication itself is in a loop; quietly drop it.
+	 */
+	if (hdr->type == NHRP_PACKET_ERROR_INDICATION
+	    && sockunion_same(&pp.src_nbma, &nifp->nbma)
+	    && sockunion_same(&pp.src_proto, &pp.if_ad->addr))
+		goto drop;
 
 	/* Figure out if this is local */
 	target_addr = (packet_types[hdr->type].type == PACKET_REPLY)

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -183,6 +183,8 @@ struct nhrp_packet_parser {
 	enum nhrp_route_type route_type;
 	struct prefix route_prefix;
 	union sockunion src_nbma, src_proto, dst_proto;
+	/** An Error Indication has already been generated for this packet */
+	bool error_sent;
 };
 
 struct nhrp_reqid_pool {


### PR DESCRIPTION
### Root cause

Three rules of RFC 2332 Section 5.2.7 are not enforced:

1. An NHRP Error Indication SHALL NEVER be generated in response to another Error Indication.  The receive path only exempts an Error Indication carrying the Authentication Failure code from the authentication-error reply; an Error Indication with any other code (e.g. Hop Count Exceeded) that fails authentication still triggers a new Error Indication, so two NHSs can bounce Code 11 messages off each other.

2. In no case should more than one Error Indication be generated for a single NHRP packet.  `nhrp_packet_send_error()` sends unconditionally on every call; the invariant is not represented anywhere, so any future check added after an existing one can emit a second error.

3. An NHS that sees its own Protocol and NBMA addresses in the Source NBMA and Source Protocol address fields of a transiting Error Indication must quietly drop it (the Error Indication itself is in a loop).  The route decision only looks at the packet class and destination, so a looped-back Error Indication keeps being forwarded until the hop count runs out.

### Fix

- Centralize the checks in `nhrp_packet_send_error()`: refuse to send when the offending packet is itself an Error Indication, or when an Error Indication has already been sent for this packet (new `error_sent` flag in `struct nhrp_packet_parser`).
- Drop the Error-Indication special case in the authentication failure path — the helper now covers it.
- Quietly discard a transiting Error Indication whose source NBMA and Protocol addresses are our own, before the route lookup.