### PR TITLE
babeld: reject seqno requests with an all-zero or all-ones router id

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -2057,6 +2057,16 @@ void handle_request(struct neighbour *neigh, const unsigned char *prefix, unsign
 	struct babel_route *route;
 	struct neighbour *successor = NULL;
 
+	/* RFC 8966 section 4.6.11: the router id in a seqno request must
+	 * not be all-zero or all-ones; a request carrying a reserved
+	 * value is not answerable and must not be forwarded either.
+	 */
+	if (is_all_zero(id, 8) || is_all_ones(id, 8)) {
+		debugf(BABEL_DEBUG_COMMON, "Received request with invalid router id %s.",
+		       format_eui64(id));
+		return;
+	}
+
 	xroute = find_xroute(prefix, plen);
 	route = find_installed_route(prefix, plen);
 


### PR DESCRIPTION
# babeld: reject seqno requests with an all-zero or all-ones router id

## Problem

A Seqno Request (MESSAGE_MH_REQUEST) carries the router id of the
source whose seqno is being requested.  RFC 8966 section 4.6.11
requires this router id not to be all-zero or all-ones, and section
4.1.3 defines both values as reserved.

The parse path validated the prefix and the hop count, but passed the
8-byte router id at TLV body offset 6 straight to `handle_request()`.
`handle_request()` compares the value against the local `myid` and the
ids of selected routes, and may answer with an Update, bump the local
seqno, forward the request, or record it in the recently-forwarded
request state — all driven by a reserved value from a remote peer.

## Fix

Validate the 8-byte router id in the `MESSAGE_MH_REQUEST` branch before
calling `handle_request()` and reject the whole Seqno Request on an
all-zero or all-ones value, mirroring the check already applied to the
Router-Id TLV in the `MESSAGE_ROUTER_ID` branch.
