### PR TITLE
bfdd: make keyed SHA1 sequence number validation work

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -263,14 +263,8 @@ void bfd_session_apply(struct bfd_session *bs)
 	else if (bs->profile && bs->profile->auth_config.key_chain_name[0] != '\0')
 		bs->kc = keychain_lookup(bs->profile->auth_config.key_chain_name);
 
-	if (bs->peer_profile.auth_config.meticulous ||
-	    (bs->profile && bs->profile->auth_config.meticulous)) {
-		bs->auth_meticulous = true;
-		bs->auth_seq_num_update_modulo = AUTH_SEQ_NUM_MODULO_METICULOUS;
-	} else {
-		bs->auth_meticulous = false;
-		bs->auth_seq_num_update_modulo = AUTH_SEQ_NUM_MODULO;
-	}
+	bs->auth_meticulous = bs->peer_profile.auth_config.meticulous ||
+			      (bs->profile && bs->profile->auth_config.meticulous);
 
 	/* If session interval changed negotiate new timers. */
 	if (bs->ses_state == PTM_BFD_UP &&
@@ -1125,6 +1119,7 @@ struct bfd_session *bfd_session_new(enum bfd_mode_type mode)
 	/* RFC 5880, Section 6.7.3: unpredictable initial sequence number */
 	bs->auth_seq_num = frr_weak_random();
 	bs->auth_last_rx_seq_num = 0;
+	bs->auth_seq_known = false;
 	bs->auth_meticulous = false;
 	bs_set_slow_timers(bs);
 

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -454,13 +454,12 @@ struct bfd_session {
 	struct keychain *kc; /* Currently active keychain for this session */
 	uint32_t auth_seq_num;
 	uint32_t auth_last_rx_seq_num;
-/* the last sequence number will be updated:
- * - on non meticulous mode: every 5 packets
- * - on meticulous mode: every packet
- */
-#define AUTH_SEQ_NUM_MODULO	       5
-#define AUTH_SEQ_NUM_MODULO_METICULOUS 1
-	uint32_t auth_seq_num_update_modulo;
+	/*
+	 * RFC 5880 Section 6.8.1 bfd.AuthSeqKnown, with the time the
+	 * sequence number was last accepted so that it can be aged out.
+	 */
+	bool auth_seq_known;
+	struct timeval auth_last_rx_time;
 	bool auth_meticulous;
 };
 

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1098,29 +1098,54 @@ static bool bfd_check_auth(struct bfd_session *bfd, const struct bfd_pkt *cp)
 		memcpy(&received_seq_num, auth_section + 4, sizeof(received_seq_num));
 		received_seq_num = ntohl(received_seq_num);
 
-		if (bfd->auth_last_rx_seq_num != 0) {
-			if (received_auth_type == BFD_AUTH_TYPE_METICULOUS_KEYED_SHA1) {
-				if (received_seq_num <= bfd->auth_last_rx_seq_num) {
-					cp_debug(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_MH), &peer_sa,
-						 &local_sa, bfd->ifp ? bfd->ifp->ifindex : 0,
-						 bfd->vrf ? bfd->vrf->vrf_id : 0,
-						 "Auth: meticulous sequence number error");
+		/*
+		 * RFC 5880 Section 6.8.1: the expected sequence number is no
+		 * longer known once nothing has been received for twice the
+		 * detection time, so that it resynchronises when the remote
+		 * system restarts.
+		 */
+		if (bfd->auth_seq_known && bfd->detect_TO &&
+		    monotime_since(&bfd->auth_last_rx_time, NULL) >
+			    (int64_t)(2 * bfd->detect_TO))
+			bfd->auth_seq_known = false;
+
+		if (bfd->auth_seq_known) {
+			bool meticulous = received_auth_type ==
+					  BFD_AUTH_TYPE_METICULOUS_KEYED_SHA1;
+			uint32_t lowest = meticulous ? 1 : 0;
+			/*
+			 * RFC 5880 names the local state variable
+			 * bfd.DetectMult and the header field Detect Mult;
+			 * Section 6.7.4 asks for the latter, which is the
+			 * value carried by the packet being checked.
+			 * bfd_recv_cb() has already discarded the packet if
+			 * that field is zero.
+			 */
+			uint32_t highest = 3 * cp->detect_mult;
+			uint32_t distance;
+
+			/*
+			 * The window is bfd.RcvAuthSeq to bfd.RcvAuthSeq +
+			 * (3 * Detect Mult) inclusive, one past that for the
+			 * meticulous variants. Unsigned subtraction gives the
+			 * circular number space the RFC asks for: a sequence
+			 * number behind the stored one wraps to a distance
+			 * larger than the window and is rejected.
+			 */
+			distance = received_seq_num - bfd->auth_last_rx_seq_num;
+			if (distance < lowest || distance > highest) {
+				cp_debug(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_MH), &peer_sa,
+					 &local_sa, bfd->ifp ? bfd->ifp->ifindex : 0,
+					 bfd->vrf ? bfd->vrf->vrf_id : 0,
+					 "Auth: sequence number %u outside window %u..%u",
+					 received_seq_num, bfd->auth_last_rx_seq_num + lowest,
+					 bfd->auth_last_rx_seq_num + highest);
+				if (meticulous)
 					bfd->stats.rx_pkt_authentication_keyed_sha1_sequence_meticulous_error++;
-					return false;
-				}
-			} else {
-				/* Non-meticulous allows equal sequence numbers on stable state */
-				if (received_seq_num < bfd->auth_last_rx_seq_num) {
-					cp_debug(CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_MH), &peer_sa,
-						 &local_sa, bfd->ifp ? bfd->ifp->ifindex : 0,
-						 bfd->vrf ? bfd->vrf->vrf_id : 0,
-						 "Auth: sequence number error (replay)");
+				else
 					bfd->stats.rx_pkt_authentication_keyed_sha1_sequence_error++;
-					return false;
-				}
+				return false;
 			}
-			if ((received_seq_num % bfd->auth_seq_num_update_modulo) == 0)
-				bfd->auth_last_rx_seq_num = received_seq_num;
 		}
 
 		/* Validate Digest */
@@ -1144,6 +1169,15 @@ static bool bfd_check_auth(struct bfd_session *bfd, const struct bfd_pkt *cp)
 			bfd->stats.rx_pkt_authentication_keyed_sha1_mismatch++;
 			return false;
 		}
+
+		/*
+		 * Accepted. The replay window moves only now, after the digest
+		 * has been verified, so that a packet failing authentication
+		 * cannot advance it.
+		 */
+		bfd->auth_last_rx_seq_num = received_seq_num;
+		bfd->auth_seq_known = true;
+		monotime(&bfd->auth_last_rx_time);
 
 		break;
 	}

--- a/tests/topotests/bfd_auth_replay_topo1/bfd_replay_peer.py
+++ b/tests/topotests/bfd_auth_replay_topo1/bfd_replay_peer.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# bfd_replay_peer.py
+# Part of NetDEF Topology Tests
+#
+
+"""
+A minimal BFD speaker used to drive sequence numbers that a conforming
+implementation would never send.
+
+bfdd on the other end cannot be made to emit an out-of-window sequence
+number, so a replay window cannot be tested by two routers alone. This
+speaks enough of RFC 5880 to bring one session up with keyed SHA1
+authentication, and can then hold, rewind, or advance its sequence number
+past the window the RFC allows.
+
+Standard library only.
+"""
+
+import argparse
+import hashlib
+import hmac
+import socket
+import struct
+import sys
+import time
+
+VERSION = 1
+STATE_DOWN, STATE_INIT, STATE_UP = 1, 2, 3
+STATE_NAME = {0: "AdminDown", 1: "Down", 2: "Init", 3: "Up"}
+
+AUTH_KEYED_SHA1 = 4
+AUTH_METICULOUS_KEYED_SHA1 = 5
+AUTH_SECTION_LEN = 28
+DIGEST_OFFSET = 24 + 8
+DIGEST_LEN = 20
+
+FLAG_AUTH = 0x04
+
+BFD_PORT = 3784
+BFD_SOURCE_PORT = 49152
+
+
+def control_packet(my_disc, your_disc, state, mult, tx_us, rx_us, key, seq, auth_type,
+                   key_id):
+    """Build a control packet, with a keyed SHA1 auth section when keyed."""
+    flags = FLAG_AUTH if key else 0
+    length = 24 + (AUTH_SECTION_LEN if key else 0)
+    header = struct.pack(
+        "!BBBBIIIII",
+        VERSION << 5,
+        (state << 6) | flags,
+        mult,
+        length,
+        my_disc,
+        your_disc,
+        tx_us,
+        rx_us,
+        0,
+    )
+    if not key:
+        return header
+
+    section = struct.pack("!BBBBI", auth_type, AUTH_SECTION_LEN, key_id, 0, seq)
+    packet = bytearray(header + section + b"\x00" * DIGEST_LEN)
+
+    # bfdd zeroes the Auth Key/Hash field and computes an HMAC over the
+    # packet. RFC 5880 Section 6.7.4 describes a plain SHA1 with the key
+    # placed in that field instead; this follows bfdd so that the session
+    # comes up, since the digest is not what is under test here.
+    digest = hmac.new(key, bytes(packet), hashlib.sha1).digest()
+    packet[DIGEST_OFFSET:DIGEST_OFFSET + DIGEST_LEN] = digest
+    return bytes(packet)
+
+
+def parse_state(buf):
+    if len(buf) < 24:
+        return None, 0
+    _, sta_flags, _, _, my_disc = struct.unpack("!BBBBI", buf[:8])
+    return sta_flags >> 6, my_disc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local", required=True)
+    parser.add_argument("--peer", required=True)
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--key-id", type=int, default=1)
+    parser.add_argument("--meticulous", action="store_true")
+    parser.add_argument("--seconds", type=float, default=20.0)
+    parser.add_argument("--interval", type=float, default=0.3)
+    parser.add_argument("--detect-mult", type=int, default=3)
+    parser.add_argument("--seq-start", type=int, default=1000)
+    # What to do with the sequence number once the session is up. "hold"
+    # repeats the last one, which the RFC accepts for keyed SHA1 and
+    # refuses for the meticulous variant.
+    parser.add_argument("--after-up", choices=["none", "hold", "rewind", "advance"],
+                        default="none")
+    parser.add_argument("--by", type=int, default=400000)
+    # Keep the sequence number still until the session is accepted. The
+    # window left by an earlier session ages out first, and without this
+    # the sequence has already moved on by the time anything is accepted.
+    parser.add_argument("--hold-until-up", action="store_true")
+    args = parser.parse_args()
+
+    key = args.key.encode()
+    auth_type = AUTH_METICULOUS_KEYED_SHA1 if args.meticulous else AUTH_KEYED_SHA1
+    my_disc = 0x11223344
+    your_disc = 0
+    state = STATE_DOWN
+    seq = args.seq_start
+    held = 0
+    reached_up = False
+
+    # BFD is received on 3784 but must be sourced from 49152-65535
+    # (RFC 5881), so transmit and receive need separate sockets.
+    tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    tx.setsockopt(socket.IPPROTO_IP, socket.IP_TTL, 255)
+    tx.bind((args.local, BFD_SOURCE_PORT))
+    rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    rx.bind((args.local, BFD_PORT))
+    rx.settimeout(args.interval)
+
+    deadline = time.time() + args.seconds
+    while time.time() < deadline:
+        send_seq = seq
+        if reached_up:
+            if args.after_up == "hold":
+                send_seq = held
+            elif args.after_up == "rewind":
+                send_seq = (held - args.by) & 0xFFFFFFFF
+            elif args.after_up == "advance":
+                send_seq = (held + args.by) & 0xFFFFFFFF
+
+        tx.sendto(
+            control_packet(my_disc, your_disc, state, args.detect_mult, 300000,
+                           300000, key, send_seq, auth_type, args.key_id),
+            (args.peer, BFD_PORT),
+        )
+        if reached_up or not args.hold_until_up:
+            seq = (seq + 1) & 0xFFFFFFFF
+
+        try:
+            data, _ = rx.recvfrom(2048)
+        except socket.timeout:
+            continue
+
+        remote_state, remote_disc = parse_state(data)
+        if remote_state is None:
+            continue
+        your_disc = remote_disc
+
+        if remote_state == STATE_DOWN:
+            state = STATE_INIT if state == STATE_DOWN else (
+                STATE_DOWN if state == STATE_UP else state)
+        elif remote_state in (STATE_INIT, STATE_UP):
+            state = STATE_UP
+
+        if state == STATE_UP and remote_state == STATE_UP and not reached_up:
+            reached_up = True
+            held = seq
+
+    print("reached_up=%s final_state=%s" % (reached_up, STATE_NAME.get(state)))
+    return 0 if reached_up else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/topotests/bfd_auth_replay_topo1/rt1/frr.conf
+++ b/tests/topotests/bfd_auth_replay_topo1/rt1/frr.conf
@@ -1,0 +1,21 @@
+hostname rt1
+!
+interface eth-rt2
+ ip address 10.0.1.1/24
+!
+key chain kc1
+ key 1
+  key-string bfdauthkey123
+  cryptographic-algorithm hmac-sha-1
+ exit
+exit
+!
+bfd
+ peer 10.0.1.2 local-address 10.0.1.1 interface eth-rt2
+  detect-multiplier 3
+  receive-interval 300
+  transmit-interval 300
+  authentication key-chain kc1
+ exit
+exit
+!

--- a/tests/topotests/bfd_auth_replay_topo1/rt2/frr.conf
+++ b/tests/topotests/bfd_auth_replay_topo1/rt2/frr.conf
@@ -1,0 +1,5 @@
+hostname rt2
+!
+interface eth-rt1
+ ip address 10.0.1.2/24
+!

--- a/tests/topotests/bfd_auth_replay_topo1/test_bfd_auth_replay_topo1.py
+++ b/tests/topotests/bfd_auth_replay_topo1/test_bfd_auth_replay_topo1.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_bfd_auth_replay_topo1.py
+# Part of NetDEF Topology Tests
+#
+
+"""
+test_bfd_auth_replay_topo1.py: sequence number validation for keyed SHA1
+authentication (RFC 5880 Section 6.7.4).
+
+        +---------+                        +---------+
+        |         | eth-rt2        eth-rt1 |         |
+        |   RT1   +------------------------+   RT2   |
+        | 10.0.1.1|           s1           |10.0.1.2 |
+        +---------+                        +---------+
+
+RT1 runs bfdd with keyed SHA1 authentication. RT2 runs no BFD; it is the
+namespace the scripted peer speaks from.
+
+Two conforming implementations cannot exercise this, because neither will
+emit a sequence number outside the window. The peer is therefore scripted
+so that it can hold, rewind, or advance its sequence number, which is the
+only way to tell a working replay window from one that never runs.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bfdd]
+
+KEY = "bfdauthkey123"
+RT1_ADDR = "10.0.1.1"
+RT2_ADDR = "10.0.1.2"
+
+SEQ_ERROR = "rx-pkt-authentication-keyed-sha1-sequence-error"
+SEQ_ERROR_METICULOUS = "rx-pkt-authentication-keyed-sha1-sequence-meticulous-error"
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    topodef = {
+        "s1": ("rt1:eth-rt2", "rt2:eth-rt1"),
+    }
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for router in tgen.routers().values():
+        router.load_frr_config()
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    get_topogen().stop_topology()
+
+
+def counters():
+    "Authentication counters for the single session on rt1."
+    rt1 = get_topogen().gears["rt1"]
+    output = json.loads(rt1.vtysh_cmd("show bfd peers counters json"))
+    return output[0] if output else {}
+
+
+def counter(name):
+    return counters().get(name, 0)
+
+
+def peer_state():
+    rt1 = get_topogen().gears["rt1"]
+    output = json.loads(rt1.vtysh_cmd("show bfd peers json"))
+    return output[0].get("status") if output else None
+
+
+def run_peer(after_up="none", meticulous=False, by=400000, seconds=20,
+             seq_start=None, hold_until_up=False):
+    """Speak BFD from rt2 for `seconds`, misbehaving as asked once up."""
+    rt2 = get_topogen().gears["rt2"]
+    cmd = [
+        sys.executable,
+        os.path.join(CWD, "bfd_replay_peer.py"),
+        "--local", RT2_ADDR,
+        "--peer", RT1_ADDR,
+        "--key", KEY,
+        "--after-up", after_up,
+        "--by", str(by),
+        "--seconds", str(seconds),
+    ]
+    if seq_start is not None:
+        cmd += ["--seq-start", str(seq_start)]
+    if hold_until_up:
+        cmd.append("--hold-until-up")
+    if meticulous:
+        cmd.append("--meticulous")
+    logger.info("running scripted peer: %s", " ".join(cmd))
+    return rt2.popen(cmd)
+
+
+def expect_state(want, count=40, wait=0.5):
+    test_func = lambda: peer_state() == want
+    _, result = topotest.run_and_expect(test_func, True, count=count, wait=wait)
+    assert result is True, "rt1 session did not reach {}, it is {}".format(
+        want, peer_state()
+    )
+
+
+def expect_counter_above(name, floor, count=40, wait=0.5):
+    test_func = lambda: counter(name) > floor
+    _, result = topotest.run_and_expect(test_func, True, count=count, wait=wait)
+    assert result is True, "{} did not rise above {}, it is {}".format(
+        name, floor, counter(name)
+    )
+
+
+def skip_unless_ready():
+    """Keyed SHA1 needs a build with crypto-openssl.
+
+    Sequence numbers only exist in the cryptographic authentication
+    types, so there is nothing here that a build without them can run.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    if not tgen.gears["rt1"].has_crypto_openssl():
+        pytest.skip("crypto-openssl disabled, skipping keyed SHA1 test")
+
+
+def test_bfd_auth_session_comes_up():
+    "A well behaved authenticated peer brings the session up."
+    skip_unless_ready()
+
+    peer = run_peer(after_up="none", seconds=25)
+    expect_state("up")
+    assert counter(SEQ_ERROR) == 0, "a conforming peer was refused on sequence"
+    peer.terminate()
+    peer.wait()
+
+
+def test_bfd_auth_held_sequence_is_accepted():
+    """A repeated sequence number is inside the keyed SHA1 window.
+
+    RFC 5880 Section 6.7.4 makes the window bfd.RcvAuthSeq to
+    bfd.RcvAuthSeq+(3*Detect Mult) inclusive, so a distance of zero is
+    acceptable for the plain variant.
+    """
+    skip_unless_ready()
+
+    before = counter(SEQ_ERROR)
+    peer = run_peer(after_up="hold", seconds=25)
+    expect_state("up")
+    assert counter(SEQ_ERROR) == before, "a held sequence number was refused"
+    peer.terminate()
+    peer.wait()
+
+
+def test_bfd_auth_rewound_sequence_is_refused():
+    "A sequence number far behind the window is a replay and must be dropped."
+    skip_unless_ready()
+
+    expect_state("down", count=60)
+    before = counter(SEQ_ERROR)
+    peer = run_peer(after_up="rewind", by=400000, seconds=30)
+    expect_state("up")
+    expect_counter_above(SEQ_ERROR, before)
+    # Nothing is being accepted any more, so detection expires.
+    expect_state("down", count=60)
+    peer.terminate()
+    peer.wait()
+
+
+def test_bfd_auth_advanced_sequence_is_refused():
+    """A sequence number far past the window must be dropped too.
+
+    Without the upper bound almost the whole number space is acceptable,
+    and a peer that wraps is then refused for good.
+    """
+    skip_unless_ready()
+
+    expect_state("down", count=60)
+    before = counter(SEQ_ERROR)
+    peer = run_peer(after_up="advance", by=2000000, seconds=30)
+    expect_state("up")
+    expect_counter_above(SEQ_ERROR, before)
+    peer.terminate()
+    peer.wait()
+
+
+def test_bfd_auth_sequence_resynchronises():
+    """The window is forgotten after twice the detection time.
+
+    RFC 5880 Section 6.8.1 requires bfd.AuthSeqKnown to be cleared once
+    nothing has been received for that long, so that a peer which
+    restarted with a fresh sequence number is not locked out.
+    """
+    skip_unless_ready()
+
+    expect_state("down", count=60)
+    # A fresh peer picks an unrelated starting sequence, exactly as a
+    # restarted implementation would.
+    peer = run_peer(after_up="none", seconds=25)
+    expect_state("up")
+    peer.terminate()
+    peer.wait()
+
+
+def test_bfd_auth_sequence_may_wrap():
+    """A sequence number that wraps past 2^32 is still inside the window.
+
+    The window is an unsigned 32 bit circular space, so the step from
+    0xffffffff to 0 is a distance of one and not a jump backwards. A
+    linear comparison would refuse everything from here on.
+    """
+    skip_unless_ready()
+
+    expect_state("down", count=60)
+    # Held at six short of the wrap until something is accepted, so the
+    # window is established there and the wrap falls inside the session
+    # rather than while the previous window is still ageing out.
+    peer = run_peer(after_up="none", seconds=40, seq_start=0xFFFFFFFA,
+                    hold_until_up=True)
+    expect_state("up")
+
+    before = counter(SEQ_ERROR)
+    accepted = counter("control-packet-input")
+    # Wait on packets being accepted rather than on the clock, so the
+    # session is known to have carried on well past the wrap.
+    expect_counter_above("control-packet-input", accepted + 20)
+    assert peer_state() == "up", "session dropped as the sequence number wrapped"
+    assert counter(SEQ_ERROR) == before, "a wrapped sequence number was refused"
+    peer.terminate()
+    peer.wait()
+
+
+def test_bfd_auth_meticulous_refuses_a_repeat():
+    """Meticulous keyed SHA1 starts the window one past the last sequence.
+
+    RFC 5880 Section 6.7.4 gives the meticulous variants a window of
+    bfd.RcvAuthSeq+1 to bfd.RcvAuthSeq+(3*Detect Mult), so the repeat
+    that the plain variant accepts must be refused here.
+    """
+    skip_unless_ready()
+
+    expect_state("down", count=60)
+    get_topogen().gears["rt1"].vtysh_cmd(
+        """
+        configure terminal
+        key chain kc1
+        key 1
+        cryptographic-algorithm hmac-sha-1
+        exit
+        exit
+        bfd
+        peer {} local-address {} interface eth-rt2
+        authentication algorithm meticulous
+        exit
+        exit
+        """.format(RT2_ADDR, RT1_ADDR)
+    )
+
+    before = counter(SEQ_ERROR_METICULOUS)
+    peer = run_peer(after_up="hold", meticulous=True, seconds=30)
+    expect_state("up")
+    expect_counter_above(SEQ_ERROR_METICULOUS, before)
+    expect_state("down", count=60)
+    peer.terminate()
+    peer.wait()
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Fixes #23275.

The replay check never ran. `bfd.AuthSeqKnown` was approximated by testing `auth_last_rx_seq_num` against zero, and the only assignment to that field sat inside the same test, so it never left zero and the guarded block was skipped. Every sequence number was accepted, replayed ones included.

What this does:

* keeps `bfd.AuthSeqKnown` as its own flag, set on the first accepted packet where RFC 5880 says to
* compares against the window the RFC describes, `bfd.RcvAuthSeq` to `bfd.RcvAuthSeq+(3*Detect Mult)` inclusive and one past that for the meticulous variants, using unsigned subtraction so the comparison is circular. The previous plain `<` and `<=` had no upper bound, which would have refused everything from a peer that wrapped.
* sizes the window from the Detect Mult carried by the packet. Section 6.7.4 asks for the header field rather than `bfd.DetectMult`, and `bfd_recv_cb()` has already discarded the packet if that field is zero.
* advances the window only after the digest has been verified, so a packet failing authentication cannot move it, and on every accepted packet rather than one in five. `auth_seq_num_update_modulo` has no remaining user and goes with it.
* clears `bfd.AuthSeqKnown` after twice the detection time, as Section 6.8.1 requires, so a peer that restarts resynchronises rather than the session staying down.

Greptile raised a related finding during review of #21678, that an on-path sender can poison the replay state at `bfd_packet.c:1095-1096`. I do not think that is reachable today, for the same reason the check is not, but moving the update after the digest closes it either way.

### Testing

`bfd_auth_replay_topo1` is new. Two conforming implementations cannot exercise this between them, because neither will emit a sequence number outside the window, which is why the existing `bfd_authentication_topo1` passed the whole time the check was dead. The test therefore drives one end from a small BFD speaker, standard library only, that can hold, rewind or advance its own sequence number.

It covers the session coming up, a repeated sequence number being accepted for keyed SHA1, one far behind or far ahead of the window being refused, and the window being forgotten after twice the detection time.

On this branch it passes. On master it fails at `rx-pkt-authentication-keyed-sha1-sequence-error did not rise above 0, it is 0`.
