### PR TITLE
ospfd: fix memory leaks in ospf_router_info_show_info()

### DIFF
--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1693,8 +1693,13 @@ static void ospf_router_info_show_info(struct vty *vty,
 	if (json) {
 		if (json_object_object_length(jpce) > 1)
 			json_object_object_add(jri, "pceInformation", jpce);
+		else
+			json_object_free(jpce);
+
 		if (json_object_object_length(jsr) > 1)
 			json_object_object_add(jri, "segmentRouting", jsr);
+		else
+			json_object_free(jsr);
 	}
 	return;
 }


### PR DESCRIPTION
Hi, it seems to me that memory deallocation is indeed missing here.

Dynamic memory, referenced by 'jpce' and 'jsr', is allocated at ospf_ri.c:1658 by calling function 'json_object_new_object' and lost at ospf_ri.c:1699. When condition json_object_object_length is false - a memory leak is occurring.

Found by the static analyzer Svace (ISP RAS).