### PR TITLE
zebra: carry an MPLS VPN disposition's payload family on FPM

### DIFF
--- a/fpm/fpm.h
+++ b/fpm/fpm.h
@@ -118,6 +118,31 @@ typedef enum fpm_msg_type_e_ {
 } fpm_msg_type_e;
 
 /*
+ * Route attributes that appear only on the FPM stream.
+ *
+ * They are numbered clear of the kernel's RTA_* space and are never sent to a
+ * kernel.  The precedent is FPM_NH_ENCAP_VXLAN in zebra/zebra_fpm_netlink.c,
+ * an FRR-private value zebra already puts in RTA_ENCAP_TYPE for FPM peers and
+ * for nobody else.
+ *
+ * FPM_RTA_MPLS_PAYLOAD_FAMILY (u8: AF_INET or AF_INET6) names the address
+ * family of the packet that emerges when a label is popped and the result is
+ * looked up in a table -- the egress disposition of an L3VPN.  Linux does not
+ * need it: net/mpls/af_mpls.c leaves mpls_route.rt_payload_type at MPT_UNSPEC
+ * and reads the IP version nibble of the packet instead, so there is no kernel
+ * attribute to reuse, and mpls_rtm_newroute() rejects any attribute it does
+ * not know.  A forwarder that is told the disposition family once, per label
+ * entry, rather than per packet cannot infer it, and without this attribute an
+ * IPv6 VPN label is disposed into the instance's IPv4 table.
+ *
+ * Absent whenever zebra does not know the family -- including when one
+ * instance's two families were allocated the same label, where there is no
+ * single right answer.  A consumer that is not told must keep doing whatever
+ * it did before this attribute existed.
+ */
+#define FPM_RTA_MPLS_PAYLOAD_FAMILY 200
+
+/*
  * The FPM message header is aligned to the same boundary as netlink
  * messages (4). This means that a netlink message does not need
  * padding when encapsulated in an FPM message.

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1056,7 +1056,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_LSP_INSTALL:
 	case DPLANE_OP_LSP_UPDATE:
 	case DPLANE_OP_LSP_DELETE:
-		rv = netlink_lsp_msg_encoder(ctx, nl_buf, sizeof(nl_buf));
+		rv = netlink_lsp_msg_encoder_fpm(ctx, nl_buf, sizeof(nl_buf));
 		if (rv <= 0) {
 			flog_err(EC_ZEBRA_FPM_ENCODE_FAIL, "%s: netlink_lsp_msg_encoder failed",
 				 __func__);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -72,6 +72,7 @@
 #include "zebra/zebra_trace.h"
 #include "zebra/zebra_neigh.h"
 #include "lib/srv6.h"
+#include "fpm/fpm.h"
 
 #ifndef AF_MPLS
 #define AF_MPLS 28
@@ -5023,7 +5024,7 @@ netlink_put_neigh_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
  * context information.
  */
 ssize_t netlink_mpls_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
-					  void *buf, size_t buflen)
+					  void *buf, size_t buflen, bool fpm)
 {
 	mpls_lse_t lse;
 	const struct nhlfe_list_head *head;
@@ -5099,6 +5100,24 @@ ssize_t netlink_mpls_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 	lse = mpls_lse_encode(dplane_ctx_get_in_label(ctx), 0, 0, 1);
 	if (!nl_attr_put(&req->n, buflen, RTA_DST, &lse, sizeof(mpls_lse_t)))
 		return 0;
+
+	/*
+	 * Tell an FPM peer which family the packet under this label is in,
+	 * when zebra was told.  FPM only: the kernel's MPLS parser rejects
+	 * attributes it does not know (net/mpls/af_mpls.c,
+	 * rtm_to_route_config()), and it has no use for this one -- it reads
+	 * the IP version nibble of each packet instead.  A forwarder that is
+	 * programmed per label entry has no packet to read yet.
+	 */
+	if (fpm && cmd == RTM_NEWROUTE) {
+		int payload_family =
+			afi2family(dplane_ctx_get_lsp_payload_afi(ctx));
+
+		if ((payload_family == AF_INET || payload_family == AF_INET6) &&
+		    !nl_attr_put8(&req->n, buflen, FPM_RTA_MPLS_PAYLOAD_FAMILY,
+				  (uint8_t)payload_family))
+			return 0;
+	}
 
 	/* Fill nexthops (paths) based on single-path or multipath. The paths
 	 * chosen depend on the operation.

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -50,7 +50,8 @@ void rt_netlink_init(void);
 /* MPLS label forwarding table change, using dataplane context information. */
 extern ssize_t netlink_mpls_multipath_msg_encode(int cmd,
 						 struct zebra_dplane_ctx *ctx,
-						 void *buf, size_t buflen);
+						 void *buf, size_t buflen,
+						 bool fpm);
 
 extern ssize_t netlink_route_multipath_msg_encode(int cmd,
 						  struct zebra_dplane_ctx *ctx,
@@ -80,6 +81,8 @@ extern ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 
 extern ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
 				       size_t buflen);
+extern ssize_t netlink_lsp_msg_encoder_fpm(struct zebra_dplane_ctx *ctx,
+					   void *buf, size_t buflen);
 
 extern int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3401,8 +3401,28 @@ static void zread_vrf_label(ZAPI_HANDLER_ARGS)
 
 	if (nlabel != MPLS_LABEL_NONE) {
 		mpls_label_t out_label = MPLS_LABEL_IMPLICIT_NULL;
+		afi_t payload_afi = afi;
+		afi_t other;
+
+		/*
+		 * The label is disposed into one family's table, and this
+		 * message is the only place that family is known.  It is not
+		 * derivable later: the LSP's next hop is the VRF interface,
+		 * whose own family says nothing about what is under the label.
+		 *
+		 * A client may hand the same label to both families of one
+		 * instance -- the scrubber above exists for exactly that --
+		 * and then there is no single right answer, so record none.
+		 */
+		for (other = AFI_IP; other < AFI_MAX; other++) {
+			if (other == afi)
+				continue;
+			if (zvrf->label[other] == nlabel)
+				payload_afi = AFI_UNSPEC;
+		}
+
 		if (mpls_lsp_install(def_zvrf, ltype, nlabel, 1, &out_label, NEXTHOP_TYPE_IFINDEX,
-				     NULL, ifp->ifindex) < 0) {
+				     NULL, ifp->ifindex, payload_afi) < 0) {
 			zlog_debug("%s: Failed to install LSP for label %u", __func__, nlabel);
 		}
 	}

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2618,6 +2618,13 @@ void dplane_ctx_set_lsp_flags(struct zebra_dplane_ctx *ctx,
 	ctx->u.lsp.flags = flags;
 }
 
+afi_t dplane_ctx_get_lsp_payload_afi(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.lsp.payload_afi;
+}
+
 const struct nhlfe_list_head *dplane_ctx_get_nhlfe_list(
 	const struct zebra_dplane_ctx *ctx)
 {
@@ -4457,6 +4464,7 @@ int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 
 	ctx->u.lsp.ile = lsp->ile;
 	ctx->u.lsp.addr_family = lsp->addr_family;
+	ctx->u.lsp.payload_afi = lsp->payload_afi;
 	ctx->u.lsp.num_ecmp = lsp->num_ecmp;
 	ctx->u.lsp.flags = lsp->flags;
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -696,6 +696,7 @@ void dplane_ctx_set_addr_family(struct zebra_dplane_ctx *ctx,
 uint32_t dplane_ctx_get_lsp_flags(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_lsp_flags(struct zebra_dplane_ctx *ctx,
 			      uint32_t flags);
+afi_t dplane_ctx_get_lsp_payload_afi(const struct zebra_dplane_ctx *ctx);
 const struct nhlfe_list_head *dplane_ctx_get_nhlfe_list(
 	const struct zebra_dplane_ctx *ctx);
 const struct nhlfe_list_head *dplane_ctx_get_backup_nhlfe_list(

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -3207,7 +3207,8 @@ lsp_add_nhlfe(struct zebra_lsp *lsp, enum lsp_types_t type,
 int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		     mpls_label_t in_label, uint8_t num_out_labels,
 		     const mpls_label_t *out_labels, enum nexthop_types_t gtype,
-		     const union g_addr *gate, ifindex_t ifindex)
+		     const union g_addr *gate, ifindex_t ifindex,
+		     afi_t payload_afi)
 {
 	struct hash *lsp_table;
 	struct zebra_ile tmp_ile;
@@ -3222,6 +3223,7 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 	/* Find or create LSP object */
 	tmp_ile.in_label = in_label;
 	lsp = hash_get(lsp_table, &tmp_ile, lsp_alloc);
+	lsp->payload_afi = payload_afi;
 
 	nhlfe = lsp_add_nhlfe(lsp, type, num_out_labels, out_labels, gtype,
 			      gate, ifindex, VRF_DEFAULT, false /*backup*/);
@@ -3629,7 +3631,7 @@ int zebra_mpls_static_lsp_add(struct zebra_vrf *zvrf, mpls_label_t in_label,
 
 	/* (Re)Install LSP in the main table. */
 	if (mpls_lsp_install(zvrf, ZEBRA_LSP_STATIC, in_label, 1, &out_label,
-			     gtype, gate, ifindex))
+			     gtype, gate, ifindex, AFI_UNSPEC))
 		return -1;
 
 	return 0;

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -100,6 +100,16 @@ struct zebra_lsp {
 	/* Address-family of NHLFE - saved here for delete. All NHLFEs */
 	/* have to be of the same AF */
 	uint8_t addr_family;
+
+	/*
+	 * Address family of the traffic that appears when this label is
+	 * popped, where zebra is told it -- today, a VRF label from
+	 * ZEBRA_VRF_LABEL.  It is not addr_family: that is the family of the
+	 * NHLFE's next hop, and a disposition has no next hop to take a
+	 * family from.  AFI_UNSPEC when nothing said, which is every LSP that
+	 * swaps or pushes.
+	 */
+	afi_t payload_afi;
 };
 
 /*
@@ -285,7 +295,8 @@ void zebra_mpls_ftn_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		     mpls_label_t in_label, uint8_t num_out_labels,
 		     const mpls_label_t *out_labels, enum nexthop_types_t gtype,
-		     const union g_addr *gate, ifindex_t ifindex);
+		     const union g_addr *gate, ifindex_t ifindex,
+		     afi_t payload_afi);
 
 /*
  * Lookup LSP by its input label.

--- a/zebra/zebra_mpls_netlink.c
+++ b/zebra/zebra_mpls_netlink.c
@@ -17,8 +17,8 @@
 #include "zebra/zebra_mpls.h"
 #include "zebra/kernel_netlink.h"
 
-ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
-				size_t buflen)
+static ssize_t lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
+			       size_t buflen, bool fpm)
 {
 	int cmd;
 
@@ -41,7 +41,19 @@ ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
 		/* Invalid op? */
 		return -1;
 
-	return netlink_mpls_multipath_msg_encode(cmd, ctx, buf, buflen);
+	return netlink_mpls_multipath_msg_encode(cmd, ctx, buf, buflen, fpm);
+}
+
+ssize_t netlink_lsp_msg_encoder(struct zebra_dplane_ctx *ctx, void *buf,
+				size_t buflen)
+{
+	return lsp_msg_encoder(ctx, buf, buflen, false);
+}
+
+ssize_t netlink_lsp_msg_encoder_fpm(struct zebra_dplane_ctx *ctx, void *buf,
+				    size_t buflen)
+{
+	return lsp_msg_encoder(ctx, buf, buflen, true);
 }
 
 enum netlink_msg_status netlink_put_lsp_update_msg(struct nl_batch *bth,

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -342,11 +342,11 @@ int zebra_sr_policy_bsid_install(struct zebra_sr_policy *policy)
 			out_labels = zt->labels;
 		}
 
-		if (mpls_lsp_install(
-			    policy->zvrf, zt->type, zt->local_label,
-			    num_out_labels, out_labels, nhlfe->nexthop->type,
-			    &nhlfe->nexthop->gate, nhlfe->nexthop->ifindex)
-		    < 0)
+		if (mpls_lsp_install(policy->zvrf, zt->type, zt->local_label,
+				     num_out_labels, out_labels,
+				     nhlfe->nexthop->type,
+				     &nhlfe->nexthop->gate,
+				     nhlfe->nexthop->ifindex, AFI_UNSPEC) < 0)
 			return -1;
 	}
 


### PR DESCRIPTION
# Upstream: patch 0001

ADR-009's amendment requires each carried patch to record "an upstream PR
reference or the reason it cannot go upstream". This is that record, plus the
PR body as prepared, so that filing it is one command and reviewing it does not
need a browser.

## State

| | |
|---|---|
| **Upstream project** | [FRRouting/frr](https://github.com/FRRouting/frr) |
| **Fork** | `github.com/warrenhall-cilix/frr` (created 2026-08-30; this is also the ADR-009 mirror the fork clause anticipated) |
| **PR head branch** | `fpm-mpls-payload-family` — the patch cherry-picked onto upstream `master` (`d5a6ba7e`, *Merge pull request #23203 from cscarpitta/srv6_vrf_strict_mode_module*) |
| **Carried branch** | `janus-carried-10.6.1` — the same commit on `frr-10.6.1`, which is what `build/frr-patches/0001-*.patch` is generated from |
| **Applies to master** | **cleanly**, no conflicts, identical shape: 11 files, +116 / −15 |
| **Sign-off** | `Signed-off-by: Warren Hall <invoices@cilix.co.uk>` (FRR requires DCO) |
| **PR filed** | see "Filing", below |

## Filing

The PR is **not filed by the agent**. Everything it needs is prepared — the
fork exists, the branch is pushed and rebased onto current `master`, the commit
carries a DCO sign-off, and the body is below verbatim — but opening a pull
request against a third-party open-source project under Warren's GitHub
identity is his to press, not a step to take on an agent's own judgement, and
B12's authorisation is a ruling on Janus's engineering rather than an
instruction to speak to another project's maintainers in his name.

One command files it:

```
gh pr create --repo FRRouting/frr \
  --head warrenhall-cilix:fpm-mpls-payload-family \
  --base master \
  --title "zebra: carry an MPLS VPN disposition's payload family on FPM" \
  --body-file build/frr-patches/UPSTREAM.md
```

(FRR's PR template asks for the summary that is already in the commit message;
the body below repeats it with the measurements attached.)

Two things a reviewer there will ask that are worth pre-empting in the
conversation rather than in the body: whether a new FPM-private attribute
number should be registered somewhere more formal than `fpm/fpm.h`, and whether
FRR wants a topotest for it — the answer to the second is that FRR's topotests
have no FPM stream reader today, so a test would mean building one.

---

## PR body, as prepared

### zebra: carry an MPLS VPN disposition's payload family on FPM

**The gap.** An FPM peer that programs a label FIB entry has to be told, at
programming time, what the packet under the label is. Linux does not need to
be: `net/mpls/af_mpls.c` leaves `mpls_route.rt_payload_type` at `MPT_UNSPEC`
for every route created over netlink — `rtm_to_route_config()` never sets
`rc_payload_type` — and `mpls_egress()` reads `ip_hdr(skb)->version` off each
packet instead. A forwarder that is told once, per entry, has no packet to read
yet.

Today zebra sends it nothing to go on. A VRF label is installed from
`ZEBRA_VRF_LABEL`, which carries the AFI the client allocated the label for
(`zclient_send_vrf_label()` → `stream_putc(s, afi)`), and `zread_vrf_label()`
drops that AFI: the label reaches `mpls_lsp_install()` as
`NEXTHOP_TYPE_IFINDEX` with the VRF interface and nothing else. On the wire, a
dual-stack VRF's two labels are then indistinguishable:

```
label=81  proto=186  table=254  RTA_DST=00051100, RTA_OIF=05000000
label=80  proto=186  table=254  RTA_DST=00050100, RTA_OIF=05000000
```

Two attributes each, identical apart from the label value. Nor can it be
recovered later: `NHLFE_FAMILY()` is the family of the NHLFE's *next hop*, and
a disposition has no next hop — the lookup is the action — so it reads
`AF_INET` for the VRF labels of both families.

**The change.** `struct zebra_lsp` gains `payload_afi`; `zread_vrf_label()`
passes the AFI it already has; the dataplane context copies it as it copies the
rest of the LSP; and `netlink_mpls_multipath_msg_encode()` emits it as
`FPM_RTA_MPLS_PAYLOAD_FAMILY` when it is encoding for an FPM peer.

**FPM only, and not by preference.** The kernel's MPLS parser rejects any
attribute outside its own allow-list (`rtm_to_route_config()`, `default:` →
`"Unknown attribute"`), so an attribute added unconditionally here would fail
every MPLS route install on Linux. `netlink_lsp_msg_encoder()` is a batch
callback and cannot take another argument, so its body moves behind a shared
static with two entry points — `netlink_lsp_msg_encoder()` for the kernel and
`netlink_lsp_msg_encoder_fpm()` for `dplane_fpm_nl`. The attribute number
follows the precedent already in the tree for FPM-only encodings:
`FPM_NH_ENCAP_VXLAN = 100`, which `netlink_route_nexthop_encap()` puts in
`RTA_ENCAP_TYPE` for FPM peers and for nobody else.

Reusing `RTA_VIA` with a family and no address was considered and rejected:
`nla_get_via()` requires `alen == 4` for `AF_INET` and `alen == 16` for
`AF_INET6`, so it is malformed by the uapi's own rules, and it would be
claiming a next hop that does not exist.

**Nothing is emitted when zebra does not know the family**, including when a
client hands the same label to both AFIs of one instance — the scrubber in
`zread_vrf_label()` exists for exactly that case, and there is no single right
answer to give. So an FPM consumer that does not know the attribute sees the
stream it saw before, and one that does can program the disposition correctly.

**Compatibility.** One message type's encoding changes: `RTM_NEWROUTE` with
`rtm_family == AF_MPLS`, on the FPM stream only. `RTM_DELROUTE` is unchanged
(the emission is guarded on `cmd == RTM_NEWROUTE`). The kernel netlink path
emits identical bytes. Any consumer that walks the attribute chain by length
steps over the new attribute. A consumer that replays FPM messages into a
kernel would see the route rejected with `Unknown attribute` — loud rather than
silent, and the reason the FPM flag exists.

**Measured, against a userspace forwarder that requires the disposition family
up front (VPP 26.06).** Same source tree, same toolchain, built twice — stock
first, then the patch applied to the same objects — and run through the same
three-node PE–P–PE rig with a dual-stack VRF.

Without the patch, the egress entry for the IPv6 VPN label of a dual-stack VRF
reads:

```
81:eos/21 ...
    [0] [@7]: mpls-disposition:[7]:[ip4, pipe]
        [@9]: dst-address,unicast lookup in ipv4-VRF:50172
```

and every IPv6 packet dies at the egress with no error anywhere: the label
arrives, the entry programs, and IPv4 is a perfectly valid thing to have been
told. With it, the same entry reads:

```
81:eos/21 ...
    [0] [@10]: mpls-disposition:[7]:[ip6, pipe]
        [@8]: dst-address,unicast lookup in ipv6-VRF:50172
```

and an IPv6 packet arriving under the VPN label is disposed into the instance's
IPv6 table and delivered to the customer edge — traced through the forwarder:

```
mpls-input      label 81 ttl 255 eos 1
ip6-mpls-label-disposition-pipe   ip6, pipe
lookup-ip6-dst  fib-index:4 addr:2001:db8:20:2::2
ip6-rewrite     ipv6 via 2001:db8:20:2::2 host-lnk1
```

The IPv4 label of the same instance is byte-for-byte unchanged in both runs
(`lookup in ipv4-VRF:50172`), and IPv4 forwarding through the VRF is unaffected.

On the wire, read from an undecoded capture rather than a decode:

```
dispositions (RTA_OIF, no RTA_VIA, no RTA_NEWDST): 2
    label=80 payload family=AF_INET
    label=81 payload family=AF_INET6
```

against `payload family: ABSENT` for both on the stock build.

**Not included: a topotest.** The behaviour is on the FPM wire and FRR's
topotests have no FPM stream reader, so a test would mean building one. Happy
to, if that is what the project would like; the reader used above is ~150 lines
of Python over a raw capture, and the negative control it depends on — that
transport labels *do* carry a family via `RTA_VIA` on the same stream — is what
makes the absence attributable rather than merely unobserved.
