### PR TITLE
zebra: fix stale FDB NHG cleanup after restart

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1382,17 +1382,12 @@ static int nhg_ctx_process_new(struct nhg_ctx *ctx)
 	SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 
 	/*
-	 * On startup Zebra is creating the nexthop group cache entry
-	 * after the router has it's startup time set.  This is because
-	 * the process of grabbing routes and nexthops is now *after*
-	 * the dataplane starts up, which is after the routers startup
-	 * time is set.  So let's just cheat a tiny bit on the time
-	 * and set the nexthop group hash entry startup time to be
-	 * slightly before the zrouter.startup_time.  Then graceful
-	 * restart sweeping will work properly for these nexthop entries
+	 * The startup boundary is recorded after kernel nexthops are read.
+	 * Use zero to mark an entry imported before that boundary.  A later
+	 * protocol update replaces it with the current monotonic time.
 	 */
 	if (startup) {
-		nhe->uptime = zrouter.startup_time - 1;
+		nhe->uptime = 0;
 		/* tag stale FDB NH/NHG and reserve its bitmap bit; sweep
 		 * releases the bit via zebra_evpn_mh_release_stale_nhid()
 		 */
@@ -1888,6 +1883,9 @@ static void zebra_nhg_timer(struct event *event)
 
 void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 {
+	bool unrefreshed_stale_fdb = CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_STALE_FDB) &&
+				     nhe->uptime == 0;
+
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: nhe %p (%pNG) %d => %d", __func__, nhe, nhe,
 			   nhe->refcnt, nhe->refcnt - 1);
@@ -1897,7 +1895,8 @@ void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 	if (!zebra_router_in_shutdown() && nhe->refcnt <= 0 &&
 	    (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) ||
 	     CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) &&
-	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND)) {
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND) &&
+	    !unrefreshed_stale_fdb) {
 		nhe->refcnt = 1;
 		SET_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND);
 		event_add_timer(zrouter.master, zebra_nhg_timer, nhe,
@@ -3775,13 +3774,11 @@ static int zebra_nhg_sweep_entry(struct hash_bucket *bucket, void *arg)
 	}
 
 	/*
-	 * same logic as with routes.
-	 *
-	 * If older than startup time, we know we read them in from the
-	 * kernel and have not gotten and update for them since startup
-	 * from an upper level proto.
+	 * Entries imported from the kernel during startup have an uptime of
+	 * zero.  An upper-level protocol refresh gives the entry a nonzero
+	 * timestamp.
 	 */
-	if (zrouter.startup_time < nhe->uptime)
+	if (nhe->uptime != 0)
 		return HASHWALK_CONTINUE;
 
 	/*


### PR DESCRIPTION
Issue 1: startup-imported nexthops are misclassified as refreshed.

Kernel nexthops are imported before zebra_main_router_started() records startup_time. Setting their uptime to startup_time - 1 therefore wraps to UINT64_MAX and makes stale entries look refreshed during the sweep. Use zero as the startup-import marker; a protocol refresh replaces it with the current monotonic time.

Issue 2: keep-around prevents stale dependency cleanup.

Consider a stale singleton referenced by two stale FDB groups:
```
  id 268435462 via 192.168.100.17 proto zebra fdb
  id 536870916 group 268435462/268435463 proto zebra fdb
  id 536870917 group 268435462/268435463 proto zebra fdb
```
The groups each have refcount one, while singleton 268435462 has refcount five: its own reference plus two references from each group.

Before this fix, decrementing each group from one to zero applies the generic keep-around behavior. It restores the group refcount to one, starts its timer, and returns before releasing dependency references:
```
  536870916 refcnt 1 -> 0 -> 1, KEEP_AROUND
  536870917 refcnt 1 -> 0 -> 1, KEEP_AROUND
  268435462 refcnt in place at refcnt 5
```
The hash count does not change, so zebra_nhg_sweep_table() finishes. When the group timers later expire, their dependency releases reduce 268435462 from refcount five to one. The sweep is no longer running, so the stale singleton remains and EVPN replay creates a duplicate:
```
  id 268435462 via 192.168.100.17 proto zebra fdb
  id 268435467 via 192.168.100.17 proto zebra fdb
```
After this fix, an FDB entry carrying both STALE_FDB and the zero startup-import marker bypasses keep-around. Each stale group is deleted immediately and releases its singleton references:
```
  delete 536870916: 268435462 refcnt 5 -> 3
  delete 536870917: 268435462 refcnt 3 -> 1
  next sweep pass:  268435462 refcnt 1 -> 0, delete
```
Each deletion changes the hash count, causing the sweep to restart until the dependency chain is gone. Protocol-refreshed FDB entries and normal NHGs retain the existing keep-around behavior.

