### PR TITLE
lib,bgpd: honor --no_zebra for ZAPI communication

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1234,6 +1234,9 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	if (!bgp_zclient)
 		return;
 
+	if (bgp_option_check(BGP_OPT_NO_ZEBRA))
+		return;
+
 	/* Don't try to register if Zebra doesn't know of this instance. */
 	if (!IS_BGP_INST_KNOWN_TO_ZEBRA(bnc->bgp)) {
 		if (BGP_DEBUG(zebra, ZEBRA))

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -4624,9 +4624,13 @@ void bgp_zebra_init(struct event_loop *master, unsigned short instance)
 	hook_register_prio(if_down, 0, bgp_ifp_down);
 	hook_register_prio(if_unreal, 0, bgp_ifp_destroy);
 
-	/* Set default values. */
 	bgp_zclient = zclient_new(master, &zclient_options_default, bgp_handlers,
 				  array_size(bgp_handlers));
+
+	if (bgp_option_check(BGP_OPT_NO_ZEBRA))
+		bgp_zclient->auto_connect = false;
+
+	/* Set default values. */
 	zclient_init(bgp_zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	bgp_zclient->zebra_buffer_write_ready = bgp_zebra_buffer_write_ready;
 	bgp_zclient->zebra_connected = bgp_zebra_connected;
@@ -4642,7 +4646,7 @@ void bgp_zebra_init(struct event_loop *master, unsigned short instance)
 	bgp_zclient_sync->session_id = 1;
 	bgp_zclient_sync->privs = &bgpd_privs;
 
-	if (!bgp_zebra_label_manager_ready())
+	if (!bgp_option_check(BGP_OPT_NO_ZEBRA) && !bgp_zebra_label_manager_ready())
 		event_add_timer(master, bgp_start_label_manager, NULL, 1,
 				&bm->t_bgp_start_label_manager);
 }

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -84,6 +84,7 @@ struct zclient *zclient_new(struct event_loop *master,
 
 	zclient->synchronous = opt->synchronous;
 	zclient->auxiliary = opt->auxiliary;
+	zclient->auto_connect = true;
 
 	return zclient;
 }
@@ -895,6 +896,9 @@ void zclient_init(struct zclient *zclient, int redist_default,
 		/* Set default-information redistribute to zero. */
 		vrf_bitmap_init(&zclient->default_information[afi]);
 	}
+
+	if (!zclient->auto_connect)
+		return;
 
 	if (zclient_debug)
 		zlog_debug("scheduling zclient connection");
@@ -5016,6 +5020,9 @@ static void zclient_event(enum zclient_event event, struct zclient *zclient)
 				&zclient->t_connect);
 		break;
 	case ZCLIENT_CONNECT:
+		if (!zclient->auto_connect)
+			break;
+
 		if (zclient_debug)
 			zlog_debug("zclient connect failures: %d schedule interval is now %d",
 				   zclient->fail,

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -325,6 +325,9 @@ struct zclient {
 	 */
 	bool auxiliary;
 
+	/* Automatically establish a connection to zebra. */
+	bool auto_connect;
+
 	/* BFD enabled with bfd_protocol_integration_init() */
 	bool bfd_integration;
 


### PR DESCRIPTION
Hello!

When I started bgpd without zebra:

```bash
sudo ip netns exec r1 \
    ~/u/frr/build/bgpd/bgpd \
    -S \
    -Z \
    -N r1 \
    -f /tmp/r1/bgpd.conf \
    --log stdout \
    --log-level debugging
```

 I got this log:

```
2026/08/20 19:15:56 BGP: [T83RR-8SM5G] bgpd 10.8.0-dev-g6a306e1fbe starting: vty@2605, bgp@<all>:179
2026/08/20 19:15:56 BGP: [GNTN9-G7K6J] BGP-LS: Module initialized for instance VRF default
2026/08/20 19:15:57 BGP: [VMFZK-56S5Y] bgp_zebra_label_manager_connect: failed connecting synchronous zclient!
2026/08/20 19:15:57 BGP: [YTHK0-FSPPJ][EC 33554500] sendmsg_nexthop: zclient_send_message() failed
2026/08/20 19:15:58 BGP: [VMFZK-56S5Y] bgp_zebra_label_manager_connect: failed connecting synchronous zclient!
2026/08/20 19:15:59 BGP: [VMFZK-56S5Y] bgp_zebra_label_manager_connect: failed connecting synchronous zclient!
2026/08/20 19:16:00 BGP: [VMFZK-56S5Y] bgp_zebra_label_manager_connect: failed connecting synchronous zclient!
...
```

But since I'm running without Zebra, those warnings and connection attempts shouldn't appear in the log. The log should look like this:

```
2026/08/20 19:01:29 BGP: [T83RR-8SM5G] bgpd 10.8.0-dev-gf6b671b087 starting: vty@2605, bgp@<all>:179
2026/08/20 19:01:29 BGP: [GNTN9-G7K6J] BGP-LS: Module initialized for instance VRF default
2026/08/20 19:01:34 BGP: [M59KS-A3ZXZ] bgp_update_receive_eor: rcvd End-of-RIB for IPv4 Unicast from 10.10.0.2 in vrf default
```

As it turns out, there is already an open issue.
Fixes #18035

---

The --no_zebra option is intended to prevent bgpd from communicating with Zebra. However, zclient_init() unconditionally schedules a Zebra connection, bgpd starts the synchronous label-manager client, and nexthop tracking still attempts to send registration messages.

Keep the zclient objects initialized since bgpd relies on their local state even when Zebra communication is disabled, but disable automatic connection scheduling when BGP_OPT_NO_ZEBRA is set. Also skip the label-manager connection timer and nexthop registration messages in this mode.

This preserves the existing behavior for normal operation and --no_kernel while preventing ZAPI communication when --no_zebra is specified.