### PR TITLE
bgpd: fix clearing BGP dampening for a specific prefix

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -19771,7 +19771,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 			if (rm == NULL)
 				continue;
 
-			const struct prefix *rm_p = bgp_dest_get_prefix(dest);
+			const struct prefix *rm_p = bgp_dest_get_prefix(rm);
 
 			if (!prefix_check
 			    || rm_p->prefixlen == match.prefixlen) {
@@ -19796,7 +19796,7 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 
 		const struct prefix *dest_p = bgp_dest_get_prefix(dest);
 
-		if (prefix_check || dest_p->prefixlen != match.prefixlen) {
+		if (prefix_check && dest_p->prefixlen != match.prefixlen) {
 			bgp_dest_unlock_node(dest);
 			return CMD_SUCCESS;
 		}
@@ -19811,8 +19811,10 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 			pi_temp = pi->next;
 			struct bgp_damp_info *bdi = pi->extra->damp_info;
 
-			if (bdi->lastrecord != BGP_RECORD_UPDATE)
+			if (bdi->lastrecord != BGP_RECORD_UPDATE) {
+				pi = pi_temp;
 				continue;
+			}
 
 			bgp_aggregate_increment(bgp,
 						bgp_dest_get_prefix(bdi->dest),
@@ -19894,8 +19896,7 @@ DEFUN (clear_ip_bgp_dampening_address_mask,
 		return CMD_WARNING;
 	}
 
-	return bgp_clear_damp_route(vty, NULL, prefix_str, AFI_IP, SAFI_UNICAST,
-				    NULL, 0);
+	return bgp_clear_damp_route(vty, NULL, prefix_str, AFI_IP, SAFI_UNICAST, NULL, 1);
 }
 
 static void show_bgp_connectionhash_entry(struct hash_bucket *bucket, void *arg)


### PR DESCRIPTION
Clearing dampening for a given prefix never took effect. The unicast guard returned early whenever an exact prefix was requested instead of only on a prefix-length mismatch, and the VPN path read the length from the RD node rather than the matched route.

Fixing those exposes a path-list loop that never advanced its iterator when skipping a path, which would spin forever, so correct that too.