### PR TITLE
bgpd: show L3VNI data for auto-created BGP VRFs

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -6905,7 +6905,7 @@ DEFUN (show_bgp_vrf_l3vni_info,
 		json = json_object_new_object();
 
 	name = argv[idx_vrf]->arg;
-	bgp = bgp_lookup_by_name(name);
+	bgp = bgp_lookup_by_name_filter(name, false);
 	if (strmatch(name, VRF_DEFAULT_NAME))
 		bgp = bgp_get_default();
 


### PR DESCRIPTION
Commit: f153b9a9b636e7ca16ef066e934d355ba922df2b
Changed bgp_lookup_by_name() to ignore auto-created BGP VRF instances.  The `show bgp vrf VRFNAME vni` handler uses this filtered lookup even though L3VNI state can belong to an auto-created instance. The command therefore reported that the BGP instance did not exist.

Use the unfiltered lookup for this operational show command so the auto-created instance remains visible.

Before this change:

  PE1# show bgp vrf vrf-blue vni json
  { "warning": "BGP instance not found" }

After this change:

  PE1# show bgp vrf vrf-blue vni json
  {
    "vrf":"vrf-blue",
    "local-ip":"10.10.10.10",
    "l3vni":3109,
    "rmac":"02:44:b6:c3:9b:f8",
    "vniFilter":"none",
    "l2vnis":[
    ],
    "export-rts":[
      "RT:65000:3109"
    ],
    "import-rts":[
      "RT:65000:3109"
    ],
    "rd":"10.99.99.1:2"
  }