### PR TITLE
isisd: Fix NEXT-CSID length for combined uA SIDs (backport #23204)

### DIFF
--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1078,7 +1078,8 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 		SET_SRV6_FLV_OP(ctx.flv.flv_ops,
 				ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 		ctx.flv.lcblock_len = sra->locator->block_bits_length;
-		ctx.flv.lcnode_func_len = sra->locator->node_bits_length;
+		ctx.flv.lcnode_func_len = sra->locator->node_bits_length +
+					  sra->locator->function_bits_length;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_RESERVED:
 	case SRV6_ENDPOINT_BEHAVIOR_END:

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -1141,6 +1141,44 @@ def test_ping_step9():
     check_ping6("rt1", "fc00:0:9::1", True)
 
 
+def iproute2_can_show_seg6local_flavors(router):
+    """Check whether iproute2 can display SEG6_LOCAL_FLAVORS attributes."""
+    version = router.run("ip -Version").strip()
+    help_output = router.run("ip -6 route help 2>&1")
+
+    return (
+        "flavors FLAVORS" in help_output and "next-csid" in help_output,
+        version,
+    )
+
+
+def test_srv6_ua_sid_kernel_attributes():
+    """Verify the NEXT-CSID flavor of the dynamic uA SID."""
+    logger.info("Test: Verify NEXT-CSID flavor of the dynamic uA SID")
+    tgen = get_topogen()
+
+    # Required linux kernel version for this case to run.
+    result = required_linux_kernel_version("6.17")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met, kernel version should be >=6.17")
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    rt2 = tgen.gears["rt2"]
+    supported, version = iproute2_can_show_seg6local_flavors(rt2)
+    logger.info("Installed iproute2: %s", version)
+    if not supported:
+        pytest.skip(
+            "Installed iproute2 cannot display SEG6_LOCAL_FLAVORS "
+            f"attributes: {version}"
+        )
+
+    output = rt2.run("ip -6 -d route show exact fc00:0:2:4::/64")
+    assert "flavors next-csid lblen 32 nflen 32" in output, output
+
+
 # Memory leak test template
 def test_memory_leak():
     "Run the memory leak test and report results."


### PR DESCRIPTION
Manual backport of #23204 for FRR 10.4

Replaces #23231