### PR TITLE
isisd: add local-only uA SIDs

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3818,7 +3818,7 @@ static int bgp_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 
 	/* Decode the received notification message */
 	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr, &sid_func, &sid_wide_func,
-					 &note, loc_name, sizeof(loc_name))) {
+					 &note, loc_name, sizeof(loc_name), NULL)) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -638,6 +638,21 @@ data plane (SRv6) as per RFC 9352.
    SID and adjacency SIDs, creates local SID entries in the data plane, and
    advertises them in the IGP domain.
 
+   For a uSID locator using the ``usid-f3216`` or ``usid-f4816`` SID format,
+   each primary adjacency has two local End.X NEXT-CSID
+   (uA) representations sharing the same function and nexthop: the combined
+   block:node:function SID and the local-only block:function SID. Only the
+   combined SID is advertised in IS-IS. The local-only SID is installed in
+   the data plane with a zero-length node field; its NEXT-CSID node-function
+   length is the function length alone. For a 32/16/16 locator, the combined
+   and local-only routes are /64 and /48, respectively, with NEXT-CSID
+   node-function lengths of 32 and 16 bits. Both are removed when the
+   adjacency is removed and restored after reconnection to Zebra.
+
+   A uSID locator without a SID format retains only the combined entry:
+   its function allocation range is not separated from Global CSIDs, so a
+   local-only SID could overlap a node locator prefix.
+
 .. clicmd:: interface NAME
 
    Specify the dummy interface used to install SRv6 SIDs in the Linux data plane.

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -185,7 +185,7 @@ bool isis_srv6_locator_unset(struct isis_area *area)
 		 */
 		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 		ctx.nh6 = sra->nexthop;
-		ctx.ifindex = sra->adj->circuit->interface->ifindex;
+		ctx.ifindex = sra->ifindex;
 		isis_zebra_release_srv6_sid(&ctx, area->srv6db.config.srv6_locator_name);
 
 		srv6_endx_sid_del(sra);
@@ -317,45 +317,34 @@ void isis_area_delete_backup_srv6_endx_sids(struct isis_area *area, int level)
 /* --- SRv6 End.X SID management functions ------------------- */
 
 /**
- * Add new local End.X SID.
+ * Create the logical adjacency before requesting its SID representations.
  *
  * @param adj	   IS-IS Adjacency
  * @param backup   True to initialize backup Adjacency SID
  * @param nexthops List of backup nexthops (for backup End.X SIDs only)
- * @param sid_value SID value associated to be associated with the adjacency
  */
-void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup, struct list *nexthops,
-			      struct in6_addr *sid_value)
+struct srv6_adjacency *srv6_endx_sid_alloc(struct isis_adjacency *adj, bool backup,
+					   struct list *nexthops)
 {
 	struct isis_circuit *circuit = adj->circuit;
 	struct isis_area *area = circuit->area;
 	struct srv6_adjacency *sra;
-	struct isis_srv6_endx_sid_subtlv *adj_sid;
-	struct isis_srv6_lan_endx_sid_subtlv *ladj_sid;
 	struct in6_addr nexthop;
-	uint8_t flags = 0;
 	struct srv6_locator *locator;
 	uint32_t behavior;
 
 	if (!area || !area->srv6db.srv6_locator)
-		return;
+		return NULL;
 
 	sr_debug("ISIS-SRv6 (%s): Add %s End.X SID", area->area_tag, backup ? "Backup" : "Primary");
 
 	/* Determine nexthop IP address */
 	if (!circuit->ipv6_router || !adj->ll_ipv6_count)
-		return;
+		return NULL;
 
 	locator = area->srv6db.srv6_locator;
 
 	nexthop = adj->ll_ipv6_addrs[0];
-
-	/* Prepare SRv6 End.X as per RFC9352 section #8.1 */
-	if (backup)
-		SET_FLAG(flags, EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG);
-
-	if (circuit->ext == NULL)
-		circuit->ext = isis_alloc_ext_subtlvs();
 
 	behavior = (CHECK_FLAG(locator->flags, SRV6_LOCATOR_USID))
 			   ? SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID
@@ -367,19 +356,64 @@ void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup, struct li
 	sra->locator = locator;
 	isis_srv6_sid_structure_init(&sra->structure, locator, behavior);
 	sra->nexthop = nexthop;
+	sra->ifindex = circuit->interface->ifindex;
+	sra->backup_nexthops = nexthops;
+	sra->adj = adj;
+	if (backup)
+		SET_FLAG(sra->flags, EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG);
 
-	sra->sid = *sid_value;
+	listnode_add(area->srv6db.srv6_endx_sids, sra);
+	listnode_add(adj->srv6_endx_sids, sra);
+	return sra;
+}
+
+static void srv6_endx_sid_unadvertise(struct srv6_adjacency *sra)
+{
+	struct isis_circuit *circuit = sra->adj->circuit;
+
+	if (!sra->u.endx_sid)
+		return;
+
+	if (circuit->circ_type == CIRCUIT_T_BROADCAST)
+		isis_tlvs_del_srv6_lan_endx_sid(circuit->ext, sra->u.lendx_sid);
+	else
+		isis_tlvs_del_srv6_endx_sid(circuit->ext, sra->u.endx_sid);
+	sra->u.endx_sid = NULL;
+}
+
+/* Return true only when the advertised SID changes. */
+bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value)
+{
+	struct srv6_adjacency_sid *state = &sra->combined;
+	struct isis_circuit *circuit = sra->adj->circuit;
+	struct isis_srv6_endx_sid_subtlv *adj_sid;
+	struct isis_srv6_lan_endx_sid_subtlv *ladj_sid;
+
+	if (state->allocated && IPV6_ADDR_SAME(&state->sid, sid_value)) {
+		isis_zebra_srv6_adj_sid_install(sra);
+		if (sra->u.endx_sid)
+			return false;
+	} else {
+		isis_zebra_srv6_adj_sid_uninstall(sra);
+		state->sid = *sid_value;
+		state->allocated = true;
+		isis_zebra_srv6_adj_sid_install(sra);
+	}
+
+	srv6_endx_sid_unadvertise(sra);
+	if (!circuit->ext)
+		circuit->ext = isis_alloc_ext_subtlvs();
 
 	switch (circuit->circ_type) {
 	/* SRv6 LAN End.X SID for Broadcast interface section #8.2 */
 	case CIRCUIT_T_BROADCAST:
 		ladj_sid = XCALLOC(MTYPE_ISIS_SUBTLV, sizeof(*ladj_sid));
-		memcpy(ladj_sid->neighbor_id, adj->sysid, sizeof(ladj_sid->neighbor_id));
-		ladj_sid->flags = flags;
+		memcpy(ladj_sid->neighbor_id, sra->adj->sysid, sizeof(ladj_sid->neighbor_id));
+		ladj_sid->flags = sra->flags;
 		ladj_sid->algorithm = SR_ALGORITHM_SPF;
 		ladj_sid->weight = 0;
 		ladj_sid->behavior = sra->behavior;
-		ladj_sid->sid = sra->sid;
+		ladj_sid->sid = state->sid;
 		ladj_sid->subsubtlvs =
 			isis_alloc_subsubtlvs(ISIS_CONTEXT_SUBSUBTLV_SRV6_LAN_ENDX_SID);
 		ladj_sid->subsubtlvs->srv6_sid_structure =
@@ -397,11 +431,11 @@ void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup, struct li
 	/* SRv6 End.X SID for Point to Point interface section #8.1 */
 	case CIRCUIT_T_P2P:
 		adj_sid = XCALLOC(MTYPE_ISIS_SUBTLV, sizeof(*adj_sid));
-		adj_sid->flags = flags;
+		adj_sid->flags = sra->flags;
 		adj_sid->algorithm = SR_ALGORITHM_SPF;
 		adj_sid->weight = 0;
 		adj_sid->behavior = sra->behavior;
-		adj_sid->sid = sra->sid;
+		adj_sid->sid = state->sid;
 		adj_sid->subsubtlvs = isis_alloc_subsubtlvs(ISIS_CONTEXT_SUBSUBTLV_SRV6_ENDX_SID);
 		adj_sid->subsubtlvs->srv6_sid_structure =
 			XCALLOC(MTYPE_ISIS_SUBSUBTLV,
@@ -420,51 +454,16 @@ void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup, struct li
 		exit(1);
 	}
 
-	/* Add Adjacency-SID in SRDB */
-	sra->adj = adj;
-	listnode_add(area->srv6db.srv6_endx_sids, sra);
-	listnode_add(adj->srv6_endx_sids, sra);
-
-	isis_zebra_srv6_adj_sid_install(sra);
+	return true;
 }
 
-/**
- * Add Primary and Backup local SRv6 End.X SID.
- *
- * @param adj	  IS-IS Adjacency
- */
-void srv6_endx_sid_add(struct isis_adjacency *adj, struct in6_addr *sid_value)
-{
-	srv6_endx_sid_add_single(adj, false, NULL, sid_value);
-}
-
-/**
- * Delete local SRv6 End.X SID.
- *
- * @param sra	SRv6 Adjacency
- */
 void srv6_endx_sid_del(struct srv6_adjacency *sra)
 {
-	struct isis_circuit *circuit = sra->adj->circuit;
-	struct isis_area *area = circuit->area;
+	struct isis_area *area = sra->adj->circuit->area;
 
 	sr_debug("ISIS-SRv6 (%s): Delete SRv6 End.X SID", area->area_tag);
-
 	isis_zebra_srv6_adj_sid_uninstall(sra);
-
-	/* Release dynamic SRv6 SID and remove subTLVs */
-	switch (circuit->circ_type) {
-	case CIRCUIT_T_BROADCAST:
-		isis_tlvs_del_srv6_lan_endx_sid(circuit->ext, sra->u.lendx_sid);
-		break;
-	case CIRCUIT_T_P2P:
-		isis_tlvs_del_srv6_endx_sid(circuit->ext, sra->u.endx_sid);
-		break;
-	default:
-		flog_err(EC_LIB_DEVELOPMENT, "%s: unexpected circuit type: %u", __func__,
-			 circuit->circ_type);
-		exit(1);
-	}
+	srv6_endx_sid_unadvertise(sra);
 
 	if (sra->type == ISIS_SRV6_ADJ_BACKUP && sra->backup_nexthops) {
 		sra->backup_nexthops->del = (void (*)(void *))isis_nexthop_delete;
@@ -510,8 +509,10 @@ static int srv6_adj_state_change(struct isis_adjacency *adj)
 	if (!adj->circuit->area->srv6db.config.enabled)
 		return 0;
 
-	if (adj->adj_state == ISIS_ADJ_UP)
+	if (adj->adj_state == ISIS_ADJ_UP) {
+		isis_zebra_request_srv6_sid_endx(adj);
 		return 0;
+	}
 
 	for (ALL_LIST_ELEMENTS(adj->srv6_endx_sids, node, nnode, sra))
 		srv6_endx_sid_del(sra);

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -388,6 +388,7 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 	struct isis_srv6_lan_endx_sid_subtlv *ladj_sid;
 	struct srv6_adjacency *other;
 	struct listnode *node;
+	uint8_t arg_len = sra->structure.arg_len;
 
 	if (state->allocated && IPV6_ADDR_SAME(&state->sid, sid_value)) {
 		isis_zebra_srv6_adj_sid_install(sra, is_localonly);
@@ -415,6 +416,11 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 	if (!circuit->ext)
 		circuit->ext = isis_alloc_ext_subtlvs();
 
+	/* RFC 9800: NEXT-CSID arguments occupy the remaining SID bits. */
+	if (sra->behavior == SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID)
+		arg_len = IPV6_MAX_BITLEN - sra->structure.loc_block_len -
+			  sra->structure.loc_node_len - sra->structure.func_len;
+
 	switch (circuit->circ_type) {
 	/* SRv6 LAN End.X SID for Broadcast interface section #8.2 */
 	case CIRCUIT_T_BROADCAST:
@@ -435,7 +441,7 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 		ladj_sid->subsubtlvs->srv6_sid_structure->loc_node_len =
 			sra->structure.loc_node_len;
 		ladj_sid->subsubtlvs->srv6_sid_structure->func_len = sra->structure.func_len;
-		ladj_sid->subsubtlvs->srv6_sid_structure->arg_len = sra->structure.arg_len;
+		ladj_sid->subsubtlvs->srv6_sid_structure->arg_len = arg_len;
 		isis_tlvs_add_srv6_lan_endx_sid(circuit->ext, ladj_sid);
 		sra->u.lendx_sid = ladj_sid;
 		break;
@@ -455,7 +461,7 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 			sra->structure.loc_block_len;
 		adj_sid->subsubtlvs->srv6_sid_structure->loc_node_len = sra->structure.loc_node_len;
 		adj_sid->subsubtlvs->srv6_sid_structure->func_len = sra->structure.func_len;
-		adj_sid->subsubtlvs->srv6_sid_structure->arg_len = sra->structure.arg_len;
+		adj_sid->subsubtlvs->srv6_sid_structure->arg_len = arg_len;
 		isis_tlvs_add_srv6_endx_sid(circuit->ext, adj_sid);
 		sra->u.endx_sid = adj_sid;
 		break;

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -177,19 +177,8 @@ bool isis_srv6_locator_unset(struct isis_area *area)
 	}
 
 	/* Uninstall all local Adjacency-SIDs. */
-	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode, sra)) {
-		/*
-		 * Inform the SID Manager that IS-IS will no longer use the SID, so
-		 * that the SID Manager can remove the SID context ownership from IS-IS
-		 * and release/free the SID context if it is not yes by other protocols.
-		 */
-		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
-		ctx.nh6 = sra->nexthop;
-		ctx.ifindex = sra->ifindex;
-		isis_zebra_release_srv6_sid(&ctx, area->srv6db.config.srv6_locator_name);
-
-		srv6_endx_sid_del(sra);
-	}
+	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode, sra))
+		srv6_endx_sid_del(sra, true);
 
 	/* Inform Zebra that we are releasing the SRv6 locator */
 	ret = isis_zebra_srv6_manager_release_locator_chunk(area->srv6db.config.srv6_locator_name);
@@ -311,7 +300,7 @@ void isis_area_delete_backup_srv6_endx_sids(struct isis_area *area, int level)
 
 	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode, sra))
 		if (sra->type == ISIS_SRV6_ADJ_BACKUP && (sra->adj->level & level))
-			srv6_endx_sid_del(sra);
+			srv6_endx_sid_del(sra, true);
 }
 
 /* --- SRv6 End.X SID management functions ------------------- */
@@ -370,9 +359,17 @@ struct srv6_adjacency *srv6_endx_sid_alloc(struct isis_adjacency *adj, bool back
 static void srv6_endx_sid_unadvertise(struct srv6_adjacency *sra)
 {
 	struct isis_circuit *circuit = sra->adj->circuit;
+	struct srv6_adjacency *other;
+	struct listnode *node;
 
 	if (!sra->u.endx_sid)
 		return;
+	for (ALL_LIST_ELEMENTS_RO(circuit->area->srv6db.srv6_endx_sids, node, other)) {
+		if (other != sra && other->u.endx_sid == sra->u.endx_sid) {
+			sra->u.endx_sid = NULL;
+			return;
+		}
+	}
 
 	if (circuit->circ_type == CIRCUIT_T_BROADCAST)
 		isis_tlvs_del_srv6_lan_endx_sid(circuit->ext, sra->u.lendx_sid);
@@ -388,6 +385,8 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 	struct isis_circuit *circuit = sra->adj->circuit;
 	struct isis_srv6_endx_sid_subtlv *adj_sid;
 	struct isis_srv6_lan_endx_sid_subtlv *ladj_sid;
+	struct srv6_adjacency *other;
+	struct listnode *node;
 
 	if (state->allocated && IPV6_ADDR_SAME(&state->sid, sid_value)) {
 		isis_zebra_srv6_adj_sid_install(sra);
@@ -401,6 +400,15 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 	}
 
 	srv6_endx_sid_unadvertise(sra);
+	/* The circuit's sub-TLV list is shared by its L1 and L2 adjacencies. */
+	for (ALL_LIST_ELEMENTS_RO(circuit->area->srv6db.srv6_endx_sids, node, other)) {
+		if (other != sra && other->adj->circuit == circuit && other->type == sra->type &&
+		    other->u.endx_sid && IPV6_ADDR_SAME(&other->combined.sid, sid_value) &&
+		    memcmp(other->adj->sysid, sra->adj->sysid, ISIS_SYS_ID_LEN) == 0) {
+			sra->u = other->u;
+			return false;
+		}
+	}
 	if (!circuit->ext)
 		circuit->ext = isis_alloc_ext_subtlvs();
 
@@ -457,12 +465,55 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 	return true;
 }
 
-void srv6_endx_sid_del(struct srv6_adjacency *sra)
+/* L1/L2 LAN adjacencies can share a single SID Manager context. */
+static bool srv6_endx_sid_shared(struct srv6_adjacency *sra)
+{
+	struct srv6_adjacency *other;
+	struct listnode *node;
+	struct srv6_adjacency_sid *state = &sra->combined;
+	struct srv6_adjacency_sid *other_state;
+
+	for (ALL_LIST_ELEMENTS_RO(sra->adj->circuit->area->srv6db.srv6_endx_sids, node, other)) {
+		if (other == sra || other->ifindex != sra->ifindex ||
+		    !IPV6_ADDR_SAME(&other->nexthop, &sra->nexthop) ||
+		    strcmp(other->locator->name, sra->locator->name) != 0)
+			continue;
+		other_state = &other->combined;
+		if (!other_state->requested && !other_state->allocated)
+			continue;
+		/* Preserve FIB ownership even if the other allocation reply is pending. */
+		if (!other_state->allocated && state->allocated) {
+			other_state->sid = state->sid;
+			other_state->allocated = true;
+		}
+		other_state->installed |= state->installed;
+		return true;
+	}
+	return false;
+}
+
+static void srv6_endx_sid_cleanup(struct srv6_adjacency *sra, bool release)
+{
+	struct srv6_adjacency_sid *state = &sra->combined;
+	struct srv6_sid_ctx ctx = {};
+
+	if (srv6_endx_sid_shared(sra))
+		return;
+	if (release && (state->requested || state->allocated)) {
+		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
+		ctx.nh6 = sra->nexthop;
+		ctx.ifindex = sra->ifindex;
+		isis_zebra_release_srv6_sid(&ctx, sra->locator->name);
+	}
+	isis_zebra_srv6_adj_sid_uninstall(sra);
+}
+
+void srv6_endx_sid_del(struct srv6_adjacency *sra, bool release)
 {
 	struct isis_area *area = sra->adj->circuit->area;
 
 	sr_debug("ISIS-SRv6 (%s): Delete SRv6 End.X SID", area->area_tag);
-	isis_zebra_srv6_adj_sid_uninstall(sra);
+	srv6_endx_sid_cleanup(sra, release);
 	srv6_endx_sid_unadvertise(sra);
 
 	if (sra->type == ISIS_SRV6_ADJ_BACKUP && sra->backup_nexthops) {
@@ -515,7 +566,7 @@ static int srv6_adj_state_change(struct isis_adjacency *adj)
 	}
 
 	for (ALL_LIST_ELEMENTS(adj->srv6_endx_sids, node, nnode, sra))
-		srv6_endx_sid_del(sra);
+		srv6_endx_sid_del(sra, true);
 
 	return 0;
 }
@@ -559,7 +610,7 @@ static int srv6_adj_ip_disabled(struct isis_adjacency *adj, int family, bool glo
 		return 0;
 
 	for (ALL_LIST_ELEMENTS(adj->srv6_endx_sids, node, nnode, sra))
-		srv6_endx_sid_del(sra);
+		srv6_endx_sid_del(sra, true);
 
 	return 0;
 }
@@ -760,7 +811,7 @@ void isis_srv6_area_term(struct isis_area *area)
 	/* Uninstall all local SRv6 End.X SIDs */
 	if (area->srv6db.config.enabled)
 		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode, sra))
-			srv6_endx_sid_del(sra);
+			srv6_endx_sid_del(sra, true);
 
 	/* Free SRv6 Locator chunks list */
 	for (ALL_LIST_ELEMENTS(srv6db->srv6_locator_chunks, node, nnode, chunk))

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -170,7 +170,7 @@ bool isis_srv6_locator_unset(struct isis_area *area)
 		 * and release/free the SID context if it is not yes by other protocols.
 		 */
 		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END;
-		isis_zebra_release_srv6_sid(&ctx, area->srv6db.config.srv6_locator_name);
+		isis_zebra_release_srv6_sid(&ctx, area->srv6db.config.srv6_locator_name, false);
 
 		listnode_delete(area->srv6db.srv6_sids, sid);
 		isis_srv6_sid_free(sid);
@@ -378,10 +378,11 @@ static void srv6_endx_sid_unadvertise(struct srv6_adjacency *sra)
 	sra->u.endx_sid = NULL;
 }
 
-/* Return true only when the advertised SID changes. */
-bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value)
+/* Return true only when the advertised (combined) SID changes. */
+bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value,
+			  bool is_localonly)
 {
-	struct srv6_adjacency_sid *state = &sra->combined;
+	struct srv6_adjacency_sid *state = is_localonly ? &sra->localonly : &sra->combined;
 	struct isis_circuit *circuit = sra->adj->circuit;
 	struct isis_srv6_endx_sid_subtlv *adj_sid;
 	struct isis_srv6_lan_endx_sid_subtlv *ladj_sid;
@@ -389,15 +390,17 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 	struct listnode *node;
 
 	if (state->allocated && IPV6_ADDR_SAME(&state->sid, sid_value)) {
-		isis_zebra_srv6_adj_sid_install(sra);
-		if (sra->u.endx_sid)
+		isis_zebra_srv6_adj_sid_install(sra, is_localonly);
+		if (is_localonly || sra->u.endx_sid)
 			return false;
 	} else {
-		isis_zebra_srv6_adj_sid_uninstall(sra);
+		isis_zebra_srv6_adj_sid_uninstall(sra, is_localonly);
 		state->sid = *sid_value;
 		state->allocated = true;
-		isis_zebra_srv6_adj_sid_install(sra);
+		isis_zebra_srv6_adj_sid_install(sra, is_localonly);
 	}
+	if (is_localonly)
+		return false;
 
 	srv6_endx_sid_unadvertise(sra);
 	/* The circuit's sub-TLV list is shared by its L1 and L2 adjacencies. */
@@ -466,11 +469,11 @@ bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid
 }
 
 /* L1/L2 LAN adjacencies can share a single SID Manager context. */
-static bool srv6_endx_sid_shared(struct srv6_adjacency *sra)
+static bool srv6_endx_sid_shared(struct srv6_adjacency *sra, bool is_localonly)
 {
 	struct srv6_adjacency *other;
 	struct listnode *node;
-	struct srv6_adjacency_sid *state = &sra->combined;
+	struct srv6_adjacency_sid *state = is_localonly ? &sra->localonly : &sra->combined;
 	struct srv6_adjacency_sid *other_state;
 
 	for (ALL_LIST_ELEMENTS_RO(sra->adj->circuit->area->srv6db.srv6_endx_sids, node, other)) {
@@ -478,7 +481,7 @@ static bool srv6_endx_sid_shared(struct srv6_adjacency *sra)
 		    !IPV6_ADDR_SAME(&other->nexthop, &sra->nexthop) ||
 		    strcmp(other->locator->name, sra->locator->name) != 0)
 			continue;
-		other_state = &other->combined;
+		other_state = is_localonly ? &other->localonly : &other->combined;
 		if (!other_state->requested && !other_state->allocated)
 			continue;
 		/* Preserve FIB ownership even if the other allocation reply is pending. */
@@ -492,20 +495,20 @@ static bool srv6_endx_sid_shared(struct srv6_adjacency *sra)
 	return false;
 }
 
-static void srv6_endx_sid_cleanup(struct srv6_adjacency *sra, bool release)
+static void srv6_endx_sid_cleanup(struct srv6_adjacency *sra, bool is_localonly, bool release)
 {
-	struct srv6_adjacency_sid *state = &sra->combined;
+	struct srv6_adjacency_sid *state = is_localonly ? &sra->localonly : &sra->combined;
 	struct srv6_sid_ctx ctx = {};
 
-	if (srv6_endx_sid_shared(sra))
+	if (srv6_endx_sid_shared(sra, is_localonly))
 		return;
 	if (release && (state->requested || state->allocated)) {
 		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 		ctx.nh6 = sra->nexthop;
 		ctx.ifindex = sra->ifindex;
-		isis_zebra_release_srv6_sid(&ctx, sra->locator->name);
+		isis_zebra_release_srv6_sid(&ctx, sra->locator->name, is_localonly);
 	}
-	isis_zebra_srv6_adj_sid_uninstall(sra);
+	isis_zebra_srv6_adj_sid_uninstall(sra, is_localonly);
 }
 
 void srv6_endx_sid_del(struct srv6_adjacency *sra, bool release)
@@ -513,7 +516,8 @@ void srv6_endx_sid_del(struct srv6_adjacency *sra, bool release)
 	struct isis_area *area = sra->adj->circuit->area;
 
 	sr_debug("ISIS-SRv6 (%s): Delete SRv6 End.X SID", area->area_tag);
-	srv6_endx_sid_cleanup(sra, release);
+	srv6_endx_sid_cleanup(sra, false, release);
+	srv6_endx_sid_cleanup(sra, true, release);
 	srv6_endx_sid_unadvertise(sra);
 
 	if (sra->type == ISIS_SRV6_ADJ_BACKUP && sra->backup_nexthops) {

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -727,12 +727,31 @@ int isis_srv6_ifp_up_notify(struct interface *ifp)
 	return 0;
 }
 
-/**
- * Request SRv6 locator info from the SID Manager for all IS-IS areas where SRv6
- * is enabled and a locator has been configured.
- * This function is called as soon as the connection with Zebra is established
- * to get information about all configured locators.
- */
+/* Discard local state without releasing SID Manager ownership. */
+void isis_srv6_locator_reset(struct isis_area *area)
+{
+	struct listnode *node, *nnode;
+	struct isis_srv6_sid *sid;
+	struct srv6_adjacency *sra;
+	struct srv6_locator_chunk *chunk;
+
+	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_sids, node, nnode, sid)) {
+		isis_zebra_srv6_sid_uninstall(area, sid);
+		listnode_delete(area->srv6db.srv6_sids, sid);
+		isis_srv6_sid_free(sid);
+	}
+	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode, sra))
+		srv6_endx_sid_del(sra, false);
+	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_locator_chunks, node, nnode, chunk)) {
+		listnode_delete(area->srv6db.srv6_locator_chunks, chunk);
+		srv6_locator_chunk_free(&chunk);
+	}
+	srv6_locator_free(area->srv6db.srv6_locator);
+	area->srv6db.srv6_locator = NULL;
+	lsp_regenerate_schedule(area, area->is_type, 0);
+}
+
+/* Rebuild SRv6 state whenever the connection with Zebra is established. */
 void isis_srv6_locators_request(void)
 {
 	struct isis *isis = isis_lookup_by_vrfid(VRF_DEFAULT);
@@ -743,8 +762,10 @@ void isis_srv6_locators_request(void)
 
 	frr_each (isis_area_list, &isis->area_list, area)
 		if (area->srv6db.config.enabled &&
-		    area->srv6db.config.srv6_locator_name[0] != '\0' && !area->srv6db.srv6_locator)
+		    area->srv6db.config.srv6_locator_name[0] != '\0') {
+			isis_srv6_locator_reset(area);
 			isis_zebra_srv6_manager_get_locator(area->srv6db.config.srv6_locator_name);
+		}
 }
 
 /**

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -167,6 +167,7 @@ struct isis_srv6_sid *isis_srv6_sid_alloc(struct isis_area *area, struct srv6_lo
 extern void isis_srv6_sid_free(struct isis_srv6_sid *sid);
 
 void isis_srv6_locators_request(void);
+void isis_srv6_locator_reset(struct isis_area *area);
 
 extern void isis_srv6_area_init(struct isis_area *area);
 extern void isis_srv6_area_term(struct isis_area *area);

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -72,6 +72,14 @@ enum srv6_adj_type {
 	ISIS_SRV6_ADJ_BACKUP,
 };
 
+/* Allocation and FIB state of an adjacency SID. */
+struct srv6_adjacency_sid {
+	struct in6_addr sid;
+	bool requested;
+	bool allocated;
+	bool installed;
+};
+
 /* SRv6 Adjacency. */
 struct srv6_adjacency {
 	/* Adjacency type */
@@ -80,8 +88,8 @@ struct srv6_adjacency {
 	/* SID flags */
 	uint8_t flags;
 
-	/* SID value */
-	struct in6_addr sid;
+	/* Allocation and forwarding state of the advertised SID. */
+	struct srv6_adjacency_sid combined;
 
 	/* Endpoint behavior bound to the SID */
 	enum srv6_endpoint_behavior_codepoint behavior;
@@ -94,6 +102,7 @@ struct srv6_adjacency {
 
 	/* Adjacency-SID nexthop information */
 	struct in6_addr nexthop;
+	ifindex_t ifindex;
 
 	/* End.X SID TI-LFA backup nexthops */
 	struct list *backup_nexthops;
@@ -172,9 +181,9 @@ void isis_srv6_end_sid2subtlv(const struct isis_srv6_sid *sid,
 void isis_srv6_locator2tlv(const struct isis_srv6_locator *loc,
 			   struct isis_srv6_locator_tlv *loc_tlv);
 
-void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup, struct list *nexthops,
-			      struct in6_addr *sid_value);
-void srv6_endx_sid_add(struct isis_adjacency *adj, struct in6_addr *sid_value);
+struct srv6_adjacency *srv6_endx_sid_alloc(struct isis_adjacency *adj, bool backup,
+					   struct list *nexthops);
+bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value);
 void srv6_endx_sid_del(struct srv6_adjacency *sra);
 struct srv6_adjacency *isis_srv6_endx_sid_find(struct isis_adjacency *adj, enum srv6_adj_type type);
 void isis_area_delete_backup_srv6_endx_sids(struct isis_area *area, int level);

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -72,7 +72,7 @@ enum srv6_adj_type {
 	ISIS_SRV6_ADJ_BACKUP,
 };
 
-/* Allocation and FIB state of an adjacency SID. */
+/* Allocation and FIB state of one representation of an adjacency SID. */
 struct srv6_adjacency_sid {
 	struct in6_addr sid;
 	bool requested;
@@ -88,8 +88,9 @@ struct srv6_adjacency {
 	/* SID flags */
 	uint8_t flags;
 
-	/* Allocation and forwarding state of the advertised SID. */
+	/* Only the combined representation is advertised in IS-IS. */
 	struct srv6_adjacency_sid combined;
+	struct srv6_adjacency_sid localonly;
 
 	/* Endpoint behavior bound to the SID */
 	enum srv6_endpoint_behavior_codepoint behavior;
@@ -183,7 +184,8 @@ void isis_srv6_locator2tlv(const struct isis_srv6_locator *loc,
 
 struct srv6_adjacency *srv6_endx_sid_alloc(struct isis_adjacency *adj, bool backup,
 					   struct list *nexthops);
-bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value);
+bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value,
+			  bool is_localonly);
 void srv6_endx_sid_del(struct srv6_adjacency *sra, bool release);
 struct srv6_adjacency *isis_srv6_endx_sid_find(struct isis_adjacency *adj, enum srv6_adj_type type);
 void isis_area_delete_backup_srv6_endx_sids(struct isis_area *area, int level);

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -184,7 +184,7 @@ void isis_srv6_locator2tlv(const struct isis_srv6_locator *loc,
 struct srv6_adjacency *srv6_endx_sid_alloc(struct isis_adjacency *adj, bool backup,
 					   struct list *nexthops);
 bool srv6_endx_sid_update(struct srv6_adjacency *sra, const struct in6_addr *sid_value);
-void srv6_endx_sid_del(struct srv6_adjacency *sra);
+void srv6_endx_sid_del(struct srv6_adjacency *sra, bool release);
 struct srv6_adjacency *isis_srv6_endx_sid_find(struct isis_adjacency *adj, enum srv6_adj_type type);
 void isis_area_delete_backup_srv6_endx_sids(struct isis_area *area, int level);
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1536,7 +1536,7 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 
 	/* Decode the received notification message */
 	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr,
-					 &sid_func, NULL, &note, NULL, 0)) {
+					 &sid_func, NULL, &note, NULL, 0, NULL)) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -701,7 +701,17 @@ void isis_zebra_request_srv6_sid_endx(struct isis_adjacency *adj)
 	ctx.ifindex = sra->ifindex;
 	if (!sra->combined.requested && !sra->combined.allocated) {
 		sra->combined.requested = isis_zebra_request_srv6_sid(&ctx, &sid_value,
-								    sra->locator->name);
+								      sra->locator->name, false);
+	}
+	/* Formatted uSID locators have disjoint Global/Local CSID ranges.
+	 * Both representations use the same context, hence the same function.
+	 */
+	if (sra->behavior == SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID &&
+	    (CHECK_FLAG(sra->locator->flags, SRV6_LOCATOR_F3216) ||
+	     CHECK_FLAG(sra->locator->flags, SRV6_LOCATOR_F4816)) &&
+	    !sra->localonly.requested && !sra->localonly.allocated) {
+		sra->localonly.requested = isis_zebra_request_srv6_sid(&ctx, &sid_value,
+								       sra->locator->name, true);
 	}
 }
 
@@ -719,8 +729,8 @@ static void request_srv6_sids(struct isis_area *area)
 
 	/* Request new SRv6 End SID */
 	ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END;
-	ret = isis_zebra_request_srv6_sid(&ctx, &sid_value,
-					  area->srv6db.config.srv6_locator_name);
+	ret = isis_zebra_request_srv6_sid(&ctx, &sid_value, area->srv6db.config.srv6_locator_name,
+					  false);
 	if (!ret) {
 		zlog_err("%s: not allocated new End SID for IS-IS area %s",
 			 __func__, area->area_tag);
@@ -1113,7 +1123,7 @@ void isis_zebra_srv6_sid_uninstall(struct isis_area *area,
 			      action, &ctx);
 }
 
-void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
+void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra, bool is_localonly)
 {
 	enum seg6local_action_t action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
 	struct seg6local_context ctx = {};
@@ -1124,12 +1134,18 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 
 	if (!sra)
 		return;
-	state = &sra->combined;
+	state = is_localonly ? &sra->localonly : &sra->combined;
 	if (!state->allocated || state->installed)
 		return;
 
 	circuit = sra->adj->circuit;
 	area = circuit->area;
+	if (!isis_zebra_srv6_sid_structure_to_context(&ctx, &sra->structure)) {
+		zlog_warn("ISIS-SRv6 (%s): invalid SID structure", area->area_tag);
+		return;
+	}
+	if (is_localonly)
+		ctx.node_len = 0;
 
 	sr_debug("ISIS-SRv6 (%s): setting adjacency SID %pI6", area->area_tag, &state->sid);
 
@@ -1142,14 +1158,13 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID:
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_X;
-		prefixlen = sra->structure.loc_block_len + sra->structure.loc_node_len +
-			    sra->structure.func_len;
+		prefixlen = ctx.block_len + ctx.node_len + ctx.function_len;
 		ctx.nh6 = sra->nexthop;
 		ctx.ifindex = sra->ifindex;
 		SET_SRV6_FLV_OP(ctx.flv.flv_ops,
 				ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
-		ctx.flv.lcblock_len = sra->structure.loc_block_len;
-		ctx.flv.lcnode_func_len = sra->structure.loc_node_len + sra->structure.func_len;
+		ctx.flv.lcblock_len = ctx.block_len;
+		ctx.flv.lcnode_func_len = ctx.node_len + ctx.function_len;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_RESERVED:
 	case SRV6_ENDPOINT_BEHAVIOR_END:
@@ -1180,17 +1195,12 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 		return;
 	}
 
-	if (!isis_zebra_srv6_sid_structure_to_context(&ctx, &sra->structure)) {
-		zlog_warn("ISIS-SRv6 (%s): invalid SID structure", area->area_tag);
-		return;
-	}
-
 	state->installed = zclient_send_localsid(isis_zclient, ZEBRA_ROUTE_ADD, &state->sid,
 						 prefixlen, sra->ifindex, action,
 						 &ctx) != ZCLIENT_SEND_FAILURE;
 }
 
-void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
+void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra, bool is_localonly)
 {
 	enum seg6local_action_t action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
 	struct seg6local_context ctx = {};
@@ -1201,20 +1211,25 @@ void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
 
 	if (!sra)
 		return;
-	state = &sra->combined;
+	state = is_localonly ? &sra->localonly : &sra->combined;
 	if (!state->installed)
 		return;
 
 	circuit = sra->adj->circuit;
 	area = circuit->area;
+	if (!isis_zebra_srv6_sid_structure_to_context(&ctx, &sra->structure)) {
+		zlog_warn("ISIS-SRv6 (%s): invalid SID structure", area->area_tag);
+		return;
+	}
+	if (is_localonly)
+		ctx.node_len = 0;
 
 	switch (sra->behavior) {
 	case SRV6_ENDPOINT_BEHAVIOR_END_X:
 		prefixlen = IPV6_MAX_BITLEN;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID:
-		prefixlen = sra->structure.loc_block_len + sra->structure.loc_node_len +
-			    sra->structure.func_len;
+		prefixlen = ctx.block_len + ctx.node_len + ctx.function_len;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_RESERVED:
 	case SRV6_ENDPOINT_BEHAVIOR_END:
@@ -1242,11 +1257,6 @@ void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
 		zlog_err(
 			"ISIS-SRv6 (%s): unsupported SRv6 endpoint behavior %u",
 			area->area_tag, sra->behavior);
-		return;
-	}
-
-	if (!isis_zebra_srv6_sid_structure_to_context(&ctx, &sra->structure)) {
-		zlog_warn("ISIS-SRv6 (%s): invalid SID structure", area->area_tag);
 		return;
 	}
 
@@ -1464,10 +1474,10 @@ int isis_zebra_srv6_manager_get_locator(const char *name)
  * @param ctx Context to be associated with the request SID
  * @param sid_value IPv6 address to be associated with the requested SID (optional)
  * @param locator_name Name of the locator from which the SID must be allocated
+ * @param is_localonly Request the block:function representation
  */
-bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx,
-				 struct in6_addr *sid_value,
-				 const char *locator_name)
+bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx, struct in6_addr *sid_value,
+				 const char *locator_name, bool is_localonly)
 {
 	int ret;
 
@@ -1478,7 +1488,7 @@ bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx,
 	 * Send the Get SRv6 SID request to the SRv6 Manager and check the
 	 * result
 	 */
-	ret = srv6_manager_get_sid(isis_zclient, ctx, sid_value, locator_name, NULL, false);
+	ret = srv6_manager_get_sid(isis_zclient, ctx, sid_value, locator_name, NULL, is_localonly);
 	if (ret < 0) {
 		zlog_warn("%s: error getting SRv6 SID!", __func__);
 		return false;
@@ -1495,8 +1505,10 @@ bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx,
  *
  * @param ctx Context to be associated with the SID to be released
  * @param locator_name Parent locator of the SID
+ * @param is_localonly Release the block:function representation
  */
-void isis_zebra_release_srv6_sid(const struct srv6_sid_ctx *ctx, const char *locator_name)
+void isis_zebra_release_srv6_sid(const struct srv6_sid_ctx *ctx, const char *locator_name,
+				 bool is_localonly)
 {
 	int ret;
 
@@ -1507,7 +1519,7 @@ void isis_zebra_release_srv6_sid(const struct srv6_sid_ctx *ctx, const char *loc
 	 * Send the Release SRv6 SID request to the SRv6 Manager and check the
 	 * result
 	 */
-	ret = srv6_manager_release_sid(isis_zclient, ctx, locator_name, false);
+	ret = srv6_manager_release_sid(isis_zclient, ctx, locator_name, is_localonly);
 	if (ret < 0) {
 		zlog_warn("%s: error releasing SRv6 SID!", __func__);
 		return;
@@ -1524,8 +1536,10 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 	struct isis_area *area;
 	struct listnode *node, *nnode;
 	char buf[256];
+	char locator_name[SRV6_LOCNAME_SIZE];
+	uint8_t flags;
+	bool is_localonly;
 	struct srv6_locator *locator;
-	struct prefix_ipv6 tmp_prefix;
 	struct srv6_adjacency *sra;
 	struct srv6_adjacency_sid *state;
 	enum srv6_endpoint_behavior_codepoint behavior;
@@ -1535,11 +1549,12 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 		return -1;
 
 	/* Decode the received notification message */
-	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr,
-					 &sid_func, NULL, &note, NULL, 0, NULL)) {
+	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr, &sid_func, NULL, &note,
+					 locator_name, sizeof(locator_name), &flags)) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}
+	is_localonly = CHECK_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_IS_LOCALONLY);
 
 	sr_debug("%s: received SRv6 SID notify: ctx %s sid_value %pI6 sid_func %u note %s",
 		 __func__, srv6_sid_ctx2str(buf, sizeof(buf), &ctx), &sid_addr,
@@ -1550,19 +1565,9 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 			continue;
 
 		locator = area->srv6db.srv6_locator;
-		/* Verify that the received SID belongs to the configured locator */
-		if (note == ZAPI_SRV6_SID_ALLOCATED) {
-			tmp_prefix.family = AF_INET6;
-			tmp_prefix.prefixlen = IPV6_MAX_BITLEN;
-			tmp_prefix.prefix = sid_addr;
-
-			if (!prefix_match((struct prefix *)&locator->prefix,
-					  (struct prefix *)&tmp_prefix)) {
-				sr_debug("%s : ignoring SRv6 SID notify: locator (area %s) does not match",
-					 __func__, area->area_tag);
-				continue;
-			}
-		}
+		/* Local-only SIDs belong to the locator block, not its node prefix. */
+		if (strcmp(locator->name, locator_name) != 0)
+			continue;
 
 		if (ctx.behavior == ZEBRA_SEG6_LOCAL_ACTION_END_X) {
 			for (ALL_LIST_ELEMENTS_RO(area->srv6db.srv6_endx_sids, node, sra)) {
@@ -1571,12 +1576,12 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 				    sra->ifindex != ctx.ifindex ||
 				    !IPV6_ADDR_SAME(&sra->nexthop, &ctx.nh6))
 					continue;
-				state = &sra->combined;
+				state = is_localonly ? &sra->localonly : &sra->combined;
 				if (!state->requested && !state->allocated)
 					continue;
 				if (note == ZAPI_SRV6_SID_ALLOCATED) {
 					state->requested = false;
-					if (srv6_endx_sid_update(sra, &sid_addr))
+					if (srv6_endx_sid_update(sra, &sid_addr, is_localonly))
 						lsp_regenerate_schedule(area, area->is_type, 0);
 				} else if (note == ZAPI_SRV6_SID_FAIL_ALLOC) {
 					state->requested = false;
@@ -1584,6 +1589,8 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 			}
 			continue;
 		}
+		if (is_localonly)
+			continue;
 
 		/* Handle notification */
 		switch (note) {

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1303,7 +1303,7 @@ static int isis_zebra_process_srv6_locator_internal(struct srv6_locator *locator
 			 locator->name, &locator->prefix, area->area_tag);
 
 		if (area->srv6db.srv6_locator)
-			srv6_locator_free(area->srv6db.srv6_locator);
+			isis_srv6_locator_reset(area);
 
 		/* Store the locator in the IS-IS area */
 		area->srv6db.srv6_locator = srv6_locator_alloc(locator->name);
@@ -1347,10 +1347,6 @@ static int isis_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	struct isis *isis = isis_lookup_by_vrfid(VRF_DEFAULT);
 	struct srv6_locator loc = {};
 	struct isis_area *area;
-	struct listnode *node, *nnode;
-	struct srv6_locator_chunk *chunk;
-	struct isis_srv6_sid *sid;
-	struct srv6_adjacency *sra;
 
 	if (!isis)
 		return -1;
@@ -1372,46 +1368,7 @@ static int isis_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			    sizeof(area->srv6db.config.srv6_locator_name)) != 0)
 			continue;
 
-		/* Delete SRv6 SIDs */
-		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_sids, node, nnode,
-				       sid)) {
-
-			sr_debug(
-				"Deleting SRv6 SID (locator %s, sid %pI6) from IS-IS area %s",
-				area->srv6db.config.srv6_locator_name,
-				&sid->sid, area->area_tag);
-
-			/* Uninstall the SRv6 SID from the forwarding plane
-			 * through Zebra */
-			isis_zebra_srv6_sid_uninstall(area, sid);
-
-			listnode_delete(area->srv6db.srv6_sids, sid);
-			isis_srv6_sid_free(sid);
-		}
-
-		/* Uninstall all local Adjacency-SIDs. */
-		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode,
-				       sra))
-			srv6_endx_sid_del(sra, false);
-
-		/* Free the SRv6 locator chunks */
-		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_locator_chunks, node,
-				       nnode, chunk)) {
-			if (prefix_match((struct prefix *)&loc.prefix,
-					 (struct prefix *)&chunk->prefix)) {
-				listnode_delete(
-					area->srv6db.srv6_locator_chunks,
-					chunk);
-				srv6_locator_chunk_free(&chunk);
-			}
-		}
-
-		srv6_locator_free(area->srv6db.srv6_locator);
-		area->srv6db.srv6_locator = NULL;
-
-		/* Regenerate LSPs to advertise that the locator no longer
-		 * exists */
-		lsp_regenerate_schedule(area, area->is_type, 0);
+		isis_srv6_locator_reset(area);
 	}
 
 	return 0;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1382,7 +1382,7 @@ static int isis_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 		/* Uninstall all local Adjacency-SIDs. */
 		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode,
 				       sra))
-			srv6_endx_sid_del(sra);
+			srv6_endx_sid_del(sra, false);
 
 		/* Free the SRv6 locator chunks */
 		for (ALL_LIST_ELEMENTS(area->srv6db.srv6_locator_chunks, node,

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -678,29 +678,30 @@ void isis_zebra_request_srv6_sid_endx(struct isis_adjacency *adj)
 {
 	struct isis_circuit *circuit = adj->circuit;
 	struct isis_area *area = circuit->area;
-	struct in6_addr nexthop;
 	struct srv6_sid_ctx ctx = {};
 	struct in6_addr sid_value = {};
-	bool ret;
+	struct srv6_adjacency *sra;
 
-	if (!area || !area->srv6db.srv6_locator)
+	if (!area || !area->srv6db.config.enabled || !area->srv6db.srv6_locator ||
+	    adj->adj_state != ISIS_ADJ_UP)
 		return;
 
 	/* Determine nexthop IP address */
 	if (!circuit->ipv6_router || !adj->ll_ipv6_count)
 		return;
 
-	nexthop = adj->ll_ipv6_addrs[0];
+	sra = isis_srv6_endx_sid_find(adj, ISIS_SRV6_ADJ_NORMAL);
+	if (!sra)
+		sra = srv6_endx_sid_alloc(adj, false, NULL);
+	if (!sra)
+		return;
 
 	ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
-	ctx.nh6 = nexthop;
-	ctx.ifindex = circuit->interface->ifindex;
-	ret = isis_zebra_request_srv6_sid(&ctx, &sid_value,
-					  area->srv6db.config.srv6_locator_name);
-	if (!ret) {
-		zlog_err("%s: not allocated new End.X SID for IS-IS area %s",
-			 __func__, area->area_tag);
-		return;
+	ctx.nh6 = sra->nexthop;
+	ctx.ifindex = sra->ifindex;
+	if (!sra->combined.requested && !sra->combined.allocated) {
+		sra->combined.requested = isis_zebra_request_srv6_sid(&ctx, &sid_value,
+								    sra->locator->name);
 	}
 }
 
@@ -1117,38 +1118,38 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 	enum seg6local_action_t action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
 	struct seg6local_context ctx = {};
 	uint16_t prefixlen = IPV6_MAX_BITLEN;
-	struct interface *ifp;
 	struct isis_circuit *circuit;
 	struct isis_area *area;
+	struct srv6_adjacency_sid *state;
 
 	if (!sra)
+		return;
+	state = &sra->combined;
+	if (!state->allocated || state->installed)
 		return;
 
 	circuit = sra->adj->circuit;
 	area = circuit->area;
 
-	sr_debug("ISIS-SRv6 (%s): setting adjacency SID %pI6", area->area_tag,
-		 &sra->sid);
+	sr_debug("ISIS-SRv6 (%s): setting adjacency SID %pI6", area->area_tag, &state->sid);
 
 	switch (sra->behavior) {
 	case SRV6_ENDPOINT_BEHAVIOR_END_X:
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 		prefixlen = IPV6_MAX_BITLEN;
 		ctx.nh6 = sra->nexthop;
-		ctx.ifindex = sra->adj->circuit->interface->ifindex;
+		ctx.ifindex = sra->ifindex;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID:
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_X;
-		prefixlen = sra->locator->block_bits_length +
-			    sra->locator->node_bits_length +
-			    sra->locator->function_bits_length;
+		prefixlen = sra->structure.loc_block_len + sra->structure.loc_node_len +
+			    sra->structure.func_len;
 		ctx.nh6 = sra->nexthop;
-		ctx.ifindex = sra->adj->circuit->interface->ifindex;
+		ctx.ifindex = sra->ifindex;
 		SET_SRV6_FLV_OP(ctx.flv.flv_ops,
 				ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
-		ctx.flv.lcblock_len = sra->locator->block_bits_length;
-		ctx.flv.lcnode_func_len = sra->locator->node_bits_length +
-					  sra->locator->function_bits_length;
+		ctx.flv.lcblock_len = sra->structure.loc_block_len;
+		ctx.flv.lcnode_func_len = sra->structure.loc_node_len + sra->structure.func_len;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_RESERVED:
 	case SRV6_ENDPOINT_BEHAVIOR_END:
@@ -1184,22 +1185,24 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 		return;
 	}
 
-	ifp = sra->adj->circuit->interface;
-
-	zclient_send_localsid(isis_zclient, ZEBRA_ROUTE_ADD, &sra->sid, prefixlen, ifp->ifindex,
-			      action, &ctx);
+	state->installed = zclient_send_localsid(isis_zclient, ZEBRA_ROUTE_ADD, &state->sid,
+						 prefixlen, sra->ifindex, action,
+						 &ctx) != ZCLIENT_SEND_FAILURE;
 }
 
 void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
 {
 	enum seg6local_action_t action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
 	struct seg6local_context ctx = {};
-	struct interface *ifp;
 	uint16_t prefixlen = IPV6_MAX_BITLEN;
 	struct isis_circuit *circuit;
 	struct isis_area *area;
+	struct srv6_adjacency_sid *state;
 
 	if (!sra)
+		return;
+	state = &sra->combined;
+	if (!state->installed)
 		return;
 
 	circuit = sra->adj->circuit;
@@ -1210,9 +1213,8 @@ void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
 		prefixlen = IPV6_MAX_BITLEN;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID:
-		prefixlen = sra->locator->block_bits_length +
-			    sra->locator->node_bits_length +
-			    sra->locator->function_bits_length;
+		prefixlen = sra->structure.loc_block_len + sra->structure.loc_node_len +
+			    sra->structure.func_len;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_RESERVED:
 	case SRV6_ENDPOINT_BEHAVIOR_END:
@@ -1248,13 +1250,11 @@ void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
 		return;
 	}
 
-	ifp = sra->adj->circuit->interface;
+	sr_debug("ISIS-SRv6 (%s): delete End.X SID %pI6", area->area_tag, &state->sid);
 
-	sr_debug("ISIS-SRv6 (%s): delete End.X SID %pI6", area->area_tag,
-		 &sra->sid);
-
-	zclient_send_localsid(isis_zclient, ZEBRA_ROUTE_DELETE, &sra->sid, prefixlen, ifp->ifindex,
-			      action, &ctx);
+	zclient_send_localsid(isis_zclient, ZEBRA_ROUTE_DELETE, &state->sid, prefixlen,
+			      sra->ifindex, action, &ctx);
+	state->installed = false;
 }
 
 /**
@@ -1527,9 +1527,9 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 	struct srv6_locator *locator;
 	struct prefix_ipv6 tmp_prefix;
 	struct srv6_adjacency *sra;
+	struct srv6_adjacency_sid *state;
 	enum srv6_endpoint_behavior_codepoint behavior;
 	struct isis_srv6_sid *sid;
-	struct isis_adjacency *adj;
 
 	if (!isis)
 		return -1;
@@ -1550,7 +1550,6 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 			continue;
 
 		locator = area->srv6db.srv6_locator;
-
 		/* Verify that the received SID belongs to the configured locator */
 		if (note == ZAPI_SRV6_SID_ALLOCATED) {
 			tmp_prefix.family = AF_INET6;
@@ -1563,6 +1562,27 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 					 __func__, area->area_tag);
 				continue;
 			}
+		}
+
+		if (ctx.behavior == ZEBRA_SEG6_LOCAL_ACTION_END_X) {
+			for (ALL_LIST_ELEMENTS_RO(area->srv6db.srv6_endx_sids, node, sra)) {
+				if (sra->type != ISIS_SRV6_ADJ_NORMAL ||
+				    sra->adj->adj_state != ISIS_ADJ_UP ||
+				    sra->ifindex != ctx.ifindex ||
+				    !IPV6_ADDR_SAME(&sra->nexthop, &ctx.nh6))
+					continue;
+				state = &sra->combined;
+				if (!state->requested && !state->allocated)
+					continue;
+				if (note == ZAPI_SRV6_SID_ALLOCATED) {
+					state->requested = false;
+					if (srv6_endx_sid_update(sra, &sid_addr))
+						lsp_regenerate_schedule(area, area->is_type, 0);
+				} else if (note == ZAPI_SRV6_SID_FAIL_ALLOC) {
+					state->requested = false;
+				}
+			}
+			continue;
 		}
 
 		/* Handle notification */
@@ -1603,26 +1623,6 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 				/* Store the SID */
 				listnode_add(area->srv6db.srv6_sids, sid);
 
-			} else if (ctx.behavior ==
-				   ZEBRA_SEG6_LOCAL_ACTION_END_X) {
-				frr_each (isis_area_adj_list, &area->adjacency_list, adj) {
-					/* Check if the End.X SID is for this adjacecny */
-					if (adj->ll_ipv6_count == 0 ||
-					    memcmp(&adj->ll_ipv6_addrs[0],
-						   &ctx.nh6,
-						   sizeof(struct in6_addr)) != 0)
-						continue;
-
-					/* Remove old End.X SIDs, if any */
-					for (ALL_LIST_ELEMENTS(adj->srv6_endx_sids,
-							       node, nnode, sra))
-						srv6_endx_sid_del(sra);
-
-					/* Allocate new End.X SID for the adjacency */
-					srv6_endx_sid_add_single(adj, false,
-								 NULL,
-								 &sid_addr);
-				}
 			} else {
 				zlog_warn("%s: unsupported behavior %u",
 					  __func__, ctx.behavior);

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -63,17 +63,17 @@ extern void isis_zebra_srv6_sid_install(struct isis_area *area,
 extern void isis_zebra_srv6_sid_uninstall(struct isis_area *area,
 					  struct isis_srv6_sid *sid);
 
-void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra);
-void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra);
+void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra, bool is_localonly);
+void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra, bool is_localonly);
 
 extern int isis_zebra_srv6_manager_get_locator_chunk(const char *name);
 extern int isis_zebra_srv6_manager_release_locator_chunk(const char *name);
 
 extern int isis_zebra_srv6_manager_get_locator(const char *name);
 extern void isis_zebra_request_srv6_sid_endx(struct isis_adjacency *adj);
-extern bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx,
-					struct in6_addr *sid_value,
-					const char *locator_name);
-extern void isis_zebra_release_srv6_sid(const struct srv6_sid_ctx *ctx, const char *locator_name);
+extern bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx, struct in6_addr *sid_value,
+					const char *locator_name, bool is_localonly);
+extern void isis_zebra_release_srv6_sid(const struct srv6_sid_ctx *ctx, const char *locator_name,
+					bool is_localonly);
 
 #endif /* _ZEBRA_ISIS_ZEBRA_H */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2367,12 +2367,13 @@ stream_failure:
 }
 
 bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
-				 struct in6_addr *sid_value, uint32_t *func,
-				 uint32_t *wide_func, enum zapi_srv6_sid_notify *note,
-				 char *locator_name, size_t loc_size)
+				 struct in6_addr *sid_value, uint32_t *func, uint32_t *wide_func,
+				 enum zapi_srv6_sid_notify *note, char *locator_name,
+				 size_t loc_size, uint8_t *flags)
 {
 	uint32_t f, wf;
 	uint16_t len = 0;
+	uint8_t sid_flags = 0;
 
 	STREAM_GET(note, s, sizeof(*note));
 	STREAM_GET(ctx, s, sizeof(struct srv6_sid_ctx));
@@ -2403,6 +2404,12 @@ bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
 		/* Advance the stream */
 		STREAM_FORWARD_GETP(s, len);
 	}
+
+	/* Older notifications have no representation flags. */
+	if (STREAM_READABLE(s) > 0)
+		STREAM_GETC(s, sid_flags);
+	if (flags)
+		*flags = sid_flags;
 
 	return true;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1215,9 +1215,9 @@ bool zapi_ipset_notify_decode(struct stream *s,
 
 /* Normally use SRV6_LOCNAME_SIZE for the locator name buffer */
 bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
-				 struct in6_addr *sid_value, uint32_t *func,
-				 uint32_t *wide_func, enum zapi_srv6_sid_notify *note,
-				 char *locator_name, size_t loc_size);
+				 struct in6_addr *sid_value, uint32_t *func, uint32_t *wide_func,
+				 enum zapi_srv6_sid_notify *note, char *locator_name,
+				 size_t loc_size, uint8_t *flags);
 
 /* Nexthop-group message apis */
 extern enum zclient_send_status

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -1400,7 +1400,7 @@ static int static_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 
 	/* Decode the received notification message */
 	if (!zapi_srv6_sid_notify_decode(zclient->ibuf, &ctx, &sid_addr, &sid_func, NULL, &note,
-					 NULL, 0)) {
+					 NULL, 0, NULL)) {
 		zlog_err("%s : error in msg decode", __func__);
 		return -1;
 	}

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -333,6 +333,14 @@ tests_lib_test_srcdest_table_SOURCES = tests/lib/test_srcdest_table.c tests/help
 EXTRA_DIST += tests/lib/test_srcdest_table.py
 
 
+check_PROGRAMS += tests/lib/test_srv6_sid_notify
+tests_lib_test_srv6_sid_notify_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_srv6_sid_notify_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_srv6_sid_notify_LDADD = $(ALL_TESTS_LDADD)
+tests_lib_test_srv6_sid_notify_SOURCES = tests/lib/test_srv6_sid_notify.c
+EXTRA_DIST += tests/lib/test_srv6_sid_notify.py
+
+
 check_PROGRAMS += tests/lib/test_stream
 tests_lib_test_stream_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_stream_CPPFLAGS = $(TESTS_CPPFLAGS)

--- a/tests/lib/test_srv6_sid_notify.c
+++ b/tests/lib/test_srv6_sid_notify.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* SRv6 SID notification representation flags. */
+
+#include <zebra.h>
+
+#include "stream.h"
+#include "zclient.h"
+
+static const char locator_name[] = "MAIN";
+
+static struct stream *notification(bool with_flags)
+{
+	struct stream *s = stream_new(256);
+	struct srv6_sid_ctx ctx = {0};
+	struct in6_addr sid = IN6ADDR_ANY_INIT;
+	enum zapi_srv6_sid_notify note = ZAPI_SRV6_SID_ALLOCATED;
+
+	stream_put(s, &note, sizeof(note));
+	stream_put(s, &ctx, sizeof(ctx));
+	stream_put(s, &sid, sizeof(sid));
+	stream_putl(s, 0xe000);
+	stream_putl(s, 0);
+	stream_putw(s, sizeof(locator_name) - 1);
+	stream_put(s, locator_name, sizeof(locator_name) - 1);
+	if (with_flags)
+		stream_putc(s, ZAPI_SRV6_MANAGER_SID_FLAG_IS_LOCALONLY);
+
+	return s;
+}
+
+int main(void)
+{
+	struct srv6_sid_ctx ctx;
+	struct in6_addr sid;
+	enum zapi_srv6_sid_notify note;
+	char locator[sizeof(locator_name)];
+	uint8_t flags = 0;
+	struct stream *s;
+
+	s = notification(true);
+	assert(zapi_srv6_sid_notify_decode(s, &ctx, &sid, NULL, NULL, &note,
+					   locator, sizeof(locator), &flags));
+	assert(!strcmp(locator, locator_name));
+	assert(flags == ZAPI_SRV6_MANAGER_SID_FLAG_IS_LOCALONLY);
+	stream_free(s);
+	printf("Local-only flag decoded after locator.\n");
+
+	s = notification(false);
+	flags = UINT8_MAX;
+	assert(zapi_srv6_sid_notify_decode(s, &ctx, &sid, NULL, NULL, &note,
+					   locator, sizeof(locator), &flags));
+	assert(flags == 0);
+	stream_free(s);
+	printf("Legacy notification defaults to zero flags.\n");
+
+	s = notification(true);
+	assert(zapi_srv6_sid_notify_decode(s, &ctx, &sid, NULL, NULL, &note,
+					   NULL, 0, NULL));
+	assert(STREAM_READABLE(s) == 0);
+	stream_free(s);
+	printf("Unused locator and flags are consumed.\n");
+
+	return 0;
+}

--- a/tests/lib/test_srv6_sid_notify.py
+++ b/tests/lib/test_srv6_sid_notify.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+import frrtest
+
+
+class TestSrv6SidNotify(frrtest.TestMultiOut):
+    program = "./test_srv6_sid_notify"
+
+
+TestSrv6SidNotify.onesimple("Local-only flag decoded after locator.")
+TestSrv6SidNotify.onesimple("Legacy notification defaults to zero flags.")
+TestSrv6SidNotify.onesimple("Unused locator and flags are consumed.")

--- a/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
+++ b/tests/topotests/bgp_link_state_srv6/bgp_ls_nlri_srv6.json
@@ -369,7 +369,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -400,7 +400,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -431,7 +431,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -462,7 +462,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -493,7 +493,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -524,7 +524,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -555,7 +555,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -586,7 +586,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -617,7 +617,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -648,7 +648,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -679,7 +679,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -710,7 +710,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -741,7 +741,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]
@@ -772,7 +772,7 @@
 									"lbLen": 32,
 									"lnLen": 16,
 									"funLen": 16,
-									"argLen": 0
+									"argLen": 64
 								}
 							}
 						]

--- a/tests/topotests/isis_srv6_topo1/rt2/step1/show_isis_database_detail.ref
+++ b/tests/topotests/isis_srv6_topo1/rt2/step1/show_isis_database_detail.ref
@@ -31,7 +31,7 @@
                         "locBlockLen":32,
                         "locNodeLen":16,
                         "funcLen":16,
-                        "argLen":0
+                        "argLen":64
                       }
                     }
                   ]

--- a/tests/topotests/isis_srv6_ua/__init__.py
+++ b/tests/topotests/isis_srv6_ua/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: ISC

--- a/tests/topotests/isis_srv6_ua/probe_ua.py
+++ b/tests/topotests/isis_srv6_ua/probe_ua.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: ISC
+
+"""Send directly to a uA SID and observe its rewritten packet on the same LAN."""
+
+import sys
+
+from scapy.all import Ether, IPv6, Raw, conf, get_if_hwaddr
+
+
+def main():
+    interface, router_mac, destination, expected = sys.argv[1:]
+    peer_mac = get_if_hwaddr(interface)
+    source = "2001:db8::2"
+    payload = b"isis-ua-next-csid:" + destination.encode()
+    packet = (
+        Ether(src=peer_mac, dst=router_mac)
+        / IPv6(src=source, dst=destination, hlim=64, nh=59)
+        / Raw(payload)
+    )
+
+    # Open capture before sending; no readiness sleeps or background processes.
+    with conf.L2socket(iface=interface) as sock:
+        sock.send(packet)
+        received = sock.sniff(
+            timeout=5,
+            count=1,
+            lfilter=lambda p: Ether in p
+            and p[Ether].src == router_mac
+            and IPv6 in p
+            and p[IPv6].src == source,
+        )
+
+    assert received, f"No uA packet returned for {destination}"
+    forwarded = received[0]
+    assert forwarded[Ether].dst == peer_mac, forwarded.show(dump=True)
+    assert forwarded[IPv6].dst == expected, forwarded.show(dump=True)
+    assert forwarded[IPv6].hlim == 63, forwarded.show(dump=True)
+    assert bytes(forwarded[IPv6].payload) == payload, forwarded.show(dump=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/topotests/isis_srv6_ua/r1/frr.conf
+++ b/tests/topotests/isis_srv6_ua/r1/frr.conf
@@ -1,0 +1,26 @@
+hostname r1
+!
+interface r1-eth0
+ ipv6 address fe80::1/64
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+!
+segment-routing
+ srv6
+  locators
+   locator MAIN
+    prefix 2001:db8:1::/48 block-len 32 node-len 16 func-bits 16
+    format usid-f3216
+    behavior usid
+!
+router isis 1
+ net 49.0000.0000.0000.0001.00
+ is-type level-1-2
+ metric-style wide
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ segment-routing srv6
+  locator MAIN
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_ua/r2/frr.conf
+++ b/tests/topotests/isis_srv6_ua/r2/frr.conf
@@ -1,0 +1,15 @@
+hostname r2
+!
+interface r2-eth0
+ ipv6 address fe80::2/64
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+!
+router isis 1
+ net 49.0000.0000.0000.0002.00
+ is-type level-1-2
+ metric-style wide
+ topology ipv6-unicast
+ lsp-gen-interval 1
+!

--- a/tests/topotests/isis_srv6_ua/test_isis_srv6_ua.py
+++ b/tests/topotests/isis_srv6_ua/test_isis_srv6_ua.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""IS-IS uA: one advertised SID, two local representations, shared lifetime.
+
+r1 (MAIN, usid-f3216/usid-f4816) --- LAN --- r2 (LSDB observer)
+
+The LAN's L1 and L2 adjacencies share one nexthop/context. Packet probes
+exercise only the two uA representations, not generic IS-IS/SRv6 forwarding.
+"""
+
+from collections import namedtuple
+import functools
+import ipaddress
+import os
+import shlex
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, ".."))
+
+from lib import topotest
+from lib.common_config import required_linux_kernel_version
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.isisd]
+
+SidFormat = namedtuple("SidFormat", "name block node_prefix arg_len")
+F3216 = SidFormat(
+    "usid-f3216",
+    ipaddress.IPv6Network("2001:db8::/32"),
+    ipaddress.IPv6Network("2001:db8:1::/48"),
+    64,
+)
+F4816 = SidFormat(
+    "usid-f4816",
+    ipaddress.IPv6Network("2001:db8:cccc::/48"),
+    ipaddress.IPv6Network("2001:db8:cccc:1::/64"),
+    48,
+)
+
+
+def build_topo(tgen):
+    switch = tgen.add_switch("s1")
+    for name in ("r1", "r2"):
+        switch.add_link(tgen.add_router(name))
+
+
+def setup_module(mod):
+    if required_linux_kernel_version("6.17") is not True:
+        pytest.skip("uA kernel installation requires Linux >= 6.17")
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+    for name, router in tgen.routers().items():
+        # Use only the explicit link-local addresses from frr.conf.
+        router.cmd_raises(f"sysctl -w net.ipv6.conf.{name}-eth0.addr_gen_mode=1")
+        router.cmd_raises(f"ip -6 address flush dev {name}-eth0 scope link")
+        router.load_frr_config()
+    tgen.gears["r1"].cmd_raises("ip link add sr0 type dummy")
+    tgen.gears["r1"].cmd_raises("ip link set sr0 up")
+    tgen.start_router()
+
+
+def teardown_module():
+    tgen = get_topogen()
+    if tgen:
+        tgen.stop_topology()
+
+
+@pytest.fixture(autouse=True)
+def check_router_status():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+
+def wait_for(check, stable=1):
+    successes = 0
+
+    def check_stable():
+        nonlocal successes
+        result = check()
+        successes = successes + 1 if result is None else 0
+        if result is None and successes < stable:
+            return "waiting for consecutive successful observations"
+        return result
+
+    _, result = topotest.run_and_expect(check_stable, None, count=80, wait=0.5)
+    assert result is None, result
+
+
+def check_adjacencies(levels):
+    # Neighbor JSON keeps only the last LAN adjacency for each interface.
+    output = (
+        get_topogen()
+        .gears["r1"]
+        .vtysh_cmd("show isis interface r1-eth0 json", isjson=True)
+    )
+    interfaces = [
+        circuit.get("interface", {})
+        for area in output.get("areas", [])
+        for circuit in area.get("circuits", [])
+        if circuit.get("interface", {}).get("name") == "r1-eth0"
+    ]
+    if len(interfaces) != 1:
+        return f"missing IS-IS interface: {output}"
+    actual = {
+        level["level"]: level.get("active-neighbors")
+        for level in interfaces[0].get("levels", [])
+    }
+    expected = {"L1": int(1 in levels), "L2": int(2 in levels)}
+    if actual != expected:
+        return f"active adjacencies {actual}, expected {expected}"
+    return None
+
+
+def read_endx_sids():
+    output = (
+        get_topogen()
+        .gears["r1"]
+        .vtysh_cmd("show segment-routing srv6 sid json", isjson=True)
+    )
+    return {
+        sid: data
+        for sid, data in output.items()
+        if data.get("behavior") in ("uA", "End.X")
+    }
+
+
+def sid_prefix(sid, sid_format=F3216):
+    node_len = 16 if ipaddress.IPv6Address(sid) in sid_format.node_prefix else 0
+    length = sid_format.block.prefixlen + node_len + 16
+    return f"{sid}/{length}"
+
+
+def endx_tlvs(value):
+    """Collect only End.X advertisements, ignoring unrelated LSP content."""
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in ("srv6EndXSID", "srv6LanEndxSID"):
+                yield from child
+            else:
+                yield from endx_tlvs(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from endx_tlvs(child)
+
+
+def check_pair(levels=(1, 2), expected_sids=None, sid_format=F3216):
+    r1, r2 = (get_topogen().gears[name] for name in ("r1", "r2"))
+    entries = read_endx_sids()
+    combined_sids = [
+        sid for sid in entries if ipaddress.IPv6Address(sid) in sid_format.node_prefix
+    ]
+    if len(combined_sids) != 1:
+        return f"expected one combined SID, got {entries}"
+    combined = combined_sids[0]
+    block_len = sid_format.block.prefixlen
+    function = (int(ipaddress.IPv6Address(combined)) >> (128 - block_len - 32)) & 0xFFFF
+    localonly = str(
+        ipaddress.IPv6Address(
+            int(sid_format.block.network_address) | (function << (128 - block_len - 16))
+        )
+    )
+    if set(entries) != {combined, localonly}:
+        return f"expected exactly the combined/local-only pair, got {entries}"
+    if expected_sids is not None and set(entries) != expected_sids:
+        return f"pair replaced while still owned: {entries}"
+
+    context = entries[combined].get("context", {})
+    expected = {
+        sid: {
+            "sid": sid,
+            "behavior": "uA",
+            "locator": "MAIN",
+            "allocationMode": "dynamic",
+            "context": context,
+            "clients": [{"protocol": "isis", "instance": 0}],
+        }
+        for sid in (combined, localonly)
+    }
+    diff = topotest.json_cmp(entries, expected)
+    if diff:
+        return diff
+    diff = topotest.json_cmp(
+        context, {"interfaceName": "r1-eth0", "nexthopIpv6Address": "fe80::2"}
+    )
+    if diff:
+        return diff
+    if (
+        not isinstance(context.get("interfaceIndex"), int)
+        or context["interfaceIndex"] <= 0
+    ):
+        return f"missing adjacency ifindex: {context}"
+
+    routes = r1.vtysh_cmd("show ipv6 route isis json", isjson=True)
+    ua_routes = {
+        prefix: paths
+        for prefix, paths in routes.items()
+        if any(
+            nh.get("seg6local", {}).get("action") == "uA"
+            for path in paths
+            for nh in path.get("nexthops", [])
+        )
+    }
+    expected = {}
+    for sid, node_len in ((combined, 16), (localonly, 0)):
+        prefix = sid_prefix(sid, sid_format)
+        expected[prefix] = [
+            {
+                "protocol": "isis",
+                "installed": True,
+                "nexthops": [
+                    {
+                        "fib": True,
+                        "seg6local": {
+                            "action": "uA",
+                            "sidStructure": {
+                                "blockLen": block_len,
+                                "nodeLen": node_len,
+                                "funcLen": 16,
+                                "argLen": 0,
+                            },
+                        },
+                        "seg6localContext": {
+                            "nh6": "fe80::2",
+                            "interfaceName": "r1-eth0",
+                            "interfaceIndex": context.get("interfaceIndex"),
+                        },
+                    }
+                ],
+            }
+        ]
+    if set(ua_routes) != set(expected):
+        return f"unexpected uA RIB prefixes: {ua_routes}"
+    for prefix, paths in ua_routes.items():
+        if len(paths) != 1 or len(paths[0].get("nexthops", [])) != 1:
+            return f"duplicate uA RIB entries: {prefix}: {paths}"
+    diff = topotest.json_cmp(ua_routes, expected)
+    if diff:
+        return diff
+
+    database = r2.vtysh_cmd(
+        "show isis database detail 0000.0000.0001 json", isjson=True
+    )
+    peer_levels = [
+        level
+        for area in database.get("areas", [])
+        for level in area.get("levels", [])
+        if level.get("id") in levels
+    ]
+    if {level.get("id") for level in peer_levels} != set(levels):
+        return f"missing peer LSPs: {database}"
+    for level in peer_levels:
+        advertisements = list(endx_tlvs(level))
+        if len(advertisements) != 1:
+            return (
+                f"level {level['id']}: expected one combined End.X, "
+                f"got {advertisements}"
+            )
+        diff = topotest.json_cmp(
+            advertisements[0],
+            {
+                "sid": combined,
+                "behavior": "uA",
+                "srv6SidStructure": {
+                    "locBlockLen": block_len,
+                    "locNodeLen": 16,
+                    "funcLen": 16,
+                    "argLen": sid_format.arg_len,
+                },
+            },
+        )
+        if diff:
+            return diff
+    return None
+
+
+def configure_locator(sid_format):
+    get_topogen().gears["r1"].vtysh_cmd(
+        "configure terminal\nsegment-routing\nsrv6\nlocators\nlocator MAIN\n"
+        f"prefix {sid_format.node_prefix} block-len {sid_format.block.prefixlen} "
+        "node-len 16 func-bits 16\n"
+        f"format {sid_format.name}\nbehavior usid"
+    )
+
+
+@pytest.fixture(scope="module")
+def sid_format(request):
+    """Exercise each layout once, then restore F3216 for lifecycle tests."""
+    value = getattr(request, "param", F3216)
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def replace_locator(value):
+        tgen.gears["r1"].vtysh_cmd(
+            "configure terminal\nsegment-routing\nsrv6\nlocators\nno locator MAIN"
+        )
+        configure_locator(value)
+        wait_for(functools.partial(check_pair, sid_format=value))
+
+    try:
+        if value != F3216:
+            replace_locator(value)
+        yield value
+    finally:
+        if value != F3216:
+            replace_locator(F3216)
+
+
+@pytest.mark.parametrize(
+    "sid_format",
+    [F3216, F4816],
+    indirect=True,
+    scope="module",
+    ids=lambda value: value.name,
+)
+def test_pair_provisioning(sid_format):
+    """Both forms share a function/context; only combined is advertised."""
+    wait_for(functools.partial(check_adjacencies, (1, 2)))
+    wait_for(functools.partial(check_pair, sid_format=sid_format))
+
+
+@pytest.mark.parametrize(
+    "sid_format",
+    [F3216, F4816],
+    indirect=True,
+    scope="module",
+    ids=lambda value: value.name,
+)
+@pytest.mark.parametrize("localonly", [False, True], ids=["combined", "local-only"])
+def test_pair_forwarding(sid_format, localonly):
+    """Both uA forms shift to the next CSID and use the adjacency nexthop."""
+    r1, r2 = (get_topogen().gears[name] for name in ("r1", "r2"))
+    wait_for(functools.partial(check_pair, sid_format=sid_format))
+    sid = next(
+        sid
+        for sid in read_endx_sids()
+        if (ipaddress.IPv6Address(sid) not in sid_format.node_prefix) == localonly
+    )
+    # Append G(next)=2 after the current function, without an upstream uN.
+    block_len = sid_format.block.prefixlen
+    shift = 128 - block_len - (32 if localonly else 48)
+    destination = str(
+        ipaddress.IPv6Address(int(ipaddress.IPv6Address(sid)) | (2 << shift))
+    )
+    expected = str(
+        ipaddress.IPv6Address(
+            int(sid_format.block.network_address) | (2 << (128 - block_len - 16))
+        )
+    )
+    r1_mac = r1.cmd_raises("cat /sys/class/net/r1-eth0/address").strip()
+    r2.cmd_raises(
+        shlex.join(
+            [
+                "python3",
+                os.path.join(CWD, "probe_ua.py"),
+                "r2-eth0",
+                r1_mac,
+                destination,
+                expected,
+            ]
+        )
+    )
+
+
+def check_pair_withdrawn(prefixes):
+    r1 = get_topogen().gears["r1"]
+    if read_endx_sids():
+        return "SID Manager still owns an End.X representation"
+    routes = r1.vtysh_cmd("show ipv6 route isis json", isjson=True)
+    for prefix in prefixes:
+        if prefix in routes:
+            return f"released pair remains in IS-IS RIB: {routes}"
+        output = r1.cmd_raises(f"ip -6 route show exact {prefix}").strip()
+        if output:
+            return f"released pair remains in kernel: {output}"
+    return None
+
+
+def test_shared_pair_lifetime(sid_format):
+    """Keep the pair for one LAN owner; release it when its last owner leaves."""
+    r1, r2 = (get_topogen().gears[name] for name in ("r1", "r2"))
+    wait_for(check_pair)
+    sids = set(read_endx_sids())
+    prefixes = [sid_prefix(sid) for sid in sids]
+    try:
+        r2.vtysh_cmd(
+            "configure terminal\ninterface r2-eth0\nisis circuit-type level-2-only"
+        )
+        wait_for(functools.partial(check_adjacencies, (2,)))
+        # The old L1 LSP is stale; the remaining L2 advertisement must survive.
+        wait_for(
+            functools.partial(check_pair, levels=(2,), expected_sids=sids), stable=3
+        )
+        r1.cmd_raises("ip link set r1-eth0 down")
+        wait_for(functools.partial(check_adjacencies, ()))
+
+        wait_for(functools.partial(check_pair_withdrawn, prefixes))
+    finally:
+        r1.cmd_raises("ip link set r1-eth0 up")
+        r2.vtysh_cmd(
+            "configure terminal\ninterface r2-eth0\nisis circuit-type level-1-2"
+        )
+    wait_for(functools.partial(check_adjacencies, (1, 2)))
+    wait_for(check_pair)
+
+
+def test_pair_recreated_after_locator_replacement(sid_format):
+    """Withdraw both forms and the advertisement before recreating a locator."""
+    r1, r2 = (get_topogen().gears[name] for name in ("r1", "r2"))
+    wait_for(check_pair)
+    prefixes = [sid_prefix(sid) for sid in read_endx_sids()]
+    try:
+        r1.vtysh_cmd(
+            "configure terminal\nsegment-routing\nsrv6\nlocators\nno locator MAIN"
+        )
+        wait_for(functools.partial(check_pair_withdrawn, prefixes))
+
+        def unadvertised():
+            database = r2.vtysh_cmd(
+                "show isis database detail 0000.0000.0001 json", isjson=True
+            )
+            levels = {
+                level.get("id")
+                for area in database.get("areas", [])
+                for level in area.get("levels", [])
+            }
+            if levels != {1, 2}:
+                return f"missing peer LSPs: {database}"
+            if list(endx_tlvs(database)):
+                return f"withdrawn End.X remains advertised: {database}"
+            return None
+
+        wait_for(unadvertised)
+    finally:
+        configure_locator(F3216)
+    wait_for(check_pair)
+
+
+def test_pair_recreated_after_isis_restart(sid_format):
+    """A new IS-IS session reacquires both forms after the old owner exits."""
+    r1 = get_topogen().gears["r1"]
+    wait_for(check_pair)
+    prefixes = [sid_prefix(sid) for sid in read_endx_sids()]
+    r1.killDaemons(["isisd"])
+    try:
+        wait_for(functools.partial(check_pair_withdrawn, prefixes))
+    finally:
+        assert r1.startDaemons(["isisd"]) == ""
+    wait_for(functools.partial(check_adjacencies, (1, 2)))
+    wait_for(check_pair)
+
+
+def test_pair_replayed_after_zebra_restart(sid_format):
+    """A new Zebra session recreates both forms, not just stale kernel routes."""
+    r1 = get_topogen().gears["r1"]
+    wait_for(check_pair)
+    prefixes = [sid_prefix(sid) for sid in read_endx_sids()]
+    r1.killDaemons(["zebra"])
+    try:
+        for prefix in prefixes:
+            r1.cmd_raises(f"ip -6 route del {prefix}")
+    finally:
+        assert r1.startDaemons(["zebra"]) == ""
+    wait_for(check_pair)
+
+
+def test_localonly_kernel_flavor(sid_format):
+    """Inspect the new local-only nflen when iproute2 can display it."""
+    r1 = get_topogen().gears["r1"]
+    help_output = r1.run("ip -6 route help 2>&1")
+    if "flavors FLAVORS" not in help_output or "next-csid" not in help_output:
+        version = r1.run("ip -Version").strip()
+        pytest.skip(f"iproute2 cannot display SEG6_LOCAL_FLAVORS attributes: {version}")
+    wait_for(check_pair)
+    localonly = next(
+        sid
+        for sid in read_endx_sids()
+        if ipaddress.IPv6Address(sid) not in F3216.node_prefix
+    )
+    output = r1.run(f"ip -6 -d route show exact {localonly}/48")
+    assert "flavors next-csid lblen 32 nflen 16" in output, output
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-s", __file__] + sys.argv[1:]))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1038,13 +1038,14 @@ void zsend_neighbor_notify(int cmd, struct interface *ifp,
 }
 
 void zsend_srv6_sid_notify(struct zserv *client, const struct srv6_sid_ctx *ctx,
-			   struct in6_addr *sid_value, uint32_t func,
-			   uint32_t wide_func, const char *locator_name,
-			   enum zapi_srv6_sid_notify note)
+			   struct in6_addr *sid_value, uint32_t func, uint32_t wide_func,
+			   const char *locator_name, enum zapi_srv6_sid_notify note,
+			   bool is_localonly)
 
 {
 	struct stream *s;
 	uint16_t cmd = ZEBRA_SRV6_SID_NOTIFY;
+	uint8_t flags = 0;
 	char buf[256];
 
 	if (IS_ZEBRA_DEBUG_PACKET)
@@ -1069,6 +1070,10 @@ void zsend_srv6_sid_notify(struct zserv *client, const struct srv6_sid_ctx *ctx,
 	stream_putl(s, wide_func);
 	/* SRv6 locator name optional */
 	zapi_srv6_locname_encode(s, locator_name, __func__);
+	/* SID representation flags */
+	if (is_localonly)
+		SET_FLAG(flags, ZAPI_SRV6_MANAGER_SID_FLAG_IS_LOCALONLY);
+	stream_putc(s, flags);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -92,11 +92,10 @@ extern int zsend_sr_policy_notify_status(uint32_t color,
 extern void zsend_neighbor_notify(int cmd, struct interface *ifp,
 				  struct ipaddr *ipaddr, int ndm_state,
 				  union sockunion *link_layer_ipv4, int ip_len);
-extern void zsend_srv6_sid_notify(struct zserv *client,
-				  const struct srv6_sid_ctx *ctx,
-				  struct in6_addr *sid_value, uint32_t func,
-				  uint32_t wide_func, const char *locator_name,
-				  enum zapi_srv6_sid_notify note);
+extern void zsend_srv6_sid_notify(struct zserv *client, const struct srv6_sid_ctx *ctx,
+				  struct in6_addr *sid_value, uint32_t func, uint32_t wide_func,
+				  const char *locator_name, enum zapi_srv6_sid_notify note,
+				  bool is_localonly);
 
 extern int zsend_client_close_notify(struct zserv *client,
 				     struct zserv *closed_client);

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -734,7 +734,7 @@ static void zebra_srv6_sid_clients_notify_single(struct zebra_srv6_sid *sid,
 
 	zebra_srv6_sid_compose(&sid_value, locator, sid->func, sid->wide_func, is_localonly);
 	zsend_srv6_sid_notify(client, &sid->ctx->ctx, &sid_value, sid->func, sid->wide_func,
-			      locator->name, notify);
+			      locator->name, notify, is_localonly);
 }
 
 static void zebra_srv6_sid_clients_release_notify_all(struct zebra_srv6_sid *sid)
@@ -746,7 +746,7 @@ static void zebra_srv6_sid_clients_release_notify_all(struct zebra_srv6_sid *sid
 		frr_each (zebra_srv6_sid_client_list, &entry->clients_list, zclient)
 			zsend_srv6_sid_notify(zclient->client, &sid->ctx->ctx, &entry->sid_value,
 					      sid->func, sid->wide_func, entry->locator->name,
-					      ZAPI_SRV6_SID_RELEASED);
+					      ZAPI_SRV6_SID_RELEASED, entry->is_localonly);
 }
 
 static void zebra_srv6_sid_clients_notify_all(struct zebra_srv6_sid *sid,
@@ -765,7 +765,7 @@ static void zebra_srv6_sid_clients_notify_all(struct zebra_srv6_sid *sid,
 
 	frr_each (zebra_srv6_sid_client_list, &entry->clients_list, zclient)
 		zsend_srv6_sid_notify(zclient->client, &sid->ctx->ctx, &sid_value, sid->func,
-				      sid->wide_func, locator->name, notify);
+				      sid->wide_func, locator->name, notify, is_localonly);
 }
 
 void zebra_srv6_sid_client_add(struct zebra_srv6_sid *sid, bool is_localonly,
@@ -2664,7 +2664,7 @@ static int srv6_manager_get_sid_internal(struct zebra_srv6_sid **sid, struct zse
 				 "%s: invalid SM request arguments: SRv6 locator '%s' does not exist",
 				 __func__, locator_name);
 			zsend_srv6_sid_notify(client, ctx, sid_value ? sid_value : &zero, 0, 0,
-					      locator_name, ZAPI_SRV6_SID_FAIL_ALLOC);
+					      locator_name, ZAPI_SRV6_SID_FAIL_ALLOC, is_localonly);
 			return -1;
 		}
 	}
@@ -2680,7 +2680,7 @@ static int srv6_manager_get_sid_internal(struct zebra_srv6_sid **sid, struct zse
 
 		/* Notify client about SID alloc failure */
 		zsend_srv6_sid_notify(client, ctx, sid_value ? sid_value : &zero, 0, 0,
-				      locator_name, ZAPI_SRV6_SID_FAIL_ALLOC);
+				      locator_name, ZAPI_SRV6_SID_FAIL_ALLOC, is_localonly);
 	} else if (ret == 0) {
 		assert(*sid);
 		if (IS_ZEBRA_DEBUG_SRV6)
@@ -2831,10 +2831,10 @@ static int srv6_manager_release_sid_internal(struct zserv *client, struct srv6_s
 
 	if (ret == 0)
 		zsend_srv6_sid_notify(client, ctx, &sid_value, 0, 0, locator_name,
-				      ZAPI_SRV6_SID_RELEASED);
+				      ZAPI_SRV6_SID_RELEASED, is_localonly);
 	else
 		zsend_srv6_sid_notify(client, ctx, &sid_value, 0, 0, locator_name,
-				      ZAPI_SRV6_SID_FAIL_RELEASE);
+				      ZAPI_SRV6_SID_FAIL_RELEASE, is_localonly);
 
 	return ret;
 }


### PR DESCRIPTION
### Summary

IS-IS currently provisions the combined block:node:function uA SID, but
does not install the corresponding local-only block:function form.

Provision both End.X NEXT-CSID representations for primary adjacencies
using `usid-f3216` or `usid-f4816` locators. Both share the same SID Manager
context, function and adjacency nexthop. Advertise only the combined SID.

### Changes

- Append optional representation flags to ZAPI SID notifications. Decode
  older notifications with zero flags and allow clients to ignore them.
- Track allocation and installation independently for each representation.
  Install local-only SIDs with a zero-length node field and the corresponding
  prefix and NEXT-CSID node-function lengths.
- Preserve shared L1/L2 LAN ownership and release the pair only when its last
  owner leaves. Rebuild state after locator replacement or daemon restart.
- Advertise the uA Argument Length as `128 - LBL - LNL - FL`, as required
  by [RFC 9800, Section 8](https://www.rfc-editor.org/rfc/rfc9800.html#section-8).
  Keep locator and kernel SID structure metadata unchanged.
- Document the behavior and keep unformatted uSID locators combined-only,
  since their Global/Local CSID allocation ranges are not separated.

No new CLI is introduced. Classic End.X remains single-SID; this change does
not add TI-LFA functionality or change SID allocation policy.

### Testing

Unit tests construct ZAPI notifications in memory and verify representation
flag decoding, zero flags for legacy messages, and stream consumption when
optional outputs are unused.

A standalone two-router topotest checks F3216 and F4816 using the same
L1/L2 LAN topology. For each format it verifies the shared function and
context, route prefixes and nexthop, and the combined-only advertisement
in the peer's LSDB, including its SID Structure and Argument Length.

For each format, separate packet probes inject directly into the combined
and local-only uA forms and verify the rewritten IPv6 destination,
Ethernet nexthop, decremented hop limit and unchanged payload.

F3216 additionally covers shared ownership, withdrawal after the last
owner leaves, locator delete/add, and recovery after IS-IS/Zebra restart.
Local-only kernel flavor inspection is conditional on iproute2 display
support; packet probes do not depend on that capability.

### Components

`lib`, `zebra`, `isisd`, `tests`, `doc`; BGP and staticd decoder call sites
are updated for the optional flags output without changing their behavior.
