### PR TITLE
lib: lock-free hash table

### DIFF
--- a/doc/developer/lists.rst
+++ b/doc/developer/lists.rst
@@ -43,6 +43,9 @@ For sorted containers, these data structures are implemented:
 
 - hash table (note below)
 
+- atomic hash table (same note applies)
+
+
 Except for hash tables, each of the sorted data structures has a variant with
 unique and non-unique items.  Hash tables always require unique items
 and mostly follow the "sorted" API but use the hash value as sorting
@@ -58,8 +61,6 @@ The following sorted structures are likely to be implemented at some point
 in the future:
 
 - atomic skiplist
-
-- atomic hash table (note below)
 
 
 The APIs are all designed to be as type-safe as possible.  This means that
@@ -100,6 +101,7 @@ Available types:
    DECLARE_RBTREE_NONUNIQ
 
    DECLARE_HASH
+   DECLARE_ATOMHASH
 
 Functions provided:
 
@@ -116,7 +118,7 @@ Functions provided:
 |                                    | only  |      |      |         |            |
 | _const_last, _const_prev           |       |      |      |         |            |
 +------------------------------------+-------+------+------+---------+------------+
-| _swap_all                          | yes   | yes  | yes  | yes     | yes        |
+| _swap_all                          | yesᴬ  | yes  | yesᴬ | yesᴬ    | yesᴬ       |
 +------------------------------------+-------+------+------+---------+------------+
 | _anywhere                          | yes   | --   | --   | --      | --         |
 +------------------------------------+-------+------+------+---------+------------+
@@ -128,7 +130,7 @@ Functions provided:
 +------------------------------------+-------+------+------+---------+------------+
 | _del, _pop                         | yes   | yes  | yes  | yes     | yes        |
 +------------------------------------+-------+------+------+---------+------------+
-|  _pop_all                          | --    | --   | yes  | --      | --         |
+|  _pop_all                          | --    | --   | yesᴬ | --      | --         |
 +------------------------------------+-------+------+------+---------+------------+
 |  _pop_final                        | --    | --   | --   | yes     | yes        |
 +------------------------------------+-------+------+------+---------+------------+
@@ -141,6 +143,8 @@ Functions provided:
 | use with frr_each() macros         | yes   | yes  | yes  | yes     | yes        |
 +------------------------------------+-------+------+------+---------+------------+
 
+ᴬ The atomic containers do not provide the ``swap_all`` and ``pop_all``
+functions.
 
 
 Datastructure type setup
@@ -707,6 +711,9 @@ Heaps provide the same API as the sorted data structures, except:
 * all heap modifications are O(log n).  However, cacheline efficiency and
   latency is likely quite a bit better than with other data structures.
 
+
+.. _atomic-lists:
+
 Atomic lists
 ------------
 
@@ -808,6 +815,95 @@ Head removal (pop) and deallocation:
    /* i now guaranteed to be gone from the list.
     * note nothing between wrlock() and unlock() */
    XFREE(MTYPE_ITEM, i);
+
+
+Atomic hash table
+-----------------
+
+Most considerations discussed under :ref:`atomic-lists` apply analogous to
+atomic hash tables.  The lock-free hash table has the following
+properties (sizes for 64-bit platforms):
+
+* while the embedded item is not particularly large (16 bytes), the table head
+  is unconditionally 272 bytes large.  Needless to say, it is not a great idea
+  to use a lot of these tables.  It is intended that most of these are global.
+
+* inserting the first item immediately allocates another 256 bytes for the hash
+  bucket array.  For simplicity of the lock-free code, this memory is not freed
+  even if the last item is removed.  It is only released when the whole hash
+  table is cleaned up with the :c:func:`Z_fini()` function.
+
+* note that :c:func:`Z_fini()` is not a concurrent / lock-free function.  The
+  table must be held exclusively when calling that function.
+
+* the lock-free hash table is **strongly optimized for read-heavy accesses**.
+  Write heavy workloads will cause significant strain on the CPU caches, which
+  will in turn be quite costly for performance.  **Run benchmarks and/or use
+  plain old locking if modifications to the list are expected to exceed even
+  10% of total accesses.**
+
+The functions have the following characteristics (assuming uniform distribution
+of items across the hash value space).  Note that these are only estimates and
+not mathematically rigorous.
+
+* :c:func:`Z_first()`, :c:func:`Z_next()`: wait-free, roughly :math:`O(1)`.
+
+  Generally constant time (linked list forward iteration).
+
+  If the list is under heavy deletion load, skipping over items that are being
+  deleted *right now* can inflate the cost to :math:`O(\log n)`.
+
+* :c:func:`Z_find()`, :c:func:`Z_member()`: wait-free, roughly :math:`O(1)`.
+
+  Generally constant time, given there are no hash collisions.
+
+  Same caveat as above regarding load and deleted items and :math:`O(\log n)`.
+
+  This function will attempt at most one hash array update when encountering
+  a "hole" in the hash array (incomplete/in-progress ``grow``).  Due to not
+  being in a retry loop, this is also a constant cost.  However, CAS operations
+  can be somewhat expensive depending on CPU cache usage.
+
+* :c:func:`Z_add()`: lock-free, not wait-free.
+
+  Time strongly depends on concurrent table modification load, for roughly
+  :math:`O(p)`. (:math:`p` being threads accessing in parallel.)
+
+  This function is not wait-free due to the possibility of other threads
+  continuously making changes in the immediate vicinity of the item being
+  added, causing CAS operations to repeatedly fail.
+
+  Will occasionally trigger a *grow* operation.  The cost of this is roughly
+  :math:`O(n\cdot p)`.  However, this is amortized over table lifetime to
+  :math:`O(\frac{n\cdot p}{n})`.  One ``add`` call will only ever grow the
+  table by one level.  However, multiple threads may attempt the same ``grow``
+  operation if adding items at the same time.
+
+  .. note::
+
+     ``grow`` operations are performed inline, blocking the calling thread
+     until the new array has been allocated and filled.  (This is the same as
+     the regular hash tables above.)
+
+     The ``grow`` operation is performed after insertion of the item has
+     completed.  This is intentional: an ``add`` also performs an uniqueness
+     check of the item being added.  RCU commonly uses this in a
+     "try-alloc-insert-fail-free" pattern.  For this pattern to work
+     effectively, the time between allocation and insertion must be kept
+     minimal.
+
+* :c:func:`Z_del()`, :c:func:`Z_pop()`: lock-free, not wait-free.
+
+  Same as above, strongly depends on concurrent access patterns, and will wait
+  on CAS operations.
+
+  Unlike ``grow`` operations, ``shrink`` operations are performed *out of band*
+  in the RCU thread.  The caller will therefore not be blocked.  To avoid
+  degenerate situations, a maximum of 3 levels can be queued for shrinking in
+  the RCU thread.  If this is exceeded, levels can remain sitting around;
+  however this is generally "self-healing" as any further item removal will
+  attempt to queue the operation again.
+
 
 FAQ
 ---

--- a/lib/atomhash.c
+++ b/lib/atomhash.c
@@ -1,0 +1,1573 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* lock-free single-CAS shrinkable hash table
+ * Copyright (c) 2025-26  David 'equinox' Lamparter, for NetDEF, Inc.
+ *
+ * Training an LLM on this code is considered producing a derivative work,
+ * triggering relevant provisions of the GPL.  This implies the GPL will apply
+ * to the LLM itself as well as its output.
+ */
+
+/*
+ * The use of AI agents, LLMs or other assistive systems beyond "plain old
+ * editor autocomplete" for changes on this code will result in rejection of
+ * the PR and may be treated as 'bad faith' submission.  The reason for this is
+ * quite simply that LLMs are incapable of following the complex invariants and
+ * sequencing requirements involved in this code.  Assistive mathematical proof
+ * systems would be able to do this, but those are very different pieces of
+ * software from an LLM.  And please don't get the idea to "ask" an LLM whether
+ * it understands this code.  It will very confidently claim yes, and then
+ * proceed to make very incorrect statements.  I tried.  You have been warned.
+ */
+
+/* required reading before touching this code:
+ *
+ * "Split-Ordered Lists: Lock-Free Extensible Hash Tables",
+ * Shalev, Ori and Shavit, Nir; 2006, ACM Journal
+ * https://people.csail.mit.edu/shanir/publications/Split-Ordered_Lists.pdf
+ *
+ * (Possibly) uRCU's rculfhash implementation,
+ * https://github.com/urcu/userspace-rcu/blob/master/src/rculfhash.c
+ * (I will admit that code is even worse to read than the code here, and it's
+ * not super helpful, but maybe the reference helps at some point.)
+ *
+ * However, the code here does not in fact match either of those two
+ * references.  As a matter of fact, at the time of writing (early 2025) there
+ * are no known lock-free SCAS-only hash table implementations that perform
+ * lock-free resizing, especially not in both directions.  Most of the pieces
+ * used in this implementations were known/available, but not put together in
+ * one place previously.  (Also see the comments below about lock-free resize
+ * being a double edged sword.)
+ */
+
+/* Changes to this code MUST be tested on a system with as weak as possible
+ * memory coherency guarantees by the CPU.  Some ARM64 systems qualify for that
+ * (not all, particularly not Apple Mx CPUs, those can reconfigure their
+ * coherency guarantees), but the best we currently have available to FRR is
+ * (to my knowledge) PPC64 T4240 e6500 systems.
+ *
+ * Do NOT merge any PRs that make substantive changes to this code without
+ * specifically requesting and verifying testing of this type.  This cannot be
+ * done in CI because it is probabilistic testing, i.e. it needs to run for as
+ * long as is viable, with longer runs giving better chances at finding issues.
+ * On top of that, testing needs to run on a reasonably parallel systems and
+ * will burn as many CPU cores as you give it.  (It should be clear why this
+ * can't be done in CI.)
+ */
+
+/* Expected lock/time constraints on the functions here:
+ * (quick for the uninitiated:)
+ *   wait-free: will never run for more than X amount of CPU time
+ *   lock-free: can run indefinitely if and only if some other threads keep
+ *     making changes; progress of the system as a whole is guaranteed.
+ *
+ * - first(), next(): wait-free.  Doesn't perform any updates/writes ever.
+ * - find(): wait-free.  Does attempt to update the hash array if hitting a
+ *   NULL pointer, but only once (drops out on CAS failure.)
+ * - add(), del(): lock-free, and can trigger resizes (see below).  As with
+ *   most lock-free data structures, these restart the operation if some other
+ *   thread raced to touch the very same memory locations.
+ * - resize/grow(): also lock-free, but note allocating memory can take a trip
+ *   into the kernel, and especially if the table is large can take some time
+ *   to fill in the new level.
+ * - resize/shrink(): actually wait-free, but only since it lets the RCU thread
+ *   do the 'dirty' work.
+ *
+ * For more CPU/performance considerations on grow() and shrink(), see below.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "lib/compiler.h"
+#include "lib/frratomic.h"
+#include "lib/typesafe.h"
+#include "lib/memory.h"
+#include "lib/atomhash.h"
+#include "lib/frrcu.h"
+#include "lib/network.h"
+
+/* TESTING: the atomhash test includes this *WHOLE FILE*.  That means it gets
+ * baked into the test - with different macro defs, which is what all the
+ * following stuff is.  None of it is enabled when libfrr is built.
+ */
+
+/* TESTING: this code is heavily peppered with asserts.  However, with all
+ * lock-free code, the longer you take in a read-modify-CAS cycle, the more
+ * chance other threads have to conflict with the change.  Therefore, the
+ * asserts here are disabled in normal FRR builds and only used for the test.
+ *
+ * Theoretically, these could be wired into assume() instead, to tell the
+ * compiler that these constraints will hold.  This would, however, make any
+ * related bug much harder to track down (violating an assume() is straight up
+ * undefined behavior, i.e. the compiler could've output optimized code that in
+ * such a case just runs off into random invalid instructions.)
+ */
+#ifndef DEBUG_ATOMHASH
+#undef assert
+#define assert(...)
+#undef assertf
+#define assertf(...)
+#endif
+
+/* TESTING: these definitions serve 2 purposes:
+ * 1. shorter function names.  They're too damn long, esp. compare_exchange.
+ * 2. allow tests to provide different definitions, set TEST_HIJACK_ATOMICS and
+ *    include the .c file in particular, for chaos testing it is extremely
+ *    useful to include short [ala CPU cycles] random delays before each of
+ *    them so the probability of collisions increases
+ */
+#ifndef TEST_HIJACK_ATOMICS
+#define atomic__load	       atomic_load_explicit
+#define atomic__store	       atomic_store_explicit
+#define atomic__exchange       atomic_exchange_explicit
+#define atomic__cmpxchg_strong atomic_compare_exchange_strong_explicit
+#define atomic__cmpxchg_weak   atomic_compare_exchange_weak_explicit
+#define atomic__fetch_or       atomic_fetch_or_explicit
+#define atomic__fetch_and      atomic_fetch_and_explicit
+#define atomic__fetch_add      atomic_fetch_add_explicit
+#define atomic__fetch_sub      atomic_fetch_sub_explicit
+#endif
+
+/* TESTING: allow the test to hijack this too */
+#ifndef atomhash_rcu_call
+#define atomhash_rcu_call rcu_call
+#endif
+
+/* TESTING: allows hijacked atomics to behave differently
+ * between general atomhash functions vs. resizing.
+ * refer to tests/lib/test_atomhash.c for further details
+ */
+#define atomhash_part general
+
+/* TESTING: end **************************************************************/
+
+DEFINE_MTYPE_STATIC(LIB, ATOMHASH_TABLE, "Atomic hash table");
+DEFINE_MTYPE_STATIC(LIB, ATOMHASH_TABLE_RCU, "Atomic hash table shrink RCU");
+
+static inline struct atomhash_array *level_ptr(atomptr_t p)
+{
+	return atomptr_is_00(p) ? (struct atomhash_array *)atomptr_p(p) : NULL;
+}
+
+static inline size_t level_size(int level)
+{
+	return 1U << (ATOMHASH_LOWEST_BITS + level - (level != 0));
+}
+
+/* this type isn't really necessary (could just use a pointer) but makes
+ * understanding the code a bit easier.
+ */
+struct atomhash_array {
+	struct atomhash_item stubs[0];
+};
+
+/* return values from these are primarily for testing */
+enum resize_result {
+	RESIZE_DONE = 0,
+	RESIZE_NOOP,
+	RESIZE_RACED,
+	RESIZE_FUDGED,
+};
+
+static enum resize_result atomhash_resize_grow(struct atomhash_head *head, size_t count);
+static enum resize_result atomhash_resize_shrink(struct atomhash_head *head, size_t count);
+
+/* skip over any stubs */
+static const struct atomhash_item *atomhash_next_real(const struct atomhash_head *head,
+						      const struct atomhash_item *item)
+{
+	atomptr_t next_a;
+
+	for (; item && item != head->sentinel_end; item = atomptr_p(next_a)) {
+		next_a = atomic__load(&item->next, memory_order_acquire);
+		if (atomptr_is_00(next_a))
+			return item;
+	}
+	return NULL;
+}
+
+const struct atomhash_item *atomhash_first(const struct atomhash_head *head)
+{
+	struct atomhash_array *array;
+
+	array = level_ptr(atomic__load(&head->levels[0], memory_order_acquire));
+	if (!array)
+		return NULL;
+
+	return atomhash_next_real(head, &array->stubs[0]);
+}
+
+const struct atomhash_item *atomhash_next(const struct atomhash_head *head,
+					  const struct atomhash_item *item)
+{
+	atomptr_t next_a;
+
+	if (!item)
+		return NULL;
+	next_a = atomic__load(&item->next, memory_order_acquire);
+	return atomhash_next_real(head, atomptr_p(next_a));
+}
+
+/* hash values are used from the left, i.e. starting with the most significant
+ * bits.  This makes the split-sort order work implicitly.
+ * Each level of array adds a bit of hash value used and thus doubles in size,
+ * except the first level which is special:  there's an implied "1" bit after
+ * the LSB, *except* for the first level:
+ *
+ * with ATOMHASH_LOWEST_BITS = 4:  (that's the leftmost XXXX)
+ *
+ *           hash value & implied trailing bit
+ * level 0   XXXX 0ooo oooo ...
+ * level 1   XXXX 1ooo oooo ...
+ * level 2   XXXX X1oo oooo ...
+ * level 3   XXXX XX1o oooo ...
+ * etc.
+ *
+ * Note the "o" positions are masked to zero if the level for that bit does
+ * not exist;  shortcutting that is the (only) function of level_hint.  The
+ * stub elements always have the hash value with the would-be-masked bits
+ * filled with zeroes.
+ *
+ * the array levels look like this, with ATOMHASH_LOWEST_BITS = 4 again:
+ * level 0: 00      10      20      30     40      50 ... f0
+ * level 1:     08      18      28     38      48     ... f8
+ * level 2:   04  0c  14  1c  24  2c 34  3c  44  4c   ... fc
+ * level 3:  02.6.a.e.2.6.a.e.2.6.a.e.2.6.a.e.2.6.a.e ... fe
+ *
+ * Note that the first item on level 2 has a *lower* hash value than the first
+ * item on level 1, with all X=0.  This is the case everywhere except for the
+ * going from level 1 to 0, where the first item is all zeroes and the reason
+ * for "idx--" in the lookup code for all levels except 0.
+ *
+ * In theory, the level 0 array could also start at 10, that would make some
+ * of the code a bit easier - but then other places would need special
+ * handling for any hash value starting with zeroes.
+ * note level 0 and 1 are the same size because the first array
+ * is special regarding inserting an extra bit on each level, it
+ * essentially has a trailing zero rather than a trailing one;
+ * if you don't understand this please stop and don't touch this
+ * code until you do.
+ */
+
+/* the atomhash code uses 2 bits in the next pointer to indicate things about
+ * the owning structure, called U and L (USER and LOCK) from their definition
+ * in atomlist.h.  Both bits have to be evaluated at the same time:
+ *
+ * -- normal item    - may be retrieved, may be updated for add or delete
+ * -L deleted item   - cannot be retrieved or updated for add, delete may chain
+ * U- hash-array     - cannot be retrieved, may be updated for add or delete
+ * UL hash-inserting - cannot be retrieved/followed, may be updated indirectly
+ *
+ * A regular item progresses from "nothing" to -- to -L.  "nothing" means it's
+ * not inserted yet, as such its U/L bits are never looked at.  It is inserted
+ * atomically and shows up with --.  Deleting atomically changes -- to -L and
+ * then removes it from the list.
+ *
+ * A hash array item/bucket pointer starts as "nothing" (level doesn't exist),
+ * is then -- (level allocated but pointer not set), then UL (being inserted
+ * into the list), then U- (normal state on list), then -L (level deleting).
+ *
+ * The -- state on hash array items can only be encountered *immediately* after
+ * dereferencing a level pointer, and can thus be distinguished from normal
+ * items.  It won't ever be seen during list traversal since *being* on the
+ * list requires the pseudo-item to first have passed into UL at least.  The
+ * normal steady state needs distinction because the hash array items don't
+ * have actual data attached to them, so the compare function can't be called
+ * on them.  This distinction becomes moot on deletion since at that point
+ * the compare function won't be called anymore anyway.
+ *
+ * The UL state is necessary because at that point in time, the pseudo-item
+ * does point somewhere, but operations can be in progress from earlier that
+ * won't update it.  This can result in false negatives for find(), and since
+ * adds and deletes involve a find() first, those too.  The solution for this
+ * is that an item in UL state is treated as non-existent if encountered on
+ * direct dereference on a hash level (same special rule as for --).  So the
+ * find() progresses a level upwards and searches from there.  If an UL item
+ * is found later, on traversing the list, no special handling is necessary -
+ * the fact that was found while traversing the list means the insertion has
+ * completed (duh) even though the flag update is still pending.  This also
+ * means that UL is treated as U- when it is not being encountered immediately
+ * on dereference; the L bit is cleared on updating it.
+ */
+
+/* init and fini are outside atomicity considerations since at that point
+ * the caller needs to own the entire hash table anyway
+ */
+void atomhash_init(struct atomhash_head *head)
+{
+	memset(head, 0, sizeof(*head));
+}
+
+void atomhash_fini(struct atomhash_head *head)
+{
+	for (size_t i = 0; i < array_size(head->levels); i++) {
+		struct atomhash_array *p = level_ptr(head->levels[i]);
+
+		XFREE(MTYPE_ATOMHASH_TABLE, p);
+	}
+
+	memset(head, 0, sizeof(*head));
+}
+
+/* the hash table starts out without any arrays.  The first level is allocated
+ * when the first item is added, and never freed until the hash table as a
+ * whole is freed.  The first level is also fully populated to keep things
+ * a tiny bit simpler.
+ */
+static inline struct atomhash_array *atomhash_setup_level0(struct atomhash_head *head)
+{
+	struct atomhash_array *array;
+	atomptr_t array_a, raced = ATOMPTR_NULL;
+	size_t n = 1U << ATOMHASH_LOWEST_BITS;
+	uint32_t hashval = 0;
+
+	array = XMALLOC(MTYPE_ATOMHASH_TABLE, sizeof(array->stubs[0]) * n);
+
+	for (size_t i = 0; i < n; i++) {
+		atomic_init(&array->stubs[i].next, atomptr_i(&array->stubs[i + 1]) | ATOMPTR_USER);
+		array->stubs[i].hashval = hashval;
+
+		hashval += 1U << (32 - ATOMHASH_LOWEST_BITS);
+	}
+
+	atomic_init(&array->stubs[n - 1].next, atomptr_i(head->sentinel_end) | ATOMPTR_USER);
+
+	array_a = atomptr_i(array);
+	if (atomic__cmpxchg_strong(&head->levels[0], &raced, array_a, memory_order_release,
+				   memory_order_acquire))
+		return array;
+
+	/* lost to another thread doing the same.  Free and use its array. */
+	XFREE(MTYPE_ATOMHASH_TABLE, array);
+	return atomptr_p(raced);
+}
+
+/* example values to visualize the math:
+ *
+ * xx10 0000 ...0 ctz() = 29,  32-  = 3.  level 0(!) array size 1<<4  idx >>=28
+ * xxx1 0000 ...0 ctz() = 28,  32-  = 4.  level 0    array size 1<<4  idx >>=28
+ * xxxx 1000 ...0 ctz() = 27,  32-  = 5.  level 1    array size 1<<4  idx >>=28
+ * xxxx x100 ...0 ctz() = 26,  32-  = 6.  level 2    array size 1<<5  idx >>=27
+ * xxxx xxxx ...1 ctz() = 0,   32-  = 32. level 28   array size 1<<31 idx >>=1
+ */
+
+/* atomhash_anchor: locate appropriate array item entry point into the chain
+ *
+ * head & ref_hashval are what we're looking for.  Everything else is output:
+ *
+ * return value: the entry pointer value
+ * p_next_a: the address of the entry pointer, for inserting between it and the next item
+ * p_update: array item that we should have hit but didn't due to ongoing resizing.
+ *
+ * return value and *p_next_a will never be NULL unless the table is empty.
+ * *p_update will almost always be NULL.
+ */
+static inline struct atomhash_item *atomhash_anchor(const struct atomhash_head *head,
+						    uint32_t ref_hashval, atomptr_t *p_next_a,
+						    struct atomhash_item **p_update)
+{
+	/* first half: just the math to figure out our starting position */
+	uint32_t idx;
+	unsigned int level;
+	uint_fast32_t level_hint;
+	int use_bits;
+
+	level_hint = atomic__load(&head->level_hint, memory_order_relaxed);
+	idx = ref_hashval;
+
+	/* note signed right shifts fill with the sign bit, i.e. ones here */
+	idx &= (int32_t)0xF0000000 >> level_hint;
+
+	/* the | 0xF0000000 makes sure we never call ctz(0) (undefined) */
+	use_bits = 32 - __builtin_ctz(idx | 0xF0000000);
+
+	level = use_bits - ATOMHASH_LOWEST_BITS;
+	/* the + (level != 0) thing handles lvl0 and lvl1 being equal size */
+	idx >>= 32 - ATOMHASH_LOWEST_BITS - level + (level != 0);
+
+	assume(level < 32);
+
+	/* second half: search from the calculated position upwards
+	 *
+	 * in the 99% case, the calculated position exists and we're done.
+	 * The only situation where we need the loop at all is when a new
+	 * level has recently been added and not fully populated yet.
+	 *
+	 * That is also what the update pointer is for; filling in the slot
+	 * we /should've/ found and used.
+	 */
+	struct atomhash_item *item = NULL, *update = NULL;
+	struct atomhash_array *array;
+	atomptr_t next_a;
+
+	do {
+		array = level_ptr(atomic__load(&head->levels[level], memory_order_acquire));
+		if (likely(array)) {
+			/* address math, not a load */
+			item = &array->stubs[idx];
+
+			next_a = atomic__load(&item->next, memory_order_acquire);
+			if (likely(next_a && !atomptr_l(next_a)))
+				break;
+
+			/* ---------------------------------------------------
+			 * everything below, including looping, is "slow path"
+			 * and will rarely be taken
+			 */
+
+			else if (atomptr_l(next_a)) {
+				/* UL: array item insertion in progress, cannot
+				 *     follow this pointer as it may have
+				 *     fallen behind
+				 * -L: level ended up being deleted while we're
+				 *     looking at it.
+				 * in both cases: pretend we hit a NULL pointer,
+				 * move up (nothing to update either)
+				 *
+				 * it's theoretically possible to optimize this,
+				 * but... this is complicated enough.
+				 */
+				(void)0;
+			} else if (!update) {
+				/* we'll try updating the most specific pointer
+				 * that we should've followed, but aren't - the
+				 * resizing thread might be busy
+				 */
+				uint32_t update_hashval;
+
+				/* can't happen for level==0, that level is
+				 * always filled
+				 */
+				assert(level && !next_a);
+
+				update = item;
+				update_hashval = (idx << 1) | 1;
+				update_hashval <<= (32 - ATOMHASH_LOWEST_BITS - level);
+
+				/* multiple threads may race on this, but
+				 * they're all writing the same value
+				 */
+				atomic__store((_Atomic uint32_t *)&update->hashval, update_hashval,
+					      memory_order_relaxed);
+			}
+		}
+
+		/* special case: empty hash table */
+		if (unlikely(!level)) {
+			*p_update = NULL;
+			return NULL;
+		}
+
+		/* we're taking the (very) slow path and have to go up levels
+		 * to look for our entry point.  This can only happen while a
+		 * resize is ongoing.
+		 */
+		int shift;
+
+		level--;
+		shift = __builtin_ctz(idx | (1 << level));
+		level -= shift;
+
+		/* level 0 being the same size as level 1 and having somewhat
+		 * "offset" items needs a little care
+		 */
+		idx -= (level != 0);
+		idx >>= (level != 0) + shift;
+	} while (true);
+
+	assertf(next_a && item, "atomhash_head=%p ref_hashval=%08x idx=%u level=%u", head,
+		ref_hashval, idx, level);
+
+	*p_next_a = next_a;
+	*p_update = update;
+	return item;
+}
+
+/* The flow here is:
+ * 1. set the array item's hash value - already done in atomhash_anchor()
+ * 2. find insert location
+ * 3. set new item's next pointer, plus UL flags
+ *      if this fails, drop out; another thread is inserting the item
+ * 4. set previous item's next pointer
+ *      on failure:
+ *      - if the prev item's next pointer has L set, we need to rescan from an
+ *        earlier position
+ *      - if not, we can simply scan forward since we know the item is still on
+ *        the list and <= our hash value
+ *      either way, retry at 2.
+ * 5. clear L flag
+ *
+ * Things we can NOT do:
+ * - this insert can NOT be done cooperatively.  Fundamentally, the cmpxchg in
+ *   step 4 needs to match the next pointer we set in step 3 *and* the cmpxchg
+ *   needs to happen exactly once;  otherwise things can become really
+ *   incongruent.  Regarding the "happen exactly once" part, consider
+ *   situations where another thread inserts *and* removes another item while
+ *   we're working.
+ *   (No, I have not fully evaluated if there's some way to weasel through
+ *   safely.  It's complicated enough as it is;  at this point correctness wins
+ *   out.)
+ *
+ * Things we CAN do:
+ * - since we're the only thread working on it, we can in fact abort the insert
+ *   if we fail on step 4.  We cmpxchg the next pointer back to NULL, pretend
+ *   nothing happened and walk away.  This is useful for "drive-by" updating on
+ *   find() calls; if we can't abort the insert, the operation would become
+ *   lock-free rather than wait-free.
+ */
+
+/* technically speaking, the U,L behavior here is not "properly" lock-free and
+ * can break the complexity guarantees of accesses to the hash table, i.e.
+ * find calls may become O(log n) instead of O(1).  Practically speaking, only
+ * one stub can ever be in U,L state per each thread, so only (#threads) number
+ * of stubs can be broken in this way.  That's acceptable.
+ *
+ * The entire problem only arises because the stubs and the table are the same
+ * thing in this implementation.  That removes a one-cacheline cost on all
+ * accesses, trading it for this "weird" edge case.  The alternative option
+ * for this tradeoff would be to have the stub items be malloc()d each
+ * individually, add them into the chain, and only then publish a pointer to
+ * them on the array.  It's simpler, but... caches are the limiting factor in
+ * performance these days.  And it doesn't reduce the cost of setting up a new
+ * level when growing the hash table.  So the chosen tradeoff option here is
+ * to have the stub items be directly in the array.
+ * I hope we won't regret that choice ;)
+ */
+
+/* try inserting an array item (from a new, not yet fully populated level) into
+ * the linked list
+ *
+ * insert: the hash array pseudo-item, we've seen its next pointer being NULL a
+ *   tiny while ago.  Its ->hashval MUST be already set (atomlist_anchor()
+ *   handles this)
+ * prev: the item immediately preceding <insert>.
+ * prev_next_a: prev->next (we just did an atomic_load)
+ * next_a: same as previous, but may have skipped over deleted items.
+ *
+ * invariant: prev->hashval < insert->hashval <= next_a->hashval
+ * invariant: next_a.L = 0  (prev->next can change though, while we're here)
+ *
+ * returns whether we're done (item was successfully inserted or someone else
+ * is handling it)
+ */
+static inline bool atomhash_insert_stub(struct atomhash_item *insert, struct atomhash_item *prev,
+					atomptr_t prev_next_a, atomptr_t next_a, bool *inserted)
+{
+	atomptr_t next_a_u = next_a | ATOMPTR_USER | ATOMPTR_LOCK;
+	atomptr_t insert_next_a = ATOMPTR_NULL;
+	atomptr_t insert_a = atomptr_i(insert);
+	atomptr_t orig_prev_next_a = prev_next_a;
+
+	/* clang-format off */
+	assertf(prev != insert
+		&& !atomptr_is_0l(prev_next_a)
+		&& ((next_a == prev_next_a) || atomptr_l(next_a)),
+		"prev=%p prev_next_a=%#tx insert=%p next_a=%#tx",
+		(void *)prev, prev_next_a, (void *)insert, next_a);
+	/* clang-format on */
+
+	*inserted = false;
+
+	if (!atomic__cmpxchg_strong(&insert->next, &insert_next_a, next_a_u, memory_order_release,
+				    memory_order_relaxed))
+		/* note above on not trying to do this cooperatively */
+		return true;
+
+	insert_a = atomptr_copy_flags(insert_a, prev_next_a & ATOMPTR_USER);
+	if (!atomic__cmpxchg_strong(&prev->next, &prev_next_a, insert_a, memory_order_release,
+				    memory_order_relaxed)) {
+		/* if this fails, <insert> could only ever have been found
+		 * through the array, which anchor_update() won't allow due to
+		 * (next_a && !atomptr_l(next_a)).  I.e. nobody else should've
+		 * been able to use (and update) this item.
+		 *
+		 * if this succeeds, <insert> can now be found through the list,
+		 * and U,L might be cleared at any point now.
+		 */
+
+		/* insertion failed, list changed while we were looking at it.
+		 * abort & go back to NULL
+		 */
+		atomptr_t race_check;
+
+		race_check = atomic__exchange(&insert->next, ATOMPTR_NULL, memory_order_relaxed);
+
+		/* this should _really_ be impossible or things break hard */
+		assertf(race_check == next_a_u,
+			"prev=%p orig_prev_next_a=%#tx prev_next_a=%#tx next_a=%#tx race_check=%#tx",
+			prev, orig_prev_next_a, prev_next_a, next_a, race_check);
+		/* silence unused warning if assert is disabled */
+		(void)race_check;
+		(void)orig_prev_next_a;
+		return false;
+	}
+
+	*inserted = true;
+
+	/* transition UL -> U_
+	 *
+	 * after the previous cmpxchg, another thread may find our stub by
+	 * traversing the list, and may in fact update it despite it being in
+	 * UL.  Therefore, the next cmpxchg may fail, but it doesn't matter; if
+	 * it fails our job has been done for us.
+	 *
+	 * note we can't atomic_fetch_and() here because another thread might
+	 * be shrinking the list now and have set this to -L for deletion.  It
+	 * really needs to be cmpxchg.
+	 */
+	next_a = atomptr_copy_flags(next_a, ATOMPTR_USER);
+	if (!atomic__cmpxchg_strong(&insert->next, &next_a_u, next_a, memory_order_release,
+				    memory_order_relaxed)) {
+		assertf(!atomptr_is_ul(next_a_u), "insert=%p next_a_u = %#tx", insert, next_a_u);
+	}
+	return true;
+}
+
+/* atomhash_anchor_update: find stub for add/del and if necessary fill in NULL
+ *
+ * this is the "next wrap level" around atomhash_anchor, where that just finds
+ * the location and optionally returns an index-update location, this takes
+ * that latter and fills it with the appropriate pointers.  In 99% of cases,
+ * there won't be an index update location and it just won't hit that code
+ * path, becoming equivalent to atomhash_anchor().
+ *
+ * This function is only called by add() and del_core(). get() has a oneshot
+ * variant of this embedded instead.  setup_level() uses insert_stub directly.
+ *
+ * Parameters have the same meaning as for atomhash_anchor, with p_update gone
+ * because it's already handled in here.  For convenience:
+ *
+ * return value: the entry pointer value
+ * p_next_a: the address of the entry pointer, for inserting between it and the
+ *   next item
+ *
+ * return value and *p_next_a will never be NULL unless the table is empty.
+ */
+static inline struct atomhash_item *
+atomhash_anchor_update(struct atomhash_head *head, uint32_t ref_hashval, atomptr_t *p_next_a)
+{
+	struct atomhash_item *item, *insert, *prev;
+	atomptr_t next_a = ATOMPTR_NULL, prev_next_a;
+	bool inserted = false;
+
+	do {
+		item = atomhash_anchor(head, ref_hashval, &next_a, &insert);
+
+		if (likely(!insert) || !item) {
+			assert(!atomptr_is_0l(next_a));
+			*p_next_a = next_a;
+			return item;
+		}
+
+		assertf(!atomptr_l(next_a), "item=%p next_a=%#tx hashval=%08x", item, next_a,
+			ref_hashval);
+
+		prev = item;
+		prev_next_a = next_a;
+
+		while ((item = atomptr_p(next_a)) != head->sentinel_end) {
+			if (item->hashval >= insert->hashval)
+				break;
+
+			next_a = atomic__load(&item->next, memory_order_acquire);
+
+			/* skip over deleted items */
+			if (atomptr_is_0l(next_a))
+				continue;
+
+			prev = item;
+			prev_next_a = next_a;
+		}
+
+		/* One might be tempted to keep the non-NULL insert_next_a
+		 * around for the next loop iteration, saving a fresh atomic
+		 * load and doing cmpxchg on top of that instead, i.e.
+		 * insert->next changes NULL -> A -> B.
+		 * But we don't have a guarantee that atomhash_anchor() returns
+		 * the same "insert" in the next iteration - in which case we
+		 * leave a broken A.  So it's always cleared back to NULL here.
+		 */
+	} while (!atomhash_insert_stub(insert, prev, prev_next_a, next_a, &inserted));
+
+	if (inserted) {
+		*p_next_a = atomptr_copy_flags(next_a, ATOMPTR_USER);
+		return insert;
+	}
+
+	/* someone else is trying to do the insert right now.  give our caller
+	 * the previous element so it can continue.
+	 */
+	assertf(!atomptr_is_0l(prev_next_a), "prev_next_a=%#tx", prev_next_a);
+	*p_next_a = prev_next_a;
+	return prev;
+}
+
+/* look up an item by hash value (and compare function).
+ *
+ * ref_hashval is passed separately since for find() calls the application code
+ * won't set ref->hashval, and we can't do it either because it's const.  But
+ * we still need ref for the compare function.
+ */
+struct atomhash_item *atomhash_get(const struct atomhash_head *head,
+				   const struct atomhash_item *ref, uint32_t ref_hashval,
+				   int (*cmpfn)(const struct atomhash_item *,
+						const struct atomhash_item *))
+{
+	atomptr_t next_a = ATOMPTR_NULL, prev_next_a = ATOMPTR_NULL;
+	struct atomhash_item *item = NULL, *update = NULL, *prev;
+
+	prev = atomhash_anchor(head, ref_hashval, &prev_next_a, &update);
+	if (!prev)
+		return NULL;
+	assertf(!atomptr_is_0l(prev_next_a), "prev=%p prev_next_a=%#tx ref_hashval=%08x", prev,
+		prev_next_a, ref_hashval);
+
+	next_a = prev_next_a;
+	do {
+		item = atomptr_p(next_a);
+		assertf(item, "prev=%p prev_next_a=%#tx next_a=%#tx ref_hashval=%08x", prev,
+			prev_next_a, next_a, ref_hashval);
+
+		if (unlikely(update) &&
+		    (item->hashval >= update->hashval || item == head->sentinel_end)) {
+			bool ignore;
+
+			atomhash_insert_stub(update, prev, prev_next_a, next_a, &ignore);
+			update = NULL;
+		}
+
+		if (item->hashval > ref_hashval || item == head->sentinel_end)
+			return NULL;
+
+		next_a = atomic__load(&item->next, memory_order_acquire);
+
+		if (atomptr_is_00(next_a) && item->hashval == ref_hashval) {
+			int cmpval = cmpfn(item, ref);
+
+			if (cmpval == 0)
+				return item;
+			if (cmpval >= 0)
+				return NULL;
+		}
+
+		/* skip over deleted items */
+		if (atomptr_is_0l(next_a))
+			continue;
+
+		prev = item;
+		prev_next_a = next_a;
+	} while (true);
+}
+
+/* atomhash_add: name says all.  "easy" after atomhash_anchor_update is done.
+ *
+ * this is really just a retry loop around atomhash_anchor_update(), which
+ * gives us some position in the chain ahead of what we're trying to insert, so
+ * we just need to scan forwards.  As with the other typesafe data structures,
+ * this returns NULL if the item was inserted, or a pointer to the "old" item
+ * if a collision was found.
+ */
+struct atomhash_item *atomhash_add(struct atomhash_head *head, struct atomhash_item *newitem,
+				   int (*cmpfn)(const struct atomhash_item *,
+						const struct atomhash_item *))
+{
+	uint32_t ref_hashval = newitem->hashval;
+	atomptr_t next_a = ATOMPTR_NULL, prev_next_a;
+	struct atomhash_item *item = NULL, *prev;
+
+	do {
+		item = atomhash_anchor_update(head, ref_hashval, &next_a);
+		if (!item) {
+			struct atomhash_array *array;
+			size_t idx = ref_hashval >> (32 - ATOMHASH_LOWEST_BITS);
+
+			array = atomhash_setup_level0(head);
+			item = &array->stubs[idx];
+			next_a = atomic__load(&item->next, memory_order_acquire);
+			assert(atomptr_is_u0(next_a));
+		}
+		assertf(atomptr_p(next_a) != NULL && !atomptr_is_0l(next_a),
+			"item=%p next_a=%#tx hashval=%08x", item, next_a, ref_hashval);
+
+		prev = item;
+		prev_next_a = next_a;
+
+		while ((item = atomptr_p(next_a)) != head->sentinel_end) {
+			if (item->hashval > ref_hashval)
+				break;
+
+			next_a = atomic__load(&item->next, memory_order_acquire);
+
+			/* cooperatively help deleting other items */
+			if (atomptr_is_0l(next_a))
+				continue;
+
+			if (atomptr_is_00(next_a) && item->hashval == ref_hashval) {
+				int cmpval = cmpfn(item, newitem);
+
+				if (cmpval == 0)
+					return item;
+				if (cmpval >= 0)
+					break;
+			}
+
+			prev_next_a = next_a;
+			prev = item;
+		}
+
+		assertf(prev && !atomptr_is_0l(prev_next_a),
+			"atomhash_head=%p ref_hashval=%08x item=%p prev_next_a=%#tx", head,
+			ref_hashval, item, prev_next_a);
+
+		atomic_init(&newitem->next, atomptr_i(item));
+		next_a = atomptr_copy_flags(atomptr_i(newitem), prev_next_a & ATOMPTR_USER);
+	} while (!atomic__cmpxchg_strong(&prev->next, &prev_next_a, next_a, memory_order_release,
+					 memory_order_relaxed));
+
+	size_t count = atomic__fetch_add(&head->count, 1, memory_order_relaxed);
+
+	/* this is intentionally after the actual insertion; two threads may
+	 * be attempting to construct and insert the same item.  Delaying the
+	 * insertion itself increases the likelihood of unnecessary collisions.
+	 */
+	if (!head->freeze_size)
+		atomhash_resize_grow(head, count + 1);
+
+	return NULL;
+}
+
+/* atomhash_del_core: common part of _del and _pop
+ *
+ * again, as with _add, this is the easy part after atomhash_anchor_update()
+ */
+static void atomhash_del_core(struct atomhash_head *head, struct atomhash_item *delitem,
+			      atomptr_t del_next)
+{
+	uint32_t ref_hashval = delitem->hashval;
+	atomptr_t next_a = ATOMPTR_NULL, prev_next_a;
+	struct atomhash_item *item, *prev;
+
+	do {
+		item = atomhash_anchor_update(head, ref_hashval, &next_a);
+		assertf(item, "head=%p ref_hashval=%08x", (void *)head, ref_hashval);
+
+		prev = item;
+		prev_next_a = next_a;
+
+		while (true) {
+			item = atomptr_p(next_a);
+			if (item == delitem)
+				break;
+
+			/* This assert would be nice but will break if we have
+			 * to retry and someone else completes the delete for
+			 * us
+			 *   assert(item->hashval <= ref_hashval);
+			 */
+			if (item == head->sentinel_end || item->hashval > ref_hashval)
+				return;
+
+			next_a = atomic__load(&item->next, memory_order_acquire);
+
+			/* cooperatively help deleting other items */
+			if (atomptr_is_0l(next_a))
+				continue;
+
+			prev_next_a = next_a;
+			prev = item;
+		}
+
+		assertf(prev && !atomptr_is_0l(prev_next_a),
+			"atomhash_head=%p ref_hashval=%08x item=%p prev_next_a=%#tx", head,
+			ref_hashval, item, prev_next_a);
+
+		del_next = atomptr_copy_flags(del_next, prev_next_a & ATOMPTR_USER);
+	} while (!atomic__cmpxchg_strong(&prev->next, &prev_next_a, del_next, memory_order_release,
+					 memory_order_relaxed));
+}
+
+void atomhash_del(struct atomhash_head *head, struct atomhash_item *item)
+{
+	atomptr_t next;
+	size_t count;
+
+	/* mark ourselves in-delete - full barrier */
+	next = atomic__fetch_or(&item->next, ATOMPTR_LOCK, memory_order_seq_cst);
+	/* delete race on same item */
+	assertf(atomptr_is_00(next), "item=%p", (void *)item);
+
+	count = atomic__fetch_sub(&head->count, 1, memory_order_relaxed);
+
+	atomhash_del_core(head, item, next);
+
+	if (!head->freeze_size)
+		atomhash_resize_shrink(head, count - 1);
+}
+
+struct atomhash_item *atomhash_pop(struct atomhash_head *head)
+{
+	struct atomhash_array *array;
+	struct atomhash_item *item;
+	atomptr_t next_a;
+	size_t count;
+
+	array = level_ptr(atomic__load(&head->levels[0], memory_order_acquire));
+	if (!array)
+		return NULL;
+
+	for (item = &array->stubs[0]; item != head->sentinel_end; item = atomptr_p(next_a)) {
+		next_a = atomic__load(&item->next, memory_order_acquire);
+		if (atomptr_is_00(next_a)) {
+			next_a = atomic__fetch_or(&item->next, ATOMPTR_LOCK, memory_order_seq_cst);
+			if (!atomptr_is_00(next_a))
+				continue;
+
+			count = atomic__fetch_sub(&head->count, 1, memory_order_relaxed);
+			/* TODO: optimize */
+			atomhash_del_core(head, item, next_a);
+			if (!head->freeze_size)
+				atomhash_resize_shrink(head, count - 1);
+			return item;
+		}
+	}
+
+	return NULL;
+}
+
+/* for testing/debug only, see earlier def */
+#undef atomhash_part
+#define atomhash_part resize
+
+/* Before we get to it, a note about the kind of lock-free resizing implemented
+ * here.  The comment at the head of the file notes it's a double-edged sword.
+ *
+ * The problem is this:
+ *
+ * A pretty basic principle of RCU is that you can do the same thing in two
+ * threads, and the end result will be correct, but at the full cost doing the
+ * operation twice.  This is fine for small operations, but - growing the hash
+ * table involves allocating and initializing memory.  That can be *costly*.
+ * If the hash table is at a size where the heuristic says it should be grown,
+ * that condition will trigger the same for all threads attempting to add an
+ * item to the hash table.  So, worst case, every thread starts allocating and
+ * initializing a notable amount of memory, only to then notice another thread
+ * was faster, so it throws away the memory and all that work it just did.
+ *
+ * This is, well, "suboptimal".  The uRCU lfhash implementation doesn't try to
+ * resize without an old-fashioned lock.  I haven't seen anything stating
+ * reasons behind this, but it's a fair guess they didn't consider this
+ * worst-case behavior acceptable.
+ *
+ * What we can, however, do here is to make it probabilistic.  When a thread
+ * begins a grow operation, it sets a flag to note this.  The next thread
+ * hitting the same condition can then grab a random number and randomly skip
+ * the grow operation (a chance calculated from the size of work involved is
+ * a good idea, i.e. the larger the table, the less likely duplicate the work.)
+ *
+ * This does, to a degree, then break the runtime guarantees of a hash table.
+ * While the "one" thread is setting up the larger table, a whole bunch of
+ * items might get added to the hash table, so the chain length in each bucket
+ * no longer pans out to 1.  In theory, read accesses could become O(n/c) with
+ * c being the "old" size of the table.
+ *
+ * This sounds bad, except it can't actually get that bad in actual operation,
+ * because the grow operation is fully parallel *on distinct size levels*.  So
+ * when the hash table exceeds the *next* size threshold, another thread will
+ * start doing the resize for that.  It's not a great upper constraint, but it
+ * is one nonetheless.
+ *
+ * Another factor in this is that the "atomic" part of the grow operation is
+ * only the malloc() and zeroing, but not the filling of the freshly allocated
+ * array.  That's what the U,L state is for, and that can and will be done in
+ * parallel by any thread accessing the data.  (Refer to insert_stub for the
+ * constraint on this.)  In theory it might also be worth considering using
+ * mmap() instead of malloc()/memalign() when allocating new arrays for very
+ * large tables.  The pages returned by mmap() are guaranteed to be zero,
+ * except the kernel can leave them as virtual memory holes until they're
+ * accessed.  Page faults would then happen in parallel on any thread accessing
+ * any data that is still a hole - whether that's better or worse depends on
+ * the kernel's VM subsystem.  (It's probably worse until some very large size
+ * is reached but I don't have numbers.)
+ *
+ * For shrinking, there is also a story here, but an entirely different one.
+ * The actual shrinking work is executed on the RCU thread, i.e. out of line
+ * with actual hash table accesses.  That does lose some locality of access
+ * benefits, but is pretty convenient for the thread triggering the shrink.
+ * It works great, ...
+ * ...until you get a degenerate case with a hash table rapidly and repeatedly
+ * growing and shrinking by large deltas.  Once an array is consigned to
+ * shrinking, it cannot be brought back.  But it is both still linked on the
+ * array for some time, as well as still takes up memory.  If the same level
+ * is allocated and freed repeatedly, a theoretically unlimited number of
+ * "dead" arrays can build up.  This isn't even an O(n²) or O(2ⁿ) bound, it's
+ * O(∞).
+ *
+ * Which is why this code implements a maximum on the number of shrink
+ * operations queued.  When this maximum is reached, further shrink operations
+ * are simply not scheduled.  This may leave some memory in use for longer than
+ * needed, but is preferable to an unbounded worst case scenario.
+ * (The table can still grow in this situation.)
+ *
+ * Shrinking is checked on all delete operations (including pop), so this will
+ * "fix itself" on any later removal of an item.  If that doesn't happen,
+ * that's... "unfortunate."
+ */
+
+#define ATOMHASH_MAX_INFLIGHT_SHRINKS 3
+
+/* level 7 is 1024 items, 16kB (on 64bit machines)
+ * => start doing "the stochastic thing"
+ * overridden by test
+ */
+#ifndef ATOMHASH_GROW_STOCHASTIC_THRESHOLD
+#define ATOMHASH_GROW_STOCHASTIC_THRESHOLD 7
+#endif
+
+static bool atomhash_setup_level(struct atomhash_head *head, int level, atomptr_t replace)
+{
+	struct atomhash_array *array;
+	struct atomhash_item *prev, *item;
+	atomptr_t next_a, prev_next_a;
+	uint32_t hashval, hashinc;
+	size_t n;
+	uint_fast32_t level_hint, level_hint_adj;
+	bool prev_valid;
+
+	assert(level > 0);
+	n = level_size(level);
+
+	hashval = 1U << (32 - ATOMHASH_LOWEST_BITS - level);
+	hashinc = hashval << 1;
+
+	array = XCALLOC(MTYPE_ATOMHASH_TABLE, sizeof(array->stubs[0]) * n);
+
+	if (!atomic__cmpxchg_strong(&head->levels[level], &replace, atomptr_i(array),
+				    memory_order_release, memory_order_relaxed)) {
+		XFREE(MTYPE_ATOMHASH_TABLE, array);
+		return false;
+	}
+
+	level_hint = atomic__load(&head->level_hint, memory_order_relaxed);
+	do {
+		level_hint_adj = MAX(level_hint, (size_t)level);
+		if (level_hint_adj == level_hint)
+			break;
+	} while (!atomic__cmpxchg_strong(&head->level_hint, &level_hint, level_hint_adj,
+					 memory_order_relaxed, memory_order_relaxed));
+
+	/* since level 0 is never deleted until the entire hash table is freed,
+	 * this will always exist, and also never have the L flag set
+	 */
+	prev = &level_ptr(atomic__load(&head->levels[0], memory_order_acquire))->stubs[0];
+	prev_next_a = atomic__load(&prev->next, memory_order_acquire);
+	prev_valid = true;
+
+	/*      /#\
+	 *     // \\         +------------------------------------+
+	 *    // ! \\        | HIC SUNT DRACONES ET BESTIIS PLENA |
+	 *   //  !  \\       +------------------------------------+
+	 *  //   o   \\
+	 *  +=========+   IF YOU TOUCH THIS, EXPECT 2 MONTHS OF MANUAL TESTING.
+	 *  | DRAGONS |
+	 *  +---------+
+	 *
+	 * The stub elements to be inserted here can be found in 2 ways:
+	 * - by getting at them through the hash array level (which is already
+	 *   live at this point!!)
+	 * - by iterating through the ordered list of hash values (which is
+	 *   NOT live yet at this point)
+	 *
+	 * Fundamentally, being able to get at something in 2 ways is a massive
+	 * headache in any lock-free data structure, since you can't atomically
+	 * publish something in 2 places.  Worse, in this case here, the entire
+	 * new hash level is one chunk.
+	 *
+	 * The only reason this works at all is that the U,L bit state can be
+	 * used *COMBINED WITH* the access method to distinguish state.  If we
+	 * hit a U,L item through the level array, it is NOT usable yet.  If we
+	 * hit the same item through the ordered list, it IS usable.
+	 */
+
+	hashval -= hashinc;
+	for (size_t i = 0; i < n; i++) {
+		struct atomhash_item *stub = &array->stubs[i];
+
+		hashval += hashinc;
+		atomic__store((_Atomic uint32_t *)&stub->hashval, hashval, memory_order_relaxed);
+
+		/* another thread raced and filled this stub
+		 *
+		 * This would also result in (prev == stub) below, but it's
+		 * essentially free since we just touched the cacheline, and
+		 * we can skip atomhash_anchor().
+		 */
+		next_a = atomic__load(&stub->next, memory_order_relaxed);
+		if (next_a) {
+			/* it'll be faster to find our position again */
+			prev_valid = false;
+			continue;
+		}
+
+		if (!prev_valid) {
+			/* either the previous stub wasn't inserted
+			 * successfully, or we skipped a stub
+			 * -> find a fresh anchor position to start from
+			 */
+			struct atomhash_item *update;
+
+			prev = atomhash_anchor(head, hashval, &prev_next_a, &update);
+			if (prev == stub)
+				/* again, another thread raced */
+				continue;
+
+			/* update isn't handled here, it'd just complicate
+			 * things needlessly.
+			 */
+		}
+
+		assertf(!atomptr_is_ul(next_a), "hashval=%08x prev=%p (%08x) prev_next_a=%#tx",
+			hashval, prev, prev->hashval, prev_next_a);
+		next_a = prev_next_a;
+
+		while ((item = atomptr_p(next_a)) != head->sentinel_end) {
+			if (item->hashval >= hashval)
+				break;
+
+			next_a = atomic__load(&item->next, memory_order_acquire);
+
+			/* skip over deleted items */
+			if (atomptr_is_0l(next_a))
+				continue;
+
+			prev = item;
+			prev_next_a = next_a;
+		}
+
+		/* This can fail if another thread attempts to use this stub
+		 * right now, and tries to update it in atomhash_anchor_update.
+		 * In that case, just leave it to the other thread, it'll get
+		 * filled in one way or another.
+		 */
+		atomhash_insert_stub(stub, prev, prev_next_a, next_a, &prev_valid);
+		if (prev_valid) {
+			/* if we inserted successfully, continue walking the
+			 * list forward from there
+			 */
+			prev = stub;
+			prev_next_a = atomptr_copy_flags(next_a, ATOMPTR_USER);
+		}
+		/* negative case handled at top of loop */
+	}
+
+	return true;
+}
+
+/* Okay, so.  Freeing a level / shrinking the table is the most complicated
+ * part of the entire thing.  The sequence of operations is:
+ *
+ * 1. detach the level from head->levels (replacing with NULL pointer)
+ *   => other threads will no longer *start* using the stubs in this level,
+ *   => BUT some threads may currently be accessing the level, either to
+ *      just use it for read access, to insert/remove items, or -crucially-
+ *      to set up stubs, i.e. moving NULL => U,L => U
+ * 2. wait one RCU period to ensure everything in-progress is done, especially
+ *    any NULL => U,L => U movements, because:
+ * 3. move everything U => L.  This can't start before all NULL => U,L => U
+ *    progress is done, otherwise things break horribly.
+ *    This is done /backwards in chunks/ (cf. CHUNKING) below.  The reason to
+ *    do it backwards is that we can then just grab the start position from our
+ *    own level's preceding element, and go forward from there.  There will be
+ *    only one other stub element inbetween before what we delete, so that'll
+ *    generally be faster than doing full _anchor().
+ * 4. in the same wash, after everything in a chunk was marked L, actually
+ *    unlink the items from the list.  If we're lucky we can batch a little bit
+ *    here.  But probably not.
+ *   => other threads will no lnger *hit* the stubs while traversing the list
+ *   => BUT some threads may be positioned on some of our stubs right now, in
+ *      the course of normal forward list traversal.
+ * 5. wait another RCU period so all the traversals are guaranteed to be gone.
+ * 6. actually free the memory.
+ *
+ * So, yeah, this is *two* RCU cycles.  In theory, if we don't hit any U,L
+ * stubs we could try doing it in one, but honestly I don't think it's worth
+ * the extra complexity.
+ */
+#define CHUNKING 16
+
+/* same RCU item is used for both wait periods, therefore 2 rcu_heads
+ * (if we recycle the rcu_head, it'll break if there's ever more than 1 RCU
+ * sweeper thread.)
+ */
+struct rcu_atomhash_shrink {
+	struct atomhash_head *hash_head;
+	struct atomhash_array *array;
+	int level;
+
+	struct rcu_head rcu_unlink;
+	struct rcu_head rcu_free;
+};
+
+static void atomhash_unlink_level(struct rcu_atomhash_shrink *arg);
+static void atomhash_free_level(struct rcu_atomhash_shrink *arg);
+static void atomhash_teardown_actual(struct atomhash_head *head, struct atomhash_array *array,
+				     size_t level);
+
+/* do step 1. & queue 2. (RCU wait) */
+static enum resize_result atomhash_teardown_level(struct atomhash_head *head, int level,
+						  atomptr_t expect)
+{
+	uint_fast32_t level_hint, level_hint_adj;
+	uint_fast32_t inflight;
+
+	assert(level > 0);
+	assert(!atomptr_l(expect) && expect != ATOMPTR_NULL);
+
+	inflight = atomic__load(&head->inflight_shrinks, memory_order_relaxed);
+	if (inflight >= ATOMHASH_MAX_INFLIGHT_SHRINKS)
+		return RESIZE_FUDGED;
+
+	if (!atomic__cmpxchg_strong(&head->inflight_shrinks, &inflight, inflight + 1,
+				    memory_order_relaxed, memory_order_relaxed))
+		/* if this is racing, the teardown is gonna race too */
+		return RESIZE_RACED;
+
+	/* if this succeeds, we own the delete.  Only one shall prevail. */
+	if (!atomic__cmpxchg_strong(&head->levels[level], &expect, ATOMPTR_NULL,
+				    memory_order_acq_rel, memory_order_relaxed)) {
+		atomic__fetch_sub(&head->inflight_shrinks, 1, memory_order_relaxed);
+		return RESIZE_RACED;
+	}
+
+	level_hint = atomic__load(&head->level_hint, memory_order_relaxed);
+	do {
+		level_hint_adj = MIN(level_hint, (size_t)(level - 1));
+		if (level_hint_adj == level_hint)
+			break;
+	} while (!atomic__cmpxchg_strong(&head->level_hint, &level_hint, level_hint_adj,
+					 memory_order_release, memory_order_relaxed));
+
+	atomhash_teardown_actual(head, level_ptr(expect), level);
+	return RESIZE_DONE;
+}
+
+static void atomhash_teardown_actual(struct atomhash_head *head, struct atomhash_array *array,
+				     size_t level)
+{
+	struct rcu_atomhash_shrink *rcu;
+
+	rcu = XCALLOC(MTYPE_ATOMHASH_TABLE_RCU, sizeof(*rcu));
+	rcu->hash_head = head;
+	rcu->array = array;
+	rcu->level = level;
+	atomhash_rcu_call(atomhash_unlink_level, rcu, rcu_unlink);
+}
+
+#define _prefetch_write(addr, offs) __builtin_prefetch((char *)(addr) - (offs), 1, 3)
+
+static bool atomhash_unlink_chunk(struct atomhash_item *start, atomptr_t start_next_a,
+				  struct atomhash_item *chunk, struct atomhash_item *sentinel_end);
+
+/* 2. (RCU wait) is through, do steps 3. & 4. & queue 5. (RCU wait again) */
+static void atomhash_unlink_level(struct rcu_atomhash_shrink *rcu)
+{
+	struct atomhash_head *head = rcu->hash_head;
+	struct atomhash_array *array = rcu->array;
+	size_t n = level_size(rcu->level);
+	size_t i = n;
+
+	/* this level isn't in use as index anymore.  Other threads might still
+	 * "pass by" on traversal, but we'll really need sole ownership of the
+	 * cacheline for atomic updates.  Let's try to get it a little ahead of
+	 * time.
+	 */
+	_prefetch_write(&array->stubs[n - 1], 0);
+	_prefetch_write(&array->stubs[n - 1], -64);
+
+	assert(n % CHUNKING == 0);
+
+	while (i) {
+		struct atomhash_item *chunkpos;
+
+		i -= CHUNKING;
+		chunkpos = &array->stubs[i];
+
+		/* this will run off too far in the last iteration, but it's
+		 * only a prefetch, so it's only a wasted cacheline.
+		 */
+		_prefetch_write(chunkpos, -64);
+
+		for (size_t j = 0; j < CHUNKING; j++) {
+			struct atomhash_item *stub = &chunkpos[j];
+			atomptr_t next_a = atomic__load(&stub->next, memory_order_acquire);
+			atomptr_t new_next_a;
+
+			do {
+				/* again, we *must* be in NULL or U or
+				 * something is seriously wrong.
+				 */
+				assertf(atomptr_is_u0(next_a) || !next_a,
+					"stub=%p next_a=%#tx hashval=%08x lv=%d i=%zu j=%zu", stub,
+					next_a, stub->hashval, rcu->level, i, j);
+
+				new_next_a = atomptr_copy_flags(next_a, ATOMPTR_LOCK);
+			} while (!atomic__cmpxchg_strong(&stub->next, &next_a, new_next_a,
+							 memory_order_release,
+							 memory_order_acquire));
+		}
+
+		/* start position for forward scan to unlink the stubs */
+		struct atomhash_item *start = NULL;
+		atomptr_t start_next_a;
+
+		if (i > 0) {
+			start = chunkpos - 1;
+			start_next_a = atomic__load(&start->next, memory_order_acquire);
+
+			/* since we own the level for deletion, anything we
+			 * hit really must be either NULL or U flagged.  Both
+			 * L and U,L mean something has gone seriously wrong.
+			 */
+			assert(!atomptr_l(start_next_a));
+
+			if (!start_next_a) {
+				struct atomhash_item *discard_update;
+				uint32_t hashval;
+
+				/* NB: chunkpos->hashval can be 0 still, if we
+				 * never filled it in because the initial setup
+				 * collided with another thread, which then
+				 * aborted.
+				 */
+				hashval = 1 << (32 - ATOMHASH_LOWEST_BITS - rcu->level);
+				hashval += i * (hashval << 1);
+				hashval--;
+
+				start = atomhash_anchor(head, hashval, &start_next_a,
+							&discard_update);
+				/* this also set start_next_a for us */
+			}
+		} else {
+			/* for the first chunk of any level, lvl0[0] is always
+			 * a suitable entry point
+			 */
+			struct atomhash_array *lvl0;
+
+			lvl0 = level_ptr(atomic__load(&head->levels[0], memory_order_acquire));
+			start = &lvl0->stubs[0];
+			start_next_a = atomic__load(&start->next, memory_order_acquire);
+		}
+
+		assertf(atomptr_p(start_next_a) && atomptr_u(start_next_a),
+			"start=%p start_next_a=%#tx chunk=%p hashval=%08x i=%zu", start,
+			start_next_a, chunkpos, chunkpos->hashval, i);
+
+		/* the start position can't become invalid; either it's *our*
+		 * stub in the same array that we own for deletion, or it's
+		 * lvl0[0] which is never deleted.
+		 * start_next_a however can still change, since it's not
+		 * flagged L yet.  This would lead to a rather insidious
+		 * livelock since we keep spinning and failing to update;
+		 * another thread would need to "break us out".
+		 */
+		while (!atomhash_unlink_chunk(start, start_next_a, chunkpos, head->sentinel_end))
+			start_next_a = atomic__load(&start->next, memory_order_acquire);
+	}
+
+	atomic__fetch_sub(&head->inflight_shrinks, 1, memory_order_relaxed);
+	/* the head may be gone past this point */
+	atomhash_rcu_call(atomhash_free_level, rcu, rcu_free);
+}
+
+static bool atomhash_unlink_chunk(struct atomhash_item *start, atomptr_t start_next_a,
+				  struct atomhash_item *chunk, struct atomhash_item *sentinel_end)
+{
+	struct atomhash_item *stub, *item, *prev = start;
+	atomptr_t prev_next_a, next_a, del_next;
+
+	next_a = prev_next_a = start_next_a;
+	_prefetch_write(&prev->next, 0); // hm.
+
+	for (size_t j = 0; j < CHUNKING; j++) {
+		stub = chunk + j;
+
+		del_next = atomic__load(&stub->next, memory_order_acquire);
+		assert(atomptr_is_0l(del_next));
+		if (!atomptr_p(del_next))
+			continue;
+		assert(stub->hashval);
+
+		while (true) {
+			item = atomptr_p(del_next);
+			if (item == sentinel_end)
+				break;
+
+			atomptr_t tmp = atomic__load(&item->next, memory_order_acquire);
+
+			if (!atomptr_is_0l(tmp))
+				break;
+
+			del_next = tmp;
+		}
+
+		while (true) {
+			item = atomptr_p(next_a);
+			if (item == stub) {
+				del_next = atomptr_copy_flags(del_next, prev_next_a & ATOMPTR_USER);
+				if (atomic__cmpxchg_strong(&prev->next, &prev_next_a, del_next,
+							   memory_order_release,
+							   memory_order_acquire)) {
+					prev_next_a = next_a = del_next;
+					break;
+				} else {
+					if (atomptr_is_0l(prev_next_a))
+						return false;
+
+					next_a = prev_next_a;
+					/* don't fall through here! */
+					continue;
+				}
+			}
+			if (item == sentinel_end || item->hashval > stub->hashval)
+				/* someone else unlinked the stub for us */
+				break;
+
+			next_a = atomic__load(&item->next, memory_order_acquire);
+			if (!atomptr_is_0l(next_a)) {
+				prev_next_a = next_a;
+				prev = item;
+			}
+		}
+	}
+
+	return true;
+}
+
+/* and finally, 5. has completed, so we can do step 6. now */
+static void atomhash_free_level(struct rcu_atomhash_shrink *rcu)
+{
+	XFREE(MTYPE_ATOMHASH_TABLE, rcu->array);
+	XFREE(MTYPE_ATOMHASH_TABLE_RCU, rcu);
+}
+
+/* The hysteresis for growing and shrinking the hash table should be relatively
+ * generous, since shrinking it conflicts with immediately re-growing it while
+ * that level is still being free'd.  Insufficient hysteresis can lead to some
+ * rather bad worst-case behavior if the table oscillates between to sizes.
+ *
+ * for reference, here is the low end of thresholds:
+ *  16 -[5]> 32 -[18]> 64 -[44]> 128 -[95]> 256 -[197]> 512 -[402]> 1024 -[812]> 2048
+ *     <[2]-    <[ 5]-    <[11]-     <[24]-     <[ 50]-     <[101]-      <[203]-
+ */
+
+/* return number of highest level that should be in use, inclusive */
+static inline size_t want_levels_grow(size_t count, struct atomhash_head *head)
+{
+	uint64_t val = count;
+
+	/* size-up threshold: 80% full (*5 /4), with small positive offset */
+	val += 8;
+	val *= 5;
+	val /= 4;
+
+	int nbits = sizeof(long long) * 8 - __builtin_clzll(val);
+
+	return MIN(MAX(0, nbits - ATOMHASH_LOWEST_BITS), (int)array_size(head->levels));
+}
+
+/* return number of highest level that should be in use, inclusive */
+static inline size_t want_levels_shrink(size_t count)
+{
+	uint64_t val = count;
+
+	/* size-down threshold: 10% full (*5), with tiny positive offset
+	 * there is another *2 implied because the level number here is
+	 * the highest *in use*, we're freeing above, so that's twice the size
+	 */
+	val += 1;
+	val *= 5;
+
+	int nbits = sizeof(long long) * 8 - __builtin_clzll(val);
+
+	return MAX(0, nbits - ATOMHASH_LOWEST_BITS);
+}
+
+static enum resize_result atomhash_resize_grow(struct atomhash_head *head, size_t count)
+{
+	uint_fast32_t level_hint, level_hint_adj;
+	size_t want = want_levels_grow(count, head);
+	bool fudge = false;
+
+	for (size_t i = 1; i <= want; i++) {
+		struct atomhash_array *array;
+		atomptr_t expect_a = ATOMPTR_NULL;
+
+		array = level_ptr(atomic__load(&head->levels[i], memory_order_relaxed));
+		if (array != NULL)
+			continue;
+
+		if (i >= ATOMHASH_GROW_STOCHASTIC_THRESHOLD) {
+			if (!atomic__cmpxchg_strong(&head->levels[i], &expect_a, ATOMPTR_LOCK,
+						    memory_order_relaxed, memory_order_relaxed)) {
+				uint32_t randmask;
+
+				/* if we see ATOMPTR_LOCK, another thread is
+				 * underway.  Another value, it's complete.
+				 */
+				if (expect_a != ATOMPTR_LOCK)
+					continue;
+
+				/* base chance for level 7 is 1 of 128; scales
+				 * with level (probably needs tuning)
+				 */
+				randmask = ~((1U << i) - 1);
+				if (frr_weak_random() & randmask) {
+					fudge = true;
+					continue;
+				}
+			} else
+				expect_a = ATOMPTR_LOCK;
+		}
+
+		/* only do one step at a time */
+		return atomhash_setup_level(head, i, expect_a) ? RESIZE_DONE : RESIZE_RACED;
+	}
+
+	level_hint = atomic__load(&head->level_hint, memory_order_relaxed);
+	level_hint_adj = MAX(level_hint, want);
+	if (unlikely(level_hint_adj != level_hint))
+		atomic__cmpxchg_strong(&head->level_hint, &level_hint, level_hint_adj,
+				       memory_order_relaxed, memory_order_relaxed);
+
+	return fudge ? RESIZE_FUDGED : RESIZE_NOOP;
+}
+
+static enum resize_result atomhash_resize_shrink(struct atomhash_head *head, size_t count)
+{
+	uint_fast32_t level_hint, level_hint_adj;
+	size_t want = want_levels_shrink(count);
+
+	for (size_t i = ATOMHASH_HIGHEST_BITS - ATOMHASH_LOWEST_BITS; i > want; i--) {
+		atomptr_t array_a;
+
+		array_a = atomic__load(&head->levels[i], memory_order_acquire);
+		if (!level_ptr(array_a))
+			continue;
+
+		/* only do one step at a time */
+		return atomhash_teardown_level(head, i, array_a);
+	}
+
+	level_hint = atomic__load(&head->level_hint, memory_order_relaxed);
+	level_hint_adj = MIN(level_hint, want);
+	if (unlikely(level_hint_adj != level_hint))
+		atomic__cmpxchg_strong(&head->level_hint, &level_hint, level_hint_adj,
+				       memory_order_relaxed, memory_order_relaxed);
+
+	return RESIZE_NOOP;
+}

--- a/lib/atomhash.h
+++ b/lib/atomhash.h
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: ISC
+/* lock-free single-CAS shrinkable hash table
+ * Copyright (c) 2025-26  David Lamparter, for NetDEF, Inc.
+ */
+
+#ifndef _FRR_ATOMHASH_H
+#define _FRR_ATOMHASH_H
+
+#include "lib/atomptr.h"
+
+/* comments & explanations for these datastructures are in lib/atomhash.c */
+
+struct atomhash_item {
+	/* (struct atomhash_item *) */
+	atomic_atomptr_t next;
+
+	uint32_t hashval;
+
+#if __SIZEOF_POINTER__ >= 8
+	/* allow access to the padding rather than just wasting it */
+	uint32_t unused;
+#endif
+};
+
+/* lowest level of atomhash array is (1 << ATOMHASH_LOWEST_BITS) */
+#define ATOMHASH_LOWEST_BITS  4
+#define ATOMHASH_HIGHEST_BITS 32
+
+struct atomhash_array;
+
+/* this struct should really, *really* be aligned to 64 bytes.  But putting an
+ * _Alignas(64) on it does waste almost 64 bytes.  And, most OSes we work on
+ * only guarantee 8 or 16 bytes alignment for malloc() - and we don't control
+ * where this is malloc()ed, since it might be embedded in another struct.
+ *
+ * adding _Alignas(64) would also tell the compiler that that alignment is
+ * *guaranteed* and it may use CPU instructions that fault on misalignment...
+ *
+ * so, no _Alignas for the time being.
+ */
+struct atomhash_head {
+	/* this union exists to "overlay" sentinel_end without wasting memory
+	 * on it.  It's used in place of a NULL at the end of the split-ordered
+	 * linked list; having a specific value rather than NULL makes bugs a
+	 * little more obvious.
+	 */
+	union {
+		struct {
+			/* used on read accesses to reduce the number of wasted
+			 * cacheline fetches especially in low item count
+			 * situations.  Might be slightly out of date, but
+			 * it'll work anyway.
+			 */
+			atomic_uint_fast32_t level_hint;
+		};
+
+		/* ensure this is 8 bytes regardless of uint_fast32_t size */
+		uint64_t _pad0[1];
+
+		/* only used as pointer value -- indicates end of list */
+		struct atomhash_item sentinel_end[0];
+	};
+
+	/* (struct atomhash_array *)
+	 * if the table was non-empty at any point, levels[0] will be != NULL
+	 */
+	atomic_atomptr_t levels[ATOMHASH_HIGHEST_BITS + 1 - ATOMHASH_LOWEST_BITS];
+
+	/* other bits */
+	bool freeze_size;
+
+#if __SIZEOF_POINTER__ == 4
+	char _pad1[3];
+#elif __SIZEOF_POINTER__ == 8
+	char _pad1[15];
+#else
+#error pointers are neither 64bit nor 32bit?
+#endif
+
+	/* this is touched on any add/delete operation, it absolutely should
+	 * not be on the same cache line as the other (read-heavy) bits,
+	 * especially not level_hint
+	 */
+	atomic_size_t count;
+
+	atomic_uint_fast32_t inflight_shrinks;
+};
+
+static_assert(offsetof(struct atomhash_head, levels) == 8,
+	      "some size assumption on struct atomhash_head does not hold");
+static_assert((offsetof(struct atomhash_head, count) % 64) == 0,
+	      "alignment in struct atomhash_head is broken. please fix.");
+
+/* _init *and* _fini require the caller to be exclusive owner of the struct.
+ * for _init this tends not to be a problem, but pay attention for _fini.
+ *
+ * you will also trip an assertion if the hash table is not empty on _fini().
+ * that's not technically necessary but if there are still items in the table
+ * at that point that's a warning sign something is wrong somewhere else.
+ */
+extern void atomhash_init(struct atomhash_head *head);
+extern void atomhash_fini(struct atomhash_head *head);
+
+/* note as is generally a problem with lock-free datastructures, the return
+ * value from any kind of get/find function is already outdated by the moment
+ * it is returned.  you better have some other way to keep it valid (e.g. a
+ * refcount somewhere)
+ */
+extern struct atomhash_item *atomhash_get(const struct atomhash_head *head,
+					  const struct atomhash_item *ref, uint32_t ref_hashval,
+					  int (*cmpfn)(const struct atomhash_item *,
+						       const struct atomhash_item *));
+
+/* returns existing item if there is already one in the table one that compares
+ * equal.  relying on that property is the primary "proper" way of using most
+ * lock-free data structures in general.
+ */
+extern struct atomhash_item *atomhash_add(struct atomhash_head *head, struct atomhash_item *item,
+					  int (*cmpfn)(const struct atomhash_item *,
+						       const struct atomhash_item *));
+
+/* future: allow opportunistic deletion w/ return value? */
+extern void atomhash_del(struct atomhash_head *head, struct atomhash_item *item);
+
+extern struct atomhash_item *atomhash_pop(struct atomhash_head *head);
+
+extern const struct atomhash_item *atomhash_first(const struct atomhash_head *head);
+extern const struct atomhash_item *atomhash_next(const struct atomhash_head *head,
+						 const struct atomhash_item *item);
+
+
+/* my dog ate the homework.  or in this case, clang-format ate the formatting.
+ * ohwell, it's not what I would've formatted it like but it's passable.
+ */
+#define PREDECL_ATOMHASH(prefix)                                                                  \
+	struct prefix##_head {                                                                    \
+		struct atomhash_head hh;                                                          \
+	};                                                                                        \
+	struct prefix##_item {                                                                    \
+		struct atomhash_item hi;                                                          \
+	};                                                                                        \
+	MACRO_REQUIRE_SEMICOLON()                                                                 \
+	/* end */
+
+#define INIT_ATOMHASH(var)                                                                        \
+	{                                                                                         \
+	}
+
+#define DECLARE_ATOMHASH(prefix, type, field, cmpfn, hashfn)                                      \
+	macro_inline void prefix##_init(struct prefix##_head *h)                                  \
+	{                                                                                         \
+		atomhash_init(&h->hh);                                                            \
+	}                                                                                         \
+	macro_inline void prefix##_fini(struct prefix##_head *h)                                  \
+	{                                                                                         \
+		atomhash_fini(&h->hh);                                                            \
+	}                                                                                         \
+	macro_inline int prefix##__cmp(const struct atomhash_item *a,                             \
+				       const struct atomhash_item *b)                             \
+	{                                                                                         \
+		return cmpfn(container_of(a, type, field.hi), container_of(b, type, field.hi));   \
+	}                                                                                         \
+	macro_inline type *prefix##_add(struct prefix##_head *h, type *item)                      \
+	{                                                                                         \
+		struct atomhash_item *ret;                                                        \
+		item->field.hi.hashval = hashfn(item);                                            \
+		ret = atomhash_add(&h->hh, &item->field.hi, prefix##__cmp);                       \
+		return container_of_null(ret, type, field.hi);                                    \
+	}                                                                                         \
+	macro_inline const type *prefix##_const_find(const struct prefix##_head *h,               \
+						     const type *item)                            \
+	{                                                                                         \
+		uint32_t hashval = hashfn(item);                                                  \
+		struct atomhash_item *ret = atomhash_get(&h->hh, &item->field.hi, hashval,        \
+							 prefix##__cmp);                          \
+		return container_of_null(ret, type, field.hi);                                    \
+	}                                                                                         \
+	TYPESAFE_FIND(prefix, type)                                                               \
+	macro_inline type *prefix##_del(struct prefix##_head *h, type *item)                      \
+	{                                                                                         \
+		atomhash_del(&h->hh, &item->field.hi);                                            \
+		return item;                                                                      \
+	}                                                                                         \
+	macro_inline type *prefix##_pop(struct prefix##_head *h)                                  \
+	{                                                                                         \
+		struct atomhash_item *ret = atomhash_pop(&h->hh);                                 \
+		return container_of_null(ret, type, field.hi);                                    \
+	}                                                                                         \
+	macro_pure const type *prefix##_const_first(const struct prefix##_head *h)                \
+	{                                                                                         \
+		const struct atomhash_item *ret = atomhash_first(&h->hh);                         \
+		return container_of_null(ret, type, field.hi);                                    \
+	}                                                                                         \
+	macro_pure const type *prefix##_const_next(const struct prefix##_head *h,                 \
+						   const type *item)                              \
+	{                                                                                         \
+		const struct atomhash_item *ret = atomhash_next(&h->hh, &item->field.hi);         \
+		return container_of_null(ret, type, field.hi);                                    \
+	}                                                                                         \
+	TYPESAFE_FIRST_NEXT(prefix, type)                                                         \
+	macro_pure type *prefix##_next_safe(struct prefix##_head *h, type *item)                  \
+	{                                                                                         \
+		if (!item)                                                                        \
+			return NULL;                                                              \
+		return prefix##_next(h, item);                                                    \
+	}                                                                                         \
+	macro_pure size_t prefix##_count(const struct prefix##_head *h)                           \
+	{                                                                                         \
+		return atomic_load_explicit(&h->hh.count, memory_order_relaxed);                  \
+	}                                                                                         \
+	TYPESAFE_MEMBER_VIA_FIND(prefix, type)                                                    \
+	MACRO_REQUIRE_SEMICOLON()                                                                 \
+	/* end */
+
+#endif /* _FRR_ATOMHASH_H */

--- a/lib/frrcu.c
+++ b/lib/frrcu.c
@@ -447,6 +447,9 @@ static void rcu_watchdog(struct rcu_thread *rt)
 #endif
 }
 
+/* current position in rcu_main() */
+static seqlock_ctr_t rcu_tail_pos;
+
 static void *rcu_main(void *arg)
 {
 	struct rcu_thread *rt;
@@ -455,6 +458,7 @@ static void *rcu_main(void *arg)
 	struct timespec maxwait;
 
 	seqlock_val_t rcuval = SEQLOCK_STARTVAL;
+	atomic_init(&rcu_tail_pos, rcuval);
 
 	pthread_setspecific(rcu_thread_key, &rcu_thread_rcu);
 
@@ -486,6 +490,7 @@ static void *rcu_main(void *arg)
 		}
 
 		rcuval += SEQLOCK_INCR;
+		atomic_store_explicit(&rcu_tail_pos, rcuval, memory_order_relaxed);
 	}
 
 	/* rcu_shutdown can only be called singlethreaded, and it does a
@@ -579,6 +584,7 @@ struct rcu_local_state rcu_local_state(void)
 	 */
 	struct rcu_local_state ret;
 
+	ret.seq_tail = atomic_load_explicit(&rcu_tail_pos, memory_order_relaxed);
 	ret.seq_local = seqlock_cur(&rcu_self()->rcu);
 	ret.seq_head = seqlock_cur(&rcu_seq);
 	return ret;

--- a/lib/frrcu.h
+++ b/lib/frrcu.h
@@ -199,10 +199,18 @@ extern void rcu_close(struct rcu_head_close *head, int fd);
  *
  * seq_local is (if held) guaranteed <= seq_head, but note this is wrapping
  * sequence counter math
+ *
+ * seq_tail is the sequence number the RCU sweeper thread is waiting on, i.e.
+ * it's the last generation that might still be in use == it's guaranteed to be
+ * behind/equal to all threads, including the current one.  It's exported for
+ * use in lock-free tests (which cycle through memory rapidly.)
+ *
+ * seq_tail <= seq_local <= seq_head
  */
 struct rcu_local_state {
 	uint32_t seq_head;
 	uint32_t seq_local;
+	uint32_t seq_tail;
 };
 
 struct rcu_local_state rcu_local_state(void);

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -13,6 +13,7 @@ lib_libfrr_la_SOURCES = \
 	lib/affinitymap_northbound.c \
 	lib/agg_table.c \
 	lib/atomlist.c \
+	lib/atomhash.c \
 	lib/asn.c \
 	lib/base64.c \
 	lib/bfd.c \
@@ -200,6 +201,7 @@ nobase_pkginclude_HEADERS += \
 	lib/affinitymap.h \
 	lib/agg_table.h \
 	lib/asn.h \
+	lib/atomhash.h \
 	lib/atomlist.h \
 	lib/atomptr.h \
 	lib/base64.h \

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -29,6 +29,8 @@ frr_northbound*
 /lib/cxxcompat
 /lib/fuzz_zlog
 /lib/test_assert
+/lib/test_atomhash_fast
+/lib/test_atomhash_slow
 /lib/test_atomlist
 /lib/test_buffer
 /lib/test_checksum

--- a/tests/helpers/c/prng.c
+++ b/tests/helpers/c/prng.c
@@ -90,6 +90,25 @@ const char *prng_fuzz(struct prng *prng, const char *string,
 	return buf;
 }
 
+void prng_permute(struct prng *prng, void *array[], size_t n)
+{
+	void *tmp;
+
+	if (n <= 1)
+		return;
+	assert(n < INT_MAX);
+
+	for (size_t i = 0; i < n - 1; i++) {
+		int idx = prng_rand(prng) % (n - i);
+
+		if (!idx)
+			continue;
+		tmp = array[i + idx];
+		array[i + idx] = array[i];
+		array[i] = tmp;
+	}
+}
+
 void prng_free(struct prng *prng)
 {
 	free(prng);

--- a/tests/helpers/c/prng.h
+++ b/tests/helpers/c/prng.h
@@ -11,12 +11,15 @@
 #ifndef _PRNG_H
 #define _PRNG_H
 
+#include <stddef.h>
+
 struct prng;
 
 struct prng *prng_new(unsigned long long seed);
 int prng_rand(struct prng *);
 const char *prng_fuzz(struct prng *, const char *string, const char *charset,
 		      unsigned int operations);
+void prng_permute(struct prng *prng, void *array[], size_t n);
 void prng_free(struct prng *);
 
 #endif

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -160,6 +160,23 @@ tests_lib_test_atomlist_SOURCES = tests/lib/test_atomlist.c
 EXTRA_DIST += tests/lib/test_atomlist.py
 
 
+# test_atomhash is built twice, once in "fast" mode to catch barrier issues,
+# once in "slow" mode to catch consistency issues
+
+check_PROGRAMS += tests/lib/test_atomhash_fast
+tests_lib_test_atomhash_fast_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_atomhash_fast_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_atomhash_fast_LDADD = $(ALL_TESTS_LDADD) -lm
+tests_lib_test_atomhash_fast_SOURCES = tests/lib/test_atomhash.c tests/helpers/c/prng.c
+
+
+check_PROGRAMS += tests/lib/test_atomhash_slow
+tests_lib_test_atomhash_slow_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_atomhash_slow_CPPFLAGS = $(TESTS_CPPFLAGS) -DTEST_HIJACK_ATOMICS
+tests_lib_test_atomhash_slow_LDADD = $(ALL_TESTS_LDADD) -lm
+tests_lib_test_atomhash_slow_SOURCES = tests/lib/test_atomhash.c tests/helpers/c/prng.c
+
+
 check_PROGRAMS += tests/lib/test_buffer
 tests_lib_test_buffer_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_buffer_CPPFLAGS = $(TESTS_CPPFLAGS)

--- a/tests/lib/test_atomhash.c
+++ b/tests/lib/test_atomhash.c
@@ -1,0 +1,2423 @@
+// SPDX-License-Identifier: ISC
+/* lock-free hash table tests
+ * Copyright (c) 2025-2026  David Lamparter, for NetDEF, Inc.
+ */
+
+/* this test must be run manually, and is only useful if you understand the
+ * actual lock-free hash table code.  There are a lot of variables that need
+ * fine tuning in order to trigger specific conditions that might cause bugs.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdalign.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <signal.h>
+#include <pthread.h>
+#include <math.h>
+#include <sys/resource.h>
+#include <sys/signal.h>
+#include <sys/mman.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <getopt.h>
+
+/* gettid */
+#ifdef HAVE_PTHREAD_NP_H
+#include <pthread_np.h>
+#endif
+#ifdef linux
+#include <sys/syscall.h>
+#endif
+
+#include "lib/seqlock.h"
+#include "lib/monotime.h"
+#include "lib/typesafe.h"
+#include "lib/printfrr.h"
+#include "lib/frrcu.h"
+#include "lib/jhash.h"
+#include "lib/memory.h"
+#include "lib/network.h"
+#include "lib/atomptr.h"
+
+#include "tests/helpers/c/prng.h"
+
+#define CACHELINESIZE 64
+
+#define thread_local _Thread_local __attribute__((tls_model("local-exec")))
+#define alignas	     _Alignas
+#define atomic	     _Atomic
+
+#define DEBUG_ATOMHASH
+
+struct rcu_atomhash_shrink;
+struct amop_journal;
+
+static void hijack_atomhash_unlink_level(struct rcu_atomhash_shrink *arg);
+static void hijack_atomhash_free_level(struct rcu_atomhash_shrink *arg);
+#define atomhash_rcu_call(func, ptr, field) rcu_call(hijack_##func, ptr, field)
+
+/****************************************
+ * build mode 1: atomic ops slowed down *
+ ****************************************/
+#ifdef TEST_HIJACK_ATOMICS
+/* can't be enabled at the same time */
+#undef TEST_JOURNAL_ATOMICS
+struct slow_parameters;
+static struct slow_parameters general;
+static struct slow_parameters resize;
+static __attribute__((noinline)) void slowdown_rd(const struct slow_parameters *params);
+static __attribute__((noinline)) void slowdown_op(const struct slow_parameters *params);
+
+/* clang-format off */
+#define atomic__load(...)		({ slowdown_rd(&atomhash_part); atomic_load_explicit(__VA_ARGS__); })
+
+#define atomic__store(...)		({ slowdown_op(&atomhash_part); atomic_store_explicit(__VA_ARGS__); })
+#define atomic__exchange(...)		({ slowdown_op(&atomhash_part); atomic_exchange_explicit(__VA_ARGS__); })
+#define atomic__cmpxchg_strong(...)	({ slowdown_op(&atomhash_part); atomic_compare_exchange_strong_explicit(__VA_ARGS__); })
+#define atomic__cmpxchg_weak(...)	({ slowdown_op(&atomhash_part); atomic_compare_exchange_weak_explicit(__VA_ARGS__); })
+#define atomic__fetch_or(...)		({ slowdown_op(&atomhash_part); atomic_fetch_or_explicit(__VA_ARGS__); })
+#define atomic__fetch_and(...)		({ slowdown_op(&atomhash_part); atomic_fetch_and_explicit(__VA_ARGS__); })
+#define atomic__fetch_add(...)		({ slowdown_op(&atomhash_part); atomic_fetch_add_explicit(__VA_ARGS__); })
+#define atomic__fetch_sub(...)		({ slowdown_op(&atomhash_part); atomic_fetch_sub_explicit(__VA_ARGS__); })
+/* clang-format on */
+
+/***************************************
+ * build mode 2: atomic ops journalled *
+ ***************************************/
+#elif defined(TEST_JOURNAL_ATOMICS)
+#ifndef AMOP_JSIZE
+#define AMOP_JSIZE 1048576
+#endif
+
+enum amop_journal_ent {
+	AMOP_STORE,
+	AMOP_XCHG,
+	AMOP_CMPXCHG_SUCCESS,
+	AMOP_CMPXCHG_FAIL,
+	AMOP_FETCH_OR,
+	AMOP_FETCH_AND,
+};
+struct amop_journal {
+	enum amop_journal_ent op;
+	uint32_t pos;
+	void *addr;
+	uint64_t vals[3];
+};
+
+static thread_local struct amop_journal *amop_journal;
+static thread_local size_t amop_pos;
+/* for gdb */
+int amop_jsize = AMOP_JSIZE;
+
+static inline struct amop_journal *amop_setup(void)
+{
+	amop_journal = calloc(AMOP_JSIZE, sizeof(amop_journal[0]));
+	return amop_journal;
+}
+
+static inline void amop_record(enum amop_journal_ent op, void *addr, uint64_t val1, uint64_t val2,
+			       uint64_t val3)
+{
+	struct amop_journal *je = &amop_journal[(amop_pos++) & (AMOP_JSIZE - 1)];
+
+	je->op = op;
+	je->pos = amop_pos >> 20;
+	je->addr = addr;
+	je->vals[0] = val1;
+	je->vals[1] = val2;
+	je->vals[2] = val3;
+}
+
+/* load, fetch_add & fetch_sub just waste journal entries */
+#define atomic__load(...)      ({ atomic_load_explicit(__VA_ARGS__); })
+#define atomic__fetch_add(...) ({ atomic_fetch_add_explicit(__VA_ARGS__); })
+#define atomic__fetch_sub(...) ({ atomic_fetch_sub_explicit(__VA_ARGS__); })
+
+#define atomic__store(ptr, val, o)                                                                \
+	({                                                                                        \
+		__auto_type ptr_ = (ptr);                                                         \
+		__auto_type val_ = (val);                                                         \
+		atomic_store_explicit(ptr_, val_, o);                                             \
+		amop_record(AMOP_STORE, ptr_, val_, 0, 0);                                        \
+	})
+#define atomic__exchange(ptr, val, o)                                                             \
+	({                                                                                        \
+		__auto_type ptr_ = (ptr);                                                         \
+		__auto_type val_ = (val);                                                         \
+		__auto_type ret = atomic_exchange_explicit(ptr_, val_, o);                        \
+		amop_record(AMOP_XCHG, ptr_, val_, ret, 0);                                       \
+		ret;                                                                              \
+	})
+#define atomic__cmpxchg_strong(ptr, expect, want, o1, o2)                                         \
+	({                                                                                        \
+		__auto_type ptr_ = (ptr);                                                         \
+		__auto_type expect_ = (expect);                                                   \
+		__auto_type before_ = *expect_;                                                   \
+		__auto_type want_ = (want);                                                       \
+		__auto_type ret = atomic_compare_exchange_strong_explicit(ptr_, expect_, want_,   \
+									  o1, o2);                \
+		amop_record(ret ? AMOP_CMPXCHG_SUCCESS : AMOP_CMPXCHG_FAIL, ptr_, before_, want_, \
+			    *expect_);                                                            \
+		ret;                                                                              \
+	})
+#define atomic__fetch_or(ptr, val, o)                                                             \
+	({                                                                                        \
+		__auto_type ptr_ = (ptr);                                                         \
+		__auto_type val_ = (val);                                                         \
+		__auto_type ret = atomic_fetch_or_explicit(ptr_, val_, o);                        \
+		amop_record(AMOP_FETCH_OR, ptr_, val_, ret, 0);                                   \
+		ret;                                                                              \
+	})
+#define atomic__fetch_and(ptr, val, o)                                                            \
+	({                                                                                        \
+		__auto_type ptr_ = (ptr);                                                         \
+		__auto_type val_ = (val);                                                         \
+		__auto_type ret = atomic_fetch_and_explicit(ptr_, val_, o);                       \
+		amop_record(AMOP_FETCH_AND, ptr_, val_, ret, 0);                                  \
+		ret;                                                                              \
+	})
+
+/* suppress definitions in atomhash.c */
+#define TEST_HIJACK_ATOMICS
+#endif /* TEST_HIJACK_ATOMICS, TEST_JOURNAL_ATOMICS */
+
+#ifndef TEST_JOURNAL_ATOMICS
+#define amop_setup() NULL
+#endif
+
+#define ATOMHASH_GROW_STOCHASTIC_THRESHOLD 3
+
+/* dynamic linking works without this.  static linking would get symbol
+ * redefinition errors.  rename atomhash.c's public symbols to avoid that
+ */
+#define atomhash_add   t_atomhash_add
+#define atomhash_del   t_atomhash_del
+#define atomhash_fini  t_atomhash_fini
+#define atomhash_first t_atomhash_first
+#define atomhash_get   t_atomhash_get
+#define atomhash_init  t_atomhash_init
+#define atomhash_next  t_atomhash_next
+#define atomhash_pop   t_atomhash_pop
+
+/* prevent inlining */
+#define extern __attribute__((noinline)) extern
+
+/*****************************************************************************/
+#include "lib/atomhash.h"
+#undef extern
+#include "lib/atomhash.c"
+/*****************************************************************************/
+
+
+#ifdef TEST_HIJACK_ATOMICS
+/* undo hijack */
+/* clang-format off */
+#undef atomic__load
+#undef atomic__store
+#undef atomic__exchange
+#undef atomic__cmpxchg_strong
+#undef atomic__cmpxchg_weak
+#undef atomic__fetch_or
+#undef atomic__fetch_and
+#undef atomic__fetch_add
+#undef atomic__fetch_sub
+#define atomic__load           atomic_load_explicit
+#define atomic__store          atomic_store_explicit
+#define atomic__exchange       atomic_exchange_explicit
+#define atomic__cmpxchg_strong atomic_compare_exchange_strong_explicit
+#define atomic__cmpxchg_weak   atomic_compare_exchange_weak_explicit
+#define atomic__fetch_or       atomic_fetch_or_explicit
+#define atomic__fetch_and      atomic_fetch_and_explicit
+#define atomic__fetch_add      atomic_fetch_add_explicit
+#define atomic__fetch_sub      atomic_fetch_sub_explicit
+/* clang-format on */
+#endif /* TEST_HIJACK_ATOMICS */
+
+#ifdef TEST_JOURNAL_ATOMICS
+#undef TEST_HIJACK_ATOMICS
+#endif
+
+static uint32_t prng_seed;
+thread_local static struct prng *prng;
+
+enum slow_level {
+	SLOW_NONE = 0,
+	SLOW_LOOP,
+	SLOW_LOOP1,
+	SLOW_LOOP2,
+	SLOW_SYSCALL,
+	SLOW_YIELD,
+};
+
+static const char *const slow_names[] = {
+	/* clang-format off */
+	[SLOW_NONE] = "none",
+	[SLOW_LOOP] = "loop",
+	[SLOW_LOOP1] = "loop+",
+	[SLOW_LOOP2] = "loop++",
+	[SLOW_SYSCALL] = "syscall",
+	[SLOW_YIELD] = "sched_yield",
+	/* clang-format on */
+};
+
+static inline void slowdown(enum slow_level level)
+{
+	int r = 0;
+
+	switch (level) {
+	case SLOW_NONE:
+		return;
+	case SLOW_LOOP2:
+		r += 100 + (prng_rand(prng) & 0x7ff);
+		fallthrough;
+	case SLOW_LOOP1:
+		r += 20 + (prng_rand(prng) & 0x7f);
+#pragma GCC unroll 0
+		for (int i = 0; i < r; i++)
+			asm volatile("");
+		break;
+	case SLOW_LOOP:
+		r += prng_rand(prng) & 0x3f;
+#pragma GCC unroll 0
+		for (int i = 0; i < r; i++)
+			asm volatile("");
+		return;
+	case SLOW_SYSCALL:
+		getsid(0);
+		return;
+	case SLOW_YIELD:
+		sched_yield();
+		return;
+	}
+}
+
+/* slowdown for atomic ops */
+
+#ifdef TEST_HIJACK_ATOMICS
+struct slow_parameters {
+	enum slow_level rd, op;
+};
+static struct slow_parameters general = { SLOW_NONE, SLOW_NONE };
+static struct slow_parameters resize = { SLOW_NONE, SLOW_NONE };
+
+static __attribute__((noinline)) void slowdown_rd(const struct slow_parameters *params)
+{
+	slowdown(params->rd);
+}
+
+static __attribute__((noinline)) void slowdown_op(const struct slow_parameters *params)
+{
+	slowdown(params->op);
+}
+#endif /* TEST_HIJACK_ATOMICS */
+
+#pragma GCC optimize("O3")
+
+/* actual test code starts here */
+
+static _Alignas(64) atomic int ctl_c;
+
+static unsigned int rcu_freq;
+static int shrink_adjust = 1;
+
+static enum slow_level slow_loop = SLOW_NONE;
+static unsigned int slow_loop_freq;
+
+static size_t itercount = 1000000;
+static size_t thread_item_arena_size;
+
+static inline bool freq_apply(unsigned long i, unsigned int freq)
+{
+	unsigned int tz = i ? __builtin_ctzl(i) : 64;
+
+	return tz >= freq;
+}
+
+/*
+ * items - there's a global item_state table (n_items entries), but each thread
+ * has its own "struct item" arena (to avoid congesting on RCU)
+ */
+
+enum state {
+	OFFLIST = 0,
+	ADDING = 1,
+	ONLIST = 2,
+	REMOVING = 3,
+
+	FIND = 0x100,
+
+	BUSY_MASK = 0x101,
+};
+#define state_next(s) (((s) + 1) & 0x3)
+
+#ifdef _FRR_ATTRIBUTE_PRINTFRR
+// clang-format off
+#pragma FRR printfrr_ext "%dST" (int)
+#pragma FRR printfrr_ext "%pAI" (struct atomhash_item *)
+#pragma FRR printfrr_ext "%pIT" (struct item *)
+#pragma FRR printfrr_ext "%pIS" (struct item_state *)
+// clang-format on
+#endif
+
+printfrr_ext_autoreg_i("ST", printfrr_st);
+static ssize_t printfrr_st(struct fbuf *buf, struct printfrr_eargs *ea, uintmax_t val)
+{
+	ssize_t ret = 0;
+
+	if (val & FIND) {
+		ret += bputs(buf, "FIND|");
+		val &= ~FIND;
+	}
+	switch (val) {
+		/* clang-format off */
+#define ITEM(n) case n: return ret + bputs(buf, #n)
+	ITEM(OFFLIST);
+	ITEM(ADDING);
+	ITEM(ONLIST);
+	ITEM(REMOVING);
+#undef ITEM
+		/* clang-format on */
+	default:
+		return ret + bprintfrr(buf, "%#jx?", val);
+	}
+}
+
+#define assert_statechg(v, from, to, fmt, ...)                                                    \
+	do {                                                                                      \
+		uint32_t state_check = atomic_exchange_explicit(&v->state, (to),                  \
+								memory_order_acq_rel);            \
+		assertf(state_check == (from), fmt " %p want %dST->%dST but is %dST!",            \
+			##__VA_ARGS__, v, (int)(from), (int)(to), (int)state_check);              \
+	} while (0)
+
+struct item {
+	struct atomhash_item item;
+
+	uint32_t val;
+
+	atomic uint32_t state;
+
+	seqlock_val_t rcu_last_used;
+};
+
+static int icmp(const struct atomhash_item *a, const struct atomhash_item *b)
+{
+	const struct item *ai = container_of(a, struct item, item);
+	const struct item *bi = container_of(b, struct item, item);
+
+	return numcmp(ai->val, bi->val);
+}
+
+printfrr_ext_autoreg_p("AI", printfrr_ai);
+static ssize_t printfrr_ai(struct fbuf *buf, struct printfrr_eargs *ea, const void *arg)
+{
+	atomptr_t p = (atomptr_t)arg;
+	const struct atomhash_item *ai = atomptr_p(p);
+
+	return bprintfrr(buf, "%p%s%s=(atomhash_i){ .hashval=%08x, .item.next=%#tx }", ai,
+			 atomptr_u(p) ? ",U" : "", atomptr_l(p) ? ",L" : "", ai->hashval, ai->next);
+}
+
+printfrr_ext_autoreg_p("IT", printfrr_it);
+static ssize_t printfrr_it(struct fbuf *buf, struct printfrr_eargs *ea, const void *arg)
+{
+	const struct item *it = arg;
+
+	return bprintfrr(buf,
+			 "%p=(item      ){ .hashval=%08x, .item.next=%#tx, .state=%8dST, .val=%4d }",
+			 it, it->item.hashval, it->item.next, (int)it->state, it->val);
+}
+
+/*
+ * global item state array
+ */
+
+PREDECL_HEAP(itemstates);
+struct item_state {
+	alignas(CACHELINESIZE) atomic uint32_t state;
+	uint32_t _pad0;
+
+	uint32_t val;
+	uint32_t hashval;
+
+	struct itemstates_item heapitem;
+
+	struct item *active;
+};
+static_assert(alignof(struct item_state) % CACHELINESIZE == 0, "alignment mishap");
+
+static int itemstates_cmp(const struct item_state *a, const struct item_state *b)
+{
+	if (a->hashval != b->hashval)
+		return numcmp(a->hashval, b->hashval);
+
+	return numcmp(a->val, b->val);
+}
+DECLARE_HEAP(itemstates, struct item_state, heapitem, itemstates_cmp);
+
+static _Alignas(64) size_t n_items;
+static struct item_state *item_states;
+
+printfrr_ext_autoreg_p("IS", printfrr_is);
+static ssize_t printfrr_is(struct fbuf *buf, struct printfrr_eargs *ea, const void *arg)
+{
+	const struct item_state *is = arg;
+
+	return bprintfrr(buf,
+			 "%p=(item_state){ .hashval=%08x, .state=%8dST, .val=%4d, .active=%p }",
+			 is, is->hashval, (int)is->state, is->val, is->active);
+}
+
+/*
+ * event counters - mostly to see which code paths are getting hit & how much
+ */
+
+enum stats {
+	STAT_NONE,
+	STAT_CHECK,
+	STAT_ITER,
+	STAT_RCU_HOT,
+	STAT_ADD,
+	STAT_ADD_DONE,
+	STAT_ADD_BUSY_G,
+	STAT_ADD_BUSY_L,
+	STAT_ADDCOL,
+	STAT_ADDCOL_DONE,
+	STAT_ADDCOL_BUSY_G,
+	STAT_DEL,
+	STAT_DEL_DONE,
+	STAT_DEL_BUSY_G,
+	STAT_FIND,
+	STAT_FIND_DONE,
+	STAT_FIND_NEG,
+	STAT_FIND_BUSY_G,
+	STAT_GROW,
+	STAT_GROW_DONE,
+	STAT_GROW_NOOP = STAT_GROW_DONE + RESIZE_NOOP,
+	STAT_GROW_COLLISION = STAT_GROW_DONE + RESIZE_RACED,
+	STAT_GROW_FUDGED = STAT_GROW_DONE + RESIZE_FUDGED,
+	STAT_GROW_CEILING,
+	STAT_GROW_FAKE,
+	STAT_GROW_FAKE_DONE,
+	STAT_GROW_FAKE_COLLISION,
+	STAT_GROW_FAKE_CEILING,
+	STAT_GROW_FADD,
+	STAT_GROW_FADD_DONE,
+	STAT_GROW_FADD_EMPTY,
+	STAT_GROW_FADD_BUSY_L,
+	STAT_GROW_FADD_SKIPPED,
+	STAT_GROW_FADD_SKIPDEL,
+	STAT_GROW_FADD_NEWLVL,
+	STAT_SHRINK,
+	STAT_SHRINK_PROBABILITY,
+	STAT_SHRINK_DONE,
+	STAT_SHRINK_NOOP = STAT_SHRINK_DONE + RESIZE_NOOP,
+	STAT_SHRINK_COLLISION = STAT_SHRINK_DONE + RESIZE_RACED,
+	STAT_SHRINK_RCURATELIMIT = STAT_SHRINK_DONE + RESIZE_FUDGED,
+	STAT_SHRINK_FLOOR,
+	STAT_RCU_SAMPLES,
+	STAT_RCU_IDLE,
+	STAT_RCU_SHRINK_UNLINK,
+	STAT_RCU_SHRINK_FREE,
+};
+/* time spent in test code */
+#define STAT_AUX 0x1000
+
+static const char *const stats_names[] = {
+	[STAT_NONE] = "housekeeping",
+	[STAT_CHECK] = "check",
+	[STAT_ITER] = "iterate",
+	[STAT_RCU_HOT] = "item blocked in RCU",
+	[STAT_ADD] = "add",
+	[STAT_ADD_DONE] = "add: success",
+	[STAT_ADD_BUSY_G] = "add: failed to find empty slot",
+	[STAT_ADD_BUSY_L] = "add: failed to find empty item",
+	[STAT_ADDCOL] = "add-collide",
+	[STAT_ADDCOL_DONE] = "add-coll: success",
+	[STAT_ADDCOL_BUSY_G] = "add-coll: failed to find non-empty slot",
+	[STAT_DEL] = "del",
+	[STAT_DEL_DONE] = "del: success",
+	[STAT_DEL_BUSY_G] = "del: failed to find non-empty slot",
+	[STAT_FIND] = "find",
+	[STAT_FIND_DONE] = "find: success",
+	[STAT_FIND_NEG] = "find: success (negative)",
+	[STAT_FIND_BUSY_G] = "find: failed to find slot",
+	[STAT_GROW] = "grow",
+	[STAT_GROW_DONE] = "grow: success",
+	[STAT_GROW_NOOP] = "grow: no-op",
+	[STAT_GROW_COLLISION] = "grow: collision",
+	[STAT_GROW_FUDGED] = "grow: probability declined",
+	[STAT_GROW_CEILING] = "grow: level ceiling",
+	[STAT_GROW_FAKE] = "grow (empty)",
+	[STAT_GROW_FAKE_DONE] = "grow (empty): success",
+	[STAT_GROW_FAKE_COLLISION] = "grow (empty): collision",
+	[STAT_GROW_FAKE_CEILING] = "grow (empty): level ceiling",
+	[STAT_GROW_FADD] = "grow+add",
+	[STAT_GROW_FADD_DONE] = "grow+add: done",
+	[STAT_GROW_FADD_EMPTY] = "grow+add: empty level",
+	[STAT_GROW_FADD_SKIPPED] = "grow+add: skipped adds",
+	[STAT_GROW_FADD_SKIPDEL] = "grow+add: skipped dels",
+	[STAT_GROW_FADD_BUSY_L] = "grow+add: failed to find empty item",
+	[STAT_GROW_FADD_NEWLVL] = "grow+add: gained level",
+	[STAT_SHRINK] = "shrink",
+	[STAT_SHRINK_DONE] = "shrink: success",
+	[STAT_SHRINK_NOOP] = "shrink: no-op",
+	[STAT_SHRINK_COLLISION] = "shrink: collision",
+	[STAT_SHRINK_RCURATELIMIT] = "shrink: RCU ratelimit",
+	[STAT_SHRINK_FLOOR] = "shrink: level floor",
+	[STAT_SHRINK_PROBABILITY] = "shrink: size-based probability negative",
+	[STAT_RCU_SAMPLES] = "(RCU thread) all samples",
+	[STAT_RCU_IDLE] = "(RCU thread) idle",
+	[STAT_RCU_SHRINK_UNLINK] = "(RCU thread) shrink: unlink",
+	[STAT_RCU_SHRINK_FREE] = "(RCU thread) shrink: free",
+};
+
+static bool stats_is_base[array_size(stats_names) + 1] = {
+	/* clang-format off */
+	[STAT_NONE] = true,
+	[STAT_CHECK] = true,
+	[STAT_ITER] = true,
+	[STAT_RCU_HOT] = true,
+
+	[STAT_ADD] = true,
+	[STAT_ADDCOL] = true,
+	[STAT_DEL] = true,
+	[STAT_FIND] = true,
+	[STAT_GROW] = true,
+	[STAT_GROW_FAKE] = true,
+	[STAT_GROW_FADD] = true,
+	[STAT_SHRINK] = true,
+	[STAT_RCU_SAMPLES] = true,
+	/* clang-format on */
+};
+
+static inline bool stat_has_counters(enum stats stat)
+{
+	return stat != STAT_NONE && stat < STAT_RCU_SAMPLES;
+}
+
+/*
+ * each thread has one of these, including the RCU thread
+ */
+struct thread_info {
+	pthread_t pt;
+	sem_t start_lock;
+	struct seqlock run_lock;
+	atomic bool stopped;
+	struct timespec stop_since;
+
+	struct rcu_thread *rt;
+	long thread_num;
+	struct item *items;
+	size_t n_items, item_pos;
+	struct amop_journal *amop_journal;
+
+	alignas(CACHELINESIZE) atomic int what;
+	atomic_size_t pos;
+
+	size_t stats[array_size(stats_names)];
+};
+static thread_local struct thread_info *thread_info;
+
+static thread_local bool is_rcu_thread;
+static struct thread_info rcu_thread_info = {
+	.what = STAT_RCU_IDLE | STAT_AUX,
+};
+
+static inline void _set_what(struct thread_info *ti, int val)
+{
+	atomic_store_explicit(&ti->what, val, memory_order_relaxed);
+}
+#define set_what(val) _set_what(ti, val)
+
+bool mmap_mode = true;
+
+static void thread_setup_items(struct thread_info *ti)
+{
+	size_t pagesize = getpagesize();
+	size_t itemsize;
+	char *buf, *end;
+
+	ti->n_items = thread_item_arena_size;
+
+	itemsize = ti->n_items * sizeof(ti->items[0]);
+	itemsize = (itemsize + pagesize - 1) & ~(pagesize - 1);
+	assertf((itemsize % pagesize) == 0, "itemsize=%zu pagesize=%zu", itemsize, pagesize);
+
+	if (mmap_mode) {
+		buf = mmap(NULL, pagesize * 2 + itemsize, PROT_READ | PROT_WRITE,
+			   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		assertf(buf != (void *)-1, "mmap: %m");
+		/* guard pages */
+		assertf(!mprotect(buf, pagesize, PROT_NONE), "%m");
+		assertf(!mprotect(buf + pagesize + itemsize, pagesize, PROT_NONE), "%m");
+
+		buf += pagesize;
+	} else {
+		assert(!posix_memalign((void **)&buf, pagesize, itemsize));
+	}
+
+	ti->items = (struct item *)buf;
+
+	end = buf + itemsize;
+	/* force memory pages into RAM */
+	for (; buf < end; buf += pagesize)
+		*buf = '\0';
+}
+
+/*
+ * actual hash table head
+ */
+
+static struct atomhash_head head[1];
+
+static size_t levels_min, levels_max;
+static atomic size_t n_ul;
+static unsigned int poison_freq;
+
+/*
+ * RCU trickery
+ */
+
+struct rcu_dummy_del {
+	struct rcu_head head;
+};
+
+static void rcu_dummy_del(struct rcu_dummy_del *rcu)
+{
+	free(rcu);
+}
+
+struct rcu_poison {
+	struct rcu_head head;
+	struct item *item;
+};
+
+static void rcu_poison(struct rcu_poison *rcu)
+{
+	memset(&rcu->item->item, 0xcc, sizeof(rcu->item->item));
+	free(rcu);
+}
+
+static void mark_del(struct item *item)
+{
+	struct rcu_local_state rcu_state;
+
+	rcu_state = rcu_local_state();
+	item->rcu_last_used = rcu_state.seq_head;
+
+	if (poison_freq) {
+		unsigned int n = prng_rand(prng);
+
+		if (freq_apply(n, poison_freq)) {
+			struct rcu_poison *poison = calloc(1, sizeof(*poison));
+
+			poison->item = item;
+			rcu_call(rcu_poison, poison, head);
+		}
+	}
+}
+
+static bool can_use(struct item *item)
+{
+	struct rcu_local_state rcu_state;
+	seqlock_val_t item_rcu;
+
+	item_rcu = item->rcu_last_used;
+	if (!(item_rcu & SEQLOCK_HELD))
+		return true;
+
+	rcu_state = rcu_local_state();
+	if ((int32_t)(rcu_state.seq_tail - item_rcu) > 0)
+		return true;
+
+	return false;
+}
+
+/*
+ * core test functions
+ */
+
+static void test_check(struct thread_info *ti, unsigned int r)
+{
+	struct atomhash_item *item, *prev = NULL;
+	atomptr_t next_a;
+	size_t level_size, _n_ul = 0;
+	uint32_t prev_hash = 0;
+	uint32_t hash_val, hash_inc;
+
+	for (size_t level = 0; level < array_size(head->levels); level++) {
+		struct atomhash_array *array;
+
+		array = level_ptr(atomic_load_explicit(&head->levels[level], memory_order_acquire));
+		if (!array)
+			continue;
+
+		if (!level) {
+			hash_val = 0;
+			hash_inc = 1 << (32 - ATOMHASH_LOWEST_BITS);
+			level_size = 1 << ATOMHASH_LOWEST_BITS;
+		} else {
+			hash_val = 1 << (32 - ATOMHASH_LOWEST_BITS - level);
+			hash_inc = hash_val << 1;
+			level_size = 1 << (ATOMHASH_LOWEST_BITS + level - 1);
+		}
+
+		for (size_t i = 0; i < level_size; i++) {
+			uint32_t hash_read;
+
+			item = &array->stubs[i];
+			next_a = atomic_load_explicit(&item->next, memory_order_acquire);
+			/* the atomic here is theoretical / UB avoidance */
+			hash_read = atomic_load_explicit((atomic uint32_t *)&item->hashval,
+							 memory_order_acquire);
+
+			assertf(hash_read == hash_val || !next_a,
+				"level=%zu i=%zu next_a=%#tx hash_val=%08x hash_read=%08x hash_inc=%08x",
+				level, i, next_a, hash_val, hash_read, hash_inc);
+
+			hash_val += hash_inc;
+
+			if (atomptr_is_ul(next_a))
+				_n_ul++;
+		}
+	}
+	atomic_fetch_add_explicit(&n_ul, _n_ul, memory_order_relaxed);
+
+	next_a = (atomptr_t)&level_ptr(head->levels[0])->stubs[0];
+
+	for (item = atomptr_p(next_a); item != head->sentinel_end; item = atomptr_p(next_a)) {
+		next_a = atomic_load_explicit(&item->next, memory_order_acquire);
+		assertf(item->hashval >= prev_hash,
+			"prev=%p item=%p hashval=%08x next_a=%#tx prev_hash = %08x", prev, item,
+			item->hashval, next_a, prev_hash);
+		prev_hash = item->hashval;
+		prev = item;
+	}
+}
+
+static void test_iter(struct thread_info *ti, unsigned int r)
+{
+	const struct atomhash_item *ai;
+	uint32_t prev_hash = 0;
+
+	frr_each (atomhash, head, ai) {
+		assertf(ai->hashval >= prev_hash, "%p %08x %08x", ai, prev_hash, ai->hashval);
+
+		prev_hash = ai->hashval;
+	}
+}
+
+static void test_grow_real(struct thread_info *ti, unsigned int r)
+{
+	uint_fast32_t level = atomic__load(&head->level_hint, memory_order_relaxed);
+	enum resize_result rv;
+
+	if (level++ == levels_max) {
+		ti->stats[STAT_GROW_CEILING]++;
+		return;
+	}
+
+	set_what(STAT_GROW);
+	rv = atomhash_resize_grow(head, 1U << (level + 3));
+	set_what(STAT_GROW | STAT_AUX);
+	ti->stats[STAT_GROW_DONE + rv]++;
+}
+
+static void test_grow_fake(struct thread_info *ti, unsigned int r)
+{
+	struct atomhash_array *array;
+	size_t n;
+	uint_fast32_t level_hint, level_hint_adj;
+	uint_fast32_t level = atomic__load(&head->level_hint, memory_order_relaxed);
+	atomptr_t replace = ATOMPTR_NULL;
+
+	if (level++ == levels_max) {
+		ti->stats[STAT_GROW_FAKE_CEILING]++;
+		return;
+	}
+
+	assert(level > 0);
+	n = level_size(level);
+
+	array = XCALLOC(MTYPE_ATOMHASH_TABLE, sizeof(array->stubs[0]) * n);
+	if (!atomic__cmpxchg_strong(&head->levels[level], &replace, atomptr_i(array),
+				    memory_order_release, memory_order_relaxed)) {
+		XFREE(MTYPE_ATOMHASH_TABLE, array);
+		ti->stats[STAT_GROW_FAKE_COLLISION]++;
+		return;
+	}
+
+	level_hint = atomic__load(&head->level_hint, memory_order_relaxed);
+	do {
+		level_hint_adj = MAX(level_hint, (size_t)level);
+		if (level_hint_adj == level_hint)
+			break;
+	} while (!atomic__cmpxchg_strong(&head->level_hint, &level_hint, level_hint_adj,
+					 memory_order_relaxed, memory_order_relaxed));
+
+	ti->stats[STAT_GROW_FAKE_DONE]++;
+}
+
+static void test_shrink(struct thread_info *ti, unsigned int r)
+{
+	uint_fast32_t level = atomic__load(&head->level_hint, memory_order_relaxed);
+	enum resize_result rv;
+
+	if (level == levels_min) {
+		ti->stats[STAT_SHRINK_FLOOR]++;
+		return;
+	}
+	if ((r & ((1 << MAX(0, (int)levels_max - (int)level + shrink_adjust)) - 1))) {
+		ti->stats[STAT_SHRINK_PROBABILITY]++;
+		return;
+	}
+
+	//atomic__load(&head->levels[level], memory_order_acquire)))
+	set_what(STAT_SHRINK);
+	rv = atomhash_resize_shrink(head, 0); //(1 << level) - 1))
+	set_what(STAT_SHRINK | STAT_AUX);
+	ti->stats[STAT_SHRINK_DONE + rv]++;
+}
+
+#define RETRY_STATE 50
+#define RETRY_ITEM  1000
+
+static struct item_state *state_find_item_state(size_t start_idx, uint32_t prevstate,
+						uint32_t nextstate, bool any_nonbusy)
+{
+	size_t retry = 0;
+	size_t i;
+	struct item_state *istate;
+	uint32_t prevstate_xchg;
+
+	i = start_idx % n_items;
+
+	do {
+		if (retry++ > RETRY_STATE)
+			return NULL;
+
+		istate = &item_states[i];
+
+		i++;
+		if (i == n_items)
+			i = 0;
+
+		if (!any_nonbusy)
+			prevstate_xchg = prevstate;
+		else {
+			prevstate_xchg = atomic_load_explicit(&istate->state, memory_order_relaxed);
+			prevstate_xchg &= ~BUSY_MASK;
+			nextstate = prevstate_xchg | FIND;
+		}
+	} while (!atomic_compare_exchange_strong_explicit(&istate->state, &prevstate_xchg,
+							  nextstate, memory_order_acq_rel,
+							  memory_order_relaxed));
+
+	return istate;
+}
+
+static void rcu_bump_dummy(void)
+{
+	struct rcu_dummy_del *dummy_del = malloc(sizeof(*dummy_del));
+
+	rcu_call(rcu_dummy_del, dummy_del, head);
+}
+
+static struct item *thread_find_item_state(struct thread_info *ti, uint32_t prevstate,
+					   uint32_t nextstate)
+{
+	size_t retry = 0;
+	size_t i;
+	struct item *item;
+	uint32_t prevstate_xchg;
+
+	i = ti->item_pos;
+	while (1) {
+		do {
+			if (retry++ > RETRY_ITEM) {
+				ti->item_pos = i;
+				return NULL;
+			}
+
+			item = &ti->items[i];
+
+			i++;
+			if (i == ti->n_items)
+				i = 0;
+
+			prevstate_xchg = prevstate;
+		} while (!atomic_compare_exchange_strong_explicit(&item->state, &prevstate_xchg,
+								  nextstate, memory_order_acq_rel,
+								  memory_order_relaxed));
+
+		if (can_use(item))
+			break;
+
+		assert_statechg(item, nextstate, prevstate, "val=%u", item->val);
+		ti->stats[STAT_RCU_HOT]++;
+	}
+
+	ti->item_pos = i;
+	return item;
+}
+
+static void test_add(struct thread_info *ti, unsigned int r)
+{
+	struct item_state *istate;
+	struct item *item;
+
+	istate = state_find_item_state(r, OFFLIST, ADDING, false);
+	if (!istate) {
+		ti->stats[STAT_ADD_BUSY_G]++;
+		return;
+	}
+	assertf(!istate->active, "istate=%p val=%u active=%p", istate, istate->val, istate->active);
+
+	item = thread_find_item_state(ti, OFFLIST, ADDING);
+	if (!item) {
+		assert_statechg(istate, ADDING, OFFLIST, "val=%u", istate->val);
+		ti->stats[STAT_ADD_BUSY_L]++;
+		return;
+	}
+
+	struct atomhash_item *ret, *ai;
+
+	ai = &item->item;
+	item->val = istate->val;
+	ai->hashval = istate->hashval;
+
+	set_what(STAT_ADD);
+	ret = atomhash_add(head, ai, icmp);
+	set_what(STAT_ADD | STAT_AUX);
+
+	assert(!ret);
+	istate->active = item;
+
+	assert_statechg(item, ADDING, ONLIST, "val=%u", item->val);
+	assert_statechg(istate, ADDING, ONLIST, "val=%u", istate->val);
+
+	ti->stats[STAT_ADD_DONE]++;
+}
+
+static void test_addcol(struct thread_info *ti, unsigned int r)
+{
+	struct item_state *istate;
+	struct item local_item;
+
+	istate = state_find_item_state(r, ONLIST, ONLIST | FIND, false);
+	if (!istate) {
+		ti->stats[STAT_ADDCOL_BUSY_G]++;
+		return;
+	}
+	assertf(istate->active, "istate=%p val=%u active=%p", istate, istate->val, istate->active);
+
+	struct atomhash_item *ret, *ai;
+
+	memset(&local_item, 0xcc, sizeof(local_item));
+	ai = &local_item.item;
+	local_item.val = istate->val;
+	ai->hashval = istate->hashval;
+
+	set_what(STAT_ADDCOL);
+	ret = atomhash_add(head, ai, icmp);
+	set_what(STAT_ADDCOL | STAT_AUX);
+
+	struct item *reti = container_of(ret, struct item, item);
+
+	assertf(reti == istate->active, "istate=%p val=%u active=%p ret=%p", istate, istate->val,
+		istate->active, reti);
+
+	assert_statechg(istate, ONLIST | FIND, ONLIST, "val=%u", istate->val);
+
+	ti->stats[STAT_ADDCOL_DONE]++;
+}
+
+
+static void test_del(struct thread_info *ti, unsigned int r)
+{
+	struct item_state *istate;
+	struct item *item;
+
+	istate = state_find_item_state(r, ONLIST, REMOVING, false);
+	if (!istate) {
+		ti->stats[STAT_DEL_BUSY_G]++;
+		return;
+	}
+	assertf(istate->active, "istate=%p val=%u active=%p", istate, istate->val, istate->active);
+
+	item = istate->active;
+	assertf(item->val == istate->val, "item->val=%u istate->val=%u", item->val, istate->val);
+	assert_statechg(item, ONLIST, REMOVING, "val=%u", item->val);
+
+	set_what(STAT_DEL);
+	atomhash_del(head, &item->item);
+	set_what(STAT_DEL | STAT_AUX);
+
+	istate->active = NULL;
+	mark_del(item);
+
+	assert_statechg(item, REMOVING, OFFLIST, "val=%u", item->val);
+	assert_statechg(istate, REMOVING, OFFLIST, "val=%u", istate->val);
+
+	ti->stats[STAT_DEL_DONE]++;
+}
+
+#if 0
+/* pop() cannot easily be tested :( */
+static bool test_pop(unsigned int r)
+{
+	return false;
+}
+#endif
+
+static void test_find(struct thread_info *ti, unsigned int r)
+{
+	struct item_state *istate;
+	struct item ref;
+	bool active;
+	uint32_t state;
+
+	istate = state_find_item_state(r, 0, 0, true);
+	if (!istate) {
+		ti->stats[STAT_FIND_BUSY_G]++;
+		return;
+	}
+
+	state = istate->state;
+	assertf(state == (ONLIST | FIND) || state == (OFFLIST | FIND), "%dST", (int)state);
+	active = istate->state == (ONLIST | FIND);
+
+	assertf(active == !!istate->active, "istate=%p val=%u state=%dST active=%p", istate,
+		istate->val, (int)istate->state, istate->active);
+
+	memset(&ref, 0xcc, sizeof(ref));
+	ref.item.hashval = istate->hashval;
+	ref.val = istate->val;
+
+	struct atomhash_item *ret;
+
+	set_what(STAT_FIND);
+	ret = atomhash_get(head, &ref.item, istate->hashval, icmp);
+	set_what(STAT_FIND | STAT_AUX);
+
+	struct item *reti = container_of_null(ret, struct item, item);
+
+	assertf(active ? (reti == istate->active) : (reti == NULL),
+		"istate=%p val=%u active=%p ret=%p", istate, istate->val, istate->active, reti);
+
+	ti->stats[STAT_FIND_DONE]++;
+	if (!active)
+		ti->stats[STAT_FIND_NEG]++;
+	assert_statechg(istate, state, state & ~FIND, "val=%u", istate->val);
+}
+
+#define FAKE_OP_COUNT (n_items / 12)
+/*
+ * this is specifically designed to test lazy insertion array updates
+ */
+static void test_grow_fake_add(struct thread_info *ti, unsigned int r)
+{
+	size_t have_add, n_add = FAKE_OP_COUNT;
+	struct item_state *istates[n_add];
+	struct item *items[n_add];
+
+	size_t have_del, n_del = FAKE_OP_COUNT;
+	struct item_state *istadel[n_del];
+
+	size_t prev_idx = r;
+	struct atomhash_array *array, *old;
+	uint_fast32_t level;
+	size_t n;
+
+	level = atomic__load(&head->level_hint, memory_order_relaxed);
+	if (level == 0) {
+		ti->stats[STAT_GROW_FADD_EMPTY]++;
+		return;
+	}
+
+	for (have_add = 0; have_add < n_add; have_add++) {
+		istates[have_add] = state_find_item_state(prev_idx, OFFLIST, ADDING, false);
+		if (!istates[have_add]) {
+			ti->stats[STAT_GROW_FADD_SKIPPED]++;
+			prev_idx += RETRY_STATE;
+			continue;
+		}
+		prev_idx = istates[have_add] - item_states;
+
+		items[have_add] = thread_find_item_state(ti, OFFLIST, ADDING);
+		if (!items[have_add]) {
+			assert_statechg(istates[have_add], ADDING, OFFLIST, "");
+			istates[have_add] = NULL;
+			ti->stats[STAT_GROW_FADD_BUSY_L]++;
+			continue;
+		}
+	}
+
+	for (have_del = 0; have_del < n_del; have_del++) {
+		istadel[have_del] = state_find_item_state(prev_idx, ONLIST, REMOVING, false);
+		if (!istadel[have_del]) {
+			ti->stats[STAT_GROW_FADD_SKIPDEL]++;
+			prev_idx += RETRY_STATE;
+			continue;
+		}
+		prev_idx = istadel[have_del] - item_states;
+
+		assert_statechg(istadel[have_del]->active, ONLIST, REMOVING, "");
+	}
+
+	level = ((r >> 16) % level) + 1;
+
+	n = level_size(level);
+
+	array = XCALLOC(MTYPE_ATOMHASH_TABLE, sizeof(array->stubs[0]) * n);
+	old = level_ptr(
+		atomic__exchange(&head->levels[level], atomptr_i(array), memory_order_acq_rel));
+
+	for (size_t i = 0; i < have_add || i < have_del; i++) {
+		struct item_state *istate = istates[i];
+		struct item *item = items[i];
+
+		if (i < have_add && istate) {
+			struct atomhash_item *ret, *ai;
+
+			ai = &item->item;
+			item->val = istate->val;
+			ai->hashval = istate->hashval;
+
+			set_what(STAT_GROW_FADD);
+			ret = atomhash_add(head, ai, icmp);
+			set_what(STAT_GROW_FADD | STAT_AUX);
+
+			assert(!ret);
+			istate->active = item;
+
+			assert_statechg(item, ADDING, ONLIST, "val=%u", item->val);
+			assert_statechg(istate, ADDING, ONLIST, "val=%u", istate->val);
+		}
+
+		istate = istadel[i];
+		if (i < have_del && istate) {
+			struct atomhash_item *ai;
+
+			item = istate->active;
+			ai = &item->item;
+
+			set_what(STAT_GROW_FADD);
+			atomhash_del(head, ai);
+			set_what(STAT_GROW_FADD | STAT_AUX);
+
+			istate->active = NULL;
+			mark_del(item);
+
+			assert_statechg(item, REMOVING, OFFLIST, "val=%u", item->val);
+			assert_statechg(istate, REMOVING, OFFLIST, "val=%u", istate->val);
+		}
+	}
+
+	if (old) {
+		atomic_fetch_add_explicit(&head->inflight_shrinks, 1, memory_order_relaxed);
+		atomhash_teardown_actual(head, old, level);
+	} else
+		ti->stats[STAT_GROW_FADD_NEWLVL]++;
+
+	ti->stats[STAT_GROW_FADD_DONE]++;
+}
+
+struct test_action {
+	float chance;
+	const char *name;
+	int stat_flag;
+	void (*func)(struct thread_info *ti, unsigned int r);
+	uint32_t chance_u32;
+};
+
+/* clang-format off */
+static struct test_action actions[] = {
+	{  4,     "check",     STAT_CHECK,     test_check },
+	{  0.5,   "iter",      STAT_ITER,      test_iter },
+	{  0.010, "grow_real", STAT_GROW,      test_grow_real },
+	{  0.005, "grow_fake", STAT_GROW_FAKE, test_grow_fake },
+	{  0.002, "grow_fadd", STAT_GROW_FADD, test_grow_fake_add },
+	{  0.023, "shrink",    STAT_SHRINK,    test_shrink },
+	{ 18,     "add",       STAT_ADD,       test_add },
+	{ 18,     "del",       STAT_DEL,       test_del },
+	{  5,     "addcol",    STAT_ADDCOL,    test_addcol },
+	{ 56,     "find",      STAT_FIND,      test_find },
+};
+/* clang-format on */
+
+/* *synchronous* stop */
+static seqlock_ctr_t sync_seq_expect = SEQLOCK_STARTVAL;
+static struct seqlock sync_seq;
+
+/* *asynchronous* stop (SIGUSR1) */
+static seqlock_ctr_t async_seq_expect = SEQLOCK_STARTVAL;
+static struct seqlock async_seq;
+
+static sigset_t usr1_set;
+
+static void sigusr1(int sig)
+{
+	seqlock_val_t wait_seq = atomic_load_explicit(&async_seq_expect, memory_order_relaxed);
+
+	if (!thread_info) {
+		fprintf(stderr, "SIGUSR1: no thread info!\n\n\n");
+		return;
+	}
+
+	clock_gettime(CLOCK_MONOTONIC, &thread_info->stop_since);
+	atomic_store_explicit(&thread_info->stopped, true, memory_order_relaxed);
+
+	seqlock_acquire_val(&thread_info->run_lock, wait_seq + SEQLOCK_INCR);
+	seqlock_wait(&async_seq, wait_seq);
+
+	atomic_store_explicit(&thread_info->stopped, false, memory_order_relaxed);
+}
+
+static void thread_prio_down(void)
+{
+#ifdef linux
+	long tid = -1;
+
+	tid = syscall(__NR_gettid);
+	setpriority(PRIO_PROCESS, tid, 10);
+#endif
+}
+
+static void *thread_func(void *arg)
+{
+	struct thread_info *ti = thread_info = arg;
+	long thread_num = ti->thread_num;
+	size_t i, j;
+	seqlock_val_t sync_seq_do;
+	/* had cacheline pingpong problems with these */
+	enum slow_level slow_loop_l = slow_loop;
+	unsigned int slow_loop_freq_l = slow_loop_freq;
+	unsigned int rcu_freq_l = rcu_freq;
+
+	seqlock_init(&ti->run_lock);
+	seqlock_acquire_val(&ti->run_lock, SEQLOCK_STARTVAL);
+	ti->amop_journal = amop_setup();
+
+	rcu_thread_start(ti->rt);
+	rcu_assert_read_locked();
+
+	/* make the RCU thread run preferentially before this */
+	thread_prio_down();
+
+	prng = prng_new(0xcafef00d * (thread_num + 2342) + prng_seed);
+
+	rcu_read_unlock();
+	pthread_sigmask(SIG_UNBLOCK, &usr1_set, NULL);
+	sem_post(&ti->start_lock);
+
+	sync_seq_do = atomic_load_explicit(&sync_seq_expect, memory_order_relaxed);
+	seqlock_wait(&sync_seq, sync_seq_do);
+
+	set_what(STAT_NONE | STAT_AUX);
+
+	for (i = 0; i < itercount; i++) {
+		seqlock_val_t sync_seq_next;
+
+		if (freq_apply(i, rcu_freq_l)) {
+			rcu_read_lock();
+			rcu_bump_dummy();
+			rcu_read_unlock();
+		}
+
+		sync_seq_next = atomic_load_explicit(&sync_seq_expect, memory_order_relaxed);
+		if (sync_seq_next != sync_seq_do) {
+			sync_seq_do = sync_seq_next;
+			seqlock_wait(&sync_seq, sync_seq_do);
+		}
+
+		/* NB: range is only 0..2^31 */
+		uint32_t action = prng_rand(prng);
+
+		rcu_read_lock();
+		for (j = 0; j < array_size(actions); j++) {
+			if (action < actions[j].chance_u32) {
+				ti->stats[actions[j].stat_flag]++;
+				set_what(actions[j].stat_flag | STAT_AUX);
+				actions[j].func(ti, prng_rand(prng));
+				set_what(STAT_NONE | STAT_AUX);
+				break;
+			}
+			action -= actions[j].chance_u32;
+		}
+		rcu_read_unlock();
+
+		atomic_store(&ti->pos, i);
+
+		if (unlikely(slow_loop_l != SLOW_NONE && freq_apply(i, slow_loop_freq_l)))
+			slowdown(slow_loop_l);
+
+		if (atomic_load_explicit(&ctl_c, memory_order_relaxed))
+			goto out_cancel;
+	}
+
+	atomic_store(&ti->pos, ~0ULL);
+
+out_cancel:
+	prng_free(prng);
+
+	pthread_sigmask(SIG_BLOCK, &usr1_set, NULL);
+
+	seqlock_release(&ti->run_lock);
+	return NULL;
+}
+
+static void hijack_atomhash_unlink_level(struct rcu_atomhash_shrink *arg)
+{
+	atomic_store_explicit(&rcu_thread_info.what, STAT_RCU_SHRINK_UNLINK, memory_order_relaxed);
+	atomhash_unlink_level(arg);
+	atomic_store_explicit(&rcu_thread_info.what, STAT_RCU_IDLE | STAT_AUX,
+			      memory_order_relaxed);
+}
+
+static void hijack_atomhash_free_level(struct rcu_atomhash_shrink *arg)
+{
+	atomic_store_explicit(&rcu_thread_info.what, STAT_RCU_SHRINK_FREE, memory_order_relaxed);
+	atomhash_free_level(arg);
+	atomic_store_explicit(&rcu_thread_info.what, STAT_RCU_IDLE | STAT_AUX,
+			      memory_order_relaxed);
+}
+
+static struct amop_journal *rcu_amop_journal, *main_amop_journal;
+
+struct rcu_prng {
+	struct rcu_head rcu;
+	int close_fd;
+};
+
+static void rcu_set_prng(struct rcu_prng *rcu)
+{
+	thread_info = &rcu_thread_info;
+	thread_info->pt = pthread_self();
+	thread_info->thread_num = -1;
+	seqlock_init(&thread_info->run_lock);
+	seqlock_acquire_val(&thread_info->run_lock, SEQLOCK_STARTVAL);
+
+	pthread_sigmask(SIG_UNBLOCK, &usr1_set, NULL);
+
+	is_rcu_thread = true;
+	rcu_amop_journal = amop_setup();
+	prng = prng_new(0xf00ba75f + prng_seed);
+	close(rcu->close_fd);
+}
+
+static void rcu_prepare(void)
+{
+	struct rcu_prng rcu_prng;
+	int prngpipe[2];
+	char dummy;
+
+	/* force RCU start */
+	rcu_thread_unprepare(rcu_thread_prepare());
+
+	rcu_assert_read_locked();
+
+	pipe(prngpipe);
+	rcu_prng.close_fd = prngpipe[1];
+	rcu_call(rcu_set_prng, &rcu_prng, rcu);
+
+	rcu_read_unlock();
+
+	read(prngpipe[0], &dummy, 1);
+	close(prngpipe[0]);
+
+	rcu_read_lock();
+}
+
+static uint32_t rcu_seqno_in;
+static atomic uint32_t rcu_seqno_out;
+
+struct rcu_ping {
+	struct rcu_head head;
+	uint32_t seqno;
+};
+
+static void rcu_ping_fn(struct rcu_ping *ping)
+{
+	atomic_store_explicit(&rcu_seqno_out, ping->seqno, memory_order_relaxed);
+	XFREE(MTYPE_TMP, ping);
+}
+
+struct coloritem {
+	unsigned long long maxval;
+	const char *color;
+} delta_colors[] = {
+	{ 62, "\033[95m" },
+	{ 30, "\033[91m" },
+	{ 14, "\033[93m" },
+	{ 6, "\033[92m" },
+	{ 2, "\033[96m" },
+	{ 0, "\033[97m" },
+}, qlen_colors[] = {
+	{ 151875, "\033[95m" },
+	{ 10125, "\033[91m" },
+	{ 675, "\033[93m" },
+	{ 45, "\033[92m" },
+	{ 3, "\033[96m" },
+	{ 0, "\033[97m" },
+};
+
+static const char *colorize(const struct coloritem *table, unsigned long long value)
+{
+	const struct coloritem *i;
+
+	for (i = table; i->color; i++)
+		if (value >= i->maxval)
+			break;
+	return i->color;
+}
+
+static useconds_t sampler_interval = 100;
+static size_t sample_stats[array_size(stats_names)];
+static size_t sample_stats_aux[array_size(stats_names)];
+static size_t stop_check_rate = 10;
+
+struct sampler_args {
+	long n_threads;
+	struct thread_info *threads;
+};
+
+struct stop_stats {
+	union {
+		struct {
+			size_t total;
+			size_t ul_through_list;
+			size_t ul_off_list;
+			size_t ul_off_list_outdated;
+			size_t items_shrinking;
+			size_t items_deleted;
+		};
+		size_t vals[6];
+	};
+};
+static struct stop_stats stop_stats;
+
+#define trace(...)                                                                                \
+	do {                                                                                      \
+	} while (0)
+
+static void stop_check_inner(void)
+{
+	struct itemstates_head heap[1];
+	struct item_state *stateref;
+	struct atomhash_item *levels[array_size(head->levels)];
+	struct atomhash_item *levels_end[array_size(head->levels)];
+	uint32_t levels_hval[array_size(head->levels)];
+	size_t level_limit = 0;
+
+	struct atomhash_item *pos;
+	uint32_t hashval = 0;
+	struct stop_stats stats = { .total = 1 };
+
+	if (!head->levels[0])
+		return;
+
+	itemstates_init(heap);
+	for (size_t i = 0; i < n_items; i++)
+		itemstates_add(heap, &item_states[i]);
+
+	stateref = itemstates_pop(heap);
+
+	atomic_thread_fence(memory_order_acquire);
+
+	for (size_t i = 0; i < array_size(head->levels); i++) {
+		struct atomhash_array *array = level_ptr(head->levels[i]);
+
+		if (array) {
+			levels[i] = &array->stubs[0];
+			levels_end[i] = levels[i] + level_size(i);
+			levels_hval[i] = i ? (1 << (32 - ATOMHASH_LOWEST_BITS - i)) : 0;
+			level_limit = i + 1;
+
+			assertf(levels[i]->next == ATOMPTR_NULL || atomptr_u(levels[i]->next),
+				"i=%zu levels[i]=%p levels[i]->next=%#tx", i, levels[i],
+				levels[i]->next);
+		} else
+			levels[i] = levels_end[i] = NULL;
+	}
+
+	for (pos = levels[0]; pos != head->sentinel_end; pos = atomptr_p(pos->next)) {
+		bool lvl_found = false;
+		uint32_t hash_inc = 1 << (32 - ATOMHASH_LOWEST_BITS);
+
+		assertf(pos->hashval >= hashval && pos->next, "pos=%pAI", pos);
+		hashval = pos->hashval;
+
+		for (size_t i = 0; i < level_limit; i++) {
+			while (levels[i] && pos != levels[i] && hashval > levels_hval[i]) {
+				if (levels[i]->next != ATOMPTR_NULL) {
+					struct atomhash_item *check;
+
+					assertf(atomptr_is_ul(levels[i]->next), "i=%zu", i);
+
+					check = levels[i];
+					while (check != pos) {
+						check = atomptr_p(check->next);
+
+						assert(check);
+						if (check == head->sentinel_end)
+							break;
+						if (check->hashval > hashval)
+							break;
+					}
+
+					if (check != pos)
+						stats.ul_off_list_outdated++;
+					else
+						stats.ul_off_list++;
+				}
+
+				levels[i]++;
+				levels_hval[i] += hash_inc;
+				if (levels[i] == levels_end[i]) {
+					levels[i] = NULL;
+					assert(levels_hval[i] < (1 << (32 - ATOMHASH_LOWEST_BITS)));
+				}
+			}
+			if (i)
+				hash_inc >>= 1;
+		}
+
+		while (stateref && stateref->hashval < hashval) {
+			assertf((stateref->state & 3) != ONLIST, "stateref=%pIS pos=%pAI",
+				stateref, pos);
+
+			trace("\033[90mskip over %pIS\033[m\n", stateref);
+			stateref = itemstates_pop(heap);
+		}
+
+		if (!atomptr_u(pos->next)) {
+			/* normal item */
+			struct item *positem;
+
+			if (atomptr_l(pos->next)) {
+				stats.items_deleted++;
+				trace("deleting  %pAI\n", pos);
+				continue;
+			}
+
+			positem = container_of(pos, struct item, item);
+			trace("item >>>> %pIT\n", positem);
+
+			assertf((positem->state & 3) != OFFLIST, "%pIT", positem);
+			assert(stateref);
+
+			while (stateref->hashval < hashval ||
+			       (stateref->hashval == hashval && stateref->val < positem->val)) {
+				assertf((stateref->state & 3) != ONLIST, "stateref=%pIS pos=%pIT",
+					stateref, positem);
+
+				trace("skip over %pIS\n", stateref);
+				stateref = itemstates_pop(heap);
+				assert(stateref);
+			}
+
+			assertf(stateref->hashval == hashval && stateref->val == positem->val,
+				"stateref=%pIS pos=%pIT", stateref, positem);
+			assertf((stateref->state & 3) != OFFLIST, "stateref=%pIS pos=%pIT",
+				stateref, positem);
+			trace("\033[90m^ matches %pIS\033[m\n", stateref);
+
+			for (size_t i = 0; i < level_limit; i++)
+				assertf(!levels[i] || hashval <= levels_hval[i],
+					"%pAI hashval=%08x>%08x", levels[i], hashval,
+					levels_hval[i]);
+
+			stateref = itemstates_pop(heap);
+			continue;
+		}
+
+		trace("stub >>>> %pAI\n", pos);
+
+		hash_inc = 1 << (32 - ATOMHASH_LOWEST_BITS);
+
+		for (size_t i = 0; i < level_limit; i++) {
+			if (levels[i] == pos) {
+				assert(levels[i]->next != ATOMPTR_NULL);
+				assert(levels[i]->hashval == levels_hval[i]);
+				lvl_found = true;
+
+				assertf(levels[i]->hashval >= hashval && atomptr_u(levels[i]->next),
+					"i=%zu levels[i]=%p ->hashval=%08x ->next=%#tx", i,
+					levels[i], levels[i]->hashval, levels[i]->next);
+
+				if (atomptr_l(levels[i]->next))
+					stats.ul_through_list++;
+
+				levels[i]++;
+				levels_hval[i] += hash_inc;
+				if (levels[i] == levels_end[i]) {
+					levels[i] = NULL;
+					assert(levels_hval[i] < (1 << (32 - ATOMHASH_LOWEST_BITS)));
+				}
+				continue;
+			}
+
+			if (i)
+				hash_inc >>= 1;
+		}
+		if (!lvl_found)
+			stats.items_shrinking++;
+	}
+
+	for (size_t j = 0; j < array_size(stop_stats.vals); j++)
+		stop_stats.vals[j] += stats.vals[j];
+}
+
+static void stop_check(struct thread_info *threads, long n_threads)
+{
+	seqlock_val_t wait_seq = atomic_load_explicit(&async_seq_expect, memory_order_relaxed);
+	struct thread_info *stop_order[n_threads + 1];
+
+	for (long i = 0; i < n_threads; i++)
+		stop_order[i] = threads + i;
+
+	prng_permute(prng, (void **)stop_order, array_size(stop_order) - 1);
+	stop_order[n_threads] = &rcu_thread_info;
+
+	for (size_t i = 0; i < array_size(stop_order); i++)
+		pthread_kill(stop_order[i]->pt, SIGUSR1);
+	for (size_t i = 0; i < array_size(stop_order); i++)
+		seqlock_wait(&stop_order[i]->run_lock, wait_seq);
+
+	stop_check_inner();
+	async_seq_expect = seqlock_bump(&async_seq);
+}
+
+static void *sampler_func(void *arg)
+{
+	struct sampler_args *sa = arg;
+	size_t si = 0;
+
+	async_seq_expect = SEQLOCK_STARTVAL;
+	seqlock_init(&async_seq);
+	seqlock_acquire_val(&async_seq, SEQLOCK_STARTVAL);
+
+	prng = prng_new(0x42231337 + prng_seed);
+	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+
+	for (long i = 0; i < sa->n_threads; i++)
+		sem_wait(&sa->threads[i].start_lock);
+
+	do {
+		usleep(sampler_interval);
+		pthread_testcancel();
+
+		for (long i = 0; i < sa->n_threads; i++) {
+			size_t pos, what;
+
+			pos = atomic_load_explicit(&sa->threads[i].pos, memory_order_relaxed);
+			if (pos == 0 || pos == ~0ULL)
+				continue;
+
+			what = atomic_load_explicit(&sa->threads[i].what, memory_order_relaxed);
+			if (what & STAT_AUX)
+				sample_stats_aux[what & ~STAT_AUX]++;
+			else
+				sample_stats[what]++;
+		}
+
+		int rcu_what = atomic_load_explicit(&rcu_thread_info.what, memory_order_relaxed);
+
+		sample_stats_aux[STAT_RCU_SAMPLES]++;
+		if (rcu_what & STAT_AUX)
+			sample_stats_aux[rcu_what & ~STAT_AUX]++;
+		else
+			sample_stats[rcu_what]++;
+
+		if (stop_check_rate && !(si % stop_check_rate)) {
+			pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+			stop_check(sa->threads, sa->n_threads);
+			pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+		}
+		si++;
+	} while (1);
+
+	return NULL;
+}
+
+static void mt_tests(long n_threads, size_t levels_init)
+{
+	pthread_t sampler_thread;
+	struct thread_info threads[n_threads];
+	size_t total = n_threads * itercount;
+	size_t prev_done, speed;
+	long n_busy;
+	size_t lvl_hist[10] = {};
+	size_t lvl_hist_pos = 0;
+	pthread_attr_t pt_attr;
+	struct sched_param sp = {
+		.sched_priority = 10,
+	};
+	seqlock_val_t sync_seq_at;
+	bool stopped = false;
+	struct timespec stop_t = {};
+
+	levels_min = MAX(lrint(log2(n_items) - 3.5 - 4), 0);
+	levels_max = lrint(log2(n_items) + 2.5 - 4);
+
+	printf("levels_min=%zu, levels_max=%zu\n\n\n", levels_min, levels_max);
+
+	atomhash_init(head);
+	head->freeze_size = true;
+
+	main_amop_journal = amop_setup();
+
+	atomhash_setup_level0(head);
+	for (size_t i = 1; i <= levels_init; i++)
+		atomhash_setup_level(head, i, ATOMPTR_NULL);
+
+	pthread_attr_init(&pt_attr);
+	pthread_attr_setschedparam(&pt_attr, &sp);
+
+	seqlock_init(&sync_seq);
+	seqlock_acquire_val(&sync_seq, SEQLOCK_STARTVAL);
+
+	memset(threads, 0, sizeof(threads));
+
+	for (long i = 0; i < n_threads; i++) {
+		threads[i].thread_num = i;
+		sem_init(&threads[i].start_lock, 0, 0);
+		seqlock_init(&threads[i].run_lock);
+		seqlock_acquire_val(&threads[i].run_lock, SEQLOCK_STARTVAL);
+		thread_setup_items(&threads[i]);
+		threads[i].rt = rcu_thread_prepare();
+		pthread_create(&threads[i].pt, NULL, &thread_func, &threads[i]);
+	}
+
+	struct sampler_args sa = {
+		.n_threads = n_threads,
+		.threads = threads,
+	};
+	if (sampler_interval)
+		pthread_create(&sampler_thread, NULL, sampler_func, &sa);
+
+	pthread_attr_destroy(&pt_attr);
+
+	usleep(10);
+	sync_seq_at = seqlock_bump(&sync_seq);
+
+	printf("\n");
+	prev_done = speed = 0;
+	do {
+		struct timespec t;
+		size_t done;
+		struct rusage ru;
+		struct rcu_stats rcudbg;
+		struct rcu_ping *rcu_ping = XMALLOC(MTYPE_TMP, sizeof(*rcu_ping));
+		char stopbuf[96];
+		struct fbuf fb_stopped = { .buf = stopbuf, .pos = stopbuf, .len = sizeof(stopbuf) };
+
+		if (atomic_load(&rcu_thread_info.stopped))
+			bprintfrr(&fb_stopped, " async-stop:[RCU:%pTSMs",
+				  &rcu_thread_info.stop_since);
+
+		n_busy = 0;
+		done = 0;
+		for (long i = 0; i < n_threads; i++) {
+			size_t pos = atomic_load(&threads[i].pos);
+
+			if (pos != ~0ULL) {
+				n_busy++;
+				done += pos;
+			} else
+				done += itercount;
+
+			if (atomic_load(&threads[i].stopped)) {
+				if (fb_stopped.pos != fb_stopped.buf)
+					bputs(&fb_stopped, ", ");
+				else
+					bputs(&fb_stopped, " async-stop:[");
+				FMT_NSTD(bprintfrr(&fb_stopped, "%ld:%.3pTSMsd", i,
+						   &threads[i].stop_since));
+			}
+		}
+		if (fb_stopped.pos != fb_stopped.buf)
+			bputs(&fb_stopped, "]");
+
+		uint_fast32_t level_hint = atomic_load_explicit(&head->level_hint,
+								memory_order_relaxed);
+
+		lvl_hist[lvl_hist_pos++] = level_hint;
+		if (lvl_hist_pos == array_size(lvl_hist))
+			lvl_hist_pos = 0;
+
+		size_t lvl_min = SIZE_MAX, lvl_max = 0, lvl_sum = 0;
+
+		for (size_t i = 0; i < array_size(lvl_hist); i++) {
+			lvl_min = MIN(lvl_min, lvl_hist[i]);
+			lvl_max = MAX(lvl_max, lvl_hist[i]);
+			lvl_sum += lvl_hist[i];
+		}
+
+		float avglvl = lvl_sum / (float)array_size(lvl_hist);
+
+		clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t);
+		getrusage(RUSAGE_SELF, &ru);
+
+		speed *= 31;
+		speed += (done - prev_done) * 5;
+		speed /= 32;
+
+		rcu_stats(&rcudbg);
+
+		char stop_state[64] = "";
+
+		if (stopped)
+			FMT_NSTD(snprintfrr(stop_state, sizeof(stop_state),
+					    " \033[91;1m[stop %.3pTSMsd]\033[m", &stop_t));
+
+		const char *delta_color = colorize(delta_colors, MAX(0, rcudbg.seq_delta));
+		const char *qlen_color = colorize(qlen_colors, rcudbg.qlen);
+		unsigned int inflight_shrinks = atomic_load_explicit(&head->inflight_shrinks,
+								     memory_order_relaxed);
+
+		printfrr("\033[2A%4ld.%03ld %10zu/%10zu %7zu/s (%5.1f%%) lvl[%zu,%.1f(=%.0f),%zu -%u inflight], %ld busy, maxrss=%7zu, RCU %u%s%+d\033[m/%zu/c%zu%sq%zu\033[m (%u)%pFB%s\033[K\n",
+			 (long)t.tv_sec, (long)t.tv_nsec / 1000000, done, total, speed,
+			 done * 100. / total, lvl_min, avglvl, powf(2.0, 3.0 + avglvl), lvl_max,
+			 inflight_shrinks, n_busy, (size_t){ ru.ru_maxrss }, rcudbg.seq_head,
+			 delta_color, rcudbg.seq_delta, rcudbg.holding, rcudbg.completed,
+			 qlen_color, rcudbg.qlen, rcu_seqno_in - rcu_seqno_out, &fb_stopped,
+			 stop_state);
+		printfrr("U,L on-list: %6zu  off-list: %6zu  off-outdated: %6zu  shrinking: %6zu  deleted: %6zu\033[K\n",
+			 stop_stats.ul_through_list, stop_stats.ul_off_list,
+			 stop_stats.ul_off_list_outdated, stop_stats.items_shrinking,
+			 stop_stats.items_deleted);
+
+		if (rcudbg.qlen > 2000 && !stopped) {
+			atomic_store_explicit(&sync_seq_expect, sync_seq_at, memory_order_relaxed);
+			clock_gettime(CLOCK_MONOTONIC, &stop_t);
+			stopped = true;
+			printf("\n");
+		}
+		if (rcudbg.qlen < 10 && stopped) {
+			sync_seq_at = seqlock_bump(&sync_seq);
+			stopped = false;
+			printf("\n");
+		}
+		fflush(stdout);
+
+		rcu_ping->seqno = ++rcu_seqno_in;
+		rcu_call(rcu_ping_fn, rcu_ping, head);
+		rcu_read_unlock();
+		usleep(100 * 1000);
+		rcu_read_lock();
+
+		prev_done = done;
+	} while (n_busy && !atomic_load_explicit(&ctl_c, memory_order_relaxed));
+
+	seqlock_release(&sync_seq);
+
+	size_t stats[array_size(stats_names)] = {};
+	size_t total_done = 0, total_samples = 0;
+	size_t pos;
+
+	printf("\r%s\033[K\n", ctl_c ? "interrupted" : "done");
+
+	if (sampler_interval) {
+		pthread_cancel(sampler_thread);
+		pthread_join(sampler_thread, NULL);
+	}
+
+	for (long i = 0; i < n_threads; i++) {
+		pthread_join(threads[i].pt, NULL);
+
+		pos = atomic_load(&threads[i].pos);
+
+		total_done += (pos != ~0ULL) ? pos : itercount;
+
+		for (size_t j = 0; j < array_size(stats_names); j++)
+			stats[j] += threads[i].stats[j];
+	}
+
+	for (size_t j = 0; j < array_size(sample_stats); j++)
+		total_samples += sample_stats[j] + sample_stats_aux[j];
+
+	size_t sample_sum = 0, rel_sum = 0;
+
+	printf(" ------- event ------- ");
+	if (sampler_interval)
+		printf("-- cpu/time --- ");
+	printf("----- description -----\n");
+	printf("    count     share     ");
+	if (sampler_interval)
+		printf("  hash    test  ");
+	printf("\n");
+	for (size_t j = 0; j < array_size(stats_names); j++) {
+		const char *pre = stats_is_base[j] ? "" : stats_is_base[j + 1] ? "   └─" : "   ├─";
+		const char *post = stats_is_base[j] ? "     " : "";
+
+		if (stats_is_base[j]) {
+			sample_sum = total_samples;
+			if (j < STAT_RCU_SAMPLES)
+				sample_sum = total_samples / n_threads;
+			rel_sum = total_done;
+		}
+
+		float this_stat = stats[j] / (float)rel_sum;
+		const char *cc = "";
+
+		switch (j) {
+		case STAT_FIND_NEG:
+			this_stat = 1.0 - fabs(this_stat - 0.5) * 3;
+			fallthrough;
+		case STAT_ADD_DONE:
+		case STAT_ADDCOL_DONE:
+		case STAT_DEL_DONE:
+			if (this_stat >= 0.985)
+				cc = "\033[36m";
+			else if (this_stat >= 0.97)
+				cc = "\033[32m";
+			else if (this_stat >= 0.955)
+				cc = "\033[33m";
+			else
+				cc = "\033[31m";
+			break;
+		}
+
+		if (!stat_has_counters(j))
+			printf("%23s", "");
+		else
+			printf("%9zu %s%s%6.2f%%\033[m%s ", stats[j], pre, cc,
+			       100. * stats[j] / (float)rel_sum, post);
+
+		if (sampler_interval) {
+			if (sample_stats[j])
+				printf("%6.2f%% ", 100. * sample_stats[j] / (float)sample_sum);
+			else
+				printf("%8s", "");
+			if (sample_stats_aux[j])
+				printf("%6.2f%% ", 100. * sample_stats_aux[j] / (float)sample_sum);
+			else
+				printf("%8s", "");
+		}
+
+		printf("%s\n", stats_names[j]);
+
+		if (stats_is_base[j]) {
+			sample_sum = sample_stats[j] + sample_stats_aux[j];
+			rel_sum = stats[j];
+		}
+	}
+	printf("%9zd %*stotal grow - shrink\n",
+	       stats[STAT_GROW_DONE] + stats[STAT_GROW_FAKE_DONE] + stats[STAT_GROW_FADD_NEWLVL] -
+		       stats[STAT_SHRINK_DONE],
+	       sampler_interval ? 29 : 13, "");
+
+	if (ctl_c)
+		printf("\033[93mTEST INTERRUPTED\033[m\n");
+	else
+		printf("\033[92mTEST PASSED\033[m\n");
+}
+
+void _zlog_assert_failed(const struct xref_assert *xref, const char *extra, ...)
+{
+	va_list ap;
+	static bool in_assert;
+	int cc = ctl_c ? 33 : 31;
+
+	if (ctl_c)
+		printfrr("\033[97;1massertion failure after interrupt may be random\033[m\n");
+
+	if (extra) {
+		struct va_format vaf;
+
+		va_start(ap, extra);
+		vaf.fmt = extra;
+		vaf.va = &ap;
+
+		printfrr("\033[%dm%s:%d: %s(): assert(\033[%d;1m%s\033[%d;22m) failed, extra info: \033[97m%pVA\033[m\n",
+			 cc, xref->xref.file, xref->xref.line, xref->xref.func, cc + 60,
+			 xref->expr, cc, &vaf);
+
+		va_end(ap);
+	} else
+		printfrr("\033[%dm%s:%d: %s(): assert(\033[%d;1m%s\033[%d;4m) failed\033[m\n", cc,
+			 xref->xref.file, xref->xref.line, xref->xref.func, cc + 60, xref->expr,
+			 cc);
+
+	if (ctl_c)
+		pthread_exit(NULL);
+	if (!in_assert) {
+		in_assert = true;
+		printfrr("running consistency check...\n");
+		test_check(NULL, 0);
+		printfrr("\033[33mconsistency check passed, #UL=%zu\033[m\n", n_ul);
+	} else {
+		printfrr("\033[31mconsistency check FAILED\033[m\n");
+	}
+
+	abort();
+}
+
+static void sigint(int signo)
+{
+	atomic_store_explicit(&ctl_c, 1, memory_order_relaxed);
+	signal(SIGINT, SIG_DFL);
+}
+
+/* option processing */
+
+static unsigned long long si_num(const char *arg)
+{
+	char *endp = NULL;
+	unsigned long long num = strtoul(arg, &endp, 0);
+
+	if (!*arg || endp == arg) {
+		fprintf(stderr, "invalid number: \"%s\"\n", arg);
+		exit(2);
+	}
+	while (*endp) {
+		switch (*endp) {
+		case 'k':
+			num *= 1000;
+			break;
+		case 'M':
+			num *= 1000000;
+			break;
+		case 'G':
+			num *= 1000000000;
+			break;
+		default:
+			fprintf(stderr, "invalid number: \"%s\"\n", arg);
+			exit(2);
+		}
+		endp++;
+	}
+
+	return num;
+}
+
+static void handle_slow_opt(enum slow_level *dst, const char *arg)
+{
+	for (unsigned int i = 0; i < array_size(slow_names); i++) {
+		if (strcmp(slow_names[i], arg))
+			continue;
+
+		*dst = i;
+		return;
+	}
+
+	fprintf(stderr, "invalid slowdown option \"%s\"\n", arg);
+	exit(2);
+}
+
+static intmax_t opt_num(const char *arg, intmax_t min, intmax_t max)
+{
+	char *endp = NULL;
+	intmax_t val;
+
+	errno = 0;
+	val = strtoimax(arg, &endp, 0);
+	if (!*arg || (endp && *endp) || errno) {
+		fprintf(stderr, "invalid number: \"%s\"\n", arg);
+		exit(2);
+	}
+	if (val < min || val > max) {
+		fprintf(stderr, "value %jd out of range [%jd,%jd]\n", val, min, max);
+		exit(2);
+	}
+
+	return val;
+}
+
+enum {
+	OPTION_NO_MMAP = 1000,
+	OPTION_SLOW_LOOP,
+	OPTION_SLOW_LOOP_FREQ,
+#ifdef TEST_HIJACK_ATOMICS
+	OPTION_SLOW_GENERAL_RD,
+	OPTION_SLOW_GENERAL_OP,
+	OPTION_SLOW_RESIZE_RD,
+	OPTION_SLOW_RESIZE_OP,
+	OPTION_SLOW_GENERAL,
+	OPTION_SLOW_RESIZE,
+	OPTION_SLOW_RD,
+	OPTION_SLOW_OP,
+	OPTION_SLOW,
+#endif
+	OPTION_POISON_FREQ,
+	OPTION_RCU_FREQ,
+	OPTION_SAMPLER_USEC,
+	OPTION_STOP_CHECK,
+};
+
+static struct option longopts[] = {
+	{ "no-mmap", no_argument, NULL, OPTION_NO_MMAP },
+	{ "slow-loop", required_argument, NULL, OPTION_SLOW_LOOP },
+	{ "slow-loop-logn", required_argument, NULL, OPTION_SLOW_LOOP_FREQ },
+
+#ifdef TEST_HIJACK_ATOMICS
+	{ "slow-general-read", required_argument, NULL, OPTION_SLOW_GENERAL_RD },
+	{ "slow-general-oper", required_argument, NULL, OPTION_SLOW_GENERAL_OP },
+	{ "slow-resize-read", required_argument, NULL, OPTION_SLOW_RESIZE_RD },
+	{ "slow-resize-oper", required_argument, NULL, OPTION_SLOW_RESIZE_OP },
+	{ "slow-general", required_argument, NULL, OPTION_SLOW_GENERAL },
+	{ "slow-resize", required_argument, NULL, OPTION_SLOW_RESIZE },
+	{ "slow-read", required_argument, NULL, OPTION_SLOW_RD },
+	{ "slow-oper", required_argument, NULL, OPTION_SLOW_OP },
+	{ "slow", required_argument, NULL, OPTION_SLOW },
+#endif
+
+	{ "random-values", no_argument, NULL, 'r' },
+	{ "no-collisions", no_argument, NULL, 'C' },
+	{ "help", no_argument, NULL, 'h' },
+
+	/* logarithmic (2^n) options */
+	{ "poison-logn", required_argument, NULL, OPTION_POISON_FREQ },
+	{ "rcu-logn", required_argument, NULL, OPTION_RCU_FREQ },
+
+	{ "sampler-usec", required_argument, NULL, OPTION_SAMPLER_USEC },
+	{ "sampler-stop-check", required_argument, NULL, OPTION_STOP_CHECK },
+	{},
+};
+
+int main(int argc, char **argv)
+{
+	size_t levels_init = 0;
+	bool collisions = true, rand_mode = false;
+	long n_threads = 8;
+	int opt;
+	struct timespec ts;
+
+	rcu_freq = 16;
+	n_items = 250;
+
+	while ((opt = getopt_long(argc, argv, "rCn:N:t:i:l:L:Xx:h", longopts, NULL)) != -1) {
+		switch (opt) {
+		case 'h':
+			printf("You're on your own.\n");
+			break;
+
+		case OPTION_NO_MMAP:
+			mmap_mode = false;
+			break;
+
+		case OPTION_SLOW_LOOP:
+			handle_slow_opt(&slow_loop, optarg);
+			break;
+
+		case OPTION_SLOW_LOOP_FREQ:
+			slow_loop_freq = opt_num(optarg, 0, 32);
+			break;
+
+#ifdef TEST_HIJACK_ATOMICS
+		case OPTION_SLOW_GENERAL_RD:
+			handle_slow_opt(&general.rd, optarg);
+			break;
+
+		case OPTION_SLOW_GENERAL_OP:
+			handle_slow_opt(&general.op, optarg);
+			break;
+
+		case OPTION_SLOW_RESIZE_RD:
+			handle_slow_opt(&resize.rd, optarg);
+			break;
+
+		case OPTION_SLOW_RESIZE_OP:
+			handle_slow_opt(&resize.op, optarg);
+			break;
+
+		case OPTION_SLOW_GENERAL:
+			handle_slow_opt(&general.rd, optarg);
+			handle_slow_opt(&general.op, optarg);
+			break;
+
+		case OPTION_SLOW_RESIZE:
+			handle_slow_opt(&resize.rd, optarg);
+			handle_slow_opt(&resize.op, optarg);
+			break;
+
+		case OPTION_SLOW_RD:
+			handle_slow_opt(&general.rd, optarg);
+			handle_slow_opt(&resize.rd, optarg);
+			break;
+
+		case OPTION_SLOW_OP:
+			handle_slow_opt(&general.op, optarg);
+			handle_slow_opt(&resize.op, optarg);
+			break;
+
+		case OPTION_SLOW:
+			handle_slow_opt(&general.rd, optarg);
+			handle_slow_opt(&general.op, optarg);
+			handle_slow_opt(&resize.rd, optarg);
+			handle_slow_opt(&resize.op, optarg);
+			break;
+#endif /* TEST_HIJACK_ATOMICS */
+
+		case OPTION_POISON_FREQ:
+			poison_freq = opt_num(optarg, 0, 32);
+			break;
+
+		case OPTION_SAMPLER_USEC:
+			sampler_interval = opt_num(optarg, 0, LONG_MAX);
+			break;
+
+		case OPTION_STOP_CHECK:
+			stop_check_rate = opt_num(optarg, 0, LONG_MAX);
+			break;
+
+		case OPTION_RCU_FREQ:
+			rcu_freq = opt_num(optarg, 0, 32);
+			break;
+
+		case 'n':
+			n_items = si_num(optarg);
+			if (n_items > 1000)
+				fprintf(stderr,
+					"\033[91;1mWARNING: high item counts reduce the probability of race conditions!  Less is more.\033[m\n");
+			break;
+
+		case 'N':
+			thread_item_arena_size = si_num(optarg);
+			break;
+
+		case 't':
+			n_threads = opt_num(optarg, 1, LONG_MAX);
+			break;
+
+		case 'i':
+			itercount = si_num(optarg);
+			break;
+
+		case 'r':
+			rand_mode = true;
+			break;
+
+		case 'C':
+			collisions = false;
+			break;
+
+		case 'l':
+			shrink_adjust = opt_num(optarg, -3, 5);
+			break;
+
+		case 'L':
+			levels_init = opt_num(optarg, 0, 32);
+			break;
+
+		case 'x':
+			prng_seed = opt_num(optarg, 0, UINT32_MAX);
+			break;
+
+		case 'X':
+			clock_gettime(CLOCK_REALTIME, &ts);
+			prng_seed = ts.tv_nsec;
+			break;
+
+		default:
+			fprintf(stderr, "invalid option %c\n", opt);
+			exit(2);
+		}
+	}
+
+	while (optind < argc) {
+		const char *arg = argv[optind++];
+		const char *eq = strchr(arg, '=');
+		char *endp = NULL;
+		struct test_action *ta;
+
+		if (!eq || !eq[1]) {
+			fprintf(stderr, "invalid setting: %s\n", arg);
+			return 1;
+		}
+
+		for (ta = actions; ta < actions + array_size(actions); ta++)
+			if (strlen(ta->name) == (size_t)(eq - arg) &&
+			    !memcmp(ta->name, arg, eq - arg))
+				break;
+		if (ta == actions + array_size(actions)) {
+			fprintf(stderr, "invalid item: %.*s\n", (int)(eq - arg), arg);
+			return 1;
+		}
+
+		ta->chance = strtof(eq + 1, &endp);
+		if ((endp && *endp) || ta->chance < 0.0) {
+			fprintf(stderr, "invalid probability: %s\n", eq + 1);
+			return 1;
+		}
+	}
+
+	float running_sum = 0.0, u32f = 1. / (1U << 31);
+
+	for (struct test_action *ta = actions; ta < actions + array_size(actions); ta++)
+		running_sum += ta->chance;
+
+	running_sum = (1U << 31) / running_sum;
+
+	for (struct test_action *ta = actions; ta < actions + array_size(actions); ta++) {
+		ta->chance_u32 = lrint(ta->chance * running_sum);
+		printf("%9.5f%%  (%9.5f×) %s\n", 100. * u32f * ta->chance_u32, ta->chance,
+		       ta->name);
+	}
+
+	if (!thread_item_arena_size)
+		thread_item_arena_size = MAX(16384U, (1ULL << rcu_freq) * 4U);
+
+	prng = prng_new(0xcafef00d + prng_seed);
+
+	if (optind < argc) {
+		fprintf(stderr, "invalid options\n");
+		exit(2);
+	}
+
+	printf("%zu items, %zu thread item arena, %zu iterations, %lu threads, slow %s 1:%llu, RCU 1:%llu\n",
+	       n_items, thread_item_arena_size, itercount, n_threads, slow_names[slow_loop],
+	       (1ULL << slow_loop_freq), (1ULL << rcu_freq));
+#ifdef TEST_HIJACK_ATOMICS
+	printf("atomic ops slowdown: general[read: %s, oper: %s] resize[read: %s, oper: %s]\n",
+	       slow_names[general.rd], slow_names[general.op], slow_names[resize.rd],
+	       slow_names[resize.op]);
+#endif
+
+	if (posix_memalign((void **)&item_states, CACHELINESIZE, n_items * sizeof(item_states[0]))) {
+		perror("posix_memalign");
+		exit(1);
+	}
+	memset(item_states, 0, n_items * sizeof(item_states[0]));
+	for (size_t i = 0; i < n_items; i++) {
+		uint32_t val = rand_mode ? (uint32_t)prng_rand(prng) : i;
+		uint32_t hashval = jhash_1word(val, 0xd00dbabe);
+
+		if (collisions) {
+			/* force some collisions */
+			if (!(i & 0x7))
+				hashval &= 0xa8888888;
+			if (!(i & 0xf)) {
+				hashval |= hashval >> 1;
+				hashval |= (hashval >> 2) & 0x03333333;
+			}
+		}
+
+		item_states[i].val = val;
+		item_states[i].hashval = hashval;
+	}
+
+	signal(SIGINT, sigint);
+	signal(SIGUSR1, sigusr1);
+
+	sigemptyset(&usr1_set);
+	sigaddset(&usr1_set, SIGUSR1);
+	sigprocmask(SIG_BLOCK, &usr1_set, NULL);
+
+	rcu_prepare();
+	mt_tests(n_threads, levels_init);
+	rcu_shutdown();
+
+	return ctl_c ? 3 : 0;
+}

--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -20,6 +20,7 @@
 
 #include "typesafe.h"
 #include "atomlist.h"
+#include "atomhash.h"
 #include "memory.h"
 #include "monotime.h"
 #include "jhash.h"
@@ -62,6 +63,7 @@
 #define _T_RBTREE_NONUNIQ	(T_SORTED          | T_REVERSE)
 #define _T_ATOMSORT_UNIQ	(T_SORTED | T_UNIQ | T_ATOMIC)
 #define _T_ATOMSORT_NONUNIQ	(T_SORTED          | T_ATOMIC)
+#define _T_ATOMHASH		(T_SORTED | T_UNIQ | T_ATOMIC | T_HASH)
 
 #define _T_TYPE(type)		_T_##type
 #define IS_SORTED(type)		(_T_TYPE(type) & T_SORTED)
@@ -201,6 +203,9 @@ static void test_rb_pop(void)
 	show_rb_counts(&head);
 }
 
+#define TYPE ATOMHASH
+#include "test_typelist.h"
+
 int main(int argc, char **argv)
 {
 	srandom(1);
@@ -219,6 +224,7 @@ int main(int argc, char **argv)
 	test_RBTREE_NONUNIQ();
 	test_ATOMSORT_UNIQ();
 	test_ATOMSORT_NONUNIQ();
+	test_ATOMHASH();
 
 	test_rb_pop();
 	log_memstats(NULL, true);


### PR DESCRIPTION
Maybe I should write 52 more lines of comments for `atomhash.c`, just so I can claim it's more comments than code :laughing: … it does have a `HIC SUNT DRACONES` :dragon:.

```
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
C                                1            226            648            699
```

In seriousness though, the documentation is in the last commit.

In a galaxy far, far in the future, at the final frontier, this will be the backing for deduplicating ("interning") the various crap we have in BGP (communities, aspaths, attrs, etc.), and in the same vein allows implementing lock-free structure refcounts.

Anyway, it completed 50000 test cycles (20M ops ea) on ARM and 60000 test cycles (10M ops ea) on ppc64. (And another few times that during a bughunt for a rather nasty bug — but on the plus side the test *did* find that.)