### PR TITLE
bgpd: fix invalid JSON for empty AFI-all routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -15480,7 +15480,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 		if (is_last) {
 			unsigned long i;
 			for (i = 0; i < *json_header_depth; ++i) {
-				if (i == *json_header_depth - 1)
+				if (!all && i == *json_header_depth - 1)
 					vty_out(vty, ",\"numRoutes\":%lu\n", output_count);
 				vty_out(vty, " } ");
 				/* Put this information before closing the last `}` */
@@ -15488,7 +15488,9 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 					vty_out(vty, ", \"totalRoutes\": %ld, \"totalPaths\": %ld",
 						output_count, total_count);
 			}
-			if (!all)
+			if (all)
+				vty_out(vty, ",\n\"numRoutes\":%lu\n", output_count);
+			else
 				vty_out(vty, "\n");
 		}
 	} else {


### PR DESCRIPTION
`show bgp all json` uses a JSON header depth of one.  When the routes table was empty, bgp_show_table() emitted numRoutes while closing the empty routes object and produced output such as:

  "routes": { ,"numRoutes":0 }

The leading comma made the output invalid JSON.  Do not emit numRoutes from this location for AFI-all output.  Commands for a single AFI keep their existing numRoutes field and placement.

Fixes: c8b0a0e14847 ("bgpd: add additional attributes for evpn detail/ipv4/ipv6 detail json")