### PR TITLE
isisd, doc: unlock the srgb/srlb limit of 65535 labels

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -429,9 +429,8 @@ Known limitations:
 .. clicmd:: segment-routing global-block (16-1048575) (16-1048575) [local-block (16-1048575) (16-1048575)]
 
    Set the Segment Routing Global Block i.e. the label range used by MPLS
-   to store label in the MPLS FIB for Prefix SID. Note that the block size
-   may not exceed 65535. Optionally sets also the Segment Routing Local Block.
-   The negative command always unsets both.
+   to store label in the MPLS FIB for Prefix SID. Optionally sets also the
+   Segment Routing Local Block. The negative command always unsets both.
 
 .. clicmd:: segment-routing node-msd (1-16)
 
@@ -439,7 +438,7 @@ Known limitations:
    MPLS dataplane. E.g. for Linux kernel, since version 4.13 the maximum value
    is 32.
 
-.. clicmd:: segment-routing prefix <A.B.C.D/M|X:X::X:X/M> [algorithm (128-255)] <absolute (16-1048575)|index (0-65535) [no-php-flag|explicit-null] [n-flag-clear]
+.. clicmd:: segment-routing prefix <A.B.C.D/M|X:X::X:X/M> [algorithm (128-255)] <absolute (16-1048575)|index (0-1048575) [no-php-flag|explicit-null] [n-flag-clear]
 
    prefix. The 'no-php-flag' means NO Penultimate Hop Popping that allows SR
    node to request to its neighbor to not pop the label. The 'explicit-null'

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1595,10 +1595,10 @@ DEFPY_YANG(
 	SR_STR
 	"Segment Routing Global Block label range\n"
 	"The lower bound of the global block\n"
-	"The upper bound of the global block (block size may not exceed 65535)\n"
+	"The upper bound of the global block\n"
 	"Segment Routing Local Block label range\n"
 	"The lower bound of the local block\n"
-	"The upper bound of the local block (block size may not exceed 65535)\n")
+	"The upper bound of the local block\n")
 {
 	nb_cli_enqueue_change(vty, "./segment-routing/label-blocks/srgb/lower-bound", NB_OP_MODIFY,
 			      gb_lower_bound_str);
@@ -1619,10 +1619,10 @@ DEFPY_YANG(no_isis_sr_global_block_label_range,
 	NO_STR SR_STR
 	"Segment Routing Global Block label range\n"
 	"The lower bound of the global block\n"
-	"The upper bound of the global block (block size may not exceed 65535)\n"
+	"The upper bound of the global block\n"
 	"Segment Routing Local Block label range\n"
 	"The lower bound of the local block\n"
-	"The upper bound of the local block (block size may not exceed 65535)\n")
+	"The upper bound of the local block\n")
 {
 	nb_cli_enqueue_change(vty, "./segment-routing/label-blocks/srgb/lower-bound", NB_OP_MODIFY,
 			      NULL);
@@ -1688,7 +1688,7 @@ DEFPY_YANG (isis_sr_prefix_sid,
        isis_sr_prefix_sid_cmd,
        "segment-routing prefix\
           <A.B.C.D/M|X:X::X:X/M>$prefix\
-	  <absolute$sid_type (16-1048575)$sid_value|index$sid_type (0-65535)$sid_value>\
+	  <absolute$sid_type (16-1048575)$sid_value|index$sid_type (0-1048575)$sid_value>\
 	  [<no-php-flag|explicit-null>$lh_behavior] [n-flag-clear$n_flag_clear]",
        SR_STR
        "Prefix SID\n"
@@ -1727,7 +1727,7 @@ DEFPY_YANG (isis_sr_prefix_sid,
 DEFPY_YANG (no_isis_sr_prefix_sid,
        no_isis_sr_prefix_sid_cmd,
        "no segment-routing prefix <A.B.C.D/M|X:X::X:X/M>$prefix\
-         [<absolute$sid_type (16-1048575)|index (0-65535)> [<no-php-flag|explicit-null>]]\
+         [<absolute$sid_type (16-1048575)|index (0-1048575)> [<no-php-flag|explicit-null>]]\
 	 [n-flag-clear]",
        NO_STR
        SR_STR
@@ -1786,7 +1786,7 @@ DEFPY_YANG(
 	isis_sr_prefix_sid_algorithm, isis_sr_prefix_sid_algorithm_cmd,
 	"segment-routing prefix <A.B.C.D/M|X:X::X:X/M>$prefix\
               algorithm (128-255)$algorithm\
-              <absolute$sid_type (16-1048575)$sid_value|index$sid_type (0-65535)$sid_value>\
+              <absolute$sid_type (16-1048575)$sid_value|index$sid_type (0-1048575)$sid_value>\
               [<no-php-flag|explicit-null>$lh_behavior] [n-flag-clear$n_flag_clear]",
 	SR_STR
 	"Prefix SID\n"
@@ -1830,7 +1830,7 @@ DEFPY_YANG(
 	no_isis_sr_prefix_algorithm_sid, no_isis_sr_prefix_sid_algorithm_cmd,
 	"no segment-routing prefix <A.B.C.D/M|X:X::X:X/M>$prefix\
               algorithm (128-255)$algorithm\
-              [<absolute$sid_type (16-1048575)|index (0-65535)> [<no-php-flag|explicit-null>]]\
+              [<absolute$sid_type (16-1048575)|index (0-1048575)> [<no-php-flag|explicit-null>]]\
               [n-flag-clear]",
 	NO_STR SR_STR
 	"Prefix SID\n"

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2086,20 +2086,6 @@ int isis_instance_segment_routing_label_blocks_pre_validate(struct nb_cb_pre_val
 	srlb_lbound = yang_dnode_get_uint32(args->dnode, "srlb/lower-bound");
 	srlb_ubound = yang_dnode_get_uint32(args->dnode, "srlb/upper-bound");
 
-	/* Check that the block size does not exceed 65535 */
-	if ((srgb_ubound - srgb_lbound + 1) > 65535) {
-		snprintf(args->errmsg, args->errmsg_len,
-			 "New SR Global Block (%u/%u) exceed the limit of 65535", srgb_lbound,
-			 srgb_ubound);
-		return NB_ERR_VALIDATION;
-	}
-	if ((srlb_ubound - srlb_lbound + 1) > 65535) {
-		snprintf(args->errmsg, args->errmsg_len,
-			 "New SR Local Block (%u/%u) exceed the limit of 65535", srlb_lbound,
-			 srlb_ubound);
-		return NB_ERR_VALIDATION;
-	}
-
 	/* Validate SRGB against SRLB */
 	if (!((srgb_ubound < srlb_lbound) || (srgb_lbound > srlb_ubound))) {
 		snprintf(args->errmsg, args->errmsg_len,


### PR DESCRIPTION
There is no technical reasons to limit the size of label pools in ISIS.