### PR TITLE
tests: avoid "exact" json comparison in topotests

### DIFF
--- a/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
+++ b/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
@@ -79,48 +79,6 @@ def teardown_module(_mod):
     tgen.stop_topology()
 
 
-def _router_json_cmp_exact_filter(router, cmd, expected):
-    output = router.vtysh_cmd(cmd)
-    logger.info("{}: {}\n{}".format(router.name, cmd, output))
-
-    json_output = json.loads(output)
-
-    # filter out tableVersion, version, nhVrfId and vrfId
-    for _, attrs in json_output.items():
-        for attr in attrs:
-            if "table" in attr:
-                attr.pop("table")
-            if "internalStatus" in attr:
-                attr.pop("internalStatus")
-            if "internalFlags" in attr:
-                attr.pop("internalFlags")
-            if "internalNextHopNum" in attr:
-                attr.pop("internalNextHopNum")
-            if "internalNextHopActiveNum" in attr:
-                attr.pop("internalNextHopActiveNum")
-            if "internalNextHopFibInstalledNum" in attr:
-                attr.pop("internalNextHopFibInstalledNum")
-            if "nexthopGroupId" in attr:
-                attr.pop("nexthopGroupId")
-            if "installedNexthopGroupId" in attr:
-                attr.pop("installedNexthopGroupId")
-            if "uptime" in attr:
-                attr.pop("uptime")
-            if "prefixLen" in attr:
-                attr.pop("prefixLen")
-            if "asPath" in attr:
-                attr.pop("asPath")
-            if "receivedNexthopGroupId" in attr:
-                attr.pop("receivedNexthopGroupId")
-            for nexthop in attr.get("nexthops", []):
-                if "flags" in nexthop:
-                    nexthop.pop("flags")
-                if "interfaceIndex" in nexthop:
-                    nexthop.pop("interfaceIndex")
-
-    return topotest.json_cmp(json_output, expected, exact=True)
-
-
 def _check_zebra_rib_r1(with_redistributed_route, with_second_route=False):
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -148,7 +106,7 @@ def _check_zebra_rib_r1(with_redistributed_route, with_second_route=False):
     step(f"Checking IPv4 routes for convergence on r1 with{with_str} kernel route")
     expected = json.loads(open(json_file).read())
     test_func = partial(
-        _router_json_cmp_exact_filter,
+        topotest.router_json_cmp,
         router,
         "show ip route bgp json",
         expected,

--- a/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
+++ b/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
@@ -132,79 +132,6 @@ def teardown_module(_mod):
     tgen.stop_topology()
 
 
-def router_json_cmp_exact_filter(router, cmd, expected):
-    output = router.vtysh_cmd(cmd)
-    logger.info("{}: {}\n{}".format(router.name, cmd, output))
-
-    json_output = json.loads(output)
-
-    # filter out tableVersion, version and nhVrfID
-    json_output.pop("tableVersion")
-    if "totalRoutes" in json_output:
-        json_output.pop("totalRoutes")
-    if "totalPaths" in json_output:
-        json_output.pop("totalPaths")
-    if "numRoutes" in json_output:
-        json_output.pop("numRoutes")
-    if "routes" in json_output:
-        json_output["routes"].pop("numRoutes", None)
-    for rd, data in json_output["routes"]["routeDistinguishers"].items():
-        if isinstance(data, dict) and "numRoutes" in data:
-            data.pop("numRoutes")
-        for _, attrs in data.items():
-            for attr in attrs:
-                if "nhVrfId" in attr:
-                    attr.pop("nhVrfId")
-                if "version" in attr:
-                    attr.pop("version")
-
-    # filter out RD with no data (e.g. "444:3": {})
-    json_tmp = deepcopy(json_output)
-    for rd, data in json_tmp["routes"]["routeDistinguishers"].items():
-        if len(data.keys()) == 0:
-            json_output["routes"]["routeDistinguishers"].pop(rd)
-
-    return topotest.json_cmp(json_output, expected, exact=True)
-
-
-def router_vrf_json_cmp_exact_filter(router, cmd, expected):
-    output = router.vtysh_cmd(cmd)
-    logger.info("{}: {}\n{}".format(router.name, cmd, output))
-
-    json_output = json.loads(output)
-
-    print(json_output)
-
-    # filter out tableVersion, version, nhVrfId and vrfId
-    for vrf, data in json_output.items():
-        if "vrfId" in data:
-            data.pop("vrfId")
-        if "tableVersion" in data:
-            data.pop("tableVersion")
-        if "totalRoutes" in data:
-            data.pop("totalRoutes")
-        if "totalPaths" in data:
-            data.pop("totalPaths")
-        if "numRoutes" in data:
-            data.pop("numRoutes")
-        if "routes" not in data:
-            continue
-        for _, attrs in data["routes"].items():
-            for attr in attrs:
-                if "nhVrfId" in attr:
-                    attr.pop("nhVrfId")
-                if "version" in attr:
-                    attr.pop("version")
-
-    # filter out VRF with no routes
-    json_tmp = deepcopy(json_output)
-    for vrf, data in json_tmp.items():
-        if "routes" not in data or len(data["routes"].keys()) == 0:
-            json_output.pop(vrf)
-
-    return topotest.json_cmp(json_output, expected, exact=True)
-
-
 def check_show_bgp_ipv4_vpn(rname, json_file):
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -216,7 +143,7 @@ def check_show_bgp_ipv4_vpn(rname, json_file):
     json_file = "{}/{}/{}".format(CWD, router.name, json_file)
     expected = json.loads(open(json_file).read())
     test_func = partial(
-        router_json_cmp_exact_filter,
+        topotest.router_json_cmp,
         router,
         "show bgp ipv4 vpn json",
         expected,
@@ -260,7 +187,7 @@ def check_show_bgp_vrf_ipv4(rname, json_file):
     json_file = "{}/{}/{}".format(CWD, router.name, json_file)
     expected = json.loads(open(json_file).read())
     test_func = partial(
-        router_vrf_json_cmp_exact_filter,
+        topotest.router_json_cmp,
         router,
         "show bgp vrf all ipv4 unicast json",
         expected,

--- a/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
+++ b/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
@@ -155,7 +155,7 @@ def router_json_cmp_exact_filter(router, cmd, expected):
                 # IPv4, just checking the nexthop
                 router_output.get(label).get("nexthops")[i].pop("interface")
 
-    return topotest.json_cmp(router_output, expected, exact=True)
+    return topotest.json_cmp(router_output, expected)
 
 
 router_compare_json_output = partial(

--- a/tests/topotests/route_map_check_unused/test_route_map_check_unused.py
+++ b/tests/topotests/route_map_check_unused/test_route_map_check_unused.py
@@ -123,7 +123,7 @@ def test_route_map_check_unused():
             "bgpd": {},
         }
 
-        return topotest.json_cmp(output, expected, exact=True)
+        return topotest.json_cmp(output, expected)
 
     test_func = functools.partial(_check_unused_route_maps)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)


### PR DESCRIPTION
Stop trying to use "exact" json comparison in several topotests. New keys in json objects should generally be benign. We had several examples where the test code was carefully removing json data, instead of just ... testing for the data/keys/attributes that the test required.

