### PR TITLE
tests: Fix a race condition in the creation of a mac on a bridge

### DIFF
--- a/tests/topotests/bgp_evpn_rt2_v6_vrf_import/test_bgp_evpn_rt2_v6_vrf_import.py
+++ b/tests/topotests/bgp_evpn_rt2_v6_vrf_import/test_bgp_evpn_rt2_v6_vrf_import.py
@@ -73,7 +73,7 @@ def _setup_pe(router, idx):
             [
                 "ip link set eth-h2 master br100",
                 "bridge link set dev eth-h2 learning off",
-                "bridge fdb add 02:00:00:00:00:02 dev eth-h2 master static sticky",
+                "bridge fdb replace 02:00:00:00:00:02 dev eth-h2 master static sticky",
                 "ip neigh add 192.168.0.2 lladdr 02:00:00:00:00:02 dev br100",
             ]
         )


### PR DESCRIPTION
We are seeing this race condition:

a) start up h2
b) Set h2's mac
c) pe2 creates br100
d) pe2 adds eth-h2 to br100, bridge learning is on e) Learning is turned off after the port is already added to the bridge f) bridge fdb add ... runs after the mac is already learned.

Use replace instead of add.