### PR TITLE
ospfd: Fix Segment Routing Extended Prefix LSA race

### DIFF
--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -1310,6 +1310,10 @@ static int ospf_ext_pref_lsa_originate(void *arg)
 		if (exti->stype != PREF_SID)
 			continue;
 
+		/* Skip Inactive Extended Prefix */
+		if (!CHECK_FLAG(exti->flags, EXT_LPFLG_LSA_ACTIVE))
+			continue;
+
 		/* Process only Extended Prefix with valid Area ID */
 		if ((exti->area == NULL)
 		    || (!IPV4_ADDR_SAME(&exti->area->area_id, &area->area_id)))

--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -995,14 +995,18 @@ static void build_tlv(struct stream *s, struct tlv_header *tlvh)
 /* Build an Extended Prefix Opaque LSA body for extended prefix TLV */
 static void ospf_ext_pref_lsa_body_set(struct stream *s, struct ext_itf *exti)
 {
+	uint16_t size = EXT_TLV_PREFIX_SIZE;
 
 	/* Sanity check */
 	if ((exti == NULL) || (exti->stype != PREF_SID))
 		return;
 
+	/* Only account for the Prefix-SID SubTLV if present */
+	if (ntohs(TLV_TYPE(exti->node_sid)) != 0)
+		size += TLV_HDR_SIZE + ntohs(TLV_LEN(exti->node_sid));
+
 	/* Adjust Extended Prefix TLV size */
-	TLV_LEN(exti->prefix) = htons(ntohs(TLV_LEN(exti->node_sid))
-				      + EXT_TLV_PREFIX_SIZE + TLV_HDR_SIZE);
+	TLV_LEN(exti->prefix) = htons(size);
 
 	/* Build LSA body for an Extended Prefix TLV */
 	build_tlv_header(s, &exti->prefix.header);

--- a/tests/topotests/ospf_ext_prefix_sid_race/r1/frr.conf
+++ b/tests/topotests/ospf_ext_prefix_sid_race/r1/frr.conf
@@ -1,0 +1,14 @@
+hostname r1
+!
+interface lo
+ ip address 1.1.1.1/32
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+router ospf
+ ospf router-id 1.1.1.1
+ network 1.1.1.1/32 area 0.0.0.0
+ network 10.0.0.0/24 area 0.0.0.0
+ segment-routing on
+!

--- a/tests/topotests/ospf_ext_prefix_sid_race/r2/frr.conf
+++ b/tests/topotests/ospf_ext_prefix_sid_race/r2/frr.conf
@@ -1,0 +1,13 @@
+hostname r2
+!
+interface lo
+ ip address 2.2.2.2/32
+!
+interface r2-eth0
+ ip address 10.0.0.2/24
+!
+router ospf
+ ospf router-id 2.2.2.2
+ network 2.2.2.2/32 area 0.0.0.0
+ network 10.0.0.0/24 area 0.0.0.0
+!

--- a/tests/topotests/ospf_ext_prefix_sid_race/test_ospf_ext_prefix_sid_race.py
+++ b/tests/topotests/ospf_ext_prefix_sid_race/test_ospf_ext_prefix_sid_race.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_ospf_ext_prefix_sid_race.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2026 by
+# Wataru Mishima <watal.i27e@gmail.com>
+#
+
+"""
+test_ospf_ext_prefix_sid_race.py:
+
+Regression test for malformed Extended Prefix Opaque-LSA origination
+when a Prefix-SID candidate has no Prefix-SID configured.
+"""
+
+from lib.topogen import Topogen, get_topogen
+from lib import topotest
+import os
+import sys
+
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+
+pytestmark = [pytest.mark.ospfd]
+
+
+def build_topo(tgen):
+    "Build the topology: r1 <-> r2 over a single switch"
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module():
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def opaque_area_lsas(router, area="0.0.0.0"):
+    "Return the list of Area-Local Opaque-LSAs in `area`"
+    output = router.vtysh_cmd(
+        "show ip ospf database opaque-area json", isjson=True
+    )
+    return output.get("areaLocalOpaqueLsa", {}).get("areas", {}).get(area, [])
+
+
+def find_lsa(lsas, opaque_type):
+    "Return the first LSA of `opaque_type` in `lsas`, or None"
+    for lsa in lsas:
+        if lsa.get("opaqueType") == opaque_type:
+            return lsa
+    return None
+
+
+def test_ospf_convergence():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].expect_ospfv2_neighbor("2.2.2.2")
+    tgen.gears["r2"].expect_ospfv2_neighbor("1.1.1.1")
+
+
+def test_no_extended_prefix_lsa_without_prefix_sid():
+    """
+    Verify that the Opaque-LSA origination batch does not produce an
+    Extended Prefix Opaque-LSA for a loopback without a configured
+    Prefix-SID or otherwise produce a malformed self-originated LSA.
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    def extended_link_lsa_exists():
+        return (
+            find_lsa(opaque_area_lsas(r1), "Extended Link Opaque LSA")
+            is not None
+        )
+
+    _, result = topotest.run_and_expect(
+        extended_link_lsa_exists, True, count=60, wait=1
+    )
+    assert result, "r1 never originated its Extended Link Opaque-LSA"
+
+    lsas = opaque_area_lsas(r1)
+    for lsa in lsas:
+        assert lsa.get("opaqueLengthValid", True), (
+            "Malformed Opaque-LSA {} (link-state-id {}) on r1: declared "
+            "TLV length exceeds the LSA body".format(
+                lsa.get("opaqueType"), lsa.get("linkStateId")
+            )
+        )
+
+    assert find_lsa(lsas, "Extended Prefix Opaque LSA") is None, (
+        "r1 originated an Extended Prefix Opaque-LSA for a loopback "
+        "that was never assigned a Prefix-SID"
+    )
+
+
+def test_prefix_sid_after_configuration():
+    "Prefix-SID origination must still work once actually configured"
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    r1.vtysh_multicmd(
+        [
+            "configure terminal",
+            "router ospf",
+            "segment-routing prefix 1.1.1.1/32 index 10",
+        ]
+    )
+
+    def configured_index():
+        lsa = find_lsa(opaque_area_lsas(r1), "Extended Prefix Opaque LSA")
+        if lsa is None:
+            return None
+        return lsa["opaqueValues"]["extendedPrefix"]["prefixSID"]["index"]
+
+    _, result = topotest.run_and_expect(
+        configured_index, 10, count=60, wait=1
+    )
+    assert result == 10, "r1 failed to originate the configured Prefix-SID LSA"
+
+    lsa = find_lsa(opaque_area_lsas(r1), "Extended Prefix Opaque LSA")
+    assert lsa["opaqueLengthValid"] is True
+    assert lsa["opaqueValues"]["extendedPrefix"]["address"] == "1.1.1.1"
+    assert lsa["opaqueValues"]["extendedPrefix"]["prefixLength"] == 32
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
## Summary

Fix a startup race in `ospfd` that could produce malformed Segment Routing Extended Prefix LSAs.

Loopback interfaces may be marked as `PREF_SID` before their Segment Routing prefixes become active.
Because Opaque-LSA origination is asynchronous, inactive entries could be processed, causing the Prefix TLV length to include a Prefix-SID sub-TLV that was not written. 

This resulted in:

```
TLV size 16 exceeds buffer size. Abort!
```

Skip inactive Extended Prefix entries during origination and only include the Prefix-SID sub-TLV when `node_sid` is populated.

## Testing

Added a regression test covering:

- No malformed Extended Prefix LSA is originated before a Prefix-SID is configured.
- A valid Extended Prefix LSA is originated after configuring a Prefix-SID.