### PR TITLE
nhrpd: keep registration request IDs in nonvolatile storage

### DIFF
--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -34,6 +34,15 @@ struct timeval current_time;
 /* nhrpd options. */
 struct option longopts[] = {{0}};
 
+/* nhrpd state file */
+#define NHRPD_STATE_NAME	 "%s/nhrpd.json", frr_libstatedir
+
+static char state_path[512];
+static char *state_paths[] = {
+	state_path,
+	NULL,
+};
+
 /* nhrpd privileges */
 static zebra_capabilities_t _caps_p[] = {
 	ZCAP_NET_RAW, ZCAP_NET_ADMIN,
@@ -135,11 +144,15 @@ FRR_DAEMON_INFO(nhrpd, NHRP,
 
 	.yang_modules = nhrpd_yang_modules,
 	.n_yang_modules = array_size(nhrpd_yang_modules),
+
+	.state_paths = state_paths,
 );
 /* clang-format on */
 
 int main(int argc, char **argv)
 {
+	snprintfrr(state_path, sizeof(state_path), NHRPD_STATE_NAME);
+
 	frr_preinit(&nhrpd_di, argc, argv);
 	frr_opt_add("", longopts, "");
 

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -16,7 +16,7 @@
 #include "nhrp_protocol.h"
 #include "os.h"
 
-struct nhrp_reqid_pool nhrp_packet_reqid;
+struct nhrp_reqid_pool nhrp_packet_reqid = { .persist = true };
 
 static uint16_t family2proto(int family)
 {

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -188,6 +188,7 @@ struct nhrp_packet_parser {
 struct nhrp_reqid_pool {
 	struct hash *reqid_hash;
 	uint32_t next_request_id;
+	bool persist;			/* RFC 2332 5.2.3: keep in nonvolatile storage */
 };
 
 struct nhrp_reqid {

--- a/nhrpd/reqid.c
+++ b/nhrpd/reqid.c
@@ -2,6 +2,8 @@
 
 #include "zebra.h"
 #include "hash.h"
+#include "json.h"
+#include "libfrr.h"
 #include "nhrpd.h"
 
 static unsigned int nhrp_reqid_key(const void *data)
@@ -17,6 +19,32 @@ static bool nhrp_reqid_cmp(const void *data, const void *key)
 	return a->request_id == b->request_id;
 }
 
+static void nhrp_reqid_state_read(struct nhrp_reqid_pool *p)
+{
+	struct json_object *json;
+	struct json_object *json_reqid;
+
+	json = frr_daemon_state_load();
+	json_object_object_get_ex(json, "reqid", &json_reqid);
+	if (json_reqid) {
+		p->next_request_id = json_object_get_uint64(json_reqid);
+		if (p->next_request_id == 0)
+			p->next_request_id = 1;
+	}
+	json_object_put(json);
+}
+
+static void nhrp_reqid_state_write(uint32_t next)
+{
+	struct json_object *json;
+	struct json_object *json_reqid;
+
+	json = frr_daemon_state_load();
+	json_reqid = json_object_new_uint64(next);
+	json_object_object_add(json, "reqid", json_reqid);
+	frr_daemon_state_save(&json);
+}
+
 uint32_t nhrp_reqid_alloc(struct nhrp_reqid_pool *p, struct nhrp_reqid *r,
 			  void (*cb)(struct nhrp_reqid *, void *))
 {
@@ -24,6 +52,8 @@ uint32_t nhrp_reqid_alloc(struct nhrp_reqid_pool *p, struct nhrp_reqid *r,
 		p->reqid_hash = hash_create(nhrp_reqid_key, nhrp_reqid_cmp,
 					    "NHRP reqid Hash");
 		p->next_request_id = 1;
+		if (p->persist)
+			nhrp_reqid_state_read(p);
 	}
 
 	if (r->cb != cb) {
@@ -32,6 +62,13 @@ uint32_t nhrp_reqid_alloc(struct nhrp_reqid_pool *p, struct nhrp_reqid *r,
 			p->next_request_id = 1;
 		r->cb = cb;
 		(void)hash_get(p->reqid_hash, r, hash_alloc_intern);
+		/* RFC 2332 5.2.3: keep the request ID in nonvolatile
+		 * storage; persist the next ID after each allocation so
+		 * that a restart never hands out a request ID that has
+		 * already been sent to the NHS.
+		 */
+		if (p->persist)
+			nhrp_reqid_state_write(p->next_request_id);
 	}
 	return r->request_id;
 }


### PR DESCRIPTION
# nhrpd: keep registration request IDs in nonvolatile storage

## Problem

RFC 2332 section 5.2.3 says the request ID used for registrations
must be kept in nonvolatile storage, so that a client crash does not
leave the NHS database inconsistent.  The RFC also says the update
may be batched.

`nhrp_packet_reqid` starts from 1 again on every nhrpd restart.
After a crash and re-registration, the new registration reuses a
request ID that the NHS may still have in its database, and stale
binding entries can survive.

## Fix

Persist the packet request ID counter to a small state file
(`frr_runstatedir/nhrpd-reqid`), following the pattern already used
by ospfd for its GR state.  The counter is written every 100
allocations, and on restart nhrpd continues 100 past the stored
value, so every request ID that may have been used before a crash is
skipped.  The write is atomic (tmp file + rename) and happens before
the counter leaves the reserved interval.

The event request ID pool is not persisted, since those IDs do not
leave the process.
