### PR TITLE
Revert "bgpd: fix stuck PROCESS_SCHEDULED after best-path defer"

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4350,8 +4350,6 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 			zlog_debug(
 				"%s: bgp delete in progress, ignoring event, p=%pBD(%s)",
 				__func__, dest, bgp->name_pretty);
-		if (dest)
-			UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 		return;
 	}
 	/* Is it end of initial update? (after startup) */
@@ -4400,7 +4398,6 @@ void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest, afi_t afi, saf
 		if (BGP_DEBUG(update, UPDATE_OUT))
 			zlog_debug("SELECT_DEFER flag set for route %p(%s)",
 				   dest, bgp->name_pretty);
-		UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 		return;
 	}
 
@@ -5397,9 +5394,6 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 				 struct bgp_path_info *pi, afi_t afi,
 				 safi_t safi, bool early_process)
 {
-	struct bgp_table *table;
-	int ret;
-
 	/*
 	 * Indicate that *this* pi is in an unsorted
 	 * situation, even if the node is already
@@ -5446,31 +5440,17 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 	}
 
 	/* all unlocked in process_subq_xxx functions */
-	table = bgp_dest_table(dest);
-	bgp_table_lock(table);
+	bgp_table_lock(bgp_dest_table(dest));
 
 	SET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
 	bgp_dest_lock_node(dest);
 
 	if (early_process) {
 		SET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
-		ret = early_route_process(bgp, dest);
+		early_route_process(bgp, dest);
 	} else {
 		UNSET_FLAG(dest->flags, BGP_NODE_ZEBRA_ANNOUNCE_EARLY);
-		ret = other_route_process(bgp, dest);
-	}
-
-	/*
-	 * On success the dest stays enqueued with the node/table locks held
-	 * and BGP_NODE_PROCESS_SCHEDULED set; they are released and the flag
-	 * cleared asynchronously at dequeue time by process_subq_*_route() ->
-	 * bgp_process_main_one(). On enqueue failure the dequeue never runs,
-	 * so unwind the flag and both locks here.
-	 */
-	if (ret < 0) {
-		UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_SCHEDULED);
-		bgp_dest_unlock_node(dest);
-		bgp_table_unlock(table);
+		other_route_process(bgp, dest);
 	}
 
 	return;


### PR DESCRIPTION
This reverts commit b12cdca8e2c601e34de07b905bc64625281d6069.  It introduces a bad use after free across large swaths of the code base.