### PR TITLE
ripngd: never put link-local prefixes in a response RTE

### DIFF
--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1633,6 +1633,16 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 	ripng_rte_list = ripng_rte_new();
 
 	for (rp = agg_route_top(ripng->table); rp; rp = agg_route_next(rp)) {
+		/* RFC 2080 Section 2.5.2: routes to link-local destinations
+		 * must never be included in an RTE, and a compliant
+		 * neighbor discards such an RTE as invalid (Section 2.4.2).
+		 * Filter the destination prefix here, at generation time,
+		 * so it never reaches the response.
+		 */
+		p = (struct prefix_ipv6 *)agg_node_get_prefix(rp);
+		if (IN6_IS_ADDR_LINKLOCAL(&p->prefix))
+			continue;
+
 		if ((list = rp->info) != NULL
 		    && (rinfo = ripng_info_list_first(list)) != NULL
 		    && rinfo->suppress == 0) {
@@ -1640,7 +1650,6 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 			 * following
 			 * information.
 			 */
-			p = (struct prefix_ipv6 *)agg_node_get_prefix(rp);
 			rinfo->metric_out = rinfo->metric;
 			rinfo->tag_out = rinfo->tag;
 			memset(&rinfo->nexthop_out, 0,
@@ -1778,7 +1787,6 @@ void ripng_output_process(struct interface *ifp, struct sockaddr_in6 *to,
 			 * following
 			 * information.
 			 */
-			p = (struct prefix_ipv6 *)agg_node_get_prefix(rp);
 			aggregate->metric_set = 0;
 			aggregate->metric_out = aggregate->metric;
 			aggregate->tag_out = aggregate->tag;


### PR DESCRIPTION
### Root cause

`ripng_rte_send()` serializes every entry of the outgoing RTE list unconditionally. RFC 2080 Section 2.5.2 requires that routes to link-local destinations never be included in an RTE, and Section 2.4.2 requires a compliant receiver to treat such an RTE as invalid and discard it.

The receive path, redistribution (`ripng_redistribute_add()`) and the zebra hook all filter link-local prefixes, so the routing table normally does not contain them, but the final serialization point is not protected: any link-local prefix that reaches the RTE list - through an internal path, future code, or a corrupted table entry - is written into the Response on the wire.

### Impact

FRR emits an RTE that RFC 2080 explicitly forbids. Compliant neighbors discard the entry as a bad route, so the update is silently ignored and error counters increase; neighbors that lack input validation may propagate a link-local range that only makes sense on one link.

### Fix

Skip link-local destination prefixes while assembling the response in `ripng_rte_send()`, before any next-hop or destination RTE is written for the entry. Skipping at the top of the loop also guarantees no orphaned next-hop RTE (a next-hop RTE with no following destination RTE) can be left in the packet.

Related: #18923
