### PR TITLE
pathd: free path struct for PCInitiate and PCUpd

### DIFF
--- a/pathd/path_pcep.c
+++ b/pathd/path_pcep.c
@@ -256,9 +256,20 @@ int pcep_main_event_initiate_candidate(struct path *path)
 			return ret;
 			break;
 		}
+		/*
+		 * On error, the path object (linked by error->path) is
+		 * freed after the error message is sent.
+		 */
 		pcep_ctrl_send_error(pcep_g->fpt, path->pcc_id, error);
-	} else if (ret != PATH_NB_ERR && path->srp_id != 0)
-		notify_status(path, ret == PATH_NB_NO_CHANGE);
+	} else {
+		if (ret != PATH_NB_ERR && path->srp_id != 0)
+			notify_status(path, ret == PATH_NB_NO_CHANGE);
+		/*
+		 * The path was parsed from the PCInitiate message and its
+		 * content copied into the candidate, now clean up the path.
+		 */
+		pcep_free_path(path);
+	}
 	return ret;
 }
 
@@ -269,6 +280,8 @@ int pcep_main_event_update_candidate(struct path *path)
 	ret = path_pcep_config_update_path(path);
 	if (ret != PATH_NB_ERR && path->srp_id != 0)
 		notify_status(path, ret == PATH_NB_NO_CHANGE);
+	/* Same ownership as the initiate case: the parsed path is ours. */
+	pcep_free_path(path);
 	return ret;
 }
 

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -1224,6 +1224,7 @@ void handle_pcep_lsp_initiate(struct ctrl_state *ctrl_state,
 			  format_pcep_message(msg));
 		send_pcep_error(pcc_state, PCEP_ERRT_LSP_INSTANTIATE_ERROR,
 				PCEP_ERRV_UNACCEPTABLE_INSTANTIATE_ERROR, path);
+		pcep_free_path(path);
 		return;
 	}
 
@@ -1262,6 +1263,7 @@ void handle_pcep_lsp_initiate(struct ctrl_state *ctrl_state,
 			send_pcep_error(pcc_state,
 					PCEP_ERRT_LSP_INSTANTIATE_ERROR,
 					PCEP_ERRV_INTERNAL_ERROR, path);
+			pcep_free_path(path);
 			return;
 		}
 
@@ -1278,6 +1280,7 @@ void handle_pcep_lsp_initiate(struct ctrl_state *ctrl_state,
 			send_pcep_error(pcc_state, PCEP_ERRT_INVALID_OPERATION,
 					PCEP_ERRV_LSP_INIT_NON_ZERO_PLSP_ID,
 					path);
+			pcep_free_path(path);
 			return;
 		}
 
@@ -1294,6 +1297,7 @@ void handle_pcep_lsp_initiate(struct ctrl_state *ctrl_state,
 			send_pcep_error(
 				pcc_state, PCEP_ERRT_RECEPTION_OF_INV_OBJECT,
 				PCEP_ERRV_SYMBOLIC_PATH_NAME_TLV_MISSING, path);
+			pcep_free_path(path);
 			return;
 		}
 	}


### PR DESCRIPTION
Every PCInitiate and PCUpd message leaks the path struct after it has been parsed.  The parsed path elements are copied into srte structures, but the original path struct is never freed.

The solution is when not removing the policy for PCInitiate, to clean up the path struct afterwards, and always clean up for PCUpd.

This memory leak was found during the testing of a new topotest for pcep.