### PR TITLE
bfdd,lib: move network address parser to lib

### DIFF
--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -9,9 +9,6 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <sys/un.h>
-
-#include <err.h>
 
 #include "filter.h"
 #include "if.h"
@@ -26,6 +23,7 @@
 #include "lib/plist.h"
 #include "lib/hook.h"
 #include "lib/keychain.h"
+#include "lib/network.h"
 
 
 /*
@@ -178,142 +176,21 @@ const struct bfd_state_str_list state_list[] = {
 	{.str = NULL},
 };
 
-static uint16_t
-parse_port(const char *str)
-{
-	char *nulbyte;
-	long rv;
-
-	errno = 0;
-	rv = strtol(str, &nulbyte, 10);
-	/* No conversion performed. */
-	if (rv == 0 && errno == EINVAL) {
-		fprintf(stderr, "invalid BFD data plane address port: %s\n",
-			str);
-		exit(0);
-	}
-	/* Invalid number range. */
-	if ((rv <= 0 || rv >= 65535) || errno == ERANGE) {
-		fprintf(stderr, "invalid BFD data plane port range: %s\n",
-			str);
-		exit(0);
-	}
-	/* There was garbage at the end of the string. */
-	if (*nulbyte != 0) {
-		fprintf(stderr, "invalid BFD data plane port: %s\n",
-			str);
-		exit(0);
-	}
-
-	return (uint16_t)rv;
-}
-
 static void
 distributed_bfd_init(const char *arg)
 {
-	char *sptr, *saux;
-	bool is_client = false;
-	size_t slen;
-	socklen_t salen;
-	char addr[64];
-	char type[64];
-	union {
-		struct sockaddr_in sin;
-		struct sockaddr_in6 sin6;
-		struct sockaddr_un sun;
-	} sa;
+	struct network_address address;
+	bool is_client;
 
-	/* Basic parsing: find ':' to figure out type part and address part. */
-	sptr = strchr((char *)arg, ':');
-	if (sptr == NULL) {
-		fprintf(stderr, "invalid BFD data plane socket: %s\n", arg);
+	if (!network_address_parse(arg, &address, BFD_DATA_PLANE_DEFAULT_PORT)) {
+		zlog_err("%s: failed to parse address: %s", __func__, address.error);
 		exit(1);
 	}
 
-	/* Calculate type string length. */
-	slen = (size_t)(sptr - arg);
-
-	/* Copy the address part. */
-	sptr++;
-	strlcpy(addr, sptr, sizeof(addr));
-
-	/* Copy type part. */
-	strlcpy(type, arg, slen + 1);
-
-	/* Reset address data. */
-	memset(&sa, 0, sizeof(sa));
-
-	/* Fill the address information. */
-	if (strcmp(type, "unix") == 0 || strcmp(type, "unixc") == 0) {
-		if (strcmp(type, "unixc") == 0)
-			is_client = true;
-
-		salen = sizeof(sa.sun);
-		sa.sun.sun_family = AF_UNIX;
-		strlcpy(sa.sun.sun_path, addr, sizeof(sa.sun.sun_path));
-	} else if (strcmp(type, "ipv4") == 0 || strcmp(type, "ipv4c") == 0) {
-		if (strcmp(type, "ipv4c") == 0)
-			is_client = true;
-
-		salen = sizeof(sa.sin);
-		sa.sin.sin_family = AF_INET;
-
-		/* Parse port if any. */
-		sptr = strchr(addr, ':');
-		if (sptr == NULL) {
-			sa.sin.sin_port = htons(BFD_DATA_PLANE_DEFAULT_PORT);
-		} else {
-			*sptr = 0;
-			sa.sin.sin_port = htons(parse_port(sptr + 1));
-		}
-
-		if (inet_pton(AF_INET, addr, &sa.sin.sin_addr) != 1)
-			errx(1, "%s: inet_pton: invalid address %s", __func__,
-			     addr);
-	} else if (strcmp(type, "ipv6") == 0 || strcmp(type, "ipv6c") == 0) {
-		if (strcmp(type, "ipv6c") == 0)
-			is_client = true;
-
-		salen = sizeof(sa.sin6);
-		sa.sin6.sin6_family = AF_INET6;
-
-		/* Check for IPv6 enclosures '[]' */
-		sptr = &addr[0];
-		if (*sptr != '[')
-			errx(1, "%s: invalid IPv6 address format: %s", __func__,
-			     addr);
-
-		saux = strrchr(addr, ']');
-		if (saux == NULL)
-			errx(1, "%s: invalid IPv6 address format: %s", __func__,
-			     addr);
-
-		/* Consume the '[]:' part. */
-		slen = saux - sptr;
-		memmove(addr, addr + 1, slen);
-		addr[slen - 1] = 0;
-
-		/* Parse port if any. */
-		saux++;
-		sptr = strrchr(saux, ':');
-		if (sptr == NULL) {
-			sa.sin6.sin6_port = htons(BFD_DATA_PLANE_DEFAULT_PORT);
-		} else {
-			*sptr = 0;
-			sa.sin6.sin6_port = htons(parse_port(sptr + 1));
-		}
-
-		if (inet_pton(AF_INET6, addr, &sa.sin6.sin6_addr) != 1)
-			errx(1, "%s: inet_pton: invalid address %s", __func__,
-			     addr);
-	} else {
-		fprintf(stderr, "invalid BFD data plane socket type: %s\n",
-			type);
-		exit(1);
-	}
+	is_client = !address.listen;
 
 	/* Initialize BFD data plane listening socket. */
-	bfd_dplane_init((struct sockaddr *)&sa, salen, is_client);
+	bfd_dplane_init((struct sockaddr *)&address.address, address.address_size, is_client);
 }
 
 static void __bfd_process_keychain_updated(const char *keychain_name, bool is_mhop,

--- a/lib/network.c
+++ b/lib/network.c
@@ -5,6 +5,9 @@
  */
 
 #include <zebra.h>
+
+#include <sys/un.h>
+
 #include <fcntl.h>
 #include "log.h"
 #include "network.h"
@@ -128,4 +131,213 @@ uint32_t frr_sequence32_next(void)
 {
 	/* coverity[Y2K38_SAFETY] */
 	return (uint32_t)frr_sequence_next();
+}
+
+/**
+ * Parses an address port from string and validates its format.
+ *
+ * If `error` parameter is `NULL` no error explanation will be returned.
+ *
+ * \param port_string the port in string format.
+ * \param error pointer to buffer to write errors.
+ * \param error_size error buffer size.
+ * \returns port value on success otherwise `0`.
+ */
+static uint16_t parse_port(const char *port_string, char *error, size_t error_size)
+{
+	char *nullbyte;
+	long rv;
+
+	/*
+	 * `strtol` silently accepts leading white space and a '+'/'-' sign:
+	 * only allow plain decimal numbers here.
+	 */
+	if (!isdigit((unsigned char)*port_string)) {
+		if (error)
+			snprintfrr(error, error_size, "invalid format: %s", port_string);
+		return 0;
+	}
+
+	errno = 0;
+	rv = strtol(port_string, &nullbyte, 10);
+	/* Invalid number range. */
+	if ((rv <= 0 || rv > UINT16_MAX) || errno == ERANGE) {
+		if (error)
+			snprintfrr(error, error_size, "outside valid range: %s", port_string);
+		return 0;
+	}
+	/* There was garbage at the end of the string. */
+	if (*nullbyte != 0) {
+		if (error)
+			snprintfrr(error, error_size, "unexpected ending: %s", nullbyte);
+		return 0;
+	}
+
+	return (uint16_t)rv;
+}
+
+bool network_address_parse(const char *address_string, struct network_address *address,
+			   uint16_t default_port)
+{
+	char *str_pos, *str_pos_aux;
+	size_t str_len;
+	char addr[128];
+	char type[64];
+	char port_error[64];
+
+	assert(address_string != NULL);
+
+	memset(address, 0, sizeof(*address));
+
+	/* Basic parsing: find ':' to figure out type part and address part. */
+	str_pos = strchr(address_string, ':');
+	if (!str_pos) {
+		snprintfrr(address->error, sizeof(address->error), "invalid address format: %s",
+			   address_string);
+		return false;
+	}
+
+	/* Calculate type string length. */
+	str_len = (size_t)(str_pos - address_string);
+
+	/* Copy the address part. */
+	str_pos++;
+	strlcpy(addr, str_pos, sizeof(addr));
+
+	if (strlen(addr) == 0) {
+		snprintfrr(address->error, sizeof(address->error), "address part is empty");
+		return false;
+	}
+
+	/* Copy type part. */
+	strlcpy(type, address_string, MIN(str_len + 1, sizeof(type)));
+
+	/* Fill the address information. */
+	if (strcmp(type, "unix") == 0 || strcmp(type, "unixc") == 0) {
+		struct sockaddr_un *sunp = (struct sockaddr_un *)&address->address;
+
+		address->listen = (strcmp(type, "unixc") != 0);
+
+		sunp->sun_family = AF_UNIX;
+		if (strlcpy(sunp->sun_path, addr, sizeof(sunp->sun_path)) >=
+		    sizeof(sunp->sun_path)) {
+			snprintfrr(address->error, sizeof(address->error), "unix path is too long");
+			return false;
+		}
+#ifdef HAVE_STRUCT_SOCKADDR_UN_SUN_LEN
+		sunp->sun_len = SUN_LEN(sunp);
+#endif /* HAVE_STRUCT_SOCKADDR_UN_SUN_LEN */
+		address->address_size = sizeof(struct sockaddr_un);
+	} else if (strcmp(type, "ipv4") == 0 || strcmp(type, "ipv4c") == 0) {
+		struct sockaddr_in *sin = (struct sockaddr_in *)&address->address;
+
+		address->listen = (strcmp(type, "ipv4c") != 0);
+
+		sin->sin_family = AF_INET;
+#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
+		sin->sin_len = sizeof(*sin);
+#endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
+		sin->sin_port = htons(default_port);
+
+		address->address_size = sizeof(struct sockaddr_in);
+
+		/* Parse port if any. */
+		str_pos = strchr(addr, ':');
+		if (str_pos != NULL) {
+			uint16_t port;
+
+			*str_pos = 0;
+			port = parse_port(str_pos + 1, port_error, sizeof(port_error));
+			if (port == 0) {
+				snprintfrr(address->error, sizeof(address->error),
+					   "invalid port: %s", port_error);
+				return false;
+			}
+
+			sin->sin_port = htons(port);
+		}
+
+		if (inet_pton(AF_INET, addr, &sin->sin_addr) != 1) {
+			snprintfrr(address->error, sizeof(address->error),
+				   "invalid IPv4 address: %s", addr);
+			return false;
+		}
+	} else if (strcmp(type, "ipv6") == 0 || strcmp(type, "ipv6c") == 0) {
+		struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&address->address;
+
+		address->listen = (strcmp(type, "ipv6c") != 0);
+
+		sin6->sin6_family = AF_INET6;
+#ifdef SIN6_LEN
+		sin6->sin6_len = sizeof(*sin6);
+#endif /* SIN6_LEN */
+		sin6->sin6_port = htons(default_port);
+
+		address->address_size = sizeof(struct sockaddr_in6);
+
+		/* Check for IPv6 enclosures '[]' */
+		str_pos = &addr[0];
+		if (*str_pos != '[') {
+			snprintfrr(address->error, sizeof(address->error),
+				   "invalid IPv6 format (expected '['): %s", addr);
+			return false;
+		}
+
+		str_pos_aux = strrchr(addr, ']');
+		if (!str_pos_aux) {
+			snprintfrr(address->error, sizeof(address->error),
+				   "invalid IPv6 format (expected ']'): %s", addr);
+			return false;
+		}
+
+		/* Consume the '[]:' part. */
+		str_len = (size_t)(str_pos_aux - str_pos);
+		memmove(addr, addr + 1, str_len);
+		addr[str_len - 1] = 0;
+
+		/*
+		 * Parse port if any: only a port or the end of the string may
+		 * follow the ']'.
+		 */
+		str_pos_aux++;
+		if (*str_pos_aux == ':') {
+			uint16_t port;
+
+			port = parse_port(str_pos_aux + 1, port_error, sizeof(port_error));
+			if (port == 0) {
+				snprintfrr(address->error, sizeof(address->error),
+					   "invalid port: %s", port_error);
+				return false;
+			}
+			sin6->sin6_port = htons(port);
+		} else if (*str_pos_aux != 0) {
+			snprintfrr(address->error, sizeof(address->error),
+				   "expected port or nothing, got: %s", str_pos_aux);
+			return false;
+		}
+
+		/* Parse the scope/zone identifier if any. */
+		str_pos = strchr(addr, '%');
+		if (str_pos != NULL) {
+			*str_pos = 0;
+			sin6->sin6_scope_id = if_nametoindex(str_pos + 1);
+			if (sin6->sin6_scope_id == 0) {
+				snprintfrr(address->error, sizeof(address->error),
+					   "invalid IPv6 scope: %s", str_pos + 1);
+				return false;
+			}
+		}
+
+		if (inet_pton(AF_INET6, addr, &sin6->sin6_addr) != 1) {
+			snprintfrr(address->error, sizeof(address->error),
+				   "invalid IPv6 address: %s", addr);
+			return false;
+		}
+	} else {
+		snprintfrr(address->error, sizeof(address->error), "invalid address type: %s",
+			   type);
+		return false;
+	}
+
+	return true;
 }

--- a/lib/network.h
+++ b/lib/network.h
@@ -7,6 +7,9 @@
 #ifndef _ZEBRA_NETWORK_H
 #define _ZEBRA_NETWORK_H
 
+#include <sys/socket.h>
+
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -102,6 +105,43 @@ static inline long frr_weak_random(void)
 	/* coverity[dont_call] */
 	return random();
 }
+
+/** Parsed network address information. */
+struct network_address {
+	/** Address storage. */
+	struct sockaddr_storage address;
+	/** Used address storage. */
+	socklen_t address_size;
+	/** Listen mode otherwise connect. */
+	bool listen;
+	/** Error string (if function returned false). */
+	char error[256];
+};
+
+/**
+ * Parses a string and returns the formatted network address if successful.
+ *
+ * When the parse fails the function returns `false` and the parameter
+ * `address` member `error` is set with the error message that occurred.
+ *
+ * When no port is present on the string the corresponding `sockaddr` port
+ * field will be set to the provided `default_port`.  `default_port` is used
+ * as-is and is not validated: a port explicitly written as `0` is rejected
+ * (it is most likely a typo), but callers that have no meaningful default
+ * may pass `0` to get the wildcard port.
+ *
+ * IPv6 addresses must be enclosed in `[]` and may carry a scope/zone
+ * identifier (e.g. `ipv6:[fe80::1%eth0]:1234`), which is resolved with
+ * `if_nametoindex()` and stored in `sin6_scope_id`.
+ *
+ * \param address_string the string to parse
+ * \param address the formatted address output
+ * \param default_port port to use if none found in string (IPv4/IPv6 only).
+ * \returns `true` on success with address set in `address` members, otherwise
+ *          `false` and error message in `address.error`.
+ */
+extern bool network_address_parse(const char *address_string, struct network_address *address,
+				  uint16_t default_port);
 
 #ifdef __cplusplus
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -42,6 +42,7 @@ frr_northbound*
 /lib/test_heavy_wq
 /lib/test_idalloc
 /lib/test_memory
+/lib/test_network_address
 /lib/test_nexthop
 /lib/test_nexthop_iter
 /lib/test_ntop

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -227,6 +227,17 @@ tests_lib_test_memory_LDADD = $(ALL_TESTS_LDADD)
 tests_lib_test_memory_SOURCES = tests/lib/test_memory.c
 
 
+check_PROGRAMS += tests/lib/test_network_address
+tests_lib_test_network_address_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_network_address_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_network_address_LDADD = $(ALL_TESTS_LDADD)
+tests_lib_test_network_address_SOURCES = tests/lib/test_network_address.c
+EXTRA_DIST += \
+	tests/lib/test_network_address.py \
+	tests/lib/test_network_address.refout \
+	# end
+
+
 check_PROGRAMS += tests/lib/test_nexthop_iter
 tests_lib_test_nexthop_iter_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_nexthop_iter_CPPFLAGS = $(TESTS_CPPFLAGS)

--- a/tests/lib/test_network_address.c
+++ b/tests/lib/test_network_address.c
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * network_address_parse() unit test
+ * Copyright (C) 2026 Rafael Zalamena
+ */
+
+#include <zebra.h>
+
+#include <sys/un.h>
+
+#include "lib/network.h"
+
+/*
+ * Keep the output free of platform dependent values (`AF_*` numbers,
+ * `sizeof(struct sockaddr_un)`, interface indexes) so the reference output
+ * matches everywhere.
+ */
+static void test(const char *address_string, uint16_t default_port)
+{
+	struct network_address address = {};
+	char buf[INET6_ADDRSTRLEN];
+
+	printf("'%s' (default port %u)\n", address_string, default_port);
+
+	if (!network_address_parse(address_string, &address, default_port)) {
+		printf("  error: '%s'\n", address.error);
+		return;
+	}
+
+	printf("  mode: %s\n", address.listen ? "listen" : "connect");
+
+	switch (address.address.ss_family) {
+	case AF_INET: {
+		struct sockaddr_in *sin = (struct sockaddr_in *)&address.address;
+
+		printf("  type: ipv4\n");
+		printf("  address: %s\n", inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf)));
+		printf("  port: %u\n", ntohs(sin->sin_port));
+		assert(address.address_size == sizeof(*sin));
+		break;
+	}
+	case AF_INET6: {
+		struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&address.address;
+
+		printf("  type: ipv6\n");
+		printf("  address: %s\n", inet_ntop(AF_INET6, &sin6->sin6_addr, buf, sizeof(buf)));
+		printf("  port: %u\n", ntohs(sin6->sin6_port));
+		printf("  scope: %s\n", sin6->sin6_scope_id ? "set" : "unset");
+		assert(address.address_size == sizeof(*sin6));
+		break;
+	}
+	case AF_UNIX: {
+		struct sockaddr_un *sunp = (struct sockaddr_un *)&address.address;
+
+		printf("  type: unix\n");
+		printf("  path: %s\n", sunp->sun_path);
+		assert(address.address_size == sizeof(*sunp));
+		break;
+	}
+	default:
+		printf("  unexpected family\n");
+		break;
+	}
+}
+
+/*
+ * `sun_path` is not the same size on every platform, so exercise the length
+ * boundary relative to it and print only the outcome.
+ */
+static void test_unix_path_length(size_t length)
+{
+	struct network_address address = {};
+	struct sockaddr_un sun;
+	char address_string[sizeof(sun.sun_path) + 128];
+
+	assert(length < sizeof(address_string) - sizeof("unix:"));
+
+	strlcpy(address_string, "unix:", sizeof(address_string));
+	memset(address_string + strlen("unix:"), 'a', length);
+	address_string[strlen("unix:") + length] = 0;
+
+	printf("unix path of sizeof(sun_path)%+d bytes: %s\n",
+	       (int)length - (int)sizeof(sun.sun_path),
+	       network_address_parse(address_string, &address, 4444) ? "accepted" : "rejected");
+}
+
+int main(int argc, char *argv[])
+{
+	struct sockaddr_un sun;
+
+	printf("== IPv4 ==\n");
+	test("ipv4:127.0.0.1", 4444);
+	test("ipv4:127.0.0.1:8080", 4444);
+	test("ipv4c:127.0.0.1:8080", 4444);
+	test("ipv4:0.0.0.0:1", 4444);
+	test("ipv4:255.255.255.255:65535", 4444);
+
+	printf("\n== IPv6 ==\n");
+	test("ipv6:[::1]", 4444);
+	test("ipv6:[::1]:8080", 4444);
+	test("ipv6c:[::1]:8080", 4444);
+	test("ipv6:[2001:db8::1]:179", 4444);
+	test("ipv6:[::]:1", 4444);
+
+	printf("\n== unix ==\n");
+	test("unix:/var/run/frr/test.sock", 4444);
+	test("unixc:/var/run/frr/test.sock", 4444);
+	/* The port is meaningless for unix sockets: ':' is part of the path. */
+	test("unix:/var/run/frr/test.sock:8080", 4444);
+
+	printf("\n== invalid type ==\n");
+	test("", 4444);
+	test("nocolon", 4444);
+	test("IPV4:127.0.0.1", 4444);
+	test("bogus:127.0.0.1", 4444);
+	test(":127.0.0.1", 4444);
+	test("ipv4:", 4444);
+	test("ipv6:", 4444);
+	test("unix:", 4444);
+
+	printf("\n== invalid address ==\n");
+	test("ipv4:256.0.0.1", 4444);
+	test("ipv4:not-an-address", 4444);
+	test("ipv6:[::g]", 4444);
+	test("ipv6:::1", 4444);
+	test("ipv6:[::1", 4444);
+	test("ipv6:[]", 4444);
+
+	printf("\n== trailing garbage after ']' ==\n");
+	test("ipv6:[::1]junk", 4444);
+	test("ipv6:[::1]junk:80", 4444);
+	test("ipv6:[::1]:80:90", 4444);
+
+	printf("\n== invalid port ==\n");
+	test("ipv4:127.0.0.1:0", 4444);
+	test("ipv4:127.0.0.1:65536", 4444);
+	test("ipv4:127.0.0.1:-1", 4444);
+	test("ipv4:127.0.0.1:+80", 4444);
+	test("ipv4:127.0.0.1: 80", 4444);
+	test("ipv4:127.0.0.1:80x", 4444);
+	test("ipv4:127.0.0.1:", 4444);
+	test("ipv4:127.0.0.1:99999999999999999999", 4444);
+	test("ipv6:[::1]:0", 4444);
+	test("ipv6:[::1]:65536", 4444);
+
+	printf("\n== IPv6 scope ==\n");
+	test("ipv6:[fe80::1%frr-no-such-if]:1234", 4444);
+
+	printf("\n== unix path length boundary ==\n");
+	/* The longest path that still leaves room for the NUL terminator. */
+	test_unix_path_length(sizeof(sun.sun_path) - 1);
+	/* One byte too long: the NUL terminator no longer fits. */
+	test_unix_path_length(sizeof(sun.sun_path));
+	test_unix_path_length(sizeof(sun.sun_path) + 64);
+
+	return 0;
+}

--- a/tests/lib/test_network_address.py
+++ b/tests/lib/test_network_address.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+import frrtest
+
+
+class TestNetworkAddress(frrtest.TestRefOut):
+    program = "./test_network_address"

--- a/tests/lib/test_network_address.refout
+++ b/tests/lib/test_network_address.refout
@@ -1,0 +1,143 @@
+== IPv4 ==
+'ipv4:127.0.0.1' (default port 4444)
+  mode: listen
+  type: ipv4
+  address: 127.0.0.1
+  port: 4444
+'ipv4:127.0.0.1:8080' (default port 4444)
+  mode: listen
+  type: ipv4
+  address: 127.0.0.1
+  port: 8080
+'ipv4c:127.0.0.1:8080' (default port 4444)
+  mode: connect
+  type: ipv4
+  address: 127.0.0.1
+  port: 8080
+'ipv4:0.0.0.0:1' (default port 4444)
+  mode: listen
+  type: ipv4
+  address: 0.0.0.0
+  port: 1
+'ipv4:255.255.255.255:65535' (default port 4444)
+  mode: listen
+  type: ipv4
+  address: 255.255.255.255
+  port: 65535
+
+== IPv6 ==
+'ipv6:[::1]' (default port 4444)
+  mode: listen
+  type: ipv6
+  address: ::1
+  port: 4444
+  scope: unset
+'ipv6:[::1]:8080' (default port 4444)
+  mode: listen
+  type: ipv6
+  address: ::1
+  port: 8080
+  scope: unset
+'ipv6c:[::1]:8080' (default port 4444)
+  mode: connect
+  type: ipv6
+  address: ::1
+  port: 8080
+  scope: unset
+'ipv6:[2001:db8::1]:179' (default port 4444)
+  mode: listen
+  type: ipv6
+  address: 2001:db8::1
+  port: 179
+  scope: unset
+'ipv6:[::]:1' (default port 4444)
+  mode: listen
+  type: ipv6
+  address: ::
+  port: 1
+  scope: unset
+
+== unix ==
+'unix:/var/run/frr/test.sock' (default port 4444)
+  mode: listen
+  type: unix
+  path: /var/run/frr/test.sock
+'unixc:/var/run/frr/test.sock' (default port 4444)
+  mode: connect
+  type: unix
+  path: /var/run/frr/test.sock
+'unix:/var/run/frr/test.sock:8080' (default port 4444)
+  mode: listen
+  type: unix
+  path: /var/run/frr/test.sock:8080
+
+== invalid type ==
+'' (default port 4444)
+  error: 'invalid address format: '
+'nocolon' (default port 4444)
+  error: 'invalid address format: nocolon'
+'IPV4:127.0.0.1' (default port 4444)
+  error: 'invalid address type: IPV4'
+'bogus:127.0.0.1' (default port 4444)
+  error: 'invalid address type: bogus'
+':127.0.0.1' (default port 4444)
+  error: 'invalid address type: '
+'ipv4:' (default port 4444)
+  error: 'address part is empty'
+'ipv6:' (default port 4444)
+  error: 'address part is empty'
+'unix:' (default port 4444)
+  error: 'address part is empty'
+
+== invalid address ==
+'ipv4:256.0.0.1' (default port 4444)
+  error: 'invalid IPv4 address: 256.0.0.1'
+'ipv4:not-an-address' (default port 4444)
+  error: 'invalid IPv4 address: not-an-address'
+'ipv6:[::g]' (default port 4444)
+  error: 'invalid IPv6 address: ::g'
+'ipv6:::1' (default port 4444)
+  error: 'invalid IPv6 format (expected '['): ::1'
+'ipv6:[::1' (default port 4444)
+  error: 'invalid IPv6 format (expected ']'): [::1'
+'ipv6:[]' (default port 4444)
+  error: 'invalid IPv6 address: '
+
+== trailing garbage after ']' ==
+'ipv6:[::1]junk' (default port 4444)
+  error: 'expected port or nothing, got: junk'
+'ipv6:[::1]junk:80' (default port 4444)
+  error: 'expected port or nothing, got: junk:80'
+'ipv6:[::1]:80:90' (default port 4444)
+  error: 'invalid port: unexpected ending: :90'
+
+== invalid port ==
+'ipv4:127.0.0.1:0' (default port 4444)
+  error: 'invalid port: outside valid range: 0'
+'ipv4:127.0.0.1:65536' (default port 4444)
+  error: 'invalid port: outside valid range: 65536'
+'ipv4:127.0.0.1:-1' (default port 4444)
+  error: 'invalid port: invalid format: -1'
+'ipv4:127.0.0.1:+80' (default port 4444)
+  error: 'invalid port: invalid format: +80'
+'ipv4:127.0.0.1: 80' (default port 4444)
+  error: 'invalid port: invalid format:  80'
+'ipv4:127.0.0.1:80x' (default port 4444)
+  error: 'invalid port: unexpected ending: x'
+'ipv4:127.0.0.1:' (default port 4444)
+  error: 'invalid port: invalid format: '
+'ipv4:127.0.0.1:99999999999999999999' (default port 4444)
+  error: 'invalid port: outside valid range: 99999999999999999999'
+'ipv6:[::1]:0' (default port 4444)
+  error: 'invalid port: outside valid range: 0'
+'ipv6:[::1]:65536' (default port 4444)
+  error: 'invalid port: outside valid range: 65536'
+
+== IPv6 scope ==
+'ipv6:[fe80::1%frr-no-such-if]:1234' (default port 4444)
+  error: 'invalid IPv6 scope: frr-no-such-if'
+
+== unix path length boundary ==
+unix path of sizeof(sun_path)-1 bytes: accepted
+unix path of sizeof(sun_path)+0 bytes: rejected
+unix path of sizeof(sun_path)+64 bytes: rejected


### PR DESCRIPTION
Move the network address parser to `lib/` and add some tests to make sure nothing ever breaks.

This code will be used in the future to parse command line arguments for other daemons (e.g. PIM new southbound).