### PR TITLE
zebra: keep kernel routes on interfaces that never had an IPv4 address

### DIFF
--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -694,6 +694,117 @@ def test_zebra_ipv6_dad_kernel_route():
     assert result is None, result
 
 
+def test_zebra_kernel_route_on_addressless_interface():
+    """Kernel route on an interface that never had an IPv4 address must survive
+    unrelated interface events.
+
+    zebra emulates the kernel dropping IPv4 routes when an interface loses its
+    last IPv4 address. That emulation runs as a walk over every kernel route in
+    every VRF, so it must only reap routes on the interface that actually lost
+    an address - not on an interface that never carried one. See issue #23164.
+    """
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    # victim never gets an IPv4 address and carries the route under test;
+    # other is unrelated and only exists to generate the trigger events.
+    victim = "dummy23164a"
+    other = "dummy23164b"
+    prefix = "198.51.100.0/24"
+    connected = "192.0.2.0/24"
+
+    def _wait_zebra_route(pfx, present, msg):
+        expected = {pfx: [] if present else None}
+        test_func = partial(
+            topotest.router_json_cmp, router, "show ip route json", expected
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+        assert result is None, msg.format(result)
+
+    def _assert_kernel_route(present, msg):
+        routes = topotest.ip4_route(router)
+        cmp = topotest.json_cmp(routes, {prefix: {} if present else None})
+        assert cmp is None, msg.format(cmp)
+
+    def _assert_zebra_keeps_route(msg):
+        # The deletion this guards against is asynchronous, so a single
+        # "still there" check could pass before zebra even processed the
+        # trigger. The caller has already synchronised on an observable
+        # effect of the trigger; give the walk a moment on top of that.
+        topotest.sleep(2, "Waiting for zebra to finish the kernel route walk")
+        _wait_zebra_route(prefix, True, msg)
+
+    step("Create an addressless interface carrying a scope-link kernel route")
+    router.run(f"ip link add {victim} type dummy")
+    router.run(f"ip link set {victim} up")
+    router.run(f"ip link add {other} type dummy")
+    router.run(f"ip link set {other} up")
+    router.run(f"ip -4 addr add 192.0.2.171/24 dev {other}")
+    router.run(f"ip -4 route add {prefix} dev {victim} scope link proto static")
+
+    _assert_kernel_route(
+        True, "Unexpected kernel behaviour: route should have been added:\n{}"
+    )
+    _wait_zebra_route(prefix, True, "Expected zebra to learn the kernel route:\n{}")
+    _wait_zebra_route(
+        connected, True, "Expected zebra to learn the connected route:\n{}"
+    )
+
+    step("Take an unrelated interface down")
+    router.run(f"ip link set {other} down")
+
+    # Synchronise: once the connected route of "other" is gone, zebra has
+    # processed the interface-down event that triggers the kernel route walk.
+    _wait_zebra_route(
+        connected, False, "Expected zebra to withdraw the connected route:\n{}"
+    )
+    _assert_kernel_route(
+        True,
+        "Unexpected kernel behaviour: route should have survived an unrelated interface going down:\n{}",
+    )
+    _assert_zebra_keeps_route(
+        "zebra deleted a kernel route on an addressless interface after an unrelated interface went down:\n{}"
+    )
+
+    step("Delete the last IPv4 address of the unrelated interface")
+    router.run(f"ip link set {other} up")
+    _wait_zebra_route(
+        connected, True, "Expected zebra to relearn the connected route:\n{}"
+    )
+    router.run(f"ip -4 addr del 192.0.2.171/24 dev {other}")
+
+    # Same synchronisation, for the last-address-deleted trigger.
+    _wait_zebra_route(
+        connected,
+        False,
+        "Expected zebra to withdraw the connected route after address deletion:\n{}",
+    )
+    _assert_kernel_route(
+        True,
+        "Unexpected kernel behaviour: route should have survived an unrelated last address deletion:\n{}",
+    )
+    _assert_zebra_keeps_route(
+        "zebra deleted a kernel route on an addressless interface after an unrelated interface lost its last IPv4 address:\n{}"
+    )
+
+    step("Take the route's own interface down - the route must now go away")
+    router.run(f"ip link set {victim} down")
+
+    _assert_kernel_route(
+        False,
+        "Unexpected kernel behaviour: route should have been deleted with its own interface:\n{}",
+    )
+    _wait_zebra_route(
+        prefix,
+        False,
+        "Expected zebra to delete the kernel route when its own interface went down:\n{}",
+    )
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1385,8 +1385,18 @@ static void zebra_if_addr_update_ctx(struct zebra_dplane_ctx *ctx,
 	 * See rib_update_handle_kernel_route_down_possibility for more details
 	 */
 	if (op != DPLANE_OP_INTF_ADDR_ADD && addr->family == AF_INET &&
-	    !if_has_connected_with_family(ifp, AF_INET))
+	    !if_has_connected_with_family(ifp, AF_INET)) {
+		struct zebra_if *zif = ifp->info;
+
+		/* Record which interface lost its last IPv4 address, so that
+		 * the walk below only reaps the routes the kernel actually
+		 * dropped.
+		 */
+		if (zif)
+			SET_FLAG(zif->flags, ZIF_FLAG_IPV4_ADDR_GONE);
+
 		rib_update(RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED);
+	}
 }
 
 static void zebra_if_update_ctx(struct zebra_dplane_ctx *ctx,

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -81,7 +81,16 @@ enum zebra_if_flags {
 	/* Kernel protodown state from RTM_NEWLINK - used to detect kernel
 	 * protodown transitions independently from ZIF_FLAG_PROTODOWN
 	 */
-	ZIF_FLAG_KERNEL_PROTODOWN_SET = (1 << 6)
+	ZIF_FLAG_KERNEL_PROTODOWN_SET = (1 << 6),
+
+	/* The last IPv4 address of this interface has just been deleted and
+	 * the RIB walk that emulates the kernel's implicit removal of the
+	 * IPv4 routes using it has not run yet.  Only while this is set does
+	 * "interface has no IPv4 address" mean "the kernel dropped the
+	 * routes"; an interface that never had an address keeps its routes.
+	 * See rib_update_handle_kernel_route_down_possibility().
+	 */
+	ZIF_FLAG_IPV4_ADDR_GONE = (1 << 7)
 };
 
 #define ZEBRA_IF_IS_PROTODOWN(zif) ((zif)->flags & ZIF_FLAG_PROTODOWN)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4690,6 +4690,7 @@ rib_update_handle_kernel_route_down_possibility(struct route_node *rn,
 						struct route_entry *re)
 {
 	struct nexthop *nexthop = NULL;
+	struct zebra_if *zif;
 	bool alive = false;
 
 	for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
@@ -4727,8 +4728,17 @@ rib_update_handle_kernel_route_down_possibility(struct route_node *rn,
 			break;
 		}
 
-		/* Check if there are any IPv4 addresses connected, if yes - set alive */
-		if (if_has_connected_with_family(ifp, AF_INET)) {
+		/*
+		 * That deletion is a transition, not a state: only an interface
+		 * that just lost its last IPv4 address had its routes dropped.
+		 * An interface that never carried one - a route installed as
+		 * "dev <ifname> scope link" on an addressless interface - keeps
+		 * its routes, and so must we.  Without this the walk reaps live
+		 * routes whenever any unrelated interface goes down or loses an
+		 * address, since it visits every kernel route in every VRF.
+		 */
+		zif = ifp->info;
+		if (!zif || !CHECK_FLAG(zif->flags, ZIF_FLAG_IPV4_ADDR_GONE)) {
 			alive = true;
 			break;
 		}
@@ -4828,6 +4838,26 @@ void rib_update_table(struct route_table *table, enum rib_update_event event,
 	}
 }
 
+/*
+ * ZIF_FLAG_IPV4_ADDR_GONE marks a single transition and is consumed by the
+ * walk above.  Clear it once the walk is done, or the next walk - triggered
+ * by some unrelated interface - would reap kernel routes installed on the
+ * interface after the kernel dropped the earlier ones.
+ */
+static void rib_update_clear_ipv4_addr_gone(void)
+{
+	struct interface *ifp;
+	struct zebra_if *zif;
+	struct vrf *vrf;
+
+	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			zif = ifp->info;
+			if (zif)
+				UNSET_FLAG(zif->flags, ZIF_FLAG_IPV4_ADDR_GONE);
+		}
+}
+
 void rib_update_handle_vrf_all(enum rib_update_event event, int rtype)
 {
 	struct zebra_router_table *zrt;
@@ -4839,6 +4869,9 @@ void rib_update_handle_vrf_all(enum rib_update_event event, int rtype)
 	/* Just iterate over all the route tables, rather than vrf lookups */
 	RB_FOREACH (zrt, zebra_router_table_head, &zrouter.tables)
 		rib_update_table(zrt->table, event, rtype);
+
+	if (event == RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED)
+		rib_update_clear_ipv4_addr_gone();
 }
 
 struct rib_update_ctx {


### PR DESCRIPTION
### Summary

`rib_update_handle_kernel_route_down_possibility()` emulates the kernel dropping
IPv4 routes when an interface loses its last IPv4 address, since the kernel does
that without sending `RTM_DELROUTE` (#19564, fixing #13561).

That deletion is a transition, but the check tests state: "this interface has no
IPv4 address" cannot distinguish "it lost one" from "it never had one". A route
installed as `dev <ifname> scope link` on an addressless interface is valid and
the kernel keeps it, yet zebra deletes it from the RIB. `rib_update_table()`
walks every kernel route in every VRF, so the trigger is any unrelated interface
going down, or any unrelated interface losing its last IPv4 address. The RIB then
permanently disagrees with the FIB, and nothing re-adds the route.

Measured kernel behaviour (plain `ip link` / `ip route`), which the walk has to
emulate:

| Kernel route on an interface with no IPv4 address... | kept? | |
|---|---|---|
| unrelated interface goes down | **yes** | zebra deletes it today |
| unrelated interface loses its last IPv4 address | **yes** | zebra deletes it today |
| that same interface goes down | no | already handled by `!if_is_up()` |
| (interface that *had* an address loses its last one) | no | what #19564 emulates |

Both false positives matter in practice: deleting a veth removes the interface
*and* its addresses, so fixing only the interface-down path would not be enough.

The fix makes the transition explicit — flag the interface that lost its last
IPv4 address with `ZIF_FLAG_IPV4_ADDR_GONE`, apply the "no address means the
kernel dropped the routes" rule only to a flagged interface, and clear the flag
once the walk it was raised for has run. Flagging the interface rather than
passing an ifindex into the walk keeps the existing event coalescing correct:
`rib_update()` keeps only one scheduled event per type, so an ifindex carried in
the context would be lost when several interfaces lose their addresses before the
walk runs.

Only one case changes: a nexthop interface that never had an IPv4 address now
keeps its routes. Interfaces with an address, and interfaces that just lost their
last one, behave exactly as before.

### Testing

New topotest in `zebra_multiple_connected`, a kernel route on an interface
that never carried an IPv4 address must survive an unrelated interface going down
and an unrelated interface losing its last address, and must still be removed
when its own interface goes down. Each step asserts the kernel state first and
zebra second, so the table above is re-checked on every run.

**1. The new test alone, without the zebra change** — fails at the first trigger.
The assertion retries for 20s, so this is a real deletion and not a convergence
race:

```
$ sudo -E pytest -s -v test_zebra_multiple_connected.py::test_zebra_kernel_route_on_addressless_interface

test_zebra_multiple_connected.py:739: in _assert_zebra_keeps_route
    _wait_zebra_route(prefix, True, msg)

pfx = '198.51.100.0/24', present = True

>       assert result is None, msg.format(result)
E       AssertionError: zebra deleted a kernel route on an addressless interface after an unrelated interface went down:
E         > $: expected has key '198.51.100.0/24' which is not present in output

ERROR: topo: 'router_json_cmp' failed after 20.42 seconds
=========================== 1 failed in 27.95s ===========================
```

**2. The same test with the change** — all four steps pass, including the last
one, which checks the route is still removed when its own interface goes down:

```
$ sudo -E pytest -s -v test_zebra_multiple_connected.py::test_zebra_kernel_route_on_addressless_interface

STEP 1: 'Create an addressless interface carrying a scope-link kernel route'
STEP 2: 'Take an unrelated interface down'
STEP 3: 'Delete the last IPv4 address of the unrelated interface'
STEP 4: 'Take the route's own interface down - the route must now go away'
PASSED
=========================== 1 passed in 8.52s ============================
```

**3. The whole file with the change** — 12 pre-existing tests plus the new one,
so the behaviour #19564 added is covered as well:

```
$ sudo -E pytest -s -v test_zebra_multiple_connected.py

test_zebra_connected_multiple PASSED
test_zebra_system_recursion PASSED
test_zebra_noprefix_connected PASSED
test_zebra_noprefix_connected_add PASSED
test_zebra_kernel_route_add PASSED
test_zebra_kernel_route_blackhole_add PASSED
test_zebra_kernel_route_interface_linkdown PASSED
test_zebra_mtu_single_local_route_per_address PASSED
test_zebra_kernel_last_ipv4_address_deleted PASSED
test_zebra_metaq_early_route_table_discriminator PASSED
test_zebra_kernel_last_ipv6_address_deleted PASSED
test_zebra_ipv6_dad_kernel_route PASSED
test_zebra_kernel_route_on_addressless_interface PASSED

=========================== 13 passed in 13.77s ==========================
```
### Related Issue

Fixes: #23164

### Components

zebra, tests