### PR TITLE
bfdd: fix the --vrfs allowlist (inverted comparator, exit leaks)

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2728,8 +2728,10 @@ static void init_bfd_perm_vrfs_data(const char *context)
 
 	frrstr_split(context, delim, &vrfs_list, &num);
 
-	for (int i = 0; i < num; i++)
+	for (int i = 0; i < num; i++) {
 		insert_bfd_perm_vrf(vrfs_list[i]);
+		XFREE(MTYPE_TMP, vrfs_list[i]);
+	}
 
 	XFREE(MTYPE_TMP, vrfs_list);
 }
@@ -2739,9 +2741,12 @@ static void destroy_bfd_perm_vrfs_data(void)
 	struct bfd_perm_vrf *vrf_item;
 
 	frr_each_safe (bfd_perm_vrfs, &bfd_perm_vrfs, vrf_item) {
+		bfd_perm_vrfs_del(&bfd_perm_vrfs, vrf_item);
 		XFREE(MTYPE_TMP, vrf_item->vrf_name);
 		XFREE(MTYPE_BFD_PERM_VRF, vrf_item);
 	}
+
+	bfd_perm_vrfs_fini(&bfd_perm_vrfs);
 }
 
 /*

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2300,7 +2300,7 @@ static unsigned int bfd_perm_vrfs_hash_do(const struct bfd_perm_vrf *vrf)
 
 static bool bfd_perm_vrfs_hash_cmp(const struct bfd_perm_vrf *vrf1, const struct bfd_perm_vrf *vrf2)
 {
-	return strmatch(vrf1->vrf_name, vrf2->vrf_name);
+	return !strmatch(vrf1->vrf_name, vrf2->vrf_name);
 }
 
 /*

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -468,7 +468,7 @@ int main(int argc, char *argv[])
 		distributed_bfd_init(dplane_addr);
 
 	if (perm_vrfs)
-		free(perm_vrfs);
+		XFREE(MTYPE_TMP, perm_vrfs);
 
 	frr_run(master);
 	/* NOTREACHED */

--- a/tests/topotests/bfd_vrf_allowlist/r1/bfdd.conf
+++ b/tests/topotests/bfd_vrf_allowlist/r1/bfdd.conf
@@ -1,0 +1,1 @@
+! No BFD peers configured at startup.

--- a/tests/topotests/bfd_vrf_allowlist/r1/zebra.conf
+++ b/tests/topotests/bfd_vrf_allowlist/r1/zebra.conf
@@ -1,0 +1,3 @@
+interface r1-eth0
+ ip address 192.168.0.1/24
+!

--- a/tests/topotests/bfd_vrf_allowlist/r2/bfdd.conf
+++ b/tests/topotests/bfd_vrf_allowlist/r2/bfdd.conf
@@ -1,0 +1,1 @@
+! No BFD peers configured at startup.

--- a/tests/topotests/bfd_vrf_allowlist/r2/zebra.conf
+++ b/tests/topotests/bfd_vrf_allowlist/r2/zebra.conf
@@ -1,0 +1,3 @@
+interface r2-eth0
+ ip address 192.168.0.2/24
+!

--- a/tests/topotests/bfd_vrf_allowlist/test_bfd_vrf_allowlist.py
+++ b/tests/topotests/bfd_vrf_allowlist/test_bfd_vrf_allowlist.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: ISC
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+#
+# Copyright (C) 2026  Nevoa Solutions Ltda.
+
+"""
+Test the bfdd --vrfs allowlist.
+
+r1 runs bfdd with "--vrfs=default": the default VRF is on the allowlist,
+so its BFD sockets must open and a single-hop session to r2 must come
+up.  With the inverted typesafe-hash comparator (bfd_perm_vrfs_hash_cmp
+returning strmatch) the allowlist lookup never matched and bfdd opened
+no socket in any VRF.
+"""
+
+import os
+import re
+import sys
+
+import json
+
+import pytest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topotest import run_and_expect
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.bfdd]
+
+# BFD well-known single-hop UDP port
+BFD_SINGLE_HOP_PORT = 3784
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    topodef = {
+        "s1": ("r1", "r2"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        options = "--vrfs=default" if rname == "r1" else None
+        router.load_config(
+            TopoRouter.RD_BFD, os.path.join(CWD, "{}/bfdd.conf".format(rname)), options
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment: stop topologies and free resources."
+    tgen = get_topogen()
+    # Remove the peers so bfdd exits without live sessions: a live
+    # session at exit makes the daemon print memstats, which the
+    # teardown memory-leak check would flag.
+    for rname, peer in (("r1", "192.168.0.2"), ("r2", "192.168.0.1")):
+        if rname in tgen.gears:
+            tgen.gears[rname].vtysh_cmd(
+                f"""
+configure terminal
+bfd
+ no peer {peer}
+ !
+!
+"""
+            )
+    tgen.stop_topology()
+
+
+def bfd_socket_count(router, port):
+    """Count the number of UDP sockets bound to the given port."""
+    output = router.cmd("ss -ulpn sport = :{}".format(port))
+    count = 0
+    for line in output.strip().splitlines():
+        if re.search(r":{}(?!\d)".format(port), line):
+            count += 1
+    return count
+
+
+def _peer_status(router, peer):
+    "Return the remote peer status from 'show bfd peers json'."
+    output = router.vtysh_cmd("show bfd peers json", isjson=False)
+    try:
+        entries = json.loads(output)
+    except json.JSONDecodeError:
+        return None
+    for entry in entries:
+        if entry.get("peer") == peer:
+            return entry.get("status")
+    return None
+
+
+def test_allowlisted_vrf_serves_bfd():
+    "A VRF on the --vrfs allowlist must open its sockets and run sessions."
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    r1.vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.2
+  no shutdown
+ !
+!
+"""
+    )
+    r2.vtysh_cmd(
+        """
+configure terminal
+bfd
+ peer 192.168.0.1
+  no shutdown
+ !
+!
+"""
+    )
+
+    # The allowlisted default VRF must open the single-hop socket.
+    ok, ret = run_and_expect(
+        lambda: None if bfd_socket_count(r1, BFD_SINGLE_HOP_PORT) > 0 else "no socket",
+        None,
+        count=30,
+        wait=1,
+    )
+    assert ok, "r1 has no BFD single-hop socket (--vrfs=default): {}".format(ret)
+
+    # And the session must establish.
+    ok, ret = run_and_expect(
+        lambda: None if _peer_status(r1, "192.168.0.2") == "up" else "session down",
+        None,
+        count=30,
+        wait=2,
+    )
+    assert ok, "r1 BFD session did not come up: {}".format(ret)
+    ok, ret = run_and_expect(
+        lambda: None if _peer_status(r2, "192.168.0.1") == "up" else "session down",
+        None,
+        count=30,
+        wait=2,
+    )
+    assert ok, "r2 BFD session did not come up: {}".format(ret)


### PR DESCRIPTION
#### Is this a fix / feature / documentation update?

Fix (two commits, each self-contained).

#### What I did

**Commit 1 — inverted typesafe comparator (functional breakage)**

`DECLARE_HASH` (`lib/typesafe.h`) requires the comparator to return non-zero when the items are **different** (strcmp-like; `_add`/`_const_find` test `cmpfn(...) == 0` for a match). `bfd_perm_vrfs_hash_cmp()` returned `strmatch()`, which is true when the names are **equal** — exactly inverted.

Impact: with a non-empty `--vrfs` allowlist, `_bfd_perm_vrf_find()` never matched, `bfd_vrf_is_perm()` returned false for every VRF — including the allowlisted ones — and `bfd_vrf_start_sockets()` opened **no BFD socket in any VRF** (udp/3784/4784 never bound; the feature introduced in #19136 never worked).

The one-line inversion fix is originally by **Alexandra Rukomoinikova (Sashhkaa)** (commit `b1315a2` in her personal fork, Dec 2025), never submitted upstream; it is carried here with a regression test. Verified still inverted in master as of today (`f276f0db35`).

**Commit 2 — exit path of the same feature**

- `destroy_bfd_perm_vrfs_data()` XFREE'd the entries without unlinking them from the hash (dangling pointers, non-zero count) and never called `bfd_perm_vrfs_fini()`, so the hash itself leaked;
- `init_bfd_perm_vrfs_data()` freed only the `frrstr_split()` result array, leaking one strdup per VRF token;
- `bfdd.c` freed the strdup'd `--vrfs` argument with plain `free()` instead of `XFREE()`.

#### How to test it

New topotest `bfd_vrf_allowlist`: r1 runs `bfdd --vrfs=default`, r2 plain bfdd; both configure a single-hop peer. RED without commit 1 (no single-hop socket ever opens, session never comes up); GREEN with it (socket opens, session up on both routers, exit without memstats and without cores — the memstats-quiet exit also requires commit 2).

#### Database changes

None.

#### External users

None observed: `bfd_perm_vrfs` is bfdd-internal.

#### Additional context

Discovered while validating per-VRF BFD isolation for an internal deployment. Original fix author credited in commit 1; happy to rework credits/trailers if maintainers prefer a different attribution form.