### PR TITLE
bgpd: add "bgp shutdown no-notify" option for HA setups

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5471,7 +5471,7 @@ DEFPY(bgp_shutdown_msg, bgp_shutdown_msg_cmd, "bgp shutdown message MSG...",
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	bgp_shutdown_enable(bgp, msgstr);
+	bgp_shutdown_enable(bgp, msgstr, true);
 	XFREE(MTYPE_TMP, msgstr);
 
 	return CMD_SUCCESS;
@@ -5482,7 +5482,19 @@ DEFPY(bgp_shutdown, bgp_shutdown_cmd, "bgp shutdown",
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	bgp_shutdown_enable(bgp, NULL);
+	bgp_shutdown_enable(bgp, NULL, true);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(bgp_shutdown_no_notify, bgp_shutdown_no_notify_cmd, "bgp shutdown no-notify",
+      BGP_STR
+      "Administrative shutdown of the BGP instance\n"
+      "Do not send BGP notification (for HA standby transition)\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+
+	bgp_shutdown_enable(bgp, NULL, false);
 
 	return CMD_SUCCESS;
 }
@@ -5501,6 +5513,11 @@ ALIAS(no_bgp_shutdown, no_bgp_shutdown_msg_cmd,
       "no bgp shutdown message MSG...", NO_STR BGP_STR
       "Administrative shutdown of the BGP instance\n"
       "Add a shutdown message (RFC 8203)\n" "Shutdown message\n")
+
+ALIAS(no_bgp_shutdown, no_bgp_shutdown_no_notify_cmd,
+      "no bgp shutdown no-notify", NO_STR BGP_STR
+      "Administrative shutdown of the BGP instance\n"
+      "Do not send BGP notification (for HA standby transition)\n")
 
 DEFUN (neighbor_remote_as,
        neighbor_remote_as_cmd,
@@ -22766,8 +22783,12 @@ int bgp_config_write(struct vty *vty)
 			vty_out(vty, " bgp default shutdown\n");
 
 		/* BGP instance administrative shutdown */
-		if (CHECK_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN))
-			vty_out(vty, " bgp shutdown\n");
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN)) {
+			if (CHECK_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN_NO_NOTIFY))
+				vty_out(vty, " bgp shutdown no-notify\n");
+			else
+				vty_out(vty, " bgp shutdown\n");
+		}
 
 		/* Automatic RA enabling by BGP */
 		if (!CHECK_FLAG(bm->flags, BM_FLAG_IPV6_NO_AUTO_RA))
@@ -23834,8 +23855,10 @@ void bgp_vty_init(void)
 	/* "bgp shutdown" commands */
 	install_element(BGP_NODE, &bgp_shutdown_cmd);
 	install_element(BGP_NODE, &bgp_shutdown_msg_cmd);
+	install_element(BGP_NODE, &bgp_shutdown_no_notify_cmd);
 	install_element(BGP_NODE, &no_bgp_shutdown_cmd);
 	install_element(BGP_NODE, &no_bgp_shutdown_msg_cmd);
+	install_element(BGP_NODE, &no_bgp_shutdown_no_notify_cmd);
 
 	/* "neighbor remote-as" commands. */
 	install_element(BGP_NODE, &neighbor_remote_as_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5799,7 +5799,7 @@ static void peer_flag_modify_action(struct peer *peer, uint64_t flag)
 }
 
 /* Enable global administrative shutdown of all peers of BGP instance */
-void bgp_shutdown_enable(struct bgp *bgp, const char *msg)
+void bgp_shutdown_enable(struct bgp *bgp, const char *msg, bool send_notify)
 {
 	struct peer *peer;
 	struct listnode *node;
@@ -5816,14 +5816,22 @@ void bgp_shutdown_enable(struct bgp *bgp, const char *msg)
 
 	/* iterate through peers of BGP instance */
 	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
-		peer_set_last_reset(peer, PEER_DOWN_USER_SHUTDOWN);
-
 		/* continue, if peer is already in administrative shutdown. */
 		if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN))
 			continue;
 
-		/* send a RFC 4486 notification message if necessary */
-		if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->connection->status)) {
+		/*
+		 * Send a RFC 4486 notification message if necessary.
+		 *
+		 * Note that BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN may be converted
+		 * to BGP_NOTIFY_CEASE_HARD_RESET in the notification, and
+		 * would result in GR termination on the receiver.
+		 *
+		 * In a active/standby HA setup, when the node becomes standby,
+		 * the BGP notification should not be sent out in order to
+		 * preserve BGP Graceful Restart state on the receiver.
+		 */
+		if (send_notify && BGP_IS_VALID_STATE_FOR_NOTIF(peer->connection->status)) {
 			if (msg) {
 				size_t datalen = strlen(msg);
 
@@ -5849,10 +5857,16 @@ void bgp_shutdown_enable(struct bgp *bgp, const char *msg)
 
 		/* trigger a RFC 4271 ManualStop event */
 		BGP_EVENT_ADD(peer->connection, BGP_Stop);
+		peer_set_last_reset(peer, PEER_DOWN_USER_SHUTDOWN);
 	}
 
 	/* set the BGP instances shutdown flag */
 	SET_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN);
+
+	if (!send_notify)
+		SET_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN_NO_NOTIFY);
+	else
+		UNSET_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN_NO_NOTIFY);
 }
 
 /* Disable global administrative shutdown of all peers of BGP instance */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -791,6 +791,8 @@ struct bgp {
  * for bestpath comparison of imported paths.
  */
 #define BGP_FLAG_BESTPATH_USE_IMPORTED_ATTRS (1ULL << 47)
+/* Shutdown without sending notification (for HA standby transition) */
+#define BGP_FLAG_SHUTDOWN_NO_NOTIFY (1ULL << 48)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.
@@ -2997,7 +2999,7 @@ extern struct peer_af *peer_af_create(struct peer *peer, afi_t afi, safi_t safi)
 extern struct peer_af *peer_af_find(struct peer *peer, afi_t afi, safi_t safi);
 extern int peer_af_delete(struct peer *peer, afi_t afi, safi_t safi);
 
-extern void bgp_shutdown_enable(struct bgp *bgp, const char *msg);
+extern void bgp_shutdown_enable(struct bgp *bgp, const char *msg, bool send_notify);
 extern void bgp_shutdown_disable(struct bgp *bgp);
 
 extern void bgp_close(void);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1223,6 +1223,14 @@ Administrative Shutdown
 
    An optional shutdown message `MSG` can be specified.
 
+.. clicmd:: bgp shutdown no-notify
+
+   Administrative shutdown of all peers of a bgp instance without sending
+   BGP notification messages. This is useful in active/standby HA setups
+   where, when the node becomes standby, BGP should be shut down without
+   sending notifications in order to preserve BGP Graceful Restart state
+   on the receiving peers.
+
 
 .. _bgp-network:
 

--- a/tests/topotests/bgp_shutdown_no_notify/r1/frr.conf
+++ b/tests/topotests/bgp_shutdown_no_notify/r1/frr.conf
@@ -1,0 +1,18 @@
+!
+interface lo
+ ip address 172.16.255.1/32
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!
+ip forwarding
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ neighbor 192.168.255.2 remote-as external
+ neighbor 192.168.255.2 timers 3 9
+ address-family ipv4
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_shutdown_no_notify/r2/frr.conf
+++ b/tests/topotests/bgp_shutdown_no_notify/r2/frr.conf
@@ -1,0 +1,18 @@
+!
+interface lo
+ ip address 172.16.255.2/32
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!
+ip forwarding
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ neighbor 192.168.255.1 remote-as external
+ neighbor 192.168.255.1 timers 3 9
+ address-family ipv4
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_shutdown_no_notify/test_bgp_shutdown_no_notify.py
+++ b/tests/topotests/bgp_shutdown_no_notify/test_bgp_shutdown_no_notify.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test BGP instance shutdown with no-notify option.
+
+In an active/standby HA setup, when the node becomes standby, BGP should be
+shut down without sending notifications in order to preserve BGP Graceful
+Restart state on the receiving peers.
+
+TC1: Test "bgp shutdown no-notify"
+    - Verify that when using "bgp shutdown no-notify", no BGP notification
+      is sent to the peer
+    - Verify that routes are retained as stale on the peer (GR preserved)
+    - Verify config output shows "bgp shutdown no-notify"
+
+TC2: Test "no bgp shutdown" recovery
+    - Verify that the session re-establishes after "no bgp shutdown"
+    - Verify that routes are refreshed
+
+TC3: Test regular "bgp shutdown" (with notification)
+    - Verify that regular "bgp shutdown" sends notification
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.common_config import step
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_shutdown_no_notify():
+    """TC1: Test bgp shutdown no-notify preserves GR state on peer"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+        expected = {
+            "192.168.255.1": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_routes_stale():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast 172.16.255.1/32 json"))
+        expected = {
+            "paths": [
+                {
+                    "stale": True,
+                    "valid": True,
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_no_notification():
+        output = json.loads(r2.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+        neighbor = output.get("192.168.255.1", {})
+        if neighbor.get("bgpState") == "Established":
+            return "Peer still in Established state"
+        reason = neighbor.get("lastNotificationReason", "")
+        if "Shutdown" in reason or "Cease" in reason:
+            return f"Notification was sent: {reason}"
+        return None
+
+    def _bgp_check_config_no_notify():
+        output = r1.vtysh_cmd("show running-config")
+        if "bgp shutdown no-notify" in output:
+            return None
+        return "Config does not show 'bgp shutdown no-notify'"
+
+    step("Initial BGP converge")
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assert result is None, "Failed to see BGP convergence on R2"
+
+    step("Apply bgp shutdown no-notify on R1")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp
+         bgp shutdown no-notify
+        """
+    )
+
+    step("Check that no notification was sent to R2")
+    test_func = functools.partial(_bgp_check_no_notification)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Notification check failed: {result}"
+
+    step("Check that routes are retained as stale on R2 (GR preserved)")
+    test_func = functools.partial(_bgp_check_routes_stale)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assert result is None, "Failed to see stale routes on R2 - GR not preserved"
+
+    step("Check that config shows 'bgp shutdown no-notify'")
+    test_func = functools.partial(_bgp_check_config_no_notify)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, result
+
+
+def test_bgp_shutdown_no_notify_recovery():
+    """TC2: Test recovery with 'no bgp shutdown'"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+        expected = {
+            "192.168.255.1": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_routes_not_stale():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast 172.16.255.1/32 json"))
+        expected = {
+            "paths": [
+                {
+                    "valid": True,
+                }
+            ]
+        }
+        ret = topotest.json_cmp(output, expected)
+        if ret is not None:
+            return ret
+        for path in output.get("paths", []):
+            if path.get("stale"):
+                return "Route still marked as stale"
+        return None
+
+    step("Remove shutdown with 'no bgp shutdown'")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp
+         no bgp shutdown
+        """
+    )
+
+    step("Check BGP session re-establishes")
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assert result is None, "Failed to see BGP convergence on R2 after recovery"
+
+    step("Check routes are no longer stale")
+    test_func = functools.partial(_bgp_check_routes_not_stale)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assert result is None, "Routes still stale after recovery"
+
+
+def test_bgp_shutdown_with_notify():
+    """TC3: Test regular bgp shutdown sends notification"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+        expected = {
+            "192.168.255.1": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_notification_sent():
+        output = json.loads(r2.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+        neighbor = output.get("192.168.255.1", {})
+        reason = neighbor.get("lastNotificationReason", "")
+        if "Shutdown" in reason or "Administrative" in reason:
+            return None
+        return f"Expected shutdown notification, got: {reason}"
+
+    step("Ensure BGP is converged")
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=1)
+    assert result is None, "Failed to see BGP convergence on R2"
+
+    step("Apply regular bgp shutdown on R1")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp
+         bgp shutdown
+        """
+    )
+
+    step("Check that notification was sent to R2")
+    test_func = functools.partial(_bgp_check_notification_sent)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"Notification was not sent: {result}"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-bgp-common.yang
+++ b/yang/frr-bgp-common.yang
@@ -676,6 +676,17 @@ submodule frr-bgp-common {
         "RFC 8203 shutdown communication message.
          Maps to: bgp shutdown message MSG...";
     }
+
+    leaf shutdown-no-notify {
+      when "../shutdown = 'true'";
+      type boolean;
+      default "false";
+      description
+        "Administrative shutdown without sending BGP notification.
+         Useful in active/standby HA setups to preserve BGP Graceful
+         Restart state on receiving peers.
+         Maps to: bgp shutdown no-notify.";
+    }
   }
 
   grouping bgp-daemon-config {


### PR DESCRIPTION
In an active/standby HA setup, when a node becomes standby, BGP
should be shut down without sending notifications in order to
preserve BGP Graceful Restart state on the receiving peers.

Add a new "bgp shutdown no-notify" command that performs
administrative shutdown without sending BGP NOTIFICATION messages.
This prevents the notification (which may be converted to Hard Reset)
from terminating GR state on the peer.