### PR TITLE
pathd: cancel PCEP timer with thread cancel func

### DIFF
--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -336,7 +336,11 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 		return 0;
 	}
 
-	event_cancel(&pcc_state->t_reconnect);
+	/*
+	 * Cancel through the controller helper: a raw event_cancel()
+	 * drops the armed timer without freeing its allocated payload.
+	 */
+	pcep_thread_cancel_timer(&pcc_state->t_reconnect);
 
 	select_transport_address(pcc_state);
 
@@ -401,7 +405,7 @@ int pcep_pcc_enable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	}
 
 	// In case some best pce alternative were waiting to activate
-	event_cancel(&pcc_state->t_update_best);
+	pcep_thread_cancel_timer(&pcc_state->t_update_best);
 
 	pcc_state->status = PCEP_PCC_CONNECTING;
 


### PR DESCRIPTION
Currently pcep timers in pcep_pcc_enable are cancelled using event_cancel(). This causes the struct pcep_ctrl_timer_data to be leaked as event_cancel() does not free the struct, it is only freed through pcep_thread_timer_handler() and
pcep_thread_cancel_timer().

The proposed solution is to use pcep_thread_cancel_timer() to free the pcep_ctrl_timer_data struct.

This memory leak was found during the testing of a new topotest for pcep.