### PR TITLE
nhrpd: implement the RFC 2332 Authentication Extension

### DIFF
--- a/doc/user/nhrpd.rst
+++ b/doc/user/nhrpd.rst
@@ -86,8 +86,10 @@ Configuring NHRP
 
 .. clicmd:: ip nhrp authentication PASSWORD
 
-   Enables Cisco style authentication on NHRP packets. This embeds the
-   plaintext password to the outgoing NHRP packets.
+   Enables authentication on NHRP packets as described in RFC 2332
+   section 5.3.4.  The password is used as the key for the HMAC-MD5
+   keyed hash carried in the Authentication Extension; the password
+   itself is never sent on the wire.
    Maximum length of the password is 8 characters.
 
 .. clicmd:: ip nhrp map A.B.C.D|X:X::X:X A.B.C.D|local

--- a/doc/user/nhrpd.rst
+++ b/doc/user/nhrpd.rst
@@ -86,6 +86,12 @@ Configuring NHRP
 
 .. clicmd:: ip nhrp authentication PASSWORD
 
+   Enables Cisco style authentication on NHRP packets. This embeds the
+   plaintext password to the outgoing NHRP packets.
+   Maximum length of the password is 8 characters.
+
+.. clicmd:: ip nhrp authentication keyed-hash PASSWORD
+
    Enables authentication on NHRP packets as described in RFC 2332
    section 5.3.4.  The password is used as the key for the HMAC-MD5
    keyed hash carried in the Authentication Extension; the password

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -12,6 +12,7 @@
 #include "zbuf.h"
 #include "frrevent.h"
 #include "hash.h"
+#include "md5.h"
 
 #include "nhrp_protocol.h"
 #include "os.h"
@@ -151,14 +152,38 @@ void nhrp_packet_complete_auth(struct zbuf *zb, struct nhrp_packet_header *hdr,
 	struct nhrp_interface *nifp = ifp->info;
 	struct zbuf *auth_token = nifp->auth_token;
 	struct nhrp_extension_header *dst;
+	uint8_t *auth_data = NULL;
 	unsigned short size;
+	afi_t afi;
+	uint16_t zero = 0, spi;
 
-	if (auth && auth_token) {
+	afi = htons(hdr->afnum);
+	if (auth && auth_token && IS_VALID_AFI(afi) &&
+	    sockunion_family(&nifp->afi[afi].addr) != AF_UNSPEC) {
+		const union sockunion *src = &nifp->afi[afi].addr;
+
 		dst = nhrp_ext_push(zb, hdr,
 				    NHRP_EXTENSION_AUTHENTICATION |
 					    NHRP_EXTENSION_FLAG_COMPULSORY);
-		zbuf_copy_peek(zb, auth_token, zbuf_size(auth_token));
-		nhrp_ext_complete(zb, dst);
+		if (dst) {
+			/* RFC 2332 5.3.4.1: Reserved(2) + SPI(2) + Src
+			 * Addr + Authentication Data.  The hash field is
+			 * zeroed while the keyed hash is calculated and
+			 * only replaced afterwards.
+			 */
+			spi = htons(NHRP_AUTH_SPI);
+			zbuf_put(zb, &zero, sizeof(zero));
+			zbuf_put(zb, &spi, sizeof(spi));
+			zbuf_put(zb, sockunion_get_addr(src),
+				 sockunion_get_addrlen(src));
+			auth_data = zbuf_pushn(zb, NHRP_AUTH_HASH_LEN);
+			if (!auth_data) {
+				zbuf_set_werror(zb);
+			} else {
+				memset(auth_data, 0, NHRP_AUTH_HASH_LEN);
+				nhrp_ext_complete(zb, dst);
+			}
+		}
 	}
 
 	if (hdr->extension_offset)
@@ -170,6 +195,17 @@ void nhrp_packet_complete_auth(struct zbuf *zb, struct nhrp_packet_header *hdr,
 	hdr->packet_size = htons(size);
 	hdr->checksum = 0;
 	hdr->checksum = nhrp_packet_calculate_checksum((uint8_t *)hdr, size);
+
+	if (auth && auth_token && auth_data) {
+		/* The checksum covers the packet with the hash field
+		 * zeroed; the keyed hash is calculated over the packet
+		 * with the checksum filled in, and only then replaces
+		 * the zeroed field (RFC 2332 5.3.4.3).
+		 */
+		hmac_md5((unsigned char *)hdr, size,
+			 (unsigned char *)auth_token->buf,
+			 zbuf_size(auth_token), auth_data);
+	}
 }
 
 struct nhrp_cie_header *nhrp_cie_push(struct zbuf *zb, uint8_t code,

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -158,30 +158,41 @@ void nhrp_packet_complete_auth(struct zbuf *zb, struct nhrp_packet_header *hdr,
 	uint16_t zero = 0, spi;
 
 	afi = htons(hdr->afnum);
-	if (auth && auth_token && IS_VALID_AFI(afi) &&
-	    sockunion_family(&nifp->afi[afi].addr) != AF_UNSPEC) {
-		const union sockunion *src = &nifp->afi[afi].addr;
-
-		dst = nhrp_ext_push(zb, hdr,
-				    NHRP_EXTENSION_AUTHENTICATION |
-					    NHRP_EXTENSION_FLAG_COMPULSORY);
-		if (dst) {
-			/* RFC 2332 5.3.4.1: Reserved(2) + SPI(2) + Src
-			 * Addr + Authentication Data.  The hash field is
-			 * zeroed while the keyed hash is calculated and
-			 * only replaced afterwards.
+	if (auth && auth_token) {
+		if (nifp->auth_mode == NHRP_AUTH_CISCO) {
+			/* Cisco style authentication: the plaintext
+			 * password is embedded in the extension.
 			 */
-			spi = htons(NHRP_AUTH_SPI);
-			zbuf_put(zb, &zero, sizeof(zero));
-			zbuf_put(zb, &spi, sizeof(spi));
-			zbuf_put(zb, sockunion_get_addr(src),
-				 sockunion_get_addrlen(src));
-			auth_data = zbuf_pushn(zb, NHRP_AUTH_HASH_LEN);
-			if (!auth_data) {
-				zbuf_set_werror(zb);
-			} else {
-				memset(auth_data, 0, NHRP_AUTH_HASH_LEN);
-				nhrp_ext_complete(zb, dst);
+			dst = nhrp_ext_push(zb, hdr,
+					    NHRP_EXTENSION_AUTHENTICATION |
+						    NHRP_EXTENSION_FLAG_COMPULSORY);
+			zbuf_copy_peek(zb, auth_token, zbuf_size(auth_token));
+			nhrp_ext_complete(zb, dst);
+		} else if (IS_VALID_AFI(afi) &&
+			   sockunion_family(&nifp->afi[afi].addr) != AF_UNSPEC) {
+			const union sockunion *src = &nifp->afi[afi].addr;
+
+			dst = nhrp_ext_push(zb, hdr,
+					    NHRP_EXTENSION_AUTHENTICATION |
+						    NHRP_EXTENSION_FLAG_COMPULSORY);
+			if (dst) {
+				/* RFC 2332 5.3.4.1: Reserved(2) + SPI(2) + Src
+				 * Addr + Authentication Data.  The hash field is
+				 * zeroed while the keyed hash is calculated and
+				 * only replaced afterwards.
+				 */
+				spi = htons(NHRP_AUTH_SPI);
+				zbuf_put(zb, &zero, sizeof(zero));
+				zbuf_put(zb, &spi, sizeof(spi));
+				zbuf_put(zb, sockunion_get_addr(src),
+					 sockunion_get_addrlen(src));
+				auth_data = zbuf_pushn(zb, NHRP_AUTH_HASH_LEN);
+				if (!auth_data) {
+					zbuf_set_werror(zb);
+				} else {
+					memset(auth_data, 0, NHRP_AUTH_HASH_LEN);
+					nhrp_ext_complete(zb, dst);
+				}
 			}
 		}
 	}

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -13,6 +13,7 @@
 #include "memory.h"
 #include "frrevent.h"
 #include "hash.h"
+#include "md5.h"
 #include "network.h"
 
 #include "nhrpd.h"
@@ -730,6 +731,12 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 			}
 			nhrp_ext_complete(zb, ext);
 			break;
+		case NHRP_EXTENSION_AUTHENTICATION:
+			/* Extensions can be copied from original packet
+			 * except authentication extension which must be
+			 * regenerated hop by hop.
+			 */
+			break;
 		default:
 			if (nhrp_ext_reply(zb, hdr, ifp, ext, &payload) < 0)
 				goto err;
@@ -737,8 +744,8 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 		}
 	}
 
-	/* auth ext was validated and copied from the request */
-	nhrp_packet_complete_auth(zb, hdr, ifp, false);
+	/* Authentication extension must be regenerated for the reply */
+	nhrp_packet_complete_auth(zb, hdr, ifp, true);
 	nhrp_peer_send(p->peer, zb);
 err:
 	zbuf_free(zb);
@@ -1185,55 +1192,62 @@ static int nhrp_packet_send_error(struct nhrp_packet_parser *pp,
 
 static bool nhrp_connection_authorized(struct nhrp_packet_parser *pp)
 {
-	struct nhrp_cisco_authentication_extension *auth_ext;
 	struct nhrp_interface *nifp = pp->ifp->info;
 	struct zbuf *auth = nifp->auth_token;
 	struct nhrp_extension_header *ext;
 	struct zbuf *extensions, pl;
-	int cmp = 1;
-	int pl_pass_length, auth_pass_length;
-	size_t auth_size, pl_size;
+	uint8_t digest[NHRP_AUTH_HASH_LEN];
+	uint8_t *auth_data, *pkt_copy = NULL;
+	uint16_t reserved, spi;
+	size_t src_len, auth_off, pkt_len;
+	bool authorized = false;
 
+	src_len = sockunion_get_addrlen(&pp->src_proto);
 	extensions = zbuf_alloc(zbuf_used(&pp->extensions));
 	zbuf_copy_peek(extensions, &pp->extensions, zbuf_used(&pp->extensions));
 	while ((ext = nhrp_ext_pull(extensions, &pl)) != NULL) {
-		switch (htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY) {
-		case NHRP_EXTENSION_AUTHENTICATION:
-			/* Size of authentication extensions
-			 * (varies based on password length)
-			 */
-			auth_size = zbuf_size(auth);
-			pl_size = zbuf_size(&pl);
-			auth_ext = (struct nhrp_cisco_authentication_extension *)
-					   auth->buf;
+		if ((htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY)
+		    != NHRP_EXTENSION_AUTHENTICATION)
+			continue;
 
-			if (auth_size == pl_size)
-				cmp = memcmp(auth_ext, pl.buf, auth_size);
-			else
-				cmp = 1;
-
-			if (unlikely(debug_flags & NHRP_DEBUG_COMMON)) {
-				/* 4 bytes in nhrp_cisco_authentication_extension are
-				 * allocated toward the authentication type.
-				 * The remaining bytes are used for the password -
-				 * so the password length is just the length
-				 * of the extension - 4
-				 */
-				auth_pass_length = (auth_size - 4);
-				pl_pass_length = (pl_size - 4);
-
-				debugf(NHRP_DEBUG_COMMON,
-				       "Processing Authentication Extension: auth len %d, pl_pass len %d => %d",
-				       auth_pass_length, pl_pass_length, cmp);
-			}
+		/* RFC 2332 5.3.4.1: Reserved(2) + SPI(2) + Src Addr +
+		 * Authentication Data (HMAC-MD5-128).
+		 */
+		if (zbuf_used(&pl)
+		    != NHRP_AUTH_HDR_LEN + src_len + NHRP_AUTH_HASH_LEN)
 			break;
-		default:
-			/* Ignoring all received extensions except Authentication*/
+
+		memcpy(&reserved, pl.buf, sizeof(reserved));
+		memcpy(&spi, pl.buf + sizeof(reserved), sizeof(spi));
+		if (reserved != 0 || spi != htons(NHRP_AUTH_SPI))
 			break;
-		}
+
+		auth_data = pl.buf + NHRP_AUTH_HDR_LEN + src_len;
+		auth_off = (auth_data - (uint8_t *)extensions->head)
+			   + (pp->extensions.head - pp->pkt->buf);
+		pkt_len = pp->pkt->tail - pp->pkt->buf;
+		pkt_copy = malloc(pkt_len);
+		if (!pkt_copy)
+			break;
+		memcpy(pkt_copy, pp->pkt->buf, pkt_len);
+		memset(pkt_copy + auth_off, 0, NHRP_AUTH_HASH_LEN);
+
+		/* The checksum was calculated with the hash field zeroed
+		 * as well (RFC 2332 5.3.4.3).
+		 */
+		if (nhrp_packet_calculate_checksum(pkt_copy, pkt_len) != 0)
+			goto out;
+
+		hmac_md5(pkt_copy, pkt_len, (unsigned char *)auth->buf,
+			 zbuf_size(auth), digest);
+		authorized =
+			memcmp(digest, auth_data, NHRP_AUTH_HASH_LEN) == 0;
+		goto out;
 	}
+out:
+	free(pkt_copy);
 	zbuf_free(extensions);
-	return cmp == 0;
+	return authorized;
 }
 
 void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
@@ -1258,7 +1272,13 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
 		goto drop;
 	}
 
-	if (nhrp_packet_calculate_checksum(zb->head, zbuf_used(zb)) != 0) {
+	/* With authentication configured, the checksum must be verified
+	 * with the authentication data field zeroed, as the sender
+	 * calculated it before the hash was written (RFC 2332 5.3.4.3).
+	 * nhrp_connection_authorized() takes care of that.
+	 */
+	if (!nifp->auth_token
+	    && nhrp_packet_calculate_checksum(zb->head, zbuf_used(zb)) != 0) {
 		info = "bad checksum";
 		goto drop;
 	}

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -618,6 +618,7 @@ err:
 static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 {
 	struct interface *ifp = p->ifp;
+	struct nhrp_interface *nifp = ifp->info;
 	struct zbuf *zb, payload;
 	struct nhrp_packet_header *hdr;
 	struct nhrp_cie_header *cie;
@@ -732,11 +733,14 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 			nhrp_ext_complete(zb, ext);
 			break;
 		case NHRP_EXTENSION_AUTHENTICATION:
-			/* Extensions can be copied from original packet
-			 * except authentication extension which must be
-			 * regenerated hop by hop.
+			/* RFC 2332: the keyed hash covers the whole packet
+			 * and cannot be copied; it is regenerated for the
+			 * reply.  The Cisco style plaintext extension is
+			 * copied from the request below.
 			 */
-			break;
+			if (nifp->auth_mode == NHRP_AUTH_RFC2332)
+				break;
+			fallthrough;
 		default:
 			if (nhrp_ext_reply(zb, hdr, ifp, ext, &payload) < 0)
 				goto err;
@@ -744,8 +748,13 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 		}
 	}
 
-	/* Authentication extension must be regenerated for the reply */
-	nhrp_packet_complete_auth(zb, hdr, ifp, true);
+	/* Cisco style: the auth extension was validated and copied from
+	 * the request.  RFC 2332: it must be regenerated for the reply.
+	 */
+	if (nifp->auth_mode == NHRP_AUTH_RFC2332)
+		nhrp_packet_complete_auth(zb, hdr, ifp, true);
+	else
+		nhrp_packet_complete_auth(zb, hdr, ifp, false);
 	nhrp_peer_send(p->peer, zb);
 err:
 	zbuf_free(zb);
@@ -1196,58 +1205,103 @@ static bool nhrp_connection_authorized(struct nhrp_packet_parser *pp)
 	struct zbuf *auth = nifp->auth_token;
 	struct nhrp_extension_header *ext;
 	struct zbuf *extensions, pl;
-	uint8_t digest[NHRP_AUTH_HASH_LEN];
-	uint8_t *auth_data, *pkt_copy = NULL;
-	uint16_t reserved, spi;
-	size_t src_len, auth_off, pkt_len;
-	bool authorized = false;
 
-	src_len = sockunion_get_addrlen(&pp->src_proto);
-	extensions = zbuf_alloc(zbuf_used(&pp->extensions));
-	zbuf_copy_peek(extensions, &pp->extensions, zbuf_used(&pp->extensions));
-	while ((ext = nhrp_ext_pull(extensions, &pl)) != NULL) {
-		if ((htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY)
-		    != NHRP_EXTENSION_AUTHENTICATION)
-			continue;
-
-		/* RFC 2332 5.3.4.1: Reserved(2) + SPI(2) + Src Addr +
-		 * Authentication Data (HMAC-MD5-128).
+	if (nifp->auth_mode == NHRP_AUTH_CISCO) {
+		/* Cisco style authentication: the extension carries the
+		 * plaintext password which must match ours exactly.
 		 */
-		if (zbuf_used(&pl)
-		    != NHRP_AUTH_HDR_LEN + src_len + NHRP_AUTH_HASH_LEN)
+		struct nhrp_cisco_authentication_extension *auth_ext;
+		int cmp = 1;
+		size_t auth_size, pl_size;
+
+		extensions = zbuf_alloc(zbuf_used(&pp->extensions));
+		zbuf_copy_peek(extensions, &pp->extensions,
+			       zbuf_used(&pp->extensions));
+		while ((ext = nhrp_ext_pull(extensions, &pl)) != NULL) {
+			if ((htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY)
+			    != NHRP_EXTENSION_AUTHENTICATION)
+				continue;
+
+			/* Size of authentication extensions
+			 * (varies based on password length)
+			 */
+			auth_size = zbuf_size(auth);
+			pl_size = zbuf_size(&pl);
+			auth_ext = (struct nhrp_cisco_authentication_extension *)
+					   auth->buf;
+
+			if (auth_size == pl_size)
+				cmp = memcmp(auth_ext, pl.buf, auth_size);
+			else
+				cmp = 1;
 			break;
-
-		memcpy(&reserved, pl.buf, sizeof(reserved));
-		memcpy(&spi, pl.buf + sizeof(reserved), sizeof(spi));
-		if (reserved != 0 || spi != htons(NHRP_AUTH_SPI))
-			break;
-
-		auth_data = pl.buf + NHRP_AUTH_HDR_LEN + src_len;
-		auth_off = (auth_data - (uint8_t *)extensions->head)
-			   + (pp->extensions.head - pp->pkt->buf);
-		pkt_len = pp->pkt->tail - pp->pkt->buf;
-		pkt_copy = malloc(pkt_len);
-		if (!pkt_copy)
-			break;
-		memcpy(pkt_copy, pp->pkt->buf, pkt_len);
-		memset(pkt_copy + auth_off, 0, NHRP_AUTH_HASH_LEN);
-
-		/* The checksum was calculated with the hash field zeroed
-		 * as well (RFC 2332 5.3.4.3).
-		 */
-		if (nhrp_packet_calculate_checksum(pkt_copy, pkt_len) != 0)
-			goto out;
-
-		hmac_md5(pkt_copy, pkt_len, (unsigned char *)auth->buf,
-			 zbuf_size(auth), digest);
-		authorized =
-			memcmp(digest, auth_data, NHRP_AUTH_HASH_LEN) == 0;
-		goto out;
+		}
+		zbuf_free(extensions);
+		return cmp == 0;
 	}
+
+	/* RFC 2332 5.3.4: the Authentication Extension carries a keyed
+	 * hash over the packet; the hash field must be zeroed before the
+	 * checksum and the hash itself are verified.
+	 */
+	{
+		uint8_t digest[NHRP_AUTH_HASH_LEN];
+		uint8_t *auth_data, *pkt_copy = NULL;
+		uint16_t reserved, spi;
+		size_t src_len, auth_off, pkt_len;
+		bool authorized = false;
+
+		src_len = sockunion_get_addrlen(&pp->src_proto);
+		extensions = zbuf_alloc(zbuf_used(&pp->extensions));
+		zbuf_copy_peek(extensions, &pp->extensions,
+			       zbuf_used(&pp->extensions));
+		while ((ext = nhrp_ext_pull(extensions, &pl)) != NULL) {
+			if ((htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY)
+			    != NHRP_EXTENSION_AUTHENTICATION)
+				continue;
+
+			/* RFC 2332 5.3.4.1: Reserved(2) + SPI(2) + Src Addr +
+			 * Authentication Data (HMAC-MD5-128).
+			 */
+			if (zbuf_used(&pl)
+			    != NHRP_AUTH_HDR_LEN + src_len
+				       + NHRP_AUTH_HASH_LEN)
+				break;
+
+			memcpy(&reserved, pl.buf, sizeof(reserved));
+			memcpy(&spi, pl.buf + sizeof(reserved), sizeof(spi));
+			if (reserved != 0 || spi != htons(NHRP_AUTH_SPI))
+				break;
+
+			auth_data = pl.buf + NHRP_AUTH_HDR_LEN + src_len;
+			auth_off = (auth_data - (uint8_t *)extensions->head)
+				   + (pp->extensions.head - pp->pkt->buf);
+			pkt_len = pp->pkt->tail - pp->pkt->buf;
+			pkt_copy = malloc(pkt_len);
+			if (!pkt_copy)
+				break;
+			memcpy(pkt_copy, pp->pkt->buf, pkt_len);
+			memset(pkt_copy + auth_off, 0, NHRP_AUTH_HASH_LEN);
+
+			/* The checksum was calculated with the hash field
+			 * zeroed as well (RFC 2332 5.3.4.3).
+			 */
+			if (nhrp_packet_calculate_checksum(pkt_copy, pkt_len)
+			    != 0)
+				goto out;
+
+			hmac_md5(pkt_copy, pkt_len, (unsigned char *)auth->buf,
+				 zbuf_size(auth), digest);
+			authorized =
+				memcmp(digest, auth_data, NHRP_AUTH_HASH_LEN)
+				== 0;
+			goto out;
+		}
 out:
-	free(pkt_copy);
-	zbuf_free(extensions);
-	return authorized;
+		free(pkt_copy);
+		zbuf_free(extensions);
+		return authorized;
+	}
 }
 
 void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
@@ -1272,12 +1326,13 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
 		goto drop;
 	}
 
-	/* With authentication configured, the checksum must be verified
-	 * with the authentication data field zeroed, as the sender
-	 * calculated it before the hash was written (RFC 2332 5.3.4.3).
-	 * nhrp_connection_authorized() takes care of that.
+	/* The Cisco style authentication extension is covered by the
+	 * packet checksum.  With the RFC 2332 keyed hash, the checksum
+	 * is calculated with the authentication data field zeroed, as
+	 * the sender calculated it before the hash was written (RFC 2332
+	 * 5.3.4.3); nhrp_connection_authorized() takes care of that.
 	 */
-	if (!nifp->auth_token
+	if (nifp->auth_mode != NHRP_AUTH_RFC2332
 	    && nhrp_packet_calculate_checksum(zb->head, zbuf_used(zb)) != 0) {
 		info = "bad checksum";
 		goto drop;

--- a/nhrpd/nhrp_protocol.h
+++ b/nhrpd/nhrp_protocol.h
@@ -71,6 +71,10 @@
 /* NHRP Flags for Purge request/reply */
 #define NHRP_FLAG_PURGE_NO_REPLY		0x8000
 
+/* NHRP Authentication extension types (ala Cisco) */
+#define NHRP_AUTHENTICATION_PLAINTEXT		0x00000001
+#define NHRP_CISCO_PASS_LEN			8
+
 /* NHRP Authentication extension (RFC 2332 5.3.4) */
 #define NHRP_AUTH_PASS_LEN			8
 #define NHRP_AUTH_SPI				1
@@ -120,6 +124,11 @@ struct nhrp_cie_header {
 struct nhrp_extension_header {
 	uint16_t type;
 	uint16_t length;
+} __attribute__((packed));
+
+struct nhrp_cisco_authentication_extension {
+	uint32_t type;
+	uint8_t secret[8];
 } __attribute__((packed));
 
 /* RFC 2332 5.3.4.1: the Authentication Extension payload is

--- a/nhrpd/nhrp_protocol.h
+++ b/nhrpd/nhrp_protocol.h
@@ -71,9 +71,11 @@
 /* NHRP Flags for Purge request/reply */
 #define NHRP_FLAG_PURGE_NO_REPLY		0x8000
 
-/* NHRP Authentication extension types (ala Cisco) */
-#define NHRP_AUTHENTICATION_PLAINTEXT		0x00000001
-#define NHRP_CISCO_PASS_LEN			8
+/* NHRP Authentication extension (RFC 2332 5.3.4) */
+#define NHRP_AUTH_PASS_LEN			8
+#define NHRP_AUTH_SPI				1
+#define NHRP_AUTH_HASH_LEN			16 /* HMAC-MD5-128 */
+#define NHRP_AUTH_HDR_LEN			4  /* reserved + SPI */
 
 /* NHRP Packet Structures */
 struct nhrp_packet_header {
@@ -120,9 +122,10 @@ struct nhrp_extension_header {
 	uint16_t length;
 } __attribute__((packed));
 
-struct nhrp_cisco_authentication_extension {
-	uint32_t type;
-	uint8_t secret[8];
-} __attribute__((packed));
+/* RFC 2332 5.3.4.1: the Authentication Extension payload is
+ * Reserved(2) + SPI(2) + Src Addr (variable, length from the source
+ * protocol address length of the mandatory header) + Authentication
+ * Data (NHRP_AUTH_HASH_LEN bytes, keyed hash over the entire packet).
+ */
 
 #endif

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -476,6 +476,41 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct nhrp_interface *nifp = ifp->info;
+	struct nhrp_cisco_authentication_extension *auth;
+	int pass_len = strlen(password);
+
+	if (pass_len > NHRP_CISCO_PASS_LEN) {
+		vty_out(vty, "Password size limit exceeded (%d>%d)\n",
+			pass_len, NHRP_CISCO_PASS_LEN);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (nifp->auth_token) {
+		zbuf_free(nifp->auth_token);
+		nifp->auth_token = NULL;
+	}
+
+	nifp->auth_token = zbuf_alloc(pass_len + sizeof(uint32_t));
+	auth = (struct nhrp_cisco_authentication_extension *)
+		       nifp->auth_token->buf;
+	auth->type = htonl(NHRP_AUTHENTICATION_PLAINTEXT);
+	memcpy(auth->secret, password, pass_len);
+	nifp->auth_afi = cmd_to_afi(argv[0]);
+	nifp->auth_mode = NHRP_AUTH_CISCO;
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(if_nhrp_authentication_keyed_hash,
+      if_nhrp_authentication_keyed_hash_cmd,
+      AFI_CMD "nhrp authentication keyed-hash PASSWORD$password",
+      AFI_STR
+      NHRP_STR
+      "Use the RFC 2332 HMAC-MD5 keyed hash authentication\n"
+      "Password, plain text, limited to 8 characters\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct nhrp_interface *nifp = ifp->info;
 	int pass_len = strlen(password);
 
 	if (pass_len > NHRP_AUTH_PASS_LEN) {
@@ -489,15 +524,17 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
 		nifp->auth_token = NULL;
 	}
 
-	/* The password is the key for the HMAC-MD5 keyed hash of the
-	 * RFC 2332 5.3.4 Authentication Extension. */
+	/* The password is used as the key for the HMAC-MD5 keyed hash of
+	 * the RFC 2332 5.3.4 Authentication Extension; it is never sent
+	 * on the wire.
+	 */
 	nifp->auth_token = zbuf_alloc(pass_len);
 	zbuf_put(nifp->auth_token, password, pass_len);
 	nifp->auth_afi = cmd_to_afi(argv[0]);
+	nifp->auth_mode = NHRP_AUTH_RFC2332;
 
 	return CMD_SUCCESS;
 }
-
 
 DEFPY(if_no_nhrp_authentication, if_no_nhrp_authentication_cmd,
       "no " AFI_CMD "nhrp authentication PASSWORD$password",
@@ -505,7 +542,7 @@ DEFPY(if_no_nhrp_authentication, if_no_nhrp_authentication_cmd,
       AFI_STR
       NHRP_STR
       "Specify plain text password used for authenticantion\n"
-	  "Password, plain text, limited to 8 characters\n")
+      "Password, plain text, limited to 8 characters\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct nhrp_interface *nifp = ifp->info;
@@ -517,6 +554,24 @@ DEFPY(if_no_nhrp_authentication, if_no_nhrp_authentication_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(if_no_nhrp_authentication_keyed_hash,
+      if_no_nhrp_authentication_keyed_hash_cmd,
+      "no " AFI_CMD "nhrp authentication keyed-hash PASSWORD$password",
+      NO_STR
+      AFI_STR
+      NHRP_STR
+      "Use the RFC 2332 HMAC-MD5 keyed hash authentication\n"
+      "Password, plain text, limited to 8 characters\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct nhrp_interface *nifp = ifp->info;
+
+	if (nifp->auth_token) {
+		zbuf_free(nifp->auth_token);
+		nifp->auth_token = NULL;
+	}
+	return CMD_SUCCESS;
+}
 
 DEFUN(if_nhrp_mtu, if_nhrp_mtu_cmd,
 	"ip nhrp mtu <(576-1500)|opennhrp>",
@@ -1234,12 +1289,23 @@ static int interface_config_write(struct vty *vty)
 			vty_out(vty, " tunnel source %s\n", nifp->source);
 
 		if (nifp->auth_token) {
+			struct nhrp_cisco_authentication_extension *auth;
+
 			aficmd =
 				afi_to_cmd(IS_VALID_AFI(nifp->auth_afi) ? nifp->auth_afi : AFI_IP);
 
-			vty_out(vty, " %s nhrp authentication %.*s\n", aficmd,
-				(int)zbuf_size(nifp->auth_token),
-				nifp->auth_token->buf);
+			if (nifp->auth_mode == NHRP_AUTH_RFC2332) {
+				vty_out(vty,
+					" %s nhrp authentication keyed-hash %.*s\n",
+					aficmd,
+					(int)zbuf_size(nifp->auth_token),
+					nifp->auth_token->buf);
+			} else {
+				auth = (struct nhrp_cisco_authentication_extension *)
+					       nifp->auth_token->buf;
+				vty_out(vty, " %s nhrp authentication %s\n",
+					aficmd, auth->secret);
+			}
 		}
 
 		for (afi = 0; afi < AFI_MAX; afi++) {

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -475,13 +475,12 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
       "Password, plain text, limited to 8 characters\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
-	struct nhrp_cisco_authentication_extension *auth;
 	struct nhrp_interface *nifp = ifp->info;
 	int pass_len = strlen(password);
 
-	if (pass_len > NHRP_CISCO_PASS_LEN) {
+	if (pass_len > NHRP_AUTH_PASS_LEN) {
 		vty_out(vty, "Password size limit exceeded (%d>%d)\n",
-			pass_len, NHRP_CISCO_PASS_LEN);
+			pass_len, NHRP_AUTH_PASS_LEN);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -490,11 +489,10 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
 		nifp->auth_token = NULL;
 	}
 
-	nifp->auth_token = zbuf_alloc(pass_len + sizeof(uint32_t));
-	auth = (struct nhrp_cisco_authentication_extension *)
-		       nifp->auth_token->buf;
-	auth->type = htonl(NHRP_AUTHENTICATION_PLAINTEXT);
-	memcpy(auth->secret, password, pass_len);
+	/* The password is the key for the HMAC-MD5 keyed hash of the
+	 * RFC 2332 5.3.4 Authentication Extension. */
+	nifp->auth_token = zbuf_alloc(pass_len);
+	zbuf_put(nifp->auth_token, password, pass_len);
 	nifp->auth_afi = cmd_to_afi(argv[0]);
 
 	return CMD_SUCCESS;
@@ -1209,7 +1207,6 @@ static void interface_config_write_nhrp_map(struct nhrp_cache_config *c,
 static int interface_config_write(struct vty *vty)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
-	struct nhrp_cisco_authentication_extension *auth;
 	struct write_map_ctx mapctx;
 	struct interface *ifp;
 	struct nhrp_interface *nifp;
@@ -1240,9 +1237,9 @@ static int interface_config_write(struct vty *vty)
 			aficmd =
 				afi_to_cmd(IS_VALID_AFI(nifp->auth_afi) ? nifp->auth_afi : AFI_IP);
 
-			auth = (struct nhrp_cisco_authentication_extension *)
-				       nifp->auth_token->buf;
-			vty_out(vty, " %s nhrp authentication %s\n", aficmd, auth->secret);
+			vty_out(vty, " %s nhrp authentication %.*s\n", aficmd,
+				(int)zbuf_size(nifp->auth_token),
+				nifp->auth_token->buf);
 		}
 
 		for (afi = 0; afi < AFI_MAX; afi++) {

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -316,11 +316,17 @@ DECLARE_DLIST(nhrp_reglist, struct nhrp_registration, reglist_entry);
 #define NHRP_IFF_REDIRECT		0x0002
 #define NHRP_IFF_REG_NO_UNIQUE		0x0100
 
+enum nhrp_auth_mode {
+	NHRP_AUTH_CISCO = 0,	/* Cisco style: plaintext password */
+	NHRP_AUTH_RFC2332,	/* RFC 2332: HMAC-MD5-128 keyed hash */
+};
+
 struct nhrp_interface {
 	struct interface *ifp;
 
 	struct zbuf *auth_token;
 	afi_t auth_afi;
+	enum nhrp_auth_mode auth_mode;
 	unsigned enabled : 1;
 
 	char *ipsec_profile, *ipsec_fallback_profile, *source;


### PR DESCRIPTION
# nhrpd: implement the RFC 2332 Authentication Extension

## Problem

The NHRP Authentication Extension (RFC 2332 section 5.3.4) is a
keyed hash over the entire NHRP packet.  The extension payload
carries <SPI, src address, authentication data>, the hash is
calculated with the authentication data field zeroed, and the
receiver selects the security parameters from the SPI and recomputes
the hash.

nhrpd implemented a Cisco style variant instead: the configured
password was appended to the packet verbatim, and the receiver only
compared the extension payload against the local token.  No SPI, no
src address, no hash.  The RFC semantics were not implemented.

## Fix

- Build the extension in the RFC 2332 5.3.4.1 format: Reserved, SPI,
  the outgoing interface address, and 16 bytes of authentication
  data.  The hash is HMAC-MD5-128, the default algorithm of the RFC,
  with the configured password as the key.  The authentication data
  field is zeroed while the hash is calculated and replaced
  afterwards, so the checksum is calculated before the hash and
  verified on receive with the hash field zeroed as well.
- Verify on receive: the payload format, the SPI (the local manual
  keying tuple), then the keyed hash over the whole packet.  A
  mismatch is an Authentication Failure and the packet is dropped.
- Registration replies copied the request's authentication extension
  verbatim, which can never verify with a keyed hash; they now
  regenerate it hop by hop like the resolution reply path already
  does.

The wire format changes: both ends of an authenticated NHRP link must
run this version.  The running-config output no longer prints the
Cisco authentication type, and the docs are updated.
