### PR TITLE
bfdd: check the packet's State field when Your Discriminator is zero

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1316,9 +1316,15 @@ void bfd_recv_cb(struct event *t)
 		return;
 	}
 
-	/* Ensure that existing good sessions are not overridden. */
-	if (!cp->discrs.remote_discr && bfd->ses_state != PTM_BFD_DOWN &&
-	    bfd->ses_state != PTM_BFD_ADM_DOWN) {
+	/*
+	 * RFC 5880 Section 6.8.6: a packet carrying a zero Your Discriminator
+	 * is discarded when the State field in that packet is not Down or
+	 * AdminDown. Testing the local state instead would refuse a peer that
+	 * has lost its state and is correctly announcing Down, which in demand
+	 * mode is never recovered from because no detection timer is running.
+	 */
+	if (!cp->discrs.remote_discr && BFD_GETSTATE(cp->flags) != PTM_BFD_DOWN &&
+	    BFD_GETSTATE(cp->flags) != PTM_BFD_ADM_DOWN) {
 		frrtrace(6, frr_bfd, packet_remote_discr_zero, is_mhop, &peer, &local, ifindex,
 			 vrfid, bfd->ses_state);
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,

--- a/tests/topotests/bfd_demand_topo1/test_bfd_demand_topo1.py
+++ b/tests/topotests/bfd_demand_topo1/test_bfd_demand_topo1.py
@@ -359,6 +359,46 @@ def test_bfd_demand_both_ends_disable():
     assert flaps == 0, "r1 recorded {} down events on a healthy path".format(flaps)
 
 
+def test_bfd_demand_peer_restart_recovers():
+    """A peer that restarts must be able to re-establish the session.
+
+    The restarted peer has lost its discriminator, so it announces itself
+    with Your Discriminator zero and State Down, which RFC 5880 section
+    6.8.6 permits.  r1 is the demanding end here and therefore the one not
+    running a detection timer, so if it refuses those packets there is
+    nothing left to bring the session back: it holds a stale remote
+    discriminator and r2 stays in Down.
+
+    Asynchronous mode does not show this, because the detection timer
+    expires and the session is Down by the time the peer returns.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1, r2 = tgen.gears["r1"], tgen.gears["r2"]
+
+    _set_demand(r1, R2_ADDR, True)
+
+    test_func = partial(
+        _check_peer, r1, R2_ADDR, {"status": "up", "demand-mode": True}
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=16, wait=1)
+    assert result is None, "r1 is not up in demand mode before the restart"
+
+    # Restart the end that is not demanding, so the end that keeps its
+    # session is the one without a detection timer.
+    r2.killDaemons(["bfdd"])
+    r2.startDaemons(["bfdd"])
+
+    for router, peer in ((r1, R2_ADDR), (r2, R1_ADDR)):
+        test_func = partial(_check_peer, router, peer, {"status": "up"})
+        _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+        assert result is None, "{} did not recover after bfdd restarted on r2".format(
+            router.name
+        )
+
+
 def test_memory_leak():
     "Run the memory leak test and report results."
     tgen = get_topogen()


### PR DESCRIPTION
Fixes #23283.

RFC 5880 section 6.8.6 discards a packet carrying a zero Your Discriminator only when the State field in that packet is not Down or AdminDown. bfdd tested its own session state instead:

```c
	if (!cp->discrs.remote_discr && bfd->ses_state != PTM_BFD_DOWN &&
	    bfd->ses_state != PTM_BFD_ADM_DOWN) {
```

So a peer that has lost its state and correctly announces Your Discriminator zero with State Down is refused for as long as the local session is Up.

Asynchronous mode hides it. The detection timer expires, the session goes Down, and the next packet is accepted. Demand mode suppresses that timer and the session then deadlocks: the end that did not restart keeps a stale remote discriminator and never accepts the peer again, while the peer sits in Down announcing itself correctly. The condition is that the end which did not restart is the one whose detection timer is suppressed, which is why restarting the demanding end recovers normally.

What the check was guarding is kept, since a packet claiming Up or Init with a zero Your Discriminator is still discarded.

### Testing

Two bfdd instances on a veth pair, no other daemons. The decoded packet fields and the counter values are in the issue.

| scenario | before | after |
| --- | --- | --- |
| demand mode both ends, restart either | one end up on a stale discriminator, the other down, discard counter climbing | both up, no discards |
| demand mode on one end, restart the other | same, with `RX fail packet` reaching 40 against exactly 40 discard log lines | both up, no discards |
| demand mode on one end, restart the demanding end | recovers | recovers |
| asynchronous, restart either | recovers | recovers |

The topotest case restarts bfdd on the end that is not demanding, so the end that keeps its session is the one with no detection timer running, and requires both back to Up.

Against this branch `bfd_demand_topo1` is 7 passed and 1 skipped in 62 seconds, the new case accounting for 3.7 of those. With the first commit reverted the new case fails with `r2 did not recover after bfdd restarted on r2`, and the six existing cases pass either way.

### Note

I implemented demand mode in #23023 and hit this while doing so, but attributed it in that pull request to the state machine refusing a Down to Up transition. The captures rule that out: with demand mode on both ends the restarted peer receives nothing at all to transition on, because the surviving end has ceased periodic transmission and never resumes.

The `demand-mode` note in `doc/user/bfd.rst` is about a failed path going undetected. That is a separate matter and stays correct, so nothing there needs changing.
