### PR TITLE
lib: optional binding IP support for gRPC server

### DIFF
--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1271,7 +1271,7 @@ static int frr_grpc_init(std::string host, uint port)
 
 	grpc_debug("%s: entered", __func__);
 
-	grpc_args *args = new grpc_args {
+	grpc_args *args = new grpc_args{
 		.host = std::move(host),
 		.port = port,
 	};
@@ -1366,9 +1366,8 @@ static void frr_grpc_module_very_late_init(struct event *event)
 				size_t close_bracket = arg.find(']');
 
 				if (close_bracket == std::string::npos) {
-					flog_err(EC_LIB_GRPC_INIT,
-						"%s: invalid IPv6 address '%s'",
-						__func__, args);
+					flog_err(EC_LIB_GRPC_INIT, "%s: invalid IPv6 address '%s'",
+						 __func__, args);
 					goto error;
 				}
 
@@ -1383,15 +1382,14 @@ static void frr_grpc_module_very_late_init(struct event *event)
 				} else {
 					if (arg.find(':') != colon) {
 						flog_err(EC_LIB_GRPC_INIT,
-							"%s: IPv6 address must use [addr]:port format",
-							__func__);
+							 "%s: IPv6 address must use [addr]:port format",
+							 __func__);
 						goto error;
 					}
 
 					if (colon == 0) {
 						flog_err(EC_LIB_GRPC_INIT,
-							"%s: host must not be empty",
-							__func__);
+							 "%s: host must not be empty", __func__);
 						goto error;
 					}
 
@@ -1402,14 +1400,13 @@ static void frr_grpc_module_very_late_init(struct event *event)
 
 			if (port < 1024 || port > UINT16_MAX) {
 				flog_err(EC_LIB_GRPC_INIT,
-					"%s: port number must be between 1024 and %d",
-					__func__, UINT16_MAX);
+					 "%s: port number must be between 1024 and %d", __func__,
+					 UINT16_MAX);
 				goto error;
 			}
 		} catch (const std::exception &e) {
-			flog_err(EC_LIB_GRPC_INIT,
-				 "%s: invalid gRPC argument '%s': %s",
-				 __func__, args, e.what());
+			flog_err(EC_LIB_GRPC_INIT, "%s: invalid gRPC argument '%s': %s", __func__,
+				 args, e.what());
 			goto error;
 		}
 	}

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1394,7 +1394,7 @@ static void frr_grpc_module_very_late_init(struct event *event)
 							__func__);
 						goto error;
 					}
-					
+
 					host = arg.substr(0, colon);
 					port = std::stoul(arg.substr(colon + 1));
 				}

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -24,8 +24,13 @@
 #include <memory>
 #include <string>
 
+#define GRPC_DEFAULT_HOST "0.0.0.0"
 #define GRPC_DEFAULT_PORT 50051
 
+struct grpc_args {
+	std::string host;
+	uint port;
+};
 
 // ------------------------------------------------------
 //                 File Local Variables
@@ -1136,6 +1141,9 @@ static grpc::ServerCompletionQueue *s_cq;
 static void *grpc_pthread_start(void *arg)
 {
 	struct frr_pthread *fpt = static_cast<frr_pthread *>(arg);
+	struct grpc_args *args = static_cast<struct grpc_args *>(fpt->data);
+
+	std::string host = args->host;
 	uint port = (uint) reinterpret_cast<intptr_t>(fpt->data);
 
 	Candidates candidates;
@@ -1145,7 +1153,7 @@ static void *grpc_pthread_start(void *arg)
 
 	frr_pthread_set_name(fpt);
 
-	server_address << "0.0.0.0:" << port;
+	server_address << host << ":" << port;
 	builder.AddListeningPort(server_address.str(),
 				 grpc::InsecureServerCredentials());
 	builder.RegisterService(&service);
@@ -1256,7 +1264,7 @@ static void *grpc_pthread_start(void *arg)
 }
 
 
-static int frr_grpc_init(uint port)
+static int frr_grpc_init(std::string host, uint port)
 {
 	struct frr_pthread_attr attr = {
 		.start = grpc_pthread_start,
@@ -1265,8 +1273,13 @@ static int frr_grpc_init(uint port)
 
 	grpc_debug("%s: entered", __func__);
 
+	grpc_args *args = new grpc_args {
+		.host = std::move(host),
+		.port = port,
+	};
+
 	fpt = frr_pthread_new(&attr, "frr-grpc", "frr-grpc");
-	fpt->data = reinterpret_cast<void *>((intptr_t)port);
+	fpt->data = args;
 
 	/* Create a pthread for gRPC since it runs its own event loop. */
 	if (frr_pthread_run(fpt, NULL) < 0) {
@@ -1330,19 +1343,44 @@ static int frr_grpc_finish(void)
 static void frr_grpc_module_very_late_init(struct event *event)
 {
 	const char *args = THIS_MODULE->load_args;
+	std::string host = GRPC_DEFAULT_HOST;
 	uint port = GRPC_DEFAULT_PORT;
 
 	if (args) {
-		port = std::stoul(args);
-		if (port < 1024 || port > UINT16_MAX) {
+		try {
+			std::string arg(args);
+			size_t colon = arg.find_last_of(':');
+
+			if (colon == std::string::npos) {
+				// backward compatible with port-only config
+				port = std::stoul(arg);
+			} else {
+				if (colon == 0) {
+					flog_err(EC_LIB_GRPC_INIT,
+						"%s: host must not be empty",
+						__func__);
+					goto error;
+				}
+				
+				host = arg.substr(0, colon);
+				port = std::stoul(arg.substr(colon + 1));
+			}
+
+			if (port < 1024 || port > UINT16_MAX) {
+				flog_err(EC_LIB_GRPC_INIT,
+					"%s: port number must be between 1025 and %d",
+					__func__, UINT16_MAX);
+				goto error;
+			}
+		} catch (const std::exception &e) {
 			flog_err(EC_LIB_GRPC_INIT,
-				 "%s: port number must be between 1025 and %d",
-				 __func__, UINT16_MAX);
+				 "%s: invalid gRPC argument '%s': %s",
+				 __func__, args, e.what());
 			goto error;
 		}
 	}
 
-	if (frr_grpc_init(port) < 0)
+	if (frr_grpc_init(host, port) < 0)
 		goto error;
 
 	return;

--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -1128,11 +1128,6 @@ grpc::Status HandleUnaryExecute(
 		_rpcState->do_request(&service, cq.get(), true);               \
 	} while (0)
 
-struct grpc_pthread_attr {
-	struct frr_pthread_attr attr;
-	unsigned long port;
-};
-
 // Capture these objects so we can try to shut down cleanly
 static pthread_mutex_t s_server_lock = PTHREAD_MUTEX_INITIALIZER;
 static grpc::Server *s_server;
@@ -1144,7 +1139,10 @@ static void *grpc_pthread_start(void *arg)
 	struct grpc_args *args = static_cast<struct grpc_args *>(fpt->data);
 
 	std::string host = args->host;
-	uint port = (uint) reinterpret_cast<intptr_t>(fpt->data);
+	uint port = args->port;
+
+	delete args;
+	fpt->data = nullptr;
 
 	Candidates candidates;
 	grpc::ServerBuilder builder;
@@ -1278,11 +1276,18 @@ static int frr_grpc_init(std::string host, uint port)
 		.port = port,
 	};
 
-	fpt = frr_pthread_new(&attr, "frr-grpc", "frr-grpc");
+	if (!(fpt = frr_pthread_new(&attr, "frr-grpc", "frr-grpc"))) {
+		delete args;
+		return -1;
+	}
+
 	fpt->data = args;
 
 	/* Create a pthread for gRPC since it runs its own event loop. */
 	if (frr_pthread_run(fpt, NULL) < 0) {
+		delete args;
+		fpt->data = nullptr;
+
 		flog_err(EC_LIB_SYSTEM_CALL, "%s: error creating pthread: %s",
 			 __func__, safe_strerror(errno));
 		return -1;
@@ -1349,26 +1354,55 @@ static void frr_grpc_module_very_late_init(struct event *event)
 	if (args) {
 		try {
 			std::string arg(args);
-			size_t colon = arg.find_last_of(':');
 
-			if (colon == std::string::npos) {
-				// backward compatible with port-only config
-				port = std::stoul(arg);
-			} else {
-				if (colon == 0) {
+			if (arg.empty())
+				goto error;
+
+			if (arg[0] == '[') {
+				/*
+				 * IPv6 address must be:
+				 * [::1]:50051
+				 */
+				size_t close_bracket = arg.find(']');
+
+				if (close_bracket == std::string::npos) {
 					flog_err(EC_LIB_GRPC_INIT,
-						"%s: host must not be empty",
-						__func__);
+						"%s: invalid IPv6 address '%s'",
+						__func__, args);
 					goto error;
 				}
-				
-				host = arg.substr(0, colon);
-				port = std::stoul(arg.substr(colon + 1));
+
+				host = arg.substr(0, close_bracket + 1);
+				port = std::stoul(arg.substr(close_bracket + 2));
+			} else {
+				size_t colon = arg.find_last_of(':');
+
+				if (colon == std::string::npos) {
+					// backward compatible with port-only config
+					port = std::stoul(arg);
+				} else {
+					if (arg.find(':') != colon) {
+						flog_err(EC_LIB_GRPC_INIT,
+							"%s: IPv6 address must use [addr]:port format",
+							__func__);
+						goto error;
+					}
+
+					if (colon == 0) {
+						flog_err(EC_LIB_GRPC_INIT,
+							"%s: host must not be empty",
+							__func__);
+						goto error;
+					}
+					
+					host = arg.substr(0, colon);
+					port = std::stoul(arg.substr(colon + 1));
+				}
 			}
 
 			if (port < 1024 || port > UINT16_MAX) {
 				flog_err(EC_LIB_GRPC_INIT,
-					"%s: port number must be between 1025 and %d",
+					"%s: port number must be between 1024 and %d",
 					__func__, UINT16_MAX);
 				goto error;
 			}


### PR DESCRIPTION
# Usage
Binding IP can be configured in **daemons** file for individual daemon options using `-M grpc:<IP>:<port>`.
This is fully backward compatible with port-only config.

# Changes
Instead of directly using `std::stoul` on the argument, it is divided into two parts at last occuring **":"** character, given it is present. Default IP is same as **0.0.0.0**.
Inside `frr_grpc_init`, the combined data is stored as fields of a `struct` whose pointer is placed in `fpt->data`.
This is used in `AddListeningPort` method of `grpc::ServerBuilder` inside `grpc_pthread_start` while building `grpc::Server`.

# Resolves
Resolves #23294