### PR TITLE
bgpd: fix use transparent mode when nexthop-unchanged set between peers

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2618,8 +2618,10 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	}
 
 	/* Transparency check. */
-	if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_RSERVER_CLIENT)
-	    && CHECK_FLAG(from->af_flags[afi][safi], PEER_FLAG_RSERVER_CLIENT))
+	if ((CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_RSERVER_CLIENT) &&
+	     CHECK_FLAG(from->af_flags[afi][safi], PEER_FLAG_RSERVER_CLIENT)) ||
+	    (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_NEXTHOP_UNCHANGED) &&
+	     CHECK_FLAG(from->af_flags[afi][safi], PEER_FLAG_NEXTHOP_UNCHANGED)))
 		transparent = 1;
 	else
 		transparent = 0;


### PR DESCRIPTION
When using route-server configuration, an incoming VPN nexthop has 48 byte long, while an outgoing VPN nexthop has 24 bytes long. This is not the case if the 'attribute-unchanged next-hop' only command is used.

Actually, the same behavior should apply for both cases. Fix this by including the case with attribute-unchanged.