### PR TITLE
pimd: static-group and GM membership must not tear down each other's OIF

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -527,7 +527,7 @@ static void gm_sg_update(struct gm_sg *sg, bool has_expired)
 				  gm_ifp->ifp->name);
 
 	} else if (sg->tib_joined && !new_join) {
-		tib_sg_gm_prune(gm_ifp->pim, sg->sgaddr, gm_ifp->ifp, &sg->oil);
+		tib_sg_gm_prune(gm_ifp->pim, sg->sgaddr, gm_ifp->ifp, TIB_GM_SUB_DYNAMIC, &sg->oil);
 
 		sg->oil = NULL;
 		sg->tib_joined = false;

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -53,6 +53,7 @@ static void pim_if_gm_join_del_all(struct interface *ifp);
 static void pim_if_static_group_del_all(struct interface *ifp);
 static void pim_if_gm_join_replay(struct interface *ifp);
 static void pim_if_static_group_replay(struct interface *ifp);
+static void pim_if_static_group_deactivate_all(struct interface *ifp);
 
 static int gm_join_sock(const char *ifname, ifindex_t ifindex,
 			pim_addr group_addr, pim_addr source_addr,
@@ -1136,6 +1137,14 @@ int pim_if_del_vif(struct interface *ifp)
 		zlog_debug("%s: vif_index=%d  on interface %s ifindex=%d", __func__,
 			   pim_ifp->mroute_vif_index, ifp->name, ifp->ifindex);
 
+	/*
+	 * The VIF, and with it every OIF on it, is going away.  Give up the
+	 * TIB state the static groups hold, otherwise static_group_activate()
+	 * keeps returning early on stgrp->oilp and pim_if_static_group_replay()
+	 * never picks the entries up again when a VIF comes back.
+	 */
+	pim_if_static_group_deactivate_all(ifp);
+
 	/* if the device was a pim_vxlan iif/oif update vxlan mroute entries */
 	pim_vxlan_del_vif(ifp);
 
@@ -1513,6 +1522,24 @@ static bool static_group_activate(struct interface *ifp, struct static_group *st
 	}
 
 	return true;
+}
+
+static void pim_if_static_group_deactivate_all(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct listnode *node;
+	struct static_group *stgrp;
+
+	if (!pim_ifp || !pim_ifp->static_group_list)
+		return;
+
+	for (ALL_LIST_ELEMENTS_RO(pim_ifp->static_group_list, node, stgrp)) {
+		if (!stgrp->oilp)
+			continue;
+
+		pim_channel_oil_del(stgrp->oilp, __func__);
+		stgrp->oilp = NULL;
+	}
 }
 
 static void pim_if_static_group_replay(struct interface *ifp)

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1772,7 +1772,7 @@ int pim_if_static_group_del(struct interface *ifp, pim_addr group_addr,
 	sg.src = source_addr;
 	sg.grp = group_addr;
 
-	tib_sg_gm_prune(pim_ifp->pim, sg, ifp, &(stgrp->oilp));
+	tib_sg_gm_prune(pim_ifp->pim, sg, ifp, TIB_GM_SUB_STATIC, &(stgrp->oilp));
 
 	listnode_delete(pim_ifp->static_group_list, stgrp);
 	static_group_free(stgrp);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -243,7 +243,7 @@ void igmp_source_forward_stop(struct gm_source *source)
 		return;
 	}
 
-	tib_sg_gm_prune(pim_oif->pim, sg, group->interface,
+	tib_sg_gm_prune(pim_oif->pim, sg, group->interface, TIB_GM_SUB_DYNAMIC,
 			&source->source_channel_oil);
 	IGMP_SOURCE_DONT_FORWARDING(source->source_flags);
 }

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -474,7 +474,7 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 				oil_origin(channel_oil),
 				oil_mcastgrp(channel_oil));
 		}
-		return -3;
+		return PIM_OIF_ADD_EXISTS;
 	}
 
 	/* Allow other protocol to request subscription of same interface to

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -186,6 +186,15 @@ void pim_clear_nocache_state(struct pim_interface *pim_ifp);
 struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name);
 
+/*
+ * pim_channel_add_oif() return code for "this protocol has already subscribed
+ * this OIF to this channel".  PIM_OIF_FLAG_PROTO_GM is shared by
+ * "ip igmp static-group" / "ipv6 mld static-group" and by IGMP/MLD membership
+ * learned on the interface, so for that flag this is a shared subscription
+ * rather than an error.
+ */
+#define PIM_OIF_ADD_EXISTS (-3)
+
 int pim_channel_add_oif(struct channel_oil *c_oil, struct interface *oif,
 			uint32_t proto_mask, const char *caller);
 int pim_channel_del_oif(struct channel_oil *c_oil, struct interface *oif,

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -347,6 +347,8 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 {
 	struct pim_interface *pim_oif = oif->info;
 	struct channel_oil *c_oil;
+	bool created = false;
+	int result = 0;
 
 	if (!pim_oif) {
 		if (PIM_DEBUG_GM_TRACE)
@@ -355,10 +357,13 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 		return false;
 	}
 
-	if (!*oilp)
+	if (!*oilp) {
 		*oilp = tib_sg_oil_setup(pim, sg, oif);
-	if (!*oilp)
-		return false;
+		if (!*oilp)
+			return false;
+
+		created = true;
+	}
 
 	tib_sg_proxy_join_prune_check(pim, sg, oif, true);
 
@@ -393,15 +398,20 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 	}
 
 	if (PIM_I_am_DR(pim_oif) || PIM_I_am_DualActive(pim_oif)) {
-		int result;
-
 		result = pim_channel_add_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
 					     __func__);
-		if (result) {
+		/*
+		  PIM_OIF_ADD_EXISTS means the other subscriber on this
+		  interface - a static group, or IGMP/MLD membership - claimed
+		  the flag first.  The forwarding state this join asks for is
+		  in place, it is just shared, so this is a success here too
+		  and this subscriber is on the hook for releasing it.
+		 */
+		if (result && result != PIM_OIF_ADD_EXISTS) {
 			if (PIM_DEBUG_MROUTE)
 				zlog_warn("%s: add_oif() failed with return=%d",
 					  __func__, result);
-			return false;
+			goto fail;
 		}
 	} else {
 		if (PIM_DEBUG_GM_TRACE)
@@ -409,11 +419,11 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 				"%s: %pSG was received on %s interface but we are not DR for that interface",
 				__func__, &sg, oif->name);
 
-		return false;
+		goto fail;
 	}
 	/*
-	  Feed IGMPv3-gathered local membership information into PIM
-	  per-interface (S,G) state.
+	 * Feed IGMPv3-gathered local membership information into PIM
+	 * per-interface (S,G) state.
 	 */
 	if (!pim_ifchannel_local_membership_add(oif, &sg, false /*is_vxlan*/)) {
 		if (PIM_DEBUG_MROUTE)
@@ -421,22 +431,148 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 				"%s: Failure to add local membership for %pSG",
 				__func__, &sg);
 
-		pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
-				    __func__);
-		return false;
+		/* only undo a subscription this call actually made */
+		if (result != PIM_OIF_ADD_EXISTS)
+			pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM, __func__);
+		goto fail;
 	}
 
 	return true;
+
+fail:
+	/*
+	 * Do not leave a caller that did not get a join holding a channel_oil
+	 * reference for it.  static_group_activate() returns early when
+	 * stgrp->oilp is set and pim_if_static_group_replay() only retries
+	 * entries with a NULL oilp, so a static group whose activation failed
+	 * would look activated forever.  Only what this call created is given
+	 * back; a reference the caller already held is left alone.
+	 */
+	if (created) {
+		pim_channel_oil_del(*oilp, __func__);
+		*oilp = NULL;
+	}
+
+	return false;
 }
 
-void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
-		     struct interface *oif, struct channel_oil **oilp)
+/*
+ * "ip igmp static-group" / "ipv6 mld static-group" and IGMP/MLD membership
+ * learned on the interface are independent subscribers to the same OIF, but
+ * PIM_OIF_FLAG_PROTO_GM is one bit per (channel_oil, vif) and is not
+ * reference counted.  Return true when the subscriber that is *not* leaving
+ * still wants sg on oif, so only the last one out removes anything.
+ *
+ * Each half only looks at the other subscriber's own state, so the caller need
+ * not have dropped its state first - the leaver can never be found here.
+ *
+ * oif_flags is deliberately not consulted:  PIM_OIF_FLAG_PROTO_GM is also
+ * re-derived from the ifchannel by pim_forward_start() and
+ * pim_upstream_inherited_olist_decide(), and a static group's own local
+ * membership sets the ifchannel flag they read, so the bit is not evidence
+ * that a dynamic membership exists.  On the static side the configuration
+ * entry alone is not enough either: an entry whose activation failed holds no
+ * subscription, and retaining on its behalf would strand state that
+ * pim_if_static_group_del() can never release (it returns early on a NULL
+ * oilp).  stgrp->oilp is required as well, and it is accurate here: a failed
+ * activation gives the reference back and pim_if_del_vif() releases it, so
+ * the pointer is set exactly while the entry holds its subscription.
+ *
+ * Matching is exact.  A (*,G) subscriber holds its state on the (*,G)
+ * channel_oil - a different oif_flags array - and reaches (S,G) entries
+ * through PIM_OIF_FLAG_PROTO_STAR, added and removed by the ifchannel
+ * inheritance code.  Keeping an (S,G) PROTO_GM bit alive for (*,G) interest
+ * would leave a bit that no later event can clear.  gm_join_list ("ip igmp
+ * join-group") is not consulted for a similar reason:  those entries only open
+ * a kernel socket, they never call tib_sg_gm_join() and hold nothing, and
+ * pim_if_gm_join_del() never prunes.  The membership such a socket creates is
+ * seen here as ordinary IGMP/MLD membership.
+ */
+static bool tib_sg_gm_other_sub(struct interface *oif, pim_sgaddr sg, enum tib_sg_gm_sub leaving)
+{
+	struct pim_interface *pim_ifp = oif->info;
+	struct listnode *node;
+
+	if (!pim_ifp)
+		return false;
+
+	if (leaving != TIB_GM_SUB_STATIC) {
+		struct static_group *stgrp;
+
+		if (!pim_ifp->static_group_list)
+			return false;
+
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->static_group_list, node, stgrp)) {
+			/*
+			 * Configured but not activated (failed activation, or
+			 * released by pim_if_del_vif()): holds no subscription,
+			 * so it must not retain one.  Retaining here would keep
+			 * an OIF, a local membership and a proxy join that
+			 * pim_if_static_group_del() could never release - it
+			 * returns early on a NULL oilp.
+			 */
+			if (!stgrp->oilp)
+				continue;
+
+			if (!pim_addr_cmp(stgrp->group_addr, sg.grp) &&
+			    !pim_addr_cmp(stgrp->source_addr, sg.src))
+				return true;
+		}
+
+		return false;
+	}
+
+#if PIM_IPV == 4
+	if (pim_ifp->gm_group_list) {
+		struct gm_group *group;
+
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, node, group)) {
+			struct listnode *srcnode;
+			struct gm_source *src;
+
+			if (pim_addr_cmp(group->group_addr, sg.grp))
+				continue;
+
+			for (ALL_LIST_ELEMENTS_RO(group->group_source_list, srcnode, src))
+				if (!pim_addr_cmp(src->source_addr, sg.src) &&
+				    IGMP_SOURCE_TEST_FORWARDING(src->source_flags))
+					return true;
+		}
+	}
+#else
+	if (pim_ifp->mld) {
+		struct gm_sg *mlsg, ref = {};
+
+		ref.sgaddr = sg;
+		mlsg = gm_sgs_find(pim_ifp->mld->sgs, &ref);
+		if (mlsg && mlsg->tib_joined)
+			return true;
+	}
+#endif
+
+	return false;
+}
+
+void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif,
+		     enum tib_sg_gm_sub leaving, struct channel_oil **oilp)
 {
 	int result;
 	struct pim_interface *pim_oif = oif->info;
 	struct channel_oil *live;
+	bool retain;
 
-	tib_sg_proxy_join_prune_check(pim, sg, oif, false);
+	/*
+	 * When the other subscriber on this interface still wants sg, the OIF,
+	 * the PIM local membership and the upstream proxy join all have to
+	 * stay.  pim_ifchannel_local_membership_del() would drop the upstream
+	 * join and can delete the ifchannel, which removes the OIF itself, and
+	 * the proxy check cannot see what remains here because
+	 * tib_sg_downstream_receivers_remain() skips oif.
+	 */
+	retain = !pim->stopping && tib_sg_gm_other_sub(oif, sg, leaving);
+
+	if (!retain)
+		tib_sg_proxy_join_prune_check(pim, sg, oif, false);
 
 	/*
 	 It appears that in certain circumstances that
@@ -458,6 +594,21 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 
 	if (!*oilp)
 		return;
+
+	if (retain) {
+		if (PIM_DEBUG_GM_TRACE)
+			zlog_debug("%s: %pSG on %s still has another subscriber, keeping OIF",
+				   __func__, &sg, oif->name);
+
+		/*
+		 * No need for the pim_find_channel_oil() check below: nothing
+		 * that could free the channel oil has run, and the remaining
+		 * subscriber holds a reference of its own.
+		 */
+		pim_channel_oil_del(*oilp, __func__);
+		*oilp = NULL;
+		return;
+	}
 
 	result = pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
 				     __func__);

--- a/pimd/pim_tib.h
+++ b/pimd/pim_tib.h
@@ -12,10 +12,28 @@
 struct pim_instance;
 struct channel_oil;
 
+/*
+ * Which of the two subscribers that share PIM_OIF_FLAG_PROTO_GM on an OIF is
+ * dropping its subscription.  The flag is a single bit per (channel_oil, vif)
+ * and is not reference counted, so the OIF may only be removed once both are
+ * gone.
+ */
+enum tib_sg_gm_sub {
+	/* IGMP/MLD membership learned on the interface */
+	TIB_GM_SUB_DYNAMIC,
+	/* "ip igmp static-group" / "ipv6 mld static-group" */
+	TIB_GM_SUB_STATIC,
+};
+
 extern bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 			   struct interface *oif, struct channel_oil **oilp);
-extern void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
-			    struct interface *oif, struct channel_oil **oilp);
+/*
+ * Drop one subscriber's (S,G) subscription on oif.  The OIF, the PIM local
+ * membership and the upstream proxy join are only torn down when the other
+ * subscriber named by "leaving" is gone as well.
+ */
+extern void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif,
+			    enum tib_sg_gm_sub leaving, struct channel_oil **oilp);
 extern void tib_sg_proxy_join_prune_check(struct pim_instance *pim,
 					  pim_sgaddr sg, struct interface *oif,
 					  bool join);

--- a/tests/topotests/pim6_mld_static_group_shared_oif/r1/frr.conf
+++ b/tests/topotests/pim6_mld_static_group_shared_oif/r1/frr.conf
@@ -1,0 +1,7 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ipv6 address 2001:db8:1::1/64
+ ipv6 pim
+!

--- a/tests/topotests/pim6_mld_static_group_shared_oif/r2/frr.conf
+++ b/tests/topotests/pim6_mld_static_group_shared_oif/r2/frr.conf
@@ -1,0 +1,14 @@
+!
+hostname r2
+!
+interface r2-eth0
+ ipv6 address 2001:db8:1::2/64
+ ipv6 pim
+!
+interface r2-eth1
+ ipv6 address 2001:db8:2::1/64
+ ipv6 mld
+ ipv6 pim
+!
+ipv6 route 2001:db8:10::/64 2001:db8:1::1
+!

--- a/tests/topotests/pim6_mld_static_group_shared_oif/test_pim6_mld_static_group_shared_oif.py
+++ b/tests/topotests/pim6_mld_static_group_shared_oif/test_pim6_mld_static_group_shared_oif.py
@@ -222,7 +222,15 @@ def test_static_group_added_second_survives_receiver_leave():
     standing and MUST retain the OIF.
 
     Before the fix the second claim was a silent no-op, so the receiver's
-    leave took the OIF with it and nothing ever restored it."""
+    leave took the OIF with it and nothing ever restored it.
+
+    COVERAGE CAVEAT, measured: this direction PASSES on unfixed master, so it
+    does not currently reproduce that half of the defect and must not be counted
+    as protecting it. Run against master + this test only, the module scores
+    1 failed / 3 passed -- the failure is the REVERSE direction below, which is
+    the one this file genuinely guards. Kept because it documents the intended
+    invariant and costs nothing; strengthening it (a different add/leave
+    interleaving, or asserting on oilSize rather than membership) is open work."""
     tgen = get_topogen()
 
     if tgen.routers_have_failure():
@@ -257,7 +265,10 @@ def test_static_group_removed_leaves_receiver_oif_intact():
 
     Before the fix the static-group's removal pruned the OIF out from under
     the live receiver, and gm_sg_update() then took neither branch, so it
-    never came back."""
+    never came back.
+
+    THIS is the assertion that actually catches the regression: verified to FAIL
+    on unfixed master and PASS with the fix, same test binary, same topology."""
     tgen = get_topogen()
 
     if tgen.routers_have_failure():

--- a/tests/topotests/pim6_mld_static_group_shared_oif/test_pim6_mld_static_group_shared_oif.py
+++ b/tests/topotests/pim6_mld_static_group_shared_oif/test_pim6_mld_static_group_shared_oif.py
@@ -107,11 +107,16 @@ def _oif_present():
     data = _json_cmd("r2", "show ipv6 mroute json")
     if data is None:
         return "r2: unparseable v6 mroute JSON (pim6d dead?)"
-    oil = data.get(GROUP6, {}).get(SOURCE6, {})
-    if not oil:
+    sg = data.get(GROUP6, {}).get(SOURCE6, {})
+    if not sg:
         return "r2 has no ({}, {}) mroute at all: {}".format(SOURCE6, GROUP6, data)
+    # The outgoing interfaces are a SUB-object under "oil", not keys of the (S,G)
+    # entry itself -- the entry's own keys are iif/flags/installed/refCount. Reading
+    # the entry directly finds no interface and reports a missing OIF on a perfectly
+    # good OIL.
+    oil = sg.get("oil", {})
     if OIF not in oil:
-        return "r2 ({}, {}) OIL is missing {}: {}".format(SOURCE6, GROUP6, OIF, oil)
+        return "r2 ({}, {}) OIL is missing {}: oil={}".format(SOURCE6, GROUP6, OIF, oil)
     return None
 
 

--- a/tests/topotests/pim6_mld_static_group_shared_oif/test_pim6_mld_static_group_shared_oif.py
+++ b/tests/topotests/pim6_mld_static_group_shared_oif/test_pim6_mld_static_group_shared_oif.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+test_pim6_mld_static_group_shared_oif.py: an `ipv6 mld static-group` and a
+learned MLD membership for the SAME (S,G) on the SAME interface are two
+independent subscribers to one OIF, and neither may tear it down while the
+other still wants it.
+
+Regression test for a shared-flag strand: PIM_OIF_FLAG_PROTO_GM is one bit
+per (channel_oil, vif) with NO reference count, and both subscribers claim it
+through tib_sg_gm_join().  pim_channel_add_oif() refuses the second with -3
+and tib_sg_gm_prune() then removed the OIF, the PIM local membership and the
+upstream proxy join on the FIRST leave -- whichever subscriber it belonged to.
+
+Both orderings lose, and neither self-heals:
+
+  * add static-group while a receiver is already joined (what `frr reload`
+    does on a running router) is a silent no-op; when that receiver leaves,
+    the OIF leaves with it.  The static group is still in the running config
+    and still in static_group_list, with no OIF.
+
+  * remove a static-group while a receiver is still joined pulls the OIF out
+    from under the live receiver.  gm_sg_update() then takes neither branch,
+    so it never comes back.
+
+The failure is invisible to every other signal: the configuration still reads
+correctly, `show ipv6 mld static-group` still lists the entry, and only the
+OIL disagrees.  That is why this test asserts on the OIL and not on config.
+
+Topology (same shape as pim6_mld_join_toggle):
+
+    r1 ---- s1 ---- r2 ---- s2 (receiver stub)
+
+r1 is only a PIM6 neighbor: r2 RPF-resolves the (never-sending) source
+through a static route toward r1, so the (S,G) upstream has a real RPF
+interface and the OIL can be built.  Both subscribers live on r2-eth1, where
+r2 is its own MLD querier and the kernel join-group socket supplies the
+MLDv2 report that creates the LEARNED membership.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.pim6d, pytest.mark.staticd]
+
+SOURCE6 = "2001:db8:10::10"
+GROUP6 = "ff3e::10"
+OIF = "r2-eth1"
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    # s1: the RPF segment (r1 is r2's PIM6 neighbor toward the source)
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # s2: r2's receiver stub -- both subscribers attach here
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf", daemons=["zebra", "pim6d"])
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _json_cmd(rname, cmd):
+    """vtysh JSON helper: returns None (NOT {}) on unparseable output, so a
+    crashed or unresponsive daemon can never satisfy a presence-assertion
+    vacuously -- every predicate must treat None as failure."""
+    out = get_topogen().gears[rname].vtysh_cmd(cmd)
+    try:
+        return json.loads(out)
+    except ValueError:
+        return None
+
+
+def _oif_present():
+    """None when r2 has the (S,G) OIL entry on OIF, else a reason string.
+
+    The OIL is the ONLY signal that separates the bug from correct behaviour:
+    the running config, static_group_list and `show ipv6 mld static-group` all
+    still show the entry after the OIF has been torn out from under it."""
+    data = _json_cmd("r2", "show ipv6 mroute json")
+    if data is None:
+        return "r2: unparseable v6 mroute JSON (pim6d dead?)"
+    oil = data.get(GROUP6, {}).get(SOURCE6, {})
+    if not oil:
+        return "r2 has no ({}, {}) mroute at all: {}".format(SOURCE6, GROUP6, data)
+    if OIF not in oil:
+        return "r2 ({}, {}) OIL is missing {}: {}".format(SOURCE6, GROUP6, OIF, oil)
+    return None
+
+
+def _add_join_group():
+    get_topogen().gears["r2"].vtysh_cmd(
+        """
+configure terminal
+interface {0}
+ ipv6 mld join-group {1} {2}
+""".format(OIF, GROUP6, SOURCE6)
+    )
+
+
+def _del_join_group():
+    get_topogen().gears["r2"].vtysh_cmd(
+        """
+configure terminal
+interface {0}
+ no ipv6 mld join-group {1} {2}
+""".format(OIF, GROUP6, SOURCE6)
+    )
+
+
+def _add_static_group():
+    get_topogen().gears["r2"].vtysh_cmd(
+        """
+configure terminal
+interface {0}
+ ipv6 mld static-group {1} {2}
+""".format(OIF, GROUP6, SOURCE6)
+    )
+
+
+def _del_static_group():
+    get_topogen().gears["r2"].vtysh_cmd(
+        """
+configure terminal
+interface {0}
+ no ipv6 mld static-group {1} {2}
+""".format(OIF, GROUP6, SOURCE6)
+    )
+
+
+def test_pim6_neighbor_up():
+    """r2 sees r1 as a PIM6 neighbor on the RPF segment."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _neighbor_up():
+        data = _json_cmd("r2", "show ipv6 pim neighbor json")
+        if data is None:
+            return "r2: unparseable v6 pim neighbor JSON (pim6d dead?)"
+        if not data.get("r2-eth0"):
+            return "r2 has no PIM6 neighbor on r2-eth0: {}".format(data)
+        return None
+
+    _, result = topotest.run_and_expect(_neighbor_up, None, count=60, wait=1)
+    assert result is None, result
+
+
+def test_learned_membership_builds_oil():
+    """A learned MLD membership alone builds the OIL -- the starting state
+    for both orderings below.
+
+    The join is added at RUNTIME, not in the startup config: a join-group
+    configured before zebra delivers the interface (ifindex still 0 at
+    config-from-file time) never issues the kernel socket join, so no MLDv2
+    report is ever emitted for r2's own querier to learn from."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _add_join_group()
+
+    # RPF must resolve before the OIL can exist at all.
+    def _rpf_resolved():
+        ups = _json_cmd("r2", "show ipv6 pim upstream json")
+        if ups is None:
+            return "r2: unparseable v6 pim upstream JSON (pim6d dead?)"
+        sg = ups.get(GROUP6, {}).get(SOURCE6, {})
+        if not sg:
+            return "r2 (S,G) upstream not created yet: {}".format(ups)
+        if sg.get("inboundInterface", "Unknown") == "Unknown":
+            return "r2 (S,G) upstream RPF not resolved yet: {}".format(ups)
+        return None
+
+    _, result = topotest.run_and_expect(_rpf_resolved, None, count=60, wait=1)
+    assert result is None, result
+
+    _, result = topotest.run_and_expect(_oif_present, None, count=90, wait=1)
+    assert result is None, result
+
+
+def test_static_group_added_second_survives_receiver_leave():
+    """DIRECTION A -- the `frr reload` case.
+
+    Add the static-group while the learned membership already holds the OIF
+    (tib_sg_gm_join() takes pim_channel_add_oif()'s -3 / PIM_OIF_ADD_EXISTS
+    path), then drop the receiver.  The static group is the last subscriber
+    standing and MUST retain the OIF.
+
+    Before the fix the second claim was a silent no-op, so the receiver's
+    leave took the OIF with it and nothing ever restored it."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _add_static_group()
+
+    # Both subscribers now hold it; the OIL must be unchanged.
+    _, result = topotest.run_and_expect(_oif_present, None, count=30, wait=1)
+    assert result is None, result
+
+    _del_join_group()
+
+    # Give a wrong implementation time to tear the OIF down before asserting
+    # it is still there: run_and_expect returns on the FIRST success, so
+    # without this settle the assertion can pass on stale pre-leave state.
+    topotest.sleep(5, "waiting for the receiver leave to be processed")
+
+    result = _oif_present()
+    assert result is None, (
+        "static-group did not retain the OIF after the learned membership "
+        "left (PROTO_GM shared-bit strand): {}".format(result)
+    )
+
+
+def test_static_group_removed_leaves_receiver_oif_intact():
+    """DIRECTION B -- the reverse ordering.
+
+    With the static-group holding the OIF, re-add the receiver, then remove
+    the static-group.  The learned membership is now the last subscriber and
+    MUST keep the OIF.
+
+    Before the fix the static-group's removal pruned the OIF out from under
+    the live receiver, and gm_sg_update() then took neither branch, so it
+    never came back."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _add_join_group()
+
+    _, result = topotest.run_and_expect(_oif_present, None, count=60, wait=1)
+    assert result is None, result
+
+    _del_static_group()
+
+    topotest.sleep(5, "waiting for the static-group removal to be processed")
+
+    result = _oif_present()
+    assert result is None, (
+        "removing the static-group tore the OIF out from under the still-joined "
+        "receiver (PROTO_GM shared-bit strand): {}".format(result)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/pim6_mld_static_group_vif_flap/r1/frr.conf
+++ b/tests/topotests/pim6_mld_static_group_vif_flap/r1/frr.conf
@@ -1,0 +1,7 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ipv6 address 2001:db8:1::1/64
+ ipv6 pim
+!

--- a/tests/topotests/pim6_mld_static_group_vif_flap/r2/frr.conf
+++ b/tests/topotests/pim6_mld_static_group_vif_flap/r2/frr.conf
@@ -1,0 +1,18 @@
+!
+hostname r2
+!
+debug pimv6 events
+debug pimv6 trace
+debug mroute6
+!
+interface r2-eth0
+ ipv6 address 2001:db8:1::2/64
+ ipv6 pim
+!
+interface r2-eth1
+ ipv6 address 2001:db8:2::1/64
+ ipv6 mld
+ ipv6 pim
+!
+ipv6 route 2001:db8:10::/64 2001:db8:1::1
+!

--- a/tests/topotests/pim6_mld_static_group_vif_flap/test_pim6_mld_static_group_vif_flap.py
+++ b/tests/topotests/pim6_mld_static_group_vif_flap/test_pim6_mld_static_group_vif_flap.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+"""
+test_pim6_mld_static_group_vif_flap.py: a configured `ipv6 mld static-group`
+must come back after its interface's VIF is deleted and re-created (link
+flap, address change).
+
+Regression test for a stale-activation strand: pim_if_del_vif() tears down
+the VIF and every OIF on it but never touches static_group_list, so
+stgrp->oilp survives holding a stale channel OIL reference.  Both paths that
+could revive the entry test that pointer -- static_group_activate() returns
+early when it is set, and pim_if_static_group_replay() only activates entries
+whose oilp is NULL -- so after a link flap the static group is silently dead
+until the configuration is removed and re-added.
+
+The static-group is added at RUNTIME, not in the startup config: startup
+activation strands on its own, independently of the flap defect this file
+guards.  Measured on this topology with `debug pimv6 events`: the northbound
+applies `ipv6 mld static-group` BEFORE `ipv6 pim` inside the same startup
+transaction, so the first activation fails in
+pim_ifchannel_local_membership_add() ("PIM is not configured on this
+interface"), and the replay that fires moments later still finds no usable
+RPF interface; nothing re-activates on pim-enable or on NHT resolution, so
+the entry never recovers.  That is a separate upstream defect (activation is
+replayed only on VIF/address events, never reconciled) and would mask this
+test's baseline.
+
+Topology (same shape as pim6_mld_static_group_shared_oif):
+
+    r1 ---- s1 ---- r2 ---- s2 (receiver stub)
+
+r1 is only a PIM6 neighbor: r2 RPF-resolves the (never-sending) source
+through a static route toward r1, so the (S,G) upstream has a real RPF
+interface and the OIL can be built.  The static group is the ONLY subscriber
+on r2-eth1 -- no learned MLD membership anywhere, so nothing can mask the
+strand by re-joining.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.pim6d, pytest.mark.staticd]
+
+SOURCE6 = "2001:db8:10::10"
+GROUP6 = "ff3e::10"
+OIF = "r2-eth1"
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    # s1: the RPF segment (r1 is r2's PIM6 neighbor toward the source)
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # s2: r2's receiver stub -- the static group's interface
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config("frr.conf", daemons=["zebra", "pim6d"])
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _json_cmd(rname, cmd):
+    """vtysh JSON helper: returns None (NOT {}) on unparseable output, so a
+    crashed or unresponsive daemon can never satisfy a presence-assertion
+    vacuously -- every predicate must treat None as failure."""
+    out = get_topogen().gears[rname].vtysh_cmd(cmd)
+    try:
+        return json.loads(out)
+    except ValueError:
+        return None
+
+
+def _oif_present():
+    """None when r2 has the (S,G) OIL entry on OIF, else a reason string.
+
+    The OIL is the ONLY signal that separates the bug from correct behaviour:
+    the running config and `show ipv6 mld static-group` still show the entry
+    while stgrp->oilp holds its stale reference."""
+    data = _json_cmd("r2", "show ipv6 mroute json")
+    if data is None:
+        return "r2: unparseable v6 mroute JSON (pim6d dead?)"
+    sg = data.get(GROUP6, {}).get(SOURCE6, {})
+    if not sg:
+        return "r2 has no ({}, {}) mroute at all".format(SOURCE6, GROUP6)
+    # The outgoing interfaces are a SUB-object under "oil", not keys of the
+    # (S,G) entry itself.
+    oil = sg.get("oil", {})
+    if OIF not in oil:
+        return "r2 ({}, {}) OIL is missing {}: oil={}".format(SOURCE6, GROUP6, OIF, oil)
+    return None
+
+
+def _oif_absent():
+    """Inverse predicate, used to prove the flap really tore the state down
+    before asserting on the recovery."""
+    if _oif_present() is None:
+        return "r2 ({}, {}) still has {} in the OIL".format(SOURCE6, GROUP6, OIF)
+    return None
+
+
+def _add_static_group():
+    get_topogen().gears["r2"].vtysh_cmd(
+        """
+configure terminal
+interface {0}
+ ipv6 mld static-group {1} {2}
+""".format(OIF, GROUP6, SOURCE6)
+    )
+
+
+def test_pim6_neighbor_up():
+    """r2 sees r1 as a PIM6 neighbor on the RPF segment."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _neighbor_up():
+        data = _json_cmd("r2", "show ipv6 pim neighbor json")
+        if data is None:
+            return "r2: unparseable v6 pim neighbor JSON (pim6d dead?)"
+        if not data.get("r2-eth0"):
+            return "r2 has no PIM6 neighbor on r2-eth0: {}".format(data)
+        return None
+
+    _, result = topotest.run_and_expect(_neighbor_up, None, count=60, wait=1)
+    assert result is None, result
+
+
+def test_static_group_builds_oil():
+    """A static group added at runtime, as the only subscriber, builds the
+    OIL -- the baseline state the flap below must restore."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    _add_static_group()
+
+    _, result = topotest.run_and_expect(_oif_present, None, count=90, wait=1)
+    assert result is None, result
+
+
+def test_static_group_survives_link_flap():
+    """Down/up the static group's interface; the OIF must come back.
+
+    The down leg is asserted too: if the flap did not actually delete the
+    VIF and its OIF, the recovery assertion would pass vacuously and this
+    test would guard nothing.
+
+    Before the fix the recovery times out: pim_if_del_vif() left
+    stgrp->oilp pointing at the torn-down channel OIL, so
+    pim_if_static_group_replay() on the way back up skips the entry and
+    static_group_activate() short-circuits on it forever after."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.run("ip link set dev {} down".format(OIF))
+
+    _, result = topotest.run_and_expect(_oif_absent, None, count=30, wait=1)
+    assert result is None, (
+        "link down did not tear down the ({}, {}) OIF -- the flap premise "
+        "does not hold on this platform: {}".format(SOURCE6, GROUP6, result)
+    )
+
+    r2.run("ip link set dev {} up".format(OIF))
+
+    _, result = topotest.run_and_expect(_oif_present, None, count=90, wait=1)
+    assert result is None, (
+        "static-group did not reactivate after the link flap (stale "
+        "stgrp->oilp strand): {}".format(result)
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
`ip igmp static-group` / `ipv6 mld static-group` and IGMP/MLD membership learned on the same interface are two independent subscribers to one OIF, but `PIM_OIF_FLAG_PROTO_GM` is a single non-refcounted bit per (channel_oil, vif). `pim_channel_add_oif()` refuses the second subscriber with -3, and `tib_sg_gm_prune()` removes the OIF, the PIM local membership and the upstream proxy join on the FIRST leave, whichever subscriber it belonged to. Both orderings lose, and neither self-heals; the running config still shows the static group throughout, so the only signal is the OIL itself.

Two fixes:

1. **`pimd: release static group TIB state when the VIF is deleted`**: `pim_if_del_vif()` never touches `static_group_list`, so `stgrp->oilp` survives holding a stale reference; `static_group_activate()` short-circuits on it and `pim_if_static_group_replay()` never retries. A configured static group is silently dead after a link flap or address change until its configuration is toggled.
2. **`pimd: keep a GM OIF the other subscriber on the interface still needs`**: tell `tib_sg_gm_prune()` which subscriber is leaving and consult the other one's own state, so the OIF, local membership and proxy join are torn down only by the last one out. Accepts `add_oif`'s "already subscribed" for the GM flag as shared success, and gives the OIL reference back on failed joins so a failed activation stays retryable. Static-side retention requires the entry to actually hold its subscription (`stgrp->oilp` set): a configured group whose activation failed holds nothing and retains nothing, since the state kept on its behalf could never be released (`pim_if_static_group_del()` returns early on a NULL oilp). The commit message documents why `oif_flags` is not the retention predicate, why `stgrp->oilp` is reliable within this series, and why matching is exact.

If maintainers would rather see per-protocol refcounting on the OIF flags than the two-subscriber check, happy to rework in that direction; the two-subscriber shape was chosen as the minimal change to the existing structure.

Two topotests are included, verified in the frr-topotests container against master and against this branch:

- `pim6_mld_static_group_shared_oif`: removing a static-group while a receiver is still joined tears the OIF out from under the live membership; fails on master, passes with the fix. The reverse direction (static-group added second, receiver leaves) is asserted as well but currently passes on unfixed master in this topology; it documents the invariant rather than guarding it, as noted in the test.
- `pim6_mld_static_group_vif_flap`: a static group as the sole subscriber must come back after `ip link set down`/`up`; the down leg is asserted too so the recovery cannot pass vacuously. Fails on master (stale `stgrp->oilp`), passes with the fix.

Separately observed while writing these tests, and deliberately NOT addressed here: a static-group in startup config can strand on current master because activation is only replayed on VIF/address events (the northbound applies the static-group before `ipv6 pim` in the boot transaction, the first activation fails, and nothing re-activates on pim-enable or NHT resolution).
