### PR TITLE
bfdd: implement RFC 5880 Demand mode

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -235,6 +235,14 @@ void bfd_session_apply(struct bfd_session *bs)
 			bfd_set_passive_mode(bs, bs->peer_profile.passive);
 	}
 
+	/* Toggle 'demand-mode' if default value. */
+	if (bs->bfd_mode == BFD_MODE_TYPE_BFD) {
+		if (bs->peer_profile.demand_mode == false)
+			bfd_set_demand_mode(bs, bp->demand_mode);
+		else
+			bfd_set_demand_mode(bs, bs->peer_profile.demand_mode);
+	}
+
 	/* Toggle 'no shutdown' if default value. */
 	if (bs->peer_profile.admin_shutdown == false)
 		bfd_set_shutdown(bs, bp->admin_shutdown);
@@ -1359,6 +1367,15 @@ void bfd_set_polling(struct bfd_session *bs)
 		zlog_debug("[%s] Setting polling=1 to negotiate timer change", bs_to_string(bs));
 
 	bs->polling = 1;
+
+	/*
+	 * A poll sequence in demand mode arms the detection timer with
+	 * the demand mode detection time: if no packet arrives after the
+	 * poll was sent, the session is declared down.
+	 *
+	 * RFC 5880, Section 6.8.4.
+	 */
+	bs_demand_mode_handler(bs);
 }
 
 /*
@@ -1669,15 +1686,6 @@ void bs_final_handler(struct bfd_session *bs)
 	bs->cur_timers.required_min_rx = bs->timers.required_min_rx;
 
 	/*
-	 * TODO: demand mode. See RFC 5880 Section 6.1.
-	 *
-	 * When using demand mode we must disable the detection timer
-	 * for lost control packets.
-	 */
-	if (bs->demand_mode)
-		return;
-
-	/*
 	 * Calculate transmission time based on new timers.
 	 *
 	 * Transmission calculation:
@@ -1866,6 +1874,115 @@ void bfd_set_passive_mode(struct bfd_session *bs, bool passive)
 
 		/* Session is down, let it attempt to start the connection. */
 		bfd_xmttimer_update(bs, bs->xmt_TO);
+		bfd_recvtimer_update(bs);
+	}
+}
+
+void bfd_set_demand_mode(struct bfd_session *bs, bool demand_mode)
+{
+	if (bs->demand_mode == demand_mode)
+		return;
+
+	bs->demand_mode = demand_mode;
+
+	if (bs->ses_state == PTM_BFD_UP) {
+		/*
+		 * Changing the demand bit requires a poll sequence in
+		 * conjunction with the change so both systems become aware
+		 * of it. ptm_bfd_snd() will set the poll bit because the
+		 * transmitted demand bit value changes.
+		 *
+		 * RFC 5880, Section 6.6.
+		 */
+		ptm_bfd_snd(bs, 0);
+	}
+
+	/* Re-evaluate the demand mode timers. */
+	bs_demand_mode_handler(bs);
+}
+
+/*
+ * Demand mode (RFC 5880, Section 6.6).
+ *
+ * Evaluates whether demand mode is active in either direction and
+ * starts or stops the periodic transmission and detection timers
+ * accordingly:
+ *
+ * - when the remote system is in demand mode and both ends are up, the
+ *   local system MUST cease the periodic transmission of control
+ *   packets (unless a poll sequence is being transmitted) and resume it
+ *   once the remote system leaves demand mode;
+ *
+ * - when the local system is in demand mode and both ends are up, the
+ *   remote system will stop sending periodic control packets, so the
+ *   detection timer must be suspended and only run in conjunction with
+ *   our own poll sequences, using the detection time calculated from
+ *   our own transmit rate.
+ *
+ * RFC 5880, Sections 6.8.4, 6.8.6 and 6.8.14.
+ */
+void bs_demand_mode_handler(struct bfd_session *bs)
+{
+	bool local_demand, remote_demand;
+
+	if (bs->bfd_mode != BFD_MODE_TYPE_BFD)
+		return;
+
+	/* Demand mode is only effective while the session is up. */
+	local_demand = bs->demand_mode && bs->ses_state == PTM_BFD_UP &&
+		       bs->remote_state == PTM_BFD_UP;
+	remote_demand = bs->remote_demand_mode &&
+			bs->ses_state == PTM_BFD_UP && bs->remote_state == PTM_BFD_UP;
+
+	if (remote_demand) {
+		/*
+		 * The remote system wants demand mode: cease the periodic
+		 * transmission of control packets. A poll sequence in
+		 * progress must be allowed to continue.
+		 *
+		 * RFC 5880, Sections 6.8.6 and 6.8.7.
+		 */
+		if (bs->polling)
+			ptm_bfd_start_xmt_timer(bs, false);
+		else
+			bfd_xmttimer_delete(bs);
+	} else if (!event_is_scheduled(bs->xmttimer_ev)) {
+		/*
+		 * Demand mode is no longer active on the remote system:
+		 * resume the periodic transmission of control packets.
+		 *
+		 * RFC 5880, Section 6.8.14.
+		 */
+		ptm_bfd_start_xmt_timer(bs, false);
+	}
+
+	if (local_demand) {
+		if (bs->polling) {
+			/*
+			 * We are verifying connectivity with a poll
+			 * sequence: the detection time is based on our
+			 * own transmit rate.
+			 *
+			 * RFC 5880, Section 6.8.4.
+			 */
+			if (bs->timers.desired_min_tx > bs->remote_timers.required_min_rx)
+				bs->detect_TO = bs->detect_mult * bs->timers.desired_min_tx;
+			else
+				bs->detect_TO = bs->detect_mult * bs->remote_timers.required_min_rx;
+			bfd_recvtimer_update(bs);
+		} else {
+			/*
+			 * We want demand mode: the remote system will stop
+			 * sending periodic control packets, so the
+			 * detection timer must be suspended until we
+			 * initiate a poll sequence to verify connectivity.
+			 *
+			 * RFC 5880, Section 6.8.4.
+			 */
+			bfd_recvtimer_delete(bs);
+		}
+	} else if (!event_is_scheduled(bs->recvtimer_ev)) {
+		/* Not in demand mode: normal detection applies. */
 		bfd_recvtimer_update(bs);
 	}
 }

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -336,6 +336,8 @@ struct bfd_profile {
 	bool admin_shutdown;
 	/** Passive mode. */
 	bool passive;
+	/** Demand mode. */
+	bool demand_mode;
 	/** Log session changes. */
 	bool log_session_changes;
 	/** Minimum expected TTL value. */
@@ -384,6 +386,12 @@ struct bfd_session {
 	struct bfd_discrs discrs;
 	uint8_t local_diag;
 	uint8_t demand_mode;
+	/* Last session state reported by the remote peer. */
+	uint8_t remote_state;
+	/* Last demand bit value received from the remote peer. */
+	uint8_t remote_demand_mode;
+	/* Last demand bit value sent to the remote peer. */
+	uint8_t last_sent_demand;
 	uint8_t detect_mult;
 	uint8_t remote_detect_mult;
 	uint8_t mh_ttl;
@@ -745,6 +753,22 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown);
  * \param passive the passive mode.
  */
 void bfd_set_passive_mode(struct bfd_session *bs, bool passive);
+
+/**
+ * Set the BFD session demand mode.
+ *
+ * \param bs the BFD session.
+ * \param demand_mode the demand mode.
+ */
+void bfd_set_demand_mode(struct bfd_session *bs, bool demand_mode);
+
+/**
+ * Evaluate whether demand mode is active for the session and start or
+ * stop the periodic transmission and detection timers accordingly.
+ *
+ * \param bs the BFD session.
+ */
+void bs_demand_mode_handler(struct bfd_session *bs);
 
 /**
  * Set the BFD session to log or not log session changes.

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -457,7 +457,28 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
 		BFD_SETCBIT(cp.flags, BFD_CBIT);
 
-	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
+	/*
+	 * The demand bit may only be set when the local system wants to
+	 * use demand mode and both ends of the session are up.
+	 *
+	 * RFC 5880, Section 6.8.7.
+	 */
+	bool demand = bfd->demand_mode && bfd->ses_state == PTM_BFD_UP &&
+		      bfd->remote_state == PTM_BFD_UP;
+
+	/*
+	 * Any change to the transmitted demand bit must be confirmed
+	 * with a poll sequence, as the peer has no other way to
+	 * acknowledge the demand mode transition.
+	 *
+	 * RFC 5880, Section 6.6.
+	 */
+	if (demand != bfd->last_sent_demand) {
+		bfd->polling = 1;
+		bfd->last_sent_demand = demand;
+	}
+
+	BFD_SETDEMANDBIT(cp.flags, demand);
 
 	/* Polling and Final can't be set at the same time.
 	 *
@@ -1402,6 +1423,13 @@ void bfd_recv_cb(struct event *t)
 	else
 		bfd->remote_cbit = 0;
 
+	/* Save the demand bit and remote state for demand mode handling.
+	 *
+	 * RFC 5880, Section 6.8.6.
+	 */
+	bfd->remote_demand_mode = BFD_GETDEMANDBIT(cp->flags);
+	bfd->remote_state = BFD_GETSTATE(cp->flags);
+
 	/* The initiator handle SBFD reflect packet. */
 	if (bfd->bfd_mode == BFD_MODE_TYPE_SBFD_INIT) {
 		sbfd_initiator_state_handler(bfd, PTM_BFD_UP);
@@ -1454,6 +1482,13 @@ void bfd_recv_cb(struct event *t)
 
 	/* Apply new receive timer immediately. */
 	bfd_recvtimer_update(bfd);
+
+	/* Start or stop the periodic transmission and detection timers
+	 * depending on the demand mode state of both systems.
+	 *
+	 * RFC 5880, Section 6.8.6.
+	 */
+	bs_demand_mode_handler(bfd);
 
 	/* Handle echo timers changes. */
 	bs_echo_timer_handler(bfd);

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -758,6 +758,24 @@ void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 		yang_dnode_get_bool(dnode, NULL) ? "" : "no ");
 }
 
+DEFPY_YANG(
+	bfd_peer_demand_mode, bfd_peer_demand_mode_cmd,
+	"[no] demand-mode",
+	NO_STR
+	"Operate the session in Demand mode (RFC 5880, Section 6.6)\n")
+{
+	nb_cli_enqueue_change(vty, "./demand-mode", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void bfd_cli_show_demand_mode(struct vty *vty, const struct lyd_node *dnode,
+			      bool show_defaults)
+{
+	vty_out(vty, "  %sdemand-mode\n",
+		yang_dnode_get_bool(dnode, NULL) ? "" : "no ");
+}
+
 DEFPY_YANG(bfd_peer_log_session_changes, bfd_peer_log_session_changes_cmd,
 	   "[no] log-session-changes",
 	   NO_STR
@@ -1187,6 +1205,11 @@ ALIAS_YANG(bfd_peer_passive, bfd_profile_passive_cmd,
       NO_STR
       "Don't attempt to start sessions\n")
 
+ALIAS_YANG(bfd_peer_demand_mode, bfd_profile_demand_mode_cmd,
+      "[no] demand-mode",
+      NO_STR
+      "Operate the session in Demand mode (RFC 5880, Section 6.6)\n")
+
 ALIAS_YANG(bfd_peer_log_session_changes, bfd_profile_log_session_changes_cmd,
 	   "[no] log-session-changes", NO_STR "Log Up/Down session changes in the profile\n")
 
@@ -1495,6 +1518,7 @@ bfdd_cli_init(void)
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_receive_interval_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_profile_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_passive_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_demand_mode_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_log_session_changes_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_minimum_ttl_cmd);
 	install_element(BFD_PEER_NODE, &no_bfd_peer_minimum_ttl_cmd);
@@ -1519,6 +1543,7 @@ bfdd_cli_init(void)
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_transmit_interval_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_receive_interval_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_passive_cmd);
+	install_element(BFD_PROFILE_NODE, &bfd_profile_demand_mode_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_log_session_changes_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_minimum_ttl_cmd);
 	install_element(BFD_PROFILE_NODE, &no_bfd_profile_minimum_ttl_cmd);

--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -70,6 +70,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 				.cli_show = bfd_cli_show_passive,
                         }
                 },
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/profile/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_profile_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand_mode,
+			}
+		},
                 {
                         .xpath = "/frr-bfdd:bfdd/bfd/profile/log-session-changes",
                         .cbs = {
@@ -165,6 +172,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
 				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand_mode,
 			}
 		},
 		{
@@ -374,6 +388,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
 				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand_mode,
 			}
 		},
 		{
@@ -606,6 +627,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand_mode,
+			}
+		},
+		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/log-session-changes",
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_log_session_changes_modify,
@@ -832,6 +860,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
 				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/demand-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_demand_mode_modify,
+				.cli_show = bfd_cli_show_demand_mode,
 			}
 		},
 		{

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -24,6 +24,7 @@ int bfdd_bfd_profile_required_receive_interval_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_administrative_down_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_passive_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_demand_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_log_session_changes_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_minimum_ttl_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args);
@@ -64,6 +65,8 @@ int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
 int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_passive_mode_modify(
+	struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_single_hop_demand_mode_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_log_session_changes_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_echo_mode_modify(
@@ -245,6 +248,8 @@ void bfd_cli_peer_profile_show(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
 void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
+void bfd_cli_show_demand_mode(struct vty *vty, const struct lyd_node *dnode,
+			      bool show_defaults);
 void bfd_cli_show_log_session_changes(struct vty *vty, const struct lyd_node *dnode,
 				      bool show_defaults);
 void bfd_cli_show_minimum_ttl(struct vty *vty, const struct lyd_node *dnode,

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -596,6 +596,23 @@ int bfdd_bfd_profile_passive_mode_modify(struct nb_cb_modify_args *args)
 }
 
 /*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/demand-mode
+ */
+int bfdd_bfd_profile_demand_mode_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	bp = nb_running_get_entry(args->dnode, NULL, true);
+	bp->demand_mode = yang_dnode_get_bool(args->dnode, NULL);
+	bfd_profile_update(bp);
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-bfdd:bfdd/bfd/profile/log-session-changes
  */
 int bfdd_bfd_profile_log_session_changes_modify(struct nb_cb_modify_args *args)
@@ -1109,6 +1126,33 @@ int bfdd_bfd_sessions_single_hop_passive_mode_modify(
 
 	bs = nb_running_get_entry(args->dnode, NULL, true);
 	bs->peer_profile.passive = passive;
+	bfd_session_apply(bs);
+
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_single_hop_demand_mode_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct bfd_session *bs;
+	bool demand_mode;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	demand_mode = yang_dnode_get_bool(args->dnode, NULL);
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->peer_profile.demand_mode = demand_mode;
 	bfd_session_apply(bs);
 
 	return NB_OK;

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -218,6 +218,21 @@ BFD peers and profiles share the same BFD session configuration commands.
 
    The default is active-mode (or ``no passive-mode``).
 
+.. clicmd:: demand-mode
+
+   Enable BFD Demand mode (RFC 5880, section 6.6) for this session:
+   the local system signals the remote peer (D bit) that it should stop
+   sending periodic BFD control packets.  The remote peer keeps
+   monitoring the session by sending it polls, and the local system
+   responds with finals.
+
+   This feature is useful when you want to reduce the amount of BFD
+   control packets sent on a link while keeping connectivity detection
+   at the remote peer.
+
+   The D bit is only set while both ends are Up.  The default is
+   asynchronous mode (or ``no demand-mode``).
+
 .. clicmd:: minimum-ttl (1-254)
 
    For multi hop sessions only: configure the minimum expected TTL for

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -221,6 +221,13 @@ module frr-bfdd {
         "Don't attempt to start session establishment.";
     }
 
+    leaf demand-mode {
+      type boolean;
+      default false;
+      description
+        "Operate the session in Demand mode (RFC 5880, Section 6.6).";
+    }
+
     leaf log-session-changes {
       type boolean;
       default false;


### PR DESCRIPTION
## Summary

Implement BFD Demand mode (RFC 5880, section 6.6) end to end: a
`demand-mode` knob is added to the BFD profile and to every session
type (peer, single/multi-hop, sbfd-echo, sbfd-init), following the
existing `passive-mode` implementation.

## Root cause

FRR bfdd never implemented Demand mode:

- `bfd_packet.c` unconditionally cleared the demand bit on every
  transmitted control packet (`BFD_SETDEMANDBIT(cp.flags,
  BFD_DEF_DEMAND)`), so the local system could never ask the remote
  system to stop sending periodic BFD packets.
- `bs_final_handler()` had an explicit `TODO: demand mode` early return
  that disabled the detection timer for any session with `demand-mode`
  enabled, leaving the session without failure detection entirely.
- There was no way to configure demand mode from the CLI/YANG.

## Impact

A session configured with `demand-mode` in the profile silently lost
its failure detection: `bs_final_handler()` returned early on timer
changes and the detection timer was never armed, so a link failure was
never detected. In addition, without the D bit being transmitted the
remote system kept sending periodic BFD packets, so Demand mode was
completely non-functional.

## Fix

- Transmit the demand bit only while the local system wants Demand mode
  and both ends are up (section 6.8.7), and confirm any change of the
  transmitted demand bit with a poll sequence (section 6.6).
- Stop the periodic transmission of control packets while the remote
  system is in Demand mode and the session is up (section 6.8.6), and
  resume it once the remote system leaves Demand mode (section 6.8.14).
- While the local system is in Demand mode, suspend the detection timer
  and arm it only in conjunction with the local poll sequences, using
  the detection time calculated from the local transmit rate (section
  6.8.4).
- Remove the `TODO: demand mode` early return from `bs_final_handler()`
  so timer renegotiation works for sessions with Demand mode enabled.
- Add the `demand-mode` leaf to the YANG module and wire it through the
  northbound and CLI for profiles and all session types.

Note: this branch contains only this commit; it does not include the
demand-bit transmission state machine from #23061 (`remote_state` /
`last_sent_demand` / poll-on-change are re-introduced here so the
branch is self-consistent on master). The two patches share the same
code and merge without conflict.
