### PR TITLE
zebra: yield to the event loop in rib_process_dplane_results

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5389,6 +5389,14 @@ static void rib_process_dplane_results(struct event *event)
 			ctx = dplane_ctx_dequeue(&ctxlist);
 		}
 
+		/*
+		 * If the dplane still has results queued, yield back to the
+		 * event loop instead of draining everything in this one call.
+		 * Re-arm rib_process_dplane_results below to serve other events.
+		 */
+		if (work_left_to_do)
+			break;
+
 	} while (1);
 
 #ifdef HAVE_SCRIPTING


### PR DESCRIPTION
**Below is the issue scenario and fix:**
100 vrfs, each vrf having 10 SVIs, ~30k routes
With above scale, when all the interfaces are flapped at a time, the watchfrr echo is timedout. This is causing SIGABRT on all the daemons

The loop just spins back for the next batch of 100 until the Q is fully drained, essentially run to completion of all 1000 entries. This creates starvation when there are 100s of interface events received at a time. so, rib_process_dplane_results is synchronously prcessing for more than a minute and leads to watchfrr echo timeout sometimes which lead to SIGABRT of all daemons.
```
  take 100 (900 left) -> process 100
  take 100 (800 left) -> process 100
  take 100 (700 left) -> process 100
  looping...
  take 100 (0 left) -> process 100
  take 0 -> ctx == NULL -> break
```
breaks only when the Q is empty — and at that point work_left_to_do is 0,
so the existing re-arm code can never fire, no matter how many events arrived.

So the batching is already there, but it only limits how many contexts are taken per iteration. it does not bound the work done per callback, since the loop simply spins back for the next batch. The re-arm below therefore never fires.

The idea is to actually re-arm rib_process_dplane_results so that the callback returns and the event loop reaches poll(), letting pending I/O be processed (the watchfrr echo)

**with this fix:**
```
  enter -> take 100 (900 left) -> process 100 -> work left -> break -> re-arm event_add_event(); return
  event loop runs poll()  <-- watchfrr echo read + answered
  enter -> take 100 (800 left) -> process 100 -> work left -> break -> re-arm event_add_event(); return
  poll() again
  ...
  enter -> take 100 (  0 left) -> process 100 -> no work left -> loop
  take   0 -> ctx == NULL -> break, no re-arm
```

So, this achieves 10 callbacks, poll()/other-events between each