### PR TITLE
tests: Remove unused JSON helper from SRv6 topotest

### DIFF
--- a/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
+++ b/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
@@ -31,14 +31,6 @@ from lib.topolog import logger
 pytestmark = [pytest.mark.sharpd]
 
 
-def open_json_file(filename):
-    try:
-        with open(filename, "r") as f:
-            return json.load(f)
-    except IOError:
-        assert False, "Could not read file {}".format(filename)
-
-
 def setup_module(mod):
     tgen = Topogen({None: "r1"}, mod.__name__)
     tgen.start_topology()


### PR DESCRIPTION
The `srv6_encap_src_addr` topotest defines `open_json_file()`, but never uses it. Remove the unused function.