### PR TITLE
bgpd: fix bgp flag conflict

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -787,11 +787,10 @@ struct bgp {
 #define BGP_FLAG_VRF_MAY_LISTEN		    (1ULL << 44)
 #define BGP_FLAG_SOFT_VERSION_CAPABILITY_NEW (1ULL << 45)
 #define BGP_FLAG_USE_RECURSIVE_WEIGHT (1ULL << 46)
-
 /* Use current (imported) path's attributes instead of source path's attributes
  * for bestpath comparison of imported paths.
  */
-#define BGP_FLAG_BESTPATH_USE_IMPORTED_ATTRS (1ULL << 45)
+#define BGP_FLAG_BESTPATH_USE_IMPORTED_ATTRS (1ULL << 47)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.


### PR DESCRIPTION
BGP_FLAG_SOFT_VERSION_CAPABILITY_NEW and
BGP_FLAG_BESTPATH_USE_IMPORTED_ATTRS have the same value.