### PR TITLE
lib: northbound: copy-on-write dnode sharing for candidate  config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2726,6 +2726,20 @@ size_t ac_x; ac_x = malloc_size(NULL);
   ])
 ])
 
+AC_MSG_CHECKING([whether malloc_trim is available])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+]], [[
+malloc_trim(0);
+]])], [
+  AC_MSG_RESULT([yes])
+  AC_DEFINE([HAVE_MALLOC_TRIM], [1], [malloc_trim])
+], [
+  AC_MSG_RESULT([no])
+])
+
 dnl ----------
 dnl configure date
 dnl ----------

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -6,6 +6,10 @@
 
 #include <zebra.h>
 
+#ifdef HAVE_MALLOC_TRIM
+#include <malloc.h>
+#endif
+
 #include "darr.h"
 #include "host_nb.h"
 #include "libfrr.h"
@@ -352,13 +356,15 @@ struct nb_config *nb_config_new(struct lyd_node *dnode)
 	else
 		config->dnode = yang_dnode_new(ly_native_ctx, true);
 	config->version = 0;
+	config->dnode_shared = false;
 
 	return config;
 }
 
 void nb_config_free(struct nb_config *config)
 {
-	if (config->dnode)
+	/* Don't free shared dnode - it's owned by running_config */
+	if (config->dnode && !config->dnode_shared)
 		yang_dnode_free(config->dnode);
 
 	XFREE(MTYPE_NB_CONFIG, config);
@@ -371,6 +377,7 @@ struct nb_config *nb_config_dup(const struct nb_config *config)
 	dup = XCALLOC(MTYPE_NB_CONFIG, sizeof(*dup));
 	dup->dnode = yang_dnode_dup(config->dnode);
 	dup->version = config->version;
+	dup->dnode_shared = false;
 
 	return dup;
 }
@@ -397,9 +404,12 @@ void nb_config_replace(struct nb_config *config_dst,
 	if (config_src->version != 0)
 		config_dst->version = config_src->version;
 
-	/* Update dnode. */
-	if (config_dst->dnode)
+	/* Update dnode - don't free if shared (owned by running_config) */
+	if (config_dst->dnode && !config_dst->dnode_shared)
 		yang_dnode_free(config_dst->dnode);
+
+	config_dst->dnode_shared = false;
+
 	if (preserve_source) {
 		config_dst->dnode = yang_dnode_dup(config_src->dnode);
 	} else {
@@ -407,6 +417,28 @@ void nb_config_replace(struct nb_config *config_dst,
 		config_src->dnode = NULL;
 		nb_config_free(config_src);
 	}
+}
+
+void nb_config_share_running(struct nb_config *candidate)
+{
+	/* Already sharing or no candidate - nothing to do */
+	if (!candidate || candidate->dnode_shared)
+		return;
+
+	/* Free existing candidate dnode */
+	if (candidate->dnode)
+		yang_dnode_free(candidate->dnode);
+
+	/* Share running_config's dnode */
+	candidate->dnode = running_config->dnode;
+	candidate->dnode_shared = true;
+	candidate->version = running_config->version;
+	candidate->cow_share_count++;
+
+	/* Release freed memory to OS */
+#ifdef HAVE_MALLOC_TRIM
+	malloc_trim(0);
+#endif
 }
 
 /* Generate the nb_config_cbs tree. */
@@ -757,6 +789,25 @@ static LY_ERR dnode_create(struct nb_config *candidate, const char *xpath, const
 	return LY_SUCCESS;
 }
 
+/*
+ * Copy-on-write: duplicate shared dnode before modification.
+ *
+ * If running_config was replaced (e.g., by rollback) since we started
+ * sharing, our dnode pointer is stale. Detect this via version mismatch
+ * and re-share from current running_config before duplicating.
+ */
+static void nb_candidate_cow_trigger(struct nb_config *candidate)
+{
+	if (!candidate->dnode_shared)
+		return;
+
+	if (candidate->version != running_config->version)
+		candidate->dnode = running_config->dnode;
+	candidate->dnode = yang_dnode_dup(candidate->dnode);
+	candidate->dnode_shared = false;
+	candidate->cow_trigger_count++;
+}
+
 int nb_candidate_edit(struct nb_config *candidate, const struct nb_node *nb_node,
 		      enum nb_operation operation, const char *xpath, const char *value)
 {
@@ -765,6 +816,8 @@ int nb_candidate_edit(struct nb_config *candidate, const struct nb_node *nb_node
 	struct lyd_node *parent = NULL;
 	uint32_t options = 0;
 	LY_ERR err;
+
+	nb_candidate_cow_trigger(candidate);
 
 	switch (operation) {
 	case NB_OP_CREATE:
@@ -1093,6 +1146,8 @@ int nb_candidate_edit_tree(struct nb_config *candidate,
 			   char *xpath_created, char *errmsg, size_t errmsg_len)
 {
 	int ret = NB_ERR;
+
+	nb_candidate_cow_trigger(candidate);
 
 	switch (operation) {
 	case NB_OP_CREATE_EXCL:

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -810,6 +810,28 @@ struct nb_transaction {
 struct nb_config {
 	struct lyd_node *dnode;
 	uint32_t version;
+
+	/*
+	 * Copy-on-write sharing with running_config.
+	 *
+	 * After a commit, candidate->dnode is identical in content to
+	 * running_config->dnode. Setting dnode_shared=true lets candidate
+	 * borrow running_config->dnode directly (no copy), halving the
+	 * steady-state libyang memory between config sessions.
+	 *
+	 * Before any modification to candidate->dnode, nb_candidate_edit()
+	 * detects dnode_shared=true and makes a fresh independent copy
+	 * (copy-on-write trigger).
+	 *
+	 * IMPORTANT: when dnode_shared=true, candidate->dnode must NOT be
+	 * freed - it is owned by running_config. nb_config_free() and
+	 * nb_config_replace() both guard against this.
+	 */
+	bool dnode_shared;
+
+	/* Debug/test counters for copy-on-write */
+	uint64_t cow_share_count;   /* times nb_config_share_running() called */
+	uint64_t cow_trigger_count; /* times COW triggered on candidate edit */
 };
 
 /*
@@ -1015,6 +1037,21 @@ extern int nb_config_merge(struct nb_config *config_dst,
 extern void nb_config_replace(struct nb_config *config_dst,
 			      struct nb_config *config_src,
 			      bool preserve_source);
+
+/*
+ * Share running_config's dnode with candidate (copy-on-write).
+ *
+ * After a successful commit, candidate and running have identical content.
+ * Instead of maintaining a separate O(N) copy, this function lets candidate
+ * borrow running_config's dnode directly, halving steady-state memory.
+ *
+ * The next nb_candidate_edit() will trigger copy-on-write, making a fresh
+ * independent copy before any modification.
+ *
+ * candidate
+ *    The candidate configuration to share with running.
+ */
+extern void nb_config_share_running(struct nb_config *candidate);
 
 /*
  * Return a human-readable string representing a northbound operation.

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -63,6 +63,12 @@ static int nb_cli_classic_commit(struct vty *vty)
 		/* Successful commit. Print warnings (if any). */
 		if (strlen(errmsg) > 0)
 			vty_out(vty, "%s\n", errmsg);
+		/*
+		 * Share running_config's dnode with candidate (copy-on-write).
+		 * This halves steady-state memory since candidate and running
+		 * now have identical content.
+		 */
+		nb_config_share_running(vty->candidate_config);
 		break;
 	case NB_ERR_NO_CHANGES:
 		break;
@@ -452,6 +458,10 @@ static int nb_cli_commit(struct vty *vty, bool force,
 	case NB_OK:
 		nb_config_replace(vty->candidate_config_base, running_config,
 				  true);
+		/*
+		 * Share running_config's dnode with candidate (copy-on-write).
+		 */
+		nb_config_share_running(vty->candidate_config);
 		vty_out(vty,
 			"%% Configuration committed successfully (Transaction ID #%u).\n\n",
 			transaction_id);
@@ -1815,6 +1825,34 @@ DEFPY (rollback_config,
 #endif /* HAVE_CONFIG_ROLLBACKS */
 }
 
+/* Show northbound state. */
+DEFPY (show_nb_state,
+       show_nb_state_cmd,
+       "show northbound",
+       SHOW_STR
+       "Northbound state information\n")
+{
+	struct nb_config *candidate = vty->candidate_config;
+
+	if (!candidate)
+		candidate = vty_mgmt_candidate_config ? vty_mgmt_candidate_config
+						      : vty_shared_candidate_config;
+
+	vty_out(vty, "Northbound state:\n");
+	vty_out(vty, "  Candidate config:\n");
+	if (candidate) {
+		vty_out(vty, "    dnode_shared: %s\n", candidate->dnode_shared ? "yes" : "no");
+		vty_out(vty, "    version: %u\n", candidate->version);
+		vty_out(vty, "    cow_share_count: %" PRIu64 "\n", candidate->cow_share_count);
+		vty_out(vty, "    cow_trigger_count: %" PRIu64 "\n", candidate->cow_trigger_count);
+	} else {
+		vty_out(vty, "    (not available)\n");
+	}
+	vty_out(vty, "  Running config:\n");
+	vty_out(vty, "    version: %u\n", running_config->version);
+	return CMD_SUCCESS;
+}
+
 /* Debug CLI commands. */
 DEFPY (debug_nb,
        debug_nb_cmd,
@@ -1956,6 +1994,8 @@ void nb_cli_init(struct event_loop *tm)
 
 	/* Other commands. */
 	install_element(ENABLE_NODE, &show_config_running_cmd);
+	install_element(ENABLE_NODE, &show_nb_state_cmd);
+	install_element(CONFIG_NODE, &show_nb_state_cmd);
 	install_element(CONFIG_NODE, &yang_module_translator_load_cmd);
 	install_element(CONFIG_NODE, &yang_module_translator_unload_cmd);
 	install_element(ENABLE_NODE, &show_yang_operational_data_cmd);

--- a/mgmtd/mgmt_txn_cfg.c
+++ b/mgmtd/mgmt_txn_cfg.c
@@ -537,9 +537,20 @@ static void txn_finish_commit(struct txn_req_commit *ccreq, enum mgmt_result res
 					    !ccreq->unlock_info);
 
 		mgmt_ds_copy_dss(ccreq->dst_ds_ctx, ccreq->src_ds_ctx, create_cmt_info_rec);
+		/*
+		 * Share running_config's dnode with candidate (copy-on-write).
+		 * After commit, candidate and running have identical content.
+		 */
+		nb_config_share_running(mgmt_ds_get_nb_config(ccreq->src_ds_ctx));
 	}
-	if (discard_changes)
+	if (discard_changes) {
 		mgmt_ds_copy_dss(ccreq->src_ds_ctx, ccreq->dst_ds_ctx, false);
+		/*
+		 * Share running_config's dnode with candidate (copy-on-write).
+		 * After discard, candidate is reset to match running.
+		 */
+		nb_config_share_running(mgmt_ds_get_nb_config(ccreq->src_ds_ctx));
+	}
 
 	/*
 	 * Release transaction datastore locks before sending replies to

--- a/tests/topotests/nb_copy_on_write/r1/frr.conf
+++ b/tests/topotests/nb_copy_on_write/r1/frr.conf
@@ -1,0 +1,9 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+!

--- a/tests/topotests/nb_copy_on_write/test_nb_copy_on_write.py
+++ b/tests/topotests/nb_copy_on_write/test_nb_copy_on_write.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test for the northbound copy-on-write dnode sharing optimization.
+
+This test verifies that:
+1. After a commit, candidate's dnode is shared with running_config
+   (dnode_shared = yes)
+2. After an edit, candidate's dnode is independent (dnode_shared = no)
+   due to copy-on-write trigger
+3. After another commit, sharing is restored (dnode_shared = yes)
+
+The test covers both code paths:
+- bgpd: uses classic CLI mode, exercises nb_cli_classic_commit()
+- mgmtd: uses static routes, exercises txn_finish_commit()
+"""
+
+import os
+import re
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd, pytest.mark.mgmtd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _get_nb_state(router, daemon):
+    """Get northbound state from 'show northbound' for a specific daemon."""
+    output = router.vtysh_cmd(f"show northbound {daemon}")
+    topotest.logger.info(f"show northbound output ({daemon}):\n{output}")
+
+    state = {}
+    match = re.search(r"dnode_shared:\s*(yes|no)", output)
+    state["shared"] = match.group(1) == "yes" if match else None
+
+    match = re.search(r"cow_share_count:\s*(\d+)", output)
+    state["share_count"] = int(match.group(1)) if match else 0
+
+    match = re.search(r"cow_trigger_count:\s*(\d+)", output)
+    state["trigger_count"] = int(match.group(1)) if match else 0
+
+    return state
+
+
+def test_copy_on_write():
+    """
+    Verify copy-on-write behavior for bgpd using config file loading.
+
+    bgpd uses FRR_CLI_CLASSIC mode. DEFUN_YANG commands (like route-map,
+    prefix-list, interface) go through northbound. DEFUN commands (like
+    neighbor) bypass northbound.
+
+    This test uses route-map commands (DEFUN_YANG) via vtysh -f to verify:
+    1. After initial config load, dnode is shared (dnode_shared = yes)
+    2. After loading more config via vtysh -f, trigger_count increases
+    3. After commit, dnode is shared again
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    # After initial config load, dnode should be shared
+    state1 = _get_nb_state(router, "bgpd")
+    topotest.logger.info(f"bgpd state after startup: {state1}")
+    assert state1["shared"] is True, "dnode_shared should be 'yes' after config load"
+    assert state1["share_count"] >= 1, "share_count should be at least 1"
+
+    # Load more config via vtysh -f (pretty_output=False triggers batch mode)
+    # Use route-map command (DEFUN_YANG) which goes through northbound
+    # This should trigger COW since dnode is currently shared
+    router.vtysh_multicmd(
+        """
+        configure terminal
+        route-map TEST permit 10
+         set local-preference 200
+        end
+        """,
+        pretty_output=False,
+    )
+
+    # After config load, dnode should be shared again, and trigger_count increased
+    state2 = _get_nb_state(router, "bgpd")
+    topotest.logger.info(f"bgpd state after vtysh -f: {state2}")
+    assert state2["shared"] is True, "dnode_shared should be 'yes' after commit"
+    assert state2["share_count"] > state1["share_count"], "share_count should increase"
+    assert state2["trigger_count"] > state1["trigger_count"], "trigger_count should increase after editing shared dnode"
+
+    # Verify config was applied
+    output = router.vtysh_cmd("show running-config")
+    assert "route-map TEST" in output, "Route-map not configured"
+
+    topotest.logger.info("Copy-on-write test passed for bgpd")
+
+
+def test_copy_on_write_mgmtd():
+    """
+    Verify copy-on-write behavior for mgmtd using static routes.
+    Static routes use mgmtd backend, so this exercises the COW
+    optimization in mgmtd's txn_finish_commit().
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    # Get initial state
+    state0 = _get_nb_state(router, "mgmtd")
+
+    # Step 1: Add a static route (uses mgmtd backend)
+    router.vtysh_cmd(
+        """
+        configure terminal
+        ip route 192.168.100.0/24 10.0.0.254
+        end
+        """
+    )
+
+    # After commit, dnode should be shared in mgmtd
+    state1 = _get_nb_state(router, "mgmtd")
+    topotest.logger.info(f"mgmtd after commit: {state1}")
+    assert state1["shared"] is True, "mgmtd dnode_shared should be 'yes' after commit"
+    assert state1["share_count"] >= 1, "share_count should be at least 1"
+
+    # Step 2: Add another static route
+    router.vtysh_cmd(
+        """
+        configure terminal
+        ip route 192.168.101.0/24 10.0.0.254
+        end
+        """
+    )
+
+    # After second commit, dnode should still be shared
+    state2 = _get_nb_state(router, "mgmtd")
+    topotest.logger.info(f"mgmtd after second commit: {state2}")
+    assert state2["shared"] is True, "mgmtd dnode_shared should be 'yes' after second commit"
+    assert state2["share_count"] > state1["share_count"], "share_count should increase after second commit"
+    assert state2["trigger_count"] > state1["trigger_count"], "trigger_count should increase after editing shared dnode"
+
+    # Verify routes were configured (check running-config, not RIB)
+    output = router.vtysh_cmd("show running-config")
+    assert "ip route 192.168.100.0/24" in output, "First static route not configured"
+    assert "ip route 192.168.101.0/24" in output, "Second static route not configured"
+
+    topotest.logger.info("Copy-on-write test passed for mgmtd")
+
+
+if __name__ == "__main__":
+    args = ["-s", "-v", __file__]
+    sys.exit(pytest.main(args))

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3548,6 +3548,19 @@ DEFUN (vtysh_show_memory,
 	return CMD_SUCCESS;
 }
 
+DEFUN (vtysh_show_northbound,
+       vtysh_show_northbound_cmd,
+       "show northbound [" DAEMONS_LIST "]",
+       SHOW_STR
+       "Northbound state information\n"
+       DAEMONS_STR)
+{
+	if (argc == 3)
+		return show_one_daemon(vty, argv, argc - 1, argv[argc - 1]->text);
+
+	return show_per_daemon(vty, argv, argc, "Northbound state for %s:\n");
+}
+
 /*
  * Support clis when using the tcmalloc lib
  */
@@ -5962,6 +5975,7 @@ void vtysh_init_vty(void)
 
 	/* northbound */
 	install_element(ENABLE_NODE, &show_config_running_cmd);
+	install_element(ENABLE_NODE, &vtysh_show_northbound_cmd);
 	install_element(ENABLE_NODE, &show_yang_operational_data_cmd);
 	install_element(ENABLE_NODE, &show_yang_module_cmd);
 	install_element(ENABLE_NODE, &show_yang_module_detail_cmd);


### PR DESCRIPTION
Problem: The candidate config maintains a full copy of the dnode tree
even when it's identical to running_config. This doubles memory usage
for the configuration data structure in steady state.

Solution: Implement copy-on-write optimization. After a commit,
candidate shares running_config's dnode (dnode_shared=true). On first
edit, a deep copy is made (copy-on-write trigger).

Changes:
- Add dnode_shared flag to struct nb_config
- Add nb_config_share_running() to enable sharing after commit
- Trigger copy-on-write in nb_candidate_edit() and nb_candidate_edit_tree()
- Handle shared dnode properly in nb_config_free() and nb_config_replace()
- Detect stale shared dnode via version mismatch (e.g., after rollback)
- Add 'show northbound' command to display dnode_shared state
- Add cow_share_count and cow_trigger_count counters for debug/test
- Apply optimization in both classic CLI mode and mgmtd
- Call malloc_trim(0) to release freed memory back to OS