### PR TITLE
lib: drain gRPC CQ on early shutdown during server startup

### DIFF
--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1159,17 +1159,25 @@ static void *grpc_pthread_start(void *arg)
 
 	pthread_mutex_lock(&s_server_lock); // Make coverity happy
 	if (grpc_state == GRPC_STATE_SHUTDOWN) {
+		unsigned int n = 0;
+
 		pthread_mutex_unlock(&s_server_lock);
 		if (server)
 			server->Shutdown();
-		/*
-		 * No RPC handlers have been posted yet; REQUEST_NEWRPC*() calls
-		 * happen below after grpc_state is set to RUNNING, so there are
-		 * no RpcStateBase tags to drain from this CQ.
-		 */
 		if (cq)
 			cq->Shutdown();
-		grpc_debug("%s: early shutdown, exiting", __func__);
+		/*
+		 * BuildAndStart() may already have posted library
+		 * events. Drain them before unique_ptr dtors run;
+		 * grpc_completion_queue_destroy() asserts the queue
+		 * is empty. REQUEST_NEWRPC*() has not run, so these
+		 * tags are not RpcStateBase.
+		 */
+		while (cq && cq->Next(&tag, &ok))
+			n++;
+
+		grpc_debug("%s: early shutdown, drained %u CQ events",
+			   __func__, n);
 		return NULL;
 	}
 


### PR DESCRIPTION
SIGTERM can arrive after BuildAndStart() but before RPC handlers are posted. The gRPC thread then shut down the server and completion queue and returned without Next(), so destroying the queue hit gRPC's empty-queue assert on leftover library events. There are no RpcStateBase tags yet, so the drain must not delete them. The already-running server path is unchanged.

  2026-08-11T12:00:10.048 leaf02 frrinit.sh[95652]:
    E0811 12:00:10.047820515   95689 completion_queue.cc:256]
      `assertion failed: queue.num_items() == 0`

Upon watchfrr restart all, only mgmtd came up. Zebra was still in early init and had not published its VTY when the 90s restart timeout fired, so watchfrr sent SIGTERM to the restart-all process group.

FRR does not run the terminate handler until the event loop starts, so zebra kept going, then entered frr_run and started the gRPC server. Shutdown hit that server while it was still coming up: the early-exit path tore down the server and its completion queue without draining leftover library events, so destroying the queue hit gRPC's empty-queue assert (queue.num_items() == 0). Those events are not RPC handler objects, so the drain must not treat them as such.

Commit aaadad2e43 ([PR-22898](https://github.com/FRRouting/frr/pull/22898)) handle gRPC shutdown during server startup) added early-exit so shutdown during server start would not deadlock, but it returned without draining the gRPC completion queue

```
  Thread 1 (LWP 95689) frr-grpc:
  #7  abort
  #8  grpc_cq_internal_unref
  #9  grpc_completion_queue_destroy
  #10 grpc::ServerCompletionQueue::~ServerCompletionQueue()
  #13 grpc_pthread_start () at northbound_grpc.cpp:1366

  Thread 2 (LWP 95652) zebra:
  #2  frr_grpc_finish () at northbound_grpc.cpp:1447
  #3  hook_call_frr_fini / frr_fini
  #5  zebra_finalize () at zebra/main.c:288
```

Timeline:
```
11:58:28.473  watchfrr forks restart all (pid 93673)
11:58:33.581  mgmtd up                         ← the “1”
              (zebra is next; never opens zebra.vty)
11:59:23.432  55s: startup timeout, 1/5
11:59:58.473  90s: SIGTERM to 93673
12:00:10.041  zebra unregisters (shutdown)
12:00:10.047  gRPC CQ assert / abort
12:00:58      watchfrr retries restart all → all 5 up in ~2s
```
