### PR TITLE
*: turn hooks sideways & use separate "_hooks.h" files

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -39,8 +39,10 @@
 
 #include "bgpd/bgp_debug_clippy.c"
 
-DEFINE_HOOK(bgp_hook_config_write_debug, (struct vty *vty, bool running),
-	    (vty, running));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_debug_hooks.h"
+#include "lib/hooks_end.h"
 
 unsigned long conf_bgp_debug_as4;
 unsigned long conf_bgp_debug_neighbor_events;

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -12,8 +12,10 @@
 #include "bgp_attr.h"
 #include "bgp_updgrp.h"
 
-DECLARE_HOOK(bgp_hook_config_write_debug, (struct vty *vty, bool running),
-	     (vty, running));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_debug_hooks.h"
+#include "lib/hooks_end.h"
 
 /* sort of packet direction */
 #define DUMP_ON        1

--- a/bgpd/bgp_debug_hooks.h
+++ b/bgpd/bgp_debug_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_debug.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(bgp_hook_config_write_debug, (struct vty *, vty), (bool, running));

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -45,9 +45,10 @@
 #include "bgpd/bgp_trace.h"
 #include "bgpd/bgp_ls.h"
 
-DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer));
-DEFINE_HOOK(peer_status_changed, (struct peer * peer), (peer));
-DEFINE_HOOK(bgp_rpki_connection_status, (const char *vrf_name), (vrf_name));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_fsm_hooks.h"
+#include "lib/hooks_end.h"
 
 bool bgp_rpki_cache_connected(struct bgp *bgp)
 {

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -145,8 +145,6 @@ extern void bgp_start_routeadv(struct bgp *bgp);
 extern void bgp_adjust_routeadv(struct peer *peer);
 
 #include "hook.h"
-DECLARE_HOOK(peer_backward_transition, (struct peer *peer), (peer));
-
 int bgp_gr_update_all(struct bgp *bgp, enum global_gr_command global_gr_cmd);
 int bgp_neighbor_graceful_restart(struct peer *peer,
 				  enum peer_gr_command peer_gr_cmd);

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -146,7 +146,6 @@ extern void bgp_adjust_routeadv(struct peer *peer);
 
 #include "hook.h"
 DECLARE_HOOK(peer_backward_transition, (struct peer *peer), (peer));
-DECLARE_HOOK(peer_established, (struct peer *peer), (peer));
 
 int bgp_gr_update_all(struct bgp *bgp, enum global_gr_command global_gr_cmd);
 int bgp_neighbor_graceful_restart(struct peer *peer,

--- a/bgpd/bgp_fsm_hooks.h
+++ b/bgpd/bgp_fsm_hooks.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_fsm.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(peer_backward_transition, (struct peer *, peer));
+
+DO_HOOK(peer_status_changed, (struct peer *, peer));
+
+DO_HOOK(bgp_rpki_connection_status, (const char *, vrf_name));

--- a/bgpd/bgp_fsm_hooks.h
+++ b/bgpd/bgp_fsm_hooks.h
@@ -5,7 +5,6 @@
  */
 
 DO_HOOK(peer_backward_transition, (struct peer *, peer));
-
 DO_HOOK(peer_status_changed, (struct peer *, peer));
 
 DO_HOOK(bgp_rpki_connection_status, (const char *, vrf_name));

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -52,15 +52,14 @@
 #include "bgpd/bgp_routemap_nb.h"
 #include "bgpd/bgp_community_alias.h"
 
-DEFINE_HOOK(bgp_hook_config_write_vrf, (struct vty *vty, struct vrf *vrf),
-	    (vty, vrf));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_main_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
 #endif
-
-DEFINE_HOOK(bgp_hook_vrf_update, (struct vrf *vrf, bool enabled),
-	    (vrf, enabled));
 
 /* bgpd options, we use GNU getopt library. */
 static const struct option longopts[] = { { "bgp_port", required_argument, NULL, 'p' },

--- a/bgpd/bgp_main_hooks.h
+++ b/bgpd/bgp_main_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_main.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(bgp_hook_config_write_vrf, (struct vty *, vty), (struct vrf *, vrf));
+
+DO_HOOK(bgp_hook_vrf_update, (struct vrf *, vrf), (bool, enabled));

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -42,8 +42,10 @@ static bool make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p,
 			struct bgp *bgp_nexthop, struct bgp_path_info *pi_source);
 static void bgp_nht_ifp_initial(struct event *event);
 
-DEFINE_HOOK(bgp_nht_path_update, (struct bgp *bgp, struct bgp_path_info *pi, bool valid),
-	    (bgp, pi, valid));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_nht_hooks.h"
+#include "lib/hooks_end.h"
 
 static int bgp_isvalid_nexthop(struct bgp_nexthop_cache *bnc)
 {

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -83,8 +83,9 @@ extern void bgp_nht_ifp_down(struct interface *ifp);
 
 extern void bgp_nht_interface_events(struct peer *peer);
 
-/* called when a path becomes valid or invalid, because of nexthop tracking */
-DECLARE_HOOK(bgp_nht_path_update, (struct bgp *bgp, struct bgp_path_info *pi, bool valid),
-	     (bgp, pi, valid));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_nht_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _BGP_NHT_H */

--- a/bgpd/bgp_nht_hooks.h
+++ b/bgpd/bgp_nht_hooks.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_nht.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* called when a path becomes valid or invalid, because of nexthop tracking */
+DO_HOOK(bgp_nht_path_update, (struct bgp *, bgp), (struct bgp_path_info *, pi), (bool, valid));

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -53,15 +53,10 @@
 #include "bgpd/bgp_trace.h"
 #include "bgpd/bgp_ls.h"
 
-DEFINE_HOOK(bgp_packet_dump,
-		(struct peer *peer, uint8_t type, bgp_size_t size,
-			struct stream *s),
-		(peer, type, size, s));
-
-DEFINE_HOOK(bgp_packet_send,
-		(struct peer *peer, uint8_t type, bgp_size_t size,
-			struct stream *s),
-		(peer, type, size, s));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_packet_hooks.h"
+#include "lib/hooks_end.h"
 
 /**
  * Sets marker and type fields for a BGP message.

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -14,15 +14,10 @@ struct bgp_enhe_capability {
 	uint16_t nh_afi;
 };
 
-DECLARE_HOOK(bgp_packet_dump,
-		(struct peer *peer, uint8_t type, bgp_size_t size,
-			struct stream *s),
-		(peer, type, size, s));
-
-DECLARE_HOOK(bgp_packet_send,
-		(struct peer *peer, uint8_t type, bgp_size_t size,
-			struct stream *s),
-		(peer, type, size, s));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_packet_hooks.h"
+#include "lib/hooks_end.h"
 
 #define BGP_NLRI_LENGTH       1U
 #define BGP_TOTAL_ATTR_LEN    2U

--- a/bgpd/bgp_packet_hooks.h
+++ b/bgpd/bgp_packet_hooks.h
@@ -6,6 +6,5 @@
 
 DO_HOOK(bgp_packet_dump, (struct peer *, peer), (uint8_t, type), (bgp_size_t, size),
 	(struct stream *, s));
-
 DO_HOOK(bgp_packet_send, (struct peer *, peer), (uint8_t, type), (bgp_size_t, size),
 	(struct stream *, s));

--- a/bgpd/bgp_packet_hooks.h
+++ b/bgpd/bgp_packet_hooks.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_packet.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(bgp_packet_dump, (struct peer *, peer), (uint8_t, type), (bgp_size_t, size),
+	(struct stream *, s));
+
+DO_HOOK(bgp_packet_send, (struct peer *, peer), (uint8_t, type), (bgp_size_t, size),
+	(struct stream *, s));

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -107,19 +107,10 @@ DEFINE_MTYPE_STATIC(BGPD, BGP_METAQ, "BGP MetaQ");
 /* Memory for batched clearing of peers from the RIB */
 DEFINE_MTYPE(BGPD, CLEARING_BATCH, "Clearing batch");
 
-DEFINE_HOOK(bgp_snmp_update_stats,
-	    (struct bgp_dest *rn, struct bgp_path_info *pi, bool added),
-	    (rn, pi, added));
-
-DEFINE_HOOK(bgp_rpki_prefix_status,
-	    (struct peer *peer, struct attr *attr,
-	     const struct prefix *prefix),
-	    (peer, attr, prefix));
-
-DEFINE_HOOK(bgp_route_update,
-	    (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	     struct bgp_path_info *old_route, struct bgp_path_info *new_route),
-	    (bgp, afi, safi, bn, old_route, new_route));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_route_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Extern from bgp_dump.c */
 extern const char *bgp_origin_str[];
@@ -233,13 +224,6 @@ static inline char *bgp_route_dump_path_info_flags(struct bgp_path_info *pi,
 
 	return buf;
 }
-
-DEFINE_HOOK(bgp_process,
-	    (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	     struct peer *peer, bool withdraw),
-	    (bgp, afi, safi, bn, peer, withdraw));
-
-DEFINE_HOOK(bgp_adj_in_needed, (struct peer *peer, afi_t afi, safi_t safi), (peer, afi, safi));
 
 /* The peer's Adj-RIB-In is maintained when soft-reconfiguration inbound is
  * configured, or when another component consuming it (BMP pre-policy

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -807,23 +807,6 @@ static inline bool bgp_check_withdrawal(struct bgp *bgp, struct bgp_dest *dest,
 	return true;
 }
 
-/* called before bgp_process() */
-DECLARE_HOOK(bgp_process,
-	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	      struct peer *peer, bool withdraw),
-	     (bgp, afi, safi, bn, peer, withdraw));
-
-/* whether a component other than soft-reconfiguration inbound needs the
- * peer's Adj-RIB-In to be maintained (e.g. BMP pre-policy monitoring)
- */
-DECLARE_HOOK(bgp_adj_in_needed, (struct peer *peer, afi_t afi, safi_t safi), (peer, afi, safi));
-
-/* called when a route is updated in the rib */
-DECLARE_HOOK(bgp_route_update,
-	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	      struct bgp_path_info *old_route, struct bgp_path_info *new_route),
-	     (bgp, afi, safi, bn, old_route, new_route));
-
 extern int bgp_pi_hash_cmp(const struct bgp_path_info *p1, const struct bgp_path_info *p2);
 extern uint32_t bgp_pi_hash_hashfn(const struct bgp_path_info *pi);
 

--- a/bgpd/bgp_route_hooks.h
+++ b/bgpd/bgp_route_hooks.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_route.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(bgp_snmp_update_stats, (struct bgp_dest *, rn), (struct bgp_path_info *, pi),
+	(bool, added));
+
+DO_HOOK(bgp_rpki_prefix_status, (struct peer *, peer), (struct attr *, attr),
+	(const struct prefix *, prefix));
+
+/* called when a route is updated in the rib */
+DO_HOOK(bgp_route_update, (struct bgp *, bgp), (afi_t, afi), (safi_t, safi),
+	(struct bgp_dest *, bn), (struct bgp_path_info *, old_route),
+	(struct bgp_path_info *, new_route));
+
+/* called before bgp_process() */
+DO_HOOK(bgp_process, (struct bgp *, bgp), (afi_t, afi), (safi_t, safi), (struct bgp_dest *, bn),
+	(struct peer *, peer), (bool, withdraw));
+
+/* whether a component other than soft-reconfiguration inbound needs the
+ * peer's Adj-RIB-In to be maintained (e.g. BMP pre-policy monitoring)
+ */
+DO_HOOK(bgp_adj_in_needed, (struct peer *, peer), (afi_t, afi), (safi_t, safi));

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -147,14 +147,10 @@ FRR_CFG_DEFAULT_BOOL(BGP_IPV6_NEXTHOP_PREFER_GLOBAL,
 	{ .val_bool = false },
 );
 
-DEFINE_HOOK(bgp_inst_config_write,
-		(struct bgp *bgp, struct vty *vty),
-		(bgp, vty));
-DEFINE_HOOK(bgp_snmp_update_last_changed, (struct bgp *bgp), (bgp));
-DEFINE_HOOK(bgp_snmp_init_stats, (struct bgp *bgp), (bgp));
-DEFINE_HOOK(bgp_snmp_traps_config_write, (struct vty * vty), (vty));
-DEFINE_HOOK(bgp_route_distinguisher_update, (struct bgp *bgp, afi_t afi, bool preconfig),
-	    (bgp, afi, preconfig));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_vty_hooks.h"
+#include "lib/hooks_end.h"
 
 static struct peer_group *listen_range_exists(struct bgp *bgp,
 					      struct prefix *range, int exact);
@@ -23025,8 +23021,6 @@ static const struct cmd_variable_handler bgp_var_neighbor[] = {
 static const struct cmd_variable_handler bgp_var_peergroup[] = {
 	{.tokenname = "PGNAME", .completions = bgp_ac_peergroup},
 	{.completions = NULL} };
-
-DEFINE_HOOK(bgp_config_end, (struct bgp *bgp), (bgp));
 
 static struct event *t_bgp_cfg;
 

--- a/bgpd/bgp_vty_hooks.h
+++ b/bgpd/bgp_vty_hooks.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_vty.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(bgp_inst_config_write, (struct bgp *, bgp), (struct vty *, vty));
+
+DO_HOOK(bgp_snmp_update_last_changed, (struct bgp *, bgp));
+
+DO_HOOK(bgp_snmp_init_stats, (struct bgp *, bgp));
+
+DO_HOOK(bgp_snmp_traps_config_write, (struct vty *, vty));
+
+DO_HOOK(bgp_route_distinguisher_update, (struct bgp *, bgp), (afi_t, afi), (bool, preconfig));
+
+DO_HOOK(bgp_config_end, (struct bgp *, bgp));

--- a/bgpd/bgp_vty_hooks.h
+++ b/bgpd/bgp_vty_hooks.h
@@ -7,9 +7,7 @@
 DO_HOOK(bgp_inst_config_write, (struct bgp *, bgp), (struct vty *, vty));
 
 DO_HOOK(bgp_snmp_update_last_changed, (struct bgp *, bgp));
-
 DO_HOOK(bgp_snmp_init_stats, (struct bgp *, bgp));
-
 DO_HOOK(bgp_snmp_traps_config_write, (struct vty *, vty));
 
 DO_HOOK(bgp_route_distinguisher_update, (struct bgp *, bgp), (afi_t, afi), (bool, preconfig));

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -64,9 +64,10 @@ struct zclient *bgp_zclient = NULL;
 struct zclient *bgp_zclient_sync;
 static bool bgp_zebra_label_manager_connect(void);
 
-/* hook to indicate vrf status change for SNMP */
-DEFINE_HOOK(bgp_vrf_status_changed, (struct bgp *bgp, struct interface *ifp),
-	    (bgp, ifp));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_zebra_hooks.h"
+#include "lib/hooks_end.h"
 
 DEFINE_MTYPE_STATIC(BGPD, BGP_IF_INFO, "BGP interface context");
 

--- a/bgpd/bgp_zebra_hooks.h
+++ b/bgpd/bgp_zebra_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgp_zebra.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* hook to indicate vrf status change for SNMP */
+/* Hooks */
+DO_HOOK(bgp_vrf_status_changed, (struct bgp *, bgp), (struct interface *, ifp));

--- a/bgpd/bgp_zebra_hooks.h
+++ b/bgpd/bgp_zebra_hooks.h
@@ -5,5 +5,4 @@
  */
 
 /* hook to indicate vrf status change for SNMP */
-/* Hooks */
 DO_HOOK(bgp_vrf_status_changed, (struct bgp *, bgp), (struct interface *, ifp));

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -87,9 +87,11 @@ DEFINE_MTYPE_STATIC(BGPD, PEER_TX_SHUTDOWN_MSG, "Peer shutdown message (TX)");
 DEFINE_QOBJ_TYPE(bgp_master);
 DEFINE_QOBJ_TYPE(bgp);
 DEFINE_QOBJ_TYPE(peer);
-DEFINE_HOOK(bgp_inst_delete, (struct bgp *bgp), (bgp));
-DEFINE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
-DEFINE_HOOK(bgp_routerid_update, (struct bgp *bgp, bool withdraw), (bgp, withdraw));
+
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgpd_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Peers with connection error/failure, per bgp instance */
 DECLARE_DLIST(bgp_peer_conn_errlist, struct peer_connection, conn_err_link);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -58,9 +58,6 @@ struct bgp_upa_prefix_entry {
 	struct bgp_upa_prefix_hash_item hash_link;
 };
 
-DECLARE_HOOK(bgp_hook_config_write_vrf, (struct vty *vty, struct vrf *vrf),
-	     (vty, vrf));
-
 #define BGP_MAX_HOSTNAME 64	/* Linux max, is larger than most other sys */
 #define BGP_PEER_MAX_HASH_SIZE 16384
 
@@ -1193,19 +1190,6 @@ struct bgp_interface {
 #define BGP_INTERFACE_MPLS_L3VPN_SWITCHING (1 << 1)
 	uint32_t flags;
 };
-
-DECLARE_HOOK(bgp_inst_delete, (struct bgp *bgp), (bgp));
-DECLARE_HOOK(bgp_inst_config_write,
-		(struct bgp *bgp, struct vty *vty),
-		(bgp, vty));
-DECLARE_HOOK(bgp_snmp_traps_config_write, (struct vty *vty), (vty));
-DECLARE_HOOK(bgp_config_end, (struct bgp *bgp), (bgp));
-DECLARE_HOOK(bgp_hook_vrf_update, (struct vrf *vrf, bool enabled),
-	     (vrf, enabled));
-DECLARE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
-DECLARE_HOOK(bgp_routerid_update, (struct bgp *bgp, bool withdraw), (bgp, withdraw));
-DECLARE_HOOK(bgp_route_distinguisher_update, (struct bgp *bgp, afi_t afi, bool preconfig),
-	     (bgp, afi, preconfig));
 
 /* Thread callback information */
 struct afi_safi_info {
@@ -3401,20 +3385,15 @@ extern int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char
 				      enum asnotation_mode asnotation, const char *name,
 				      enum bgp_instance_type inst_type, bool force_config);
 
-/* Hooks */
-DECLARE_HOOK(bgp_vrf_status_changed, (struct bgp *bgp, struct interface *ifp),
-	     (bgp, ifp));
-DECLARE_HOOK(peer_status_changed, (struct peer *peer), (peer));
-DECLARE_HOOK(bgp_snmp_init_stats, (struct bgp *bgp), (bgp));
-DECLARE_HOOK(bgp_snmp_update_last_changed, (struct bgp *bgp), (bgp));
-DECLARE_HOOK(bgp_snmp_update_stats,
-	     (struct bgp_dest *rn, struct bgp_path_info *pi, bool added),
-	     (rn, pi, added));
-DECLARE_HOOK(bgp_rpki_prefix_status,
-	     (struct peer * peer, struct attr *attr,
-	      const struct prefix *prefix),
-	     (peer, attr, prefix));
-DECLARE_HOOK(bgp_rpki_connection_status, (const char *vrf_name), (vrf_name));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_fsm_hooks.h"
+#include "bgpd/bgp_main_hooks.h"
+#include "bgpd/bgp_route_hooks.h"
+#include "bgpd/bgp_vty_hooks.h"
+#include "bgpd/bgp_zebra_hooks.h"
+#include "bgpd/bgpd_hooks.h"
+#include "lib/hooks_end.h"
 
 void peer_nsf_stop(struct peer *peer);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -3385,16 +3385,6 @@ extern int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char
 				      enum asnotation_mode asnotation, const char *name,
 				      enum bgp_instance_type inst_type, bool force_config);
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "bgpd/bgp_fsm_hooks.h"
-#include "bgpd/bgp_main_hooks.h"
-#include "bgpd/bgp_route_hooks.h"
-#include "bgpd/bgp_vty_hooks.h"
-#include "bgpd/bgp_zebra_hooks.h"
-#include "bgpd/bgpd_hooks.h"
-#include "lib/hooks_end.h"
-
 void peer_nsf_stop(struct peer *peer);
 
 void peer_tcp_mss_set(struct peer *peer, uint32_t tcp_mss);
@@ -3454,5 +3444,16 @@ struct srv6_locator *bgp_srv6_locator_lookup(struct bgp *bgp_vrf, struct bgp *bg
 	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_ADV) &&                                       \
 	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_RCV) &&                                       \
 	 IN6_IS_ADDR_LINKLOCAL(&_peer->nexthop.v6_local))
+
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "bgpd/bgp_fsm_hooks.h"
+#include "bgpd/bgp_main_hooks.h"
+#include "bgpd/bgp_route_hooks.h"
+#include "bgpd/bgp_vty_hooks.h"
+#include "bgpd/bgp_zebra_hooks.h"
+#include "bgpd/bgpd_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _QUAGGA_BGPD_H */

--- a/bgpd/bgpd_hooks.h
+++ b/bgpd/bgpd_hooks.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for bgpd/bgpd.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(bgp_inst_delete, (struct bgp *, bgp));
+
+DO_HOOK(bgp_instance_state, (struct bgp *, bgp));
+
+DO_HOOK(bgp_routerid_update, (struct bgp *, bgp), (bool, withdraw));

--- a/bgpd/bgpd_hooks.h
+++ b/bgpd/bgpd_hooks.h
@@ -5,7 +5,6 @@
  */
 
 DO_HOOK(bgp_inst_delete, (struct bgp *, bgp));
-
 DO_HOOK(bgp_instance_state, (struct bgp *, bgp));
 
 DO_HOOK(bgp_routerid_update, (struct bgp *, bgp), (bool, withdraw));

--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -176,6 +176,16 @@ noinst_HEADERS += \
 	bgpd/bgp_attr_srv6.h \
 	bgpd/bgp_srv6.h \
 	\
+	bgpd/bgp_debug_hooks.h \
+	bgpd/bgp_fsm_hooks.h \
+	bgpd/bgp_main_hooks.h \
+	bgpd/bgp_nht_hooks.h \
+	bgpd/bgp_packet_hooks.h \
+	bgpd/bgp_route_hooks.h \
+	bgpd/bgp_vty_hooks.h \
+	bgpd/bgp_zebra_hooks.h \
+	bgpd/bgpd_hooks.h \
+	\
 	bgpd/rfapi/bgp_rfapi_cfg.h \
 	bgpd/rfapi/rfapi_import.h \
 	bgpd/rfapi/rfapi.h \

--- a/doc/developer/hooks.rst
+++ b/doc/developer/hooks.rst
@@ -12,31 +12,81 @@ the appropriate function signature (parameters) for the hook.
 Example:
 
 .. code-block:: c
+   :caption: mydaemon_hooks.h
+
+   /* note: file may be included multiple times - no include guard! */
+   DO_HOOK(some_update_event, (struct eventinfo *, info));
+
+.. code-block:: c
    :caption: mydaemon.h
 
-   #include "hook.h"
-   DECLARE_HOOK(some_update_event,
-                (struct eventinfo *, info));
+   #define HOOKS_DECLARE
+   #include "lib/hooks_begin.h"
+   #include "mydaemon/mydaemon_hooks.h"
+   #include "lib/hooks_end.h"
 
 .. code-block:: c
    :caption: mydaemon.c
 
-   #include "mydaemon.h"
-   DEFINE_HOOK(some_update_event,
-               (struct eventinfo *, info));
+   #include "mydaemon/mydaemon.h"
+
+   #define HOOKS_DEFINE
+   #include "lib/hooks_begin.h"
+   #include "mydaemon/mydaemon_hooks.h"
+   #include "lib/hooks_end.h"
+
    ...
    hook_call(some_update_event, info);
 
 .. code-block:: c
    :caption: mymodule.c
 
-   #include "mydaemon.h"
+   #include "mydaemon/mydaemon.h"
    static int event_handler(struct eventinfo *info);
    ...
    hook_register(some_update_event, event_handler);
 
 Do not use parameter names starting with "hook", these can collide with
 names used by the hook code itself.
+
+
+File splitting and positioning
+------------------------------
+
+As shown in the example above, the actual hook definitions are now split off
+into separate ``_hooks.h`` files.  These files should contain only
+:c:macro:`DO_HOOK` and :c:macro:`DO_KOOH` macro statements and their comments
+(and possibly some ``#ifdef``), nothing else.
+
+The ``lib/hooks_begin.h`` and ``lib/hooks_end.h`` files connect the
+:c:macro:`DO_HOOK` macro into :c:macro:`DECLARE_HOOK`, :c:macro:`DEFINE_HOOK`
+or :c:macro:`LUA_HOOK` (plus analog for ``_KOOH``), depending on whether
+``HOOKS_DECLARE``, ``HOOKS_DEFINE`` or ``HOOKS_LUA`` were set.
+
+The purpose of this is that the same "definition" can be reused for the hook
+declaration, definition, and at some point in the future scripting language
+bindings.
+
+.. todo::
+
+   The :c:macro:`LUA_HOOK` macro used when ``HOOKS_LUA`` is set don't actually
+   exist yet.
+
+Generally, the following patterns should be followed in this regard:
+
+* each "block" (declaration/definition per hooks file) should only be included
+  in one place.  Including it more than once will cause compiler errors due to
+  duplicate symbols.
+* if a file references multiple ``_hooks.h`` files (this should only happen
+  in header files), group them all together and include ``hooks_begin.h`` /
+  ``hooks_end.h`` only once.
+* the ``_hooks.h`` is mostly named to match the ``.c`` file that the hooks are
+  defined and invoked in.
+* the ``HOOKS_DECLARE`` block in a ``.h`` file should be towards the end of
+  the file (but inside the ``extern "C"`` block if there is one.)
+* the ``HOOKS_DEFINE`` block in a ``.c`` file should be towards the beginning
+  of the file, after all ``#include`` statements and before any function
+  definitions.
 
 
 Return values
@@ -93,6 +143,17 @@ the same thing as DECLARE_HOOK, it's just there to make it obvious.)
 Definition
 ----------
 
+.. c:macro:: DO_HOOK(name, args...)
+.. c:macro:: DO_KOOH(name, args...)
+
+   :param name: Name of the hook to be defined
+   :param args: List of (type, name) tuples specifying hook parameters.
+
+   "dispatcher" macros for use in ``_hooks.h`` files that get included multiple
+   times.  What it expands to depends on whether ``HOOKS_DECLARE``,
+   ``HOOKS_DEFINE`` or ``HOOKS_LUA`` was set before including
+   ``hooks_begin.h``.
+
 .. c:macro:: DECLARE_HOOK(name, args...)
 .. c:macro:: DECLARE_KOOH(name, args...)
 
@@ -144,6 +205,14 @@ Definition
 
    Same as ``DEFINE_HOOK``, but the sense of priorities / order of callbacks
    is reversed.  This should be used for cleanup hooks.
+
+.. c:macro:: LUA_HOOK(name, args...)
+
+   Expands into a Lua binding for the given hook.  Note there is no need for a
+   ``KOOH`` form of this, only a ``HOOK`` form for this which would be used for
+   both call orderings.
+
+   .. todo:: not implemented yet.
 
 .. c:function:: int hook_call(name, ...)
 

--- a/doc/developer/hooks.rst
+++ b/doc/developer/hooks.rst
@@ -15,13 +15,15 @@ Example:
    :caption: mydaemon.h
 
    #include "hook.h"
-   DECLARE_HOOK(some_update_event, (struct eventinfo *info), (info));
+   DECLARE_HOOK(some_update_event,
+                (struct eventinfo *, info));
 
 .. code-block:: c
    :caption: mydaemon.c
 
    #include "mydaemon.h"
-   DEFINE_HOOK(some_update_event, (struct eventinfo *info), (info));
+   DEFINE_HOOK(some_update_event,
+               (struct eventinfo *, info));
    ...
    hook_call(some_update_event, info);
 
@@ -91,17 +93,16 @@ the same thing as DECLARE_HOOK, it's just there to make it obvious.)
 Definition
 ----------
 
-.. c:macro:: DECLARE_HOOK(name, arglist, passlist)
-.. c:macro:: DECLARE_KOOH(name, arglist, passlist)
+.. c:macro:: DECLARE_HOOK(name, args...)
+.. c:macro:: DECLARE_KOOH(name, args...)
 
    :param name: Name of the hook to be defined
-   :param arglist: Function definition style parameter list in braces.
-   :param passlist: List of the same parameters without their types.
+   :param args: List of (type, name) tuples specifying hook parameters.
 
-   Note:  the second and third macro args must be the hook function's
-   parameter list, with the same names for each parameter.  The second
-   macro arg is with types (used for defining things), the third arg is
-   just the names (used for passing along parameters).
+   The tuples specifying parameters are essentially just "insert a comma
+   between the type and the name and put braces around it".  Without the extra
+   comma, the macro would be unable to use the name without the declaration in
+   front of it.
 
    This macro must be placed in a header file;  this header file must be
    included to register a callback on the hook.
@@ -110,11 +111,24 @@ Definition
 
    .. code-block:: c
 
-      DECLARE_HOOK(foo, (), ());
-      DECLARE_HOOK(bar, (int arg), (arg));
-      DECLARE_HOOK(baz, (const void *x, in_addr_t y), (x, y));
+      DECLARE_HOOK(foo);
+      DECLARE_HOOK(bar, (int, arg));
+      DECLARE_HOOK(baz, (const void *, x), (in_addr_t, y));
 
-.. c:macro:: DEFINE_HOOK(name, arglist, passlist)
+   .. note::
+      Due to this way of specifying the parameter list, it is not possible to
+      use plain function pointers as parameters on hooks, since there the
+      function pointer's parameter list is after the name of the parameter.
+
+      This is considered an acceptable limitation of the way this macro works.
+      The workaround/solution to defining a hook that takes a function pointer
+      as a parameter is to either use a typedef for the function pointer, put
+      the function pointer in a struct, or use ``__typeof__``.
+
+      At the time this note was written, none of the hooks in FRR had a
+      function pointer parameter.
+
+.. c:macro:: DEFINE_HOOK(name, args...)
 
    Implements an hook.  Each ``DECLARE_HOOK`` must have be accompanied by
    exactly one ``DEFINE_HOOK``, which needs to be placed in a source file.
@@ -126,7 +140,7 @@ Definition
    doesn't exist will therefore result in a linker error, or a module
    load-time error for dynamic modules.
 
-.. c:macro:: DEFINE_KOOH(name, arglist, passlist)
+.. c:macro:: DEFINE_KOOH(name, args...)
 
    Same as ``DEFINE_HOOK``, but the sense of priorities / order of callbacks
    is reversed.  This should be used for cleanup hooks.

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -42,6 +42,11 @@
 DEFINE_MTYPE_STATIC(ISISD, ISIS_ADJACENCY, "ISIS adjacency");
 DEFINE_MTYPE(ISISD, ISIS_ADJACENCY_INFO, "ISIS adjacency info");
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_adjacency_hooks.h"
+#include "lib/hooks_end.h"
+
 static struct isis_adjacency *adj_alloc(struct isis_circuit *circuit,
 					const uint8_t *id)
 {
@@ -138,11 +143,6 @@ const struct isis_adjacency *isis_adj_find(const struct isis_area *area,
 
 	return NULL;
 }
-
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "isisd/isis_adjacency_hooks.h"
-#include "lib/hooks_end.h"
 
 void isis_delete_adj(void *arg)
 {

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -139,7 +139,10 @@ const struct isis_adjacency *isis_adj_find(const struct isis_area *area,
 	return NULL;
 }
 
-DEFINE_HOOK(isis_adj_state_change_hook, (struct isis_adjacency *adj), (adj));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_adjacency_hooks.h"
+#include "lib/hooks_end.h"
 
 void isis_delete_adj(void *arg)
 {

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -122,13 +122,13 @@ void isis_delete_adj(void *adj);
 void isis_adj_process_threeway(struct isis_adjacency **padj,
 			       struct isis_threeway_adj *tw_adj,
 			       enum isis_adj_usage adj_usage);
-DECLARE_HOOK(isis_adj_state_change_hook, (struct isis_adjacency *adj), (adj));
-DECLARE_HOOK(isis_adj_ip_enabled_hook,
-	     (struct isis_adjacency * adj, int family, bool global),
-	     (adj, family, global));
-DECLARE_HOOK(isis_adj_ip_disabled_hook,
-	     (struct isis_adjacency * adj, int family, bool global),
-	     (adj, family, global));
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_adjacency_hooks.h"
+#include "isisd/isis_tlvs_hooks.h"
+#include "lib/hooks_end.h"
+
 void isis_log_adj_change(struct isis_adjacency *adj,
 			 enum isis_adj_state old_state,
 			 enum isis_adj_state new_state, const char *reason);

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -123,12 +123,6 @@ void isis_adj_process_threeway(struct isis_adjacency **padj,
 			       struct isis_threeway_adj *tw_adj,
 			       enum isis_adj_usage adj_usage);
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "isisd/isis_adjacency_hooks.h"
-#include "isisd/isis_tlvs_hooks.h"
-#include "lib/hooks_end.h"
-
 void isis_log_adj_change(struct isis_adjacency *adj,
 			 enum isis_adj_state old_state,
 			 enum isis_adj_state new_state, const char *reason);
@@ -148,4 +142,11 @@ void isis_bfd_startup_timer(struct event *event);
 const char *isis_adj_name(const struct isis_adjacency *adj);
 bool isis_adj_ipv4_usable(const struct isis_adjacency *adj);
 bool isis_adj_ipv6_usable(const struct isis_adjacency *adj);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_adjacency_hooks.h"
+#include "isisd/isis_tlvs_hooks.h"
+#include "lib/hooks_end.h"
+
 #endif /* ISIS_ADJACENCY_H */

--- a/isisd/isis_adjacency_hooks.h
+++ b/isisd/isis_adjacency_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for isisd/isis_adjacency.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(isis_adj_state_change_hook, (struct isis_adjacency *, adj));

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -56,16 +56,16 @@ DEFINE_MTYPE_STATIC(ISISD, ISIS_CIRCUIT, "ISIS circuit");
 
 DEFINE_QOBJ_TYPE(isis_circuit);
 
-DEFINE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_circuit_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Prototypes.
  */
 int isis_if_new_hook(struct interface *);
 int isis_if_delete_hook(struct interface *);
-
-DEFINE_HOOK(isis_circuit_new_hook, (struct isis_circuit *circuit), (circuit));
-DEFINE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
 
 static void isis_circuit_enable(struct isis_circuit *circuit)
 {
@@ -276,9 +276,6 @@ struct isis_circuit *circuit_scan_by_ifp(struct interface *ifp)
 {
 	return (struct isis_circuit *)ifp->info;
 }
-
-DEFINE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit),
-	    (circuit));
 
 /*
  * A local IP address was added or removed on this circuit. Re-evaluate
@@ -1222,10 +1219,6 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 }
 
 #ifdef FABRICD
-DEFINE_HOOK(isis_circuit_config_write,
-	    (struct isis_circuit *circuit, struct vty *vty),
-	    (circuit, vty));
-
 static int isis_interface_config_write(struct vty *vty)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -23,8 +23,6 @@
 #include "isis_common.h"
 #include "isis_csm.h"
 
-DECLARE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp));
-
 /* Typesafe list declarations for circuits */
 PREDECL_DLIST(isis_circuit_list);
 
@@ -236,13 +234,11 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid, boo
 void isis_reset_hello_timer(struct isis_circuit *circuit);
 
 #ifdef FABRICD
-DECLARE_HOOK(isis_circuit_config_write,
-	     (struct isis_circuit *circuit, struct vty *vty), (circuit, vty));
 #endif
 
-DECLARE_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *circuit), (circuit));
-
-DECLARE_HOOK(isis_circuit_new_hook, (struct isis_circuit *circuit), (circuit));
-DECLARE_HOOK(isis_circuit_del_hook, (struct isis_circuit *circuit), (circuit));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_circuit_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */

--- a/isisd/isis_circuit_hooks.h
+++ b/isisd/isis_circuit_hooks.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for isisd/isis_circuit.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(isis_if_new_hook, (struct interface *, ifp));
+
+DO_HOOK(isis_circuit_new_hook, (struct isis_circuit *, circuit));
+
+DO_HOOK(isis_circuit_del_hook, (struct isis_circuit *, circuit));
+
+DO_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *, circuit));
+
+#ifdef FABRICD
+DO_HOOK(isis_circuit_config_write, (struct isis_circuit *, circuit), (struct vty *, vty));
+#endif

--- a/isisd/isis_circuit_hooks.h
+++ b/isisd/isis_circuit_hooks.h
@@ -7,7 +7,6 @@
 DO_HOOK(isis_if_new_hook, (struct interface *, ifp));
 
 DO_HOOK(isis_circuit_new_hook, (struct isis_circuit *, circuit));
-
 DO_HOOK(isis_circuit_del_hook, (struct isis_circuit *, circuit));
 
 DO_HOOK(isis_circuit_add_addr_hook, (struct isis_circuit *, circuit));

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -549,48 +549,10 @@ void isis_notif_own_lsp_purge(const struct isis_circuit *circuit, const uint8_t 
 /* cmp */
 int cli_cmp_isis_redistribute_table(const struct lyd_node *dnode1, const struct lyd_node *dnode2);
 
-/* We also declare hook for every notification */
-
-DECLARE_HOOK(isis_hook_db_overload, (const struct isis_area *area), (area));
-DECLARE_HOOK(isis_hook_lsp_too_large,
-	     (const struct isis_circuit *circuit, uint32_t pdu_size, const uint8_t *lsp_id),
-	     (circuit, pdu_size, lsp_id));
-/* Note: no isis_hook_corrupted_lsp - because this notification is not used */
-DECLARE_HOOK(isis_hook_lsp_exceed_max, (const struct isis_area *area, const uint8_t *lsp_id),
-	     (area, lsp_id));
-DECLARE_HOOK(isis_hook_max_area_addr_mismatch,
-	     (const struct isis_circuit *circuit, uint8_t max_addrs, const char *raw_pdu,
-	      size_t raw_pdu_len),
-	     (circuit, max_addrs, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_authentication_type_failure,
-	     (const struct isis_circuit *circuit, const char *raw_pdu, size_t raw_pdu_len),
-	     (circuit, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_authentication_failure,
-	     (const struct isis_circuit *circuit, const char *raw_pdu, size_t raw_pdu_len),
-	     (circuit, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_adj_state_change, (const struct isis_adjacency *adj), (adj));
-DECLARE_HOOK(isis_hook_reject_adjacency,
-	     (const struct isis_circuit *circuit, const char *raw_pdu,
-	      size_t raw_pdu_len),
-	     (circuit, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_area_mismatch,
-	     (const struct isis_circuit *circuit, const char *raw_pdu, size_t raw_pdu_len),
-	     (circuit, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_id_len_mismatch,
-	     (const struct isis_circuit *circuit, uint8_t rcv_id_len, const char *raw_pdu,
-	      size_t raw_pdu_len),
-	     (circuit, rcv_id_len, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_version_skew,
-	     (const struct isis_circuit *circuit, uint8_t version, const char *raw_pdu,
-	      size_t raw_pdu_len),
-	     (circuit, version, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_lsp_error,
-	     (const struct isis_circuit *circuit, const uint8_t *lsp_id, const char *raw_pdu,
-	      size_t raw_pdu_len),
-	     (circuit, lsp_id, raw_pdu, raw_pdu_len));
-DECLARE_HOOK(isis_hook_seqno_skipped, (const struct isis_circuit *circuit, const uint8_t *lsp_id),
-	     (circuit, lsp_id));
-DECLARE_HOOK(isis_hook_own_lsp_purge, (const struct isis_circuit *circuit, const uint8_t *lsp_id),
-	     (circuit, lsp_id));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_nb_notifications_hooks.h"
+#include "isisd/isisd_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* ISISD_ISIS_NB_H_ */

--- a/isisd/isis_nb_notifications.c
+++ b/isisd/isis_nb_notifications.c
@@ -15,55 +15,10 @@
 #include "isisd/isis_dynhn.h"
 #include "isisd/isis_misc.h"
 
-DEFINE_HOOK(isis_hook_lsp_too_large,
-	    (const struct isis_circuit *circuit, uint32_t pdu_size,
-	     const uint8_t *lsp_id),
-	    (circuit, pdu_size, lsp_id));
-DEFINE_HOOK(isis_hook_corrupted_lsp, (const struct isis_area *area), (area));
-DEFINE_HOOK(isis_hook_lsp_exceed_max,
-	    (const struct isis_area *area, const uint8_t *lsp_id),
-	    (area, lsp_id));
-DEFINE_HOOK(isis_hook_max_area_addr_mismatch,
-	    (const struct isis_circuit *circuit, uint8_t max_addrs,
-	     const char *raw_pdu, size_t raw_pdu_len),
-	    (circuit, max_addrs, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_authentication_type_failure,
-	    (const struct isis_circuit *circuit, const char *raw_pdu,
-	     size_t raw_pdu_len),
-	    (circuit, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_authentication_failure,
-	    (const struct isis_circuit *circuit, const char *raw_pdu,
-	     size_t raw_pdu_len),
-	    (circuit, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_adj_state_change, (const struct isis_adjacency *adj),
-	    (adj));
-DEFINE_HOOK(isis_hook_reject_adjacency,
-	    (const struct isis_circuit *circuit, const char *raw_pdu,
-	     size_t raw_pdu_len),
-	    (circuit, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_area_mismatch,
-	    (const struct isis_circuit *circuit, const char *raw_pdu,
-	     size_t raw_pdu_len),
-	    (circuit, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_id_len_mismatch,
-	    (const struct isis_circuit *circuit, uint8_t rcv_id_len,
-	     const char *raw_pdu, size_t raw_pdu_len),
-	    (circuit, rcv_id_len, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_version_skew,
-	    (const struct isis_circuit *circuit, uint8_t version,
-	     const char *raw_pdu, size_t raw_pdu_len),
-	    (circuit, version, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_lsp_error,
-	    (const struct isis_circuit *circuit, const uint8_t *lsp_id,
-	     const char *raw_pdu, size_t raw_pdu_len),
-	    (circuit, lsp_id, raw_pdu, raw_pdu_len));
-DEFINE_HOOK(isis_hook_seqno_skipped,
-	    (const struct isis_circuit *circuit, const uint8_t *lsp_id),
-	    (circuit, lsp_id));
-DEFINE_HOOK(isis_hook_own_lsp_purge,
-	    (const struct isis_circuit *circuit, const uint8_t *lsp_id),
-	    (circuit, lsp_id));
-
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_nb_notifications_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Helper functions.

--- a/isisd/isis_nb_notifications_hooks.h
+++ b/isisd/isis_nb_notifications_hooks.h
@@ -6,38 +6,25 @@
 
 DO_HOOK(isis_hook_lsp_too_large, (const struct isis_circuit *, circuit), (uint32_t, pdu_size),
 	(const uint8_t *, lsp_id));
-
 DO_HOOK(isis_hook_corrupted_lsp, (const struct isis_area *, area));
-
 /* Note: no isis_hook_corrupted_lsp - because this notification is not used */
 DO_HOOK(isis_hook_lsp_exceed_max, (const struct isis_area *, area), (const uint8_t *, lsp_id));
-
 DO_HOOK(isis_hook_max_area_addr_mismatch, (const struct isis_circuit *, circuit),
 	(uint8_t, max_addrs), (const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_authentication_type_failure, (const struct isis_circuit *, circuit),
 	(const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_authentication_failure, (const struct isis_circuit *, circuit),
 	(const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_adj_state_change, (const struct isis_adjacency *, adj));
-
 DO_HOOK(isis_hook_reject_adjacency, (const struct isis_circuit *, circuit),
 	(const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_area_mismatch, (const struct isis_circuit *, circuit), (const char *, raw_pdu),
 	(size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_id_len_mismatch, (const struct isis_circuit *, circuit), (uint8_t, rcv_id_len),
 	(const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_version_skew, (const struct isis_circuit *, circuit), (uint8_t, version),
 	(const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_lsp_error, (const struct isis_circuit *, circuit), (const uint8_t *, lsp_id),
 	(const char *, raw_pdu), (size_t, raw_pdu_len));
-
 DO_HOOK(isis_hook_seqno_skipped, (const struct isis_circuit *, circuit), (const uint8_t *, lsp_id));
-
 DO_HOOK(isis_hook_own_lsp_purge, (const struct isis_circuit *, circuit), (const uint8_t *, lsp_id));

--- a/isisd/isis_nb_notifications_hooks.h
+++ b/isisd/isis_nb_notifications_hooks.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for isisd/isis_nb_notifications.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(isis_hook_lsp_too_large, (const struct isis_circuit *, circuit), (uint32_t, pdu_size),
+	(const uint8_t *, lsp_id));
+
+DO_HOOK(isis_hook_corrupted_lsp, (const struct isis_area *, area));
+
+/* Note: no isis_hook_corrupted_lsp - because this notification is not used */
+DO_HOOK(isis_hook_lsp_exceed_max, (const struct isis_area *, area), (const uint8_t *, lsp_id));
+
+DO_HOOK(isis_hook_max_area_addr_mismatch, (const struct isis_circuit *, circuit),
+	(uint8_t, max_addrs), (const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_authentication_type_failure, (const struct isis_circuit *, circuit),
+	(const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_authentication_failure, (const struct isis_circuit *, circuit),
+	(const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_adj_state_change, (const struct isis_adjacency *, adj));
+
+DO_HOOK(isis_hook_reject_adjacency, (const struct isis_circuit *, circuit),
+	(const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_area_mismatch, (const struct isis_circuit *, circuit), (const char *, raw_pdu),
+	(size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_id_len_mismatch, (const struct isis_circuit *, circuit), (uint8_t, rcv_id_len),
+	(const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_version_skew, (const struct isis_circuit *, circuit), (uint8_t, version),
+	(const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_lsp_error, (const struct isis_circuit *, circuit), (const uint8_t *, lsp_id),
+	(const char *, raw_pdu), (size_t, raw_pdu_len));
+
+DO_HOOK(isis_hook_seqno_skipped, (const struct isis_circuit *, circuit), (const uint8_t *, lsp_id));
+
+DO_HOOK(isis_hook_own_lsp_purge, (const struct isis_circuit *, circuit), (const uint8_t *, lsp_id));

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -43,11 +43,10 @@ DEFINE_MTYPE_STATIC(ISISD, ISIS_NEXTHOP, "ISIS nexthop");
 DEFINE_MTYPE_STATIC(ISISD, ISIS_ROUTE_INFO, "ISIS route info");
 DEFINE_MTYPE_STATIC(ISISD, ISIS_ROUTE_TABLE_INFO, "ISIS route table info");
 
-
-DEFINE_HOOK(isis_route_update_hook,
-	    (struct isis_area *area, struct prefix *prefix,
-	     struct isis_route_info *route_info),
-	    (area, prefix, route_info));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_route_hooks.h"
+#include "lib/hooks_end.h"
 
 static struct isis_nexthop *nexthoplookup(struct list *nexthops, int family, union g_addr *ip,
 					  ifindex_t ifindex);

--- a/isisd/isis_route.h
+++ b/isisd/isis_route.h
@@ -42,10 +42,10 @@ struct isis_route_table_info {
 	uint8_t algorithm;
 };
 
-DECLARE_HOOK(isis_route_update_hook,
-	     (struct isis_area *area, struct prefix *prefix,
-	      struct isis_route_info *route_info),
-	     (area, prefix, route_info));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_route_hooks.h"
+#include "lib/hooks_end.h"
 
 void isis_nexthop_delete(struct isis_nexthop *nexthop);
 void adjinfo2nexthop(int family, struct list *nexthops, struct isis_adjacency *adj,

--- a/isisd/isis_route_hooks.h
+++ b/isisd/isis_route_hooks.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for isisd/isis_route.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(isis_route_update_hook, (struct isis_area *, area), (struct prefix *, prefix),
+	(struct isis_route_info *, route_info));

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -7423,12 +7423,10 @@ static void tlvs_protocols_supported_to_adj(struct isis_tlvs *tlvs, struct isis_
 	memcpy(adj->nlpids.nlpids, reduced.nlpids, reduced.count);
 }
 
-DEFINE_HOOK(isis_adj_ip_enabled_hook,
-	    (struct isis_adjacency *adj, int family, bool global),
-	    (adj, family, global));
-DEFINE_HOOK(isis_adj_ip_disabled_hook,
-	    (struct isis_adjacency *adj, int family, bool global),
-	    (adj, family, global));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_tlvs_hooks.h"
+#include "lib/hooks_end.h"
 
 static void tlvs_ipv4_addresses_to_adj(struct isis_tlvs *tlvs, struct isis_adjacency *adj,
 				       bool *changed)

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -43,6 +43,11 @@
 #define TLV_SIZE_MISMATCH(log, indent, target)                                                    \
 	sbuf_push(log, indent, "TLV size does not match expected size for " target "!\n")
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isis_tlvs_hooks.h"
+#include "lib/hooks_end.h"
+
 DEFINE_MTYPE_STATIC(ISISD, ISIS_TLV, "ISIS TLVs");
 DEFINE_MTYPE(ISISD, ISIS_SUBTLV, "ISIS Sub-TLVs");
 DEFINE_MTYPE(ISISD, ISIS_SUBSUBTLV, "ISIS Sub-Sub-TLVs");
@@ -7422,11 +7427,6 @@ static void tlvs_protocols_supported_to_adj(struct isis_tlvs *tlvs, struct isis_
 	adj->nlpids.count = reduced.count;
 	memcpy(adj->nlpids.nlpids, reduced.nlpids, reduced.count);
 }
-
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "isisd/isis_tlvs_hooks.h"
-#include "lib/hooks_end.h"
 
 static void tlvs_ipv4_addresses_to_adj(struct isis_tlvs *tlvs, struct isis_adjacency *adj,
 				       bool *changed)

--- a/isisd/isis_tlvs_hooks.h
+++ b/isisd/isis_tlvs_hooks.h
@@ -5,5 +5,4 @@
  */
 
 DO_HOOK(isis_adj_ip_enabled_hook, (struct isis_adjacency *, adj), (int, family), (bool, global));
-
 DO_HOOK(isis_adj_ip_disabled_hook, (struct isis_adjacency *, adj), (int, family), (bool, global));

--- a/isisd/isis_tlvs_hooks.h
+++ b/isisd/isis_tlvs_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for isisd/isis_tlvs.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(isis_adj_ip_enabled_hook, (struct isis_adjacency *, adj), (int, family), (bool, global));
+
+DO_HOOK(isis_adj_ip_disabled_hook, (struct isis_adjacency *, adj), (int, family), (bool, global));

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -94,14 +94,10 @@ struct isis_master *im;
 /* ISIS config processing thread */
 struct event *t_isis_cfg;
 
-#ifndef FABRICD
-
 #define HOOKS_DEFINE
 #include "lib/hooks_begin.h"
 #include "isisd/isisd_hooks.h"
 #include "lib/hooks_end.h"
-
-#endif /* ifndef FABRICD */
 
 /*
  * Prototypes.

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -95,7 +95,12 @@ struct isis_master *im;
 struct event *t_isis_cfg;
 
 #ifndef FABRICD
-DEFINE_HOOK(isis_hook_db_overload, (const struct isis_area *area), (area));
+
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "isisd/isisd_hooks.h"
+#include "lib/hooks_end.h"
+
 #endif /* ifndef FABRICD */
 
 /*

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -291,8 +291,6 @@ DECLARE_MTYPE(ISIS_AREA_ADDR);	/* isis_area->area_addrs */
 DECLARE_MTYPE(ISIS_PLIST_NAME);
 DECLARE_MTYPE(ISIS_BFD_PROFILE); /* isis_circuit->bfd_config.profile */
 
-DECLARE_HOOK(isis_area_overload_bit_update, (struct isis_area * area), (area));
-
 void isis_terminate(void);
 void isis_master_init(struct event_loop *master);
 void isis_master_terminate(void);

--- a/isisd/isisd_hooks.h
+++ b/isisd/isisd_hooks.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for isisd/isisd.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+#ifndef FABRICD
+/* We also declare hook for every notification */
+DO_HOOK(isis_hook_db_overload, (const struct isis_area *, area));
+#endif

--- a/isisd/subdir.am
+++ b/isisd/subdir.am
@@ -55,6 +55,13 @@ noinst_HEADERS += \
 	isisd/isisd.h \
 	isisd/iso_checksum.h \
 	isisd/fabricd.h \
+	\
+	isisd/isis_adjacency_hooks.h \
+	isisd/isis_circuit_hooks.h \
+	isisd/isis_nb_notifications_hooks.h \
+	isisd/isis_route_hooks.h \
+	isisd/isis_tlvs_hooks.h \
+	isisd/isisd_hooks.h \
 	# end
 
 LIBISIS_SOURCES = \

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -85,7 +85,10 @@ static pid_t		 lde_pid;
 
 static struct frr_daemon_info ldpd_di;
 
-DEFINE_HOOK(ldp_register_mib, (struct event_loop * tm), (tm));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ldpd/ldpd_hooks.h"
+#include "lib/hooks_end.h"
 
 static void ldp_load_module(const char *name)
 {

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -902,7 +902,10 @@ void ldp_zebra_regdereg_zebra_info(bool want_register);
 	(__IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_INTFACELOCAL))
 #endif
 
-DECLARE_HOOK(ldp_register_mib, (struct event_loop * tm), (tm));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ldpd/ldpd_hooks.h"
+#include "lib/hooks_end.h"
 
 extern void ldp_agentx_enabled(void);
 

--- a/ldpd/ldpd_hooks.h
+++ b/ldpd/ldpd_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: ISC
+/* hook definitions for ldpd/ldpd.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ldp_register_mib, (struct event_loop *, tm));

--- a/ldpd/ldpe.h
+++ b/ldpd/ldpe.h
@@ -306,7 +306,9 @@ void ldpe_l2vpn_exit(struct l2vpn *l2vpn);
 void ldpe_l2vpn_pw_init(struct l2vpn_pw *pw);
 void ldpe_l2vpn_pw_exit(struct l2vpn_pw *pw);
 
-DECLARE_HOOK(ldp_nbr_state_change, (struct nbr * nbr, int old_state),
-	     (nbr, old_state));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ldpd/neighbor_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif	/* _LDPE_H_ */

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -15,8 +15,10 @@
 #include "lde.h"
 #include "log.h"
 
-DEFINE_HOOK(ldp_nbr_state_change, (struct nbr * nbr, int old_state),
-	    (nbr, old_state));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ldpd/neighbor_hooks.h"
+#include "lib/hooks_end.h"
 
 static __inline int	 nbr_id_compare(const struct nbr *, const struct nbr *);
 static __inline int	 nbr_addr_compare(const struct nbr *, const struct nbr *);

--- a/ldpd/neighbor_hooks.h
+++ b/ldpd/neighbor_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: ISC
+/* hook definitions for ldpd/neighbor.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ldp_nbr_state_change, (struct nbr *, nbr), (int, old_state));

--- a/ldpd/subdir.am
+++ b/ldpd/subdir.am
@@ -59,6 +59,9 @@ noinst_HEADERS += \
 	ldpd/ldpe.h \
 	ldpd/log.h \
 	ldpd/rlfa.h \
+	\
+	ldpd/ldpd_hooks.h \
+	ldpd/neighbor_hooks.h \
 	# end
 
 ldpd_ldpd_SOURCES = ldpd/ldpd.c

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -26,7 +26,10 @@
 
 XREF_SETUP();
 
-DEFINE_HOOK(agentx_enabled, (), ());
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/agentx_hooks.h"
+#include "lib/hooks_end.h"
 
 //bool agentx_enabled = false;
 

--- a/lib/agentx_hooks.h
+++ b/lib/agentx_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/agentx.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+#ifdef SNMP_AGENTX
+DO_HOOK(agentx_enabled);
+#endif

--- a/lib/command.c
+++ b/lib/command.c
@@ -1144,17 +1144,12 @@ int cmd_execute_command_strict(vector vline, struct vty *vty,
  * cmd_out
  *    The result of any processing.
  */
-DECLARE_HOOK(cmd_execute,
-	     (struct vty *vty, const char *cmd_in, char **cmd_out),
-	     (vty, cmd_in, cmd_out));
-DEFINE_HOOK(cmd_execute, (struct vty *vty, const char *cmd_in, char **cmd_out),
-	    (vty, cmd_in, cmd_out));
+DECLARE_HOOK(cmd_execute, (struct vty *, vty), (const char *, cmd_in), (char **, cmd_out));
+DEFINE_HOOK(cmd_execute, (struct vty *, vty), (const char *, cmd_in), (char **, cmd_out));
 
 /* Hook executed after a CLI command. */
-DECLARE_KOOH(cmd_execute_done, (struct vty *vty, const char *cmd_exec),
-	     (vty, cmd_exec));
-DEFINE_KOOH(cmd_execute_done, (struct vty *vty, const char *cmd_exec),
-	    (vty, cmd_exec));
+DECLARE_KOOH(cmd_execute_done, (struct vty *, vty), (const char *, cmd_exec));
+DEFINE_KOOH(cmd_execute_done, (struct vty *, vty), (const char *, cmd_exec));
 
 /*
  * cmd_execute hook subscriber to handle `|` actions.

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -138,70 +138,110 @@ extern "C" {
 #define MACRO_REQUIRE_SEMICOLON() \
 	_Static_assert(1, "please add a semicolon after this macro")
 
+/* the purpose of these macros is to deal with C's macro expansion rules;
+ * specifically token pasting and nesting.
+ */
+#define _MACRO_EXPAND(a) a
+#define _CONCAT2(a, b)	 a##b
+#define _CONCAT(a, b)	 _CONCAT2(a, b)
+
+#define MACRO_APPLY(NAME, ARGS) NAME ARGS
+
+#define NAMECTR(name) _CONCAT(name, __COUNTER__)
+
+/* clang-format off */
+
 /* variadic macros, use like:
  * #define V_0()  ...
  * #define V_1(x) ...
  * #define V(...) MACRO_VARIANT(V, ##__VA_ARGS__)(__VA_ARGS__)
  */
-#define _MACRO_VARIANT(A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10, N, ...) N
+#define _MACRO_VARIANT(A0, \
+		       A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, \
+		       A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, \
+		       A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, \
+		       A31, A32, A33, A34, A35, A36, A37, A38, A39, A40, \
+		       N, ...) N
 
-#define _CONCAT2(a, b) a ## b
-#define _CONCAT(a, b) _CONCAT2(a,b)
-
+/* _XX for 11..20, _YY for 21..30, _ZZ for 31..40 - hopefully that's enough.
+ * _XX, _YY and _ZZ are expected to "recurse back"
+ */
 #define MACRO_VARIANT(NAME, ...) \
 	_CONCAT(NAME, _MACRO_VARIANT(0, ##__VA_ARGS__, \
-			_10, _9, _8, _7, _6, _5, _4, _3, _2, _1, _0))
-
-#define NAMECTR(name) _CONCAT(name, __COUNTER__)
+			_ZZ, _ZZ, _ZZ, _ZZ, _ZZ, _ZZ, _ZZ, _ZZ, _ZZ, _ZZ, \
+			_YY, _YY, _YY, _YY, _YY, _YY, _YY, _YY, _YY, _YY, \
+			_XX, _XX, _XX, _XX, _XX, _XX, _XX, _XX, _XX, _XX, \
+			_10,  _9,  _8,  _7,  _6,  _5,  _4,  _3,  _2,  _1, \
+			_0))
 
 /* per-arg repeat macros, use like:
  * #define PERARG(n) ...n...
  * #define FOO(...) MACRO_REPEAT(PERARG, ##__VA_ARGS__)
  */
 
-#define _MACRO_REPEAT_0(NAME)
-#define _MACRO_REPEAT_1(NAME, A1) \
-	NAME(A1)
-#define _MACRO_REPEAT_2(NAME, A1, A2) \
-	NAME(A1) NAME(A2)
-#define _MACRO_REPEAT_3(NAME, A1, A2, A3) \
-	NAME(A1) NAME(A2) NAME(A3)
-#define _MACRO_REPEAT_4(NAME, A1, A2, A3, A4) \
-	NAME(A1) NAME(A2) NAME(A3) NAME(A4)
-#define _MACRO_REPEAT_5(NAME, A1, A2, A3, A4, A5) \
-	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5)
-#define _MACRO_REPEAT_6(NAME, A1, A2, A3, A4, A5, A6) \
-	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5) NAME(A6)
-#define _MACRO_REPEAT_7(NAME, A1, A2, A3, A4, A5, A6, A7) \
-	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5) NAME(A6) NAME(A7)
-#define _MACRO_REPEAT_8(NAME, A1, A2, A3, A4, A5, A6, A7, A8) \
-	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5) NAME(A6) NAME(A7) NAME(A8)
+#define _EMPTY()
+#define _SEMICOLON() ;
+#define _COMMA()     ,
 
-#define MACRO_REPEAT(NAME, ...) \
-	MACRO_VARIANT(_MACRO_REPEAT, ##__VA_ARGS__)(NAME, ##__VA_ARGS__)
-
-/* per-arglist repeat macro, use like this:
- * #define foo(...) MAP_LISTS(F, ##__VA_ARGS__)
- * where F is a n-ary function where n is the number of args in each arglist.
- * e.g.: MAP_LISTS(f, (a, b), (c, d))
- * expands to: f(a, b); f(c, d)
+/* multiple copies to get around the macro being disabled while being itself
+ * expanded, for _MACRO_REPEAT_{XX,YY,ZZ} below
  */
+#define _MACRO_REPEAT0(SEP, MARGS, NAME, ...)                                                     \
+	MACRO_VARIANT(_MACRO_REPEAT, ##__VA_ARGS__)(SEP, MARGS, NAME, ##__VA_ARGS__)
+#define _MACRO_REPEAT1(SEP, MARGS, NAME, ...)                                                     \
+	MACRO_VARIANT(_MACRO_REPEAT, ##__VA_ARGS__)(SEP, MARGS, NAME, ##__VA_ARGS__)
+#define _MACRO_REPEAT2(SEP, MARGS, NAME, ...)                                                     \
+	MACRO_VARIANT(_MACRO_REPEAT, ##__VA_ARGS__)(SEP, MARGS, NAME, ##__VA_ARGS__)
+#define _MACRO_REPEAT3(SEP, MARGS, NAME, ...)                                                     \
+	MACRO_VARIANT(_MACRO_REPEAT, ##__VA_ARGS__)(SEP, MARGS, NAME, ##__VA_ARGS__)
 
-#define ESC(...) __VA_ARGS__
-#define MAP_LISTS(M, ...)                                                      \
-	_CONCAT(_MAP_LISTS_, PP_NARG(__VA_ARGS__))(M, ##__VA_ARGS__)
-#define _MAP_LISTS_0(M)
-#define _MAP_LISTS_1(M, _1) ESC(M _1)
-#define _MAP_LISTS_2(M, _1, _2) ESC(M _1; M _2)
-#define _MAP_LISTS_3(M, _1, _2, _3) ESC(M _1; M _2; M _3)
-#define _MAP_LISTS_4(M, _1, _2, _3, _4) ESC(M _1; M _2; M _3; M _4)
-#define _MAP_LISTS_5(M, _1, _2, _3, _4, _5) ESC(M _1; M _2; M _3; M _4; M _5)
-#define _MAP_LISTS_6(M, _1, _2, _3, _4, _5, _6)                                \
-	ESC(M _1; M _2; M _3; M _4; M _5; M _6)
-#define _MAP_LISTS_7(M, _1, _2, _3, _4, _5, _6, _7)                            \
-	ESC(M _1; M _2; M _3; M _4; M _5; M _6; M _7)
-#define _MAP_LISTS_8(M, _1, _2, _3, _4, _5, _6, _7, _8)                        \
-	ESC(M _1; M _2; M _3; M _4; M _5; M _6; M _7; M _8)
+#define _MACRO_REPEAT_0(SEP, MARGS, NAME)
+#define _MACRO_REPEAT_1(SEP, MARGS, NAME, A1) \
+	NAME(MARGS, A1)
+#define _MACRO_REPEAT_2(SEP, MARGS, NAME, A1, A2) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2)
+#define _MACRO_REPEAT_3(SEP, MARGS, NAME, A1, A2, A3) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3)
+#define _MACRO_REPEAT_4(SEP, MARGS, NAME, A1, A2, A3, A4)                                         \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4)
+#define _MACRO_REPEAT_5(SEP, MARGS, NAME, A1, A2, A3, A4, A5) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4) SEP() NAME(MARGS, A5)
+#define _MACRO_REPEAT_6(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4) SEP() NAME(MARGS, A5) SEP() NAME(MARGS, A6)
+#define _MACRO_REPEAT_7(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4) SEP() NAME(MARGS, A5) SEP() NAME(MARGS, A6) SEP() NAME(MARGS, A7)
+#define _MACRO_REPEAT_8(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4) SEP() NAME(MARGS, A5) SEP() NAME(MARGS, A6) SEP() NAME(MARGS, A7) SEP() NAME(MARGS, A8)
+#define _MACRO_REPEAT_9(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4) SEP() NAME(MARGS, A5) SEP() NAME(MARGS, A6) SEP() NAME(MARGS, A7) SEP() NAME(MARGS, A8) SEP() NAME(MARGS, A9)
+#define _MACRO_REPEAT_10(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) \
+	NAME(MARGS, A1) SEP() NAME(MARGS, A2) SEP() NAME(MARGS, A3) SEP() NAME(MARGS, A4) SEP() NAME(MARGS, A5) SEP() NAME(MARGS, A6) SEP() NAME(MARGS, A7) SEP() NAME(MARGS, A8) SEP() NAME(MARGS, A9) SEP() NAME(MARGS, A10)
+
+/* clang-format on */
+
+/* note these must use a separate copy of _MACRO_REPEAT */
+#define _MACRO_REPEAT_XX(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, ...)          \
+	_MACRO_REPEAT_10(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)               \
+	SEP() _MACRO_REPEAT1(SEP, MARGS, NAME, __VA_ARGS__)
+
+#define _MACRO_REPEAT_YY(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, ...)          \
+	_MACRO_REPEAT_10(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)               \
+	SEP() _MACRO_REPEAT2(SEP, MARGS, NAME, __VA_ARGS__)
+
+#define _MACRO_REPEAT_ZZ(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, ...)          \
+	_MACRO_REPEAT_10(SEP, MARGS, NAME, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)               \
+	SEP() _MACRO_REPEAT3(SEP, MARGS, NAME, __VA_ARGS__)
+
+#define _MACRO_PLAIN_ARG(NAME, ARG) NAME(ARG)
+#define _MACRO_REPEAT(NAME, ...)    _MACRO_REPEAT0(_EMPTY, NAME, _MACRO_PLAIN_ARG, ##__VA_ARGS__)
+#define MACRO_REPEAT(...)	    _MACRO_REPEAT(__VA_ARGS__)
+
+#define _MACRO_REPEAT_SEMICOLON(NAME, ...)                                                        \
+	_MACRO_REPEAT0(_SEMICOLON, NAME, MACRO_APPLY, ##__VA_ARGS__)
+#define MACRO_REPEAT_SEMICOLON(...) _MACRO_REPEAT_SEMICOLON(__VA_ARGS__)
+
+#define _ONE(ARG)	 +1
+#define MACRO_NARGS(...) (0 MACRO_REPEAT(_ONE, ##__VA_ARGS__))
 
 /*
  * for warnings on macros, put in the macro content like this:
@@ -317,29 +357,6 @@ extern "C" {
 	})
 
 #define array_size(ar) (sizeof(ar) / sizeof(ar[0]))
-
-/* Some insane macros to count number of varargs to a functionlike macro */
-#define PP_ARG_N( \
-          _1,  _2,  _3,  _4,  _5,  _6,  _7,  _8,  _9, _10, \
-         _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
-         _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
-         _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
-         _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
-         _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
-         _61, _62, _63, N, ...) N
-
-#define PP_RSEQ_N()                                        \
-         62, 61, 60,                                       \
-         59, 58, 57, 56, 55, 54, 53, 52, 51, 50,           \
-         49, 48, 47, 46, 45, 44, 43, 42, 41, 40,           \
-         39, 38, 37, 36, 35, 34, 33, 32, 31, 30,           \
-         29, 28, 27, 26, 25, 24, 23, 22, 21, 20,           \
-         19, 18, 17, 16, 15, 14, 13, 12, 11, 10,           \
-          9,  8,  7,  6,  5,  4,  3,  2,  1,  0
-
-#define PP_NARG_(...) PP_ARG_N(__VA_ARGS__)
-#define PP_NARG(...)     PP_NARG_(_, ##__VA_ARGS__, PP_RSEQ_N())
-
 
 /* sigh. this is so ugly, it overflows and wraps to being nice again.
  *

--- a/lib/frrscript.h
+++ b/lib/frrscript.h
@@ -286,35 +286,31 @@ int _frrscript_call_lua(struct lua_function_state *lfs, int nargs);
  * Returns:
  *    0 if the script ran successfully, nonzero otherwise.
  */
-#define frrscript_call(fs, f, ...)                                                                                                                                 \
-	({                                                                                                                                                         \
-		struct lua_function_state lookup = {.name = (f)};                                                                                                  \
-		struct lua_function_state *lfs;                                                                                                                    \
-		lfs = hash_lookup((fs)->lua_function_hash, &lookup);                                                                                               \
-		lfs == NULL ? ({                                                                                                                                   \
-			zlog_err(                                                                                                                                  \
-				"frrscript: '%s.lua': '%s': tried to call this function but it was not loaded",                                                    \
-				(fs)->name, (f));                                                                                                                  \
-			1;                                                                                                                                         \
-		})                                                                                                                                                 \
-			    : ({                                                                                                                                   \
-				      lua_settop(lfs->L, 0);                                                                                                       \
-				      lua_getglobal(lfs->L, f);                                                                                                    \
-				      MACRO_REPEAT_SEMICOLON(ENCODE_ARGS, ##__VA_ARGS__);                                                                          \
-				      _frrscript_call_lua(                                                                                                         \
-					      lfs, MACRO_NARGS(__VA_ARGS__));                                                                                      \
-			      }) != 0                                                                                                                              \
-				      ? ({                                                                                                                         \
-						zlog_err(                                                                                                          \
-							"frrscript: '%s.lua': '%s': this function called but returned non-zero exit code. No variables modified.", \
-							(fs)->name, (f));                                                                                          \
-						1;                                                                                                                 \
-					})                                                                                                                         \
-				      : ({                                                                                                                         \
-						MACRO_REPEAT_SEMICOLON(DECODE_ARGS,                                                                                \
-							  ##__VA_ARGS__);                                                                                          \
-						0;                                                                                                                 \
-					});                                                                                                                        \
+#define frrscript_call(fs, f, ...)                                                                                                                    \
+	({                                                                                                                                            \
+		struct lua_function_state lookup = { .name = (f) };                                                                                   \
+		struct lua_function_state *lfs;                                                                                                       \
+		lfs = hash_lookup((fs)->lua_function_hash, &lookup);                                                                                  \
+		lfs == NULL ? ({                                                                                                                      \
+			zlog_err("frrscript: '%s.lua': '%s': tried to call this function but it was not loaded",                                      \
+				 (fs)->name, (f));                                                                                                    \
+			1;                                                                                                                            \
+		})                                                                                                                                    \
+		: ({                                                                                                                                  \
+			  lua_settop(lfs->L, 0);                                                                                                      \
+			  lua_getglobal(lfs->L, f);                                                                                                   \
+			  MACRO_REPEAT_SEMICOLON(ENCODE_ARGS, ##__VA_ARGS__);                                                                         \
+			  _frrscript_call_lua(lfs, MACRO_NARGS(__VA_ARGS__));                                                                         \
+		  }) != 0                                                                                                                             \
+			? ({                                                                                                                          \
+				  zlog_err("frrscript: '%s.lua': '%s': this function called but returned non-zero exit code. No variables modified.", \
+					   (fs)->name, (f));                                                                                          \
+				  1;                                                                                                                  \
+			  })                                                                                                                          \
+			: ({                                                                                                                          \
+				  MACRO_REPEAT_SEMICOLON(DECODE_ARGS, ##__VA_ARGS__);                                                                 \
+				  0;                                                                                                                  \
+			  });                                                                                                                         \
 	})
 
 /*

--- a/lib/frrscript.h
+++ b/lib/frrscript.h
@@ -300,9 +300,9 @@ int _frrscript_call_lua(struct lua_function_state *lfs, int nargs);
 			    : ({                                                                                                                                   \
 				      lua_settop(lfs->L, 0);                                                                                                       \
 				      lua_getglobal(lfs->L, f);                                                                                                    \
-				      MAP_LISTS(ENCODE_ARGS, ##__VA_ARGS__);                                                                                       \
+				      MACRO_REPEAT_SEMICOLON(ENCODE_ARGS, ##__VA_ARGS__);                                                                          \
 				      _frrscript_call_lua(                                                                                                         \
-					      lfs, PP_NARG(__VA_ARGS__));                                                                                          \
+					      lfs, MACRO_NARGS(__VA_ARGS__));                                                                                      \
 			      }) != 0                                                                                                                              \
 				      ? ({                                                                                                                         \
 						zlog_err(                                                                                                          \
@@ -311,7 +311,7 @@ int _frrscript_call_lua(struct lua_function_state *lfs, int nargs);
 						1;                                                                                                                 \
 					})                                                                                                                         \
 				      : ({                                                                                                                         \
-						MAP_LISTS(DECODE_ARGS,                                                                                             \
+						MACRO_REPEAT_SEMICOLON(DECODE_ARGS,                                                                                \
 							  ##__VA_ARGS__);                                                                                          \
 						0;                                                                                                                 \
 					});                                                                                                                        \

--- a/lib/hook.c
+++ b/lib/hook.c
@@ -20,7 +20,7 @@ void _hook_register(struct hook *hook, struct hookent *stackent, void *funcptr,
 {
 	struct hookent *he, **pos;
 
-	if (!stackent->ent_used)
+	if (stackent && !stackent->ent_used)
 		he = stackent;
 	else {
 		he = XCALLOC(MTYPE_HOOK_ENTRY, sizeof(*he));

--- a/lib/hook.h
+++ b/lib/hook.h
@@ -171,14 +171,26 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
 #define hook_call(hookname, ...) hook_call_##hookname(__VA_ARGS__)
 
 /* helpers to add the void * arg */
-#define HOOK_ADDDEF(...) (void *hookarg, ##__VA_ARGS__)
-#define HOOK_ADDARG(...) (hookarg, ##__VA_ARGS__)
+#define _HOOK_COMMA_ARGNAME(decl, name, ...) , name
+#define _HOOK_COMMA_ARGDECL(decl, name, ...) , decl name
+
+#define _HOOK_JOIN_(NAME, ...) _MACRO_REPEAT0(_EMPTY, NAME, MACRO_APPLY, ##__VA_ARGS__)
+#define _HOOK_JOIN(...)	       _HOOK_JOIN_(__VA_ARGS__)
+#define HOOK_ADDARG(...)       (hookarg _HOOK_JOIN(_HOOK_COMMA_ARGNAME, ##__VA_ARGS__))
+#define HOOK_ADDDEF(...)       (void *hookarg _HOOK_JOIN(_HOOK_COMMA_ARGDECL, ##__VA_ARGS__))
 
 /* and another helper to convert () into (void) to get a proper prototype */
 #define _SKIP_10(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, ret, ...) ret
 #define _MAKE_VOID(...) _SKIP_10(, ##__VA_ARGS__, , , , , , , , , , void)
 
-#define HOOK_VOIDIFY(...) (_MAKE_VOID(__VA_ARGS__) __VA_ARGS__)
+#define _HOOK_ARGNAME(decl, name, ...) name
+#define _HOOK_ARGDECL(decl, name, ...) decl name
+
+#define _HOOK_COMMA_JOIN_(NAME, ...) _MACRO_REPEAT0(_COMMA, NAME, MACRO_APPLY, ##__VA_ARGS__)
+#define _HOOK_COMMA_JOIN(...)	     _HOOK_COMMA_JOIN_(__VA_ARGS__)
+
+#define HOOK_PASSARG(...) (_HOOK_COMMA_JOIN(_HOOK_ARGNAME, ##__VA_ARGS__))
+#define HOOK_VOIDIFY(...) (_MAKE_VOID(__VA_ARGS__) _HOOK_COMMA_JOIN(_HOOK_ARGDECL, ##__VA_ARGS__))
 
 /* use in header file - declares the hook and its arguments
  * usage:  DECLARE_HOOK(my_hook, (int arg1, struct foo *arg2), (arg1, arg2));
@@ -187,26 +199,25 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
  * theoretically passlist is not necessary, but let's keep things simple and
  * use exact same args on DECLARE and DEFINE.
  */
-#define DECLARE_HOOK(hookname, arglist, passlist)                                                 \
+#define DECLARE_HOOK(hookname, ...)                                                               \
 	extern struct hook _hook_##hookname;                                                      \
 	__attribute__((unused)) static inline void *_hook_typecheck_##hookname(                   \
-		int(*funcptr) HOOK_VOIDIFY arglist)                                               \
+		int(*funcptr) HOOK_VOIDIFY(__VA_ARGS__))                                          \
 	{                                                                                         \
 		return (void *)funcptr;                                                           \
 	}                                                                                         \
 	__attribute__((unused)) static inline void *_hook_typecheck_arg_##hookname(               \
-		int(*funcptr) HOOK_ADDDEF arglist)                                                \
+		int(*funcptr) HOOK_ADDDEF(__VA_ARGS__))                                           \
 	{                                                                                         \
 		return (void *)funcptr;                                                           \
 	}                                                                                         \
 	MACRO_REQUIRE_SEMICOLON() /* end */
 
-#define DECLARE_KOOH(hookname, arglist, passlist)                              \
-	DECLARE_HOOK(hookname, arglist, passlist)
+#define DECLARE_KOOH(hookname, ...) DECLARE_HOOK(hookname, ##__VA_ARGS__)
 
 /* use in source file - contains hook-related definitions.
  */
-#define DEFINE_HOOK_INT(hookname, arglist, passlist, rev)                                         \
+#define DEFINE_HOOK_INT(hookname, arglist, rev)                                                   \
 	struct hook _hook_##hookname = {                                                          \
 		.name = #hookname,                                                                \
 		.entries = NULL,                                                                  \
@@ -226,18 +237,16 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
 			hookarg = he->hookarg;                                                    \
 			hookp.voidptr = he->hookfn;                                               \
 			if (!he->has_arg)                                                         \
-				hooksum += hookp.fptr passlist;                                   \
+				hooksum += hookp.fptr HOOK_PASSARG arglist;                       \
 			else                                                                      \
-				hooksum += hookp.farg HOOK_ADDARG passlist;                       \
+				hooksum += hookp.farg HOOK_ADDARG arglist;                        \
 		}                                                                                 \
 		return hooksum;                                                                   \
 	}                                                                                         \
 	MACRO_REQUIRE_SEMICOLON() /* end */
 
-#define DEFINE_HOOK(hookname, arglist, passlist)                               \
-	DEFINE_HOOK_INT(hookname, arglist, passlist, false)
-#define DEFINE_KOOH(hookname, arglist, passlist)                               \
-	DEFINE_HOOK_INT(hookname, arglist, passlist, true)
+#define DEFINE_HOOK(hookname, ...) DEFINE_HOOK_INT(hookname, (__VA_ARGS__), false)
+#define DEFINE_KOOH(hookname, ...) DEFINE_HOOK_INT(hookname, (__VA_ARGS__), true)
 
 #ifdef __cplusplus
 }

--- a/lib/hook.h
+++ b/lib/hook.h
@@ -171,8 +171,8 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
 #define hook_call(hookname, ...) hook_call_##hookname(__VA_ARGS__)
 
 /* helpers to add the void * arg */
-#define HOOK_ADDDEF(...) (void *hookarg , ## __VA_ARGS__)
-#define HOOK_ADDARG(...) (hookarg , ## __VA_ARGS__)
+#define HOOK_ADDDEF(...) (void *hookarg, ##__VA_ARGS__)
+#define HOOK_ADDARG(...) (hookarg, ##__VA_ARGS__)
 
 /* and another helper to convert () into (void) to get a proper prototype */
 #define _SKIP_10(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, ret, ...) ret
@@ -187,19 +187,18 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
  * theoretically passlist is not necessary, but let's keep things simple and
  * use exact same args on DECLARE and DEFINE.
  */
-#define DECLARE_HOOK(hookname, arglist, passlist)                              \
-	extern struct hook _hook_##hookname;                                   \
-	__attribute__((unused)) static inline void *                           \
-		_hook_typecheck_##hookname(int(*funcptr) HOOK_VOIDIFY arglist) \
-	{                                                                      \
-		return (void *)funcptr;                                        \
-	}                                                                      \
-	__attribute__((unused)) static inline void                             \
-		*_hook_typecheck_arg_##hookname(int(*funcptr)                  \
-							HOOK_ADDDEF arglist)   \
-	{                                                                      \
-		return (void *)funcptr;                                        \
-	}                                                                      \
+#define DECLARE_HOOK(hookname, arglist, passlist)                                                 \
+	extern struct hook _hook_##hookname;                                                      \
+	__attribute__((unused)) static inline void *_hook_typecheck_##hookname(                   \
+		int(*funcptr) HOOK_VOIDIFY arglist)                                               \
+	{                                                                                         \
+		return (void *)funcptr;                                                           \
+	}                                                                                         \
+	__attribute__((unused)) static inline void *_hook_typecheck_arg_##hookname(               \
+		int(*funcptr) HOOK_ADDDEF arglist)                                                \
+	{                                                                                         \
+		return (void *)funcptr;                                                           \
+	}                                                                                         \
 	MACRO_REQUIRE_SEMICOLON() /* end */
 
 #define DECLARE_KOOH(hookname, arglist, passlist)                              \
@@ -207,30 +206,32 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
 
 /* use in source file - contains hook-related definitions.
  */
-#define DEFINE_HOOK_INT(hookname, arglist, passlist, rev)                      \
-	struct hook _hook_##hookname = {                                       \
-		.name = #hookname, .entries = NULL, .reverse = rev,            \
-	};                                                                     \
-	static int hook_call_##hookname HOOK_VOIDIFY arglist                   \
-	{                                                                      \
-		int hooksum = 0;                                               \
-		struct hookent *he = _hook_##hookname.entries;                 \
-		void *hookarg;                                                 \
-		union {                                                        \
-			void *voidptr;                                         \
-			int(*fptr) HOOK_VOIDIFY arglist;                       \
-			int(*farg) HOOK_ADDDEF arglist;                        \
-		} hookp;                                                       \
-		for (; he; he = he->next) {                                    \
-			hookarg = he->hookarg;                                 \
-			hookp.voidptr = he->hookfn;                            \
-			if (!he->has_arg)                                      \
-				hooksum += hookp.fptr passlist;                \
-			else                                                   \
-				hooksum += hookp.farg HOOK_ADDARG passlist;    \
-		}                                                              \
-		return hooksum;                                                \
-	}                                                                      \
+#define DEFINE_HOOK_INT(hookname, arglist, passlist, rev)                                         \
+	struct hook _hook_##hookname = {                                                          \
+		.name = #hookname,                                                                \
+		.entries = NULL,                                                                  \
+		.reverse = rev,                                                                   \
+	};                                                                                        \
+	static int hook_call_##hookname HOOK_VOIDIFY arglist                                      \
+	{                                                                                         \
+		int hooksum = 0;                                                                  \
+		struct hookent *he = _hook_##hookname.entries;                                    \
+		void *hookarg;                                                                    \
+		union {                                                                           \
+			void *voidptr;                                                            \
+			int(*fptr) HOOK_VOIDIFY arglist;                                          \
+			int(*farg) HOOK_ADDDEF arglist;                                           \
+		} hookp;                                                                          \
+		for (; he; he = he->next) {                                                       \
+			hookarg = he->hookarg;                                                    \
+			hookp.voidptr = he->hookfn;                                               \
+			if (!he->has_arg)                                                         \
+				hooksum += hookp.fptr passlist;                                   \
+			else                                                                      \
+				hooksum += hookp.farg HOOK_ADDARG passlist;                       \
+		}                                                                                 \
+		return hooksum;                                                                   \
+	}                                                                                         \
 	MACRO_REQUIRE_SEMICOLON() /* end */
 
 #define DEFINE_HOOK(hookname, arglist, passlist)                               \

--- a/lib/hooks_begin.h
+++ b/lib/hooks_begin.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (c) 2016  David Lamparter, for NetDEF, Inc.
+ */
+
+/* Header intended to be included multiple times - no include guard! */
+#ifdef DO_HOOK
+#error Definitions from previous hooks_begin.h around - forgot hooks_end.h somewhere?
+#endif
+
+/* DO => DECLARE */
+#if defined(HOOKS_DECLARE)
+#define DO_HOOK DECLARE_HOOK
+#define DO_KOOH DECLARE_KOOH
+
+/* DO => DEFINE */
+#elif defined(HOOKS_DEFINE)
+#define DO_HOOK DEFINE_HOOK
+#define DO_KOOH DEFINE_KOOH
+
+/* DO => LUA */
+#elif defined(HOOKS_LUA)
+#define DO_HOOK LUA_HOOK
+#define DO_KOOH LUA_HOOK
+
+#else
+#error No operation requested, define one of HOOKS_DECLARE, HOOKS_DEFINE or HOOKS_LUA!
+#endif

--- a/lib/hooks_end.h
+++ b/lib/hooks_end.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (c) 2016  David Lamparter, for NetDEF, Inc.
+ */
+
+/* Header intended to be included multiple times - no include guard! */
+#ifndef DO_HOOK
+#error No hook definitions active - hooks_end.h without hooks_begin.h?
+#endif
+
+#undef DO_HOOK
+#undef DO_KOOH
+
+#ifdef HOOKS_DECLARE
+#undef HOOKS_DECLARE
+#endif
+#ifdef HOOKS_DEFINE
+#undef HOOKS_DEFINE
+#endif
+#ifdef HOOKS_LUA
+#undef HOOKS_LUA
+#endif

--- a/lib/if.c
+++ b/lib/if.c
@@ -51,14 +51,10 @@ RB_GENERATE(if_index_head, interface, index_entry, if_cmp_index_func);
 
 DEFINE_QOBJ_TYPE(interface);
 
-DEFINE_HOOK(if_add, (struct interface *ifp), (ifp));
-DEFINE_KOOH(if_del, (struct interface *ifp), (ifp));
-
-DEFINE_HOOK(if_real, (struct interface *ifp), (ifp));
-DEFINE_KOOH(if_unreal, (struct interface *ifp), (ifp));
-
-DEFINE_HOOK(if_up, (struct interface *ifp), (ifp));
-DEFINE_KOOH(if_down, (struct interface *ifp), (ifp));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/if_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Compare interface names, returning an integer greater than, equal to, or
  * less than 0, (following the strcmp convention), according to the

--- a/lib/if.h
+++ b/lib/if.h
@@ -402,35 +402,10 @@ DECLARE_QOBJ_TYPE(interface);
 	if (vrf)                                                               \
 		RB_FOREACH (ifp, if_name_head, &vrf->ifaces_by_name)
 
-/* called from the library code whenever interfaces are created/deleted
- * note: interfaces may not be fully realized at that point; also they
- * may not exist in the system (ifindex = IFINDEX_INTERNAL)
- *
- * priority values are important here, daemons should be at 0 while modules
- * can use 1000+ so they run after the daemon has initialised daemon-specific
- * interface data
- */
-DECLARE_HOOK(if_add, (struct interface *ifp), (ifp));
-DECLARE_KOOH(if_del, (struct interface *ifp), (ifp));
-
-/* called (in daemons) when ZAPI tells us the interface actually exists
- * (ifindex != IFINDEX_INTERNAL)
- *
- * WARNING: these 2 hooks NEVER CALLED inside zebra!
- */
-DECLARE_HOOK(if_real, (struct interface *ifp), (ifp));
-DECLARE_KOOH(if_unreal, (struct interface *ifp), (ifp));
-
-/* called (in daemons) on state changes on interfaces.  Whether this is admin
- * state (= pure config) or carrier state (= hardware link plugged) depends on
- * zebra's "link-detect" configuration.  By default, it's carrier state, so
- * this won't happen until the interface actually has a link.
- *
- * WARNING: these 2 hooks NEVER CALLED inside zebra!
- */
-DECLARE_HOOK(if_up, (struct interface *ifp), (ifp));
-DECLARE_KOOH(if_down, (struct interface *ifp), (ifp));
-
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/if_hooks.h"
+#include "lib/hooks_end.h"
 
 #define METRIC_MAX (~0)
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -402,11 +402,6 @@ DECLARE_QOBJ_TYPE(interface);
 	if (vrf)                                                               \
 		RB_FOREACH (ifp, if_name_head, &vrf->ifaces_by_name)
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "lib/if_hooks.h"
-#include "lib/hooks_end.h"
-
 #define METRIC_MAX (~0)
 
 /* Connected address structure. */
@@ -654,6 +649,11 @@ extern void if_update_state_speed(struct interface *ifp, uint32_t speed);
 extern bool if_notify_oper_changes;
 extern const struct frr_yang_module_info frr_interface_info;
 extern const struct frr_yang_module_info frr_interface_cli_info;
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/if_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/if_hooks.h
+++ b/lib/if_hooks.h
@@ -13,16 +13,14 @@
  * interface data
  */
 DO_HOOK(if_add, (struct interface *, ifp));
-
 DO_KOOH(if_del, (struct interface *, ifp));
 
 /* called (in daemons) when ZAPI tells us the interface actually exists
  * (ifindex != IFINDEX_INTERNAL)
  *
- * WARNING: these 2 hooks NEVER CALLED inside zebra!
+ * WARNING: these 2 hooks are NEVER CALLED inside zebra!
  */
 DO_HOOK(if_real, (struct interface *, ifp));
-
 DO_KOOH(if_unreal, (struct interface *, ifp));
 
 /* called (in daemons) on state changes on interfaces.  Whether this is admin
@@ -30,8 +28,7 @@ DO_KOOH(if_unreal, (struct interface *, ifp));
  * zebra's "link-detect" configuration.  By default, it's carrier state, so
  * this won't happen until the interface actually has a link.
  *
- * WARNING: these 2 hooks NEVER CALLED inside zebra!
+ * WARNING: these 2 hooks are NEVER CALLED inside zebra!
  */
 DO_HOOK(if_up, (struct interface *, ifp));
-
 DO_KOOH(if_down, (struct interface *, ifp));

--- a/lib/if_hooks.h
+++ b/lib/if_hooks.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/if.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* called from the library code whenever interfaces are created/deleted
+ * note: interfaces may not be fully realized at that point; also they
+ * may not exist in the system (ifindex = IFINDEX_INTERNAL)
+ *
+ * priority values are important here, daemons should be at 0 while modules
+ * can use 1000+ so they run after the daemon has initialised daemon-specific
+ * interface data
+ */
+DO_HOOK(if_add, (struct interface *, ifp));
+
+DO_KOOH(if_del, (struct interface *, ifp));
+
+/* called (in daemons) when ZAPI tells us the interface actually exists
+ * (ifindex != IFINDEX_INTERNAL)
+ *
+ * WARNING: these 2 hooks NEVER CALLED inside zebra!
+ */
+DO_HOOK(if_real, (struct interface *, ifp));
+
+DO_KOOH(if_unreal, (struct interface *, ifp));
+
+/* called (in daemons) on state changes on interfaces.  Whether this is admin
+ * state (= pure config) or carrier state (= hardware link plugged) depends on
+ * zebra's "link-detect" configuration.  By default, it's carrier state, so
+ * this won't happen until the interface actually has a link.
+ *
+ * WARNING: these 2 hooks NEVER CALLED inside zebra!
+ */
+DO_HOOK(if_up, (struct interface *, ifp));
+
+DO_KOOH(if_down, (struct interface *, ifp));

--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -16,7 +16,11 @@ DEFINE_MTYPE(LIB, KEYCHAIN_DESC, "Key chain description");
 
 DEFINE_QOBJ_TYPE(keychain);
 DEFINE_QOBJ_TYPE(key);
-DEFINE_HOOK(keychain_removed, (const char *keychain_name), (keychain_name));
+
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/keychain_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Master list of key chain. */
 struct list *keychain_list;

--- a/lib/keychain.h
+++ b/lib/keychain.h
@@ -129,9 +129,11 @@ extern struct key *key_match_for_accept(const struct keychain *keychain,
 extern struct key *key_lookup_for_send(const struct keychain *);
 const char *keychain_algo_str(enum keychain_hash_algo hash_algo);
 
-
-DECLARE_HOOK(keychain_updated, (const char *keychain_name), (keychain_name));
-DECLARE_HOOK(keychain_removed, (const char *keychain_name), (keychain_name));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/keychain_hooks.h"
+#include "lib/keychain_nb_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/keychain_hooks.h
+++ b/lib/keychain_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/keychain.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(keychain_removed, (const char *, keychain_name));

--- a/lib/keychain_nb.c
+++ b/lib/keychain_nb.c
@@ -9,7 +9,10 @@
 #include "northbound.h"
 #include "keychain.h"
 
-DEFINE_HOOK(keychain_updated, (const char *keychain_name), (keychain_name));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/keychain_nb_hooks.h"
+#include "lib/hooks_end.h"
 
 static void keychain_touch(struct keychain *keychain)
 {

--- a/lib/keychain_nb_hooks.h
+++ b/lib/keychain_nb_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/keychain_nb.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(keychain_updated, (const char *, keychain_name));

--- a/lib/libagentx.c
+++ b/lib/libagentx.c
@@ -8,8 +8,10 @@
 #include "lib/libagentx.h"
 #include "command.h"
 
-DEFINE_HOOK(agentx_cli_enabled, (), ());
-DEFINE_HOOK(agentx_cli_disabled, (), ());
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/libagentx_hooks.h"
+#include "lib/hooks_end.h"
 
 bool agentx_enabled;
 

--- a/lib/libagentx.h
+++ b/lib/libagentx.h
@@ -10,7 +10,9 @@
 extern void libagentx_init(void);
 extern bool agentx_enabled;
 
-DECLARE_HOOK(agentx_cli_enabled, (), ());
-DECLARE_HOOK(agentx_cli_disabled, (), ());
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/libagentx_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif

--- a/lib/libagentx_hooks.h
+++ b/lib/libagentx_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/libagentx.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(agentx_cli_enabled);
+
+DO_HOOK(agentx_cli_disabled);

--- a/lib/libagentx_hooks.h
+++ b/lib/libagentx_hooks.h
@@ -5,5 +5,4 @@
  */
 
 DO_HOOK(agentx_cli_enabled);
-
 DO_HOOK(agentx_cli_disabled);

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -40,12 +40,10 @@
 
 #include "lib/config_paths.h"
 
-DEFINE_HOOK(frr_early_init, (struct event_loop * tm), (tm));
-DEFINE_HOOK(frr_late_init, (struct event_loop * tm), (tm));
-DEFINE_HOOK(frr_config_pre, (struct event_loop * tm), (tm));
-DEFINE_HOOK(frr_config_post, (struct event_loop * tm), (tm));
-DEFINE_KOOH(frr_early_fini, (), ());
-DEFINE_KOOH(frr_fini, (), ());
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/libfrr_hooks.h"
+#include "lib/hooks_end.h"
 
 const char frr_sysconfdir[] = SYSCONFDIR;
 char frr_runstatedir[256] = FRR_RUNSTATE_PATH;

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -215,13 +215,10 @@ struct json_object;
 extern struct json_object *frr_daemon_state_load(void);
 extern void frr_daemon_state_save(struct json_object **statep);
 
+/* before the protocol daemon does its own shutdown */
 extern void frr_early_fini(void);
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "lib/libfrr_hooks.h"
-#include "lib/hooks_end.h"
-
+/* after the daemon did its own cleanup */
 extern void frr_fini(void);
 
 extern char config_default[512];
@@ -285,6 +282,12 @@ void frr_exit_with_buffer_flush(int status);
 #define FRR_MEM_RELEASE_MB_DEFAULT 1
 void frr_mem_release_config(uint32_t rate);
 uint32_t frr_mem_release_rate_get(void);
+
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/libfrr_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -201,13 +201,6 @@ extern enum frr_cli_mode frr_get_cli_mode(void);
 extern uint32_t frr_get_fd_limit(void);
 extern bool frr_is_startup_fd(int fd);
 extern bool frr_is_daemon(void);
-/* call order of these hooks is as ordered here */
-DECLARE_HOOK(frr_early_init, (struct event_loop * tm), (tm));
-DECLARE_HOOK(frr_late_init, (struct event_loop * tm), (tm));
-/* fork() happens between late_init and config_pre */
-DECLARE_HOOK(frr_config_pre, (struct event_loop * tm), (tm));
-DECLARE_HOOK(frr_config_post, (struct event_loop * tm), (tm));
-
 extern void frr_config_fork(void);
 
 extern void frr_run(struct event_loop *master);
@@ -222,12 +215,13 @@ struct json_object;
 extern struct json_object *frr_daemon_state_load(void);
 extern void frr_daemon_state_save(struct json_object **statep);
 
-/* these two are before the protocol daemon does its own shutdown
- * it's named this way being the counterpart to frr_late_init */
-DECLARE_KOOH(frr_early_fini, (), ());
 extern void frr_early_fini(void);
-/* and these two are after the daemon did its own cleanup */
-DECLARE_KOOH(frr_fini, (), ());
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/libfrr_hooks.h"
+#include "lib/hooks_end.h"
+
 extern void frr_fini(void);
 
 extern char config_default[512];

--- a/lib/libfrr_hooks.h
+++ b/lib/libfrr_hooks.h
@@ -6,17 +6,14 @@
 
 /* call order of these hooks is as ordered here */
 DO_HOOK(frr_early_init, (struct event_loop *, tm));
-
 DO_HOOK(frr_late_init, (struct event_loop *, tm));
 
 /* fork() happens between late_init and config_pre */
 DO_HOOK(frr_config_pre, (struct event_loop *, tm));
-
 DO_HOOK(frr_config_post, (struct event_loop *, tm));
 
-/* these two are before the protocol daemon does its own shutdown
+/* this is before the protocol daemon does its own shutdown
  * it's named this way being the counterpart to frr_late_init */
 DO_KOOH(frr_early_fini);
-
-/* and these two are after the daemon did its own cleanup */
+/* and this is after the daemon did its own cleanup */
 DO_KOOH(frr_fini);

--- a/lib/libfrr_hooks.h
+++ b/lib/libfrr_hooks.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/libfrr.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* call order of these hooks is as ordered here */
+DO_HOOK(frr_early_init, (struct event_loop *, tm));
+
+DO_HOOK(frr_late_init, (struct event_loop *, tm));
+
+/* fork() happens between late_init and config_pre */
+DO_HOOK(frr_config_pre, (struct event_loop *, tm));
+
+DO_HOOK(frr_config_post, (struct event_loop *, tm));
+
+/* these two are before the protocol daemon does its own shutdown
+ * it's named this way being the counterpart to frr_late_init */
+DO_KOOH(frr_early_fini);
+
+/* and these two are after the daemon did its own cleanup */
+DO_KOOH(frr_fini);

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -22,8 +22,10 @@
 
 #define ZLOG_MAXLVL(a, b) MAX(a, b)
 
-DEFINE_HOOK(zlog_rotate, (), ());
-DEFINE_HOOK(zlog_cli_show, (struct vty * vty), (vty));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/log_vty_hooks.h"
+#include "lib/hooks_end.h"
 
 uint logmsgs_with_persist_bt;
 

--- a/lib/log_vty.h
+++ b/lib/log_vty.h
@@ -25,10 +25,12 @@ extern const char *log_lev2sev(const char *level);
 extern int facility_match(const char *str);
 extern const char *facility_name(int facility);
 
-DECLARE_HOOK(zlog_rotate, (), ());
 extern void zlog_rotate(void);
 
-DECLARE_HOOK(zlog_cli_show, (struct vty * vty), (vty));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/log_vty_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Default logging level in the YANG model */
 extern const int log_default_lvl;

--- a/lib/log_vty.h
+++ b/lib/log_vty.h
@@ -27,11 +27,6 @@ extern const char *facility_name(int facility);
 
 extern void zlog_rotate(void);
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "lib/log_vty_hooks.h"
-#include "lib/hooks_end.h"
-
 /* Default logging level in the YANG model */
 extern const int log_default_lvl;
 
@@ -52,6 +47,11 @@ void log_stdout_apply_level(void);
 void clear_cmdline_targets(void);
 
 extern struct frr_yang_module_info frr_logging_cli_info;
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/log_vty_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/log_vty_hooks.h
+++ b/lib/log_vty_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/log_vty.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(zlog_rotate);
+
+DO_HOOK(zlog_cli_show, (struct vty *, vty));

--- a/lib/log_vty_hooks.h
+++ b/lib/log_vty_hooks.h
@@ -5,5 +5,4 @@
  */
 
 DO_HOOK(zlog_rotate);
-
 DO_HOOK(zlog_cli_show, (struct vty *, vty));

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -2452,8 +2452,10 @@ bool nb_cb_operation_is_valid(enum nb_cb_operation operation,
 	}
 }
 
-DEFINE_HOOK(nb_notification_send, (const char *xpath, struct list *arguments),
-	    (xpath, arguments));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/northbound_hooks.h"
+#include "lib/hooks_end.h"
 
 int nb_notification_send(const char *xpath, struct list *arguments)
 {
@@ -2514,9 +2516,6 @@ done:
 
 	return ret;
 }
-
-DEFINE_HOOK(nb_notification_tree_send,
-	    (const char *xpath, const struct lyd_node *tree), (xpath, tree));
 
 int nb_notification_tree_send(const char *xpath, const struct lyd_node *tree)
 {

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -26,6 +26,11 @@ DEFINE_MTYPE_STATIC(LIB, NB_CONFIG, "Northbound Config");
 DEFINE_MTYPE_STATIC(LIB, NB_CONFIG_ENTRY, "Northbound Config Entry");
 DEFINE_MTYPE_STATIC(LIB, NB_TRANS, "NB transaction");
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/northbound_hooks.h"
+#include "lib/hooks_end.h"
+
 /* Running configuration - shouldn't be modified directly. */
 struct nb_config *running_config;
 
@@ -2451,11 +2456,6 @@ bool nb_cb_operation_is_valid(enum nb_cb_operation operation,
 		return false;
 	}
 }
-
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "lib/northbound_hooks.h"
-#include "lib/hooks_end.h"
 
 int nb_notification_send(const char *xpath, struct list *arguments)
 {

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -866,11 +866,6 @@ typedef enum nb_error (*nb_oper_data_finish_cb)(const struct lyd_node *tree,
 /* Iterate over direct child nodes only. */
 #define NB_OPER_DATA_ITER_NORECURSE 0x0001
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "lib/northbound_hooks.h"
-#include "lib/hooks_end.h"
-
 /* Northbound debugging records */
 extern struct debug nb_dbg_cbs_config;
 extern struct debug nb_dbg_cbs_state;
@@ -1965,6 +1960,11 @@ extern void nb_notif_enable_multi_thread(void);
 
 extern void nb_notif_init(struct event_loop *loop);
 extern void nb_notif_terminate(void);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/northbound_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -866,11 +866,10 @@ typedef enum nb_error (*nb_oper_data_finish_cb)(const struct lyd_node *tree,
 /* Iterate over direct child nodes only. */
 #define NB_OPER_DATA_ITER_NORECURSE 0x0001
 
-/* Hooks. */
-DECLARE_HOOK(nb_notification_send, (const char *xpath, struct list *arguments),
-	     (xpath, arguments));
-DECLARE_HOOK(nb_notification_tree_send,
-	     (const char *xpath, const struct lyd_node *tree), (xpath, tree));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/northbound_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Northbound debugging records */
 extern struct debug nb_dbg_cbs_config;

--- a/lib/northbound_hooks.h
+++ b/lib/northbound_hooks.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/northbound.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* Hooks. */
+DO_HOOK(nb_notification_send, (const char *, xpath), (struct list *, arguments));
+
+DO_HOOK(nb_notification_tree_send, (const char *, xpath), (const struct lyd_node *, tree));

--- a/lib/northbound_hooks.h
+++ b/lib/northbound_hooks.h
@@ -6,5 +6,4 @@
 
 /* Hooks. */
 DO_HOOK(nb_notification_send, (const char *, xpath), (struct list *, arguments));
-
 DO_HOOK(nb_notification_tree_send, (const char *, xpath), (const struct lyd_node *, tree));

--- a/lib/routing_nb.h
+++ b/lib/routing_nb.h
@@ -32,12 +32,12 @@ int routing_control_plane_protocols_control_plane_protocol_destroy(
 	"/frr-routing:routing/control-plane-protocols/"                        \
 	"control-plane-protocol[vrf='%s']"
 
+void routing_control_plane_protocols_register_vrf_dependency(void);
+
 #define HOOKS_DECLARE
 #include "lib/hooks_begin.h"
 #include "lib/routing_nb_config_hooks.h"
 #include "lib/hooks_end.h"
-
-void routing_control_plane_protocols_register_vrf_dependency(void);
 
 #ifdef __cplusplus
 }

--- a/lib/routing_nb.h
+++ b/lib/routing_nb.h
@@ -32,13 +32,10 @@ int routing_control_plane_protocols_control_plane_protocol_destroy(
 	"/frr-routing:routing/control-plane-protocols/"                        \
 	"control-plane-protocol[vrf='%s']"
 
-/*
- * callbacks for routing to handle configuration events
- * based on the control plane protocol
- */
-DECLARE_HOOK(routing_conf_event, (struct nb_cb_create_args *args), (args));
-DECLARE_HOOK(routing_create, (struct nb_cb_create_args *args), (args));
-DECLARE_KOOH(routing_destroy, (struct nb_cb_destroy_args *args), (args));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/routing_nb_config_hooks.h"
+#include "lib/hooks_end.h"
 
 void routing_control_plane_protocols_register_vrf_dependency(void);
 

--- a/lib/routing_nb_config.c
+++ b/lib/routing_nb_config.c
@@ -12,10 +12,10 @@
 #include "lib_errors.h"
 #include "routing_nb.h"
 
-
-DEFINE_HOOK(routing_conf_event, (struct nb_cb_create_args *args), (args));
-DEFINE_HOOK(routing_create, (struct nb_cb_create_args *args), (args));
-DEFINE_KOOH(routing_destroy, (struct nb_cb_destroy_args *args), (args));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/routing_nb_config_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol

--- a/lib/routing_nb_config_hooks.h
+++ b/lib/routing_nb_config_hooks.h
@@ -9,7 +9,5 @@
  * based on the control plane protocol
  */
 DO_HOOK(routing_conf_event, (struct nb_cb_create_args *, args));
-
 DO_HOOK(routing_create, (struct nb_cb_create_args *, args));
-
 DO_KOOH(routing_destroy, (struct nb_cb_destroy_args *, args));

--- a/lib/routing_nb_config_hooks.h
+++ b/lib/routing_nb_config_hooks.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for lib/routing_nb_config.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/*
+ * callbacks for routing to handle configuration events
+ * based on the control plane protocol
+ */
+DO_HOOK(routing_conf_event, (struct nb_cb_create_args *, args));
+
+DO_HOOK(routing_create, (struct nb_cb_create_args *, args));
+
+DO_KOOH(routing_destroy, (struct nb_cb_destroy_args *, args));

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -156,7 +156,10 @@ extern void oid_copy_int(oid oid[], int *val);
 extern void oid2string(oid oid[], int len, char *string);
 extern void oid_copy_str(oid oid[], const char *string, int len);
 
-DECLARE_HOOK(agentx_enabled, (), ());
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/agentx_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -234,6 +234,8 @@ nobase_pkginclude_HEADERS += \
 	lib/graph.h \
 	lib/hash.h \
 	lib/hook.h \
+	lib/hooks_begin.h \
+	lib/hooks_end.h \
 	lib/host_nb.h \
 	lib/iana_afi.h \
 	lib/id_alloc.h \

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -334,6 +334,17 @@ nobase_pkginclude_HEADERS += \
 	lib/tc.h \
 	lib/routing_nb.h \
 	\
+	lib/agentx_hooks.h \
+	lib/if_hooks.h \
+	lib/keychain_hooks.h \
+	lib/keychain_nb_hooks.h \
+	lib/libagentx_hooks.h \
+	lib/libfrr_hooks.h \
+	lib/log_vty_hooks.h \
+	lib/northbound_hooks.h \
+	lib/routing_nb_config_hooks.h \
+	lib/zlog_hooks.h \
+	\
 	lib/assert/assert.h \
 	# end
 

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -57,12 +57,10 @@
 DEFINE_MTYPE_STATIC(LIB, LOG_MESSAGE,  "log message");
 DEFINE_MTYPE_STATIC(LIB, LOG_TLSBUF,   "log thread-local buffer");
 
-DEFINE_HOOK(zlog_init, (const char *progname, const char *protoname,
-			unsigned short instance, uid_t uid, gid_t gid),
-		       (progname, protoname, instance, uid, gid));
-DEFINE_KOOH(zlog_fini, (), ());
-DEFINE_HOOK(zlog_aux_init, (const char *prefix, int prio_min),
-			   (prefix, prio_min));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "lib/zlog_hooks.h"
+#include "lib/hooks_end.h"
 
 char zlog_prefix[128];
 size_t zlog_prefixsz;

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -252,15 +252,9 @@ extern struct zlog_target *zlog_target_replace(struct zlog_target *oldzt,
 #define zlog_target_free(mt, zt) \
 	rcu_free(mt, zt, rcu_head)
 
-extern void zlog_init(const char *progname, const char *protoname,
-		      unsigned short instance, uid_t uid, gid_t gid);
-DECLARE_HOOK(zlog_init, (const char *progname, const char *protoname,
-			 unsigned short instance, uid_t uid, gid_t gid),
-			(progname, protoname, instance, uid, gid));
-
+extern void zlog_init(const char *progname, const char *protoname, unsigned short instance,
+		      uid_t uid, gid_t gid);
 extern void zlog_fini(void);
-DECLARE_KOOH(zlog_fini, (), ());
-
 extern void zlog_set_prefix_ec(bool enable);
 extern bool zlog_get_prefix_ec(void);
 extern void zlog_set_prefix_xid(bool enable);
@@ -270,8 +264,11 @@ extern bool zlog_get_prefix_xid(void);
  * (no cleanup needed at exit)
  */
 extern void zlog_aux_init(const char *prefix, int prio_min);
-DECLARE_HOOK(zlog_aux_init, (const char *prefix, int prio_min),
-			    (prefix, prio_min));
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/zlog_hooks.h"
+#include "lib/hooks_end.h"
 
 extern void zlog_startup_end(void);
 

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -265,11 +265,6 @@ extern bool zlog_get_prefix_xid(void);
  */
 extern void zlog_aux_init(const char *prefix, int prio_min);
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "lib/zlog_hooks.h"
-#include "lib/hooks_end.h"
-
 extern void zlog_startup_end(void);
 
 extern void zlog_tls_buffer_init(void);
@@ -284,6 +279,11 @@ extern const char *zlog_priority_str(int priority);
 
 /* Remove temp dirs at shutdown */
 void zlog_tmpdir_fini(void);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "lib/zlog_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/lib/zlog_hooks.h
+++ b/lib/zlog_hooks.h
@@ -6,7 +6,6 @@
 
 DO_HOOK(zlog_init, (const char *, progname), (const char *, protoname), (unsigned short, instance),
 	(uid_t, uid), (gid_t, gid));
-
 DO_KOOH(zlog_fini);
 
 DO_HOOK(zlog_aux_init, (const char *, prefix), (int, prio_min));

--- a/lib/zlog_hooks.h
+++ b/lib/zlog_hooks.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: ISC
+/* hook definitions for lib/zlog.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(zlog_init, (const char *, progname), (const char *, protoname), (unsigned short, instance),
+	(uid_t, uid), (gid_t, gid));
+
+DO_KOOH(zlog_fini);
+
+DO_HOOK(zlog_aux_init, (const char *, prefix), (int, prio_min));

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -46,9 +46,11 @@ DEFINE_MTYPE(OSPF6D, OSPF6_AUTH_KEYCHAIN, "OSPF6 auth keychain");
 DEFINE_MTYPE(OSPF6D, OSPF6_AUTH_MANUAL_KEY, "OSPF6 auth key");
 DEFINE_MTYPE_STATIC(OSPF6D, CFG_PLIST_NAME, "configured prefix list names");
 DEFINE_QOBJ_TYPE(ospf6_interface);
-DEFINE_HOOK(ospf6_interface_change,
-	    (struct ospf6_interface * oi, int state, int old_state),
-	    (oi, state, old_state));
+
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospf6d/ospf6_interface_hooks.h"
+#include "lib/hooks_end.h"
 
 unsigned char conf_debug_ospf6_interface = 0;
 

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -274,8 +274,10 @@ extern uint8_t dr_election(struct ospf6_interface *oi);
 extern void ospf6_interface_auth_trailer_cmd_init(void);
 extern void ospf6_auth_write_config(struct vty *vty,
 				    struct ospf6_auth_data *at_data);
-DECLARE_HOOK(ospf6_interface_change,
-	     (struct ospf6_interface * oi, int state, int old_state),
-	     (oi, state, old_state));
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ospf6d/ospf6_interface_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* OSPF6_INTERFACE_H */

--- a/ospf6d/ospf6_interface_hooks.h
+++ b/ospf6d/ospf6_interface_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ospf6d/ospf6_interface.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ospf6_interface_change, (struct ospf6_interface *, oi), (int, state), (int, old_state));

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -46,9 +46,10 @@ DECLARE_RBTREE_UNIQ(ospf6_if_p2xp_neighcfgs, struct ospf6_if_p2xp_neighcfg,
 
 static void p2xp_neigh_refresh(struct ospf6_neighbor *on, uint32_t prev_cost);
 
-DEFINE_HOOK(ospf6_neighbor_change,
-	    (struct ospf6_neighbor * on, int state, int next_state),
-	    (on, state, next_state));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospf6d/ospf6_neighbor_hooks.h"
+#include "lib/hooks_end.h"
 
 unsigned char conf_debug_ospf6_neighbor = 0;
 

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -229,8 +229,9 @@ extern int config_write_ospf6_p2xp_neighbor(struct vty *vty,
 					    struct ospf6_interface *oi);
 extern void install_element_ospf6_debug_neighbor(void);
 
-DECLARE_HOOK(ospf6_neighbor_change,
-	     (struct ospf6_neighbor * on, int state, int next_state),
-	     (on, state, next_state));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ospf6d/ospf6_neighbor_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* OSPF6_NEIGHBOR_H */

--- a/ospf6d/ospf6_neighbor_hooks.h
+++ b/ospf6d/ospf6_neighbor_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ospf6d/ospf6_neighbor.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ospf6_neighbor_change, (struct ospf6_neighbor *, on), (int, state), (int, next_state));

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -63,6 +63,9 @@ noinst_HEADERS += \
 	ospf6d/ospf6_zebra.h \
 	ospf6d/ospf6d.h \
 	ospf6d/ospf6_auth_trailer.h \
+	\
+	ospf6d/ospf6_interface_hooks.h \
+	ospf6d/ospf6_neighbor_hooks.h \
 	# end
 
 ospf6d_ospf6d_LDADD = ospf6d/libospf6.a lib/libfrr.la $(LIBCAP)

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -41,10 +41,11 @@
 #include "ospfd/ospf_te.h"
 
 DEFINE_QOBJ_TYPE(ospf_interface);
-DEFINE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd));
-DEFINE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd));
-DEFINE_HOOK(ospf_if_update, (struct interface * ifp), (ifp));
-DEFINE_HOOK(ospf_if_delete, (struct interface * ifp), (ifp));
+
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_interface_hooks.h"
+#include "lib/hooks_end.h"
 
 int ospf_interface_neighbor_count(struct ospf_interface *oi)
 {

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -490,10 +490,10 @@ extern void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
 				   bool is_addr);
 
 extern void ospf_interface_fifo_flush(struct ospf_interface *oi);
-DECLARE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd));
-DECLARE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd));
 
-DECLARE_HOOK(ospf_if_update, (struct interface * ifp), (ifp));
-DECLARE_HOOK(ospf_if_delete, (struct interface * ifp), (ifp));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_interface_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _ZEBRA_OSPF_INTERFACE_H */

--- a/ospfd/ospf_interface_hooks.h
+++ b/ospfd/ospf_interface_hooks.h
@@ -5,9 +5,7 @@
  */
 
 DO_HOOK(ospf_vl_add, (struct ospf_vl_data *, vd));
-
 DO_HOOK(ospf_vl_delete, (struct ospf_vl_data *, vd));
 
 DO_HOOK(ospf_if_update, (struct interface *, ifp));
-
 DO_HOOK(ospf_if_delete, (struct interface *, ifp));

--- a/ospfd/ospf_interface_hooks.h
+++ b/ospfd/ospf_interface_hooks.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ospfd/ospf_interface.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ospf_vl_add, (struct ospf_vl_data *, vd));
+
+DO_HOOK(ospf_vl_delete, (struct ospf_vl_data *, vd));
+
+DO_HOOK(ospf_if_update, (struct interface *, ifp));
+
+DO_HOOK(ospf_if_delete, (struct interface *, ifp));

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -28,9 +28,10 @@
 #include "ospfd/ospf_flood.h"
 #include "ospfd/ospf_abr.h"
 
-DEFINE_HOOK(ospf_ism_change,
-	    (struct ospf_interface * oi, int state, int oldstate),
-	    (oi, state, oldstate));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_ism_hooks.h"
+#include "lib/hooks_end.h"
 
 /* elect DR and BDR. Refer to RFC2319 section 9.4 */
 static struct ospf_neighbor *ospf_dr_election_sub(struct list *routers)

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -77,8 +77,9 @@ extern void ism_change_status(struct ospf_interface *oi, int status);
 extern void ospf_hello_timer(struct event *event);
 extern int ospf_dr_election(struct ospf_interface *oi);
 
-DECLARE_HOOK(ospf_ism_change,
-	     (struct ospf_interface * oi, int state, int oldstate),
-	     (oi, state, oldstate));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_ism_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _ZEBRA_OSPF_ISM_H */

--- a/ospfd/ospf_ism_hooks.h
+++ b/ospfd/ospf_ism_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ospfd/ospf_ism.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ospf_ism_change, (struct ospf_interface *, oi), (int, state), (int, oldstate));

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -62,11 +62,10 @@ static struct ospf_lsa *
 ospf_exnl_lsa_prepare_and_flood(struct ospf *ospf, struct external_info *ei,
 				struct in_addr id);
 
-/*
- * LSA Update and Delete Hook LSAs.
- */
-DEFINE_HOOK(ospf_lsa_update, (struct ospf_lsa *lsa), (lsa));
-DEFINE_HOOK(ospf_lsa_delete, (struct ospf_lsa *lsa), (lsa));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_lsa_hooks.h"
+#include "lib/hooks_end.h"
 
 uint32_t get_metric(uint8_t *metric)
 {

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -39,6 +39,11 @@
 #include "ospfd/ospf_abr.h"
 #include "ospfd/ospf_errors.h"
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_lsa_hooks.h"
+#include "lib/hooks_end.h"
+
 static struct ospf_lsa *ospf_handle_summarylsa_lsId_chg(struct ospf_area *area,
 							struct prefix_ipv4 *p,
 							uint8_t type,
@@ -61,11 +66,6 @@ static struct ospf_lsa *ospf_handle_exnl_lsa_lsId_chg(struct ospf *ospf,
 static struct ospf_lsa *
 ospf_exnl_lsa_prepare_and_flood(struct ospf *ospf, struct external_info *ei,
 				struct in_addr id);
-
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "ospfd/ospf_lsa_hooks.h"
-#include "lib/hooks_end.h"
 
 uint32_t get_metric(uint8_t *metric)
 {

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -374,9 +374,9 @@ static inline bool ospf_check_indication_lsa(struct ospf_lsa *lsa)
 	return false;
 }
 
-/*
- * LSA Update and Delete Hook LSAs.
- */
-DECLARE_HOOK(ospf_lsa_update, (struct ospf_lsa *lsa), (lsa));
-DECLARE_HOOK(ospf_lsa_delete, (struct ospf_lsa *lsa), (lsa));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_lsa_hooks.h"
+#include "lib/hooks_end.h"
+
 #endif /* _ZEBRA_OSPF_LSA_H */

--- a/ospfd/ospf_lsa_hooks.h
+++ b/ospfd/ospf_lsa_hooks.h
@@ -7,9 +7,5 @@
 /*
  * LSA Update and Delete Hook LSAs.
  */
-/*
- * LSA Update and Delete Hook LSAs.
- */
 DO_HOOK(ospf_lsa_update, (struct ospf_lsa *, lsa));
-
 DO_HOOK(ospf_lsa_delete, (struct ospf_lsa *, lsa));

--- a/ospfd/ospf_lsa_hooks.h
+++ b/ospfd/ospf_lsa_hooks.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ospfd/ospf_lsa.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/*
+ * LSA Update and Delete Hook LSAs.
+ */
+/*
+ * LSA Update and Delete Hook LSAs.
+ */
+DO_HOOK(ospf_lsa_update, (struct ospf_lsa *, lsa));
+
+DO_HOOK(ospf_lsa_delete, (struct ospf_lsa *, lsa));

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -39,9 +39,10 @@
 #include "ospfd/ospf_errors.h"
 #include "ospfd/ospf_quicknbr.h"
 
-DEFINE_HOOK(ospf_nsm_change,
-	    (struct ospf_neighbor * on, int state, int oldstate),
-	    (on, state, oldstate));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_nsm_hooks.h"
+#include "lib/hooks_end.h"
 
 /* RFC4222/R5: struct ospf_neighbor is fully defined here so DECLARE_LIST
  * can access pacing_link.  Callers outside this file use the wrappers below.

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -83,8 +83,9 @@ extern void ospf_adj_pacing_queue_init(struct ospf_adj_pacing *p);
 extern void ospf_adj_pacing_queue_fini(struct ospf_adj_pacing *p);
 extern void ospf_adj_pacing_queue_flush(struct ospf_interface *oi);
 
-DECLARE_HOOK(ospf_nsm_change,
-	     (struct ospf_neighbor * on, int state, int oldstate),
-	     (on, state, oldstate));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ospfd/ospf_nsm_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _ZEBRA_OSPF_NSM_H */

--- a/ospfd/ospf_nsm_hooks.h
+++ b/ospfd/ospf_nsm_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ospfd/ospf_nsm.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(ospf_nsm_change, (struct ospf_neighbor *, on), (int, state), (int, oldstate));

--- a/ospfd/subdir.am
+++ b/ospfd/subdir.am
@@ -110,6 +110,11 @@ noinst_HEADERS += \
 	ospfd/ospf_vty.h \
 	ospfd/ospf_zebra.h \
 	ospfd/ospf_auth.h \
+	\
+	ospfd/ospf_interface_hooks.h \
+	ospfd/ospf_ism_hooks.h \
+	ospfd/ospf_lsa_hooks.h \
+	ospfd/ospf_nsm_hooks.h \
 	# end
 
 ospfd_ospfd_LDADD = ospfd/libfrrospf.a ospfd/libfrrospfclient.a lib/libfrr.la $(LIBCAP) $(LIBM)

--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -45,9 +45,10 @@ static int segment_list_has_prefix(
 
 DEFINE_MTYPE_STATIC(PATHD, PATH_CLI, "Client");
 
-DEFINE_HOOK(pathd_srte_check_config_not_empty, (), ());
-DEFINE_HOOK(pathd_srte_config_write, (struct vty *vty), (vty));
-DEFINE_HOOK(pathd_srte_no_srte, (), ());
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "pathd/path_cli_hooks.h"
+#include "lib/hooks_end.h"
 
 /* Vty node structures. */
 static struct cmd_node segment_routing_node = {

--- a/pathd/path_cli_hooks.h
+++ b/pathd/path_cli_hooks.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for pathd/path_cli.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/*
+ * If config is not empty, pathd_srte_check_config_not_empty must
+ * return 1, otherwise - 0. If no hook subscribers return 1 and there is no
+ * configuration in pathd, headers `segment-routing/traffic-eng` won't be
+ * output for `write` command and `pathd_srte_config_write` won't be called.
+ */
+DO_HOOK(pathd_srte_check_config_not_empty);
+
+DO_HOOK(pathd_srte_config_write, (struct vty *, vty));
+
+/* Sent when user requests 'no traffic-eng', please clean configuration */
+DO_HOOK(pathd_srte_no_srte);

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -26,12 +26,10 @@ DEFINE_MTYPE_STATIC(PATHD, PATH_SEGMENT_LIST, "Segment List");
 DEFINE_MTYPE_STATIC(PATHD, PATH_SR_POLICY, "SR Policy");
 DEFINE_MTYPE_STATIC(PATHD, PATH_SR_CANDIDATE, "SR Policy candidate path");
 
-DEFINE_HOOK(pathd_candidate_created, (struct srte_candidate * candidate),
-	    (candidate));
-DEFINE_HOOK(pathd_candidate_updated, (struct srte_candidate * candidate),
-	    (candidate));
-DEFINE_HOOK(pathd_candidate_removed, (struct srte_candidate * candidate),
-	    (candidate));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "pathd/pathd_hooks.h"
+#include "lib/hooks_end.h"
 
 struct debug path_policy_debug = {
 	.conf = "debug pathd policy",

--- a/pathd/pathd.h
+++ b/pathd/pathd.h
@@ -355,12 +355,6 @@ struct srte_policy {
 RB_HEAD(srte_policy_head, srte_policy);
 RB_PROTOTYPE(srte_policy_head, srte_policy, entry, srte_policy_compare)
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "pathd/path_cli_hooks.h"
-#include "pathd/pathd_hooks.h"
-#include "lib/hooks_end.h"
-
 extern struct srte_segment_list_head srte_segment_lists;
 extern struct srte_policy_head srte_policies;
 extern struct zebra_privs_t pathd_privs;
@@ -472,4 +466,12 @@ int32_t srte_ted_do_query_type_e(struct srte_segment_entry *entry,
  */
 int32_t srte_ted_do_query_type_f(struct srte_segment_entry *entry,
 				 struct ipaddr *local, struct ipaddr *remote);
+
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "pathd/path_cli_hooks.h"
+#include "pathd/pathd_hooks.h"
+#include "lib/hooks_end.h"
+
 #endif /* _FRR_PATHD_H_ */

--- a/pathd/pathd.h
+++ b/pathd/pathd.h
@@ -21,17 +21,6 @@
 
 DECLARE_MGROUP(PATHD);
 
-/*
- * If config is not empty, pathd_srte_check_config_not_empty must
- * return 1, otherwise - 0. If no hook subscribers return 1 and there is no
- * configuration in pathd, headers `segment-routing/traffic-eng` won't be
- * output for `write` command and `pathd_srte_config_write` won't be called.
- */
-DECLARE_HOOK(pathd_srte_check_config_not_empty, (), ());
-DECLARE_HOOK(pathd_srte_config_write, (struct vty *vty), (vty));
-/* Sent when user requests 'no traffic-eng', please clean configuration */
-DECLARE_HOOK(pathd_srte_no_srte, (), ());
-
 enum srte_protocol_origin {
 	SRTE_ORIGIN_UNDEFINED = 0,
 	SRTE_ORIGIN_PCEP = 1,
@@ -366,12 +355,11 @@ struct srte_policy {
 RB_HEAD(srte_policy_head, srte_policy);
 RB_PROTOTYPE(srte_policy_head, srte_policy, entry, srte_policy_compare)
 
-DECLARE_HOOK(pathd_candidate_created, (struct srte_candidate * candidate),
-	     (candidate));
-DECLARE_HOOK(pathd_candidate_updated, (struct srte_candidate * candidate),
-	     (candidate));
-DECLARE_HOOK(pathd_candidate_removed, (struct srte_candidate * candidate),
-	     (candidate));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "pathd/path_cli_hooks.h"
+#include "pathd/pathd_hooks.h"
+#include "lib/hooks_end.h"
 
 extern struct srte_segment_list_head srte_segment_lists;
 extern struct srte_policy_head srte_policies;

--- a/pathd/pathd_hooks.h
+++ b/pathd/pathd_hooks.h
@@ -5,7 +5,5 @@
  */
 
 DO_HOOK(pathd_candidate_created, (struct srte_candidate *, candidate));
-
 DO_HOOK(pathd_candidate_updated, (struct srte_candidate *, candidate));
-
 DO_HOOK(pathd_candidate_removed, (struct srte_candidate *, candidate));

--- a/pathd/pathd_hooks.h
+++ b/pathd/pathd_hooks.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for pathd/pathd.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(pathd_candidate_created, (struct srte_candidate *, candidate));
+
+DO_HOOK(pathd_candidate_updated, (struct srte_candidate *, candidate));
+
+DO_HOOK(pathd_candidate_removed, (struct srte_candidate *, candidate));

--- a/pathd/subdir.am
+++ b/pathd/subdir.am
@@ -47,6 +47,9 @@ noinst_HEADERS += \
 	pathd/path_ted.h \
 	pathd/path_zebra.h \
 	pathd/pathd.h \
+	\
+	pathd/path_cli_hooks.h \
+	pathd/pathd_hooks.h \
 	# end
 
 pathd_pathd_SOURCES = \

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -31,8 +31,11 @@
 
 DEFINE_MTYPE_STATIC(RIPD, RIP_INTERFACE, "RIP interface");
 DEFINE_MTYPE(RIPD, RIP_INTERFACE_STRING, "RIP Interface String");
-DEFINE_HOOK(rip_ifaddr_add, (struct connected * ifc), (ifc));
-DEFINE_HOOK(rip_ifaddr_del, (struct connected * ifc), (ifc));
+
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "ripd/rip_interface_hooks.h"
+#include "lib/hooks_end.h"
 
 /* static prototypes */
 static void rip_enable_apply(struct interface *);

--- a/ripd/rip_interface_hooks.h
+++ b/ripd/rip_interface_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for ripd/rip_interface.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(rip_ifaddr_add, (struct connected *, ifc));
+
+DO_HOOK(rip_ifaddr_del, (struct connected *, ifc));

--- a/ripd/rip_interface_hooks.h
+++ b/ripd/rip_interface_hooks.h
@@ -5,5 +5,4 @@
  */
 
 DO_HOOK(rip_ifaddr_add, (struct connected *, ifc));
-
 DO_HOOK(rip_ifaddr_del, (struct connected *, ifc));

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -565,13 +565,13 @@ extern struct rip_instance_head rip_instances;
 /* Master thread structure. */
 extern struct event_loop *master;
 
+extern void rip_ecmp_change(struct rip *rip);
+
+extern uint32_t zebra_ecmp_count;
+
 #define HOOKS_DECLARE
 #include "lib/hooks_begin.h"
 #include "ripd/rip_interface_hooks.h"
 #include "lib/hooks_end.h"
-
-extern void rip_ecmp_change(struct rip *rip);
-
-extern uint32_t zebra_ecmp_count;
 
 #endif /* _ZEBRA_RIP_H */

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -565,8 +565,10 @@ extern struct rip_instance_head rip_instances;
 /* Master thread structure. */
 extern struct event_loop *master;
 
-DECLARE_HOOK(rip_ifaddr_add, (struct connected * ifc), (ifc));
-DECLARE_HOOK(rip_ifaddr_del, (struct connected * ifc), (ifc));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "ripd/rip_interface_hooks.h"
+#include "lib/hooks_end.h"
 
 extern void rip_ecmp_change(struct rip *rip);
 

--- a/ripd/subdir.am
+++ b/ripd/subdir.am
@@ -42,6 +42,8 @@ noinst_HEADERS += \
 	ripd/rip_interface.h \
 	ripd/rip_nb.h \
 	ripd/ripd.h \
+	\
+	ripd/rip_interface_hooks.h \
 	# end
 
 ripd_ripd_LDADD = lib/libfrr.la $(LIBCAP)

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -35,8 +35,8 @@
 #include <grpcpp/security/credentials.h>
 #include "grpc/frr-northbound.grpc.pb.h"
 
-DEFINE_HOOK(test_grpc_late_init, (struct event_loop * tm), (tm));
-DEFINE_KOOH(test_grpc_fini, (), ());
+DEFINE_HOOK(test_grpc_late_init, (struct event_loop *, tm));
+DEFINE_KOOH(test_grpc_fini);
 
 struct vty *vty;
 

--- a/tests/zebra/test_lm_plugin.c
+++ b/tests/zebra/test_lm_plugin.c
@@ -14,7 +14,7 @@
 extern struct label_manager lbl_mgr;
 
 /* shim out unused functions/variables to allow the lablemanager to compile*/
-DEFINE_KOOH(zserv_client_close, (struct zserv * client), (client));
+DEFINE_KOOH(zserv_client_close, (struct zserv *, client));
 unsigned long zebra_debug_packet = 0;
 struct zserv *zserv_find_client_session(uint8_t proto, unsigned short instance,
 					uint32_t session_id)

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -3782,6 +3782,7 @@ sub process {
 			}
 
 			if ($msg_type ne "" &&
+			    $realfile !~ m@^lib/(compiler|frrscript)\.h$@ &&
 			    (show_type("LONG_LINE") || show_type($msg_type))) {
 				my $msg_level = \&WARN;
 				$msg_level = \&CHK if ($file);
@@ -5887,7 +5888,8 @@ sub process {
 			my $stmt_cnt = statement_rawlines($ctx);
 			my $herectx = get_stat_here($linenr, $stmt_cnt, $here);
 
-			if ($dstat ne '' &&
+			if ($realfile !~ m@^lib/(compiler|hook)\.h$@ &&
+			    $dstat ne '' &&
 			    $dstat !~ /^(?:$Ident|-?$Constant),$/ &&			# 10, // foo(),
 			    $dstat !~ /^(?:$Ident|-?$Constant);$/ &&			# foo();
 			    $dstat !~ /^[!~-]?(?:$Lval|$Constant)$/ &&		# 10 // foo() // !foo // ~foo // -foo // foo->bar // foo.bar->baz
@@ -5982,6 +5984,7 @@ sub process {
 # macro should not end with a semicolon
 		if ($perl_version_ok &&
 		    $realfile !~ m@/vmlinux.lds.h$@ &&
+		    $realfile !~ m@^lib/compiler\.h$@ &&
 		    $line =~ /^.\s*\#\s*define\s+$Ident(\()?/) {
 			my $ln = $linenr;
 			my $cnt = $realcnt;

--- a/tools/hook_conv.py
+++ b/tools/hook_conv.py
@@ -1,0 +1,433 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2026  David Lamparter for NetDEF, Inc.
+"""
+Flips the "cardinality" of DEFINE_HOOK/DECLARE_HOOK parameters.
+
+Before:
+    DECLARE_HOOK(foo, (int a, char *b), (a, b));
+After:
+    DECLARE_HOOK(foo, (int, a), (char *, b));
+
+It won't be useful to rerun this script, it's just provided for posterity.
+"""
+
+import sys
+import os
+import re
+from dataclasses import dataclass, field
+import subprocess
+import argparse
+from pprint import pprint
+import _clippy
+
+cmdargp = argparse.ArgumentParser(description="FRR hook rewriting tool")
+cmdargp.add_argument("--verbose", "-v", action="store_true")
+cmdargp.add_argument("--nosplit", "-n", action="store_true")
+cmdargp.add_argument("--git-add", "-G", action="store_true")
+cmdargs = cmdargp.parse_args()
+
+
+def git(*args) -> str:
+    return subprocess.check_output(["git"] + list(args), encoding="UTF-8")
+
+
+class CPPStack(list):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.ignored_header_guard = False
+
+    def feed(self, pp_token, filename):
+        line = pp_token["line"].strip()
+        directive_args = line.split(maxsplit=1)
+
+        if not directive_args:
+            return
+        directive = directive_args[0]
+        if directive in ["if", "ifdef", "ifndef"]:
+            if filename.endswith(".h") and not self and not self.ignored_header_guard:
+                macro_name = filename.upper().rsplit("/", 1)[-1].replace(".", "_")
+                fudges = {"LIBFRR_H": "FRR_H", "SMUX_H": "SNMP_H", "RIPD_H": "RIP_H"}
+                macro_name = fudges.get(macro_name, macro_name)
+                macro_names = [macro_name]
+                for m in macro_names[:]:
+                    macro_names.append(m + "_")
+                    macro_names.append(m + "__")
+                if line.endswith(tuple(macro_names)):
+                    self.ignored_header_guard = True
+                    return
+                assert False, f"header guard problem in {filename}"
+            self.append(line)
+        elif directive in ["elif", "else"]:
+            prev_line = self.pop(-1)
+            self.append(prev_line + "\n" + line)
+        elif directive in ["endif"]:
+            if self.ignored_header_guard and not self:
+                self.ignored_header_guard = False
+            else:
+                self.pop(-1)
+
+    def copy(self):
+        return CPPStack(self)
+
+    def output(self, prev_stack: CPPStack) -> bytes:
+        out = []
+        for _ in prev_stack[len(self) :]:
+            out.insert(0, "#endif\n")
+        same_until = 0
+        for i, (prev, this) in enumerate(zip(prev_stack, self)):
+            if prev != this:
+                break
+            same_until = i
+        for _ in prev_stack[same_until : len(self)]:
+            out.insert(0, "#endif\n")
+        for cond in self[same_until:]:
+            out.append("#" + cond.replace("\n", "\n#") + "\n")
+        prev_stack[:] = self[:]
+        return "".join(out).encode("UTF-8")
+
+
+@dataclass
+class Item:
+    filename: str
+    lineno: int
+    hookname: str
+    raw_argspec: str
+    cpp_stack: CPPStack
+    comments: list[bytes] = field(default_factory=list)
+    replacement: bytes | None = None
+
+    @property
+    def loc(self):
+        return f"{self.filename}:{self.lineno}"
+
+    def to_bytes(self, prev_stack: CPPStack) -> bytes:
+        return (
+            b"\n"
+            + self.cpp_stack.output(prev_stack)
+            + b"".join(line + b"\n" for line in self.comments)
+            + self.replacement
+            + b";\n"
+        )
+
+
+@dataclass
+class SplitFile:
+    filename: str
+    orig_filename: str
+    spdx: str
+    hooks: list[Item] = field(default_factory=list)
+    decl_from: str | None = None
+
+
+spdx_re = re.compile(
+    rb"""SPDX-License-Identifier:[ \t]*(?P<license>[0-9a-zA-Z-. \t]+)[ \t]*(?:\*[ \t]*)?$""",
+    flags=re.MULTILINE,
+)
+line_comment_re = re.compile(rb"""^\s*//.*""")
+comment_start_re = re.compile(rb"""^\s*/\*""")
+comment_end_re = re.compile(rb"""\*/\s*$""")
+
+os.chdir(git("rev-parse", "--show-toplevel").removesuffix("\n"))
+
+all_hooks: dict[str, dict[str, Item]] = {}
+decl_def_map: dict[str, list[str]] = {}
+split_files: dict[str, list[bytes]] = {}
+nosplit: set(str) = set()
+
+
+def file_order(filename):
+    if filename.startswith("tests/"):
+        return (4, filename)
+    if filename.endswith(".c"):
+        return (1, filename)
+    if filename == "bgpd/bgpd.h":
+        return (2, filename)
+    if filename.endswith(".h"):
+        return (3, filename)
+    return (0, filename)
+
+
+hookfiles = git("grep", "-lE", "(DEFINE|DECLARE)_(HOOK|KOOH)").splitlines()
+hookfiles.sort(key=file_order)
+for filename in hookfiles:
+    if filename.rsplit(".")[-1] not in ["c", "h"]:
+        sys.stderr.write(f"ignoring {filename}, not a C file\n")
+        continue
+    if filename in ["lib/hooks_begin.h", "lib/hooks_end.h"]:
+        continue
+
+    with open(filename, "rb") as fd:
+        rawdata = fd.read()
+
+    spdx_m = spdx_re.search(rawdata)
+    assert spdx_m is not None, f"no license ID in {filename}!"
+    spdx = spdx_m.group("license").decode("UTF-8")
+
+    cpp_stack = CPPStack()
+    fparse = _clippy.parse(filename)
+    tokens = fparse["data"]
+    replacements = []
+    splitfiles_decl = set()
+    splitfiles_def = set()
+    while tokens:
+        token = tokens.pop(0)
+        if token["type"] == "PREPROC":
+            cpp_stack.feed(token, filename)
+        if token["type"] != "HOOK":
+            continue
+        loc = f"{filename}:{token["lineno"]}"
+
+        if len(token["args"]) != 3:
+            sys.stderr.write(
+                f"{loc}: HOOK macro with {len(token["args"])} args.\n"
+                + "Has this script already been run?  Aborting.\n"
+            )
+            sys.exit(1)
+
+        assert len(token["args"][0]) == 1
+        assert len(token["args"][1]) >= 2
+        assert token["args"][1][0] == "(" and token["args"][1][-1] == ")"
+        assert len(token["args"][2]) >= 2
+        assert token["args"][2][0] == "(" and token["args"][2][-1] == ")"
+
+        hookname = token["args"][0][0]
+        which = "def" if token["value"].startswith("DEFINE_") else "decl"
+
+        argspec = token["args"][1][1:-1]
+
+        argtmp = token["args"][2][1:-1]
+        argnames = argtmp[0::2]
+        assert set(argtmp[1::2]) <= set([","])
+
+        all_hook = all_hooks.setdefault(hookname, {})
+        if not filename.startswith("tests/"):
+            raw_argspec = " ".join(argspec)
+            item = Item(
+                filename, token["lineno"], hookname, raw_argspec, cpp_stack.copy()
+            )
+            if which in all_hook:
+                sys.stderr.write(
+                    f"{loc}: \033[91mduplicate {which} for {hookname}, previous one in {all_hook[which].loc}\033[m\n"
+                )
+            else:
+                all_hook[which] = item
+
+            if all_hook.get("def", item).raw_argspec != raw_argspec:
+                sys.stderr.write(
+                    f"{loc}: \033[91m{hookname} mismatch with existing definition @ {all_hook["def"].loc}\033[m\n"
+                )
+                continue
+            if all_hook.get("decl", item).raw_argspec != raw_argspec:
+                sys.stderr.write(
+                    f"{loc}: \033[91m{hookname} mismatch with existing declaration @ {all_hook["decl"].loc}\033[m\n"
+                )
+                continue
+
+            if "def" in all_hook and "decl" in all_hook:
+                decl_def_map.setdefault(all_hook["decl"].filename, set()).add(
+                    all_hook["def"].filename
+                )
+
+        if "def" not in all_hook:
+            sys.stderr.write(
+                f"{loc}: \033[91mhaven't seen definition for {hookname} yet!\033[m\n"
+            )
+            nosplit.add(hookname)
+            nosplit_this = True
+        elif filename.startswith("tests/"):
+            nosplit_this = True
+        else:
+            nosplit_this = cmdargs.nosplit or hookname in nosplit
+            split_filename = all_hook["def"].filename.removesuffix(".c") + "_hooks.h"
+
+        args = {}
+        i = 0
+        while argspec:
+            if i >= len(argnames):
+                sys.stderr.write(
+                    f"{loc}: \033[91m{hookname} missing arg-pass name\033[m\n"
+                )
+                i = None
+                break
+
+            arg = {
+                "name": argnames[i],
+                "decl": [],
+            }
+            args[i] = arg
+            i += 1
+
+            braces = 0
+            while argspec and (argspec[0] != "," or braces > 0):
+                argtoken = argspec.pop(0)
+                arg["decl"].append(argtoken)
+                if argtoken in ["(", "[", "{"]:
+                    braces += 1
+                elif argtoken in [")", "]", "}"]:
+                    braces -= 1
+
+            assert braces == 0
+            if argspec:
+                assert argspec.pop(0) == ","
+
+            if arg["decl"][-1] != arg["name"]:
+                sys.stderr.write(
+                    f"{loc}: \033[91m{hookname} argument declaration/name mismatch\033[m\n"
+                )
+            arg["declstr"] = " ".join(arg["decl"][:-1])
+
+        if i is None:
+            continue
+        if len(args) != len(argnames):
+            sys.stderr.write(
+                f"{loc}: \033[91m{hookname} malformed argument list\033[m\n"
+            )
+            continue
+
+        if cmdargs.verbose:
+            sys.stderr.write(
+                f"{loc}: {hookname} {token["args"][0][0]} ({", ".join(argnames)})\n"
+            )
+            rawdef = rawdata[token["start"] : token["end"]].decode("UTF-8")
+            sys.stderr.write(
+                f"{token["start"]}->{token["end"]}:\n\033[100m{rawdef}\033[94m%%\033[K\033[m\n"
+            )
+            pprint(args)
+
+        ilen = len(token["value"]) + 1
+        indent = "\t" * (ilen // 8) + " " * (ilen % 8)
+        replacement = []
+        replacement.append(f"{token["value"]}({hookname}")
+        for idx, arg in args.items():
+            replacement.append(f",\n{indent}({arg["declstr"]}, {arg["name"]})")
+        replacement.append(")")
+        replacement = "".join(replacement).encode("UTF-8")
+
+        if nosplit_this:
+            replacements.insert(0, (token["start"], token["end"], replacement))
+        else:
+            start = token["start"]
+            end = token["end"] + 1
+            assert rawdata[end - 1 : end] == b";"
+            while rawdata[end : end + 1] == b"\n":
+                end += 1
+
+            start -= 1
+            assert rawdata[start : start + 1] == b"\n"
+            scan_start = start
+            prev_start = None
+            in_comment = False
+            comment_lines = []
+            while scan_start != prev_start:
+                prev_start = scan_start
+
+                line_start = rawdata.rfind(b"\n", 0, scan_start)
+                line = rawdata[line_start + 1 : scan_start]
+                if comment_end_re.search(line):
+                    in_comment = True
+                if in_comment:
+                    comment_lines.insert(0, line)
+                    start = line_start
+                    if comment_start_re.search(line):
+                        in_comment = False
+                elif line != b"":
+                    break
+
+                scan_start = line_start
+
+            assert rawdata[start : start + 1] == b"\n"
+            start += 1
+
+            all_hook["def"].comments.extend(comment_lines)
+            text = b""
+
+            if replacements:
+                prev_s, prev_e, prev_text = replacements[0]
+                if prev_e == start:
+                    start = prev_s
+                    text = prev_text
+                    replacements.pop(0)
+
+            replacements.insert(0, (start, end, text))
+            if which == "decl":
+                sf = split_files[split_filename]
+                if sf.decl_from is not None and sf.decl_from != filename:
+                    sys.stderr.write(
+                        f"{loc}: \033[91m{hookname}: {split_filename} decls already in {sf.decl_from}, not duplicating in {filename}\033[m\n"
+                    )
+                else:
+                    sf.decl_from = filename
+                    splitfiles_decl.add(split_filename)
+            else:
+                splitfiles_def.add(split_filename)
+                sf = split_files.setdefault(
+                    split_filename, SplitFile(split_filename, filename, spdx)
+                )
+                replacement = b"DO_" + replacement.removeprefix(b"DEFINE_")
+                assert item.replacement in [None, replacement]
+                item.replacement = replacement
+                sf.hooks.append(item)
+
+    if splitfiles_decl or splitfiles_def:
+        if filename.endswith(".h"):
+            hookpos = 0
+        else:
+            hookpos = -1
+
+        start, end, text = replacements[hookpos]
+        if rawdata[start - 2 : start - 1] != b"\n":
+            text = b"\n" + text
+        if rawdata[start - 3 : start - 1] == b"\n\n":
+            start -= 1
+        if splitfiles_decl:
+            incls = "".join(
+                f"""#include "{filename}"\n""" for filename in sorted(splitfiles_decl)
+            ).encode("UTF-8")
+            text = (
+                text
+                + b"""#define HOOKS_DECLARE\n#include "lib/hooks_begin.h"\n"""
+                + incls
+                + b"""#include "lib/hooks_end.h"\n\n"""
+            )
+        if splitfiles_def:
+            incls = "".join(
+                f"""#include "{filename}"\n""" for filename in sorted(splitfiles_def)
+            ).encode("UTF-8")
+            text = (
+                text
+                + b"""#define HOOKS_DEFINE\n#include "lib/hooks_begin.h"\n"""
+                + incls
+                + b"""#include "lib/hooks_end.h"\n\n"""
+            )
+        replacements[hookpos] = start, end, text
+
+    for start, end, text in replacements:
+        rawdata = rawdata[:start] + text + rawdata[end:]
+
+    with open(filename, "wb") as fd:
+        fd.write(rawdata)
+
+    if cmdargs.git_add:
+        git("add", filename)
+
+for header, sources in decl_def_map.items():
+    if len(sources) > 1:
+        sys.stderr.write(
+            f"note: hooks declared in {header} definitions spread over multiple source files:\n\t{"\n\t".join(sorted(sources))}\n"
+        )
+
+for sf in split_files.values():
+    prev_stack = CPPStack()
+    with open(sf.filename, "wb") as fd:
+        fd.write(f"""// SPDX-License-Identifier: {sf.spdx}
+/* hook definitions for {sf.orig_filename}
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+""".encode("UTF-8"))
+        fd.write(b"".join(hook.to_bytes(prev_stack) for hook in sf.hooks))
+        fd.write(CPPStack().output(prev_stack))
+
+    if cmdargs.git_add:
+        git("add", sf.filename)

--- a/vrrpd/subdir.am
+++ b/vrrpd/subdir.am
@@ -28,6 +28,8 @@ noinst_HEADERS += \
 	vrrpd/vrrp_packet.h \
 	vrrpd/vrrp_vty.h \
 	vrrpd/vrrp_zebra.h \
+	\
+	vrrpd/vrrp_hooks.h \
 	# end
 
 clippy_scan += \

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -1368,10 +1368,10 @@ done:
 	return ret;
 }
 
-
-/* State machine ----------------------------------------------------------- */
-
-DEFINE_HOOK(vrrp_change_state_hook, (struct vrrp_router *r, int to), (r, to));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "vrrpd/vrrp_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Handle any necessary actions during state change to MASTER state.

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -30,6 +30,11 @@
 DEFINE_MTYPE_STATIC(VRRPD, VRRP_IP, "VRRP IP address");
 DEFINE_MTYPE_STATIC(VRRPD, VRRP_RTR, "VRRP Router");
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "vrrpd/vrrp_hooks.h"
+#include "lib/hooks_end.h"
+
 /* statics */
 struct hash *vrrp_vrouters_hash;
 bool vrrp_autoconfig_is_on;
@@ -1368,10 +1373,7 @@ done:
 	return ret;
 }
 
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "vrrpd/vrrp_hooks.h"
-#include "lib/hooks_end.h"
+/* State machine ----------------------------------------------------------- */
 
 /*
  * Handle any necessary actions during state change to MASTER state.

--- a/vrrpd/vrrp.h
+++ b/vrrpd/vrrp.h
@@ -471,14 +471,10 @@ int vrrp_del_ipv6(struct vrrp_vrouter *vr, struct in6_addr v6);
 
 extern const char *const vrrp_state_names[3];
 
-/*
- * This hook called whenever the state of a Virtual Router changes, after the
- * specific internal state handlers have run.
- *
- * Use this if you need to react to state changes to perform non-critical
- * tasks. Critical tasks should go in the internal state change handlers.
- */
-DECLARE_HOOK(vrrp_change_state_hook, (struct vrrp_router *r, int to), (r, to));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "vrrpd/vrrp_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Trigger a VRRP event on a given Virtual Router..

--- a/vrrpd/vrrp.h
+++ b/vrrpd/vrrp.h
@@ -471,11 +471,6 @@ int vrrp_del_ipv6(struct vrrp_vrouter *vr, struct in6_addr v6);
 
 extern const char *const vrrp_state_names[3];
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "vrrpd/vrrp_hooks.h"
-#include "lib/hooks_end.h"
-
 /*
  * Trigger a VRRP event on a given Virtual Router..
  *
@@ -557,5 +552,11 @@ int vrrp_config_write_global(struct vty *vty);
  * Find VRRP Virtual Router by Virtual Router ID
  */
 struct vrrp_vrouter *vrrp_lookup(const struct interface *ifp, uint8_t vrid);
+
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "vrrpd/vrrp_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* __VRRP_H__ */

--- a/vrrpd/vrrp_hooks.h
+++ b/vrrpd/vrrp_hooks.h
@@ -4,7 +4,6 @@
  * note: file may be included multiple times - intentionally no include guard!
  */
 
-/* State machine ----------------------------------------------------------- */
 /*
  * This hook called whenever the state of a Virtual Router changes, after the
  * specific internal state handlers have run.

--- a/vrrpd/vrrp_hooks.h
+++ b/vrrpd/vrrp_hooks.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for vrrpd/vrrp.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* State machine ----------------------------------------------------------- */
+/*
+ * This hook called whenever the state of a Virtual Router changes, after the
+ * specific internal state handlers have run.
+ *
+ * Use this if you need to react to state changes to perform non-critical
+ * tasks. Critical tasks should go in the internal state change handlers.
+ */
+DO_HOOK(vrrp_change_state_hook, (struct vrrp_router *, r), (int, to));

--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -31,7 +31,10 @@ unsigned long zebra_debug_neigh;
 unsigned long zebra_debug_tc;
 unsigned long zebra_debug_srv6;
 
-DEFINE_HOOK(zebra_debug_show_debugging, (struct vty *vty), (vty));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/debug_hooks.h"
+#include "lib/hooks_end.h"
 
 DEFUN_NOSH (show_debugging_zebra,
 	    show_debugging_zebra_cmd,

--- a/zebra/debug.h
+++ b/zebra/debug.h
@@ -147,7 +147,10 @@ extern unsigned long zebra_debug_srv6;
 
 extern void zebra_debug_init(void);
 
-DECLARE_HOOK(zebra_debug_show_debugging, (struct vty *vty), (vty));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/debug_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/debug_hooks.h
+++ b/zebra/debug_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/debug.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(zebra_debug_show_debugging, (struct vty *, vty));

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -42,8 +42,10 @@ DEFINE_MTYPE_STATIC(ZEBRA, ZINFO, "Zebra Interface Information");
 
 #define ZEBRA_PTM_SUPPORT
 
-DEFINE_HOOK(zebra_if_extra_info, (struct vty * vty, json_object *json_if, struct interface *ifp),
-	    (vty, json_if, ifp));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/interface_hooks.h"
+#include "lib/hooks_end.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZIF_DESC, "Intf desc");
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -217,11 +217,6 @@ struct zebra_if {
 	char *desc;
 };
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/interface_hooks.h"
-#include "lib/hooks_end.h"
-
 #define IS_ZEBRA_IF_VRF(ifp)                                                   \
 	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_VRF)
 
@@ -359,6 +354,12 @@ extern int interface_list_proc(void);
 #ifdef HAVE_PROC_NET_IF_INET6
 extern int ifaddr_proc_ipv6(void);
 #endif /* HAVE_PROC_NET_IF_INET6 */
+
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/interface_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -217,8 +217,10 @@ struct zebra_if {
 	char *desc;
 };
 
-DECLARE_HOOK(zebra_if_extra_info, (struct vty * vty, json_object *json_if, struct interface *ifp),
-	     (vty, json_if, ifp));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/interface_hooks.h"
+#include "lib/hooks_end.h"
 
 #define IS_ZEBRA_IF_VRF(ifp)                                                   \
 	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_VRF)

--- a/zebra/interface_hooks.h
+++ b/zebra/interface_hooks.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/interface.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(zebra_if_extra_info, (struct vty *, vty), (json_object *, json_if),
+	(struct interface *, ifp));

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -38,25 +38,10 @@ struct label_manager lbl_mgr;
 DEFINE_MGROUP(LBL_MGR, "Label Manager");
 DEFINE_MTYPE_STATIC(LBL_MGR, LM_CHUNK, "Label Manager Chunk");
 
-/* define hooks for the basic API, so that it can be specialized or served
- * externally
- */
-
-DEFINE_HOOK(lm_client_connect, (struct zserv *client, vrf_id_t vrf_id),
-	    (client, vrf_id));
-DEFINE_HOOK(lm_client_disconnect, (struct zserv *client), (client));
-DEFINE_HOOK(lm_get_chunk,
-	     (struct label_manager_chunk * *lmc, struct zserv *client,
-	      uint8_t keep, uint32_t size, uint32_t base, vrf_id_t vrf_id),
-	     (lmc, client, keep, size, base, vrf_id));
-DEFINE_HOOK(lm_release_chunk,
-	     (struct zserv *client, uint32_t start, uint32_t end),
-	     (client, start, end));
-/* show running-config needs an API for dynamic-block */
-DEFINE_HOOK(lm_write_label_block_config,
-	    (struct vty *vty, struct zebra_vrf *zvrf),
-	    (vty, zvrf));
-DEFINE_HOOK(lm_cbs_inited, (), ());
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/label_manager_hooks.h"
+#include "lib/hooks_end.h"
 
 /* define wrappers to be called in zapi_msg.c or zebra_mpls_vty.c (as hooks
  * must be called in source file where they were defined)

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -47,11 +47,6 @@ struct label_manager_chunk {
 	uint32_t end;   /* Last label of the chunk */
 };
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/label_manager_hooks.h"
-#include "lib/hooks_end.h"
-
 /* declare wrappers to be called in zapi_msg.c or zebra_mpls_vty.c (as hooks
  * must be called in source file where they were defined)
  */
@@ -93,6 +88,11 @@ int release_label_chunk(uint8_t proto, unsigned short instance,
 			uint32_t session_id, uint32_t start, uint32_t end);
 int lm_client_disconnect_cb(struct zserv *client);
 int release_daemon_label_chunks(struct zserv *client);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/label_manager_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -47,26 +47,10 @@ struct label_manager_chunk {
 	uint32_t end;   /* Last label of the chunk */
 };
 
-/* declare hooks for the basic API, so that it can be specialized or served
- * externally. Also declare a hook when those functions have been registered,
- * so that any external module wanting to replace those can react
- */
-
-DECLARE_HOOK(lm_client_connect, (struct zserv *client, vrf_id_t vrf_id),
-	     (client, vrf_id));
-DECLARE_HOOK(lm_client_disconnect, (struct zserv *client), (client));
-DECLARE_HOOK(lm_get_chunk,
-	     (struct label_manager_chunk * *lmc, struct zserv *client,
-	      uint8_t keep, uint32_t size, uint32_t base, vrf_id_t vrf_id),
-	     (lmc, client, keep, size, base, vrf_id));
-DECLARE_HOOK(lm_release_chunk,
-	     (struct zserv *client, uint32_t start, uint32_t end),
-	     (client, start, end));
-DECLARE_HOOK(lm_write_label_block_config,
-	     (struct vty *vty, struct zebra_vrf *zvrf),
-	     (vty, zvrf));
-DECLARE_HOOK(lm_cbs_inited, (), ());
-
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/label_manager_hooks.h"
+#include "lib/hooks_end.h"
 
 /* declare wrappers to be called in zapi_msg.c or zebra_mpls_vty.c (as hooks
  * must be called in source file where they were defined)

--- a/zebra/label_manager_hooks.h
+++ b/zebra/label_manager_hooks.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/label_manager.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* define hooks for the basic API, so that it can be specialized or served
+ * externally
+ */
+/* declare hooks for the basic API, so that it can be specialized or served
+ * externally. Also declare a hook when those functions have been registered,
+ * so that any external module wanting to replace those can react
+ */
+DO_HOOK(lm_client_connect, (struct zserv *, client), (vrf_id_t, vrf_id));
+
+DO_HOOK(lm_client_disconnect, (struct zserv *, client));
+
+DO_HOOK(lm_get_chunk, (struct label_manager_chunk **, lmc), (struct zserv *, client),
+	(uint8_t, keep), (uint32_t, size), (uint32_t, base), (vrf_id_t, vrf_id));
+
+DO_HOOK(lm_release_chunk, (struct zserv *, client), (uint32_t, start), (uint32_t, end));
+
+/* show running-config needs an API for dynamic-block */
+DO_HOOK(lm_write_label_block_config, (struct vty *, vty), (struct zebra_vrf *, zvrf));
+
+DO_HOOK(lm_cbs_inited);

--- a/zebra/label_manager_hooks.h
+++ b/zebra/label_manager_hooks.h
@@ -4,20 +4,15 @@
  * note: file may be included multiple times - intentionally no include guard!
  */
 
-/* define hooks for the basic API, so that it can be specialized or served
- * externally
- */
 /* declare hooks for the basic API, so that it can be specialized or served
  * externally. Also declare a hook when those functions have been registered,
  * so that any external module wanting to replace those can react
  */
 DO_HOOK(lm_client_connect, (struct zserv *, client), (vrf_id_t, vrf_id));
-
 DO_HOOK(lm_client_disconnect, (struct zserv *, client));
 
 DO_HOOK(lm_get_chunk, (struct label_manager_chunk **, lmc), (struct zserv *, client),
 	(uint8_t, keep), (uint32_t, size), (uint32_t, base), (vrf_id_t, vrf_id));
-
 DO_HOOK(lm_release_chunk, (struct zserv *, client), (uint32_t, start), (uint32_t, end));
 
 /* show running-config needs an API for dynamic-block */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -606,9 +606,10 @@ static inline void rib_tables_iter_cleanup(rib_tables_iter_t *iter)
 	iter->state = RIB_TABLES_ITER_S_DONE;
 }
 
-DECLARE_HOOK(rib_update, (struct route_node * rn, const char *reason),
-	     (rn, reason));
-DECLARE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_rib_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Access installed/fib nexthops, which may be a subset of the

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -606,11 +606,6 @@ static inline void rib_tables_iter_cleanup(rib_tables_iter_t *iter)
 	iter->state = RIB_TABLES_ITER_S_DONE;
 }
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/zebra_rib_hooks.h"
-#include "lib/hooks_end.h"
-
 /*
  * Access installed/fib nexthops, which may be a subset of the
  * rib nexthops.
@@ -649,6 +644,12 @@ void route_entry_dump_nh(const struct route_entry *re, const char *straddr,
 #define ZEBRA_ON_RIB_PROCESS_HOOK_CALL "on_rib_process_dplane_results"
 
 extern char *zebra_rib_dump_re_status(const struct route_entry *re, char *buf, size_t len);
+
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_rib_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -198,6 +198,18 @@ nobase_pkginclude_HEADERS += \
 	zebra/zebra_l2_bridge_if.h \
 	zebra/zebra_vxlan_if.h \
 	zebra/zserv.h \
+	\
+	zebra/debug_hooks.h \
+	zebra/interface_hooks.h \
+	zebra/label_manager_hooks.h \
+	zebra/zebra_mlag_hooks.h \
+	zebra/zebra_pbr_hooks.h \
+	zebra/zebra_pw_hooks.h \
+	zebra/zebra_rib_hooks.h \
+	zebra/zebra_router_hooks.h \
+	zebra/zebra_srv6_hooks.h \
+	zebra/zebra_vxlan_hooks.h \
+	zebra/zserv_hooks.h \
 	# end
 
 noinst_HEADERS += \

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -20,12 +20,10 @@
 #include "mlag/mlag.pb-c.h"
 #endif
 
-DEFINE_HOOK(zebra_mlag_private_write_data,
-	    (uint8_t *data, uint32_t len), (data, len));
-DEFINE_HOOK(zebra_mlag_private_monitor_state, (), ());
-DEFINE_HOOK(zebra_mlag_private_open_channel, (), ());
-DEFINE_HOOK(zebra_mlag_private_close_channel, (), ());
-DEFINE_HOOK(zebra_mlag_private_cleanup_data, (), ());
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_mlag_hooks.h"
+#include "lib/hooks_end.h"
 
 #define ZEBRA_MLAG_METADATA_LEN 4
 #define ZEBRA_MLAG_MSG_BCAST 0xFFFFFFFF

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -17,11 +17,6 @@ extern "C" {
 #define ZEBRA_MLAG_BUF_LIMIT 32768
 #define ZEBRA_MLAG_LEN_SIZE 4
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/zebra_mlag_hooks.h"
-#include "lib/hooks_end.h"
-
 extern uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
 extern uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];
 
@@ -53,6 +48,12 @@ int zebra_mlag_protobuf_encode_client_data(struct stream *s,
 					   uint32_t *msg_type);
 int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				       uint32_t len);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_mlag_hooks.h"
+#include "lib/hooks_end.h"
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -17,12 +17,10 @@ extern "C" {
 #define ZEBRA_MLAG_BUF_LIMIT 32768
 #define ZEBRA_MLAG_LEN_SIZE 4
 
-DECLARE_HOOK(zebra_mlag_private_write_data,
-	     (uint8_t *data, uint32_t len), (data, len));
-DECLARE_HOOK(zebra_mlag_private_monitor_state, (), ());
-DECLARE_HOOK(zebra_mlag_private_open_channel, (), ());
-DECLARE_HOOK(zebra_mlag_private_close_channel, (), ());
-DECLARE_HOOK(zebra_mlag_private_cleanup_data, (), ());
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_mlag_hooks.h"
+#include "lib/hooks_end.h"
 
 extern uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
 extern uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];

--- a/zebra/zebra_mlag_hooks.h
+++ b/zebra/zebra_mlag_hooks.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_mlag.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(zebra_mlag_private_write_data, (uint8_t *, data), (uint32_t, len));
+
+DO_HOOK(zebra_mlag_private_monitor_state);
+
+DO_HOOK(zebra_mlag_private_open_channel);
+
+DO_HOOK(zebra_mlag_private_close_channel);
+
+DO_HOOK(zebra_mlag_private_cleanup_data);

--- a/zebra/zebra_mlag_hooks.h
+++ b/zebra/zebra_mlag_hooks.h
@@ -5,11 +5,7 @@
  */
 
 DO_HOOK(zebra_mlag_private_write_data, (uint8_t *, data), (uint32_t, len));
-
 DO_HOOK(zebra_mlag_private_monitor_state);
-
 DO_HOOK(zebra_mlag_private_open_channel);
-
 DO_HOOK(zebra_mlag_private_close_channel);
-
 DO_HOOK(zebra_mlag_private_cleanup_data);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -28,6 +28,10 @@ DEFINE_MTYPE_STATIC(ZEBRA, PBR_IPSET, "PBR ipset");
 DEFINE_MTYPE_STATIC(ZEBRA, PBR_IPSET_ENTRY, "PBR ipset entry");
 DEFINE_MTYPE(ZEBRA, PBR_IPTABLE, "PBR iptable");
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_pbr_hooks.h"
+#include "lib/hooks_end.h"
 
 /* definitions */
 static const struct message ipset_type_msg[] = {
@@ -121,11 +125,6 @@ struct zebra_pbr_env_display {
 	struct vty *vty;
 	char *name;
 };
-
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "zebra/zebra_pbr_hooks.h"
-#include "lib/hooks_end.h"
 
 /* resolve nexthop for dataplane (dpdk) programming */
 static bool zebra_pbr_expand_action;

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -122,25 +122,10 @@ struct zebra_pbr_env_display {
 	char *name;
 };
 
-/* static function declarations */
-DEFINE_HOOK(zebra_pbr_ipset_entry_get_stat,
-	    (struct zebra_pbr_ipset_entry *ipset, uint64_t *pkts,
-	     uint64_t *bytes),
-	    (ipset, pkts, bytes));
-
-DEFINE_HOOK(zebra_pbr_iptable_get_stat,
-	    (struct zebra_pbr_iptable *iptable, uint64_t *pkts,
-	     uint64_t *bytes),
-	    (iptable, pkts, bytes));
-
-DEFINE_HOOK(zebra_pbr_iptable_update,
-	    (int cmd, struct zebra_pbr_iptable *iptable), (cmd, iptable));
-
-DEFINE_HOOK(zebra_pbr_ipset_entry_update,
-	    (int cmd, struct zebra_pbr_ipset_entry *ipset), (cmd, ipset));
-
-DEFINE_HOOK(zebra_pbr_ipset_update,
-	    (int cmd, struct zebra_pbr_ipset *ipset), (cmd, ipset));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_pbr_hooks.h"
+#include "lib/hooks_end.h"
 
 /* resolve nexthop for dataplane (dpdk) programming */
 static bool zebra_pbr_expand_action;

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -264,21 +264,10 @@ extern void zebra_pbr_show_rule(struct vty *vty);
 extern void zebra_pbr_show_rule_unit(struct zebra_pbr_rule *rule,
 				     struct vty *vty);
 
-DECLARE_HOOK(zebra_pbr_ipset_entry_get_stat,
-	     (struct zebra_pbr_ipset_entry *ipset, uint64_t *pkts,
-	      uint64_t *bytes),
-	     (ipset, pkts, bytes));
-DECLARE_HOOK(zebra_pbr_iptable_get_stat,
-	     (struct zebra_pbr_iptable *iptable, uint64_t *pkts,
-	      uint64_t *bytes),
-	     (iptable, pkts, bytes));
-DECLARE_HOOK(zebra_pbr_iptable_update,
-	     (int cmd, struct zebra_pbr_iptable *iptable), (cmd, iptable));
-
-DECLARE_HOOK(zebra_pbr_ipset_entry_update,
-	     (int cmd, struct zebra_pbr_ipset_entry *ipset), (cmd, ipset));
-DECLARE_HOOK(zebra_pbr_ipset_update,
-	     (int cmd, struct zebra_pbr_ipset *ipset), (cmd, ipset));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_pbr_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_pbr_hooks.h
+++ b/zebra/zebra_pbr_hooks.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_pbr.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* static function declarations */
+DO_HOOK(zebra_pbr_ipset_entry_get_stat, (struct zebra_pbr_ipset_entry *, ipset),
+	(uint64_t *, pkts), (uint64_t *, bytes));
+
+DO_HOOK(zebra_pbr_iptable_get_stat, (struct zebra_pbr_iptable *, iptable), (uint64_t *, pkts),
+	(uint64_t *, bytes));
+
+DO_HOOK(zebra_pbr_iptable_update, (int, cmd), (struct zebra_pbr_iptable *, iptable));
+
+DO_HOOK(zebra_pbr_ipset_entry_update, (int, cmd), (struct zebra_pbr_ipset_entry *, ipset));
+
+DO_HOOK(zebra_pbr_ipset_update, (int, cmd), (struct zebra_pbr_ipset *, ipset));

--- a/zebra/zebra_pbr_hooks.h
+++ b/zebra/zebra_pbr_hooks.h
@@ -4,15 +4,10 @@
  * note: file may be included multiple times - intentionally no include guard!
  */
 
-/* static function declarations */
 DO_HOOK(zebra_pbr_ipset_entry_get_stat, (struct zebra_pbr_ipset_entry *, ipset),
 	(uint64_t *, pkts), (uint64_t *, bytes));
-
+DO_HOOK(zebra_pbr_ipset_entry_update, (int, cmd), (struct zebra_pbr_ipset_entry *, ipset));
+DO_HOOK(zebra_pbr_ipset_update, (int, cmd), (struct zebra_pbr_ipset *, ipset));
 DO_HOOK(zebra_pbr_iptable_get_stat, (struct zebra_pbr_iptable *, iptable), (uint64_t *, pkts),
 	(uint64_t *, bytes));
-
 DO_HOOK(zebra_pbr_iptable_update, (int, cmd), (struct zebra_pbr_iptable *, iptable));
-
-DO_HOOK(zebra_pbr_ipset_entry_update, (int, cmd), (struct zebra_pbr_ipset_entry *, ipset));
-
-DO_HOOK(zebra_pbr_ipset_update, (int, cmd), (struct zebra_pbr_ipset *, ipset));

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -25,8 +25,10 @@ DEFINE_MTYPE_STATIC(LIB, PW, "Pseudowire");
 
 DEFINE_QOBJ_TYPE(zebra_pw);
 
-DEFINE_HOOK(pw_install, (struct zebra_pw * pw), (pw));
-DEFINE_HOOK(pw_uninstall, (struct zebra_pw * pw), (pw));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_pw_hooks.h"
+#include "lib/hooks_end.h"
 
 #define MPLS_NO_LABEL MPLS_INVALID_LABEL
 

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -54,11 +54,6 @@ RB_PROTOTYPE(zebra_pw_head, zebra_pw, pw_entry, zebra_pw_compare);
 RB_HEAD(zebra_static_pw_head, zebra_pw);
 RB_PROTOTYPE(zebra_static_pw_head, zebra_pw, static_pw_entry, zebra_pw_compare);
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/zebra_pw_hooks.h"
-#include "lib/hooks_end.h"
-
 struct zebra_pw *zebra_pw_add(struct zebra_vrf *zvrf, const char *ifname,
 			      uint8_t protocol, struct zserv *client);
 void zebra_pw_del(struct zebra_vrf *zvrf, struct zebra_pw *pw);
@@ -73,6 +68,11 @@ void zebra_pw_exit_vrf(struct zebra_vrf *zvrf);
 void zebra_pw_terminate(void);
 void zebra_pw_vty_init(void);
 void zebra_pw_handle_dplane_results(struct zebra_dplane_ctx *ctx);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_pw_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -54,8 +54,10 @@ RB_PROTOTYPE(zebra_pw_head, zebra_pw, pw_entry, zebra_pw_compare);
 RB_HEAD(zebra_static_pw_head, zebra_pw);
 RB_PROTOTYPE(zebra_static_pw_head, zebra_pw, static_pw_entry, zebra_pw_compare);
 
-DECLARE_HOOK(pw_install, (struct zebra_pw * pw), (pw));
-DECLARE_HOOK(pw_uninstall, (struct zebra_pw * pw), (pw));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_pw_hooks.h"
+#include "lib/hooks_end.h"
 
 struct zebra_pw *zebra_pw_add(struct zebra_vrf *zvrf, const char *ifname,
 			      uint8_t protocol, struct zserv *client);

--- a/zebra/zebra_pw_hooks.h
+++ b/zebra/zebra_pw_hooks.h
@@ -5,5 +5,4 @@
  */
 
 DO_HOOK(pw_install, (struct zebra_pw *, pw));
-
 DO_HOOK(pw_uninstall, (struct zebra_pw *, pw));

--- a/zebra/zebra_pw_hooks.h
+++ b/zebra/zebra_pw_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_pw.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(pw_install, (struct zebra_pw *, pw));
+
+DO_HOOK(pw_uninstall, (struct zebra_pw *, pw));

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -72,10 +72,10 @@ static _Atomic uint32_t rib_dplane_q_max;
 static _Atomic bool dplane_results_plugged;
 #endif
 
-DEFINE_HOOK(rib_update, (struct route_node * rn, const char *reason),
-	    (rn, reason));
-DEFINE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
-
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_rib_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Meta Q's specific names

--- a/zebra/zebra_rib_hooks.h
+++ b/zebra/zebra_rib_hooks.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_rib.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(rib_update, (struct route_node *, rn), (const char *, reason));
+
+DO_HOOK(rib_shutdown, (struct route_node *, rn));

--- a/zebra/zebra_rib_hooks.h
+++ b/zebra/zebra_rib_hooks.h
@@ -5,5 +5,4 @@
  */
 
 DO_HOOK(rib_update, (struct route_node *, rn), (const char *, reason));
-
 DO_HOOK(rib_shutdown, (struct route_node *, rn));

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -27,7 +27,10 @@ struct zebra_router zrouter = {
 	.zav.multipath_num = MULTIPATH_NUM,
 };
 
-DEFINE_HOOK(nos_initialize_data, (struct zebra_architectural_values *zav), (zav));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_router_hooks.h"
+#include "lib/hooks_end.h"
 
 static inline int
 zebra_router_table_entry_compare(const struct zebra_router_table *e1,

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -333,7 +333,10 @@ extern void zebra_main_router_started(void);
 /* zebra_northbound.c */
 extern const struct frr_yang_module_info frr_zebra_info;
 
-DECLARE_HOOK(nos_initialize_data, (struct zebra_architectural_values *zav), (zav));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_router_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_router_hooks.h
+++ b/zebra/zebra_router_hooks.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_router.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(nos_initialize_data, (struct zebra_architectural_values *, zav));

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -47,39 +47,10 @@ static void release_srv6_sid_func(const struct zebra_srv6_sid_ctx *zctx);
 static bool zebra_srv6_sid_compose(struct in6_addr *sid_value, struct srv6_locator *locator,
 				   uint32_t sid_func, uint32_t sid_func_wide, bool is_localonly);
 
-/* define hooks for the basic API, so that it can be specialized or served
- * externally
- */
-
-DEFINE_HOOK(srv6_manager_client_connect,
-	    (struct zserv *client, vrf_id_t vrf_id),
-	    (client, vrf_id));
-DEFINE_HOOK(srv6_manager_client_disconnect,
-	    (struct zserv *client), (client));
-DEFINE_HOOK(srv6_manager_get_chunk,
-	    (struct srv6_locator **loc,
-	     struct zserv *client,
-	     const char *locator_name,
-	     vrf_id_t vrf_id),
-	    (loc, client, locator_name, vrf_id));
-DEFINE_HOOK(srv6_manager_release_chunk,
-	    (struct zserv *client,
-	     const char *locator_name,
-	     vrf_id_t vrf_id),
-	    (client, locator_name, vrf_id));
-
-DEFINE_HOOK(srv6_manager_get_sid,
-	    (struct zebra_srv6_sid **sid, struct zserv *client, struct srv6_sid_ctx *ctx,
-	     struct in6_addr *sid_value, const char *locator_name, bool is_localonly),
-	    (sid, client, ctx, sid_value, locator_name, is_localonly));
-DEFINE_HOOK(srv6_manager_release_sid,
-	    (struct zserv *client, struct srv6_sid_ctx *ctx, const char *locator_name,
-	     bool is_localonly),
-	    (client, ctx, locator_name, is_localonly));
-DEFINE_HOOK(srv6_manager_get_locator,
-	    (struct srv6_locator **locator, struct zserv *client,
-	     const char *locator_name),
-	    (locator, client, locator_name));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_srv6_hooks.h"
+#include "lib/hooks_end.h"
 
 /* define wrappers to be called in zapi_msg.c (as hooks must be called in
  * source file where they were defined)

--- a/zebra/zebra_srv6.h
+++ b/zebra/zebra_srv6.h
@@ -245,40 +245,10 @@ struct zebra_srv6 {
 	struct list *sid_blocks;
 };
 
-/* declare hooks for the basic API, so that it can be specialized or served
- * externally. Also declare a hook when those functions have been registered,
- * so that any external module wanting to replace those can react
- */
-
-DECLARE_HOOK(srv6_manager_client_connect,
-	    (struct zserv *client, vrf_id_t vrf_id),
-	    (client, vrf_id));
-DECLARE_HOOK(srv6_manager_client_disconnect,
-	     (struct zserv *client), (client));
-DECLARE_HOOK(srv6_manager_get_chunk,
-	     (struct srv6_locator **loc,
-	      struct zserv *client,
-	      const char *locator_name,
-	      vrf_id_t vrf_id),
-	     (loc, client, locator_name, vrf_id));
-DECLARE_HOOK(srv6_manager_release_chunk,
-	     (struct zserv *client,
-	      const char *locator_name,
-	      vrf_id_t vrf_id),
-	     (client, locator_name, vrf_id));
-
-DECLARE_HOOK(srv6_manager_get_sid,
-	     (struct zebra_srv6_sid **sid, struct zserv *client, struct srv6_sid_ctx *ctx,
-	      struct in6_addr *sid_value, const char *locator_name, bool is_localonly),
-	     (sid, client, ctx, sid_value, locator_name, is_localonly));
-DECLARE_HOOK(srv6_manager_release_sid,
-	     (struct zserv *client, struct srv6_sid_ctx *ctx, const char *locator_name,
-	      bool is_localonly),
-	     (client, ctx, locator_name, is_localonly));
-DECLARE_HOOK(srv6_manager_get_locator,
-	     (struct srv6_locator **locator, struct zserv *client,
-	      const char *locator_name),
-	     (locator, client, locator_name));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_srv6_hooks.h"
+#include "lib/hooks_end.h"
 
 extern void zebra_srv6_locator_add(struct srv6_locator *locator);
 extern void zebra_srv6_locator_delete(struct srv6_locator *locator);

--- a/zebra/zebra_srv6.h
+++ b/zebra/zebra_srv6.h
@@ -245,11 +245,6 @@ struct zebra_srv6 {
 	struct list *sid_blocks;
 };
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/zebra_srv6_hooks.h"
-#include "lib/hooks_end.h"
-
 extern void zebra_srv6_locator_add(struct srv6_locator *locator);
 extern void zebra_srv6_locator_delete(struct srv6_locator *locator);
 extern struct srv6_locator *zebra_srv6_locator_lookup(const char *name);
@@ -348,5 +343,10 @@ extern void zebra_srv6_sid_ctx_free(struct zebra_srv6_sid_ctx *ctx);
 extern void delete_zebra_srv6_sid_ctx(void *val);
 extern struct zebra_srv6_sid_ctx *zebra_srv6_sid_ctx_lookup(const struct srv6_sid_ctx *ctx,
 							    struct zebra_srv6_sid_block *block);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_srv6_hooks.h"
+#include "lib/hooks_end.h"
 
 #endif /* _ZEBRA_SRV6_H */

--- a/zebra/zebra_srv6_hooks.h
+++ b/zebra/zebra_srv6_hooks.h
@@ -4,27 +4,21 @@
  * note: file may be included multiple times - intentionally no include guard!
  */
 
-/* define hooks for the basic API, so that it can be specialized or served
- * externally
- */
 /* declare hooks for the basic API, so that it can be specialized or served
  * externally. Also declare a hook when those functions have been registered,
  * so that any external module wanting to replace those can react
  */
 DO_HOOK(srv6_manager_client_connect, (struct zserv *, client), (vrf_id_t, vrf_id));
-
 DO_HOOK(srv6_manager_client_disconnect, (struct zserv *, client));
 
 DO_HOOK(srv6_manager_get_chunk, (struct srv6_locator **, loc), (struct zserv *, client),
 	(const char *, locator_name), (vrf_id_t, vrf_id));
-
 DO_HOOK(srv6_manager_release_chunk, (struct zserv *, client), (const char *, locator_name),
 	(vrf_id_t, vrf_id));
 
 DO_HOOK(srv6_manager_get_sid, (struct zebra_srv6_sid **, sid), (struct zserv *, client),
 	(struct srv6_sid_ctx *, ctx), (struct in6_addr *, sid_value), (const char *, locator_name),
 	(bool, is_localonly));
-
 DO_HOOK(srv6_manager_release_sid, (struct zserv *, client), (struct srv6_sid_ctx *, ctx),
 	(const char *, locator_name), (bool, is_localonly));
 

--- a/zebra/zebra_srv6_hooks.h
+++ b/zebra/zebra_srv6_hooks.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_srv6.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* define hooks for the basic API, so that it can be specialized or served
+ * externally
+ */
+/* declare hooks for the basic API, so that it can be specialized or served
+ * externally. Also declare a hook when those functions have been registered,
+ * so that any external module wanting to replace those can react
+ */
+DO_HOOK(srv6_manager_client_connect, (struct zserv *, client), (vrf_id_t, vrf_id));
+
+DO_HOOK(srv6_manager_client_disconnect, (struct zserv *, client));
+
+DO_HOOK(srv6_manager_get_chunk, (struct srv6_locator **, loc), (struct zserv *, client),
+	(const char *, locator_name), (vrf_id_t, vrf_id));
+
+DO_HOOK(srv6_manager_release_chunk, (struct zserv *, client), (const char *, locator_name),
+	(vrf_id_t, vrf_id));
+
+DO_HOOK(srv6_manager_get_sid, (struct zebra_srv6_sid **, sid), (struct zserv *, client),
+	(struct srv6_sid_ctx *, ctx), (struct in6_addr *, sid_value), (const char *, locator_name),
+	(bool, is_localonly));
+
+DO_HOOK(srv6_manager_release_sid, (struct zserv *, client), (struct srv6_sid_ctx *, ctx),
+	(const char *, locator_name), (bool, is_localonly));
+
+DO_HOOK(srv6_manager_get_locator, (struct srv6_locator **, locator), (struct zserv *, client),
+	(const char *, locator_name));

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -51,10 +51,10 @@ DEFINE_MTYPE_STATIC(ZEBRA, L3NEIGH, "EVPN Neighbor");
 DEFINE_MTYPE_STATIC(ZEBRA, ZVXLAN_SG, "zebra VxLAN multicast group");
 DEFINE_MTYPE_STATIC(ZEBRA, EVPN_VTEP, "zebra VxLAN VTEP IP");
 
-DEFINE_HOOK(zebra_rmac_update,
-	    (struct zebra_mac * rmac, struct zebra_l3vni *zl3vni, bool delete,
-	     const char *reason),
-	    (rmac, zl3vni, delete, reason));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_vxlan_hooks.h"
+#include "lib/hooks_end.h"
 
 /* config knobs */
 static bool accept_bgp_seq = true;

--- a/zebra/zebra_vxlan_hooks.h
+++ b/zebra/zebra_vxlan_hooks.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zebra_vxlan.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+DO_HOOK(zebra_rmac_update, (struct zebra_mac *, rmac), (struct zebra_l3vni *, zl3vni),
+	(bool, delete), (const char *, reason));

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -216,11 +216,10 @@ extern struct interface *zl3vni_map_to_mac_vlan_if(struct zebra_l3vni *zl3vni);
 extern struct zebra_l3vni *zl3vni_lookup(vni_t vni);
 extern vni_t vni_id_from_svi(struct interface *ifp, struct interface *br_if);
 
-DECLARE_HOOK(zebra_rmac_update,
-	     (struct zebra_mac * rmac, struct zebra_l3vni *zl3vni, bool delete,
-	      const char *reason),
-	     (rmac, zl3vni, delete, reason));
-
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zebra_vxlan_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -56,6 +56,11 @@
 #endif
 /* clang-format on */
 
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zserv_hooks.h"
+#include "lib/hooks_end.h"
+
 /* privileges */
 extern struct zebra_privs_t zserv_privs;
 
@@ -620,11 +625,6 @@ int zserv_send_batch(struct zserv *client, struct stream_fifo *fifo)
 
 	return 0;
 }
-
-#define HOOKS_DEFINE
-#include "lib/hooks_begin.h"
-#include "zebra/zserv_hooks.h"
-#include "lib/hooks_end.h"
 
 /*
  * Deinitialize zebra client.

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -621,9 +621,10 @@ int zserv_send_batch(struct zserv *client, struct stream_fifo *fifo)
 	return 0;
 }
 
-/* Hooks for client connect / disconnect */
-DEFINE_HOOK(zserv_client_connect, (struct zserv *client), (client));
-DEFINE_KOOH(zserv_client_close, (struct zserv *client), (client));
+#define HOOKS_DEFINE
+#include "lib/hooks_begin.h"
+#include "zebra/zserv_hooks.h"
+#include "lib/hooks_end.h"
 
 /*
  * Deinitialize zebra client.

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -248,9 +248,10 @@ DECLARE_LIST(zserv_stale_client_list, struct zserv, stale_client_list_entry);
 	struct zserv *client, struct zmsghdr *hdr, struct stream *msg,         \
 		struct zebra_vrf *zvrf
 
-/* Hooks for client connect / disconnect */
-DECLARE_HOOK(zserv_client_connect, (struct zserv *client), (client));
-DECLARE_KOOH(zserv_client_close, (struct zserv *client), (client));
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zserv_hooks.h"
+#include "lib/hooks_end.h"
 
 #define DYNAMIC_CLIENT_GR_DISABLED(_client)                                    \
 	((_client->proto <= ZEBRA_ROUTE_LOCAL) || !(_client->gr_instance_count))

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -248,11 +248,6 @@ DECLARE_LIST(zserv_stale_client_list, struct zserv, stale_client_list_entry);
 	struct zserv *client, struct zmsghdr *hdr, struct stream *msg,         \
 		struct zebra_vrf *zvrf
 
-#define HOOKS_DECLARE
-#include "lib/hooks_begin.h"
-#include "zebra/zserv_hooks.h"
-#include "lib/hooks_end.h"
-
 #define DYNAMIC_CLIENT_GR_DISABLED(_client)                                    \
 	((_client->proto <= ZEBRA_ROUTE_LOCAL) || !(_client->gr_instance_count))
 
@@ -414,6 +409,11 @@ extern void zebra_gr_stale_client_cleanup(void);
 extern void zread_client_capabilities(struct zserv *client, struct zmsghdr *hdr,
 				      struct stream *msg,
 				      struct zebra_vrf *zvrf);
+
+#define HOOKS_DECLARE
+#include "lib/hooks_begin.h"
+#include "zebra/zserv_hooks.h"
+#include "lib/hooks_end.h"
 
 #ifdef __cplusplus
 }

--- a/zebra/zserv_hooks.h
+++ b/zebra/zserv_hooks.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* hook definitions for zebra/zserv.c
+ *
+ * note: file may be included multiple times - intentionally no include guard!
+ */
+
+/* Hooks for client connect / disconnect */
+/* Hooks for client connect / disconnect */
+DO_HOOK(zserv_client_connect, (struct zserv *, client));
+
+DO_KOOH(zserv_client_close, (struct zserv *, client));

--- a/zebra/zserv_hooks.h
+++ b/zebra/zserv_hooks.h
@@ -5,7 +5,5 @@
  */
 
 /* Hooks for client connect / disconnect */
-/* Hooks for client connect / disconnect */
 DO_HOOK(zserv_client_connect, (struct zserv *, client));
-
 DO_KOOH(zserv_client_close, (struct zserv *, client));


### PR DESCRIPTION
2 major changes + a whole bunch of fluff around them:

* hook definition syntax change: rather than 2 "lists", one with types and one without, there is now 1 "list" with types and names in separate arguments:
  **before:**
  ```
  DEFINE_HOOK(foo, (int a, char *b), (a, b));
  ```
  **after:**
  ```
  DEFINE_HOOK(foo, (int, a), (char *, b));
  ```
  **There are no changes in function prototypes or how hooks are used**, this is only about the declaration and definition.
* all the hook declarations & definitions themselves are now unified in separate `foo_hooks.h` files that contain `DO_HOOK` / `DO_KOOH` rather than DEFINE/DECLARE. These separated files are "sandwich" included like this:
  ```
  #define HOOKS_DECLARE
  #include "lib/hooks_begin.h"
  #include "…/whatever_hooks.h"
  #include "lib/hooks_end.h"
  ```
  The `hooks_begin.h` / `hooks_end.h` files do the setup for turning `DO_HOOK` back into `DECLARE_HOOK` / `DEFINE_HOOK`.

The point of this is that there's a 3rd option coming up, `LUA_HOOK`, which can make hooks available to Lua scripts without much further work needed (the types of each argument of course need to have a Lua decoder/encoder function). The Lua bits are not included here yet, but they're not theoretical either (I'm just not fully done yet with them.)

This also has the advantage of avoiding desync between `DECLARE` and `DEFINE`, which had in fact happened (cf. #23046 - I actually missed 2 more where there was only a `DECLARE` left but no `DEFINE` and no usage.)

Developer docs have a bit more details.