### PR TITLE
tests: Fix get_ipv6_linklocal to properly decode v6 address

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -3015,7 +3015,7 @@ class Router(Node):
                 interface = m.group(1)
                 ll_per_if_count = 0
             m = re.search(
-                "inet6 (fe80::[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+)[/0-9]* scope link",
+                r"inet6 (fe80:[0-9a-f:]*)(?:/\d+)? scope link",
                 line,
             )
             if m:


### PR DESCRIPTION
Currently if you have this as a link local address:

6: r2-sw5@if15: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 02:00:4a:d5:ba:d7 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 fc00:a:a:a::2/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::4aff:fed5:bad7/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever

The LL address is this:
fe80::0000:4aff:fed5:bad7

Which compresses to:
fe80::4aff:fed5:bad7

The get_ipv6_linklocal function is looking for 4 octets after the `::` which will cause this to fail.

Modify the function to actually get the legally compressed value in this case.