### PR TITLE
bgpd: support VRF-aware advertisement-delay timer

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1401,14 +1401,30 @@ static void bgp_advertisement_delay_begin(struct bgp *bgp)
 }
 
 /*
- * Handle first peer Established for advertisement-delay.
+ * Called when any peer reaches Established.
+ * Start advertisement-delay for every instance that has it configured.
+ *
+ * The peer that triggered this belongs to one instance, but the timer is
+ * started for all of them, so graceful-restart has to be checked per instance
+ * here.  gr_route_sync_pending is true only while that instance is actually
+ * retaining routes for a graceful restart, which is what advertisement-delay
+ * has to stay out of the way of.
  */
-static void bgp_advertisement_delay_process_status_change(struct peer *peer)
+static void bgp_peer_established_handle_all_vrfs(void)
 {
-	struct bgp *bgp = peer->bgp;
+	struct listnode *node;
+	struct bgp *bgp;
 
-	if (peer_established(peer->connection) && !bgp->advertisement_delay_started)
-		bgp_advertisement_delay_begin(bgp);
+	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
+		if (!bgp_advertisement_delay_configured(bgp))
+			continue;
+
+		if (bgp->gr_route_sync_pending)
+			continue;
+
+		if (bgp_advertisement_delay_applicable(bgp) && !bgp->advertisement_delay_started)
+			bgp_advertisement_delay_begin(bgp);
+	}
 }
 
 /* Steps to begin the update delay:
@@ -2098,20 +2114,19 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 			bgp->maxmed_onstartup_over = 1;
 	}
 
-	/* Check for GR restarter, update-delay, or advertisement-delay.
-	 * When GR is not applicable, both update-delay and advertisement-delay
-	 * can run independently.
-	 */
+	/* Check for GR restarter or update-delay. */
 	if (gr_path_select_deferral_applicable(bgp))
 		bgp_gr_process_peer_status_change(peer);
-	else {
-		if (bgp_update_delay_configured(bgp) && bgp_update_delay_applicable(bgp))
-			bgp_update_delay_process_status_change(peer);
+	else if (bgp_update_delay_configured(bgp) && bgp_update_delay_applicable(bgp))
+		bgp_update_delay_process_status_change(peer);
 
-		if (bgp_advertisement_delay_configured(bgp) &&
-		    bgp_advertisement_delay_applicable(bgp))
-			bgp_advertisement_delay_process_status_change(peer);
-	}
+	/* advertisement-delay is VRF-aware: a peer reaching Established in any
+	 * instance starts the timer for every instance that has it configured.
+	 * Graceful-restart is checked per instance inside, so this must not be
+	 * gated on the state of the triggering peer's instance.
+	 */
+	if (status == Established)
+		bgp_peer_established_handle_all_vrfs();
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s fd %d went from %s to %s for %s", peer->host, connection->fd,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14355,6 +14355,29 @@ static void bgp_show_summary_advertisement_delay(struct vty *vty,
 	}
 }
 
+/*
+ * Per-instance identification header, shared by the peered and the peerless
+ * paths of bgp_show_summary().
+ */
+static void bgp_show_summary_instance_header(struct vty *vty, struct bgp *bgp, json_object *json,
+					     bool use_json)
+{
+	int64_t vrf_id_ui = (bgp->vrf_id == VRF_UNKNOWN) ? -1 : (int64_t)bgp->vrf_id;
+
+	if (use_json) {
+		json_object_string_addf(json, "routerId", "%pI4", &bgp->router_id);
+		asn_asn2json(json, "as", bgp->as, bgp->asnotation);
+		json_object_int_add(json, "vrfId", vrf_id_ui);
+		json_object_string_add(json, "vrfName",
+				       bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT
+					       ? VRF_DEFAULT_NAME
+					       : bgp->name);
+	} else {
+		vty_out(vty, "BGP router identifier %pI4, local AS number %s %s vrf-id %d\n",
+			&bgp->router_id, bgp->as_pretty, bgp->name_pretty, (int)vrf_id_ui);
+	}
+}
+
 static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 			    struct peer *fpeer, enum peer_asn_type as_type,
 			    as_t as, uint16_t show_flags)
@@ -14495,42 +14518,14 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 		if (!count) {
 			unsigned long ents;
 			char memstrbuf[MTYPE_MEMSTR_LEN];
-			int64_t vrf_id_ui;
-
-			vrf_id_ui = (bgp->vrf_id == VRF_UNKNOWN)
-					    ? -1
-					    : (int64_t)bgp->vrf_id;
 
 			/* Usage summary and header */
-			if (use_json) {
-				json_object_string_addf(json, "routerId",
-							"%pI4",
-							&bgp->router_id);
-				asn_asn2json(json, "as", bgp->as,
-					     bgp->asnotation);
-				json_object_int_add(json, "vrfId", vrf_id_ui);
-				json_object_string_add(
-					json, "vrfName",
-					(bgp->inst_type
-					 == BGP_INSTANCE_TYPE_DEFAULT)
-						? VRF_DEFAULT_NAME
-						: bgp->name);
-			} else {
-				vty_out(vty,
-					"BGP router identifier %pI4, local AS number %s %s vrf-id %d",
-					&bgp->router_id, bgp->as_pretty,
-					bgp->name_pretty,
-					bgp->vrf_id == VRF_UNKNOWN
-						? -1
-						: (int)bgp->vrf_id);
-				vty_out(vty, "\n");
-			}
+			bgp_show_summary_instance_header(vty, bgp, json, use_json);
 
 			bgp_show_summary_update_delay(vty, bgp, json,
 						     use_json);
 
-			bgp_show_summary_advertisement_delay(vty, bgp, json,
-							     use_json);
+			bgp_show_summary_advertisement_delay(vty, bgp, json, use_json);
 
 			if (use_json) {
 				if (bgp_maxmed_onstartup_configured(bgp)
@@ -14999,6 +14994,17 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 		}
 	}
 
+	/*
+	 * An instance with no peers in this AFI/SAFI never reached the header
+	 * block inside the loop above, but it can still have advertisement-delay
+	 * state to report: the timer is started by the first peer to reach
+	 * Established in any instance.
+	 */
+	if (!count && bgp_advertisement_delay_configured(bgp)) {
+		bgp_show_summary_instance_header(vty, bgp, json, use_json);
+		bgp_show_summary_advertisement_delay(vty, bgp, json, use_json);
+	}
+
 	if (use_json) {
 		json_object_object_add(json, "peers", json_peers);
 		json_object_int_add(json, "failedPeers", failed_count);
@@ -15042,6 +15048,36 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 	return CMD_SUCCESS;
 }
 
+/*
+ * Number of peers configured in this BGP instance, counted once per peer
+ * regardless of how many address families it is activated in.
+ */
+static uint32_t bgp_instance_peer_count(struct bgp *bgp)
+{
+	struct listnode *node;
+	struct peer *peer;
+	afi_t afi;
+	safi_t safi;
+	uint32_t count = 0;
+
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+		bool activated = false;
+
+		if (!peer_is_config_node(peer))
+			continue;
+
+		FOREACH_AFI_SAFI (afi, safi) {
+			if (peer->afc[afi][safi])
+				activated = true;
+		}
+
+		if (activated)
+			count++;
+	}
+
+	return count;
+}
+
 static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 				      int safi, struct peer *fpeer, int as_type,
 				      as_t as, uint16_t show_flags)
@@ -15052,6 +15088,11 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 	int is_wildcard = (afi_wildcard || safi_wildcard);
 	bool nbr_output = false;
 	bool use_json = CHECK_FLAG(show_flags, BGP_SHOW_OPT_JSON);
+	/* A VRF with no peers of its own still has to report its
+	 * advertisement-delay state; show it once, under IPv4 unicast.
+	 */
+	bool adv_delay_only = bgp_advertisement_delay_configured(bgp) &&
+			      !bgp_instance_peer_count(bgp);
 
 	if (use_json && is_wildcard)
 		vty_out(vty, "{\n");
@@ -15061,7 +15102,8 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 		if (safi_wildcard)
 			safi = 1; /* SAFI_UNICAST */
 		while (safi < SAFI_MAX) {
-			if (bgp_afi_safi_peer_exists(bgp, afi, safi)) {
+			if (bgp_afi_safi_peer_exists(bgp, afi, safi) ||
+			    (adv_delay_only && afi == AFI_IP && safi == SAFI_UNICAST)) {
 				nbr_output = true;
 
 				if (is_wildcard) {

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1769,9 +1769,10 @@ Redistribute routes from a routing table number into BGP.
    After a non-graceful restart, peers detect the session loss and withdraw
    routes to this router, so the receiver has no routes to this router at all.
    ``advertisement-delay`` controls when this router re-announces itself,
-   ensuring it only attracts traffic once it has fully converged.  When
-   graceful-restart is active, ``advertisement-delay`` is not started -- the
-   GR restarter path handles route retention separately.
+   ensuring it only attracts traffic once it has fully converged.  While a
+   graceful restart is in progress for a BGP instance, ``advertisement-delay``
+   is not started for that instance -- the GR restarter path handles route
+   retention separately.  Other instances are unaffected.
 
    This feature holds route advertisements to peers for a configured number of
    seconds after the first peer reaches Established status.  The delay applies
@@ -1817,19 +1818,30 @@ Redistribute routes from a routing table number into BGP.
    After a non-graceful restart, peers detect the session loss and withdraw
    routes to this router, so the receiver has no routes to this router at all.
    ``advertisement-delay`` controls when this router re-announces itself,
-   ensuring it only attracts traffic once it has fully converged.  When
-   graceful-restart is active, ``advertisement-delay`` is not started -- the
-   GR restarter path handles route retention separately.
+   ensuring it only attracts traffic once it has fully converged.  While a
+   graceful restart is in progress for a BGP instance, ``advertisement-delay``
+   is not started for that instance -- the GR restarter path handles route
+   retention separately.  Other instances are unaffected.
 
    This feature holds route advertisements to peers for a configured number of
-   seconds after the first peer reaches Established status.  Note that this
-   command is configured under the specific bgp instance/vrf that the feature
-   is enabled for.  It cannot be used at the same time as the global
-   ``bgp advertisement-delay`` described above.  The global and per-vrf
+   seconds after the first BGP peer in any VRF reaches Established status.
+   Note that this command is configured under the specific bgp instance/vrf
+   that the feature is enabled for.  It cannot be used at the same time as the
+   global ``bgp advertisement-delay`` described above.  The global and per-vrf
    approaches are mutually exclusive.
 
-   When the first peer reaches Established, a timer for the configured delay is
-   started.  During this period, best-path selection and FIB programming proceed
+   The timer is VRF-aware: when the first peer in any VRF (including the
+   default VRF) reaches Established, the advertisement-delay timer starts for
+   every VRF that has it configured.  A VRF that has no BGP peers of its own,
+   and learns its routes by import from another instance, is held as well.
+   Each VRF manages its own timer independently.
+
+   Because a peer in one VRF starts the timer everywhere it is configured,
+   enable it only on the VRFs whose advertisements should be held.  A VRF
+   that carries the sessions used to reach other routers will otherwise hold
+   those advertisements too.
+
+   During the delay period, best-path selection and FIB programming proceed
    normally, but route advertisements to peers are held.  When the timer
    expires, advertisements are released to all established peers.
 

--- a/tests/topotests/bgp_advertisement_delay/test_bgp_advertisement_delay.py
+++ b/tests/topotests/bgp_advertisement_delay/test_bgp_advertisement_delay.py
@@ -32,6 +32,8 @@ Test cases:
    finishes earlier.
 8. Re-trigger advertisement-delay on clear ip bgp *.
 9. Remove advertisement-delay, verify routes advertised promptly.
+10. A VRF with no peers of its own has its timer started by a peer
+    establishing in another VRF, and reports it in show bgp summary.
 """
 
 import os
@@ -171,9 +173,9 @@ def test_bgp_advertisement_delay_in_progress():
 
     test_func = functools.partial(_check_delay_active_with_peers)
     _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
-    assert result is None, (
-        "advertisement-delay not active with Established peers: {}".format(result)
-    )
+    assert (
+        result is None
+    ), "advertisement-delay not active with Established peers: {}".format(result)
 
 
 def test_bgp_advertisement_delay_route_installed_during_delay():
@@ -192,9 +194,7 @@ def test_bgp_advertisement_delay_route_installed_during_delay():
 
     test_func = functools.partial(_check_route_in_rib)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
-    assert result is None, (
-        "r2 should install routes in RIB during advertisement-delay"
-    )
+    assert result is None, "r2 should install routes in RIB during advertisement-delay"
 
 
 def test_bgp_advertisement_delay_completed():
@@ -227,8 +227,8 @@ def test_bgp_advertisement_delay_completed():
 
     test_func = functools.partial(_check_delay_completed)
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
-    assert result is None, (
-        "advertisement-delay did not complete properly: {}".format(result)
+    assert result is None, "advertisement-delay did not complete properly: {}".format(
+        result
     )
 
 
@@ -310,9 +310,7 @@ def test_bgp_update_delay_with_advertisement_delay():
         for peer_addr, peer_data in peers.items():
             if peer_data.get("state") == "Established":
                 if peer_data.get("pfxSnt", -1) != 0:
-                    return "pfxSnt not 0 for {} while ad-delay active".format(
-                        peer_addr
-                    )
+                    return "pfxSnt not 0 for {} while ad-delay active".format(peer_addr)
         established = [p for p in peers.values() if p.get("state") == "Established"]
         if not established:
             return "No peers Established yet"
@@ -320,9 +318,9 @@ def test_bgp_update_delay_with_advertisement_delay():
 
     test_func = functools.partial(_check_ad_delay_holding_after_ud)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
-    assert result is None, (
-        "ad-delay should hold ads after update-delay ends: {}".format(result)
-    )
+    assert (
+        result is None
+    ), "ad-delay should hold ads after update-delay ends: {}".format(result)
 
     def _check_both_completed():
         output = json.loads(r2.vtysh_cmd("show bgp summary json"))
@@ -418,9 +416,64 @@ def test_bgp_no_advertisement_delay():
 
     test_func = functools.partial(_check_no_delay)
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
-    assert result is None, (
-        "Routes not advertised promptly without advertisement-delay: {}".format(result)
+    assert (
+        result is None
+    ), "Routes not advertised promptly without advertisement-delay: {}".format(result)
+
+
+def test_bgp_advertisement_delay_vrf_without_peers():
+    """A VRF with no peers of its own is started by a peer in another VRF."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.run("ip link add vrf-quiet type vrf table 1010")
+    r2.run("ip link set vrf-quiet up")
+
+    r2.vtysh_cmd(
+        """
+          configure terminal
+            router bgp 65002 vrf vrf-quiet
+              advertisement-delay 20
+        """
     )
+
+    # vrf-quiet has no peers, so only a peer in the default VRF can start it.
+    r2.vtysh_cmd("clear ip bgp *")
+
+    def _check_delay_started():
+        output = json.loads(r2.vtysh_cmd("show bgp vrf vrf-quiet summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "advertisementDelay": 20,
+                "advertisementDelayInProgress": True,
+                "totalPeers": 0,
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_delay_started)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "advertisement-delay did not start for a VRF without peers"
+
+    def _check_delay_completed():
+        output = json.loads(r2.vtysh_cmd("show bgp vrf vrf-quiet summary json"))
+        ipv4 = output.get("ipv4Unicast", {})
+
+        if ipv4.get("advertisementDelayInProgress"):
+            return "still in progress"
+        if "advertisementDelayResumeTime" not in ipv4:
+            return "no resume time recorded"
+        return None
+
+    test_func = functools.partial(_check_delay_completed)
+    _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+    assert (
+        result is None
+    ), "advertisement-delay did not complete for a peerless VRF: {}".format(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
advertisement-delay only started its timer when a peer in the same BGP
instance came up. A VRF with no peers of its own, which gets its routes
imported from another instance, never started the timer, so the feature
did nothing there.

Now when any peer comes up, every instance that has advertisement-delay
configured starts its delay. The call stays on the non-graceful-restart
path, so GR still handles route retention as before.

show bgp summary also skipped such a VRF completely, because it only
reaches instances that have a peer in that afi/safi. A VRF with no peers
is now shown once, under IPv4 unicast, with its delay state. VRFs that
have peers are unchanged.

Adds a topotest for a VRF with no peers of its own.

`A VRF with advertisement-delay 20 and no peers of its own used to print:

    % No BGP neighbors found in VRF vrf-quiet

and now prints:

    Advertisement delay: 20 seconds
      14 seconds remaining`
      
Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>