### PR TITLE
tests: ensure interfaces are up before using them

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf4/ce1/setup.sh
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf4/ce1/setup.sh
@@ -1,1 +1,2 @@
 ip link add dum0 type dummy
+ip link set dum0 up

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf4/ce2/setup.sh
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf4/ce2/setup.sh
@@ -1,1 +1,2 @@
 ip link add dum0 type dummy
+ip link set dum0 up

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
@@ -64,8 +64,10 @@ def setup_module(mod):
 
     cmds = [
         "ip link add {0}-cust1 type vrf table 1001",
+        "ip link set {0}-cust1 up",
         "ip link add loop1 type dummy",
         "ip link set loop1 master {0}-cust1",
+        "ip link set loop1 up",
         "ip link set {0}-eth0 master {0}-cust1",
     ]
 

--- a/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
+++ b/tests/topotests/pim_basic_igmp_proxy/test_pim_igmp_proxy.py
@@ -84,6 +84,7 @@ def build_topo(tgen):
 
     # Dummy interface for static joins
     tgen.gears["r2"].run("ip link add r2-eth1 type dummy")
+    tgen.gears["r2"].run("ip link set r2-eth1 up")
 
 
 def setup_module(mod):

--- a/tests/topotests/pim_mrib/test_pim_mrib.py
+++ b/tests/topotests/pim_mrib/test_pim_mrib.py
@@ -78,6 +78,7 @@ def build_topo(tgen):
     tgen.add_link(tgen.gears["r3"], tgen.gears["r4"], "r3-eth1", "r4-eth1")
 
     tgen.gears["r4"].run("ip link add r4-dum0 type dummy")
+    tgen.gears["r4"].run("ip link set r4-dum0 up")
 
 
 def setup_module(mod):


### PR DESCRIPTION
Depending on the the test environment, some tests could fail because the interfaces are not in "up" state.