### PR TITLE
bgpd: orphan exclude refs when deleting an as-path ACL

### DIFF
--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -582,6 +582,7 @@ DEFUN (no_as_path_all,
 {
 	int idx_word = 4;
 	struct as_list *aslist;
+	struct aspath_exclude *ase;
 
 	aslist = as_list_lookup(argv[idx_word]->arg);
 	if (aslist == NULL) {
@@ -590,6 +591,12 @@ DEFUN (no_as_path_all,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	/* put aspath exclude list into orphan */
+	if (as_list_list_count(&aslist->exclude_rule))
+		while ((ase = as_list_list_pop(&aslist->exclude_rule)))
+			as_exclude_set_orphan(ase);
+
+	as_list_list_fini(&aslist->exclude_rule);
 	as_list_delete(aslist);
 
 	/* Run hook function. */

--- a/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
+++ b/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
@@ -101,6 +101,12 @@ def bgp_converge(router, expected):
     return topotest.json_cmp(output, expected)
 
 
+def bgp_route_present(router, prefix):
+    output = json.loads(router.vtysh_cmd("show bgp ipv4 unicast json"))
+
+    return None if prefix in output.get("routes", {}) else "missing"
+
+
 def test_bgp_set_aspath_exclude():
     tgen = get_topogen()
 
@@ -239,6 +245,50 @@ clear bgp *
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed to renegotiate with peers 2"
+
+
+def test_no_bgp_aspath_exclude_full_access_list_delete():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    rname = "r1"
+    r1 = tgen.gears[rname]
+
+    # Reference a dedicated ACL from the route-map, then delete the entire
+    # ACL. The full-delete path must orphan the route-map reference instead
+    # of leaving a dangling exclude_aspath_acl pointer behind.
+    r1.vtysh_cmd(
+        """
+conf
+ bgp as-path access-list FULL permit 2$
+ route-map r2 permit 6
+  set as-path exclude as-path-access-list FULL
+    """
+    )
+    r1.vtysh_cmd(
+        """
+conf
+ no bgp as-path access-list FULL
+    """
+    )
+
+    # Trigger route-map evaluation. Without the fix, bgpd dereferences the
+    # freed ACL and crashes.
+    r1.vtysh_cmd(
+        """
+clear bgp *
+    """
+    )
+
+    # The orphaned rule must not crash bgpd and the route must stay present.
+    test_func = functools.partial(
+        bgp_route_present, tgen.gears["r1"], "172.16.255.32/32"
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, "bgpd crashed or dropped the route after full ACL delete"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Orphan the  `set as-path exclude` route-map references before freeing
an entire AS-path access-list, mirroring the single-rule deletion path.

Adds a topotest that deletes a referenced access-list and verifies bgpd
survives route-map re-evaluation.

Fixes #22350