### PR TITLE
isisd: Prevent out-of-bounds access in TE vertex parser

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1912,8 +1912,13 @@ static struct ls_vertex *vertex_for_arg(struct ls_ted *ted, const char *id, stru
 	uint8_t lspid[ISIS_SYS_ID_LEN + 2] = { 0 };
 	struct isis_dynhn *dynhn;
 	uint64_t key = 0;
+	size_t id_len;
 
 	if (!id)
+		return NULL;
+
+	id_len = strlen(id);
+	if (id_len >= sizeof(sysid))
 		return NULL;
 
 	/*
@@ -1926,8 +1931,8 @@ static struct ls_vertex *vertex_for_arg(struct ls_ted *ted, const char *id, stru
 	 * xxxx.xxxx.xxxx
 	 */
 	strlcpy(sysid, id, sizeof(sysid));
-	if (strlen(id) > 3) {
-		pos = id + strlen(id) - 3;
+	if (id_len > 3) {
+		pos = id + id_len - 3;
 		if (strncmp(pos, "-", 1) == 0) {
 			memcpy(number, ++pos, 2);
 			lspid[ISIS_SYS_ID_LEN + 1] = (uint8_t)strtol((char *)number, NULL, 16);

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1907,7 +1907,7 @@ DEFUN (show_isis_mpls_te_interface,
 static struct ls_vertex *vertex_for_arg(struct ls_ted *ted, const char *id, struct isis *isis)
 {
 	char sysid[255] = { 0 };
-	uint8_t number[3];
+	uint8_t number[3] = { 0 };
 	const char *pos;
 	uint8_t lspid[ISIS_SYS_ID_LEN + 2] = { 0 };
 	struct isis_dynhn *dynhn;

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1936,6 +1936,8 @@ static struct ls_vertex *vertex_for_arg(struct ls_ted *ted, const char *id, stru
 		if (strncmp(pos, "-", 1) == 0) {
 			memcpy(number, ++pos, 2);
 			lspid[ISIS_SYS_ID_LEN + 1] = (uint8_t)strtol((char *)number, NULL, 16);
+			if (pos - id < 4)
+				return NULL;
 			pos -= 4;
 			if (strncmp(pos, ".", 1) != 0)
 				return NULL;

--- a/tests/topotests/isis_te_topo1/test_isis_te_topo1.py
+++ b/tests/topotests/isis_te_topo1/test_isis_te_topo1.py
@@ -170,6 +170,23 @@ def test_step1():
         compare_ted_json_output(tgen, rname, "ted_step1.json")
 
 
+def test_invalid_vertex_identifiers():
+    "Verify malformed vertex identifiers do not crash isisd."
+
+    tgen = setup_testcase("Test malformed IS-IS TE vertex identifiers")
+    router = tgen.gears["r1"]
+    identifiers = ["a-00", "{}.00".format("A" * 255)]
+
+    for identifier in identifiers:
+        output = router.vtysh_cmd(
+            "show isis mpls-te database vertex {}".format(identifier),
+            isjson=False,
+        )
+        assert "No vertex found for ID {}".format(identifier) in output
+
+    assert not tgen.routers_have_failure()
+
+
 def test_step2():
     "Step2: Shutdown interface between r1 and r2 and verify that \
     corresponding Edges are removed from the TED on all routers "


### PR DESCRIPTION
The `show isis mpls-te database vertex` command can trigger out-of-bounds reads and writes when parsing malformed or oversized IS-IS TE vertex identifiers.

This PR validates the input and safely handles suffix parsing to prevent those accesses.