### PR TITLE
bgpd: warn about `remote-as auto`

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -156,6 +156,15 @@ DEFINE_HOOK(bgp_snmp_traps_config_write, (struct vty * vty), (vty));
 DEFINE_HOOK(bgp_route_distinguisher_update, (struct bgp *bgp, afi_t afi, bool preconfig),
 	    (bgp, afi, preconfig));
 
+static void warn_auto(struct vty *vty, const char *linestart)
+{
+	vty_out(vty,
+		"%s the \"remote-as auto\" option is an operations and security vulnerability\n"
+		"%s eBGP and iBGP fundamentally behave very differently and should not be mixed\n"
+		"%s please use \"remote-as external\" or \"remote-as internal\" instead\n",
+		linestart, linestart, linestart);
+}
+
 static struct peer_group *listen_range_exists(struct bgp *bgp,
 					      struct prefix *range, int exact);
 
@@ -5394,6 +5403,7 @@ static int peer_remote_as_vty(struct vty *vty, const char *peer_str,
 	} else if (as_str[0] == 'a') {
 		as = 0;
 		as_type = AS_AUTO;
+		warn_auto(vty, "%");
 	} else if (!asn_str2asn(as_str, &as))
 		as_type = AS_UNSPECIFIED;
 
@@ -5606,6 +5616,7 @@ static int peer_conf_interface_get(struct vty *vty, const char *conf_if,
 			as_type = AS_EXTERNAL;
 		} else if (as_str[0] == 'a') {
 			as_type = AS_AUTO;
+			warn_auto(vty, "%");
 		} else {
 			/* Get AS number.  */
 			if (asn_str2asn(as_str, &as))
@@ -21321,6 +21332,7 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 			vty_out(vty, " remote-as external");
 			if_ras_printed = true;
 		} else if (CHECK_FLAG(peer->as_type, AS_AUTO)) {
+			warn_auto(vty, " !");
 			vty_out(vty, " remote-as auto");
 			if_ras_printed = true;
 		}
@@ -21353,6 +21365,7 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 					" neighbor %s remote-as external\n",
 					addr);
 			} else if (CHECK_FLAG(peer->as_type, AS_AUTO)) {
+				warn_auto(vty, " !");
 				vty_out(vty, " neighbor %s remote-as auto\n",
 					addr);
 			}
@@ -21379,6 +21392,7 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 					" neighbor %s remote-as external\n",
 					addr);
 			} else if (CHECK_FLAG(peer->as_type, AS_AUTO)) {
+				warn_auto(vty, " !");
 				vty_out(vty, " neighbor %s remote-as auto\n",
 					addr);
 			}

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1907,6 +1907,20 @@ Defining Peers
 
    The neighbor's ASN is detected automatically from the OPEN message.
 
+   .. warn::
+
+      This option presents a serious operational and security hazard.  BGP
+      protocol operation differs significantly between eBGP and iBGP, including
+      weaker session security properties for iBGP.  Even if security isn't an
+      issue, the distinction between the modes present massive potential for
+      operational footguns.
+
+      This option should only ever be considered in datacenter operations, and
+      only temporarily when migrating between different overall network
+      designs.  Never use this option in telecommunications setups, e.g. on the
+      open internet.  Use either of ``remote-as internal`` or ``remote-as
+      external`` instead.
+
 .. clicmd:: neighbor PEER oad
 
    Mark a peer belonging to the One Administrative Domain.


### PR DESCRIPTION
This might be a bit controversial but it's a _horrible idea_ to have a config where you don't know if a peer is going to be eBGP or iBGP.  It's a giant footgun.

One example of a really bad outcome:
* operator configures eBGP peer with `remote-as auto`
* interface is down or removed, peer address is no longer directly connected
* now anyone that can spoof the peer address (including blind TCP sequence number spraying) can establish an iBGP session from the other end of the internet

Also since eBGP and iBGP behave so differently I would argue it's close to impossible to configure filters correctly without also deciding between eBGP and iBGP. Really, _an operator should know whether they're trying to do eBGP or iBGP_.