### PR TITLE
bgpd: use DEFUN_YANG_NOSH for exit commands to skip pending commit check

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -6662,7 +6662,7 @@ DEFUN (no_bgp_evpn_vni,
 	return CMD_SUCCESS;
 }
 
-DEFUN_NOSH (exit_vni,
+DEFUN_YANG_NOSH (exit_vni,
             exit_vni_cmd,
             "exit-vni",
             "Exit from VNI mode\n")

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12079,7 +12079,7 @@ DEFPY (show_bgp_srv6,
 	return CMD_SUCCESS;
 }
 
-DEFUN_NOSH (exit_address_family,
+DEFUN_YANG_NOSH (exit_address_family,
        exit_address_family_cmd,
        "exit-address-family",
        "Exit from Address Family configuration mode\n")

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2883,7 +2883,7 @@ DEFUN (vnc_nve_group_responselifetime,
  * with the lack of rigorous level control in the command handler.
  * TBD fix command handler.
  */
-DEFUN_NOSH (exit_vnc,
+DEFUN_YANG_NOSH (exit_vnc,
        exit_vnc_cmd,
        "exit-vnc",
        "Exit VNC configuration mode\n")
@@ -3318,7 +3318,7 @@ DEFUN (vnc_vrf_policy_rd,
 	return CMD_SUCCESS;
 }
 
-DEFUN_NOSH (exit_vrf_policy,
+DEFUN_YANG_NOSH (exit_vrf_policy,
        exit_vrf_policy_cmd,
        "exit-vrf-policy",
        "Exit VRF policy configuration mode\n")


### PR DESCRIPTION
Extend the fix from commit 57811a53ba ("lib, zebra: fix exit commands") to the remaining BGP exit commands.

Change exit commands to DEFUN_YANG_NOSH.  Commands with CMD_ATTR_YANG skip the pending commit check, allowing proper batching until XFRR_end_configuration.

Note: These commands do not require YANG schemas.  CMD_ATTR_YANG is overloaded here and does not imply actual YANG modeling.  This follows the existing pattern used by exit (DEFUN_YANG), exit-vrf and exit-link-params (DEFUN_YANG_NOSH).

Commands changed:
  - exit-address-family
  - exit-vni
  - exit-vnc
  - exit-vrf-policy