### PR TITLE
bgpd: Ensure that BGP binds to connection addresses that it can

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -750,10 +750,7 @@ static void bgp_accept(struct event *event)
 static char *bgp_get_bound_name(struct peer_connection *connection)
 {
 	struct peer *peer = connection->peer;
-
-	if ((peer->bgp->vrf_id == VRF_DEFAULT) && !peer->ifname
-	    && !peer->conf_if)
-		return NULL;
+	struct connected *c;
 
 	if (connection->su.sa.sa_family != AF_INET &&
 	    connection->su.sa.sa_family != AF_INET6)
@@ -769,7 +766,20 @@ static char *bgp_get_bound_name(struct peer_connection *connection)
 	if (peer->ifname)
 		return peer->ifname;
 
-	if (peer->bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
+	/*
+	 * If a v6 neighbors address is covered by an interfaces connected prefix,
+	 * then let's use that interfaces name as the bind point.  This will prevent
+	 * 'fun' situations with DAD not fully saying an address is usable and causing
+	 * some random source address to be choosen.
+	 */
+	if (connection->su.sa.sa_family == AF_INET6) {
+		c = if_lookup_address(&connection->su.sa, connection->su.sa.sa_family,
+				      peer->bgp->vrf_id);
+		if (c)
+			return c->ifp->name;
+	}
+
+	if (peer->bgp->inst_type == BGP_INSTANCE_TYPE_VIEW || peer->bgp->vrf_id == VRF_DEFAULT)
 		return NULL;
 
 	return peer->bgp->name;


### PR DESCRIPTION
Currently in the v6 world, when an address is under DAD, it is considered `tentative`.  The current default behavior of the linux kernel is that the address is installed on the interface and additionally a prefix route is installed.  Current behavior is to install the kernel route or the connected ( see PR 23183 for a slight change in behavior of what DAD does ).  This route is acceptable from a nht perspective to allow for BGP nexthop tracking to key off of and allow the outgoing connection.

The problem that happens is that BGP can act quickly enough that the outgoing connection is attempted before DAD finishes. The linux kernel will then pick a source address from the list of available GUA values.  These may be routeable from the other side already.  This connection will succeed and if you have any type of ecmp you end up with a situation where you have multiple nexthops as the same address.  Thus causing real problems.

Modify the code base such that if when deciding what, if any, interface to bind to, that allow the selection of a connected interface if the neighbors ipv6 address is covered by that connected prefix.

The bind call should be sufficient in that if DAD is still going on, the bind call will fail on that interface, thus causing the connection to abort and giving DAD processing time to continue.