### PR TITLE
pathd: free PCEP PCC's mappings on finalize

### DIFF
--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -176,9 +176,32 @@ struct pcc_state *pcep_pcc_initialize(struct ctrl_state *ctrl_state, int index)
 void pcep_pcc_finalize(struct ctrl_state *ctrl_state,
 		       struct pcc_state *pcc_state)
 {
+	struct plspid_map_data *plspid_mapping;
+	struct nbkey_map_data *nbkey_mapping;
+	struct req_map_data *req_mapping;
+
 	PCEP_DEBUG("%s PCC finalizing...", pcc_state->tag);
 
 	pcep_pcc_disable(ctrl_state, pcc_state);
+
+	/*
+	 * The mappings are retained for the whole session so a re-created
+	 * policy keeps the PLSP-ID it had before (lookup_plspid) and PCE
+	 * updates referencing a path only by PLSP-ID keep resolving
+	 * (lookup_nbkey).  Once the PCC itself goes away neither applies,
+	 * so this is the one place they can be freed.
+	 */
+	while ((plspid_mapping = plspid_map_pop(&pcc_state->plspid_map)))
+		XFREE(MTYPE_PCEP, plspid_mapping);
+	plspid_map_fini(&pcc_state->plspid_map);
+
+	while ((nbkey_mapping = nbkey_map_pop(&pcc_state->nbkey_map)))
+		XFREE(MTYPE_PCEP, nbkey_mapping);
+	nbkey_map_fini(&pcc_state->nbkey_map);
+
+	while ((req_mapping = req_map_pop(&pcc_state->req_map)))
+		XFREE(MTYPE_PCEP, req_mapping);
+	req_map_fini(&pcc_state->req_map);
 
 	if (pcc_state->pcc_opts != NULL) {
 		XFREE(MTYPE_PCEP, pcc_state->pcc_opts);


### PR DESCRIPTION
The current behavior is that when pathd is stopped and when PCC removal is called the plspid, nbkey, and req mappings are leaked.

The proposed approach is to free these mappings when pcep_pcc_finalize is called.  These mappings cannot be freed else where because their lifetime is that of the PCC.  When a policy is re-created with the same color, endpoint, preference it must get back the same PLSP-ID, PLSP-IDs are allocated monotonically and not recycled, and lookup_nbkey() resolves a PLSP-ID to its nbkey and asserts on a missing entry, which will cause pathd to crash.

This memory leak was found during the testing of a new topotest for pcep.