### PR TITLE
pimd: report a successful IPv6 PIM send as success

### DIFF
--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -735,13 +735,20 @@ static int pim_msg_send_frame(pim_addr src, pim_addr dst, ifindex_t ifindex,
 	pktinfo->ipi6_addr = src;
 
 	retval = sendmsg(fd, &smsghdr, 0);
-	if (retval < 0)
+	if (retval < 0) {
 		flog_err(
 			EC_LIB_SOCKET,
 			"sendmsg failed: source: %pI6 Dest: %pI6 ifindex: %d: %s (%d)",
 			&src, &dst, ifindex, safe_strerror(errno), errno);
+		return -1;
+	}
 
-	return retval;
+	/*
+	 * Callers test this as a boolean, and the IPv4 half of pim_msg_send()
+	 * returns 0 for success.  sendmsg() returns the byte count, so
+	 * returning it directly made every SUCCESSFUL send read as a failure.
+	 */
+	return 0;
 }
 #endif
 

--- a/tests/topotests/pim6_hello_send_counters/r1/frr.conf
+++ b/tests/topotests/pim6_hello_send_counters/r1/frr.conf
@@ -1,0 +1,13 @@
+!
+hostname r1
+!
+debug pimv6
+debug pimv6 events
+debug pimv6 trace
+debug pimv6 packets
+!
+interface r1-eth0
+ ipv6 address 2001:db8:1::1/64
+ ipv6 pim
+ ipv6 pim hello 5
+!

--- a/tests/topotests/pim6_hello_send_counters/test_pim6_hello_send_counters.py
+++ b/tests/topotests/pim6_hello_send_counters/test_pim6_hello_send_counters.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+test_pim6_hello_send_counters.py: successful IPv6 PIM hello transmissions
+must be counted as SENT, not as failed.
+
+Regression test for the pim_msg_send() return-value mismatch: the IPv4 frame
+sender returns 0 on success, the IPv6 one returned sendmsg()'s byte count,
+and every caller tests the result as a boolean -- so on IPv6 every
+successful transmission was taken for a failure.  The visible symptoms are
+`helloSend 0` / `hellosendFailed N` on an interface whose hellos are plainly
+going out, and a "could not send PIM message on interface ..." warning for
+every periodic Join/Prune.
+
+The same symptom was reported and closed once before (FRRouting/frr issue
+regarding hello Tx counts on pim6d), so this asserts on the counters to keep
+it from coming back.
+
+A single router suffices: hellos are sent to ff02::d regardless of whether
+any neighbor exists, and the send/sendFailed split is decided entirely by
+the local return-value handling.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.pim6d]
+
+IFNAME = "r1-eth0"
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf", daemons=["zebra", "pim6d"])
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_hello_send_counted_as_sent():
+    """helloSend must accumulate; before the fix it stayed at 0 forever
+    while hellosendFailed counted every SUCCESSFUL transmission."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _hellos_sent():
+        out = tgen.gears["r1"].vtysh_cmd(
+            "show ipv6 pim interface {} json".format(IFNAME)
+        )
+        try:
+            data = json.loads(out)
+        except ValueError:
+            return "r1: unparseable pim interface JSON (pim6d dead?)"
+        row = data.get(IFNAME)
+        if row is None:
+            return "r1: no pim interface data for {}: {}".format(IFNAME, data)
+        sent = row.get("helloSend", 0)
+        failed = row.get("hellosendFailed", 0)
+        # Two accumulated hellos separate the fixed accounting from a lucky
+        # startup race; a small failed allowance covers the genuine
+        # first-send failure while the interface address is still settling.
+        if sent < 2:
+            return "helloSend={} hellosendFailed={}: successful hellos are " "not being counted as sent".format(sent, failed)
+        if failed > sent:
+            return "hellosendFailed={} exceeds helloSend={}: successes are " "still being booked as failures".format(failed, sent)
+        return None
+
+    # hello period is 5s; 40s covers many periods with margin.
+    _, result = topotest.run_and_expect(_hellos_sent, None, count=40, wait=1)
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
The two halves of `pim_msg_send()` disagree on their return contract: the IPv4 frame sender returns 0 on success and -1 on failure, while the IPv6 one returns `sendmsg()`'s value directly, which is the byte count on success. Every caller tests the result as a boolean, so on IPv6 every successful transmission is taken for a failure:

- `pim_jp_flush_packet()` warns "could not send PIM message on interface ..." for every periodic Join/Prune, once per minute per interface, on every pim6d router;
- `pim_hello_send()` increments `pim_ifstat_hello_sendfail` and never `pim_ifstat_hello_sent`, so `show ipv6 pim interface` reports `helloSend 0` / `hellosendFailed N` on an interface whose neighbor is up and whose hellos are plainly being received;
- `pim_assert_do()` returns an error for an assert that was sent.

Nothing is failing. The log line and the counters are wrong, and they send an operator hunting for a transmission problem that does not exist. No caller uses the byte count, so the fix returns 0 on success, keeping the IPv4 contract. Real failures still log `sendmsg failed: ...` with the errno via `flog_err`.

This is the same symptom reported in #11346 (2022), which was closed against the pre-merge state of #11182; the mismatched return is present on today's master.

A topotest is included: a single pim6 router asserts that `helloSend` accumulates and that `hellosendFailed` does not exceed it. Verified in the frr-topotests container: fails on current master (`helloSend=0 hellosendFailed=15` after 40s), passes with the fix.
