### PR TITLE
zebra: keep numMacs out of macs in evpn mac json output

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -465,20 +465,21 @@ static void zevpn_print_mac_hash_all_evpn(struct hash_bucket *bucket, void *ctxt
 		frr_json_set_open(json_evpn);
 		frr_json_set_open(json_mac);
 
+		/* Add numMacs before the open "macs" container: an incremental
+		 * flush during the MAC walk would otherwise print it inside "macs".
+		 */
+		if (!CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP))
+			json_object_int_add(json_evpn, "numMacs", num_macs);
 		json_object_object_add(json_evpn, "macs", json_mac);
 		json_object_object_add(json, vni_str, json_evpn);
 	}
 
-	if (!CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP)) {
-		if (json == NULL) {
-			vty_out(vty, "\nVNI %u #MACs (local and remote) %u\n\n",
-				zevpn->vni, num_macs);
-			vty_out(vty,
-				"Flags: N=sync-neighs, I=local-inactive, P=peer-active, X=peer-proxy\n");
-			vty_out(vty, "%-17s %-6s %-5s %-39s %-5s %s\n", "MAC", "Type", "Flags",
-				"Intf/Remote ES/VTEP", "VLAN", "Seq #'s");
-		} else
-			json_object_int_add(json_evpn, "numMacs", num_macs);
+	if (json == NULL && !CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP)) {
+		vty_out(vty, "\nVNI %u #MACs (local and remote) %u\n\n", zevpn->vni, num_macs);
+		vty_out(vty,
+			"Flags: N=sync-neighs, I=local-inactive, P=peer-active, X=peer-proxy\n");
+		vty_out(vty, "%-17s %-6s %-5s %-39s %-5s %s\n", "MAC", "Type", "Flags",
+			"Intf/Remote ES/VTEP", "VLAN", "Seq #'s");
 	}
 
 	if (!num_macs) {
@@ -559,17 +560,17 @@ static void zevpn_print_mac_hash_all_evpn_detail(struct hash_bucket *bucket,
 		frr_json_set_open(json_evpn);
 		frr_json_set_open(json_mac);
 
+		/* Add numMacs before the open "macs" container: an incremental
+		 * flush during the MAC walk would otherwise print it inside "macs".
+		 */
+		if (!CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP))
+			json_object_int_add(json_evpn, "numMacs", num_macs);
 		json_object_object_add(json_evpn, "macs", json_mac);
 		json_object_object_add(json, vni_str, json_evpn);
 	}
 
-	if (!CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP)) {
-		if (json == NULL) {
-			vty_out(vty, "\nVNI %u #MACs (local and remote) %u\n\n",
-				zevpn->vni, num_macs);
-		} else
-			json_object_int_add(json_evpn, "numMacs", num_macs);
-	}
+	if (json == NULL && !CHECK_FLAG(wctx->flags, SHOW_REMOTE_MAC_FROM_VTEP))
+		vty_out(vty, "\nVNI %u #MACs (local and remote) %u\n\n", zevpn->vni, num_macs);
 	/* assign per-evpn to wctx->json object to fill macs
 	 * under the evpn. Re-assign primary json object to fill
 	 * next evpn information.


### PR DESCRIPTION
### Summary

`show evpn mac vni all [detail] json` builds each VNI object with the "macs" container, held open for incremental output, followed by the "numMacs" scalar. The MAC walk flushes the top-level object each time more than 50 MACs have been added. When that flush happens in the middle of a VNI, `frr_json_obj_to_vty()` prints the open "macs" container without closing it and then prints its "numMacs" sibling, so "numMacs" ends up inside "macs" in the output.

Add "numMacs" to the VNI object before "macs", so it is printed ahead of the open container regardless of where the flush happens.

Both `zevpn_print_mac_hash_all_evpn()` and `zevpn_print_mac_hash_all_evpn_detail()` had the same ordering, so both are changed. The plain-text output is unchanged. In JSON output only the key order changes, "numMacs" now precedes "macs".

### Related Issue

Fixes #23273

### Components

zebra

### Testing

Six L2VNIs, each a bridge with a VXLAN device and a dummy access port carrying 12 static local MACs (72 MACs in total), so the walk flushes inside the VNI holding the 51st MAC.

Before, on master (1286d63), VNI 50 in both commands:

```
      "isDuplicate":false
    },
      "numMacs":12
    ,
        "02:00:00:00:32:01":{
```

`numMacs` is emitted inside `macs`, between two MAC entries, and is missing at the VNI level.

After:

```
{
  "40":{
    "numMacs":12,
    "macs":{
      "02:00:00:00:28:08":{
```

| memory of the walk | `show evpn mac vni all json` | `show evpn mac vni all detail json` |
|---|---|---|
| before | VNI 50: numMacs nested inside macs, missing at VNI level | VNI 50: same |
| after | 6/6 VNIs correct | 6/6 VNIs correct |

Checked with a script that parses both outputs, rejects duplicate keys, and verifies for every VNI that `numMacs` is a sibling of `macs` and equals the number of MAC entries. It fails on master and passes with this change.

Built on Ubuntu 24.04 with libyang 3.13.6; `zebra_vxlan.c` compiles without new warnings, and the changed lines match `clang-format` with the in-tree `.clang-format`.

I did not add a topotest: triggering this needs more than 50 MACs across several VNIs, which is a lot of setup for the existing EVPN topologies. Happy to add one if you would like it.
