### PR TITLE
tests: Fix pytest marker in SRv6 uSID locator topotest

### DIFF
--- a/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
+++ b/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.sharpd]
 
 
 def open_json_file(filename):


### PR DESCRIPTION
The `srv6_locator_usid topotest` only uses zebra and sharpd, so remove the incorrect `bgpd` pytest marker.