### PR TITLE
isisd: fix crash when ls_vertex_add returns NULL

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -734,8 +734,14 @@ static struct ls_vertex *lsp_to_vertex(struct ls_ted *ted, struct isis_lsp *lsp)
 	/* Create a new one if not found */
 	if (!vertex) {
 		old = ls_node_new(lnode.adv, inaddr_any, in6addr_any);
+		if (!old)
+			return NULL;
 		old->type = STANDARD;
 		vertex = ls_vertex_add(ted, old);
+		if (!vertex) {
+			ls_node_del(old);
+			return NULL;
+		}
 	}
 	old = vertex->node;
 	te_debug("  |- %s Vertex (%" PRIu64 ") for node %s",


### PR DESCRIPTION
ls_vertex_add can return NULL in several cases, add protection from it in lsp_to_vertex.

Additionaly ls_node_new can also return NULL, check for it.

I've stumbled on crash:

```
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000030 (pc 0x55c3629e037c bp 0x7ffc0297dff0 sp 0x7ffc0297dd70 T0)
==3079==The signal is caused by a READ memory access.
==3079==Hint: address points to the zero page.
    #0 0x55c3629e037c in lsp_to_vertex isisd/isis_te.c:740
    #1 0x55c3629e7327 in isis_te_parse_lsp isisd/isis_te.c:1473
    #2 0x55c3629ecb9c in isis_te_lsp_event isisd/isis_te.c:1643
    #3 0x55c362996e17 in lsp_inc_seqno isisd/isis_lsp.c:340
    #4 0x55c36299ec57 in lsp_seqno_update isisd/isis_lsp.c:388
    #5 0x55c36299f17e in lsp_generate isisd/isis_lsp.c:1515
    #6 0x55c362a32778 in isis_instance_area_address_create isisd/isis_nb_config.c:209
    #7 0x7f6b9229fdec in nb_callback_create lib/northbound.c:1583
    #8 0x7f6b9229fdec in nb_callback_configuration lib/northbound.c:2000
    #9 0x7f6b922a14b5 in nb_transaction_process lib/northbound.c:2133
    #10 0x7f6b922a1cac in nb_candidate_commit_apply lib/northbound.c:1445
    #11 0x7f6b922a1f86 in nb_candidate_commit lib/northbound.c:1485
    #12 0x7f6b922a2f33 in nb_cli_classic_commit lib/northbound_cli.c:59
    #13 0x7f6b922a95b2 in nb_cli_apply_changes_internal lib/northbound_cli.c:197
    #14 0x7f6b922a95b2 in _nb_cli_apply_changes lib/northbound_cli.c:230
    #15 0x7f6b922a9de4 in nb_cli_apply_changes lib/northbound_cli.c:246
    #16 0x55c362a4c889 in net_magic isisd/isis_cli.c:291
    #17 0x55c362a4cb1c in net isisd/isis_cli_clippy.c:418
    #18 0x7f6b921d55ec in cmd_execute_command_real lib/command.c:1014
    #19 0x7f6b921d603e in cmd_execute_command_strict lib/command.c:1123
    #20 0x7f6b921d6099 in command_config_read_one_line lib/command.c:1283
    #21 0x7f6b921d633c in config_from_file lib/command.c:1336
    #22 0x7f6b92346b8a in vty_read_file lib/vty.c:2550
    #23 0x7f6b92346c9d in vty_read_config lib/vty.c:2796
    #24 0x7f6b92243e17 in frr_config_read_in lib/libfrr.c:1018
    #25 0x7f6b92330495 in event_call lib/event.c:2744
    #26 0x7f6b92244fd9 in frr_run lib/libfrr.c:1258
    #27 0x55c362976654 in main isisd/isis_main.c:378
    #28 0x7f6b91c89d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #29 0x7f6b91c89e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #30 0x55c362975de4 in _start (/usr/lib/frr/isisd+0xd2de4)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV isisd/isis_te.c:740 in lsp_to_vertex
```

For me it reproduces with diff:

```diff
diff --git a/tests/topotests/isis_topo1/r1/isisd.conf b/tests/topotests/isis_topo1/r1/isisd.conf
index 1335d675c8..8af7d17f26 100644
--- a/tests/topotests/isis_topo1/r1/isisd.conf
+++ b/tests/topotests/isis_topo1/r1/isisd.conf
@@ -10,6 +10,7 @@ interface r1-eth0
 !
 router isis 1
  lsp-gen-interval 2
+ mpls-te on
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0000.00
  metric-style wide
  redistribute ipv4 connected level-2
```

And run

```bash
./tests/topotests/docker/frr-topotests.sh -vv -s isis_topo1/test_isis_topo1.py -k test_isis_convergence
```