### PR TITLE
doc: add bfd docs for ospf, isis and openfabric

### DIFF
--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -343,13 +343,31 @@ The following commands are available inside the interface configuration node.
    a new neighbor is found a BFD peer is created to monitor the link
    status for fast convergence.
 
-   Note that there will be just one BFD session per interface. In case both
-   IPv4 and IPv6 support are configured then just a IPv6 based session is
-   created.
+   A BFD session is created for each IS-IS adjacency on the interface. If IPv6
+   is enabled on the circuit, FRR uses an IPv6 link-local address for the
+   session; otherwise, if IPv4 is enabled, it uses IPv4. If IPv6 addresses are
+   not yet available, FRR waits for them instead of falling back to IPv4.
 
 .. clicmd:: isis bfd profile BFDPROF
 
    Use a BFD profile BFDPROF as provided in the BFD configuration.
+
+
+.. _bfd-openfabric-peer-config:
+
+OpenFabric BFD Configuration
+----------------------------
+
+The following command is available inside the interface configuration node.
+
+.. clicmd:: openfabric bfd
+
+   Enable BFD monitoring for OpenFabric adjacencies on the interface. A BFD
+   session is created for each adjacency to monitor the link and provide fast
+   failure detection. If IPv6 is enabled on the circuit, FRR uses an IPv6
+   link-local address for the session; otherwise, if IPv4 is enabled, it uses
+   IPv4. If IPv6 addresses are not yet available, FRR waits for them instead of
+   falling back to IPv4.
 
 
 .. _bfd-ospf-peer-config:

--- a/doc/user/fabricd.rst
+++ b/doc/user/fabricd.rst
@@ -123,6 +123,12 @@ OpenFabric interface
 
    Set CSNP interval in seconds.
 
+BFD monitoring can be enabled for OpenFabric adjacencies on an interface with
+:clicmd:`openfabric bfd`. BFD provides faster failure detection than the
+OpenFabric hello timers.
+
+.. seealso:: :ref:`bfd-openfabric-peer-config`
+
 .. clicmd:: openfabric hello-interval (1-600)
 
 

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -213,6 +213,13 @@ ISIS interface
    command :clicmd:`router isis WORD`). To enable IPv4, issue ``ip router isis
    WORD``; to enable IPv6, issue ``ipv6 router isis WORD``.
 
+BFD monitoring can be enabled for IS-IS adjacencies on an interface with
+:clicmd:`isis bfd`. BFD provides faster failure detection than the IS-IS hello
+timers. Use :clicmd:`isis bfd profile BFDPROF` to apply a BFD profile to these
+sessions.
+
+.. seealso:: :ref:`bfd-isis-peer-config`
+
 .. clicmd:: isis circuit-type [level-1 | level-1-2 | level-2]
 
    Configure circuit type for interface:

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -739,6 +739,15 @@ Interfaces
    config. The optional address ``A.B.C.D`` scopes the override to a
    specific address on multi-address interfaces.
 
+BFD monitoring can be enabled for OSPF neighbors on an interface with
+:clicmd:`ip ospf bfd [quick]`. BFD provides faster failure detection than the
+OSPF dead interval. The optional ``quick`` mode keeps BFD sessions active when
+OSPF removes a neighbor, allowing OSPF to reestablish the neighbor more quickly
+when BFD reports the peer up. Use :clicmd:`ip ospf bfd profile BFDPROF` to apply
+a BFD profile to these sessions.
+
+.. seealso:: :ref:`bfd-ospf-peer-config`
+
 .. clicmd:: ip ospf cost (1-65535)
 
 


### PR DESCRIPTION
Document how to enable bfd for these protocols. Add the missing openfabric section and fix the isis session description.