### PR TITLE
pimd: refactor the multicast interface handling

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1272,7 +1272,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 											  : ' ',
 					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_STAR) ? '*'
 											 : ' ',
-					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE) ? 'M' : ' ');
+					 channel_oif_no_forward(oif) ? 'M' : ' ');
 
 				if (first_oif) {
 					first_oif = 0;
@@ -3917,7 +3917,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 			struct interface *ifp_out;
 
 			/* do not display muted OIFs */
-			if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
+			if (channel_oif_no_forward(oif))
 				continue;
 
 			if (c_oil->iif.index == oif->index &&

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1102,6 +1102,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 		    json_object *json)
 {
 	struct channel_oil *c_oil;
+	struct channel_oif *oif;
 #if PIM_IPV != 4
 	struct ttable *tt = NULL;
 	char *table = NULL;
@@ -1137,24 +1138,20 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 		char grp_str[PIM_ADDRSTRLEN];
 		char in_ifname[IFNAMSIZ + 1];
 		char out_ifname[IFNAMSIZ + 1];
-		int oif_vif_index;
 		struct interface *ifp_in;
 		bool isRpt;
 
 		first_oif = 1;
 
-		if ((c_oil->up &&
-		     PIM_UPSTREAM_FLAG_TEST_USE_RPT(c_oil->up->flags)) ||
-		    pim_addr_is_any(*oil_origin(c_oil)))
+		if ((c_oil->up && PIM_UPSTREAM_FLAG_TEST_USE_RPT(c_oil->up->flags)) ||
+		    pim_addr_is_any(c_oil->source))
 			isRpt = true;
 		else
 			isRpt = false;
 
-		snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
-			   oil_mcastgrp(c_oil));
-		snprintfrr(src_str, sizeof(src_str), "%pPAs",
-			   oil_origin(c_oil));
-		ifp_in = pim_if_find_by_vif_index(pim, *oil_incoming_vif(c_oil));
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &c_oil->group);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &c_oil->source);
+		ifp_in = pim_if_find_by_vif_index(pim, c_oil->iif.index);
 
 		if (ifp_in)
 			strlcpy(in_ifname, ifp_in->name, sizeof(in_ifname));
@@ -1210,7 +1207,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 				json_object_int_add(json_source, "refCount",
 						    c_oil->oil_ref_count);
 				json_object_int_add(json_source, "oilListSize",
-						    c_oil->oil_size);
+						    channel_oif_list_count(&c_oil->oif_list));
 				json_object_int_add(
 					json_source, "oilRescan",
 					c_oil->oil_inherited_rescan);
@@ -1226,32 +1223,21 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 			}
 		} else
 #if PIM_IPV == 4
-			vty_out(vty, "%-6d %-15pPAs  %-15pPAs  %-3s  %-16s  ",
-				c_oil->installed, oil_origin(c_oil),
-				oil_mcastgrp(c_oil), isRpt ? "y" : "n",
-				in_ifname);
+			vty_out(vty, "%-6d %-15pPAs  %-15pPAs  %-3s  %-16s  ", c_oil->installed,
+				&c_oil->source, &c_oil->group, isRpt ? "y" : "n", in_ifname);
 #else
 			/* Add a new row for c_oil with no OIF */
-			ttable_add_row(tt, "%d|%pPAs|%pPAs|%s|%s|%c",
-				       c_oil->installed, oil_origin(c_oil),
-				       oil_mcastgrp(c_oil), isRpt ? "y" : "n",
-				       in_ifname, ' ');
+			ttable_add_row(tt, "%d|%pPAs|%pPAs|%s|%s|%c", c_oil->installed,
+				       &c_oil->source, &c_oil->group, isRpt ? "y" : "n", in_ifname,
+				       ' ');
 #endif
 
-		for (oif_vif_index = 0; oif_vif_index < MAXVIFS;
-		     ++oif_vif_index) {
+		frr_each (channel_oif_list, &c_oil->oif_list, oif) {
 			struct interface *ifp_out;
 			char oif_uptime[10];
-			int ttl;
 
-			ttl = oil_if_has(c_oil, oif_vif_index);
-			if (ttl < 1)
-				continue;
-
-			ifp_out = pim_if_find_by_vif_index(pim, oif_vif_index);
-			pim_time_uptime(
-				oif_uptime, sizeof(oif_uptime),
-				now - c_oil->oif_creation[oif_vif_index]);
+			ifp_out = pim_if_find_by_vif_index(pim, oif->index);
+			pim_time_uptime(oif_uptime, sizeof(oif_uptime), now - oif->creation);
 
 			if (ifp_out)
 				strlcpy(out_ifname, ifp_out->name,
@@ -1280,26 +1266,13 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 			} else {
 				flag[0] = '\0';
 				snprintf(flag, sizeof(flag), "(%c%c%c%c%c)",
-					 (c_oil->oif_flags[oif_vif_index] &
-					  PIM_OIF_FLAG_PROTO_GM)
-						 ? 'I'
-						 : ' ',
-					 (c_oil->oif_flags[oif_vif_index] &
-					  PIM_OIF_FLAG_PROTO_PIM)
-						 ? 'J'
-						 : ' ',
-					 (c_oil->oif_flags[oif_vif_index] &
-					  PIM_OIF_FLAG_PROTO_VXLAN)
-						 ? 'V'
-						 : ' ',
-					 (c_oil->oif_flags[oif_vif_index] &
-					  PIM_OIF_FLAG_PROTO_STAR)
-						 ? '*'
-						 : ' ',
-					 (c_oil->oif_flags[oif_vif_index] &
-					  PIM_OIF_FLAG_MUTE)
-						 ? 'M'
-						 : ' ');
+					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_GM) ? 'I' : ' ',
+					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_PIM) ? 'J' : ' ',
+					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_VXLAN) ? 'V'
+											  : ' ',
+					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_STAR) ? '*'
+											 : ' ',
+					 CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE) ? 'M' : ' ');
 
 				if (first_oif) {
 					first_oif = 0;
@@ -1313,13 +1286,10 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 					 * flag.
 					 */
 					ttable_del_row(tt, tt->nrows - 1);
-					ttable_add_row(
-						tt, "%d|%pPAs|%pPAs|%s|%s|%s%s",
-						c_oil->installed,
-						oil_origin(c_oil),
-						oil_mcastgrp(c_oil),
-						isRpt ? "y" : "n", in_ifname,
-						out_ifname, flag);
+					ttable_add_row(tt, "%d|%pPAs|%pPAs|%s|%s|%s%s",
+						       c_oil->installed, &c_oil->source,
+						       &c_oil->group, isRpt ? "y" : "n", in_ifname,
+						       out_ifname, flag);
 #endif
 				} else {
 #if PIM_IPV == 4
@@ -3815,6 +3785,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		 bool fill, json_object *json)
 {
 	struct listnode *node;
+	struct channel_oif *oif;
 	struct channel_oil *c_oil;
 	struct static_route *s_route;
 	struct ttable *tt = NULL;
@@ -3830,7 +3801,6 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 	char src_str[PIM_ADDRSTRLEN];
 	char in_ifname[IFNAMSIZ + 1];
 	char out_ifname[IFNAMSIZ + 1];
-	int oif_vif_index;
 	struct interface *ifp_in;
 	char proto[100];
 	char state_str[PIM_REG_STATE_STR_LEN] = { '\0' };
@@ -3860,27 +3830,23 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		if (!c_oil->installed)
 			continue;
 
-		if (!pim_addr_is_any(sg->grp) &&
-		    pim_addr_cmp(sg->grp, *oil_mcastgrp(c_oil)))
+		if (!pim_addr_is_any(sg->grp) && pim_addr_cmp(sg->grp, c_oil->group))
 			continue;
-		if (!pim_addr_is_any(sg->src) &&
-		    pim_addr_cmp(sg->src, *oil_origin(c_oil)))
+		if (!pim_addr_is_any(sg->src) && pim_addr_cmp(sg->src, c_oil->source))
 			continue;
 
-		snprintfrr(grp_str, sizeof(grp_str), "%pPAs",
-			   oil_mcastgrp(c_oil));
-		snprintfrr(src_str, sizeof(src_str), "%pPAs",
-			   oil_origin(c_oil));
+		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &c_oil->group);
+		snprintfrr(src_str, sizeof(src_str), "%pPAs", &c_oil->source);
 
-		ifp_in = pim_if_find_by_vif_index(pim, *oil_incoming_vif(c_oil));
+		ifp_in = pim_if_find_by_vif_index(pim, c_oil->iif.index);
 
 		if (ifp_in) {
 			strlcpy(in_ifname, ifp_in->name, sizeof(in_ifname));
-			if (!pim_iface_grp_dm(ifp_in->info, *oil_mcastgrp(c_oil)))
+			if (!pim_iface_grp_dm(ifp_in->info, c_oil->group))
 				strlcpy(state_str, "S", sizeof(state_str));
 		} else {
 			strlcpy(in_ifname, "<iif?>", sizeof(in_ifname));
-			if (!pim_is_grp_dm(pim, *oil_mcastgrp(c_oil)))
+			if (!pim_is_grp_dm(pim, c_oil->group))
 				strlcpy(state_str, "S", sizeof(state_str));
 		}
 
@@ -3938,7 +3904,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 			json_object_int_add(json_source, "refCount",
 					    c_oil->oil_ref_count);
 			json_object_int_add(json_source, "oilSize",
-					    c_oil->oil_size);
+					    channel_oif_list_count(&c_oil->oif_list));
 			json_object_int_add(json_source, "oilInheritedRescan",
 					    c_oil->oil_inherited_rescan);
 			json_object_string_add(json_source, "iif", in_ifname);
@@ -3947,24 +3913,18 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 			json_oil = NULL;
 		}
 
-		for (oif_vif_index = 0; oif_vif_index < MAXVIFS;
-		     ++oif_vif_index) {
+		frr_each (channel_oif_list, &c_oil->oif_list, oif) {
 			struct interface *ifp_out;
-			int ttl;
-
-			ttl = oil_if_has(c_oil, oif_vif_index);
-			if (ttl < 1)
-				continue;
 
 			/* do not display muted OIFs */
-			if (c_oil->oif_flags[oif_vif_index] & PIM_OIF_FLAG_MUTE)
+			if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
 				continue;
 
-			if (*oil_incoming_vif(c_oil) == oif_vif_index &&
-			    !pim_mroute_allow_iif_in_oil(c_oil, oif_vif_index))
+			if (c_oil->iif.index == oif->index &&
+			    !pim_mroute_allow_iif_in_oil(c_oil, oif->index))
 				continue;
 
-			ifp_out = pim_if_find_by_vif_index(pim, oif_vif_index);
+			ifp_out = pim_if_find_by_vif_index(pim, oif->index);
 			found_oif = 1;
 
 			if (ifp_out)
@@ -3981,13 +3941,10 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 				json_object_string_add(json_ifp_out, "group",
 						       grp_str);
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_PIM)
-					json_object_boolean_true_add(
-						json_ifp_out, "protocolPim");
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_PIM))
+					json_object_boolean_true_add(json_ifp_out, "protocolPim");
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_GM)
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_GM))
 #if PIM_IPV == 4
 					json_object_boolean_true_add(
 						json_ifp_out, "protocolIgmp");
@@ -3996,28 +3953,21 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 						json_ifp_out, "protocolMld");
 #endif
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_VXLAN)
-					json_object_boolean_true_add(
-						json_ifp_out, "protocolVxlan");
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_VXLAN))
+					json_object_boolean_true_add(json_ifp_out, "protocolVxlan");
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_STAR)
-					json_object_boolean_true_add(
-						json_ifp_out,
-						"protocolInherited");
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_STAR))
+					json_object_boolean_true_add(json_ifp_out,
+								     "protocolInherited");
 
 				json_object_string_add(json_ifp_out,
 						       "inboundInterface",
 						       in_ifname);
-				json_object_int_add(json_ifp_out, "iVifI",
-						    *oil_incoming_vif(c_oil));
-				json_object_string_add(json_ifp_out,
-						       "outboundInterface",
+				json_object_int_add(json_ifp_out, "iVifI", c_oil->iif.index);
+				json_object_string_add(json_ifp_out, "outboundInterface",
 						       out_ifname);
-				json_object_int_add(json_ifp_out, "oVifI",
-						    oif_vif_index);
-				json_object_int_add(json_ifp_out, "ttl", ttl);
+				json_object_int_add(json_ifp_out, "oVifI", oif->index);
+				json_object_int_add(json_ifp_out, "ttl", PIM_MROUTE_MIN_TTL);
 				json_object_string_add(json_ifp_out, "upTime",
 						       mroute_uptime);
 				json_object_string_add(json_source, "flags",
@@ -4031,13 +3981,10 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 						       json_ifp_out);
 			} else {
 				proto[0] = '\0';
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_PIM) {
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_PIM))
 					strlcpy(proto, "PIM", sizeof(proto));
-				}
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_GM) {
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_GM)) {
 #if PIM_IPV == 4
 					strlcpy(proto, "IGMP", sizeof(proto));
 #else
@@ -4045,20 +3992,15 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 #endif
 				}
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_VXLAN) {
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_VXLAN))
 					strlcpy(proto, "VxLAN", sizeof(proto));
-				}
 
-				if (c_oil->oif_flags[oif_vif_index] &
-				    PIM_OIF_FLAG_PROTO_STAR) {
+				if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_STAR))
 					strlcpy(proto, "STAR", sizeof(proto));
-				}
 
-				ttable_add_row(tt, "%s|%s|%s|%s|%s|%s|%d|%s",
-					       src_str, grp_str, state_str,
-					       proto, in_ifname, out_ifname,
-					       ttl, mroute_uptime);
+				ttable_add_row(tt, "%s|%s|%s|%s|%s|%s|%d|%s", src_str, grp_str,
+					       state_str, proto, in_ifname, out_ifname,
+					       PIM_MROUTE_MIN_TTL, mroute_uptime);
 
 				if (first) {
 					src_str[0] = '\0';
@@ -4072,9 +4014,8 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		}
 
 		if (!json && !found_oif) {
-			ttable_add_row(tt, "%pPAs|%pPAs|%s|%s|%s|%s|%d|%s",
-				       oil_origin(c_oil), oil_mcastgrp(c_oil),
-				       state_str, "none", in_ifname, "none", 0,
+			ttable_add_row(tt, "%pPAs|%pPAs|%s|%s|%s|%s|%d|%s", &c_oil->source,
+				       &c_oil->group, state_str, "none", in_ifname, "none", 0,
 				       "--:--:--");
 		}
 	}
@@ -4088,7 +4029,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 
 		snprintfrr(grp_str, sizeof(grp_str), "%pPAs", &s_route->group);
 		snprintfrr(src_str, sizeof(src_str), "%pPAs", &s_route->source);
-		ifp_in = pim_if_find_by_vif_index(pim, s_route->iif);
+		ifp_in = pim_if_find_by_vif_index(pim, s_route->c_oil.iif.index);
 		found_oif = 0;
 
 		if (ifp_in)
@@ -4125,21 +4066,12 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 			strlcpy(proto, "STATIC", sizeof(proto));
 		}
 
-		for (oif_vif_index = 0; oif_vif_index < MAXVIFS;
-		     ++oif_vif_index) {
+		frr_each (channel_oif_list, &s_route->c_oil.oif_list, oif) {
 			struct interface *ifp_out;
 			char oif_uptime[10];
-			int ttl;
 
-			ttl = s_route->oif_ttls[oif_vif_index];
-			if (ttl < 1)
-				continue;
-
-			ifp_out = pim_if_find_by_vif_index(pim, oif_vif_index);
-			pim_time_uptime(
-				oif_uptime, sizeof(oif_uptime),
-				now - s_route->c_oil
-						.oif_creation[oif_vif_index]);
+			ifp_out = pim_if_find_by_vif_index(pim, oif->index);
+			pim_time_uptime(oif_uptime, sizeof(oif_uptime), now - oif->creation);
 			found_oif = 1;
 
 			if (ifp_out)
@@ -4161,14 +4093,12 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 						       "inboundInterface",
 						       in_ifname);
 				json_object_int_add(json_ifp_out, "iVifI",
-						    *oil_incoming_vif(
-							    &s_route->c_oil));
+						    s_route->c_oil.iif.index);
 				json_object_string_add(json_ifp_out,
 						       "outboundInterface",
 						       out_ifname);
-				json_object_int_add(json_ifp_out, "oVifI",
-						    oif_vif_index);
-				json_object_int_add(json_ifp_out, "ttl", ttl);
+				json_object_int_add(json_ifp_out, "oVifI", oif->index);
+				json_object_int_add(json_ifp_out, "ttl", PIM_MROUTE_MIN_TTL);
 				json_object_string_add(json_ifp_out, "upTime",
 						       oif_uptime);
 				if (!json_oil) {
@@ -4179,11 +4109,10 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 				json_object_object_add(json_oil, out_ifname,
 						       json_ifp_out);
 			} else {
-				ttable_add_row(
-					tt, "%pPAs|%pPAs|%s|%s|%s|%s|%d|%s",
-					&s_route->source, &s_route->group, "-",
-					proto, in_ifname, out_ifname, ttl,
-					oif_uptime);
+				ttable_add_row(tt, "%pPAs|%pPAs|%s|%s|%s|%s|%d|%s",
+					       &s_route->source, &s_route->group, "-", proto,
+					       in_ifname, out_ifname, PIM_MROUTE_MIN_TTL,
+					       oif_uptime);
 				if (first && !fill) {
 					src_str[0] = '\0';
 					grp_str[0] = '\0';
@@ -4224,10 +4153,8 @@ static void show_mroute_count_per_channel_oil(struct channel_oil *c_oil,
 		char group_str[PIM_ADDRSTRLEN];
 		char source_str[PIM_ADDRSTRLEN];
 
-		snprintfrr(group_str, sizeof(group_str), "%pPAs",
-			   oil_mcastgrp(c_oil));
-		snprintfrr(source_str, sizeof(source_str), "%pPAs",
-			   oil_origin(c_oil));
+		snprintfrr(group_str, sizeof(group_str), "%pPAs", &c_oil->group);
+		snprintfrr(source_str, sizeof(source_str), "%pPAs", &c_oil->source);
 
 		json_object_object_get_ex(json, group_str, &json_group);
 
@@ -4245,10 +4172,8 @@ static void show_mroute_count_per_channel_oil(struct channel_oil *c_oil,
 		json_object_int_add(json_source, "wrongIf", c_oil->cc.wrong_if);
 
 	} else {
-		ttable_add_row(tt, "%pPAs|%pPAs|%llu|%ld|%ld|%ld",
-			       oil_origin(c_oil), oil_mcastgrp(c_oil),
-			       c_oil->cc.lastused / 100,
-			       c_oil->cc.pktcnt - c_oil->cc.origpktcnt,
+		ttable_add_row(tt, "%pPAs|%pPAs|%llu|%ld|%ld|%ld", &c_oil->source, &c_oil->group,
+			       c_oil->cc.lastused / 100, c_oil->cc.pktcnt - c_oil->cc.origpktcnt,
 			       c_oil->cc.bytecnt - c_oil->cc.origbytecnt,
 			       c_oil->cc.wrong_if - c_oil->cc.origwrong_if);
 	}
@@ -4309,12 +4234,12 @@ void show_mroute_summary(struct pim_instance *pim, struct vty *vty,
 
 	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		if (!c_oil->installed) {
-			if (pim_addr_is_any(*oil_origin(c_oil)))
+			if (pim_addr_is_any(c_oil->source))
 				starg_sw_mroute_cnt++;
 			else
 				sg_sw_mroute_cnt++;
 		} else {
-			if (pim_addr_is_any(*oil_origin(c_oil)))
+			if (pim_addr_is_any(c_oil->source))
 				starg_hw_mroute_cnt++;
 			else
 				sg_hw_mroute_cnt++;
@@ -4323,12 +4248,12 @@ void show_mroute_summary(struct pim_instance *pim, struct vty *vty,
 
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, s_route)) {
 		if (!s_route->c_oil.installed) {
-			if (pim_addr_is_any(*oil_origin(&s_route->c_oil)))
+			if (pim_addr_is_any(s_route->c_oil.source))
 				starg_sw_mroute_cnt++;
 			else
 				sg_sw_mroute_cnt++;
 		} else {
-			if (pim_addr_is_any(*oil_origin(&s_route->c_oil)))
+			if (pim_addr_is_any(s_route->c_oil.source))
 				starg_hw_mroute_cnt++;
 			else
 				sg_hw_mroute_cnt++;

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -72,7 +72,7 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 		if (listcount(pim_ifp->pim_neighbor_list) > 0 || pim_dm_check_gm_group_list(ifp)) {
 			frr_each (rb_pim_oil, &pim_ifp->pim->channel_oil_head, c_oil) {
 				if (pim_iface_grp_dm(pim_ifp, c_oil->group) && c_oil->installed) {
-					channel_oil_oif_add(c_oil, pim_ifp->mroute_vif_index, 0);
+					pim_channel_add_dm_oif(c_oil, ifp);
 					pim_upstream_mroute_update(c_oil, __func__);
 					if (pim_upstream_up_connected(c_oil->up) &&
 					    PIM_UPSTREAM_DM_TEST_PRUNE(c_oil->up->flags)) {
@@ -87,7 +87,9 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 	} else if (!HAVE_DENSE_MODE(mode) && HAVE_DENSE_MODE(pim_ifp->pim_mode)) {
 		frr_each (rb_pim_oil, &pim_ifp->pim->channel_oil_head, c_oil) {
 			if (pim_iface_grp_dm(pim_ifp, c_oil->group) && c_oil->installed) {
-				channel_oil_oif_delete(c_oil, pim_ifp->mroute_vif_index, 0);
+				channel_oil_oif_delete(c_oil, pim_ifp->mroute_vif_index,
+						       PIM_OIF_FLAG_PROTO_DM |
+							       PIM_OIF_FLAG_ASSERT_LOSER);
 				pim_upstream_mroute_update(c_oil, __func__);
 				if (!pim_upstream_up_connected(c_oil->up)) {
 					event_cancel(&c_oil->up->t_graft_timer);
@@ -239,9 +241,17 @@ void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_sta
 	struct interface *ifp = ch->interface;
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_upstream *up = ch->upstream;
+	struct channel_oif *coif;
 
 	if (!pim_ifp || !up || !up->channel_oil)
 		return;
+
+	coif = channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index);
+	if (new_state != PIM_IFASSERT_I_AM_LOSER && coif &&
+	    CHECK_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER)) {
+		UNSET_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER);
+		pim_upstream_mroute_update(up->channel_oil, __func__);
+	}
 
 	if (!pim_iface_grp_dm(pim_ifp, ch->sg.grp))
 		return;
@@ -255,10 +265,16 @@ void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_sta
 
 	if (new_state == PIM_IFASSERT_I_AM_LOSER) {
 		/* Defer to the Assert winner: stop forwarding the duplicate
-		 * back onto this LAN.
+		 * back onto this LAN.  Suppress the OIF rather than removing
+		 * it, so that any other protocol holding it (e.g. a local
+		 * IGMP/MLD join) keeps its subscription until the Assert is
+		 * over.  The suppression only stops dense mode's own
+		 * forwarding: `channel_oif_no_forward()` ignores this flag once
+		 * dense mode no longer owns the OIF, matching the GM path, which
+		 * never consults the Assert either.
 		 */
-		if (channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
-			channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+		if (coif && !CHECK_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER)) {
+			SET_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER);
 			pim_upstream_mroute_update(up->channel_oil, __func__);
 		}
 
@@ -286,11 +302,42 @@ void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_sta
 		if ((pim_ifp->pim_neighbor_list->count || pim_gm_has_igmp_join(ifp, ch->sg.grp)) &&
 		    !PIM_UPSTREAM_DM_TEST_PRUNE(ch->flags) &&
 		    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) &&
-		    !channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
-			channel_oil_oif_add(up->channel_oil, pim_ifp->mroute_vif_index, 0);
-			pim_upstream_mroute_update(up->channel_oil, __func__);
+		    (!coif || !CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_DM))) {
+			if (pim_channel_add_dm_oif(up->channel_oil, ifp))
+				pim_upstream_mroute_update(up->channel_oil, __func__);
 		}
 	}
+}
+
+/*
+ * The Assert suppression dense mode records on an OIF is a cache of
+ * `pim_macro_ch_lost_assert()`, which reads the ifchannel.  Once the ifchannel
+ * is gone nothing backs that cache and no further Assert transition can arrive
+ * to clear it, so release it here or the OIF stays out of the MFC for good.
+ *
+ * Note this cannot be solved by deriving the suppression when the MFC is built
+ * instead: the kernel only sees a new OIL when something calls
+ * `pim_upstream_mroute_update()`, and with the ifchannel gone nothing else
+ * would.  The push below is the point of this hook as much as the flag is.
+ *
+ * Deliberately not gated on the group still being dense: outliving dense mode
+ * is exactly the case being handled.
+ */
+void pim_dm_ifchannel_deleting(struct pim_ifchannel *ch)
+{
+	struct pim_interface *pim_ifp = ch->interface->info;
+	struct pim_upstream *up = ch->upstream;
+	struct channel_oif *coif;
+
+	if (!pim_ifp || !up || !up->channel_oil)
+		return;
+
+	coif = channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index);
+	if (!coif || !CHECK_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER))
+		return;
+
+	UNSET_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER);
+	pim_upstream_mroute_update(up->channel_oil, __func__);
 }
 
 void pim_dm_prune_send(struct pim_rpf rpf, struct pim_upstream *up, bool is_join)
@@ -366,6 +413,7 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 	struct pim_interface *pim_ifp = ifp->info;
 	pim_addr group_addr = sg->grp;
 	struct pim_ifchannel *ch, *throwaway;
+	struct channel_oif *coif;
 
 	if (!pim_ifp || !pim_ifp->pim_enable)
 		return;
@@ -380,9 +428,10 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 	if (!up)
 		return;
 
+	coif = channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index);
 	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
-	    !channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
-		channel_oil_oif_add(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+	    !(coif && CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_DM))) {
+		pim_channel_add_dm_oif(up->channel_oil, ifp);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 
 		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
@@ -390,7 +439,17 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 		if (ch) {
 			PIM_UPSTREAM_DM_UNSET_PRUNE(ch->flags);
 			event_cancel(&ch->t_ifjoin_expiry_timer);
-			pim_ifchannel_delete(ch);
+
+			/*
+			 * As in `pim_dm_prune_iff_on_timer()`, only drop the
+			 * ifchannel once the dense mode prune was the last thing
+			 * left on it.  `pim_ifchannel_delete()` releases this
+			 * interface's PIM and GM ownership of the OIF, so
+			 * deleting an ifchannel still in use would undo the
+			 * co-ownership restored just above.
+			 */
+			if (ch->flags == 0)
+				pim_ifchannel_delete(ch);
 		}
 
 		/* dm: forward graft message */
@@ -434,7 +493,8 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 
 	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
 	    channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
-		channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+		channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index,
+				       PIM_OIF_FLAG_PROTO_DM);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 
 		/* dm: we need to forward the prune upstream if needed */
@@ -498,7 +558,7 @@ void pim_dm_prune_iff_on_timer(struct event *t)
 	pim_upstream_keep_alive_timer_start(up, pim_ifp->pim->keep_alive_time);
 	if (up->channel_oil && up->channel_oil->installed &&
 	    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) && !lost_assert) {
-		channel_oil_oif_add(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+		pim_channel_add_dm_oif(up->channel_oil, ifp);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 	}
 }

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -71,9 +71,8 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 		pim_ifp->pim_mode = mode;
 		if (listcount(pim_ifp->pim_neighbor_list) > 0 || pim_dm_check_gm_group_list(ifp)) {
 			frr_each (rb_pim_oil, &pim_ifp->pim->channel_oil_head, c_oil) {
-				if (pim_iface_grp_dm(pim_ifp, *oil_mcastgrp(c_oil)) &&
-				    c_oil->installed) {
-					oil_if_set(c_oil, pim_ifp->mroute_vif_index, 1);
+				if (pim_iface_grp_dm(pim_ifp, c_oil->group) && c_oil->installed) {
+					channel_oil_oif_add(c_oil, pim_ifp->mroute_vif_index, 0);
 					pim_upstream_mroute_update(c_oil, __func__);
 					if (pim_upstream_up_connected(c_oil->up) &&
 					    PIM_UPSTREAM_DM_TEST_PRUNE(c_oil->up->flags)) {
@@ -87,8 +86,8 @@ void pim_dm_change_iif_mode(struct interface *ifp, enum pim_iface_mode mode)
 		}
 	} else if (!HAVE_DENSE_MODE(mode) && HAVE_DENSE_MODE(pim_ifp->pim_mode)) {
 		frr_each (rb_pim_oil, &pim_ifp->pim->channel_oil_head, c_oil) {
-			if (pim_iface_grp_dm(pim_ifp, *oil_mcastgrp(c_oil)) && c_oil->installed) {
-				oil_if_set(c_oil, pim_ifp->mroute_vif_index, 0);
+			if (pim_iface_grp_dm(pim_ifp, c_oil->group) && c_oil->installed) {
+				channel_oil_oif_delete(c_oil, pim_ifp->mroute_vif_index, 0);
 				pim_upstream_mroute_update(c_oil, __func__);
 				if (!pim_upstream_up_connected(c_oil->up)) {
 					event_cancel(&c_oil->up->t_graft_timer);
@@ -258,8 +257,8 @@ void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_sta
 		/* Defer to the Assert winner: stop forwarding the duplicate
 		 * back onto this LAN.
 		 */
-		if (oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
-			oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+		if (channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
+			channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 			pim_upstream_mroute_update(up->channel_oil, __func__);
 		}
 
@@ -287,8 +286,8 @@ void pim_dm_assert_state_changed(struct pim_ifchannel *ch, enum pim_ifassert_sta
 		if ((pim_ifp->pim_neighbor_list->count || pim_gm_has_igmp_join(ifp, ch->sg.grp)) &&
 		    !PIM_UPSTREAM_DM_TEST_PRUNE(ch->flags) &&
 		    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) &&
-		    !oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
-			oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
+		    !channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
+			channel_oil_oif_add(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 			pim_upstream_mroute_update(up->channel_oil, __func__);
 		}
 	}
@@ -382,8 +381,8 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 		return;
 
 	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
-	    !oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
-		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
+	    !channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
+		channel_oil_oif_add(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 
 		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
@@ -434,8 +433,8 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 	vrf = up->pim->vrf;
 
 	if (pim_iface_grp_dm(pim_ifp, group_addr) &&
-	    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
-		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+	    channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index)) {
+		channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 
 		/* dm: we need to forward the prune upstream if needed */
@@ -445,7 +444,7 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 			if (!pim_ifp2)
 				continue;
 			if (HAVE_DENSE_MODE(pim_ifp2->pim_mode) && ifp2->ifindex != ifp->ifindex &&
-			    oil_if_has(up->channel_oil, pim_ifp2->mroute_vif_index)) {
+			    channel_oil_oif_find(up->channel_oil, pim_ifp2->mroute_vif_index)) {
 				sg_connected = true;
 				break;
 			}
@@ -499,7 +498,7 @@ void pim_dm_prune_iff_on_timer(struct event *t)
 	pim_upstream_keep_alive_timer_start(up, pim_ifp->pim->keep_alive_time);
 	if (up->channel_oil && up->channel_oil->installed &&
 	    !PIM_UPSTREAM_DM_TEST_PRUNE(up->flags) && !lost_assert) {
-		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
+		channel_oil_oif_add(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 	}
 }

--- a/pimd/pim_dm.h
+++ b/pimd/pim_dm.h
@@ -33,6 +33,7 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg);
 void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16_t holdtime,
 		       pim_addr upstream, pim_sgaddr *sg, uint8_t source_flags);
 void pim_dm_prune_iff_on_timer(struct event *t);
+void pim_dm_ifchannel_deleting(struct pim_ifchannel *ch);
 void pim_dm_prefix_list_update(struct pim_instance *pim, struct prefix_list *plist);
 bool pim_is_grp_dm(struct pim_instance *pim, pim_addr group_addr);
 bool pim_is_dm_prefix_filter(struct pim_instance *pim, pim_addr group_addr);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -185,7 +185,6 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool gm, bool pim,
 	pim_sock_reset(ifp);
 
 	pim_if_add_vif(ifp, ispimreg, is_vxlan_term);
-	pim_ifp->pim->mcast_if_count++;
 
 	pim_filter_ref_init(&pim_ifp->gmp_filter);
 	pim_filter_ref_init(&pim_ifp->gm_proxy_filter);
@@ -200,8 +199,6 @@ void pim_if_delete(struct interface *ifp)
 	assert(ifp);
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
-
-	pim_ifp->pim->mcast_if_count--;
 
 	pim_upstream_rpf_interface_del(ifp);
 
@@ -1022,11 +1019,12 @@ pim_addr pim_find_primary_addr(struct interface *ifp)
 #endif
 }
 
-static int pim_iface_next_vif_index(struct interface *ifp)
+static ifindex_t pim_iface_next_vif_index(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_instance *pim = pim_ifp->pim;
-	int i;
+	struct pim_multicast_if *mif;
+	ifindex_t index;
 
 	/*
 	 * The pimreg vif is always going to be in index 0
@@ -1035,11 +1033,29 @@ static int pim_iface_next_vif_index(struct interface *ifp)
 	if (ifp->ifindex == PIM_OIF_PIM_REGISTER_VIF)
 		return 0;
 
-	for (i = 1; i < MAXVIFS; i++) {
-		if (pim->iface_vif_index[i] == 0)
-			return i;
+	/* Look for holes in the list or return the next highest number. */
+	index = 1;
+	frr_each (multicast_interface_list, &pim->mif_list, mif) {
+		/*
+		 * Index is less than the minimum, just skip it
+		 * (e.g. pimreg).
+		 */
+		if (mif->index < index)
+			continue;
+		/* Index points to already existing interface, go to the next one. */
+		if (mif->index == index) {
+			index++;
+			continue;
+		}
+
+		/* Found the hole */
+		break;
 	}
-	return MAXVIFS;
+
+	if (index >= MAXVIFS)
+		return -1;
+
+	return index;
 }
 
 /*
@@ -1087,7 +1103,7 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 
 	pim_ifp->mroute_vif_index = pim_iface_next_vif_index(ifp);
 
-	if (pim_ifp->mroute_vif_index >= MAXVIFS) {
+	if (pim_ifp->mroute_vif_index == -1) {
 		zlog_warn(
 			"%s: Attempting to configure more than MAXVIFS=%d on pim enabled interface %s",
 			__func__, MAXVIFS, ifp->name);
@@ -1106,7 +1122,7 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 		return -5;
 	}
 
-	pim_ifp->pim->iface_vif_index[pim_ifp->mroute_vif_index] = 1;
+	pim_instance_mif_add(pim_ifp->pim, pim_ifp->mroute_vif_index);
 
 	if (!ispimreg)
 		gm_ifp_update(ifp);
@@ -1143,10 +1159,7 @@ int pim_if_del_vif(struct interface *ifp)
 
 	pim_mroute_del_vif(ifp);
 
-	/*
-	  Update vif_index
-	 */
-	pim_ifp->pim->iface_vif_index[pim_ifp->mroute_vif_index] = 0;
+	pim_instance_mif_delete(pim_ifp->pim, pim_ifp->mroute_vif_index);
 
 	pim_ifp->mroute_vif_index = -1;
 	return 0;
@@ -2053,7 +2066,7 @@ static int pim_ifp_create(struct interface *ifp)
 
 	if (!strncmp(ifp->name, PIM_VXLAN_TERM_DEV_NAME,
 		     sizeof(PIM_VXLAN_TERM_DEV_NAME))) {
-		if (pim->mcast_if_count < MAXVIFS)
+		if (multicast_interface_list_count(&pim->mif_list) < MAXVIFS)
 			pim_vxlan_add_term_dev(pim, ifp);
 		else
 			zlog_warn(

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -306,8 +306,7 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 					 * supplying the implied
 					 * if channel.  So remove it.
 					 */
-					if (oil_if_has(c_oil,
-						       pim_ifp->mroute_vif_index))
+					if (channel_oil_oif_find(c_oil, pim_ifp->mroute_vif_index))
 						pim_channel_del_inherited_oif(
 							c_oil, ch->interface,
 							__func__);
@@ -1322,7 +1321,7 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 			 */
 			if (!pim_upstream_evaluate_join_desired_interface(child, chchannel,
 									  chchannelrpt, starch) ||
-			    (!chchannel && oil_if_has(c_oil, pim_ifp->mroute_vif_index))) {
+			    (!chchannel && channel_oil_oif_find(c_oil, pim_ifp->mroute_vif_index))) {
 				pim_channel_del_inherited_oif(c_oil, ifp,
 						__func__);
 			}

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -32,6 +32,7 @@
 #include "pim_ssm.h"
 #include "pim_rp.h"
 #include "pim_mlag.h"
+#include "pim_dm.h"
 
 RB_GENERATE(pim_ifchannel_rb, pim_ifchannel, pim_ifp_rb, pim_ifchannel_compare);
 
@@ -168,6 +169,9 @@ void pim_ifchannel_delete(struct pim_ifchannel *origch)
 			for (ALL_LIST_ELEMENTS_RO(up->sources, up_node, child))
 				pim_channel_del_inherited_oif(child->channel_oil, ifp, __func__);
 		}
+
+		/* Release any Assert suppression cached for this ifchannel. */
+		pim_dm_ifchannel_deleting(origch);
 	}
 
 	/*

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -27,9 +27,51 @@
 #include "pim_mlag.h"
 #include "pim_sock.h"
 
+DEFINE_MTYPE_STATIC(PIMD, PIM_MULTICAST_IF, "PIM multicast interface index");
+
+int pim_instance_mif_cmp(const struct pim_multicast_if *mifa, const struct pim_multicast_if *mifb)
+{
+	return (mifa->index > mifb->index) ? 1 : (mifa->index < mifb->index) ? -1 : 0;
+}
+
+static struct pim_multicast_if *pim_instance_mif_find(struct pim_instance *pim, ifindex_t index)
+{
+	struct pim_multicast_if entry = { .index = index };
+
+	return multicast_interface_list_find(&pim->mif_list, &entry);
+}
+
+void pim_instance_mif_add(struct pim_instance *pim, ifindex_t index)
+{
+	struct pim_multicast_if *mif = pim_instance_mif_find(pim, index);
+
+	if (mif)
+		return;
+
+	mif = XCALLOC(MTYPE_PIM_MULTICAST_IF, sizeof(*mif));
+	mif->index = index;
+	multicast_interface_list_add(&pim->mif_list, mif);
+}
+
+void pim_instance_mif_delete(struct pim_instance *pim, ifindex_t index)
+{
+	struct pim_multicast_if *mif = pim_instance_mif_find(pim, index);
+
+	if (!mif)
+		return;
+
+	multicast_interface_list_del(&pim->mif_list, mif);
+	XFREE(MTYPE_PIM_MULTICAST_IF, mif);
+}
+
 static void pim_instance_terminate(struct pim_instance *pim)
 {
+	struct pim_multicast_if *mif;
+
 	pim->stopping = true;
+
+	frr_each_safe (multicast_interface_list, &pim->mif_list, mif)
+		pim_instance_mif_delete(pim, mif->index);
 
 	pim_vxlan_exit(pim);
 
@@ -84,10 +126,11 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 
 	pim = XCALLOC(MTYPE_PIM_PIM_INSTANCE, sizeof(struct pim_instance));
 
+	multicast_interface_list_init(&pim->mif_list);
+
 	pim_ssm_init(pim);
 	pim_dm_init(pim);
 
-	pim->mcast_if_count = 0;
 	pim->keep_alive_time = PIM_KEEPALIVE_PERIOD;
 	pim->rp_keep_alive_time = PIM_RP_KEEPALIVE_PERIOD;
 	pim->staterefresh_time = PIM_STATEREFRESH_PERIOD;

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -108,6 +108,20 @@ struct pim_router {
 	struct interface *peerlink_rif_p;
 };
 
+PREDECL_SORTLIST_UNIQ(multicast_interface_list);
+struct pim_multicast_if {
+	struct multicast_interface_list_item entry;
+
+	/* Interface index */
+	ifindex_t index;
+};
+
+extern int pim_instance_mif_cmp(const struct pim_multicast_if *mifa,
+				const struct pim_multicast_if *mifb);
+
+DECLARE_SORTLIST_UNIQ(multicast_interface_list, struct pim_multicast_if, entry,
+		      pim_instance_mif_cmp);
+
 /* Per VRF PIM DB */
 struct pim_instance {
 	// vrf_id_t vrf_id;
@@ -158,8 +172,7 @@ struct pim_instance {
 	struct list *rp_list;
 	struct route_table *rp_table;
 
-	int iface_vif_index[MAXVIFS];
-	int mcast_if_count;
+	struct multicast_interface_list_head mif_list;
 
 	struct rb_pim_oil_head channel_oil_head;
 
@@ -239,6 +252,9 @@ struct pim_instance {
 	} embedded_rp;
 #endif /* PIM_IPV == 6 */
 };
+
+extern void pim_instance_mif_add(struct pim_instance *pim, ifindex_t index);
+extern void pim_instance_mif_delete(struct pim_instance *pim, ifindex_t index);
 
 void pim_vrf_init(void);
 void pim_vrf_terminate(void);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -437,7 +437,7 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 					if (pim_macro_ch_lost_assert(ch_flood))
 						continue;
 				}
-				channel_oil_oif_add(up->channel_oil, pim_ifp2->mroute_vif_index, 0);
+				pim_channel_add_dm_oif(up->channel_oil, ifp2);
 				update_oil = true;
 			}
 		}

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -413,8 +413,7 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 		}
 
 		/* resolve mfcc_parent prior to mroute_add in channel_add_oif */
-		if (up->rpf.source_nexthop.interface &&
-		    *oil_incoming_vif(up->channel_oil) >= MAXVIFS) {
+		if (up->rpf.source_nexthop.interface && up->channel_oil->iif.index >= MAXVIFS) {
 			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 		}
 
@@ -438,7 +437,7 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 					if (pim_macro_ch_lost_assert(ch_flood))
 						continue;
 				}
-				oil_if_set(up->channel_oil, pim_ifp2->mroute_vif_index, 1);
+				channel_oil_oif_add(up->channel_oil, pim_ifp2->mroute_vif_index, 0);
 				update_oil = true;
 			}
 		}
@@ -531,9 +530,8 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	up->channel_oil->cc.pktcnt++;
 
 	/* resolve mfcc_parent prior to mroute_add in channel_add_oif */
-	if (up->rpf.source_nexthop.interface && *oil_incoming_vif(up->channel_oil) >= MAXVIFS) {
+	if (up->rpf.source_nexthop.interface && up->channel_oil->iif.index >= MAXVIFS)
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
-	}
 
 	/*
 	 * I moved this debug till after the actual add because
@@ -740,7 +738,7 @@ static int pim_upstream_activate_stream(struct interface *ifp, pim_sgaddr *sg)
 	up->channel_oil->cc.pktcnt++;
 
 	/* resolve mfcc_parent prior to mroute_add in channel_add_oif */
-	if (up->rpf.source_nexthop.interface && *oil_incoming_vif(up->channel_oil) >= MAXVIFS)
+	if (up->rpf.source_nexthop.interface && up->channel_oil->iif.index >= MAXVIFS)
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
 	if (!pim_is_group_filtered(pim_ifp, &sg->grp, &sg->src) && pim_upstream_could_register(up))
@@ -902,7 +900,7 @@ static int pim_mroute_wrongvif_prefer_ingress(struct interface *ifp, pim_sgaddr 
 
 	ingress_vif = pim_ifp->mroute_vif_index;
 	if (up->channel_oil->installed && up->rpf.source_nexthop.interface == ifp &&
-	    *oil_incoming_vif(up->channel_oil) == ingress_vif)
+	    up->channel_oil->iif.index == ingress_vif)
 		/*
 		 * Already aligned with kernel ingress.  Treat as handled so
 		 * the caller does not fall through to Assert on a (*,G)
@@ -1714,52 +1712,34 @@ bool pim_mroute_allow_iif_in_oil(struct channel_oil *c_oil,
 #endif
 }
 
-static inline void pim_mroute_copy(struct channel_oil *out,
-				   struct channel_oil *in)
-{
-	int i;
-
-	*oil_origin(out) = *oil_origin(in);
-	*oil_mcastgrp(out) = *oil_mcastgrp(in);
-	*oil_incoming_vif(out) = *oil_incoming_vif(in);
-
-	for (i = 0; i < MAXVIFS; ++i) {
-		if (*oil_incoming_vif(out) == i &&
-		    !pim_mroute_allow_iif_in_oil(in, i)) {
-			oil_if_set(out, i, 0);
-			continue;
-		}
-
-		if (in->oif_flags[i] & PIM_OIF_FLAG_MUTE)
-			oil_if_set(out, i, 0);
-		else
-			oil_if_set(out, i, oil_if_has(in, i));
-	}
-}
-
 /* This function must not be called directly 0
  * use pim_upstream_mroute_add or pim_static_mroute_add instead
  */
 static int pim_mroute_add(struct channel_oil *c_oil, const char *name)
 {
 	struct pim_instance *pim = c_oil->pim;
-	struct channel_oil tmp_oil[1] = { };
+#if PIM_IPV == 4
+	struct mfcctl mfcc;
+#else
+	struct mf6cctl mfcc;
+#endif
 	int err;
 
 	pim->mroute_add_last = pim_time_monotonic_sec();
 	++pim->mroute_add_events;
 
-	/* Copy the oil to a temporary structure to fixup (without need to
-	 * later restore) before sending the mroute add to the dataplane
-	 */
-	pim_mroute_copy(tmp_oil, c_oil);
+	channel_oil_to_mfcc(c_oil, &mfcc);
 
 	/* The linux kernel *expects* the incoming
 	 * vif to be part of the outgoing list
 	 * in the case of a (*,G).
 	 */
-	if (pim_addr_is_any(*oil_origin(c_oil))) {
-		oil_if_set(tmp_oil, *oil_incoming_vif(c_oil), 1);
+	if (pim_addr_is_any(c_oil->source)) {
+#if PIM_IPV == 4
+		mfcc.mfcc_ttls[c_oil->iif.index] = PIM_MROUTE_MIN_TTL;
+#else
+		IF_SET(c_oil->iif.index, &mfcc.mf6cc_ifset);
+#endif
 	}
 
 	/*
@@ -1769,22 +1749,28 @@ static int pim_mroute_add(struct channel_oil *c_oil, const char *name)
 	 * the packets to be forwarded.  Then set it
 	 * to the correct IIF afterwards.
 	 */
-	if (!c_oil->installed && !pim_addr_is_any(*oil_origin(c_oil)) &&
-	    *oil_incoming_vif(c_oil) != 0) {
-		*oil_incoming_vif(tmp_oil) = 0;
-	}
-	/* For IPv6 MRT_ADD_MFC is defined to MRT6_ADD_MFC */
-	frr_with_privs (&pimd_privs) {
-		err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_ADD_MFC, &tmp_oil->oil,
-				 sizeof(tmp_oil->oil));
+	if (!c_oil->installed && !pim_addr_is_any(c_oil->source) && c_oil->iif.index != 0) {
+#if PIM_IPV == 4
+		mfcc.mfcc_parent = 0;
+#else
+		mfcc.mf6cc_parent = 0;
+#endif
 	}
 
-	if (!err && !c_oil->installed && !pim_addr_is_any(*oil_origin(c_oil)) &&
-	    *oil_incoming_vif(c_oil) != 0) {
-		*oil_incoming_vif(tmp_oil) = *oil_incoming_vif(c_oil);
+	/* For IPv6 MRT_ADD_MFC is defined to MRT6_ADD_MFC */
+	frr_with_privs (&pimd_privs) {
+		err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_ADD_MFC, &mfcc, sizeof(mfcc));
+	}
+
+	if (!err && !c_oil->installed && !pim_addr_is_any(c_oil->source) && c_oil->iif.index != 0) {
+#if PIM_IPV == 4
+		mfcc.mfcc_parent = c_oil->iif.index;
+#else
+		mfcc.mf6cc_parent = c_oil->iif.index;
+#endif
 		frr_with_privs (&pimd_privs) {
-			err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_ADD_MFC,
-					 &tmp_oil->oil, sizeof(tmp_oil->oil));
+			err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_ADD_MFC, &mfcc,
+					 sizeof(mfcc));
 		}
 	}
 
@@ -1839,7 +1825,7 @@ int pim_upstream_mroute_update(struct channel_oil *c_oil, const char *name)
 {
 	char buf[1000];
 
-	if (*oil_incoming_vif(c_oil) >= MAXVIFS) {
+	if (c_oil->iif.index >= MAXVIFS) {
 		/* the c_oil cannot be installed as a mroute yet */
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
@@ -1886,14 +1872,12 @@ int pim_upstream_mroute_add(struct channel_oil *c_oil, const char *name)
 
 	iif = pim_upstream_get_mroute_iif(c_oil, name);
 
-	if (*oil_incoming_vif(c_oil) != iif) {
-		*oil_incoming_vif(c_oil) = iif;
-		if (pim_addr_is_any(*oil_origin(c_oil)) &&
-				c_oil->up)
+	if (c_oil->iif.index != iif) {
+		c_oil->iif.index = iif;
+		if (pim_addr_is_any(c_oil->source) && c_oil->up)
 			pim_upstream_all_sources_iif_update(c_oil->up);
-	} else {
-		*oil_incoming_vif(c_oil) = iif;
-	}
+	} else
+		c_oil->iif.index = iif;
 
 	return pim_upstream_mroute_update(c_oil, name);
 }
@@ -1910,14 +1894,13 @@ int pim_upstream_mroute_iif_update(struct channel_oil *c_oil, const char *name)
 		return 0;
 
 	iif = pim_upstream_get_mroute_iif(c_oil, name);
-	if (*oil_incoming_vif(c_oil) == iif) {
+	if (c_oil->iif.index == iif) {
 		/* no change */
 		return 0;
 	}
-	*oil_incoming_vif(c_oil) = iif;
+	c_oil->iif.index = iif;
 
-	if (pim_addr_is_any(*oil_origin(c_oil)) &&
-			c_oil->up)
+	if (pim_addr_is_any(c_oil->source) && c_oil->up)
 		pim_upstream_all_sources_iif_update(c_oil->up);
 
 	if (PIM_DEBUG_MROUTE_DETAIL)
@@ -1939,10 +1922,10 @@ void pim_static_mroute_iif_update(struct channel_oil *c_oil,
 				int input_vif_index,
 				const char *name)
 {
-	if (*oil_incoming_vif(c_oil) == input_vif_index)
+	if (c_oil->iif.index == input_vif_index)
 		return;
 
-	*oil_incoming_vif(c_oil) = input_vif_index;
+	c_oil->iif.index = input_vif_index;
 	if (input_vif_index == MAXVIFS)
 		pim_mroute_del(c_oil, name);
 	else
@@ -1953,6 +1936,11 @@ int pim_mroute_del(struct channel_oil *c_oil, const char *name)
 {
 	struct pim_instance *pim = c_oil->pim;
 	int err;
+#if PIM_IPV == 4
+	struct mfcctl mfcc;
+#else
+	struct mf6cctl mfcc;
+#endif
 
 	pim->mroute_del_last = pim_time_monotonic_sec();
 	++pim->mroute_del_events;
@@ -1960,9 +1948,7 @@ int pim_mroute_del(struct channel_oil *c_oil, const char *name)
 	if (!c_oil->installed) {
 		if (PIM_DEBUG_MROUTE) {
 			char buf[1000];
-			struct interface *iifp =
-				pim_if_find_by_vif_index(pim, *oil_incoming_vif(
-								      c_oil));
+			struct interface *iifp = pim_if_find_by_vif_index(pim, c_oil->iif.index);
 
 			zlog_debug("%s %s: incoming interface %s for route is %s not installed, do not need to send del req. ",
 				   __FILE__, __func__,
@@ -1973,8 +1959,9 @@ int pim_mroute_del(struct channel_oil *c_oil, const char *name)
 		return -2;
 	}
 
-	err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_DEL_MFC,
-			 &c_oil->oil, sizeof(c_oil->oil));
+	channel_oil_to_mfcc(c_oil, &mfcc);
+
+	err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_DEL_MFC, &mfcc, sizeof(mfcc));
 	if (err) {
 		if (PIM_DEBUG_MROUTE)
 			zlog_warn(
@@ -2011,8 +1998,8 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 		if (PIM_DEBUG_MROUTE) {
 			pim_sgaddr sg;
 
-			sg.src = *oil_origin(c_oil);
-			sg.grp = *oil_mcastgrp(c_oil);
+			sg.src = c_oil->source;
+			sg.grp = c_oil->group;
 			zlog_debug("Channel%pSG is not installed no need to collect data from kernel",
 				   &sg);
 		}
@@ -2025,17 +2012,19 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 	pim_zlookup_sg_statistics(c_oil);
 
 #if PIM_IPV == 4
-	sgreq.src = *oil_origin(c_oil);
-	sgreq.grp = *oil_mcastgrp(c_oil);
+	sgreq.src = c_oil->source;
+	sgreq.grp = c_oil->group;
 #else
-	sgreq.src = c_oil->oil.mf6cc_origin;
-	sgreq.grp = c_oil->oil.mf6cc_mcastgrp;
+	sgreq.src.sin6_family = AF_INET6;
+	sgreq.src.sin6_addr = c_oil->source;
+	sgreq.grp.sin6_family = AF_INET6;
+	sgreq.grp.sin6_addr = c_oil->group;
 #endif
 	if (ioctl(pim->mroute_socket, PIM_SIOCGETSGCNT, &sgreq)) {
 		pim_sgaddr sg;
 
-		sg.src = *oil_origin(c_oil);
-		sg.grp = *oil_mcastgrp(c_oil);
+		sg.src = c_oil->source;
+		sg.grp = c_oil->group;
 
 		zlog_warn(
 			"ioctl(PIM_SIOCGETSGCNT=%lu) failure for (S,G)=%pSG: errno=%d: %s",

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2285,24 +2285,18 @@ static int pim_interface_num_get(const struct lyd_node *if_dnode)
 	struct pim_instance *pim;
 	const struct lyd_node *iter, *lib_dnode;
 	int cnt = 0;
-	int i;
 
 	/*
 	 * If the interface already exists in running datastore, check the
-	 * per-VRF iface_vif_index array directly for used VIF slots.
+	 * per-VRF multicast interface list directly for used VIF slots.
 	 * This correctly accounts for pimreg reserving VIF index 0, is
 	 * scoped to the correct VRF.
 	 */
 	ifp = nb_running_get_entry(if_dnode, NULL, false);
 	if (ifp) {
 		pim = ifp->vrf->info;
-		if (pim) {
-			for (i = 0; i < MAXVIFS; i++) {
-				if (pim->iface_vif_index[i] != 0)
-					cnt++;
-			}
-			return cnt;
-		}
+		if (pim)
+			return multicast_interface_list_count(&pim->mif_list);
 	}
 
 	/*

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -346,9 +346,9 @@ pim_neighbor_new(struct interface *ifp, pim_addr source_addr,
 	/* flood to the new neighbor if needed */
 	if (HAVE_DENSE_MODE(pim_ifp->pim_mode)) {
 		frr_each (rb_pim_oil, &pim_ifp->pim->channel_oil_head, c_oil) {
-			if (pim_is_grp_dm(pim_ifp->pim, *oil_mcastgrp(c_oil)) && c_oil->installed &&
-			    !oil_if_has(c_oil, pim_ifp->mroute_vif_index)) {
-				oil_if_set(c_oil, pim_ifp->mroute_vif_index, 1);
+			if (pim_is_grp_dm(pim_ifp->pim, c_oil->group) && c_oil->installed &&
+			    !channel_oil_oif_find(c_oil, pim_ifp->mroute_vif_index)) {
+				channel_oil_oif_add(c_oil, pim_ifp->mroute_vif_index, 0);
 				pim_upstream_mroute_update(c_oil, __func__);
 			}
 		}

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -348,7 +348,7 @@ pim_neighbor_new(struct interface *ifp, pim_addr source_addr,
 		frr_each (rb_pim_oil, &pim_ifp->pim->channel_oil_head, c_oil) {
 			if (pim_is_grp_dm(pim_ifp->pim, c_oil->group) && c_oil->installed &&
 			    !channel_oil_oif_find(c_oil, pim_ifp->mroute_vif_index)) {
-				channel_oil_oif_add(c_oil, pim_ifp->mroute_vif_index, 0);
+				pim_channel_add_dm_oif(c_oil, ifp);
 				pim_upstream_mroute_update(c_oil, __func__);
 			}
 		}

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -21,6 +21,8 @@
 #include "pim_time.h"
 #include "pim_vxlan.h"
 #include "pim_ssm.h"
+#include "pim_ifchannel.h"
+#include "pim_macro.h"
 
 static void pim_channel_update_mute(struct channel_oil *c_oil);
 
@@ -263,8 +265,15 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 		return 0;
 	}
 
-	/* clear mute; will be re-evaluated when the OIF becomes valid again */
-	if (coif)
+	/*
+	 * Clear mute; will be re-evaluated when the OIF becomes valid again.
+	 *
+	 * Dense mode holds its OIFs outside of `proto_mask`, so an OIF it still
+	 * wants has to be left alone here: that OIF stays in the OIL, and
+	 * releasing its mute would resume forwarding on an interface still held
+	 * down by the MLAG DF role or VXLAN termination.
+	 */
+	if (coif && !CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_DM))
 		channel_oil_oif_delete(channel_oil, coif->index, PIM_OIF_FLAG_MUTE);
 
 	if (pim_upstream_mroute_add(channel_oil, __func__)) {
@@ -459,8 +468,13 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 
 	/* Allow other protocol to request subscription of same interface to
 	 * channel (S,G), we need to note this information
+	 *
+	 * Dense mode counts as an owner here even though it is not part of
+	 * `PIM_OIF_FLAG_PROTO_ANY`: an OIF it flooded to first must still record
+	 * the protocol asking for it now, otherwise dropping dense mode's
+	 * interest later would take the OIF away from that protocol.
 	 */
-	if (coif && CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_ANY)) {
+	if (coif && CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_ANY | PIM_OIF_FLAG_PROTO_DM)) {
 		/* Updating time here is not required as this time has to
 		 * indicate when the interface is added
 		 */
@@ -595,6 +609,31 @@ struct channel_oif *channel_oil_oif_add(struct channel_oil *oil, ifindex_t index
 	return oif;
 }
 
+struct channel_oif *pim_channel_add_dm_oif(struct channel_oil *c_oil, struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct pim_ifchannel *ch, *throwaway;
+	pim_sgaddr sg = { .src = c_oil->source, .grp = c_oil->group };
+	struct channel_oif *coif;
+
+	coif = channel_oil_oif_add(c_oil, pim_ifp->mroute_vif_index, PIM_OIF_FLAG_PROTO_DM);
+	if (!coif)
+		return NULL;
+
+	if (pim_channel_eval_oif_mute(c_oil, pim_ifp))
+		SET_FLAG(coif->flags, PIM_OIF_FLAG_MUTE);
+	else
+		UNSET_FLAG(coif->flags, PIM_OIF_FLAG_MUTE);
+
+	pim_ifchannel_find(ifp, &sg, &ch, &throwaway);
+	if (ch && pim_macro_ch_lost_assert(ch))
+		SET_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER);
+	else
+		UNSET_FLAG(coif->flags, PIM_OIF_FLAG_ASSERT_LOSER);
+
+	return coif;
+}
+
 void channel_oil_oif_delete(struct channel_oil *oil, ifindex_t index, uint32_t flags)
 {
 	struct channel_oif *oif = channel_oil_oif_find(oil, index);
@@ -605,7 +644,7 @@ void channel_oil_oif_delete(struct channel_oil *oil, ifindex_t index, uint32_t f
 	UNSET_FLAG(oif->flags, flags);
 
 	/* Only ownership keeps an OIF in the list */
-	if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_ANY))
+	if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_ANY | PIM_OIF_FLAG_PROTO_DM))
 		return;
 
 	channel_oif_list_del(&oil->oif_list, oif);
@@ -624,7 +663,7 @@ void channel_oil_to_mfcc(struct channel_oil *oil, struct mfcctl *mfcc)
 	frr_each (channel_oif_list, &oil->oif_list, oif) {
 		if (oif->index == oil->iif.index && !pim_mroute_allow_iif_in_oil(oil, oif->index))
 			continue;
-		if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
+		if (channel_oif_no_forward(oif))
 			continue;
 
 		mfcc->mfcc_ttls[oif->index] = PIM_MROUTE_MIN_TTL;
@@ -647,7 +686,7 @@ void channel_oil_to_mfcc(struct channel_oil *oil, struct mf6cctl *mf6cc)
 	frr_each (channel_oif_list, &oil->oif_list, oif) {
 		if (oif->index == oil->iif.index && !pim_mroute_allow_iif_in_oil(oil, oif->index))
 			continue;
-		if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
+		if (channel_oif_no_forward(oif))
 			continue;
 
 		IF_SET(oif->index, &mf6cc->mf6cc_ifset);

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -28,23 +28,20 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 {
 	char *out;
 	struct interface *ifp;
+	struct channel_oif *oif;
 	pim_sgaddr sg;
-	int i;
 
-	sg.src = *oil_origin(c_oil);
-	sg.grp = *oil_mcastgrp(c_oil);
-	ifp = pim_if_find_by_vif_index(c_oil->pim, *oil_incoming_vif(c_oil));
+	sg.src = c_oil->source;
+	sg.grp = c_oil->group;
+	ifp = pim_if_find_by_vif_index(c_oil->pim, c_oil->iif.index);
 	snprintfrr(buf, size, "%pSG IIF: %s, OIFS: ", &sg,
 		   ifp ? ifp->name : "(?)");
 
 	out = buf + strlen(buf);
-	for (i = 0; i < MAXVIFS; i++) {
-		if (oil_if_has(c_oil, i) != 0) {
-			ifp = pim_if_find_by_vif_index(c_oil->pim, i);
-			snprintf(out, buf + size - out, "%s ",
-				 ifp ? ifp->name : "(?)");
-			out += strlen(out);
-		}
+	frr_each (channel_oif_list, &c_oil->oif_list, oif) {
+		ifp = pim_if_find_by_vif_index(c_oil->pim, oif->index);
+		snprintf(out, buf + size - out, "%s ", ifp ? ifp->name : "(?)");
+		out += strlen(out);
 	}
 
 	return buf;
@@ -57,10 +54,10 @@ int pim_channel_oil_compare(const struct channel_oil *cc1,
 	struct channel_oil *c2 = (struct channel_oil *)cc2;
 	int rv;
 
-	rv = pim_addr_cmp(*oil_mcastgrp(c1), *oil_mcastgrp(c2));
+	rv = pim_addr_cmp(c1->group, c2->group);
 	if (rv)
 		return rv;
-	rv = pim_addr_cmp(*oil_origin(c1), *oil_origin(c2));
+	rv = pim_addr_cmp(c1->source, c2->source);
 	if (rv)
 		return rv;
 	return 0;
@@ -83,6 +80,11 @@ void pim_oil_terminate(struct pim_instance *pim)
 
 void pim_channel_oil_free(struct channel_oil *c_oil)
 {
+	struct channel_oif *oif;
+
+	frr_each_safe (channel_oif_list, &c_oil->oif_list, oif)
+		channel_oil_oif_delete(c_oil, oif->index, oif->flags);
+
 	XFREE(MTYPE_PIM_CHANNEL_OIL, c_oil);
 }
 
@@ -92,8 +94,8 @@ struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
 	struct channel_oil *c_oil = NULL;
 	struct channel_oil lookup;
 
-	*oil_mcastgrp(&lookup) = sg->grp;
-	*oil_origin(&lookup) = sg->src;
+	lookup.group = sg->grp;
+	lookup.source = sg->src;
 
 	c_oil = rb_pim_oil_find(&pim->channel_oil_head, &lookup);
 
@@ -134,15 +136,16 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 
 	c_oil = XCALLOC(MTYPE_PIM_CHANNEL_OIL, sizeof(*c_oil));
 
-	*oil_mcastgrp(c_oil) = sg->grp;
-	*oil_origin(c_oil) = sg->src;
+	c_oil->group = sg->grp;
+	c_oil->source = sg->src;
 
-	*oil_incoming_vif(c_oil) = MAXVIFS;
+	c_oil->iif.index = MAXVIFS;
 	c_oil->oil_ref_count = 1;
 	c_oil->installed = 0;
 	c_oil->up = pim_upstream_find(pim, sg);
 	c_oil->pim = pim;
 
+	channel_oif_list_init(&c_oil->oif_list);
 	rb_pim_oil_add(&pim->channel_oil_head, c_oil);
 
 	if (PIM_DEBUG_MROUTE)
@@ -166,7 +169,7 @@ void pim_clear_nocache_state(struct pim_interface *pim_ifp)
 		    !(PIM_UPSTREAM_FLAG_TEST_SRC_NOCACHE(c_oil->up->flags)))
 			continue;
 
-		if (*oil_incoming_vif(c_oil) != pim_ifp->mroute_vif_index)
+		if (c_oil->iif.index != pim_ifp->mroute_vif_index)
 			continue;
 
 		event_cancel(&c_oil->up->t_ka_timer);
@@ -180,8 +183,7 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name)
 {
 	if (PIM_DEBUG_MROUTE) {
-		pim_sgaddr sg = {.src = *oil_origin(c_oil),
-				 .grp = *oil_mcastgrp(c_oil)};
+		pim_sgaddr sg = { .src = c_oil->source, .grp = c_oil->group };
 
 		zlog_debug(
 			"%s(%s): Del oil for %pSG, Ref Count: %d (Predecrement)",
@@ -224,6 +226,7 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 			uint32_t proto_mask, const char *caller)
 {
 	struct pim_interface *pim_ifp;
+	struct channel_oif *coif;
 
 	assert(channel_oil);
 	assert(oif);
@@ -234,69 +237,52 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 		"trying to del OIF %s with VIF (%d)", oif->name,
 		pim_ifp->mroute_vif_index);
 
+	coif = channel_oil_oif_find(channel_oil, pim_ifp->mroute_vif_index);
+
 	/*
 	 * Don't do anything if we've been asked to remove a source
 	 * that is not actually on it.
 	 */
-	if (!(channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask)) {
-		if (PIM_DEBUG_MROUTE) {
-			zlog_debug(
-				"%s %s: no existing protocol mask %u(%u) for requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
-				__FILE__, __func__, proto_mask,
-				channel_oil
-					->oif_flags[pim_ifp->mroute_vif_index],
-				oif->name, pim_ifp->mroute_vif_index,
-				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
-				oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil));
-		}
+	if (!coif || !CHECK_FLAG(coif->flags, proto_mask)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s %s: no existing protocol mask %u(%u) for requested OIF %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
+				   __FILE__, __func__, proto_mask, coif ? coif->flags : 0,
+				   oif->name, pim_ifp->mroute_vif_index, &channel_oil->source,
+				   &channel_oil->group);
 		return 0;
 	}
 
-	channel_oil->oif_flags[pim_ifp->mroute_vif_index] &= ~proto_mask;
+	if (coif)
+		UNSET_FLAG(coif->flags, proto_mask);
 
-	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] &
-			PIM_OIF_FLAG_PROTO_ANY) {
-		if (PIM_DEBUG_MROUTE) {
-			zlog_debug(
-				"%s %s: other protocol masks remain for requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
-				__FILE__, __func__, oif->name,
-				pim_ifp->mroute_vif_index,
-				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
-				oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil));
-		}
+	if (coif && CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_ANY)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s %s: other protocol masks remain for requested OIF %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
+				   __FILE__, __func__, oif->name, pim_ifp->mroute_vif_index,
+				   &channel_oil->source, &channel_oil->group);
 		return 0;
 	}
 
-	oil_if_set(channel_oil, pim_ifp->mroute_vif_index, 0);
 	/* clear mute; will be re-evaluated when the OIF becomes valid again */
-	channel_oil->oif_flags[pim_ifp->mroute_vif_index] &= ~PIM_OIF_FLAG_MUTE;
+	if (coif)
+		channel_oil_oif_delete(channel_oil, coif->index, PIM_OIF_FLAG_MUTE);
 
 	if (pim_upstream_mroute_add(channel_oil, __func__)) {
 		if (PIM_DEBUG_MROUTE) {
-			zlog_debug(
-				"%s %s: could not remove output interface %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
-				__FILE__, __func__, oif->name,
-				pim_ifp->mroute_vif_index,
-				oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil));
+			zlog_debug("%s %s: could not remove output interface %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
+				   __FILE__, __func__, oif->name, pim_ifp->mroute_vif_index,
+				   &channel_oil->source, &channel_oil->group);
 		}
 		return -1;
 	}
 
-	--channel_oil->oil_size;
-
 	if (PIM_DEBUG_MROUTE) {
-		struct interface *iifp =
-			pim_if_find_by_vif_index(pim_ifp->pim,
-						 *oil_incoming_vif(channel_oil));
+		struct interface *iifp = pim_if_find_by_vif_index(pim_ifp->pim,
+								  channel_oil->iif.index);
 
 		zlog_debug("%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u IIF:%s OIF=%s vif_index=%d",
-			   __func__, caller, oil_origin(channel_oil),
-			   oil_mcastgrp(channel_oil), proto_mask,
-			   iifp ? iifp->name : "Unknown", oif->name,
-			   pim_ifp->mroute_vif_index);
+			   __func__, caller, &channel_oil->source, &channel_oil->group, proto_mask,
+			   iifp ? iifp->name : "Unknown", oif->name, pim_ifp->mroute_vif_index);
 	}
 
 	return 0;
@@ -382,23 +368,21 @@ void pim_channel_update_oif_mute(struct channel_oil *c_oil,
 {
 	bool old_mute;
 	bool new_mute;
+	struct channel_oif *oif = channel_oil_oif_find(c_oil, pim_ifp->mroute_vif_index);
 
 	/* If pim_ifp is not a part of the OIL there is nothing to do */
-	if (!oil_if_has(c_oil, pim_ifp->mroute_vif_index))
+	if (!oif)
 		return;
 
-	old_mute = !!(c_oil->oif_flags[pim_ifp->mroute_vif_index] &
-			PIM_OIF_FLAG_MUTE);
+	old_mute = CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE);
 	new_mute = pim_channel_eval_oif_mute(c_oil, pim_ifp);
 	if (old_mute == new_mute)
 		return;
 
 	if (new_mute)
-		c_oil->oif_flags[pim_ifp->mroute_vif_index] |=
-			PIM_OIF_FLAG_MUTE;
+		SET_FLAG(oif->flags, PIM_OIF_FLAG_MUTE);
 	else
-		c_oil->oif_flags[pim_ifp->mroute_vif_index] &=
-			~PIM_OIF_FLAG_MUTE;
+		UNSET_FLAG(oif->flags, PIM_OIF_FLAG_MUTE);
 
 	pim_upstream_mroute_add(c_oil, __func__);
 }
@@ -425,7 +409,7 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 			uint32_t proto_mask, const char *caller)
 {
 	struct pim_interface *pim_ifp;
-	int old_ttl;
+	struct channel_oif *coif;
 
 	/*
 	 * If we've gotten here we've gone bad, but let's
@@ -448,31 +432,27 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	 * interface during RPT-to-SPT transition before the true RPF IIF is
 	 * installed.  (*,G) is handled separately in pim_mroute_add().
 	 */
-	if (!pim_addr_is_any(*oil_origin(channel_oil)) &&
-	    pim_is_grp_ssm(channel_oil->pim, *oil_mcastgrp(channel_oil)) &&
-	    *oil_incoming_vif(channel_oil) < MAXVIFS &&
-	    pim_ifp->mroute_vif_index == *oil_incoming_vif(channel_oil) &&
+	if (!pim_addr_is_any(channel_oil->source) &&
+	    pim_is_grp_ssm(channel_oil->pim, channel_oil->group) &&
+	    channel_oil->iif.index < MAXVIFS &&
+	    pim_ifp->mroute_vif_index == channel_oil->iif.index &&
 	    !pim_mroute_allow_iif_in_oil(channel_oil, pim_ifp->mroute_vif_index)) {
 		if (PIM_DEBUG_GM_TRACE || PIM_DEBUG_MROUTE)
 			zlog_debug("%s(%s): not adding OIF %s (vif %d): same as IIF for (S,G)=(%pPAs,%pPAs)",
 				   __func__, caller, oif->name, pim_ifp->mroute_vif_index,
-				   oil_origin(channel_oil), oil_mcastgrp(channel_oil));
+				   &channel_oil->source, &channel_oil->group);
 		return 0;
 	}
 
 	/* Prevent single protocol from subscribing same interface to
 	   channel (S,G) multiple times */
-	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask) {
-		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
-
+	coif = channel_oil_oif_find(channel_oil, pim_ifp->mroute_vif_index);
+	if (coif && CHECK_FLAG(coif->flags, proto_mask)) {
 		if (PIM_DEBUG_MROUTE) {
-			zlog_debug(
-				"%s %s: existing protocol mask %u requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
-				__FILE__, __func__, proto_mask, oif->name,
-				pim_ifp->mroute_vif_index,
-				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
-				oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil));
+			zlog_debug("%s %s: existing protocol mask %u requested OIF %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
+				   __FILE__, __func__, proto_mask, oif->name,
+				   pim_ifp->mroute_vif_index, &channel_oil->source,
+				   &channel_oil->group);
 		}
 		return -3;
 	}
@@ -480,54 +460,37 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* Allow other protocol to request subscription of same interface to
 	 * channel (S,G), we need to note this information
 	 */
-	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index]
-	    & PIM_OIF_FLAG_PROTO_ANY) {
-
+	if (coif && CHECK_FLAG(coif->flags, PIM_OIF_FLAG_PROTO_ANY)) {
 		/* Updating time here is not required as this time has to
 		 * indicate when the interface is added
 		 */
 
-		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
-		/* Check the OIF really exists before returning, and only log
-		   warning otherwise */
-		if (oil_if_has(channel_oil, pim_ifp->mroute_vif_index) < 1) {
-			zlog_warn(
-				"%s %s: new protocol mask %u requested nonexistent OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",
-				__FILE__, __func__, proto_mask, oif->name,
-				pim_ifp->mroute_vif_index,
-				oil_if_has(channel_oil, pim_ifp->mroute_vif_index),
-				oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil));
-		}
+		SET_FLAG(coif->flags, proto_mask);
 
 		if (PIM_DEBUG_MROUTE) {
-			zlog_debug(
-				"%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u OIF=%s vif_index=%d added to 0x%x",
-				__func__, caller, oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil),
-				proto_mask, oif->name,
-				pim_ifp->mroute_vif_index,
-				channel_oil
-					->oif_flags[pim_ifp->mroute_vif_index]);
+			zlog_debug("%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u OIF=%s vif_index=%d added to 0x%x",
+				   __func__, caller, &channel_oil->source, &channel_oil->group,
+				   proto_mask, oif->name, pim_ifp->mroute_vif_index, coif->flags);
 		}
 		return 0;
 	}
 
-	old_ttl = oil_if_has(channel_oil, pim_ifp->mroute_vif_index);
-
-	if (old_ttl > 0) {
+	if (coif) {
 		if (PIM_DEBUG_MROUTE) {
-			zlog_debug(
-				"%s %s: interface %s (vif_index=%d) is existing output for channel (S,G)=(%pPAs,%pPAs)",
-				__FILE__, __func__, oif->name,
-				pim_ifp->mroute_vif_index,
-				oil_origin(channel_oil),
-				oil_mcastgrp(channel_oil));
+			zlog_debug("%s %s: interface %s (vif_index=%d) is existing output for channel (S,G)=(%pPAs,%pPAs)",
+				   __FILE__, __func__, oif->name, pim_ifp->mroute_vif_index,
+				   &channel_oil->source, &channel_oil->group);
 		}
 		return -4;
 	}
 
-	oil_if_set(channel_oil, pim_ifp->mroute_vif_index, PIM_MROUTE_MIN_TTL);
+	coif = channel_oil_oif_add(channel_oil, pim_ifp->mroute_vif_index, 0);
+	if (!coif) {
+		zlog_warn("%s: could not add OIF %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
+			  __func__, oif->name, pim_ifp->mroute_vif_index, &channel_oil->source,
+			  &channel_oil->group);
+		return -6;
+	}
 
 	/* Some OIFs are held in a muted state i.e. the PIM state machine
 	 * decided to include the OIF but additional status check such as
@@ -535,44 +498,33 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	 * forwarding.
 	 */
 	if (pim_channel_eval_oif_mute(channel_oil, pim_ifp))
-		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |=
-			PIM_OIF_FLAG_MUTE;
+		SET_FLAG(coif->flags, PIM_OIF_FLAG_MUTE);
 	else
-		channel_oil->oif_flags[pim_ifp->mroute_vif_index] &=
-			~PIM_OIF_FLAG_MUTE;
+		UNSET_FLAG(coif->flags, PIM_OIF_FLAG_MUTE);
 
 	/* channel_oil->oil.mfcc_parent != MAXVIFS indicate this entry is not
 	 * valid to get installed in kernel.
 	 */
-	if (*oil_incoming_vif(channel_oil) != MAXVIFS) {
+	if (channel_oil->iif.index != MAXVIFS) {
 		if (pim_upstream_mroute_add(channel_oil, __func__)) {
 			if (PIM_DEBUG_MROUTE) {
-				zlog_debug(
-					"%s %s: could not add output interface %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
-					__FILE__, __func__, oif->name,
-					pim_ifp->mroute_vif_index,
-					oil_origin(channel_oil),
-					oil_mcastgrp(channel_oil));
+				zlog_debug("%s %s: could not add output interface %s (vif_index=%d) for channel (S,G)=(%pPAs,%pPAs)",
+					   __FILE__, __func__, oif->name, pim_ifp->mroute_vif_index,
+					   &channel_oil->source, &channel_oil->group);
 			}
 
-			oil_if_set(channel_oil, pim_ifp->mroute_vif_index,
-				   old_ttl);
+			channel_oil_oif_delete(channel_oil, coif->index, coif->flags);
 			return -5;
 		}
 	}
 
-	channel_oil->oif_creation[pim_ifp->mroute_vif_index] =
-		pim_time_monotonic_sec();
-	++channel_oil->oil_size;
-	channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
+	coif->creation = pim_time_monotonic_sec();
+	SET_FLAG(coif->flags, proto_mask);
 
 	if (PIM_DEBUG_MROUTE) {
-		zlog_debug(
-			"%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u OIF=%s vif_index=%d: DONE",
-			__func__, caller, oil_origin(channel_oil),
-			oil_mcastgrp(channel_oil),
-			proto_mask,
-			oif->name, pim_ifp->mroute_vif_index);
+		zlog_debug("%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u OIF=%s vif_index=%d: DONE",
+			   __func__, caller, &channel_oil->source, &channel_oil->group, proto_mask,
+			   oif->name, pim_ifp->mroute_vif_index);
 	}
 
 	return 0;
@@ -580,19 +532,125 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 
 int pim_channel_oil_empty(struct channel_oil *c_oil)
 {
-	static struct channel_oil null_oil;
+	struct channel_oif *oif;
+	bool empty = true;
 
 	if (!c_oil)
 		return 1;
 
 	/* exclude pimreg from the OIL when checking if the inherited_oil is
-	 * non-NULL.
-	 * pimreg device (in all vrfs) uses a vifi of
-	 * 0 (PIM_OIF_PIM_REGISTER_VIF) so we simply mfcc_ttls[0] */
-	if (oil_if_has(c_oil, 0))
-		oil_if_set(&null_oil, 0, 1);
-	else
-		oil_if_set(&null_oil, 0, 0);
+	 * non-NULL. pimreg device (in all vrfs) uses a vifi of 0
+	 * (PIM_OIF_PIM_REGISTER_VIF)
+	 */
+	frr_each (channel_oif_list, &c_oil->oif_list, oif) {
+		if (oif->index == PIM_OIF_PIM_REGISTER_VIF)
+			continue;
 
-	return !oil_if_cmp(&c_oil->oil, &null_oil.oil);
+		empty = false;
+		break;
+	}
+
+	return empty;
 }
+
+DEFINE_MTYPE_STATIC(PIMD, PIM_CHANNEL_OIF, "PIM channel output interface");
+
+struct channel_oif *channel_oil_oif_find(struct channel_oil *oil, ifindex_t index)
+{
+	struct channel_oif *oif;
+
+	frr_each (channel_oif_list, &oil->oif_list, oif)
+		if (oif->index == index)
+			return oif;
+
+	return NULL;
+}
+
+struct channel_oif *channel_oil_oif_add(struct channel_oil *oil, ifindex_t index, uint32_t flags)
+{
+	struct channel_oif *oif;
+
+	/*
+	 * The function `channel_oil_to_mfcc()` converts this output
+	 * interface list into a bitfield, so the index of the
+	 * interface has to respect some bounds to avoid corrupting
+	 * memory.
+	 */
+	if (index < 0 || index >= MAXVIFS) {
+		zlog_warn("%s: refusing out of range multicast interface index %d for channel (S,G)=(%pPAs,%pPAs)",
+			  __func__, index, &oil->source, &oil->group);
+		return NULL;
+	}
+
+	oif = channel_oil_oif_find(oil, index);
+	if (oif) {
+		SET_FLAG(oif->flags, flags);
+		return oif;
+	}
+
+	oif = XCALLOC(MTYPE_PIM_CHANNEL_OIF, sizeof(*oif));
+	oif->index = index;
+	oif->flags = flags;
+	channel_oif_list_add_tail(&oil->oif_list, oif);
+	return oif;
+}
+
+void channel_oil_oif_delete(struct channel_oil *oil, ifindex_t index, uint32_t flags)
+{
+	struct channel_oif *oif = channel_oil_oif_find(oil, index);
+
+	if (!oif)
+		return;
+
+	UNSET_FLAG(oif->flags, flags);
+
+	/* Only ownership keeps an OIF in the list */
+	if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_ANY))
+		return;
+
+	channel_oif_list_del(&oil->oif_list, oif);
+	XFREE(MTYPE_PIM_CHANNEL_OIF, oif);
+}
+
+#if PIM_IPV == 4
+void channel_oil_to_mfcc(struct channel_oil *oil, struct mfcctl *mfcc)
+{
+	struct channel_oif *oif;
+
+	memset(mfcc, 0, sizeof(*mfcc));
+	mfcc->mfcc_origin = oil->source;
+	mfcc->mfcc_mcastgrp = oil->group;
+	mfcc->mfcc_parent = oil->iif.index;
+	frr_each (channel_oif_list, &oil->oif_list, oif) {
+		if (oif->index == oil->iif.index && !pim_mroute_allow_iif_in_oil(oil, oif->index))
+			continue;
+		if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
+			continue;
+
+		mfcc->mfcc_ttls[oif->index] = PIM_MROUTE_MIN_TTL;
+	}
+}
+#else
+void channel_oil_to_mfcc(struct channel_oil *oil, struct mf6cctl *mf6cc)
+{
+	struct channel_oif *oif;
+
+	memset(mf6cc, 0, sizeof(*mf6cc));
+
+	mf6cc->mf6cc_origin.sin6_family = AF_INET6;
+	mf6cc->mf6cc_origin.sin6_addr = oil->source;
+
+	mf6cc->mf6cc_mcastgrp.sin6_family = AF_INET6;
+	mf6cc->mf6cc_mcastgrp.sin6_addr = oil->group;
+
+	mf6cc->mf6cc_parent = oil->iif.index;
+	frr_each (channel_oif_list, &oil->oif_list, oif) {
+		if (oif->index == oil->iif.index && !pim_mroute_allow_iif_in_oil(oil, oif->index))
+			continue;
+		if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
+			continue;
+
+		IF_SET(oif->index, &mf6cc->mf6cc_ifset);
+	}
+}
+#endif

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -53,6 +53,29 @@ struct channel_counts {
 	unsigned long oldwrong_if;
 };
 
+PREDECL_LIST(channel_oif_list);
+struct channel_oif {
+	struct channel_oif_list_item entry;
+
+	/** Interface index. */
+	ifindex_t index;
+	/** Interface flags. \see `PIM_OIF_FLAG_*`. */
+	uint32_t flags;
+	/** Time of creation. */
+	time_t creation;
+};
+DECLARE_LIST(channel_oif_list, struct channel_oif, entry);
+
+extern struct channel_oif *channel_oil_oif_find(struct channel_oil *oil, ifindex_t index);
+extern struct channel_oif *channel_oil_oif_add(struct channel_oil *oil, ifindex_t index,
+					       uint32_t flags);
+extern void channel_oil_oif_delete(struct channel_oil *oil, ifindex_t index, uint32_t flags);
+#if PIM_IPV == 4
+extern void channel_oil_to_mfcc(struct channel_oil *oil, struct mfcctl *mfcc);
+#else
+extern void channel_oil_to_mfcc(struct channel_oil *oil, struct mf6cctl *mf6cc);
+#endif
+
 /*
   qpim_channel_oil_list holds a list of struct channel_oil.
 
@@ -85,89 +108,21 @@ struct channel_oil {
 
 	struct rb_pim_oil_item oil_rb;
 
-#if PIM_IPV == 4
-	struct mfcctl oil;
-#else
-	struct mf6cctl oil;
-#endif
+	pim_addr source;
+	pim_addr group;
+
+	/* Input interface */
+	struct channel_oif iif;
+	/* List of output interfaces and their state */
+	struct channel_oif_list_head oif_list;
+
 	int installed;
 	int oil_inherited_rescan;
-	int oil_size;
 	int oil_ref_count;
-	time_t oif_creation[MAXVIFS];
-	uint32_t oif_flags[MAXVIFS];
 	struct channel_counts cc;
 	struct pim_upstream *up;
 	time_t mroute_creation;
 };
-
-#if PIM_IPV == 4
-static inline pim_addr *oil_origin(struct channel_oil *c_oil)
-{
-	return &c_oil->oil.mfcc_origin;
-}
-
-static inline pim_addr *oil_mcastgrp(struct channel_oil *c_oil)
-{
-	return &c_oil->oil.mfcc_mcastgrp;
-}
-
-static inline vifi_t *oil_incoming_vif(struct channel_oil *c_oil)
-{
-	return &c_oil->oil.mfcc_parent;
-}
-
-static inline bool oil_if_has(struct channel_oil *c_oil, vifi_t ifi)
-{
-	return !!c_oil->oil.mfcc_ttls[ifi];
-}
-
-static inline void oil_if_set(struct channel_oil *c_oil, vifi_t ifi, uint8_t set)
-{
-	c_oil->oil.mfcc_ttls[ifi] = set;
-}
-
-static inline int oil_if_cmp(struct mfcctl *oil1, struct mfcctl *oil2)
-{
-	return memcmp(&oil1->mfcc_ttls[0], &oil2->mfcc_ttls[0],
-		      sizeof(oil1->mfcc_ttls));
-}
-#else
-static inline pim_addr *oil_origin(struct channel_oil *c_oil)
-{
-	return &c_oil->oil.mf6cc_origin.sin6_addr;
-}
-
-static inline pim_addr *oil_mcastgrp(struct channel_oil *c_oil)
-{
-	return &c_oil->oil.mf6cc_mcastgrp.sin6_addr;
-}
-
-static inline mifi_t *oil_incoming_vif(struct channel_oil *c_oil)
-{
-	return &c_oil->oil.mf6cc_parent;
-}
-
-static inline bool oil_if_has(struct channel_oil *c_oil, mifi_t ifi)
-{
-	return !!IF_ISSET(ifi, &c_oil->oil.mf6cc_ifset);
-}
-
-static inline void oil_if_set(struct channel_oil *c_oil, mifi_t ifi,
-			      uint8_t set)
-{
-	if (set)
-		IF_SET(ifi, &c_oil->oil.mf6cc_ifset);
-	else
-		IF_CLR(ifi, &c_oil->oil.mf6cc_ifset);
-}
-
-static inline int oil_if_cmp(struct mf6cctl *oil1, struct mf6cctl *oil2)
-{
-	return memcmp(&oil1->mf6cc_ifset, &oil2->mf6cc_ifset,
-		      sizeof(oil1->mf6cc_ifset));
-}
-#endif
 
 extern int pim_channel_oil_compare(const struct channel_oil *c1,
 				   const struct channel_oil *c2);

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -18,6 +18,7 @@ struct pim_interface;
  * PIM - Learned from PIM
  * SOURCE - Learned from Source multicast packet received
  * STAR - Inherited
+ * DM - Dense mode flooding
  */
 #define PIM_OIF_FLAG_PROTO_GM     (1 << 0)
 #define PIM_OIF_FLAG_PROTO_PIM    (1 << 1)
@@ -29,6 +30,34 @@ struct pim_interface;
 
 /* OIF is present in the OIL but must not be used for forwarding traffic */
 #define PIM_OIF_FLAG_MUTE         (1 << 4)
+
+/*
+ * Dense mode holds its OIFs directly through `channel_oil_oif_add()` and
+ * `channel_oil_oif_delete()` instead of `pim_channel_add_oif()` and
+ * `pim_channel_del_oif()`, so it is deliberately left out of
+ * `PIM_OIF_FLAG_PROTO_ANY` above: that mask means "a `pim_channel_add_oif()`
+ * subscriber other than the one being removed still wants this OIF".
+ */
+#define PIM_OIF_FLAG_PROTO_DM (1 << 5)
+
+/*
+ * Dense mode lost the Assert election on this OIF (RFC 3973 4.6), so traffic
+ * must not be forwarded onto that LAN until the Assert is over.
+ *
+ * This deliberately does not reuse `PIM_OIF_FLAG_MUTE`: that bit is recomputed
+ * from scratch by `pim_channel_update_oif_mute()` whenever the MLAG DF role or
+ * the VXLAN termination state changes, and that computation knows nothing
+ * about the Assert. Sharing a single bit lets either owner drop the other's
+ * suppression and resume forwarding a duplicate onto the LAN.
+ */
+#define PIM_OIF_FLAG_ASSERT_LOSER (1 << 6)
+
+/*
+ * Every flag that suppresses an OIF, for clearing them in one go.  Deciding
+ * whether an OIF is actually suppressed is `channel_oif_no_forward()` below.
+ */
+#define PIM_OIF_FLAG_NO_FORWARD (PIM_OIF_FLAG_MUTE | PIM_OIF_FLAG_ASSERT_LOSER)
+
 /*
  * We need a pimreg vif id from the kernel.
  * Since ifindex == vif id for most cases and the number
@@ -75,6 +104,19 @@ extern void channel_oil_to_mfcc(struct channel_oil *oil, struct mfcctl *mfcc);
 #else
 extern void channel_oil_to_mfcc(struct channel_oil *oil, struct mf6cctl *mf6cc);
 #endif
+
+/*
+ * `PIM_OIF_FLAG_ASSERT_LOSER` only counts while dense mode still owns the OIF,
+ * so do not fold this back into a `PIM_OIF_FLAG_NO_FORWARD` mask test.
+ */
+static inline bool channel_oif_no_forward(const struct channel_oif *oif)
+{
+	if (CHECK_FLAG(oif->flags, PIM_OIF_FLAG_MUTE))
+		return true;
+
+	return CHECK_FLAG(oif->flags, PIM_OIF_FLAG_ASSERT_LOSER) &&
+	       CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_DM);
+}
 
 /*
   qpim_channel_oil_list holds a list of struct channel_oil.
@@ -143,6 +185,7 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 
 int pim_channel_add_oif(struct channel_oil *c_oil, struct interface *oif,
 			uint32_t proto_mask, const char *caller);
+extern struct channel_oif *pim_channel_add_dm_oif(struct channel_oil *c_oil, struct interface *ifp);
 int pim_channel_del_oif(struct channel_oil *c_oil, struct interface *oif,
 			uint32_t proto_mask, const char *caller);
 

--- a/pimd/pim_state_refresh.c
+++ b/pimd/pim_state_refresh.c
@@ -294,11 +294,11 @@ void pim_send_staterefresh(struct pim_upstream *up)
 	struct listnode *neighnode;
 	struct pim_neighbor *neigh;
 
-	ifp = pim_if_find_by_vif_index(up->pim, *oil_incoming_vif(up->channel_oil));
+	ifp = pim_if_find_by_vif_index(up->pim, up->channel_oil->iif.index);
 	if (!ifp) {
 		if (PIM_DEBUG_PIM_EVENTS)
-			zlog_debug("%s: could not find input interface for oil_incoming_vif=%d",
-				   __func__, *oil_incoming_vif(up->channel_oil));
+			zlog_debug("%s: could not find input interface for input interface: %d",
+				   __func__, up->channel_oil->iif.index);
 		return;
 	}
 	if (up->pim->staterefresh_counter < 3) {

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -25,6 +25,11 @@ DEFINE_MTYPE_STATIC(PIMD, PIM_STATIC_ROUTE_CFG, "PIM Static Route config");
 
 void pim_static_route_free(struct static_route *s_route)
 {
+	struct channel_oif *oif;
+
+	frr_each_safe (channel_oif_list, &s_route->c_oil.oif_list, oif)
+		channel_oil_oif_delete(&s_route->c_oil, oif->index, oif->flags);
+
 	XFREE(MTYPE_PIM_STATIC_ROUTE, s_route);
 }
 
@@ -35,26 +40,30 @@ void pim_static_route_config_free(struct static_route_config *cfg)
 
 static struct static_route *static_route_alloc(void)
 {
-	return XCALLOC(MTYPE_PIM_STATIC_ROUTE, sizeof(struct static_route));
+	struct static_route *sroute = XCALLOC(MTYPE_PIM_STATIC_ROUTE, sizeof(struct static_route));
+
+	channel_oif_list_init(&sroute->c_oil.oif_list);
+
+	return sroute;
 }
 
 static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif, pim_addr group,
 					     pim_addr source)
 {
 	struct static_route *s_route;
+	struct channel_oif *c_oif;
 
 	s_route = static_route_alloc();
 
 	s_route->group = group;
 	s_route->source = source;
-	s_route->iif = iif;
-	s_route->oif_ttls[oif] = 1;
 	s_route->c_oil.oil_ref_count = 1;
-	*oil_origin(&s_route->c_oil) = source;
-	*oil_mcastgrp(&s_route->c_oil) = group;
-	*oil_incoming_vif(&s_route->c_oil) = iif;
-	oil_if_set(&s_route->c_oil, oif, 1);
-	s_route->c_oil.oif_creation[oif] = pim_time_monotonic_sec();
+	s_route->c_oil.source = source;
+	s_route->c_oil.group = group;
+	s_route->c_oil.iif.index = iif;
+	c_oif = channel_oil_oif_add(&s_route->c_oil, oif, 0);
+	if (c_oif)
+		c_oif->creation = pim_time_monotonic_sec();
 
 	return s_route;
 }
@@ -142,6 +151,23 @@ static int static_route_config_del(struct pim_instance *pim, const char *iifname
 	return 0;
 }
 
+static void pim_static_route_copy(struct static_route *sroute_dest,
+				  struct static_route *sroute_source)
+{
+	struct channel_oif *oif;
+
+	/* Clean up old list if any entries found before copying data */
+	frr_each_safe (channel_oif_list, &sroute_dest->c_oil.oif_list, oif)
+		channel_oil_oif_delete(&sroute_dest->c_oil, oif->index, oif->flags);
+
+	memcpy(sroute_dest, sroute_source, sizeof(*sroute_source));
+
+	/* Copy the output interface list */
+	channel_oif_list_init(&sroute_dest->c_oil.oif_list);
+	frr_each (channel_oif_list, &sroute_source->c_oil.oif_list, oif)
+		channel_oil_oif_add(&sroute_dest->c_oil, oif->index, oif->flags);
+}
+
 /*
  * Install a static mroute into the kernel.  Both interfaces are guaranteed by
  * the caller to have valid VIF indices.
@@ -150,6 +176,7 @@ static int pim_static_add_install(struct pim_instance *pim, struct interface *ii
 				  struct interface *oif, pim_addr group, pim_addr source)
 {
 	struct listnode *node = NULL;
+	struct channel_oif *coif;
 	struct static_route *s_route = NULL;
 	struct static_route *original_s_route = NULL;
 	struct pim_interface *pim_iif = iif->info;
@@ -167,8 +194,9 @@ static int pim_static_add_install(struct pim_instance *pim, struct interface *ii
 
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, s_route)) {
 		if (!pim_addr_cmp(s_route->group, group) &&
-		    !pim_addr_cmp(s_route->source, source) && (s_route->iif == iif_index)) {
-			if (s_route->oif_ttls[oif_index]) {
+		    !pim_addr_cmp(s_route->source, source) &&
+		    (s_route->c_oil.iif.index == iif_index)) {
+			if (channel_oil_oif_find(&s_route->c_oil, oif_index)) {
 				zlog_warn("%s %s: Unable to add static route: Route already exists (iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
 					  __FILE__, __func__, iif_index, oif_index, &group,
 					  &source);
@@ -181,12 +209,12 @@ static int pim_static_add_install(struct pim_instance *pim, struct interface *ii
 			 * restore the previous state, so save a copy.
 			 */
 			original_s_route = static_route_alloc();
-			memcpy(original_s_route, s_route, sizeof(struct static_route));
+			pim_static_route_copy(original_s_route, s_route);
 
 			/* Adding a new output interface to an existing route. */
-			s_route->oif_ttls[oif_index] = 1;
-			oil_if_set(&s_route->c_oil, oif_index, 1);
-			s_route->c_oil.oif_creation[oif_index] = pim_time_monotonic_sec();
+			coif = channel_oil_oif_add(&s_route->c_oil, oif_index, 0);
+			if (coif)
+				coif->creation = pim_time_monotonic_sec();
 			++s_route->c_oil.oil_ref_count;
 			break;
 		}
@@ -206,7 +234,7 @@ static int pim_static_add_install(struct pim_instance *pim, struct interface *ii
 
 		/* Restore the previous state. */
 		if (original_s_route) {
-			memcpy(s_route, original_s_route, sizeof(struct static_route));
+			pim_static_route_copy(s_route, original_s_route);
 			pim_static_route_free(original_s_route);
 		} else {
 			listnode_delete(pim->static_routes, s_route);
@@ -263,12 +291,12 @@ static int pim_static_del_install(struct pim_instance *pim, struct interface *ii
 	ifindex_t oif_index = pim_oif->mroute_vif_index;
 
 	for (ALL_LIST_ELEMENTS(pim->static_routes, node, nextnode, s_route)) {
-		if (s_route->iif != iif_index || pim_addr_cmp(s_route->group, group) ||
-		    pim_addr_cmp(s_route->source, source) || !s_route->oif_ttls[oif_index])
+		if (s_route->c_oil.iif.index != iif_index || pim_addr_cmp(s_route->group, group) ||
+		    pim_addr_cmp(s_route->source, source) ||
+		    !channel_oil_oif_find(&s_route->c_oil, oif_index))
 			continue;
 
-		s_route->oif_ttls[oif_index] = 0;
-		oil_if_set(&s_route->c_oil, oif_index, 0);
+		channel_oil_oif_delete(&s_route->c_oil, oif_index, 0);
 		--s_route->c_oil.oil_ref_count;
 
 		/*
@@ -281,14 +309,11 @@ static int pim_static_del_install(struct pim_instance *pim, struct interface *ii
 			zlog_warn("%s %s: Unable to remove static route(iif=%d,oif=%d,group=%pPAs,source=%pPAs)",
 				  __FILE__, __func__, iif_index, oif_index, &group, &source);
 
-			s_route->oif_ttls[oif_index] = 1;
-			oil_if_set(&s_route->c_oil, oif_index, 1);
+			channel_oil_oif_add(&s_route->c_oil, oif_index, 0);
 			++s_route->c_oil.oil_ref_count;
 
 			return -1;
 		}
-
-		s_route->c_oil.oif_creation[oif_index] = 0;
 
 		if (s_route->c_oil.oil_ref_count <= 0) {
 			listnode_delete(pim->static_routes, s_route);
@@ -353,7 +378,7 @@ static struct static_route *pim_static_match(struct pim_instance *pim, ifindex_t
 	struct static_route *s_route;
 
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, s_route)) {
-		if (s_route->iif != iif_vif)
+		if (s_route->c_oil.iif.index != iif_vif)
 			continue;
 		if (pim_addr_cmp(s_route->group, group))
 			continue;
@@ -464,6 +489,7 @@ int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty, struct in
 {
 	struct pim_interface *pim_ifp = ifp->info;
 	struct listnode *node;
+	struct channel_oif *oif;
 	struct static_route *sroute;
 	struct static_route_config *cfg;
 	int count = 0;
@@ -473,16 +499,13 @@ int pim_static_write_mroute(struct pim_instance *pim, struct vty *vty, struct in
 
 	/* Installed routes. */
 	for (ALL_LIST_ELEMENTS_RO(pim->static_routes, node, sroute)) {
-		if (sroute->iif != pim_ifp->mroute_vif_index)
+		if (sroute->c_oil.iif.index != pim_ifp->mroute_vif_index)
 			continue;
 
-		for (int i = 0; i < MAXVIFS; i++) {
+		frr_each (channel_oif_list, &sroute->c_oil.oif_list, oif) {
 			struct interface *oifp;
 
-			if (!sroute->oif_ttls[i])
-				continue;
-
-			oifp = pim_if_find_by_vif_index(pim, i);
+			oifp = pim_if_find_by_vif_index(pim, oif->index);
 			if (!oifp)
 				continue;
 

--- a/pimd/pim_static.h
+++ b/pimd/pim_static.h
@@ -23,8 +23,6 @@ struct static_route {
 	pim_addr source;
 
 	struct channel_oil c_oil;
-	ifindex_t iif;
-	unsigned char oif_ttls[MAXVIFS];
 };
 
 /*

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -373,7 +373,7 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 			if (PIM_DEBUG_GRAFT)
 				zlog_debug("%s: Evaluating c_oil for DM graft", __func__);
 
-			if (!pim_addr_cmp(sg.grp, *oil_mcastgrp(c_oil))) {
+			if (!pim_addr_cmp(sg.grp, c_oil->group)) {
 				if (c_oil->up && PIM_UPSTREAM_DM_TEST_PRUNE(c_oil->up->flags)) {
 					struct interface *ifp =
 						c_oil->up->rpf.source_nexthop.interface;
@@ -470,7 +470,7 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	}
 
 	/* dm: check if we need to send a prune message */
-	if ((*oilp)->oil_size == 0) {
+	if (channel_oif_list_count(&(*oilp)->oif_list) == 0) {
 		/* Not forwarding to any other interfaces, prune it */
 		/* Only if the upstream is dense and group is dense */
 		if (pim_iface_grp_dm(pim_oif, sg.grp) && HAVE_DENSE_MODE(pim_oif->pim_mode)) {

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -816,40 +816,24 @@ static void pim_upstream_transition_dm_to_sm(struct pim_instance *pim, struct pi
 	/* Clear all OIFs without per-OIF kernel flushes; one final MFC
 	 * update is done after the loop. */
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		struct channel_oif *oif;
+
 		pim_ifp = ifp->info;
 		if (!pim_ifp || pim_ifp->mroute_vif_index < 0)
 			continue;
 
-		if (up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] & PIM_OIF_FLAG_PROTO_ANY) {
-			bool had_oif = oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index);
-			bool had_mute = !!(up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] &
-					   PIM_OIF_FLAG_MUTE);
-
-			/* Clear proto and mute flags together so oif_flags is
-			 * fully zeroed before any oil_if_set/oil_size update.
+		oif = channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index);
+		if (oif && CHECK_FLAG(oif->flags, PIM_OIF_FLAG_PROTO_ANY)) {
+			/* Clear proto and mute flags together so the OIF is
+			 * fully released.
 			 */
-			up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] &=
-				~(PIM_OIF_FLAG_PROTO_ANY | PIM_OIF_FLAG_MUTE);
-			if (had_oif) {
-				oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
-				if (up->channel_oil->oil_size > 0)
-					--up->channel_oil->oil_size;
-				else if (PIM_DEBUG_PIM_EVENTS)
-					zlog_debug("%s: oil_size underflow for %s vif %d",
-						   __func__, up->sg_str, pim_ifp->mroute_vif_index);
-			} else if (had_mute) {
-				/* MUTE set but TTL already zeroed externally. */
-				if (PIM_DEBUG_PIM_EVENTS)
-					zlog_debug("%s: MUTE set but OIF inactive for %s vif %d",
-						   __func__, up->sg_str, pim_ifp->mroute_vif_index);
-			}
+			channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index,
+					       PIM_OIF_FLAG_PROTO_ANY | PIM_OIF_FLAG_MUTE);
 		}
 
-		/* DM-native OIFs are installed via oil_if_set() directly. */
-		if (oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
-			oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
-			up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] = 0;
-		}
+		/* DM-native OIFs are installed via channel_oil_oif_delete() directly. */
+		if (channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index))
+			channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index, 0);
 	}
 	/* Rebuild sparse-mode forwarding; already-JOINED upstreams do not
 	 * re-enter pim_upstream_switch() via update_join_desired() alone.
@@ -2391,7 +2375,7 @@ bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 	if (!pim_ifp || !c_oil)
 		return false;
 
-	if (pim_ifp->mroute_vif_index != *oil_incoming_vif(c_oil))
+	if (pim_ifp->mroute_vif_index != c_oil->iif.index)
 		return false;
 
 	if (pim_if_connected_to_source(up->rpf.source_nexthop.interface,
@@ -2425,7 +2409,7 @@ bool pim_upstream_up_connected(struct pim_upstream *up)
 
 		if (HAVE_DENSE_MODE(pim_ifp->pim_mode) &&
 		    ifp->ifindex != up->rpf.source_nexthop.interface->ifindex &&
-		    oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index))
+		    channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index))
 			return true;
 		if (pim_gm_has_igmp_join(ifp, up->sg.grp))
 			return true;

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -831,9 +831,13 @@ static void pim_upstream_transition_dm_to_sm(struct pim_instance *pim, struct pi
 					       PIM_OIF_FLAG_PROTO_ANY | PIM_OIF_FLAG_MUTE);
 		}
 
-		/* DM-native OIFs are installed via channel_oil_oif_delete() directly. */
+		/*
+		 * Dense mode holds its OIFs directly, outside the
+		 * `pim_channel_add_oif()` accounting cleared above.
+		 */
 		if (channel_oil_oif_find(up->channel_oil, pim_ifp->mroute_vif_index))
-			channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+			channel_oil_oif_delete(up->channel_oil, pim_ifp->mroute_vif_index,
+					       PIM_OIF_FLAG_PROTO_DM | PIM_OIF_FLAG_NO_FORWARD);
 	}
 	/* Rebuild sparse-mode forwarding; already-JOINED upstreams do not
 	 * re-enter pim_upstream_switch() via update_join_desired() alone.

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -595,15 +595,14 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	int count = 0;
 	int ret;
 	pim_sgaddr more = {};
-	struct interface *ifp =
-		pim_if_find_by_vif_index(c_oil->pim, *oil_incoming_vif(c_oil));
+	struct interface *ifp = pim_if_find_by_vif_index(c_oil->pim, c_oil->iif.index);
 
 	if (PIM_DEBUG_ZEBRA) {
-		more.src = *oil_origin(c_oil);
-		more.grp = *oil_mcastgrp(c_oil);
+		more.src = c_oil->source;
+		more.grp = c_oil->group;
 		zlog_debug("Sending Request for New Channel Oil Information%pSG VIIF %d(%s:%s)",
-			   &more, *oil_incoming_vif(c_oil),
-			   ifp ? ifp->name : "Unknown", c_oil->pim->vrf->name);
+			   &more, c_oil->iif.index, ifp ? ifp->name : "Unknown",
+			   c_oil->pim->vrf->name);
 	}
 
 	if (!ifp)
@@ -613,8 +612,8 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	zclient_create_header(s, ZEBRA_IPMR_ROUTE_STATS,
 			      c_oil->pim->vrf->vrf_id);
 	stream_putl(s, PIM_AF);
-	stream_write(s, oil_origin(c_oil), sizeof(pim_addr));
-	stream_write(s, oil_mcastgrp(c_oil), sizeof(pim_addr));
+	stream_write(s, &c_oil->source, sizeof(pim_addr));
+	stream_write(s, &c_oil->group, sizeof(pim_addr));
 	stream_putl(s, ifp->ifindex);
 	stream_putw_at(s, 0, stream_get_endp(s));
 
@@ -651,8 +650,8 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	stream_get(&sg.src, s, sizeof(pim_addr));
 	stream_get(&sg.grp, s, sizeof(pim_addr));
 
-	more.src = *oil_origin(c_oil);
-	more.grp = *oil_mcastgrp(c_oil);
+	more.src = c_oil->source;
+	more.grp = c_oil->group;
 	if (pim_sgaddr_cmp(sg, more)) {
 		if (PIM_DEBUG_ZEBRA)
 			flog_err(


### PR DESCRIPTION
Refactor two parts of the code related with multicast interfaces:
1. The output interface list
2. The instance multicast subscribed interfaces list

Previously the code that handled the multicast / output interface lists dealt directly with the Operating System data structures (more specifically `mfcctl`/`mf6cctl`) or with an fixed size array (using `MAXVIFS` OS definition). That works fine if we use Linux / *BSDs data plane, however in order to support more data planes with different limits it becomes problem.

To be more flexible I turned the static data structures into dynamic linked lists and created helper functions to do the additions/removals to hide the data access (e.g. so we can change to something else later if it becomes a bottle neck).

This is a continuation of PR #23060.