### PR TITLE
lib: prevent stack overflow in yang_translate_xpath()

### DIFF
--- a/lib/yang_translator.c
+++ b/lib/yang_translator.c
@@ -100,7 +100,7 @@ static void yang_mapping_add(struct yang_translator *translator, int dir,
 
 	for (unsigned int i = 0; i < array_size(keys); i++) {
 		xpfmt = frrstr_replace(mapping->xpath_from_fmt, keys[i],
-				       "%[^']");
+				       "%127[^']");
 		strlcpy(mapping->xpath_from_fmt, xpfmt,
 			sizeof(mapping->xpath_from_fmt));
 		XFREE(MTYPE_TMP, xpfmt);


### PR DESCRIPTION
PROC_USE.VULNERABLE.SSCANF - Use of vulnerable function 'sscanf' at yang_translator.c. This function is unsafe.

xpath_from_fmt uses an unbounded "%[^']" conversion, but yang_translate_xpath() scans it into a fixed 128-byte buffer. Bound the conversion to avoid overflow.

Found by the static analyzer Svace (ISP RAS).