### PR TITLE
isisd: Advertise PSP-flavored SRv6 End SIDs

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -8047,7 +8047,10 @@ void isis_subtlvs_add_srv6_end_sid(struct isis_subtlvs *subtlvs, struct isis_srv
 	 * applied (e.g. End, End.DT6, ...). Before proceeding, let's make sure
 	 * we are encoding one of the supported behaviors. */
 	if (sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END &&
+	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_PSP &&
 	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID &&
+	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP &&
+	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD &&
 	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_DT6 &&
 	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_DT6_USID &&
 	    sid->behavior != SRV6_ENDPOINT_BEHAVIOR_END_DT4 &&
@@ -8088,7 +8091,10 @@ void isis_tlvs_add_srv6_locator(struct isis_tlvs *tlvs, uint16_t mtid,
 	loc_tlv->subtlvs = isis_alloc_subtlvs(ISIS_CONTEXT_SUBTLV_SRV6_LOCATOR);
 	for (ALL_LIST_ELEMENTS_RO(loc->srv6_sid, node, sid)) {
 		if (sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END ||
+		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_PSP ||
 		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID ||
+		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP ||
+		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD ||
 		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_DT6 ||
 		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_DT6_USID ||
 		    sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_DT4 ||

--- a/tests/topotests/isis_srv6_topo1/rt2/step1/show_isis_database_detail.ref
+++ b/tests/topotests/isis_srv6_topo1/rt2/step1/show_isis_database_detail.ref
@@ -1,0 +1,23 @@
+{
+  "areas":[
+    {
+      "levels":[
+        {
+          "lsps":[
+            {
+              "srv6Locator":{
+                "prefix":"fc00:0:1::/48",
+                "subtlvs":{
+                  "srv6EndSid":{
+                    "sidValue":"fc00:0:1::",
+                    "endpointBehavior":"uN PSP"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -290,6 +290,20 @@ def test_srv6_locator_step1():
         )
 
 
+def test_srv6_sid_advertisement_step1():
+    logger.info("Test (step 1): verify advertised SRv6 SID information")
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router_compare_json_output(
+        "rt2",
+        "show isis database detail json",
+        "step1/show_isis_database_detail.ref",
+    )
+
+
 def test_ping_step1():
     logger.info("Test (step 1): verify ping")
     tgen = get_topogen()


### PR DESCRIPTION
Commit https://github.com/FRRouting/frr/commit/555391fcc34424919a37a2435916168b575de079 added support in isisd for programming End PSP and uN PSP SIDs through Zebra. This extended the programming path, allowing these SIDs to be installed in the local FIB.

The corresponding IS-IS advertisement path was not updated. As a result, these SIDs are installed locally but omitted from the SRv6 Locator TLV and are not advertised to other IS-IS nodes.

Fix the issue by adding the PSP-flavored End SID behaviors to the advertisement filters.