### PR TITLE
babeld: keep reading after dropping a datagram from a non-Babel port

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -167,31 +167,33 @@ static void babel_read_protocol(struct event *event)
 	assert(babel_routing_process != NULL);
 	assert(protocol_socket >= 0);
 
+	/* Re-arm the receive event before reading, so an early return
+	 * below can never leave the protocol socket unobserved.
+	 */
+	event_add_read(master, &babel_read_protocol, NULL, protocol_socket,
+		       &babel_routing_process->t_read);
+
 	rc = babel_recv(protocol_socket, receive_buffer, receive_buffer_size,
 			(struct sockaddr *)&sin6, sizeof(sin6));
 	if (rc < 0) {
 		if (errno != EAGAIN && errno != EINTR) {
 			flog_err_sys(EC_LIB_SOCKET, "recv: %s", safe_strerror(errno));
 		}
-	} else {
-		if (ntohs(sin6.sin6_port) != BABEL_PORT) {
-			return;
-		}
-
-		FOR_ALL_INTERFACES (vrf, ifp) {
-			if (!if_up(ifp))
-				continue;
-			if (ifp->ifindex == (ifindex_t)sin6.sin6_scope_id) {
-				parse_packet((unsigned char *)&sin6.sin6_addr, ifp, receive_buffer,
-					     rc);
-				break;
-			}
-		}
+		return;
 	}
 
-	/* re-add event */
-	event_add_read(master, &babel_read_protocol, NULL, protocol_socket,
-		       &babel_routing_process->t_read);
+	if (ntohs(sin6.sin6_port) != BABEL_PORT)
+		return;
+
+	FOR_ALL_INTERFACES (vrf, ifp) {
+		if (!if_up(ifp))
+			continue;
+		if (ifp->ifindex == (ifindex_t)sin6.sin6_scope_id) {
+			parse_packet((unsigned char *)&sin6.sin6_addr, ifp, receive_buffer,
+				     rc);
+			break;
+		}
+	}
 }
 
 /* Zebra will give some information, especially about interfaces. This function


### PR DESCRIPTION
# babeld: keep reading after dropping a datagram from a non-Babel port

## Problem

The source port check added in 6f88868f ("babeld: ignore packets not
sent from the Babel port", PR #18583) returns from
`babel_read_protocol()` before the receive event is re-armed:

```c
if (ntohs(sin6.sin6_port) != BABEL_PORT) {
    return;   /* skips event_add_read() below */
}
...
/* re-add event */
event_add_read(master, &babel_read_protocol, NULL, protocol_socket, ...);
```

The `event_add_read()` call at the end of the receive path is the only
place the protocol socket is re-armed.  After the first datagram from a
non-Babel source port (for example a port scan or a misconfigured
neighbor), the daemon stops polling the socket and silently stops
handling all Babel traffic.

## Fix

Restructure the check so datagrams from other source ports are silently
ignored (RFC 8966 section 4: "unless the source address is
syntactically valid and the source port is the well-known Babel port,
the packet MUST be silently ignored") without skipping the
`event_add_read()` at the end of the receive path.  The parse loop now
only runs when the source port is the Babel port, and the receive event
is re-armed unconditionally.
