### PR TITLE
ci: Run all topotests during retries

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -287,7 +287,7 @@ jobs:
 
           echo RUN_TESTS: $run_tests
           if docker run --init -i --privileged --name frr-${{ matrix.cfg.platform }}-cont ${ADD_DOCKER_ENV} -v /lib/modules:/lib/modules frr-${{ matrix.cfg.platform }} \
-            bash -c 'cd ~/frr/tests/topotests ; sudo -E pytest -n$(($(nproc) * 5 / 2)) --dist=loadfile '$run_tests; then
+            bash -c 'cd ~/frr/tests/topotests ; sudo -E pytest -n$(($(nproc) * 5 / 2)) --dist=loadfile "$@"' _ $run_tests; then
             echo "All tests passed."
             exit 0
           fi
@@ -324,7 +324,7 @@ jobs:
 
           mv test-results-${{ matrix.cfg.platform }} test-results-${{ matrix.cfg.platform }}-initial
           if docker run --init -i --privileged --name frr-${{ matrix.cfg.platform }}-cont ${ADD_DOCKER_ENV} -v /lib/modules:/lib/modules frr-${{ matrix.cfg.platform }} \
-            bash -c 'cd ~/frr/tests/topotests ; sudo -E pytest '$rerun_tests; then
+            bash -c 'cd ~/frr/tests/topotests ; sudo -E pytest "$@"' _ $rerun_tests; then
             echo "All rerun tests passed."
             exit 0
           fi


### PR DESCRIPTION
When `rerun_tests` contains multiple test paths, the current `bash -c` command passes only the first path to pytest. The remaining paths become positional arguments of the inner shell, but the command does not use them.

Fix the issue by passing the test paths as positional arguments to `bash -c`.
The `_` provides the inner shell's `$0`, while `"$@"` expands to all test paths starting at `$1`.

For example:

```bash
rerun_tests="static_simple/test_static_simple.py \
static_vrf/test_static_vrf.py"
```

Without the fix:

```bash
bash -c 'cd /home/user/frr/tests/topotests ; pytest '$rerun_tests
```

Only `static_simple/test_static_simple.py` is executed:

```text
collected 4 items
static_simple/test_static_simple.py ....                                            [100%]
```

With the fix:

```bash
bash -c 'cd /home/user/frr/tests/topotests ; pytest "$@"' _ $rerun_tests
```

Both test files are executed:

```text
collected 5 items
static_simple/test_static_simple.py ....                                            [ 80%]
static_vrf/test_static_vrf.py .                                                     [100%]
```

Apply the same argument-handling fix to both the parallel/reuse run and the serial retry run.