### PR TITLE
pbrd: fix use-after-free for individual nexthop

### DIFF
--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -646,6 +646,11 @@ static void pbr_nht_release_individual_nexthop(struct pbr_map_sequence *pbrms)
 	pbr_map_check_nh_group_change(pnhgc->name);
 
 	hash_release(pbr_nhg_hash, pnhgc);
+
+	/* Release the table-ID index before freeing its backing cache entry. */
+	hash_release(pbr_nhg_allocated_id_hash, pnhgc);
+	pbr_nht_update_next_unallocated_table_id();
+
 	pbr_nhgc_delete(pnhgc);
 
 	nexthop_group_delete(&pbrms->nhg);


### PR DESCRIPTION
An individual `set nexthop` creates an internal nexthop-group cache. The cache is indexed by both its generated name in "pbr_nhg_hash" and its allocated table ID in "pbr_nhg_allocated_id_hash".

`pbr_nht_release_individual_nexthop()` removed the cache only from "pbr_nhg_hash" before freeing it. Consequently, `pbr_nhg_allocated_id_hash` wrongly retained a pointer to freed memory.

When a subsequent individual nexthop is configured, `pbr_nht_reserve_next_table_id()` looking up the previously allocated ID invokes `pbr_nhg_allocated_id_hash_equal()`, which dereferences the stale cache entry and triggers a use-after-free.

Remove the cache from "pbr_nhg_allocated_id_hash" and update the next available table ID before freeing the cache.

```
anlan(config)# pbr-map test seq 10
anlan(config-pbr-map)# set nexthop blackhole
anlan(config-pbr-map)# no set nexthop blackhole
anlan(config-pbr-map)# set nexthop blackhole
vtysh: error reading from pbrd: Success (0)Warning: closing connection to pbrd because of an I/O error!

==306355==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d000018920 at pc 0x5555555a66a7 bp 0x7fffffff8d20 sp 0x7fffffff8d18                                          READ of size 4 at 0x60d000018920 thread T0
    #0 0x5555555a66a6 in pbr_nhg_allocated_id_hash_equal ../pbrd/pbr_nht.c:1235
    #1 0x7ffff720d058 in hash_get ../lib/hash.c:142
    #2 0x7ffff720d6d6 in hash_lookup ../lib/hash.c:184
    #3 0x5555555a68aa in pbr_nht_find_next_unallocated_table_id ../pbrd/pbr_nht.c:1275
    #4 0x5555555a69fa in pbr_nht_update_next_unallocated_table_id ../pbrd/pbr_nht.c:1290
    #5 0x5555555a6a86 in pbr_nht_reserve_next_table_id ../pbrd/pbr_nht.c:1306
    #6 0x55555559e25a in pbr_nhgc_alloc ../pbrd/pbr_nht.c:192
    #7 0x7ffff720d0fd in hash_get ../lib/hash.c:147
    #8 0x5555555a1391 in pbr_nht_add_individual_nexthop ../pbrd/pbr_nht.c:600
    #9 0x55555558f898 in pbr_map_nexthop_magic ../pbrd/pbr_vty.c:1298
    #10 0x5555555870e1 in pbr_map_nexthop pbrd/pbr_vty_clippy.c:1398
    #11 0x7ffff71a2100 in cmd_execute_command_real ../lib/command.c:1011
    #12 0x7ffff71a2475 in cmd_execute_command ../lib/command.c:1070
    #13 0x7ffff71a30d6 in cmd_execute ../lib/command.c:1236
    #14 0x7ffff73a14e2 in vty_command ../lib/vty.c:593
    #15 0x7ffff73a5f4e in vty_execute ../lib/vty.c:1356
    #16 0x7ffff73ab80c in vtysh_read ../lib/vty.c:2302
    #17 0x7ffff739165e in event_call ../lib/event.c:2744
    #18 0x7ffff723f28b in frr_run ../lib/libfrr.c:1258
    #19 0x555555575fb5 in main ../pbrd/pbr_main.c:176
    #20 0x7ffff6e46249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #21 0x7ffff6e46304 in __libc_start_main_impl ../csu/libc-start.c:360
    #22 0x555555575a40 in _start (/usr/lib/frr/pbrd+0x21a40)
    
0x60d000018920 is located 112 bytes inside of 136-byte region [0x60d0000188b0,0x60d000018938)
freed by thread T0 here:
    #0 0x7ffff78b76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7ffff7275faa in qfree ../lib/memory.c:136
    #2 0x55555559e158 in pbr_nhgc_delete ../pbrd/pbr_nht.c:173
    #3 0x5555555a1f37 in pbr_nht_release_individual_nexthop ../pbrd/pbr_nht.c:650
    #4 0x5555555a2127 in pbr_nht_delete_individual_nexthop ../pbrd/pbr_nht.c:668
    #5 0x55555558eb81 in pbrms_clear_set_nexthop_config ../pbrd/pbr_vty.c:1110
    #6 0x55555558ebb4 in pbrms_clear_set_config ../pbrd/pbr_vty.c:1117
    #7 0x55555558fb49 in no_pbr_map_nexthop_magic ../pbrd/pbr_vty.c:1346
    #8 0x555555587d01 in no_pbr_map_nexthop pbrd/pbr_vty_clippy.c:1468
    #9 0x7ffff71a2100 in cmd_execute_command_real ../lib/command.c:1011
    #10 0x7ffff71a2475 in cmd_execute_command ../lib/command.c:1070
    #11 0x7ffff71a30d6 in cmd_execute ../lib/command.c:1236
    #12 0x7ffff73a14e2 in vty_command ../lib/vty.c:593
    #13 0x7ffff73a5f4e in vty_execute ../lib/vty.c:1356
    #14 0x7ffff73ab80c in vtysh_read ../lib/vty.c:2302
    #15 0x7ffff739165e in event_call ../lib/event.c:2744
    #16 0x7ffff723f28b in frr_run ../lib/libfrr.c:1258
    #17 0x555555575fb5 in main ../pbrd/pbr_main.c:176
    #18 0x7ffff6e46249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58    
```