### PR TITLE
ospfd: prevent event-loop hang on duplicate DD packets

### DIFF
--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -397,6 +397,9 @@ struct ospf_interface {
 
 	uint32_t full_nbrs;
 
+	/* Last Unknown Neighbor warn on this interface (rate-limit). */
+	struct timeval t_unknown_nbr_warn;
+
 	/* Buffered values for keychain and key */
 	struct keychain *keychain;
 	struct key *key;

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1645,6 +1645,32 @@ static int ospf_db_desc_is_dup(struct ospf_db_desc *dd,
 	return 0;
 }
 
+/*
+ * RFC 2328: neighbors are created from Hello, not DD/LSU/LSAck.
+ * After p2p ifindex churn the peer can still send those packets
+ * before Hello recreates the neighbor.  Dropping them is correct;
+ * logging each one at warn can flood syslog and stall the event loop.
+ */
+#define OSPF_UNKNOWN_NBR_WARN_USEC (10LL * 1000000LL)
+
+static void ospf_log_unknown_neighbor(uint8_t pkt_type, const char *what,
+				      struct ospf_interface *oi, const struct in_addr *rid)
+{
+	if (IS_DEBUG_OSPF_PACKET(pkt_type - 1, RECV))
+		zlog_debug("%s: Unknown Neighbor %pI4 on %s", what, rid, IF_NAME(oi));
+
+	if (timerisset(&oi->t_unknown_nbr_warn)) {
+		int64_t since;
+
+		since = monotime_since(&oi->t_unknown_nbr_warn, NULL);
+		if (since >= 0 && since < OSPF_UNKNOWN_NBR_WARN_USEC)
+			return;
+	}
+
+	flog_warn(EC_OSPF_PACKET, "%s: Unknown Neighbor %pI4 on %s", what, rid, IF_NAME(oi));
+	monotime(&oi->t_unknown_nbr_warn);
+}
+
 static void ospf_db_desc_resend_paced(struct ospf_neighbor *nbr);
 
 /* OSPF Database Description message read -- RFC2328 Section 10.6. */
@@ -1662,8 +1688,7 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 	if (nbr == NULL) {
-		flog_warn(EC_OSPF_PACKET, "Packet[DD]: Unknown Neighbor %pI4",
-			  &ospfh->router_id);
+		ospf_log_unknown_neighbor(OSPF_MSG_DB_DESC, "Packet[DD]", oi, &ospfh->router_id);
 		return;
 	}
 
@@ -1966,9 +1991,8 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 	if (nbr == NULL) {
-		flog_warn(EC_OSPF_PACKET,
-			  "Link State Request: Unknown Neighbor %pI4",
-			  &ospfh->router_id);
+		ospf_log_unknown_neighbor(OSPF_MSG_LS_REQ, "Link State Request", oi,
+					  &ospfh->router_id);
 		return;
 	}
 
@@ -2216,9 +2240,8 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 	/* Check neighbor. */
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 	if (nbr == NULL) {
-		flog_warn(EC_OSPF_PACKET,
-			  "Link State Update: Unknown Neighbor %pI4 on int: %s",
-			  &ospfh->router_id, IF_NAME(oi));
+		ospf_log_unknown_neighbor(OSPF_MSG_LS_UPD, "Link State Update", oi,
+					  &ospfh->router_id);
 		return;
 	}
 
@@ -2707,9 +2730,8 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 	if (nbr == NULL) {
-		flog_warn(EC_OSPF_PACKET,
-			  "Link State Acknowledgment: Unknown Neighbor %pI4",
-			  &ospfh->router_id);
+		ospf_log_unknown_neighbor(OSPF_MSG_LS_ACK, "Link State Acknowledgment", oi,
+					  &ospfh->router_id);
 		return;
 	}
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1645,6 +1645,8 @@ static int ospf_db_desc_is_dup(struct ospf_db_desc *dd,
 	return 0;
 }
 
+static void ospf_db_desc_resend_paced(struct ospf_neighbor *nbr);
+
 /* OSPF Database Description message read -- RFC2328 Section 10.6. */
 static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 			 struct stream *s, struct ospf_interface *oi,
@@ -1835,19 +1837,17 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 		break;
 	case NSM_Exchange:
 		if (ospf_db_desc_is_dup(dd, nbr)) {
-			if (IS_SET_DD_MS(nbr->dd_flags))
+			if (IS_SET_DD_MS(nbr->dd_flags)) {
 				/* Master: discard duplicated DD packet. */
-				zlog_info(
-					"Packet[DD] (Master): Neighbor %pI4 packet duplicated.",
-					&nbr->router_id);
-			else
-			/* Slave: cause to retransmit the last Database
-			   Description. */
-			{
-				zlog_info(
-					"Packet[DD] [Slave]: Neighbor %pI4 packet duplicated.",
-					&nbr->router_id);
-				ospf_db_desc_resend(nbr);
+				if (IS_DEBUG_OSPF_PACKET(OSPF_MSG_DB_DESC - 1, RECV))
+					zlog_debug("Packet[DD] (Master): Neighbor %pI4 packet duplicated.",
+						   &nbr->router_id);
+			} else {
+				/* Slave: retransmit last DD, paced to RxmtInterval. */
+				if (IS_DEBUG_OSPF_PACKET(OSPF_MSG_DB_DESC - 1, RECV))
+					zlog_debug("Packet[DD] [Slave]: Neighbor %pI4 packet duplicated.",
+						   &nbr->router_id);
+				ospf_db_desc_resend_paced(nbr);
 			}
 			break;
 		}
@@ -1869,8 +1869,8 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 
 		/* Check initialize bit is set. */
 		if (IS_SET_DD_I(dd->flags)) {
-			zlog_info("Packet[DD]: Neighbor %pI4 I-bit set.",
-				  &nbr->router_id);
+			if (IS_DEBUG_OSPF_PACKET(OSPF_MSG_DB_DESC - 1, RECV))
+				zlog_debug("Packet[DD]: Neighbor %pI4 I-bit set.", &nbr->router_id);
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_SeqNumberMismatch);
 			break;
 		}
@@ -1905,9 +1905,9 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 		if (ospf_db_desc_is_dup(dd, nbr)) {
 			if (IS_SET_DD_MS(nbr->dd_flags)) {
 				/* Master should discard duplicate DD packet. */
-				zlog_info(
-					"Packet[DD]: Neighbor %pI4 duplicated, packet discarded.",
-					&nbr->router_id);
+				if (IS_DEBUG_OSPF_PACKET(OSPF_MSG_DB_DESC - 1, RECV))
+					zlog_debug("Packet[DD]: Neighbor %pI4 duplicated, packet discarded.",
+						   &nbr->router_id);
 				break;
 			} else {
 				if (monotime_since(&nbr->last_send_ts, NULL)
@@ -1930,7 +1930,7 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 					   SeqNumberMismatch
 					   neighbor event. RFC2328 Section 10.8
 					   */
-					ospf_db_desc_resend(nbr);
+					ospf_db_desc_resend_paced(nbr);
 					break;
 				}
 			}
@@ -4410,6 +4410,7 @@ void ospf_db_desc_resend(struct ospf_neighbor *nbr)
 
 	/* Add packet to the interface output queue. */
 	ospf_packet_add(oi, ospf_packet_dup(nbr->last_send));
+	monotime(&nbr->last_send_ts);
 
 	/* Hook thread to write packet. */
 	OSPF_ISM_WRITE_ON(oi->ospf);
@@ -4418,6 +4419,27 @@ void ospf_db_desc_resend(struct ospf_neighbor *nbr)
 			"%s:Packet[DD]: %pI4 DB Desc resend with seqnum:%x , flags:%x",
 			ospf_get_name(oi->ospf), &nbr->router_id,
 			nbr->dd_seqnum, nbr->dd_flags);
+}
+
+/*
+ * RFC 2328 §10.8: the Slave retransmits its last DD in response to a
+ * duplicate from the Master.  Doing that 1:1 with a flood stalls
+ * ospfd's event loop until the daemon is declared unresponsive.
+ * Pace resends to RxmtInterval; the Master retransmits on the same
+ * timer, so a delayed reply is still correct.
+ */
+static void ospf_db_desc_resend_paced(struct ospf_neighbor *nbr)
+{
+	int64_t since;
+
+	if (!nbr->last_send)
+		return;
+
+	since = monotime_since(&nbr->last_send_ts, NULL);
+	if (since >= 0 && since < (int64_t)nbr->v_db_desc * 1000000LL)
+		return;
+
+	ospf_db_desc_resend(nbr);
 }
 
 /* Send Link State Request. */

--- a/tests/topotests/ospf_dd_dup_hang/capture_ospf.py
+++ b/tests/topotests/ospf_dd_dup_hang/capture_ospf.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: ISC
+#
+# capture_ospf.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+"""Sniff packets to a pcap until SIGINT/SIGTERM.
+
+Used by test_ospf_dd_dup_hang.py so the test does not depend on tcpdump,
+which is missing in some images and exits when the interface goes down.
+"""
+
+import argparse
+import os
+import signal
+import sys
+import time
+
+from scapy.all import AsyncSniffer, conf, wrpcap
+
+conf.verb = 0
+
+_stop = False
+
+
+def _request_stop(signum, frame):
+    global _stop
+    _stop = True
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iface", required=True)
+    parser.add_argument("--pcap", required=True)
+    parser.add_argument("--filter", default="ip proto 89")
+    parser.add_argument("--ready-file", default="")
+    args = parser.parse_args()
+
+    signal.signal(signal.SIGINT, _request_stop)
+    signal.signal(signal.SIGTERM, _request_stop)
+
+    sniffer = AsyncSniffer(iface=args.iface, filter=args.filter, store=True)
+    try:
+        sniffer.start()
+    except Exception as exc:
+        sys.stderr.write("scapy sniff failed on %s: %s\n" % (args.iface, exc))
+        sys.exit(1)
+
+    if args.ready_file:
+        with open(args.ready_file, "w") as f:
+            f.write("ready\n")
+
+    while not _stop:
+        time.sleep(0.1)
+
+    try:
+        sniffer.stop()
+    except Exception:
+        pass
+
+    pkts = list(sniffer.results or [])
+    wrpcap(args.pcap, pkts)
+    # Make the file visible on shared rundir mounts before we exit.
+    try:
+        os.fsync(os.open(args.pcap, os.O_RDONLY))
+    except OSError:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/topotests/ospf_dd_dup_hang/flood_dd.py
+++ b/tests/topotests/ospf_dd_dup_hang/flood_dd.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: ISC
+#
+# flood_dd.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+"""Replay the last captured OSPF Database Description packet in a burst.
+
+Used by test_ospf_dd_dup_hang.py to simulate a master that retransmits the
+same DD many times.
+"""
+
+import argparse
+import sys
+
+from scapy.all import conf, sendp
+from scapy.contrib.ospf import OSPF_Hdr
+from scapy.utils import rdpcap
+
+conf.verb = 0
+
+OSPF_MSG_DB_DESC = 2
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pcap", required=True)
+    parser.add_argument("--iface", required=True)
+    parser.add_argument("--src-rid", default="2.2.2.2")
+    parser.add_argument("--count", type=int, default=2000)
+    args = parser.parse_args()
+
+    dds = []
+    for pkt in rdpcap(args.pcap):
+        if not pkt.haslayer(OSPF_Hdr):
+            continue
+        hdr = pkt[OSPF_Hdr]
+        if hdr.type == OSPF_MSG_DB_DESC and str(hdr.src) == args.src_rid:
+            dds.append(pkt)
+
+    if not dds:
+        sys.stderr.write("no DD packets from router-id %s in %s\n" % (args.src_rid, args.pcap))
+        sys.exit(1)
+
+    sendp([dds[-1]] * args.count, iface=args.iface, verbose=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/topotests/ospf_dd_dup_hang/r1/frr.conf
+++ b/tests/topotests/ospf_dd_dup_hang/r1/frr.conf
@@ -1,0 +1,19 @@
+frr defaults traditional
+hostname r1
+log stdout
+!
+interface eth1
+ ip address 10.0.0.1/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 40
+ ip ospf retransmit-interval 5
+exit
+!
+router ospf
+ ospf router-id 1.1.1.1
+ log-adjacency-changes
+exit
+!
+end

--- a/tests/topotests/ospf_dd_dup_hang/r2/frr.conf
+++ b/tests/topotests/ospf_dd_dup_hang/r2/frr.conf
@@ -1,0 +1,19 @@
+frr defaults traditional
+hostname r2
+log stdout
+!
+interface eth1
+ ip address 10.0.0.2/24
+ ip ospf area 0.0.0.0
+ ip ospf network point-to-point
+ ip ospf hello-interval 1
+ ip ospf dead-interval 40
+ ip ospf retransmit-interval 5
+exit
+!
+router ospf
+ ospf router-id 2.2.2.2
+ log-adjacency-changes
+exit
+!
+end

--- a/tests/topotests/ospf_dd_dup_hang/test_ospf_dd_dup_hang.py
+++ b/tests/topotests/ospf_dd_dup_hang/test_ospf_dd_dup_hang.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_dd_dup_hang.py
+#
+# Copyright (c) 2026 ATCorp
+# Jafar Al-Gharaibeh
+#
+
+"""
+test_ospf_dd_dup_hang.py
+========================
+
+Regression for ospfd event-loop starvation when the OSPF Slave retransmits
+its last Database Description packet on every duplicate DD from the Master
+(RFC 2328 §10.8).  An unbounded Slave resend+zlog_info path can starve
+the event loop until the daemon is declared unresponsive.
+
+Topology
+--------
+
+    r1 (RID 1.1.1.1, Slave) ----eth1---- r2 (RID 2.2.2.2, Master)
+
+r1 has the lower router-id, so it is the DD Slave.
+
+Test plan
+---------
+
+1. test_adjacency_full
+     Baseline: point-to-point adjacency reaches Full.
+
+2. test_dd_dup_flood_slave_resend_paced
+     Sniff a real DD from the Master (scapy, not tcpdump), replay it
+     COUNT times at r1.  r1 must stay responsive (vtysh returns within
+     VTYSH_TIMEOUT_S) and must not emit one unicast DD per injected
+     duplicate.  Before the pacing fix this burst produced thousands of
+     Slave resends.
+
+3. test_p2p_flap_unknown_neighbor_recovers
+     Rapidly flap r2's link so packets can arrive before Hello recreates
+     the neighbor ("Unknown Neighbor").  r1 must remain responsive and
+     the adjacency must return to Full.
+"""
+
+import os
+import shlex
+import sys
+import time
+from functools import partial
+
+import pytest
+from scapy.contrib.ospf import OSPF_Hdr
+from scapy.utils import rdpcap
+
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.ospfd]
+
+FLOOD_COUNT = 3000
+# Unfixed ospfd resends ~1:1.  Paced ospfd resends at most once per
+# retransmit-interval (5s) during a sub-interval burst.
+MAX_SLAVE_DD_TX = 8
+VTYSH_TIMEOUT_S = 8
+OSPF_MSG_DB_DESC = 2
+R1_RID = "1.1.1.1"
+R2_RID = "2.2.2.2"
+
+
+def build_topo(tgen):
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    tgen.add_link(r1, r2, ifname1="eth1", ifname2="eth1")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module():
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _expect_full(tgen):
+    tgen.gears["r1"].expect_ospfv2_neighbor(R2_RID)
+    tgen.gears["r2"].expect_ospfv2_neighbor(R1_RID)
+
+
+def _ospfd_alive(router):
+    out = router.cmd("pidof ospfd || true").strip()
+    return bool(out)
+
+
+def _vtysh_responsive(router, timeout_s=VTYSH_TIMEOUT_S):
+    """Return (ok, elapsed_s).  timeout(1) yields rc 124 if vtysh blocks."""
+    start = time.time()
+    rc = router.cmd(
+        "timeout %s vtysh -c 'show ip ospf neighbor json' >/dev/null; echo $?"
+        % timeout_s
+    ).strip()
+    elapsed = time.time() - start
+    try:
+        ok = int(rc.splitlines()[-1]) == 0
+    except (ValueError, IndexError):
+        ok = False
+    return ok, elapsed
+
+
+def _wait_until(func, timeout_s=5, interval_s=0.25):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if func():
+            return True
+        time.sleep(interval_s)
+    return bool(func())
+
+
+def _proc_alive(router, pid):
+    out = router.cmd("kill -0 %s 2>/dev/null; echo $?" % pid).strip()
+    try:
+        return int(out.splitlines()[-1]) == 0
+    except (ValueError, IndexError):
+        return False
+
+
+def _file_ready(path):
+    try:
+        return os.path.exists(path) and os.path.getsize(path) > 0
+    except OSError:
+        return False
+
+
+def _count_dd_from(pcap_path, router_id):
+    if not os.path.exists(pcap_path) or os.path.getsize(pcap_path) < 24:
+        return 0
+    n = 0
+    for pkt in rdpcap(pcap_path):
+        if not pkt.haslayer(OSPF_Hdr):
+            continue
+        hdr = pkt[OSPF_Hdr]
+        if hdr.type == OSPF_MSG_DB_DESC and str(hdr.src) == router_id:
+            n += 1
+    return n
+
+
+def _start_capture(router, pcap_path, bpf="ip proto 89"):
+    """Sniff with scapy in the router netns. tcpdump is not used: it is often
+    missing in CI images and it exits when the peer interface goes down.
+    """
+    err_path = pcap_path + ".err"
+    ready_path = pcap_path + ".ready"
+    router.cmd(
+        "rm -f %s %s %s"
+        % (shlex.quote(pcap_path), shlex.quote(err_path), shlex.quote(ready_path))
+    )
+    # nohup: router.cmd() closing the session would otherwise SIGHUP the sniffer.
+    pid = router.cmd(
+        "nohup python3 %s/capture_ospf.py --iface eth1 --pcap %s "
+        "--filter %s --ready-file %s </dev/null >%s 2>&1 & echo $!"
+        % (
+            shlex.quote(CWD),
+            shlex.quote(pcap_path),
+            shlex.quote(bpf),
+            shlex.quote(ready_path),
+            shlex.quote(err_path),
+        )
+    ).strip()
+    if pid:
+        pid = pid.splitlines()[-1]
+    assert pid.isdigit(), "scapy capture did not start on %s (pid %r)" % (
+        router.name,
+        pid,
+    )
+    if not _wait_until(partial(_file_ready, ready_path)):
+        err = router.cmd("cat %s 2>/dev/null || true" % shlex.quote(err_path))
+        if os.path.exists(err_path):
+            with open(err_path) as f:
+                err = err or f.read()
+        assert False, "scapy capture did not become ready on %s (pid %s): %s" % (
+            router.name,
+            pid,
+            err.strip() or "no capture stderr",
+        )
+    return pid
+
+
+def _stop_capture(router, pid, pcap_path):
+    err_path = pcap_path + ".err"
+    router.cmd("kill -TERM %s >/dev/null 2>&1 || true" % pid)
+    if not _wait_until(lambda: not _proc_alive(router, pid), timeout_s=8):
+        router.cmd("kill -KILL %s >/dev/null 2>&1 || true" % pid)
+        _wait_until(lambda: not _proc_alive(router, pid))
+    if not _wait_until(
+        lambda: os.path.exists(pcap_path) and os.path.getsize(pcap_path) >= 24
+    ):
+        err = router.cmd("cat %s 2>/dev/null || true" % shlex.quote(err_path))
+        if os.path.exists(err_path):
+            with open(err_path) as f:
+                err = err or f.read()
+        assert False, "pcap %s missing after stopping capture: %s" % (
+            pcap_path,
+            err.strip() or "empty/missing file",
+        )
+
+
+def test_adjacency_full():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    _expect_full(tgen)
+
+
+def test_dd_dup_flood_slave_resend_paced():
+    """Flood duplicate Master DDs at the Slave; ospfd must not wedge or amplify."""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+    _expect_full(tgen)
+
+    # Shared rundir is visible to pytest and to both routers; /tmp in the
+    # namespace is not a reliable place to rdpcap from the host.
+    capture = os.path.join(tgen.logdir, "exch.pcap")
+    cap_pid = _start_capture(r1, capture)
+    # Retrigger DD while leaving eth1 up.  Shutdown/no-shutdown takes the
+    # p2p peer down and kills in-netns sniffers (tcpdump/tshark/scapy).
+    r2.vtysh_cmd("clear ip ospf process")
+    _expect_full(tgen)
+    _stop_capture(r1, cap_pid, capture)
+    n_master_dd = _count_dd_from(capture, R2_RID)
+    assert n_master_dd > 0, "capture has no DD packets from master %s" % R2_RID
+    logger.info("captured %d master DD packet(s) for replay", n_master_dd)
+
+    txpcap = os.path.join(tgen.logdir, "r1tx.pcap")
+    tx_pid = _start_capture(r1, txpcap, "ip proto 89 and src 10.0.0.1")
+
+    flood_cmd = (
+        "python3 %s/flood_dd.py --pcap %s --iface eth1 "
+        "--src-rid %s --count %d" % (CWD, capture, R2_RID, FLOOD_COUNT)
+    )
+    logger.info("flooding %d duplicate DDs from r2", FLOOD_COUNT)
+    t0 = time.time()
+    r2.cmd_raises(flood_cmd)
+    flood_s = time.time() - t0
+    logger.info("flood finished in %.2fs", flood_s)
+
+    _stop_capture(r1, tx_pid, txpcap)
+
+    assert _ospfd_alive(r1), "ospfd on r1 died during DD duplicate flood"
+    ok, elapsed = _vtysh_responsive(r1)
+    assert ok, "vtysh on r1 did not return within %ss after DD flood" % VTYSH_TIMEOUT_S
+    logger.info("vtysh responded in %.2fs after flood", elapsed)
+
+    slave_dd_tx = _count_dd_from(txpcap, R1_RID)
+    logger.info(
+        "r1 transmitted %d DD packet(s) during flood of %d duplicates",
+        slave_dd_tx,
+        FLOOD_COUNT,
+    )
+    assert slave_dd_tx <= MAX_SLAVE_DD_TX, (
+        "Slave DD resend amplification: r1 sent %d DD packets in response to "
+        "%d duplicates (limit %d).  RFC 2328 §10.8 requires a resend, not a "
+        "1:1 flood." % (slave_dd_tx, FLOOD_COUNT, MAX_SLAVE_DD_TX)
+    )
+
+    _expect_full(tgen)
+
+
+def test_p2p_flap_unknown_neighbor_recovers():
+    """Rapid p2p flaps must not wedge ospfd."""
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+    _expect_full(tgen)
+
+    for i in range(15):
+        r2.link_enable("eth1", enabled=False)
+        time.sleep(0.15)
+        r2.link_enable("eth1", enabled=True)
+        time.sleep(0.15)
+
+    assert _ospfd_alive(r1), "ospfd on r1 died during p2p flaps"
+    ok, elapsed = _vtysh_responsive(r1)
+    assert ok, "vtysh on r1 hung after p2p flaps (elapsed %.2fs)" % elapsed
+    logger.info("vtysh responded in %.2fs after flaps", elapsed)
+
+    _expect_full(tgen)


### PR DESCRIPTION
A burst of duplicate Database Description packets from the OSPF Master made the Slave resend its last DD 1:1 and log on every copy. That path ran unbounded and starved ospfd’s event loop until the daemon looked hung. The same stall showed up when p2p flaps delivered DD/LSU/LSAck before Hello recreated the neighbor: dropping those packets is correct, but warning on every one flooded syslog.

This change paces RFC 2328 §10.8 Slave resends to RxmtInterval, demotes the duplicate/I-bit logs to debug, and rate-limits “Unknown Neighbor” warnings per interface. A topotest floods duplicate Master DDs and flaps the p2p link; ospfd must stay responsive and must not amplify Slave DD transmit.