### PR TITLE
zebra: fix kernel route deletion for IPv6 with DAD

### DIFF
--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -656,6 +656,44 @@ def test_zebra_kernel_last_ipv6_address_deleted():
     )
 
 
+def test_zebra_ipv6_dad_kernel_route():
+    "Test that a kernel route is deleted in favor of the connected one (IPv6 with DAD enabled)"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+    router.run("sysctl -w net.ipv6.conf.r1-eth0.accept_dad=1")
+    router.run("ip -6 address add 2001:db8:dead:beef::1/64 dev r1-eth0")
+
+    def _check_duplicated_kernel_route():
+        try:
+            routes = json.loads(router.vtysh_cmd("show ipv6 route json"))
+        except (json.JSONDecodeError, TypeError) as err:
+            return "failed to parse ipv6 routes: {}".format(err)
+
+        found_connected = False
+        for route_prefix, entries in routes.items():
+            if not route_prefix == "2001:db8:dead:beef::/64":
+                continue
+            for entry in entries:
+                if entry.get("protocol") == "connected":
+                    found_connected = True
+                elif entry.get("protocol") == "kernel":
+                    return "found ipv6 kernel route"
+
+        if not found_connected:
+            return "ipv6 connected route not found"
+        return None
+
+    step("IPv6 with DAD enabled: check for duplicated kernel route")
+    _, result = topotest.run_and_expect(
+        _check_duplicated_kernel_route, None, count=20, wait=1
+    )
+    assert result is None, result
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -216,8 +216,8 @@ static void connected_remove_kernel_for_connected(afi_t afi, safi_t safi, struct
 	if (re->type != ZEBRA_ROUTE_KERNEL)
 		return;
 
-	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_KERNEL, 0, 0, p, NULL, nh, 0,
-		   zvrf->table_id, 0, 0, false);
+	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_KERNEL, re->instance,
+		   re->flags, p, NULL, nh, 0, zvrf->table_id, re->metric, re->distance, false);
 }
 
 /* Called from if_up(). */


### PR DESCRIPTION
When an IPv6 address is added to an interface with DAD enabled, the kernel route enters the RIB before the connected address. When `connected_remove_kernel_for_connected()` later attempts to clean it up, the deletion silently fails because rib_delete() is called with a hardcoded metric of 0 instead of matching the actual metric (e.g., 256). This patch fixes the above by passing the route's exact metric, distance, flags and instance to ensure successful deletion and acts as a safety net. Note: this cannot be reproduced with dummy interfaces since they bypass DAD (and, therefore, related topotests should at some point take that into account).

How to reproduce:

$ sysctl net.ipv6.conf.mgmt0.accept_dad
net.ipv6.conf.mgmt0.accept_dad = 1

$ ip -details link show mgmt0
2: mgmt0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether de:ad:de:01:02:03 brd ff:ff:ff:ff:ff:ff promiscuity 0 allmulti 0 minmtu 68 maxmtu 65535 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 parentbus virtio parentdev virtio1

$ ip a a fd00:100::1/64 dev mgmt0

$ ip -6 a s mgmt0
2: mgmt0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
    inet6 fd00:100::1/64 scope global
       valid_lft forever preferred_lft forever

$ ip -6 r
fd00:100::/64 dev mgmt0 proto kernel metric 256 pref medium

(before the fix)

vtysh> show ipv6 route
C>* fd00:100::/64 is directly connected, mgmt0, weight 1, 00:00:55
K * fd00:100::/64 [0/256] is directly connected, mgmt0, weight 1, 00:00:57
L>* fd00:100::1/128 is directly connected, mgmt0, weight 1, 00:00:55

(after the fix)

vtysh> show ipv6 route
C>* fd00:100::/64 is directly connected, mgmt0, weight 1, 00:00:16
L>* fd00:100::1/128 is directly connected, mgmt0, weight 1, 00:00:16