### PR TITLE
tools: frr-reload: fix logfile location for topotests

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -2394,10 +2394,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--logfile",
         help="logfile for frr-reload",
-        default="/var/log/frr/frr-reload.log",
+        default=None,
     )
 
     args = parser.parse_args()
+
+    # Derive logfile path if not explicitly specified.
+    # In topotest context, use cwd (router's log directory).
+    # In production, use /var/log/frr/.
+    if args.logfile is None:
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            args.logfile = os.path.join(os.getcwd(), "frr-reload.log")
+        else:
+            args.logfile = "/var/log/frr/frr-reload.log"
 
     # Logging
     # For --test log to stdout


### PR DESCRIPTION
The hardcoded default logfile path /var/log/frr/frr-reload.log causes two issues in topotests:

1. Not accessible after test completion - topotests run FRR daemons in network namespaces, and logs written to /var/log/frr/ are not consolidated with other test logs in /tmp/topotests/, making it difficult to debug reload issues.

2. Overwritten by multiple devices - in multi-router topologies, all routers write to the same file, causing logs to be overwritten and lost.

Fix by detecting topotest context via PYTEST_CURRENT_TEST environment variable (set by pytest during test execution). In topotests, write to the current working directory which is set per-router to each router's log directory, placing frr-reload.log alongside zebra.log, bgpd.log, and other daemon logs. In production, continue using /var/log/frr/frr-reload.log.