### PR TITLE
Deprecate `--no_zebra` cli in bgpd

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -440,12 +440,16 @@ int main(int argc, char **argv)
 
 	addresses->cmp = (int (*)(void *, void *))strcmp;
 
+#if CONFDATE > 20280901
+CPP_NOTICE("Remove `--no_zebra` option as that it is deprecated")
+#endif
+
 	frr_preinit(&bgpd_di, argc, argv);
 	frr_opt_add("p:l:SnZe:I:s:x" DEPRECATED_OPTIONS, longopts,
 		    "  -p, --bgp_port           Set BGP listen port number (0 means do not listen).\n"
 		    "  -l, --listenon           Listen on specified address (implies -n)\n"
 		    "  -n, --no_kernel          Do not install route to kernel.\n"
-		    "  -Z, --no_zebra           Do not communicate with Zebra.\n"
+		    "  -Z, --no_zebra           Deprecated; use -n/--no_kernel instead.\n"
 		    "  -S, --skip_runas         Skip capabilities checks, and changing user and group IDs.\n"
 		    "  -e, --ecmp               Specify ECMP to use.\n"
 		    "  -I, --int_num            Set instance number (label-manager)\n"
@@ -499,6 +503,8 @@ int main(int argc, char **argv)
 			break;
 		case 'Z':
 			no_zebra_flag = 1;
+			fprintf(stderr,
+				"The -Z/--no_zebra option is deprecated and will be removed. FRR is tightly integrated with zebra; use -n/--no_kernel (or 'bgp no-rib') to avoid installing BGP routes into zebra.\n");
 			break;
 		case 'S':
 			skip_runas = 1;

--- a/doc/manpages/frr-bgpd.rst
+++ b/doc/manpages/frr-bgpd.rst
@@ -34,10 +34,13 @@ OPTIONS available for the |DAEMON| command:
 
 .. option:: -n, --no_kernel
 
-   Do not install learned routes into the linux kernel.  This option is useful
-   for a route-reflector environment or if you are running multiple bgp
-   processes in the same namespace.  This option is different than the --no_zebra
-   option in that a ZAPI connection is made.
+   Do not install BGP routes into zebra (and therefore not into the Linux
+   kernel).  This is the supported way to keep BGP from programming routes,
+   for example on a route reflector or when running multiple bgpd processes
+   in the same namespace.
+
+   bgpd still opens a ZAPI connection to zebra.  FRR protocol daemons are
+   tightly integrated with zebra and are not intended to run without it.
 
 .. option:: -e, --ecmp
 
@@ -47,8 +50,12 @@ OPTIONS available for the |DAEMON| command:
 
 .. option:: -Z, --no_zebra
 
-   Do not communicate with zebra at all.  This is different than the --no_kernel
-   option in that we do not even open a ZAPI connection to the zebra process.
+   Deprecated.  This option is buggy and misleading: it does not fully stop
+   communication with zebra, and FRR is tightly integrated with zebra.
+
+   Do not use this option.  It will be removed in a future release.  To avoid
+   installing BGP routes into zebra, use ``-n`` / ``--no_kernel`` (or
+   ``bgp no-rib`` at runtime).
 
 .. option:: -s, --socket_size
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -47,10 +47,15 @@ be specified (:ref:`common-invocation-options`).
 
 .. option:: -n, --no_kernel
 
-   Do not install learned routes into the linux kernel.  This option is useful
-   for a route-reflector environment or if you are running multiple bgp
-   processes in the same namespace.  This option is different than the --no_zebra
-   option in that a ZAPI connection is made.
+   Do not install BGP routes into zebra (and therefore not into the Linux
+   kernel).  This is the supported way to keep BGP from programming routes
+   when you still need a working FRR process, for example a route reflector
+   or multiple bgpd processes in the same namespace.
+
+   bgpd still opens a ZAPI connection to zebra.  FRR protocol daemons are
+   tightly integrated with zebra for interface, VRF, nexthop-tracking, label,
+   and other state; they are not intended to run as a standalone process
+   without zebra.
 
    This option can also be toggled during runtime by using the
    ``[no] bgp no-rib`` commands in VTY shell.
@@ -72,8 +77,12 @@ be specified (:ref:`common-invocation-options`).
 
 .. option:: -Z, --no_zebra
 
-   Do not communicate with zebra at all.  This is different than the --no_kernel
-   option in that we do not even open a ZAPI connection to the zebra process.
+   Deprecated.  This option is buggy and misleading: it does not fully stop
+   communication with zebra, and FRR is tightly integrated with zebra.
+
+   Do not use this option.  It will be removed in a future release.  To avoid
+   installing BGP routes into zebra, use ``-n`` / ``--no_kernel`` (or
+   ``bgp no-rib`` at runtime).
 
 .. option:: -s, --socket_size
 
@@ -88,9 +97,7 @@ be specified (:ref:`common-invocation-options`).
    Allow BGP to peer in the V6 afi, when the interface only has v4 addresses.
    This allows bgp to install the v6 routes with a v6 nexthop that has the
    v4 address encoded in the nexthop.  Zebra's equivalent option currently
-   overrides the bgp setting.  This setting is only really usable when
-   the operator has turned off communication to zebra and is running bgpd
-   as a complete standalone process.
+   overrides the bgp setting.
 
 .. option:: -K, --graceful_restart
 
@@ -6032,7 +6039,8 @@ by route reflectors to avoid looping.
 
 To set and unset the BGP daemon ``-n`` / ``--no_kernel`` options during runtime
 to disable BGP route installation to the RIB (Zebra), the ``[no] bgp no-rib``
-commands can be used;
+commands can be used.  This is the supported replacement for the deprecated
+``-Z`` / ``--no_zebra`` option.
 
 Please note that setting the option during runtime will withdraw all routes in
 the daemons RIB from Zebra and unsetting it will announce all routes in the

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -85,6 +85,8 @@ struct zclient *zclient_new(struct event_loop *master,
 	zclient->synchronous = opt->synchronous;
 	zclient->auxiliary = opt->auxiliary;
 
+	zclient->sock = -1;
+
 	return zclient;
 }
 


### PR DESCRIPTION
This option is buggy and missleading on what it actually does.  Let's deprecate it and document that it's deprecated.