### PR TITLE
isisd, lib: Fix stale link-state edge double-free

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1180,6 +1180,7 @@ static int lsp_to_edge_cb(const uint8_t *id, uint32_t metric, bool old_metric,
 	if (edge->status != NEW) {
 		if (!ls_attributes_same(edge->attributes, attr)) {
 			te_debug("    |- Update Edge Attributes information");
+			ls_disconnect(edge->destination, edge, false);
 			ls_attributes_del(edge->attributes);
 			edge->attributes = attr;
 			edge->status = UPDATE;

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -858,8 +858,11 @@ struct ls_edge *ls_edge_update(struct ls_ted *ted,
 	if (old) {
 		/* Check if attributes are similar */
 		if (!ls_attributes_same(old->attributes, attributes)) {
+			ls_disconnect(old->source, old, true);
+			ls_disconnect(old->destination, old, false);
 			ls_attributes_del(old->attributes);
 			old->attributes = attributes;
+			ls_edge_connect_to(ted, old);
 		} else
 			ls_attributes_del(attributes);
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -41,6 +41,7 @@ frr_northbound*
 /lib/test_heavy_thread
 /lib/test_heavy_wq
 /lib/test_idalloc
+/lib/test_link_state
 /lib/test_memory
 /lib/test_nexthop
 /lib/test_nexthop_iter

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -193,6 +193,14 @@ EXTRA_DIST += \
 	# end
 
 
+check_PROGRAMS += tests/lib/test_link_state
+tests_lib_test_link_state_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_link_state_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_link_state_LDADD = $(ALL_TESTS_LDADD)
+tests_lib_test_link_state_SOURCES = tests/lib/test_link_state.c
+EXTRA_DIST += tests/lib/test_link_state.py
+
+
 check_PROGRAMS += tests/lib/test_heavy
 tests_lib_test_heavy_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_heavy_CPPFLAGS = $(TESTS_CPPFLAGS)

--- a/tests/lib/test_link_state.c
+++ b/tests/lib/test_link_state.c
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Link State database tests.
+ *
+ * Copyright (C) 2026 Carmine Scarpitta
+ */
+
+#include <zebra.h>
+
+#include "link_state.h"
+
+static struct in_addr ipv4(const char *address)
+{
+	struct in_addr result;
+
+	assert(inet_pton(AF_INET, address, &result) == 1);
+	return result;
+}
+
+static struct ls_node_id node_id(uint8_t id)
+{
+	struct ls_node_id result = {
+		.origin = ISIS_L1,
+		.id.iso.level = 1,
+	};
+
+	result.id.iso.sys_id[ISO_SYS_ID_LEN - 1] = id;
+	return result;
+}
+
+static struct ls_attributes *edge_attributes(uint8_t advertiser, const char *local,
+					     const char *remote)
+{
+	struct ls_attributes *attributes;
+
+	attributes = ls_attributes_new(node_id(advertiser), ipv4(local), in6addr_any, 0);
+	assert(attributes);
+
+	attributes->standard.remote = ipv4(remote);
+	SET_FLAG(attributes->flags, LS_ATTR_NEIGH_ADDR);
+	return attributes;
+}
+
+/*
+ * Verify that edge updates and reverse-edge insertion keep the TED
+ * consistent through teardown.
+ */
+static void test_edge_remote_endpoint_update(void)
+{
+	struct ls_ted *ted;
+	struct ls_edge *a_to_b;
+	struct ls_edge *b_to_a;
+	struct ls_edge *c_to_b;
+	struct ls_vertex *a;
+	struct ls_vertex *b;
+	struct ls_vertex *c;
+
+	ted = ls_ted_new(1, "link-state-test", 0);
+	assert(ted);
+
+	a_to_b = ls_edge_add(ted, edge_attributes(3, "10.0.0.3", "10.0.0.1"));
+	b_to_a = ls_edge_add(ted, edge_attributes(1, "10.0.0.1", "10.0.0.3"));
+	assert(a_to_b && b_to_a);
+	assert(a_to_b->destination == b_to_a->source);
+	assert(b_to_a->destination == a_to_b->source);
+
+	a = a_to_b->source;
+	b = b_to_a->source;
+	assert(a->key > b->key);
+
+	assert(ls_edge_update(ted, edge_attributes(1, "10.0.0.1", "10.0.0.2")) == b_to_a);
+	assert(b_to_a->destination == NULL);
+	assert(listnode_lookup(a->incoming_edges, b_to_a) == NULL);
+
+	c_to_b = ls_edge_add(ted, edge_attributes(2, "10.0.0.2", "10.0.0.1"));
+	assert(c_to_b);
+	c = c_to_b->source;
+	assert(c->key > b->key && c->key < a->key);
+	assert(b_to_a->destination == c);
+	assert(c_to_b->destination == b);
+
+	ls_ted_del_all(&ted);
+	assert(ted == NULL);
+}
+
+int main(void)
+{
+	test_edge_remote_endpoint_update();
+	printf("Link State database tests passed.\n");
+}

--- a/tests/lib/test_link_state.py
+++ b/tests/lib/test_link_state.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2026 by Carmine Scarpitta
+import frrtest
+
+
+class TestLinkState(frrtest.TestMultiOut):
+    program = "./test_link_state"
+
+
+TestLinkState.onesimple("Link State database tests passed.")


### PR DESCRIPTION
An edge is linked into its source vertex's `outgoing_edges` list and its destination vertex's `incoming_edges` list.

When an edge's remote endpoint changes, `ls_edge_update()` replaces its attributes but never disconnects the edge from its old destination. The edge stays in the old destination's `incoming_edges` list. Later, when the reverse edge is added, `ls_edge_connect_to()` finds this edge as the match and links it into the new destination's `incoming_edges` list as well, without removing it from the old one. The edge ends up linked from two destinations at once.

For example:

1. Add edge B->A: linked into A's `incoming_edges` list.
2. Update the edge with remote endpoint C instead of A: the edge stays in A's `incoming_edges` list.
3. Add edge C->B: the edge also gets linked into C's `incoming_edges` list, so it is now in both A's and C's lists, with `edge->destination == C`.

During TED teardown, a vertex frees every edge in its `outgoing_edges` list unconditionally, first disconnecting it from both its source and its current destination. Tearing down B frees the edge via its `outgoing_edges` list, which also removes it from C's `incoming_edges` list, since `edge->destination` points to C. The stale entry in A's `incoming_edges` list is untouched, since nothing about the disconnect references A. Tearing down A later still finds this stale entry, processes the already-freed edge, and frees its attributes a second time, tripping the extended admin-group bitmap assertion in
`admin_group_term()`.

Fix this by calling `ls_disconnect()` to detach the edge from its old source/destination, then replacing its attributes and calling `ls_edge_connect_to()` to relink it to the new source/destination, leaving no stale entry behind.