### PR TITLE
docker: add containerlab image with SSH support

### DIFF
--- a/doc/developer/frr-release-procedure.rst
+++ b/doc/developer/frr-release-procedure.rst
@@ -179,16 +179,23 @@ Stage 2 - Staging
          git fetch --all
          git checkout frr-$TAG
          docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6,linux/riscv64 -f docker/alpine/Dockerfile -t quay.io/frrouting/frr:$TAG --push .
+         docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6,linux/riscv64 -f docker/containerlab/Dockerfile --build-arg TAG=$TAG -t quay.io/frrouting/frr-containerlab:$TAG --push .
          git tag docker/$TAG
          git push origin docker/$TAG
 
-      This will build a multi-arch image and upload it to Quay, as well as
-      create a git tag corresponding to the commit that the image was built
+      This will build multi-arch images and upload them to Quay, as well as
+      create a git tag corresponding to the commit that the images were built
       from and upload that to Github. It's important that the git tag point to
-      the exact codebase that was used to build the docker image, so if any
+      the exact codebase that was used to build the docker images, so if any
       changes need to be made on top of the ``frr-$TAG`` release tag, make
       sure these changes are committed and pointed at by the ``docker/X.Y.Z``
       tag.
+
+      The second image is the same release with an SSH server added, for use
+      with `containerlab <https://containerlab.dev>`_. It is built ``FROM``
+      ``quay.io/frrouting/frr:$TAG``, so it must be built after the first
+      image has been pushed, and the ``TAG`` build argument must match the
+      release being built. See ``docker/containerlab/README.md``.
 
 
 Stage 3 - Publish

--- a/docker/containerlab/Dockerfile
+++ b/docker/containerlab/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# FRR image for use with containerlab (https://containerlab.dev).
+#
+# This is the released FRR image with an SSH server added. The stock image has
+# none, so a running FRR container cannot be reached with ssh, which
+# containerlab's "frr" kind expects to be possible.
+#
+# The base is the release image built from docker/alpine/Dockerfile, so this
+# image must be built after that one. TAG selects which release to build on
+# top of and defaults to the latest published release.
+#
+# See doc/developer/frr-release-procedure.rst for how this is built and pushed
+# as part of a release.
+
+ARG TAG=latest
+FROM quay.io/frrouting/frr:${TAG}
+
+RUN apk add --no-cache openssh
+
+# Starts sshd alongside watchfrr. The base image's script starts watchfrr only.
+COPY docker/containerlab/docker-start /usr/lib/frr/docker-start
+
+EXPOSE 22
+
+# ENTRYPOINT (tini) is inherited from the base image.
+CMD ["/usr/lib/frr/docker-start"]

--- a/docker/containerlab/README.md
+++ b/docker/containerlab/README.md
@@ -1,0 +1,45 @@
+# FRR container image for containerlab
+
+This directory builds the FRR image used by
+[containerlab](https://containerlab.dev)'s `frr` kind.
+
+It is the released FRR image with an SSH server added. The stock image ships
+none, so a running FRR container cannot be reached with `ssh`; containerlab
+writes the host's public keys to `/root/.ssh/authorized_keys` and expects an
+`sshd` to be listening. Host keys are generated on first start rather than at
+build time, so containers do not all share one key.
+
+Everything else, FRR included, comes from the base image unchanged.
+
+The image is published as `quay.io/frrouting/frr-containerlab` and built on
+every release; see `doc/developer/frr-release-procedure.rst`.
+
+## Building
+
+The base image is the release built from `docker/alpine/Dockerfile`, so build
+that first. `TAG` selects which release to build on top of and defaults to the
+latest published one. The build context is the repository root:
+
+```console
+docker build -f docker/containerlab/Dockerfile \
+    --build-arg TAG=10.7.1 \
+    -t quay.io/frrouting/frr-containerlab:10.7.1 .
+```
+
+## Usage
+
+```yaml
+name: frr01
+
+topology:
+  nodes:
+    router1:
+      kind: frr
+      image: quay.io/frrouting/frr-containerlab:10.7.1
+      startup-config: router1/frr.conf
+```
+
+Containerlab writes `/etc/frr/frr.conf`, `/etc/frr/daemons` and
+`/etc/frr/vtysh.conf` for each node, and the routers are reachable with
+`ssh root@clab-frr01-router1`. See the
+[`frr` kind documentation](https://containerlab.dev/manual/kinds/frr/).

--- a/docker/containerlab/docker-start
+++ b/docker/containerlab/docker-start
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copy of docker/alpine/docker-start with an sshd started alongside watchfrr,
+# which the containerlab image needs and the alpine one does not. Keep the
+# frrcommon.sh handling below in sync with that script.
+
+if [ -r "/lib/lsb/init-functions" ]; then
+        . /lib/lsb/init-functions
+else
+        log_success_msg() {
+                echo "$@"
+        }
+        log_warning_msg() {
+                echo "$@" >&2
+        }
+        log_failure_msg() {
+                echo "$@" >&2
+        }
+fi
+
+# Host keys are generated here rather than baked into the image, so that every
+# container gets its own set instead of the whole world sharing one key.
+if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
+        ssh-keygen -A >/dev/null
+fi
+
+# Containerlab writes authorized_keys into this directory after the container
+# is up. sshd rejects the file if the directory is group- or world-writable.
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+
+/usr/sbin/sshd || log_failure_msg "failed to start sshd"
+
+source /usr/lib/frr/frrcommon.sh
+# exec so that tini signals reach watchfrr directly
+exec /usr/lib/frr/watchfrr $(daemon_list)


### PR DESCRIPTION
Adding a docker image specifically for containerlab.

The released FRR image ships no SSH server, so a running FRR container cannot be reached with ssh. This allows to add a 'frr kind' to the Containerlab directory where frr is reachable over ssh

The image is built FROM quay.io/frrouting/frr:$TAG, so it must be built after that image is pushed. Both are now built during a release; the release procedure is updated accordingly.