### PR TITLE
bgpd: allow GR-helper stale paths through the evaluate_paths peer-down skip

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1440,23 +1440,30 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 	}
 
 	LIST_FOREACH (path, &(bnc->paths), nh_thread) {
+		dest = path->net;
+		assert(dest && bgp_dest_table(dest));
+		p = bgp_dest_get_prefix(dest);
+		afi = family2afi(p->family);
+		table = bgp_dest_table(dest);
+		safi = table->safi;
+
 		/*
-		 * Currently when a peer goes down, bgp immediately
-		 * sees this via the interface events( if it is directly
-		 * connected).  And in this case it takes and puts on
-		 * a special peer queue all path info's associated with
-		 * but these items are not yet processed typically when
-		 * the nexthop is being handled here.  Thus we end
-		 * up in a situation where the process Queue for BGP
-		 * is being asked to look at the same path info multiple
-		 * times.  Let's just cut to the chase here and if
-		 * the bnc has a peer associated with it and the path info
-		 * being looked at uses that peer and the peer is no
-		 * longer established we know the path_info is being
-		 * handled elsewhere and we do not need to process
-		 * it here at all since the pathinfo is going away
+		 * Currently when a peer goes down, bgp immediately sees this
+		 * via the interface events (if it is directly connected).
+		 * The peer-down queue processes the associated path infos in
+		 * the future.  Meanwhile zebra sends a nexthop removal event
+		 * to BGP too, triggering an evaluate_paths() walk that would
+		 * redo work already scheduled on the peer-down queue.  Skip
+		 * such paths here.
+		 *
+		 * Exception: GR-helper paths in a GR-covered (afi, safi) are
+		 * intentionally retained and are not removed by the peer-down
+		 * queue in bgp_clear_route_node().  Do not skip those paths
+		 * here so that an NH-unreachable event can drop them per RFC
+		 * 4724 §4.2 via bgp_nht_handle_gr_stale_nh_unreach().
 		 */
-		if (peer && path->peer == peer && !peer_established(peer->connection))
+		if (peer && path->peer == peer && !peer_established(peer->connection) &&
+		    !(CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT) && peer->nsf[afi][safi]))
 			continue;
 
 		if (path->type == ZEBRA_ROUTE_BGP &&
@@ -1475,13 +1482,6 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 		} else
 			/* don't evaluate the path */
 			continue;
-
-		dest = path->net;
-		assert(dest && bgp_dest_table(dest));
-		p = bgp_dest_get_prefix(dest);
-		afi = family2afi(p->family);
-		table = bgp_dest_table(dest);
-		safi = table->safi;
 
 		/*
 		 * handle routes from other VRFs (they can have a


### PR DESCRIPTION
Commit https://github.com/FRRouting/frr/commit/9f5536807eadbc2e729492cfd87d38007f19236c ("bgpd: Optimize evaluate paths for a peer going
down") added an optimisation to avoid redundant deletion work.  When
a peer goes down, the peer-down queue is already scheduled to walk
that peer's paths and delete them, so evaluate_paths() skips any path
whose peer is no longer Established, since the peer-down queue is
about to delete them anyway.

That assumption does not hold for GR-helper stale paths.
bgp_clear_route_node() intentionally retains those paths as
BGP_PATH_STALE rather than removing them, so the peer-down queue does
not schedule any deletion for them.  Skipping them in evaluate_paths()
means the RFC 4724 §4.2 "nexthop no longer reachable" cleanup in
bgp_nht_handle_gr_stale_nh_unreach() never runs, and stale routes
remain in the RIB until the GR restart timer expires.

Narrow the skip so it does not fire for GR-helper paths in a
GR-covered (afi, safi).  The non-GR peer-down optimisation is
preserved.

Gate on both PEER_STATUS_NSF_WAIT (session in helper wait) and
peer->nsf[afi][safi] (this AF is GR-covered), matching the
retain-as-STALE gate in bgp_clear_route_node().  Non-GR (afi, safi)
paths on a mixed-GR peer therefore keep taking the peer-down fast
path and are not processed by both evaluate_paths() and the
peer-clear queue (avoiding a double bgp_aggregate_decrement).