### PR TITLE
pathd: cancel the PCEP timer before rescheduling

### DIFF
--- a/pathd/path_pcep_controller.c
+++ b/pathd/path_pcep_controller.c
@@ -528,6 +528,15 @@ int schedule_thread_timer_with_cb(struct ctrl_state *ctrl_state, int pcc_id,
 
 	struct pcep_ctrl_timer_data *data;
 
+	/*
+	 * A timer can be re-scheduled while still armed (e.g. the
+	 * reconnect timer under backoff).  event_add_timer() ignores the
+	 * request when *thread is already set, which would orphan the
+	 * data allocated below; cancel the previous timer first, which
+	 * also frees its data.
+	 */
+	pcep_thread_cancel_timer(thread);
+
 	data = XCALLOC(MTYPE_PCEP, sizeof(*data));
 	data->ctrl_state = ctrl_state;
 	data->timer_type = timer_type;


### PR DESCRIPTION
The current behavior is that when schedule_thread_timer_with_cb() is called while a timer is still armed, the first timer wins: event_add_timer() ignores the second request. The second call has already allocated a new pcep_ctrl_timer_data, which is never attached to anything and leaks.

The proposed solution is to cancel the previous timer first, through pcep_thread_cancel_timer() then allocate and arm the new one.

This memory leak was found during the testing of a new topotest for pcep.