### PR TITLE
watchfrr: don't admit to systemd that we restart

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -209,7 +209,10 @@ daemon_stop() {
 	is_user_root || exit 1
 
 	all=false
+	sig=INT
+	# these can't be used at the same time anyway
 	[ "$2" = "--reallyall" ] && all=true
+	[ "$2" = "--reload" ] && sig=USR1
 
 	pidfile="$V_PATH/$daemon${inst:+-$inst}.pid"
 	vtyfile="$V_PATH/$daemon${inst:+-$inst}.vty"
@@ -229,8 +232,8 @@ daemon_stop() {
 		debug "kill -6 $pid"
 		kill -6 "$pid"
 	else
-		debug "kill -2 $pid"
-		kill -2 "$pid"
+		debug "kill -$sig $pid"
+		kill -$sig "$pid"
 	fi
 
 	cnt=1200

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -89,7 +89,7 @@ reload)
 	# NB: This will NOT cause the other daemons to be restarted.
 	daemon_list enabled_daemons disabled_daemons
 	watchfrr_options="$watchfrr_options $enabled_daemons"
-	daemon_stop watchfrr && \
+	daemon_stop watchfrr --reload && \
 		daemon_start watchfrr
 
 	# If we disable an arbitrary daemon and do reload,

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1031,6 +1031,13 @@ static FRR_NORETURN void sigint(void)
 	exit(0);
 }
 
+static FRR_NORETURN void sigusr1(void)
+{
+	zlog_notice("Terminating to handle reload (SIGUSR1)");
+	systemd_send_status("watchfrr restarting to handle changes in daemons");
+	exit(0);
+}
+
 static int valid_command(const char *cmd)
 {
 	const char *p;
@@ -1285,6 +1292,10 @@ static struct frr_signal_t watchfrr_signals[] = {
 	{
 		.signal = SIGCHLD,
 		.handler = sigchild,
+	},
+	{
+		.signal = SIGUSR1,
+		.handler = sigusr1,
 	},
 };
 


### PR DESCRIPTION
As of systemd 259 (98734ac74d16), once you're telling it that you're stopping, you're _stopping_, full stop.  systemd will make sure of it.

So, I guess we just shouldn't admit to systemd that we're restarting.

Fixes: #20430
References: https://github.com/systemd/systemd/commit/98734ac74d16862302c490e2a5bbc60539b7e6a4