### PR TITLE
pathd: free PCE-initiated candidate's segment list

### DIFF
--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -743,6 +743,19 @@ void srte_candidate_del(struct srte_candidate *candidate)
 	RB_REMOVE(srte_candidate_head, &srte_policy->candidate_paths,
 		  candidate);
 
+	/* A PCE-initiated candidate's segment list is created per path by
+	 * path_pcep_config_update_path() and is owned by this candidate
+	 * alone; nothing else deletes it when the candidate goes away, so
+	 * it must be reclaimed here.
+	 */
+	if (candidate->protocol_origin == SRTE_ORIGIN_PCEP &&
+	    candidate->lsp->segment_list != NULL) {
+		SET_FLAG(candidate->lsp->segment_list->flags,
+			 F_SEGMENT_LIST_DELETED);
+		srte_segment_list_del(candidate->lsp->segment_list);
+		candidate->lsp->segment_list = NULL;
+	}
+
 	XFREE(MTYPE_PATH_SR_CANDIDATE, candidate->lsp);
 	XFREE(MTYPE_PATH_SR_CANDIDATE, candidate);
 }


### PR DESCRIPTION
Currently when a PCE-initiated candidate's segment list is created for a path, it is owned by that candidate, however, the srte_candidate_del() frees the candidate and its lsp but not the segment list.  Every PCInitiate remove call causes a segment list to be orphaned in the segment list tree.  This then causes another error where when the PCE re-creates the path, the segment list gets the same name (because names are <path>-<plsp_id> and PCInitiate always carries PLSP-ID = 0), which in turn causes
srte_segment_list_add()'s RB_INSERT to fail (without warning or error) due to it having the same name.  This then causes that new segment list to not be registered in tree, and since cleanup only iterates over the tree, the segment list is leaked.

The proposed solution is to free the segment list in srte_candidate_del() when the candidate originates a PCInitiate.

This memory leak was found during the testing of a new topotest for pcep.