### PR TITLE
zebra: Add `zebra test dplane disable results` config

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -631,6 +631,10 @@ extern void rib_add_finished_startup(void);
 extern void zebra_vty_init(void);
 extern uint32_t zebra_rib_dplane_results_count(void);
 extern uint32_t zebra_rib_dplane_results_max(void);
+#ifdef DEV_BUILD
+extern void zebra_rib_dplane_results_plug(void);
+extern void zebra_rib_dplane_results_unplug(void);
+#endif
 
 extern pid_t zebra_pid;
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -68,6 +68,9 @@ static pthread_mutex_t dplane_mutex;
 static struct event *t_dplane;
 static struct dplane_ctx_list_head rib_dplane_q;
 static _Atomic uint32_t rib_dplane_q_max;
+#ifdef DEV_BUILD
+static _Atomic bool dplane_results_plugged;
+#endif
 
 DEFINE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 	    (rn, reason));
@@ -5156,6 +5159,32 @@ static void rib_process_sys_route(struct zebra_dplane_ctx *ctx)
 	}
 }
 
+static void rib_process_dplane_results(struct event *event);
+
+static void dplane_results_event_add(void)
+{
+#ifdef DEV_BUILD
+	if (atomic_load_explicit(&dplane_results_plugged, memory_order_relaxed))
+		return;
+#endif
+
+	event_add_event(zrouter.master, rib_process_dplane_results, NULL, 0, &t_dplane);
+}
+
+#ifdef DEV_BUILD
+void zebra_rib_dplane_results_plug(void)
+{
+	atomic_store_explicit(&dplane_results_plugged, true, memory_order_relaxed);
+	event_cancel(&t_dplane);
+}
+
+void zebra_rib_dplane_results_unplug(void)
+{
+	atomic_store_explicit(&dplane_results_plugged, false, memory_order_relaxed);
+	dplane_results_event_add();
+}
+#endif
+
 /*
  * Handle results from the dataplane system. Dequeue update context
  * structs, dispatch to appropriate internal handlers.
@@ -5368,8 +5397,7 @@ static void rib_process_dplane_results(struct event *event)
 #endif
 
 	if (work_left_to_do)
-		event_add_event(zrouter.master, rib_process_dplane_results, NULL, 0,
-				&t_dplane);
+		dplane_results_event_add();
 }
 
 /*
@@ -5392,8 +5420,7 @@ static int rib_dplane_results(struct dplane_ctx_list_head *ctxlist)
 	}
 
 	/* Ensure event is signalled to zebra main pthread */
-	event_add_event(zrouter.master, rib_process_dplane_results, NULL, 0,
-			&t_dplane);
+	dplane_results_event_add();
 
 	return 0;
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4119,6 +4119,26 @@ DEFPY_HIDDEN(zebra_test_metaq_plug,
 	return CMD_SUCCESS;
 }
 
+#ifdef DEV_BUILD
+DEFPY_HIDDEN(zebra_test_dplane_results_plug,
+	     zebra_test_dplane_results_plug_cmd,
+	     "[no] zebra test dplane disable results",
+	     NO_STR
+	     ZEBRA_STR
+	     "Test command\n"
+	     "Dataplane\n"
+	     "Plug dplane processing (prevent processing)\n"
+	     "Plug the dplane results queue (prevent processing)\n")
+{
+	if (no)
+		zebra_rib_dplane_results_unplug();
+	else
+		zebra_rib_dplane_results_plug();
+
+	return CMD_SUCCESS;
+}
+#endif
+
 /* Display Zebra MetaQ counters */
 DEFUN (show_zebra_metaq_counters,
        show_zebra_metaq_counters_cmd,
@@ -4391,6 +4411,9 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_dataplane_providers_cmd);
 	install_element(VIEW_NODE, &show_zebra_metaq_counters_cmd);
 	install_element(VIEW_NODE, &zebra_test_metaq_plug_cmd);
+#ifdef DEV_BUILD
+	install_element(VIEW_NODE, &zebra_test_dplane_results_plug_cmd);
+#endif
 
 #ifdef HAVE_NETLINK
 	install_element(CONFIG_NODE, &zebra_kernel_netlink_batch_tx_buf_cmd);


### PR DESCRIPTION
Add under a DEV BUILD the test command `zebra test dplane disable results` command.  This command plugs the event handler for results coming up from the dplane. This should allow for testing of ordering of events from the metaQ + dplane results as well.