### PR TITLE
tests: add pathd PCEP steering topotests

### DIFF
--- a/tests/topotests/pathd_pcep_steering_topo1/README.md
+++ b/tests/topotests/pathd_pcep_steering_topo1/README.md
@@ -1,0 +1,105 @@
+# pathd PCEP Steering Test
+
+## Overview
+
+This test validates that pathd installs a per-destination steering
+route for a PCE-initiated SR policy, withdraws it when the policy goes
+down, and reinstalls it when the policy comes back up. Both address
+families are covered: the PCE initiates one policy to an IPv4 endpoint
+and one to an IPv6 endpoint, and every check asserts both steering
+routes.
+
+This is also the first topotest to establish a live PCEP session: no
+PCE implementation exists in the test framework, these tests use a 
+scripted PCE (`mock_pce.py`) to implement a lightweight pce to
+implement pcep testing.
+
+## Topology
+
+```
+         +-------------+                       +-------------+
+         |             |eth-rt2         eth-rt1|             |
+         |     RT1     +-----------------------+     RT2     |
+         | 1.1.1.1     |     10.0.1.0/24       | 2.2.2.2     |
+         | 2001:db8::1 |  2001:db8:10:1::/64   | 2001:db8::2 |
+         +-------------+                       +-------------+
+                |
+         mock PCE (127.0.0.1:4189, inside RT1's namespace)
+```
+
+Loopbacks (= policy endpoints):
+
+| Router | IPv4       | IPv6            |
+|--------|------------|-----------------|
+| RT1    | 1.1.1.1/32 | 2001:db8::1/128 |
+| RT2    | 2.2.2.2/32 | 2001:db8::2/128 |
+
+- **RT1**: SR-TE headend. zebra + isisd (IS-IS SR, SRGB 16000-23999,
+  IPv4 + IPv6 topologies) + pathd with the `pathd_pcep` module
+  (`-M pathd_pcep`).
+- **RT2**: policy endpoint. Loopbacks 2.2.2.2/32 (prefix-SID index
+  20, label 16020) and 2001:db8::2/128 (prefix-SID index 21, label
+  16021).
+- **mock PCE**: a Python TCP server started inside RT1's network
+  namespace; pathd's PCC connects to it at 127.0.0.1:4189. It
+  initiates one policy per address family.
+
+## The scripted PCE
+
+`mock_pce.py` implements just enough of RFC 5440 (PCEP), RFC 8231
+(stateful), RFC 8281 (PCE-initiated) and RFC 8664 (SR ERO) to drive
+pathd as a PCC:
+
+1. Exchange Open/Keepalive (Open carries the STATEFUL-PCE-CAPABILITY
+   U|I bits, SR-PCE-CAPABILITY and PATH-SETUP-TYPE-CAPABILITY TLVs).
+2. Wait for the PCC's end-of-state-sync PCRpt (LSP object, PLSP-ID 0,
+   SYNC flag clear) — pathd silently discards any PCInitiate received
+   before that point.
+3. Send PCInitiate messages creating SR policies (SRP + LSP with
+   symbolic path name + IPv4 or IPv6 END-POINTS + ERO with SID-only
+   SR subobjects; an optional VENDOR-INFO object sets the policy
+   color).
+4. Answer nothing else; send Keepalives every 10 seconds.
+
+The PCE logs every state transition to a file which the test dumps on
+failure. It can also remove initiated policies (PCInitiate with the
+SRP R flag) driven through a command file — see `--command-file`.
+
+## Tests
+
+Every steering-route check asserts both address families (ipv4, ipv6).
+
+1. **test_isis_sr_convergence**: IS-IS SR converges and RT2's
+   prefix-SID labels (16020, 16021) are installed in RT1's LFIB. The
+   PCE-initiated policies resolve through these labels.
+2. **test_steering_route_installed**: after the PCEP session
+   establishes and the PCE initiates both policies, RT1 installs the
+   steering routes: `2.2.2.2/32` and `2001:db8::2/128`, proto `srte`,
+   distance 10, each resolving through its policy via SR-TE color.
+3. **test_steering_route_withdrawn_on_policy_down**: shutting RT2's
+   link takes the labels away, the policies go down, and pathd
+   withdraws both steering routes (gone from the RIB entirely, not
+   just inactive).
+4. **test_steering_route_reinstalled_on_policy_up**: bringing the
+   link back revalidates the policies and pathd reinstalls both
+   steering routes.
+5. **test_policy_churn_scale**: the PCE initiates 100 further
+   policies per address family — 100 for the IPv4 endpoint and 100
+   for the IPv6 endpoint (distinct colors, driven through the
+   command file). All 202 come up, and each endpoint's steering
+   route aggregates one colored nexthop per policy, capped at
+   zebra's multipath limit (read from `show zebra`; colors beyond
+   the cap are logged and unrepresented — each route must carry
+   exactly `min(policies, ECMP max)` nexthops).
+6. **test_policy_churn_remove_readd**: per family, remove 40 of the
+   churn policies, re-add 20 (same names and colors — pathd hands
+   back the PLSP-IDs it retained for these keys), then remove every
+   churn policy. The policy count tracks each step and both steering
+   routes collapse back to a single nexthop. Together with the
+   teardown memory check this is the leak stress: 240 PCInitiate
+   creates and 240 removes through one session.
+
+## Notes
+
+- pathd runs with `-M pathd_pcep`; the module is built whenever pathd
+  is enabled.

--- a/tests/topotests/pathd_pcep_steering_topo1/mock_pce.py
+++ b/tests/topotests/pathd_pcep_steering_topo1/mock_pce.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: ISC
+
+#
+# mock_pce.py
+#
+
+"""
+Minimal scripted PCE for the pathd PCEP steering topotest.
+
+Implements just enough of RFC 5440 (PCEP), RFC 8231 (stateful),
+RFC 8281 (PCE-initiated) and RFC 8664 (SR ERO) to drive FRR's pathd
+as a PCC:
+
+1. Accept the PCC's TCP connection and exchange Open/Keepalive.
+2. Wait for the PCC's end-of-state-sync PCRpt (an LSP object with
+   PLSP-ID 0 and the SYNC flag clear).  pathd silently discards any
+   PCInitiate received before that point.
+3. Send a single PCInitiate creating one SR policy (SRP + LSP with
+   symbolic name + IPv4 END-POINTS + ERO with one SID-only SR
+   subobject).
+4. Keep the session alive with periodic Keepalives.
+
+State transitions are appended to a log file.
+"""
+
+import argparse
+import os
+import select
+import socket
+import struct
+import threading
+import time
+
+PCEP_VERSION_BYTE = 0x20  # version 1, flags 0
+
+MSG_OPEN = 1
+MSG_KEEPALIVE = 2
+MSG_REPORT = 10
+MSG_INITIATE = 12
+
+CLASS_OPEN = 1
+CLASS_ENDPOINTS = 4
+CLASS_ERO = 7
+CLASS_LSP = 32
+CLASS_SRP = 33
+CLASS_VENDOR_INFO = 34
+
+# FRR reads the policy color from a VENDOR-INFO object carrying this
+# enterprise number and enterprise-specific info value.
+VENDOR_ENTERPRISE_CISCO = 9
+VENDOR_ESI_COLOR = 0x00010004
+
+TLV_STATEFUL_CAP = 16
+TLV_SYMBOLIC_NAME = 17
+TLV_SR_CAP = 26
+TLV_PATH_SETUP_TYPE = 28
+TLV_PST_CAP = 34
+
+LSP_FLAG_SYNC = 0x02
+
+
+def parse_policy(spec):
+    """Parse an endpoint,label,name[,color] --policy argument."""
+    fields = spec.split(",")
+    if len(fields) not in (3, 4):
+        raise argparse.ArgumentTypeError(
+            "--policy takes endpoint,label,name[,color]: %s" % spec
+        )
+    return {
+        "endpoint": fields[0],
+        "label": int(fields[1]),
+        "name": fields[2],
+        "color": int(fields[3]) if len(fields) == 4 else None,
+    }
+
+
+class MockPce:
+    def __init__(self, args):
+        self.args = args
+        self.logfile = open(args.log, "a", buffering=1)
+        self.sock = None
+        self.conn = None
+        self.sync_done = False
+        self.initiated = False
+        self.next_srp_id = 1
+        self.srp_to_name = {}
+        self.plsp_by_name = {}
+        self.command_pos = 0
+        self.deferred_removes = []
+
+        self.policies = list(args.policy or [])
+        if args.endpoint:
+            self.policies.insert(
+                0,
+                {
+                    "endpoint": args.endpoint,
+                    "label": args.label,
+                    "name": args.name,
+                    "color": args.color,
+                },
+            )
+
+    def log(self, text):
+        self.logfile.write("%.3f %s\n" % (time.time(), text))
+
+    # ------------------------------------------------------------------
+    # Message builders
+    #
+    # Every builder assembles the exact RFC wire layout with
+    # struct.pack().  The format strings read left to right, one field
+    # per letter: ">" = network (big-endian) byte order, "B" = 1 byte,
+    # "H" = 2 bytes, "I" = 4 bytes.  Fields packed into part of a byte
+    # or word (flags, PLSP-ID) are shifted/OR'd together first, since
+    # pack() only handles whole-byte fields.
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _obj(oclass, otype, body):
+        """Wrap body in the PCEP common object header (RFC 5440 S7.2):
+
+            Object-Class (1) | Object-Type(4 bits)+flags(4 bits) (1) |
+            Object Length (2, includes this header)
+        """
+        # object header: class(1) type<<4(1) total-length(2)
+        return struct.pack(">BBH", oclass, otype << 4, 4 + len(body)) + body
+
+    @staticmethod
+    def _msg(mtype, body):
+        """Wrap body in the PCEP common message header (RFC 5440 S6.1):
+
+            Version(3 bits)+Flags(5 bits) (1) | Message-Type (1) |
+            Message-Length (2, includes this header)
+        """
+        # message header: version/flags(1) type(1) total-length(2)
+        return struct.pack(">BBH", PCEP_VERSION_BYTE, mtype, 4 + len(body)) + body
+
+    def build_open(self):
+        """Open message (RFC 5440 S6.2), one OPEN object:
+
+            <Common Header>   type 1 (Open)
+            <OPEN>            Ver/Flags(1) Keepalive(1) DeadTimer(1) SID(1)
+              <STATEFUL-PCE-CAPABILITY>   RFC 8231: U|I flag bits
+              <SR-PCE-CAPABILITY>         RFC 8664: reserved/flags/MSD
+              <PATH-SETUP-TYPE-CAPABILITY> RFC 8408: PST list = [SR-TE]
+
+        pathd requires at least one TLV in the Open and needs the
+        STATEFUL-PCE-CAPABILITY U bit to send any PCRpt at all.
+        """
+        # TLV header type(2) len(2) + flags word(4): U|I = 0x05
+        tlvs = struct.pack(">HHI", TLV_STATEFUL_CAP, 4, 0x05)
+        # TLV header type(2) len(2) + reserved(1) flags(2 as two B) MSD(1),
+        # all zero
+        tlvs += struct.pack(">HHBBBB", TLV_SR_CAP, 4, 0, 0, 0, 0)
+        # TLV header type(2) len(2) + reserved(2) NumPSTs(1) PST(1)=1(SR-TE)
+        # + sub-TLV padding(4)
+        tlvs += struct.pack(">HHBBBBBBBB", TLV_PST_CAP, 8, 0, 0, 0, 1, 1, 0, 0, 0)
+        # OPEN object body: version/flags(1) keepalive(1)=30
+        # deadtimer(1)=120 session-id(1)=1
+        body = struct.pack(">BBBB", PCEP_VERSION_BYTE, 30, 120, 1)
+        return self._msg(MSG_OPEN, self._obj(CLASS_OPEN, 1, body + tlvs))
+
+    def build_keepalive(self):
+        """Keepalive message (RFC 5440 S6.3): the common header alone."""
+        return self._msg(MSG_KEEPALIVE, b"")
+
+    def build_initiate(self, policy, srp_id):
+        """PCInitiate message (RFC 8281 S5.1) creating one SR policy:
+
+            <Common Header>   type 12 (PCInitiate)
+            <SRP>             Flags(4, R clear = create) SRP-ID(4)
+              <PATH-SETUP-TYPE>           PST 1 = SR-TE (RFC 8408)
+            <LSP>             PLSP-ID(20 bits)=0 (create) |
+                              Flags(12 bits)=D|A|C
+              <SYMBOLIC-PATH-NAME>        the policy name, 4-byte padded
+            <END-POINTS>      source addr (PCC), destination addr
+                              (object type 1 = IPv4, 2 = IPv6)
+            <ERO>             one SR subobject (RFC 8664 S4.3.1):
+                              label-only SID, NAI absent
+            [<VENDOR-INFO>]   Cisco enterprise TLV carrying the color
+
+        pathd reads the policy color from the VENDOR-INFO object;
+        without it every initiated policy gets INITIATED_POLICY_COLOR
+        (1).
+        """
+        # PATH-SETUP-TYPE TLV: type(2) len(2) + reserved(3) PST(1)=1
+        srp_tlv = struct.pack(">HHBBBB", TLV_PATH_SETUP_TYPE, 4, 0, 0, 0, 1)
+        # SRP object body: flags(4)=0 (R clear = create) srp-id(4)
+        srp = self._obj(CLASS_SRP, 1, struct.pack(">II", 0, srp_id) + srp_tlv)
+
+        name = policy["name"].encode()
+        pad = (-len(name)) % 4
+        # SYMBOLIC-PATH-NAME TLV: type(2) len(2) + name, padded to 4
+        lsp_tlv = (
+            struct.pack(">HH", TLV_SYMBOLIC_NAME, len(name)) + name + b"\x00" * pad
+        )
+        # LSP object word: PLSP-ID in the top 20 bits (0 = create),
+        # flags in the low 12 (0x81 = Delegate|Administrative)
+        lsp = self._obj(CLASS_LSP, 1, struct.pack(">I", (0 << 12) | 0x81) + lsp_tlv)
+
+        # END-POINTS body: raw source then destination address,
+        # object type picked by the endpoint's family
+        if ":" in policy["endpoint"]:
+            ep_body = socket.inet_pton(socket.AF_INET6, self.args.pcc_address6)
+            ep_body += socket.inet_pton(socket.AF_INET6, policy["endpoint"])
+            ep = self._obj(CLASS_ENDPOINTS, 2, ep_body)
+        else:
+            ep_body = socket.inet_aton(self.args.pcc_address)
+            ep_body += socket.inet_aton(policy["endpoint"])
+            ep = self._obj(CLASS_ENDPOINTS, 1, ep_body)
+
+        # SR-ERO subobject: the 20-bit MPLS label sits in the TOP bits
+        # of the 32-bit SID field (RFC 8664), hence the shift
+        sid = (policy["label"] << 12) & 0xFFFFFFFF
+        # subobject: type(1)=0x24(SR) length(1)=8 NT/flags(1)=0(NAI
+        # absent) flags(1)=0x09(F|M: no NAI, SID is an MPLS label) SID(4)
+        sub = struct.pack(">BBBBI", 0x24, 8, 0x00, 0x09, sid)
+        ero = self._obj(CLASS_ERO, 1, sub)
+
+        msg = srp + lsp + ep + ero
+
+        if policy["color"] is not None:
+            # VENDOR-INFO body: enterprise(4)=9(Cisco)
+            # enterprise-specific-info(4)=color-type color-value(4)
+            vendor = self._obj(
+                CLASS_VENDOR_INFO,
+                1,
+                struct.pack(
+                    ">III",
+                    VENDOR_ENTERPRISE_CISCO,
+                    VENDOR_ESI_COLOR,
+                    policy["color"],
+                ),
+            )
+            msg += vendor
+
+        return self._msg(MSG_INITIATE, msg)
+
+    def build_remove(self, name, plsp_id, srp_id):
+        """PCInitiate removal (RFC 8281 S5.4), R flag set:
+
+            <Common Header>   type 12 (PCInitiate)
+            <SRP>             Flags(4, R set = remove) SRP-ID(4)
+            <LSP>             PLSP-ID(20 bits) = the PCC's id for the
+                              path | Flags(12 bits) = D
+              <SYMBOLIC-PATH-NAME>        repeated for good measure
+
+        A removal is addressed by the PLSP-ID the PCC assigned (learned
+        from its PCRpt); no END-POINTS/ERO are carried.
+        """
+        # SRP object body: flags(4)=1 (R set = remove) srp-id(4)
+        srp = self._obj(CLASS_SRP, 1, struct.pack(">II", 0x00000001, srp_id))
+
+        encoded = name.encode()
+        pad = (-len(encoded)) % 4
+        # SYMBOLIC-PATH-NAME TLV: type(2) len(2) + name, padded to 4
+        lsp_tlv = (
+            struct.pack(">HH", TLV_SYMBOLIC_NAME, len(encoded))
+            + encoded
+            + b"\x00" * pad
+        )
+        # LSP object word: PLSP-ID in the top 20 bits, flags in the low
+        # 12 (0x01 = Delegate)
+        lsp = self._obj(
+            CLASS_LSP, 1, struct.pack(">I", (plsp_id << 12) | 0x01) + lsp_tlv
+        )
+
+        return self._msg(MSG_INITIATE, srp + lsp)
+
+    # ------------------------------------------------------------------
+    # Receive path
+    # ------------------------------------------------------------------
+    def handle_report(self, body):
+        """Walk a PCRpt's objects (the mirror of the builders above):
+        each starts with the common object header class(1) type(1)
+        length(2); the SRP object carries the echoed SRP-ID at body
+        offset 4, the LSP object packs PLSP-ID(20 bits)|flags(12 bits)
+        into its first word."""
+        index = 0
+        srp_id = None
+        while index + 4 <= len(body):
+            oclass = body[index]
+            # object header length field: bytes 2-3, includes the header
+            olen = struct.unpack(">H", body[index + 2 : index + 4])[0]
+            if olen < 4 or index + olen > len(body):
+                break
+            if oclass == CLASS_SRP and index + 12 <= len(body):
+                # SRP body: flags(4) then srp-id(4)
+                srp_id = struct.unpack(">I", body[index + 8 : index + 12])[0]
+            if oclass == CLASS_LSP and index + 8 <= len(body):
+                # LSP first word: PLSP-ID(20 bits) | flags(12 bits)
+                word0 = struct.unpack(">I", body[index + 4 : index + 8])[0]
+                plsp_id = word0 >> 12
+                flags = word0 & 0xFF
+                oper = (flags >> 4) & 0x07
+                self.log(
+                    "REPORT plsp-id=%u flags=0x%02x oper=%u srp=%s"
+                    % (plsp_id, flags, oper, srp_id)
+                )
+                if plsp_id == 0 and not flags & LSP_FLAG_SYNC:
+                    self.sync_done = True
+                # A report echoing one of our SRP-IDs tells us the
+                # PLSP-ID the PCC assigned to that policy.
+                if srp_id in self.srp_to_name and plsp_id != 0:
+                    name = self.srp_to_name[srp_id]
+                    if name not in self.plsp_by_name:
+                        self.plsp_by_name[name] = plsp_id
+                        self.log("MAPPED name=%s plsp-id=%u" % (name, plsp_id))
+            index += olen
+
+    def handle_message(self, mtype, body):
+        if mtype == MSG_OPEN:
+            self.log("RECV-OPEN")
+        elif mtype == MSG_KEEPALIVE:
+            self.log("RECV-KEEPALIVE")
+        elif mtype == MSG_REPORT:
+            self.handle_report(body)
+        else:
+            self.log("RECV-TYPE-%u" % mtype)
+
+    def poll_commands(self):
+        """Act on new lines in the command file:
+
+        remove <name>
+        add <endpoint,label,name[,color]>
+
+        add is only meaningful once the PCC's state-sync is done (pathd
+        silently discards earlier PCInitiates); the tests churn well
+        after session establishment.
+        """
+        if not self.args.command_file:
+            return
+        if not os.path.exists(self.args.command_file):
+            return
+
+        with open(self.args.command_file) as cmds:
+            lines = cmds.readlines()
+
+        # Retry removes whose PLSP-ID mapping had not arrived yet: the
+        # PCRpt that (re-)establishes it can still be in flight when the
+        # remove command lands.
+        deferred = self.deferred_removes
+        self.deferred_removes = []
+        for name in deferred:
+            self.send_remove(name)
+
+        for line in lines[self.command_pos :]:
+            self.command_pos += 1
+            fields = line.split()
+            if len(fields) == 2 and fields[0] == "remove":
+                self.send_remove(fields[1])
+            elif len(fields) == 2 and fields[0] == "add":
+                try:
+                    policy = parse_policy(fields[1])
+                except argparse.ArgumentTypeError:
+                    self.log("ADD-BAD-SPEC %s" % fields[1])
+                    continue
+                srp_id = self.next_srp_id
+                self.next_srp_id += 1
+                self.srp_to_name[srp_id] = policy["name"]
+                self.conn.sendall(self.build_initiate(policy, srp_id))
+                self.log(
+                    "ADD-SENT endpoint=%s label=%u name=%s color=%s"
+                    % (
+                        policy["endpoint"],
+                        policy["label"],
+                        policy["name"],
+                        policy["color"],
+                    )
+                )
+
+    def send_remove(self, name):
+        """Send a PCInitiate R-flag remove, deferring until the name's
+        PLSP-ID mapping is known."""
+        if name not in self.plsp_by_name:
+            self.log("REMOVE-DEFERRED name=%s" % name)
+            self.deferred_removes.append(name)
+            return
+        srp_id = self.next_srp_id
+        self.next_srp_id += 1
+        plsp_id = self.plsp_by_name.pop(name)
+        self.conn.sendall(self.build_remove(name, plsp_id, srp_id))
+        self.log("REMOVE-SENT name=%s plsp-id=%u" % (name, plsp_id))
+
+    def keepalive_loop(self):
+        while True:
+            time.sleep(10)
+            try:
+                self.conn.sendall(self.build_keepalive())
+            except OSError:
+                return
+
+    def run(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((self.args.address, self.args.port))
+        self.sock.listen(1)
+        self.log("LISTENING %s:%u" % (self.args.address, self.args.port))
+
+        self.conn, peer = self.sock.accept()
+        self.log("CONNECT %s:%u" % peer)
+
+        # Both Open-first and Keepalive-first orders are accepted by
+        # pceplib; send both back to back.
+        self.conn.sendall(self.build_open())
+        self.conn.sendall(self.build_keepalive())
+        self.log("SENT-OPEN-KEEPALIVE")
+
+        threading.Thread(target=self.keepalive_loop, daemon=True).start()
+
+        buffer = b""
+        while True:
+            readable, _, _ = select.select([self.conn], [], [], 1.0)
+
+            # Drain and process input BEFORE acting on commands, so a
+            # remove issued right after its policy's PCRpt does not race
+            # the mapping that report establishes.
+            if readable:
+                data = self.conn.recv(65536)
+                if not data:
+                    self.log("DISCONNECT")
+                    return
+                buffer += data
+                while len(buffer) >= 4:
+                    # common message header length field: bytes 2-3,
+                    # includes the 4-byte header itself
+                    mlen = struct.unpack(">H", buffer[2:4])[0]
+                    if mlen < 4 or len(buffer) < mlen:
+                        break
+                    self.handle_message(buffer[1], buffer[4:mlen])
+                    buffer = buffer[mlen:]
+
+            self.poll_commands()
+
+            if self.sync_done and not self.initiated:
+                self.initiated = True
+                for policy in self.policies:
+                    srp_id = self.next_srp_id
+                    self.next_srp_id += 1
+                    self.srp_to_name[srp_id] = policy["name"]
+                    self.conn.sendall(self.build_initiate(policy, srp_id))
+                    self.log(
+                        "INITIATE-SENT endpoint=%s label=%u name=%s color=%s"
+                        % (
+                            policy["endpoint"],
+                            policy["label"],
+                            policy["name"],
+                            policy["color"],
+                        )
+                    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--address", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=4189)
+    parser.add_argument("--pcc-address", default="1.1.1.1")
+    parser.add_argument("--pcc-address6", default="2001:db8::1")
+    parser.add_argument("--endpoint")
+    parser.add_argument("--label", type=int)
+    parser.add_argument("--name", default="test-steer")
+    parser.add_argument("--color", type=int)
+    parser.add_argument(
+        "--policy",
+        action="append",
+        type=parse_policy,
+        help="endpoint,label,name[,color]; may be repeated",
+    )
+    parser.add_argument(
+        "--command-file",
+        help="poll this file for commands, one per line: 'remove <name>' "
+        "or 'add <endpoint,label,name[,color]>'",
+    )
+    parser.add_argument("--log", required=True)
+    args = parser.parse_args()
+
+    if not args.policy and not args.endpoint:
+        parser.error("at least one --policy or --endpoint is required")
+    if args.endpoint and args.label is None:
+        parser.error("--endpoint requires --label")
+
+    MockPce(args).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/topotests/pathd_pcep_steering_topo1/rt1/isisd.conf
+++ b/tests/topotests/pathd_pcep_steering_topo1/rt1/isisd.conf
@@ -1,0 +1,23 @@
+!
+hostname rt1
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rt2
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-multiplier 10
+!
+router isis 1
+ net 49.0000.0000.0000.0001.00
+ is-type level-1
+ topology ipv6-unicast
+ segment-routing on
+ segment-routing global-block 16000 23999
+ segment-routing prefix 1.1.1.1/32 index 10
+ segment-routing prefix 2001:db8::1/128 index 11
+!

--- a/tests/topotests/pathd_pcep_steering_topo1/rt1/pathd.conf
+++ b/tests/topotests/pathd_pcep_steering_topo1/rt1/pathd.conf
@@ -1,0 +1,16 @@
+!
+hostname rt1
+!
+segment-routing
+ traffic-eng
+  pcep
+   pce PCE1
+    address ip 127.0.0.1 port 4189
+    pce-initiated
+   !
+   pcc
+    peer PCE1
+   !
+  !
+ !
+!

--- a/tests/topotests/pathd_pcep_steering_topo1/rt1/zebra.conf
+++ b/tests/topotests/pathd_pcep_steering_topo1/rt1/zebra.conf
@@ -1,0 +1,14 @@
+!
+hostname rt1
+!
+interface lo
+ ip address 1.1.1.1/32
+ ipv6 address 2001:db8::1/128
+!
+interface eth-rt2
+ ip address 10.0.1.1/24
+ ipv6 address 2001:db8:10:1::1/64
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/pathd_pcep_steering_topo1/rt2/isisd.conf
+++ b/tests/topotests/pathd_pcep_steering_topo1/rt2/isisd.conf
@@ -1,0 +1,23 @@
+!
+hostname rt2
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rt1
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-multiplier 10
+!
+router isis 1
+ net 49.0000.0000.0000.0002.00
+ is-type level-1
+ topology ipv6-unicast
+ segment-routing on
+ segment-routing global-block 16000 23999
+ segment-routing prefix 2.2.2.2/32 index 20
+ segment-routing prefix 2001:db8::2/128 index 21
+!

--- a/tests/topotests/pathd_pcep_steering_topo1/rt2/zebra.conf
+++ b/tests/topotests/pathd_pcep_steering_topo1/rt2/zebra.conf
@@ -1,0 +1,14 @@
+!
+hostname rt2
+!
+interface lo
+ ip address 2.2.2.2/32
+ ipv6 address 2001:db8::2/128
+!
+interface eth-rt1
+ ip address 10.0.1.2/24
+ ipv6 address 2001:db8:10:1::2/64
+!
+ip forwarding
+ipv6 forwarding
+!

--- a/tests/topotests/pathd_pcep_steering_topo1/test_pathd_pcep_steering_topo1.py
+++ b/tests/topotests/pathd_pcep_steering_topo1/test_pathd_pcep_steering_topo1.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_pathd_pcep_steering_topo1.py
+#
+
+"""
+test_pathd_pcep_steering_topo1.py:
+
+Verify that pathd installs a per-destination steering route for a
+PCE-initiated SR policy, withdraws it when the policy goes down, and
+reinstalls it when the policy comes back up.
+
+         +-------------+                       +-------------+
+         |             |eth-rt2         eth-rt1|             |
+         |     RT1     +-----------------------+     RT2     |
+         | 1.1.1.1     |     10.0.1.0/24       | 2.2.2.2     |
+         | 2001:db8::1 |  2001:db8:10:1::/64   | 2001:db8::2 |
+         +-------------+                       +-------------+
+                |
+         mock PCE (127.0.0.1:4189, inside RT1's namespace)
+
+RT1 is the SR-TE headend running pathd with the PCEP module.  A
+scripted PCE (mock_pce.py) runs inside RT1's network namespace and
+initiates two SR policies towards RT2's loopbacks, one per address
+family, each with a single prefix-SID label (IPv4: 16020, IPv6:
+16021).  Once IS-IS SR has installed the labels, the policies come up
+and pathd is expected to install the steering routes:
+
+    2.2.2.2/32       proto srte distance 10, resolving via SR-TE color
+    2001:db8::2/128  proto srte distance 10, resolving via SR-TE color
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.isisd, pytest.mark.pathd]
+
+ENDPOINT = "2.2.2.2"
+PREFIX = "2.2.2.2/32"
+LABEL = 16020
+
+ENDPOINT6 = "2001:db8::2"
+PREFIX6 = "2001:db8::2/128"
+LABEL6 = 16021
+
+# Churn scale: policies created per address family beyond the two
+# initial ones, colors well away from the initiated-policy default (1)
+# and disjoint between the families.
+CHURN_COUNT = 100
+CHURN_COLOR_BASE = 1000
+CHURN_COLOR_BASE6 = 2000
+
+
+def build_topo(tgen):
+    "Build function"
+
+    for router in ["rt1", "rt2"]:
+        tgen.add_router(router)
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["rt1"], nodeif="eth-rt2")
+    switch.add_link(tgen.gears["rt2"], nodeif="eth-rt1")
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(build_topo, mod.__name__)
+
+    # The test depends on IS-IS SR labels and MPLS steering routes.
+    if not tgen.hasmpls:
+        logger.info("MPLS is not available, skipping test")
+        pytest.skip("MPLS is not available, skipping")
+
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_ISIS, os.path.join(CWD, "{}/isisd.conf".format(rname))
+        )
+
+    tgen.gears["rt1"].load_config(
+        TopoRouter.RD_PATH, os.path.join(CWD, "rt1/pathd.conf"), " -M pathd_pcep"
+    )
+
+    tgen.start_router()
+
+    # Start the scripted PCE inside rt1's network namespace.  pathd
+    # retries the PCEP connection, so starting it after the routers
+    # is fine.  The command file drives the churn tests: the PCE polls
+    # it for 'add'/'remove' lines.
+    pce_log = os.path.join(tgen.logdir, "rt1", "mock_pce.log")
+    pce_commands = os.path.join(tgen.logdir, "rt1", "pce_commands")
+    tgen.gears["rt1"].run(
+        "nohup python3 {}/mock_pce.py "
+        "--policy {},{},test-steer "
+        "--policy {},{},test-steer-v6 "
+        "--pcc-address 1.1.1.1 --pcc-address6 2001:db8::1 "
+        "--command-file {} "
+        "--log {} > /dev/null 2>&1 &".format(
+            CWD, ENDPOINT, LABEL, ENDPOINT6, LABEL6, pce_commands, pce_log
+        )
+    )
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def print_pce_log():
+    "Dump the mock PCE's session log to the test log for debugging"
+
+    tgen = get_topogen()
+    pce_log = os.path.join(tgen.logdir, "rt1", "mock_pce.log")
+    try:
+        with open(pce_log) as log:
+            logger.info("mock PCE log:\n%s", log.read())
+    except IOError:
+        logger.info("mock PCE log %s not found", pce_log)
+
+
+def check_label_installed():
+    "Check that RT2's prefix-SID labels are in RT1's LFIB"
+
+    tgen = get_topogen()
+    output = json.loads(tgen.gears["rt1"].vtysh_cmd("show mpls table json"))
+    for label in [LABEL, LABEL6]:
+        if str(label) not in output:
+            return "label {} not in LFIB".format(label)
+    return None
+
+
+def check_steering_route_af(present, prefix, show_cmd):
+    "Check one address family's steering route on RT1"
+
+    tgen = get_topogen()
+    output = json.loads(
+        tgen.gears["rt1"].vtysh_cmd("{} {} json".format(show_cmd, prefix))
+    )
+    routes = [
+        route for route in output.get(prefix, []) if route.get("protocol") == "srte"
+    ]
+
+    if not present:
+        if routes:
+            return "steering route for {} still present".format(prefix)
+        return None
+
+    if not routes:
+        return "no srte route for {}".format(prefix)
+
+    route = routes[0]
+    if route.get("distance") != 10:
+        return "wrong distance for {}: {}".format(prefix, route.get("distance"))
+    if not route.get("installed"):
+        return "steering route for {} not installed".format(prefix)
+    if not any(nh.get("active") for nh in route.get("nexthops", [])):
+        return "no active nexthop for {}".format(prefix)
+
+    return None
+
+
+def check_steering_route(present):
+    "Check the presence/absence of both steering routes on RT1"
+
+    result = check_steering_route_af(present, PREFIX, "show ip route")
+    if result is not None:
+        return result
+
+    return check_steering_route_af(present, PREFIX6, "show ipv6 route")
+
+
+def test_isis_sr_convergence():
+    "Wait for IS-IS SR to install RT2's prefix-SID label on RT1"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for labels %u and %u in rt1's LFIB", LABEL, LABEL6)
+    _, result = topotest.run_and_expect(check_label_installed, None, count=60, wait=1)
+    assert result is None, "IS-IS SR did not install labels: {}".format(result)
+
+
+def test_steering_route_installed():
+    "PCE initiates the policy; pathd must install the steering route"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for the PCEP session, PCInitiate and steering route")
+    check = lambda: check_steering_route(True)
+    _, result = topotest.run_and_expect(check, None, count=120, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "steering route missing: {}".format(result)
+
+
+def test_steering_route_withdrawn_on_policy_down():
+    "Take the policy down; pathd must withdraw the steering route"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("shutting down rt2's eth-rt1")
+    tgen.gears["rt2"].vtysh_cmd("""
+        configure terminal
+         interface eth-rt1
+          shutdown
+        """)
+
+    check = lambda: check_steering_route(False)
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "steering route not withdrawn: {}".format(result)
+
+
+def test_steering_route_reinstalled_on_policy_up():
+    "Bring the policy back up; pathd must reinstall the steering route"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("bringing rt2's eth-rt1 back up")
+    tgen.gears["rt2"].vtysh_cmd("""
+        configure terminal
+         interface eth-rt1
+          no shutdown
+        """)
+
+    check = lambda: check_steering_route(True)
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "steering route not reinstalled: {}".format(result)
+
+
+def pce_command(line):
+    "Append one command line for the mock PCE to act on"
+
+    tgen = get_topogen()
+    with open(os.path.join(tgen.logdir, "rt1", "pce_commands"), "a") as cmds:
+        cmds.write(line + "\n")
+
+
+def churn_name(i, v6=False):
+    return "churn6-{}".format(i) if v6 else "churn-{}".format(i)
+
+
+def churn_add(i, v6=False):
+    "Ask the PCE to initiate one churn policy for the family's endpoint"
+
+    endpoint = ENDPOINT6 if v6 else ENDPOINT
+    label = LABEL6 if v6 else LABEL
+    color = (CHURN_COLOR_BASE6 if v6 else CHURN_COLOR_BASE) + i
+    pce_command("add {},{},{},{}".format(endpoint, label, churn_name(i, v6), color))
+
+
+def check_policy_count(expected):
+    "Check the number of Active SR-TE policies on RT1"
+
+    tgen = get_topogen()
+    active = tgen.gears["rt1"].vtysh_cmd("show sr-te policy").count("Active")
+    if active != expected:
+        return "expected {} Active policies, have {}".format(expected, active)
+    return None
+
+
+def steering_nexthop_count(v6=False):
+    """The number of colored nexthops on RT1's steering route for the
+    family (-1 if absent).  The route's nexthops are recursive (endpoint
+    via endpoint, resolved through the policy); zebra's JSON flattens
+    each recursive parent and its resolved nexthop into the same array,
+    so count only the parents."""
+
+    prefix = PREFIX6 if v6 else PREFIX
+    show_cmd = "show ipv6 route" if v6 else "show ip route"
+    tgen = get_topogen()
+    output = json.loads(
+        tgen.gears["rt1"].vtysh_cmd("{} {} json".format(show_cmd, prefix))
+    )
+    routes = [
+        route for route in output.get(prefix, []) if route.get("protocol") == "srte"
+    ]
+    if not routes:
+        return -1
+    return len([nh for nh in routes[0].get("nexthops", []) if nh.get("recursive")])
+
+
+def ecmp_max():
+    "zebra's runtime multipath limit, which caps the route's nexthops"
+
+    tgen = get_topogen()
+    output = tgen.gears["rt1"].vtysh_cmd("show zebra")
+    match = re.search(r"ECMP Maximum\s*\|?\s*(\d+)", output)
+    assert match is not None, "cannot read ECMP Maximum from 'show zebra'"
+    return int(match.group(1))
+
+
+def check_steering_nexthops(policies, v6=False):
+    "Check the family's steering route carries min(policies, ECMP max) nexthops"
+
+    prefix = PREFIX6 if v6 else PREFIX
+    expected = min(policies, ecmp_max())
+    have = steering_nexthop_count(v6)
+    if have != expected:
+        return "expected {} nexthops on {} ({} policies, ecmp {}), have {}".format(
+            expected, prefix, policies, ecmp_max(), have
+        )
+    return None
+
+
+def check_steering_nexthops_both(policies):
+    "Check both families' steering routes at the same expected count"
+
+    result = check_steering_nexthops(policies, v6=False)
+    if result is not None:
+        return result
+
+    return check_steering_nexthops(policies, v6=True)
+
+
+def test_policy_churn_scale():
+    "Initiate CHURN_COUNT extra policies per family for the endpoints"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info(
+        "initiating %u churn policies each for %s and %s",
+        CHURN_COUNT, ENDPOINT, ENDPOINT6,
+    )
+    for i in range(CHURN_COUNT):
+        churn_add(i, v6=False)
+        churn_add(i, v6=True)
+
+    # 2 initial policies + CHURN_COUNT churn ones per family
+    check = lambda: check_policy_count(2 + 2 * CHURN_COUNT)
+    _, result = topotest.run_and_expect(check, None, count=180, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "churn policies never came up: {}".format(result)
+
+    # Each endpoint now has 1 + CHURN_COUNT policies; its steering route
+    # aggregates one colored nexthop per policy, capped at the multipath
+    # limit (colors beyond it are logged and unrepresented).
+    check = lambda: check_steering_nexthops_both(1 + CHURN_COUNT)
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    assert result is None, "steering route wrong after churn add: {}".format(result)
+
+
+def test_policy_churn_remove_readd():
+    "Remove a subset, re-add some of it, then remove all churn policies"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Remove the first 40 churn policies of each family.
+    logger.info("removing 40 churn policies per family")
+    for i in range(40):
+        pce_command("remove {}".format(churn_name(i, v6=False)))
+        pce_command("remove {}".format(churn_name(i, v6=True)))
+
+    check = lambda: check_policy_count(2 + 2 * (CHURN_COUNT - 40))
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "churn remove failed: {}".format(result)
+
+    # Re-add 20 of them per family (same names, same colors): pathd
+    # hands back the PLSP-IDs it retained for these keys.
+    logger.info("re-adding 20 churn policies per family")
+    for i in range(20):
+        churn_add(i, v6=False)
+        churn_add(i, v6=True)
+
+    check = lambda: check_policy_count(2 + 2 * (CHURN_COUNT - 40 + 20))
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "churn re-add failed: {}".format(result)
+
+    # Remove every churn policy; only the two initial ones remain, and
+    # both steering routes must collapse back to a single nexthop.
+    logger.info("removing all churn policies")
+    for v6 in (False, True):
+        for i in range(20):
+            pce_command("remove {}".format(churn_name(i, v6)))
+        for i in range(40, CHURN_COUNT):
+            pce_command("remove {}".format(churn_name(i, v6)))
+
+    check = lambda: check_policy_count(2)
+    _, result = topotest.run_and_expect(check, None, count=120, wait=1)
+    if result is not None:
+        print_pce_log()
+    assert result is None, "churn teardown failed: {}".format(result)
+
+    check = lambda: check_steering_nexthops_both(1)
+    _, result = topotest.run_and_expect(check, None, count=60, wait=1)
+    assert result is None, "steering route wrong after churn teardown: {}".format(
+        result
+    )
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
This set of topotests adds a topology test for validating pathd
steering of pcep-initiated policies. The tests creates a scripted
pce (mock_pce.py) that implements a minimal viable PCEP, and sends
Open, Keepalive, and PCInitiate messages.  These tests were created
to test the new features added in
https://github.com/FRRouting/frr/pull/23050 it will not pass topotests
until 23050 has been merged.  More broadly the purpose of the tests
are to validate pathd is installing per-destination steering for policies
initiated by a PCE.
