### PR TITLE
Interface down kernel route update handler, efficiencies

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1386,7 +1386,7 @@ static void zebra_if_addr_update_ctx(struct zebra_dplane_ctx *ctx,
 	 */
 	if (op != DPLANE_OP_INTF_ADDR_ADD && addr->family == AF_INET &&
 	    !if_has_connected_with_family(ifp, AF_INET))
-		rib_update(RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED);
+		rib_update(RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED, ZEBRA_ROUTE_ALL);
 }
 
 static void zebra_if_update_ctx(struct zebra_dplane_ctx *ctx,
@@ -2306,7 +2306,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 					frrtrace(3, frr_zebra, if_dplane_ifp_handling, name,
 						 ifp->ifindex, 1);
 					if_down(ifp);
-					rib_update(RIB_UPDATE_KERNEL);
+					rib_update(RIB_UPDATE_KERNEL, ZEBRA_ROUTE_ALL);
 				} else if (if_is_operative(ifp)) {
 					bool mac_updated = false;
 
@@ -2373,7 +2373,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 					frrtrace(3, frr_zebra, if_dplane_ifp_handling, name,
 						 ifp->ifindex, 5);
 					if_down(ifp);
-					rib_update(RIB_UPDATE_KERNEL);
+					rib_update(RIB_UPDATE_KERNEL, ZEBRA_ROUTE_ALL);
 				}
 			}
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1049,7 +1049,7 @@ void if_up(struct interface *ifp, bool install_connected)
 
 	if_handle_bond_speed_change(ifp);
 
-	rib_update_handle_vrf_all(RIB_UPDATE_KERNEL, ZEBRA_ROUTE_KERNEL);
+	rib_update(RIB_UPDATE_KERNEL, ZEBRA_ROUTE_KERNEL);
 }
 
 /* Interface goes down.  We have to manage different behavior of based
@@ -1103,7 +1103,7 @@ void if_down(struct interface *ifp)
 
 	if_handle_bond_speed_change(ifp);
 
-	rib_update_handle_vrf_all(RIB_UPDATE_INTERFACE_DOWN, ZEBRA_ROUTE_KERNEL);
+	rib_update(RIB_UPDATE_INTERFACE_DOWN, ZEBRA_ROUTE_KERNEL);
 }
 
 void if_refresh(struct interface *ifp)

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -425,7 +425,7 @@ extern void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 extern struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
 				     const union g_addr *addr, struct route_node **rn_out);
 
-extern void rib_update(enum rib_update_event event);
+extern void rib_update(enum rib_update_event event, int type);
 extern void rib_update_table(struct route_table *table,
 			     enum rib_update_event event, int rtype);
 extern void rib_sweep_route(struct event *t);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -488,7 +488,6 @@ extern uint8_t route_distance(int type);
 extern void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq,
 					   bool rt_delete);
 
-extern void rib_update_handle_vrf_all(enum rib_update_event event, int rtype);
 int zebra_show_metaq_counter(struct vty *vty, bool uj);
 
 /*

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4844,10 +4844,11 @@ void rib_update_handle_vrf_all(enum rib_update_event event, int rtype)
 struct rib_update_ctx {
 	enum rib_update_event event;
 	vrf_id_t vrf_id;
+	int type;
 };
 
-static struct rib_update_ctx *rib_update_ctx_init(vrf_id_t vrf_id,
-						  enum rib_update_event event)
+static struct rib_update_ctx *rib_update_ctx_init(vrf_id_t vrf_id, enum rib_update_event event,
+						  int type)
 {
 	struct rib_update_ctx *ctx;
 
@@ -4855,6 +4856,7 @@ static struct rib_update_ctx *rib_update_ctx_init(vrf_id_t vrf_id,
 
 	ctx->event = event;
 	ctx->vrf_id = vrf_id;
+	ctx->type = type;
 
 	return ctx;
 }
@@ -4870,7 +4872,7 @@ static void rib_update_handler(struct event *event)
 
 	ctx = EVENT_ARG(event);
 
-	rib_update_handle_vrf_all(ctx->event, ZEBRA_ROUTE_ALL);
+	rib_update_handle_vrf_all(ctx->event, ctx->type);
 
 	rib_update_ctx_fini(&ctx);
 }
@@ -4908,7 +4910,7 @@ void rib_update(enum rib_update_event event)
 	if (zebra_router_in_shutdown())
 		return;
 
-	ctx = rib_update_ctx_init(0, event);
+	ctx = rib_update_ctx_init(0, event, ZEBRA_ROUTE_ALL);
 
 	event_add_event(zrouter.master, rib_update_handler, ctx, 0,
 			&t_rib_update_threads[event]);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4828,7 +4828,7 @@ void rib_update_table(struct route_table *table, enum rib_update_event event,
 	}
 }
 
-void rib_update_handle_vrf_all(enum rib_update_event event, int rtype)
+static void rib_update_handle_vrf_all(enum rib_update_event event, int rtype)
 {
 	struct zebra_router_table *zrt;
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4900,7 +4900,7 @@ void rib_update_finish(void)
 }
 
 /* Schedule a RIB update event for all vrfs */
-void rib_update(enum rib_update_event event)
+void rib_update(enum rib_update_event event, int type)
 {
 	struct rib_update_ctx *ctx;
 
@@ -4910,7 +4910,7 @@ void rib_update(enum rib_update_event event)
 	if (zebra_router_in_shutdown())
 		return;
 
-	ctx = rib_update_ctx_init(0, event, ZEBRA_ROUTE_ALL);
+	ctx = rib_update_ctx_init(0, event, type);
 
 	event_add_event(zrouter.master, rib_update_handler, ctx, 0,
 			&t_rib_update_threads[event]);


### PR DESCRIPTION
Currently if you have a kernel interface down event, zebra is looping over every single route in the system and finding the kernel routes that use that particular interface and removes it.  This is not great if you have a very large number of routes and you have a very large number of interface down events all at the same time.  

Let's modify the code such that this handling of the kernel routes is an event, and if the event is already scheduled we do not need to schedule another one.  That way we can glom more than one down event into being handled together. In my testing when I have 1,000,005 routes ( 5 kernel and the rest sharp routes ) and I turn down 5 interfaces zebra cpu time goes from 15 seconds to 12 seconds for me.