### PR TITLE
bfdd: initialize DesiredMinTxInterval to at least 1 second

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -497,7 +497,7 @@ struct sbfd_reflector {
 /* Retrieved from ptm_timer.h from Cumulus PTM sources. */
 #define BFD_DEF_DEMAND 0
 #define BFD_DEFDETECTMULT 3
-#define BFD_DEFDESIREDMINTX (300 * 1000) /* microseconds. */
+#define BFD_DEFDESIREDMINTX (1000 * 1000) /* microseconds. */
 #define BFD_DEFREQUIREDMINRX (300 * 1000) /* microseconds. */
 #define BFD_DEF_DES_MIN_ECHO_TX (50 * 1000) /* microseconds. */
 #define BFD_DEF_REQ_MIN_ECHO_RX (50 * 1000) /* microseconds. */


### PR DESCRIPTION
# bfdd: initialize DesiredMinTxInterval to at least 1 second

## Problem

RFC 5880 section 6.8.1: `bfd.DesiredMinTxInterval` "MUST be initialized
to a value of at least one second (1,000,000 microseconds)", and
section 6.8.3 requires a value of not less than one second while the
session is not Up.

The default `BFD_DEFDESIREDMINTX` was 300 ms.  New sessions initialized
`timers.desired_min_tx` to 300 ms, which was advertised to the peer
while the session was still coming Up (the slow-timer clamp applied on
the transmit path masked the violation on the wire, but the state
variable itself, which is also used as the default in profiles and
templates, was non-compliant).

## Fix

Change the default to 1 second:

```c
#define BFD_DEFDESIREDMINTX (1000 * 1000) /* microseconds. */
```

This fixes the initial value of new sessions and of profiles at the
source.
