### PR TITLE
Pim upstream rpf changes

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1265,7 +1265,7 @@ int pim_if_jp_hold(const struct pim_interface *pim_interface)
 struct pim_neighbor *pim_if_find_neighbor(struct interface *ifp, pim_addr addr)
 {
 	struct listnode *neighnode;
-	struct pim_neighbor *neigh;
+	struct pim_neighbor *neigh, *second_neigh = NULL;
 	struct pim_interface *pim_ifp;
 	struct prefix p;
 
@@ -1280,24 +1280,36 @@ struct pim_neighbor *pim_if_find_neighbor(struct interface *ifp, pim_addr addr)
 
 	pim_addr_to_prefix(&p, addr);
 
+	/*
+	 * The goal here should always to prefer the primary address
+	 * if one matches, else choose a secondary
+	 */
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, neighnode,
 				  neigh)) {
 
-		/* primary address ? */
+		/*
+		 * If we find a primary address that matches, stop looking
+		 * for the primary address
+		 */
 		if (!pim_addr_cmp(neigh->source_addr, addr))
 			return neigh;
 
-		/* secondary address ? */
-		if (pim_neighbor_find_secondary(neigh, &p))
-			return neigh;
+		/*
+		 * Find the first secondary address that matches this
+		 * address.
+		 */
+		if (!second_neigh && pim_neighbor_find_secondary(neigh, &p)) {
+			second_neigh = neigh;
+			continue;
+		}
 	}
 
-	if (PIM_DEBUG_PIM_TRACE)
+	if (PIM_DEBUG_PIM_TRACE && !second_neigh)
 		zlog_debug(
 			"%s: neighbor not found for address %pPA on interface %s",
 			__func__, &addr, ifp->name);
 
-	return NULL;
+	return second_neigh;
 }
 
 long pim_if_t_suppressed_msec(struct interface *ifp)

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -526,7 +526,7 @@ pim_neighbor_add(struct interface *ifp, pim_addr source_addr,
 	else
 		pim_hello_restart_triggered(neigh->interface);
 
-	pim_upstream_find_new_rpf(pim_ifp->pim);
+	pim_upstream_find_new_rpf(pim_ifp->pim, ifp);
 
 	/* RNH can send nexthop update prior to PIM neibhor UP
 	   in that case nexthop cache would not consider this neighbor
@@ -654,6 +654,7 @@ void pim_neighbor_delete(struct interface *ifp, struct pim_neighbor *neigh,
 	listnode_delete(pim_ifp->pim_neighbor_list, neigh);
 
 	pim_neighbor_free(neigh);
+	pim_upstream_find_new_rpf(pim_ifp->pim, ifp);
 
 	sched_rpf_cache_refresh(pim_ifp->pim);
 }
@@ -861,5 +862,5 @@ void pim_neighbor_update(struct pim_neighbor *neigh,
 	 * resolvable. Re-evaluate upstreams that don't have a valid RPF path.
 	 */
 	if (secondary_addr_changed)
-		pim_upstream_find_new_rpf(pim_ifp->pim);
+		pim_upstream_find_new_rpf(pim_ifp->pim, neigh->interface);
 }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2255,7 +2255,7 @@ int pim_upstream_empty_inherited_olist(struct pim_upstream *up)
  * set and see if the new neighbor allows
  * the join to be sent
  */
-void pim_upstream_find_new_rpf(struct pim_instance *pim)
+void pim_upstream_find_new_rpf(struct pim_instance *pim, struct interface *ifp)
 {
 	struct pim_upstream *up;
 	struct pim_rpf old;
@@ -2273,11 +2273,11 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 			continue;
 		}
 
-		if (pim_rpf_addr_is_inaddr_any(&up->rpf)) {
+		if (pim_rpf_addr_is_inaddr_any(&up->rpf) ||
+		    up->rpf.source_nexthop.interface == ifp) {
 			if (PIM_DEBUG_PIM_TRACE)
-				zlog_debug(
-					"%s: Upstream %s without a path to send join, checking",
-					__func__, up->sg_str);
+				zlog_debug("%s: Upstream %s without a path to send join, or interface being used is getting a new neighbor, checking",
+					   __func__, up->sg_str);
 			old.source_nexthop.interface =
 				up->rpf.source_nexthop.interface;
 			rpf_result = pim_rpf_update(pim, up, &old, NULL, __func__);

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -375,7 +375,7 @@ int pim_upstream_empty_inherited_olist(struct pim_upstream *up);
 
 bool pim_upstream_kat_start_ok(struct pim_upstream *up);
 
-void pim_upstream_find_new_rpf(struct pim_instance *pim);
+void pim_upstream_find_new_rpf(struct pim_instance *pim, struct interface *ifp);
 
 void pim_upstream_init(struct pim_instance *pim);
 void pim_upstream_terminate(struct pim_instance *pim);


### PR DESCRIPTION
We have some pim topotest failures where we are seeing timing windows around the RPF and where we are not converging on a upstream RPF change when no NHT has happened.