### PR TITLE
lib, zebra: add "set" apis for ipaddrs

### DIFF
--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -55,6 +55,44 @@ struct ipaddr {
 
 #define IPADDR_STRING_SIZE 46
 
+/* Max bit/byte length of IPv4 address. */
+#define IPV4_MAX_BYTELEN   4
+#define IPV4_MAX_BITLEN    32
+#define IPV4_ADDR_CMP(D, S) memcmp((D), (S), IPV4_MAX_BYTELEN)
+
+/* Max bit/byte length of IPv6 address. */
+#define IPV6_MAX_BYTELEN  16
+#define IPV6_MAX_BITLEN   128
+#define IPV6_ADDR_CMP(D, S)  memcmp((D), (S), IPV6_MAX_BYTELEN)
+#define IPV6_ADDR_SAME(D, S) (memcmp((D), (S), IPV6_MAX_BYTELEN) == 0)
+#define IPV6_ADDR_COPY(D, S) memcpy((D), (S), IPV6_MAX_BYTELEN)
+
+static inline bool ipv4_addr_same(const struct in_addr *a,
+				  const struct in_addr *b)
+{
+	return (a->s_addr == b->s_addr);
+}
+#define IPV4_ADDR_SAME(A, B) ipv4_addr_same((A), (B))
+
+static inline void ipv4_addr_copy(struct in_addr *dst,
+				  const struct in_addr *src)
+{
+	dst->s_addr = src->s_addr;
+}
+#define IPV4_ADDR_COPY(D, S) ipv4_addr_copy((D), (S))
+
+macro_inline void ipaddr_set_v4(struct ipaddr *ip, const struct in_addr addr)
+{
+	SET_IPADDR_V4(ip);
+	ip->ipaddr_v4 = addr;
+}
+
+macro_inline void ipaddr_set_v6(struct ipaddr *ip, const struct in6_addr *addr)
+{
+	SET_IPADDR_V6(ip);
+	IPV6_ADDR_COPY(&ip->ipaddr_v6, addr);
+}
+
 static inline int ipaddr_family(const struct ipaddr *ip)
 {
 	switch (ip->ipa_type) {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -337,25 +337,6 @@ union prefixconstptr {
  */
 #define PREFIX_SG_STR_LEN (INET6_ADDRSTRLEN * 2 + 3 + 1)
 
-/* Max bit/byte length of IPv4 address. */
-#define IPV4_MAX_BYTELEN    4
-#define IPV4_MAX_BITLEN    32
-#define IPV4_ADDR_CMP(D,S)   memcmp ((D), (S), IPV4_MAX_BYTELEN)
-
-static inline bool ipv4_addr_same(const struct in_addr *a,
-				  const struct in_addr *b)
-{
-	return (a->s_addr == b->s_addr);
-}
-#define IPV4_ADDR_SAME(A,B)  ipv4_addr_same((A), (B))
-
-static inline void ipv4_addr_copy(struct in_addr *dst,
-				  const struct in_addr *src)
-{
-	dst->s_addr = src->s_addr;
-}
-#define IPV4_ADDR_COPY(D,S)  ipv4_addr_copy((D), (S))
-
 #define IPV4_NET0(a) ((((uint32_t)(a)) & 0xff000000) == 0x00000000)
 #define IPV4_NET127(a) ((((uint32_t)(a)) & 0xff000000) == 0x7f000000)
 #define IPV4_NET127_16(a)    ((((uint32_t)(a)) & 0xffff0000) == 0x7f000000)
@@ -364,13 +345,6 @@ static inline void ipv4_addr_copy(struct in_addr *dst,
 #define IPV4_CLASS_E(a) ((((uint32_t)(a)) & 0xf0000000) == 0xf0000000)
 #define IPV4_CLASS_DE(a) ((((uint32_t)(a)) & 0xe0000000) == 0xe0000000)
 #define IPV4_MC_LINKLOCAL(a) ((((uint32_t)(a)) & 0xffffff00) == 0xe0000000)
-
-/* Max bit/byte length of IPv6 address. */
-#define IPV6_MAX_BYTELEN    16
-#define IPV6_MAX_BITLEN    128
-#define IPV6_ADDR_CMP(D,S)   memcmp ((D), (S), IPV6_MAX_BYTELEN)
-#define IPV6_ADDR_SAME(D,S)  (memcmp ((D), (S), IPV6_MAX_BYTELEN) == 0)
-#define IPV6_ADDR_COPY(D,S)  memcpy ((D), (S), IPV6_MAX_BYTELEN)
 
 /* Count prefix size from mask length */
 #define PSIZE(a) (((a) + 7) / (8))

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -439,12 +439,11 @@ static int netlink_extract_gre_info(struct rtattr *link_data, struct zebra_l2inf
 
 		frrtrace(1, frr_zebra, if_netlink_parse_error, 2);
 	} else if (ipv6) {
-		SET_IPADDR_V6(&gre_info->vtep_ip);
-		IPV6_ADDR_COPY(&gre_info->vtep_ip.ipaddr_v6,
-			       (struct in6_addr *)RTA_DATA(attr[IFLA_GRE_LOCAL]));
+		ipaddr_set_v6(&gre_info->vtep_ip,
+			      (struct in6_addr *)RTA_DATA(attr[IFLA_GRE_LOCAL]));
 	} else {
-		SET_IPADDR_V4(&gre_info->vtep_ip);
-		gre_info->vtep_ip.ipaddr_v4 = *(struct in_addr *)RTA_DATA(attr[IFLA_GRE_LOCAL]);
+		ipaddr_set_v4(&gre_info->vtep_ip,
+			      *(struct in_addr *)RTA_DATA(attr[IFLA_GRE_LOCAL]));
 	}
 	if (!attr[IFLA_GRE_REMOTE]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)


### PR DESCRIPTION
Add "set" apis for ipaddr apis that manage both the "type" of the struct and the address bits. Existing code has to keep those two things aligned. I've included one example from a zebra source file.

Also moved some basic v4/v6 address utilities from prefix.h to ipaddr.h.